### PR TITLE
bigtable/bttest: fix Latin-1 regexp filters

### DIFF
--- a/bigtable/bttest/inmem.go
+++ b/bigtable/bttest/inmem.go
@@ -53,6 +53,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"rsc.io/binaryregexp"
 )
 
 const (
@@ -677,7 +678,7 @@ func includeCell(f *btpb.RowFilter, fam, col string, cell cell) (bool, error) {
 		if err != nil {
 			return false, status.Errorf(codes.InvalidArgument, "Error in field 'column_qualifier_regex_filter' : %v", err)
 		}
-		return rx.MatchString(toUTF8([]byte(col))), nil
+		return rx.MatchString(col), nil
 	case *btpb.RowFilter_ValueRegexFilter:
 		rx, err := newRegexp(f.ValueRegexFilter)
 		if err != nil {
@@ -731,17 +732,8 @@ func includeCell(f *btpb.RowFilter, fam, col string, cell cell) (bool, error) {
 	}
 }
 
-func toUTF8(bs []byte) string {
-	var rs []rune
-	for _, b := range bs {
-		rs = append(rs, rune(b))
-	}
-	return string(rs)
-}
-
-func newRegexp(patBytes []byte) (*regexp.Regexp, error) {
-	pat := toUTF8(patBytes)
-	re, err := regexp.Compile("^" + pat + "$") // match entire target
+func newRegexp(pat []byte) (*binaryregexp.Regexp, error) {
+	re, err := binaryregexp.Compile("^" + string(pat) + "$") // match entire target
 	if err != nil {
 		log.Printf("Bad pattern %q: %v", pat, err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -22,4 +22,7 @@ require (
 	google.golang.org/genproto v0.0.0-20190516172635-bb713bdc0e52
 	google.golang.org/grpc v1.19.0
 	honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a
+	rsc.io/binaryregexp v0.1.0
 )
+
+go 1.11

--- a/go.sum
+++ b/go.sum
@@ -75,3 +75,5 @@ google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZi
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a h1:/8zB6iBfHCl1qAnEAWwGPNrUvapuy6CPla1VM0k8hQw=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
+rsc.io/binaryregexp v0.1.0 h1:ljdEASqavhKW0bQr7AK1bXG8/I9evYkdTxKKw4vv5Pg=
+rsc.io/binaryregexp v0.1.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=


### PR DESCRIPTION
The simulation of RE2::Latin1 mode had two problems.

1. It did not support \C at all.
2. It parsed the regexps as if they were written in Latin-1.
They are not. RE2 regexps are always UTF-8;
RE2::Latin1 mode only affects the interpretation of the input data.

Fixes googleapis/google-cloud-go#1405.

Change-Id: I1d8c4fe648cacf606e5cfcf38c03debcc1f9ec7c