### PR TITLE
logging: Make SpanId available in logging.Entry

### DIFF
--- a/logging/logging.go
+++ b/logging/logging.go
@@ -597,6 +597,10 @@ type Entry struct {
 	// be relative to //tracing.googleapis.com.
 	Trace string
 
+	// Id of the span within the trace associated with the log entry.
+	// The ID is a 16-character hexadecimal encoding of an 8-byte array.
+	SpanId string
+
 	// Optional. Source code location information associated with the log entry,
 	// if any.
 	SourceLocation *logpb.LogEntrySourceLocation
@@ -825,6 +829,7 @@ func (l *Logger) toLogEntry(e Entry) (*logpb.LogEntry, error) {
 		Operation:      e.Operation,
 		Labels:         e.Labels,
 		Trace:          e.Trace,
+		SpanId:         e.SpanId,
 		Resource:       e.Resource,
 		SourceLocation: e.SourceLocation,
 	}


### PR DESCRIPTION
Making SpanId available in the API enables passing the trace and spanId
together per log entry. Passing in a correctly formatted span will
make the log entry visible in the StackDriver trace console, nicely
interwoven with the rest on the spans.

resolve #1250