### PR TITLE
Account for denormalized IAM emails

### DIFF
--- a/iam/iam_test.go
+++ b/iam/iam_test.go
@@ -85,3 +85,31 @@ func checkMembers(p *Policy, role RoleName, wantMembers []string) (string, bool)
 	}
 	return "", true
 }
+
+func TestNormalizedMember(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		in, exp string
+	}{
+		{"user:foo@gmail.com", "user:foo@gmail.com"},
+		{"user:foo.bar@gmail.com", "user:foobar@gmail.com"},
+		{"user:foo..bar@gmail.com", "user:foobar@gmail.com"},
+		{"user:foo..b.a.r@gmail.com", "user:foobar@gmail.com"},
+		{"user:foo..b.a.r+baz@gmail.com", "user:foobar@gmail.com"},
+		{"user:foo..b.a.r+baz@gmail.co.uk", "user:foobar@gmail.co.uk"},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run("", func(t *testing.T) {
+			t.Parallel()
+
+			act, exp := normalizedMember(tc.in), tc.exp
+			if act != exp {
+				t.Errorf("expected %q to be %q", act, exp)
+			}
+		})
+	}
+}


### PR DESCRIPTION
User accounts, particularly GMail accounts, can take on a variety of formats. The API normalizes these, but then no de-duplication occurs on the client side. This fixes that by normalizing user emails.

Originally I did this as a regular expression. For some reason, that was 1.8x slower than string manipulation and far less intuitive.