### PR TITLE
storage requests also retry if e.Code is 0 (unset)

### DIFF
--- a/storage/go110.go
+++ b/storage/go110.go
@@ -23,7 +23,7 @@ func shouldRetry(err error) bool {
 	case *googleapi.Error:
 		// Retry on 429 and 5xx, according to
 		// https://cloud.google.com/storage/docs/exponential-backoff.
-		return e.Code == 429 || (e.Code >= 500 && e.Code < 600)
+		return e.Code == 0 || e.Code == 429 || (e.Code >= 500 && e.Code < 600)
 	case interface{ Temporary() bool }:
 		return e.Temporary()
 	default:

--- a/storage/not_go110.go
+++ b/storage/not_go110.go
@@ -28,7 +28,7 @@ func shouldRetry(err error) bool {
 	case *googleapi.Error:
 		// Retry on 429 and 5xx, according to
 		// https://cloud.google.com/storage/docs/exponential-backoff.
-		return e.Code == 429 || (e.Code >= 500 && e.Code < 600)
+		return e.Code == 0 || e.Code == 429 || (e.Code >= 500 && e.Code < 600)
 	case *url.Error:
 		// Retry on REFUSED_STREAM.
 		// Unfortunately the error type is unexported, so we resort to string


### PR DESCRIPTION
This retries somewhat rare error responses that have a suffix like one of these:
```
Call error 11: Deadline exceeded (timeout)
API error 2 (urlfetch: FETCH_ERROR)
API error 5 (urlfetch: DEADLINE_EXCEEDED)
```