### PR TITLE
Demonstrate how to share publicly.

### DIFF
--- a/storage/example_test.go
+++ b/storage/example_test.go
@@ -96,6 +96,7 @@ func Example_writeObjects() {
 
 	wc := storage.NewWriter(ctx, "bucketname", "filename1", &storage.Object{
 		ContentType: "text/plain",
+		ACL:         []storage.ACLRule{storage.ACLRule{"allUsers", storage.RoleReader}}, // Shared Publicly
 	})
 	if _, err := wc.Write([]byte("hello world")); err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
One of the most-asked questions for cloud storage is how to make an object shared publicly.
This PR shows how to do this in the example apps.
