### PR TITLE
Firestore: encoding text

### DIFF
--- a/firestore/from_value.go
+++ b/firestore/from_value.go
@@ -102,13 +102,16 @@ func setReflectFromProtoValue(v reflect.Value, vproto *pb.Value, c *Client) erro
 		return nil
 	}
 
-	if pt := v.Addr(); pt.Type().Implements(typeOfTextUnmarshaler) {
-		x, ok := val.(*pb.Value_StringValue)
-		if !ok {
-			return typeErr()
+	// Check if type implement encoding
+	if v.CanAddr() {
+		switch e := v.Addr().Interface().(type) {
+		case encoding.TextUnmarshaler:
+			x, ok := val.(*pb.Value_StringValue)
+			if !ok {
+				return typeErr()
+			}
+			return e.UnmarshalText([]byte(x.StringValue))
 		}
-		tu, _ := pt.Interface().(encoding.TextUnmarshaler)
-		return tu.UnmarshalText([]byte(x.StringValue))
 	}
 
 	switch v.Kind() {

--- a/firestore/from_value.go
+++ b/firestore/from_value.go
@@ -102,12 +102,12 @@ func setReflectFromProtoValue(v reflect.Value, vproto *pb.Value, c *Client) erro
 		return nil
 	}
 
-	if v.Type().Implements(typeOfTextUnmarshaler) {
+	if pt := v.Addr(); pt.Type().Implements(typeOfTextUnmarshaler) {
 		x, ok := val.(*pb.Value_StringValue)
 		if !ok {
 			return typeErr()
 		}
-		tu, _ := v.Interface().(encoding.TextUnmarshaler)
+		tu, _ := pt.Interface().(encoding.TextUnmarshaler)
 		return tu.UnmarshalText([]byte(x.StringValue))
 	}
 

--- a/firestore/from_value.go
+++ b/firestore/from_value.go
@@ -100,7 +100,9 @@ func setReflectFromProtoValue(v reflect.Value, vproto *pb.Value, c *Client) erro
 		}
 		v.Set(reflect.ValueOf(dr))
 		return nil
-	case typeOfTextUnmarshaler:
+	}
+
+	if v.Type().Implements(typeOfTextUnmarshaler) {
 		x, ok := val.(*pb.Value_StringValue)
 		if !ok {
 			return typeErr()

--- a/firestore/from_value.go
+++ b/firestore/from_value.go
@@ -15,6 +15,7 @@
 package firestore
 
 import (
+	"encoding"
 	"errors"
 	"fmt"
 	"reflect"
@@ -99,6 +100,13 @@ func setReflectFromProtoValue(v reflect.Value, vproto *pb.Value, c *Client) erro
 		}
 		v.Set(reflect.ValueOf(dr))
 		return nil
+	case typeOfTextUnmarshaler:
+		x, ok := val.(*pb.Value_StringValue)
+		if !ok {
+			return typeErr()
+		}
+		tu, _ := v.Interface().(encoding.TextUnmarshaler)
+		return tu.UnmarshalText([]byte(x.StringValue))
 	}
 
 	switch v.Kind() {

--- a/firestore/to_value_test.go
+++ b/firestore/to_value_test.go
@@ -219,6 +219,11 @@ func TestToProtoValue_Conversions(t *testing.T) {
 			want: arrayval(intval(7)),
 		},
 		{
+			desc: "encodingText",
+			in:   encodingText{},
+			want: strval("encodingText"),
+		},
+		{
 			desc: "pointer to docref",
 			in: &DocumentRef{
 				ID:   "d",
@@ -311,6 +316,14 @@ func TestToProtoValue_Conversions(t *testing.T) {
 type stringy struct{}
 
 func (stringy) String() string { return "stringy" }
+
+type encodingText struct {
+	text string
+}
+
+func (_ encodingText) MarshalText() ([]byte, error) {
+	return []byte(`encodingText`), nil
+}
 
 func TestToProtoValue_Errors(t *testing.T) {
 	for _, in := range []interface{}{


### PR DESCRIPTION
I added support for `encoding.TextMarshaler` & `encoding.TextUnmarshaler`. It helpful to convert some types like uuid.UUID from/to strings