### PR TITLE
Fix unclear documentation for TableMetaData

### DIFF
--- a/bigquery/table.go
+++ b/bigquery/table.go
@@ -58,7 +58,7 @@ type TableMetadata struct {
 	// At most one of UseLegacySQL and UseStandardSQL can be true.
 	UseLegacySQL bool
 
-	// Use Legacy SQL for the view query. The default.
+	// Use Standard SQL for the view query. The default.
 	// At most one of UseLegacySQL and UseStandardSQL can be true.
 	// Deprecated: use UseLegacySQL.
 	UseStandardSQL bool


### PR DESCRIPTION
The documentation regarding TableMetadata.UseStandardSQL was uncorrectly referring to Legacy SQL.