### PR TITLE
remove select option from Firestore ExampleQuery_Snapshots

### DIFF
--- a/firestore/examples_test.go
+++ b/firestore/examples_test.go
@@ -463,7 +463,7 @@ func ExampleQuery_Snapshots() {
 	}
 	defer client.Close()
 
-	q := client.Collection("States").Select("pop").
+	q := client.Collection("States").
 		Where("pop", ">", 10).
 		OrderBy("pop", firestore.Desc).
 		Limit(10)


### PR DESCRIPTION
With the Select option I get the error:

code = InvalidArgument desc = 'select' clauses are not supported for real-time queries.