### PR TITLE
Initialize the Filter/CompositeFilter of the protobuf query

### DIFF
--- a/datastore/conv.go
+++ b/datastore/conv.go
@@ -128,6 +128,10 @@ func queryToQueryProto(q *Query) *pb.Query {
 	}
 	// filters
 	if len(q.filter) > 0 {
+		p.Filter = &pb.Filter{
+			CompositeFilter: &pb.CompositeFilter{},
+		}
+
 		filters := make([]*pb.Filter, len(q.filter))
 		for i, f := range q.filter {
 			filters[i] = &pb.Filter{


### PR DESCRIPTION
## Problem

Without the initialization, you can't filter as this line:

```
p.Filter.CompositeFilter.Filter = filters
```

causes this panic:

```
panic: runtime error: invalid memory address or nil pointer dereference
```
## Sample code that would cause the error

```
q := datastore.NewQuery("namespace", "kind").Filter("uniqueproperty =", "value").Limit(1)
```
## Stacktrace

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x0 pc=0x50a14c]

goroutine 26 [running]:
runtime.panic(0x7a7ba0, 0xa1b673)
    /usr/local/go/src/pkg/runtime/panic.c:279 +0xf5
github.com/GoogleCloudPlatform/gcloud-golang/datastore.queryToQueryProto(0xc2080268f0, 0xc2080882b0)
    /goenquire/vendor/src/github.com/GoogleCloudPlatform/gcloud-golang/datastore/conv.go:141 +0x55c
github.com/GoogleCloudPlatform/gcloud-golang/datastore.(*Transaction).RunQuery(0xc2080e8660, 0xc2080268f0, 0x6bec80, 0xc20807eb00, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
    /goenquire/vendor/src/github.com/GoogleCloudPlatform/gcloud-golang/datastore/datastore.go:213 +0x1a7
github.com/GoogleCloudPlatform/gcloud-golang/datastore.(*Dataset).RunQuery(0xc20803c020, 0xc2080268f0, 0x6bec80, 0xc20807eb00, 0x0, 0x0, 0x0, 0xc20803c010, 0x0, 0x0)
    /goenquire/vendor/src/github.com/GoogleCloudPlatform/gcloud-golang/datastore/datastore.go:133 +0x86
```
