### PR TITLE
Extend functions/metadata to handle string resources

### DIFF
--- a/functions/metadata/metadata.go
+++ b/functions/metadata/metadata.go
@@ -43,6 +43,31 @@ type Resource struct {
 	Name string `json:"name"`
 	// Type is the type of event.
 	Type string `json:"type"`
+	// Topic is the topic name of the event (legacy).
+	Topic string `json:"-"`
+}
+
+// UnmarshalJSON specializes the Resource unmarshalling to handle the case where the
+// value is a string instead of a map.
+func (r *Resource) UnmarshalJSON(data []byte) error {
+	// Try to unmarshal the resource into a string.
+	var topic string
+	if err := json.Unmarshal(data, &topic); err == nil {
+		r.Topic = topic
+		return nil
+	}
+
+	// // Otherwise, accept whatever the result of the normal unmarshal would be.
+	type _resource Resource
+	var res _resource
+	if err := json.Unmarshal(data, &res); err != nil {
+		return err
+	}
+
+	r.Service = res.Service
+	r.Name = res.Name
+	r.Type = res.Type
+	return nil
 }
 
 type contextKey string

--- a/functions/metadata/metadata_test.go
+++ b/functions/metadata/metadata_test.go
@@ -16,6 +16,7 @@ package metadata
 
 import (
 	"context"
+	"encoding/json"
 	"reflect"
 	"testing"
 )
@@ -41,5 +42,52 @@ func TestMetadataError(t *testing.T) {
 	}
 	if _, err := FromContext(NewContext(context.Background(), nil)); err == nil {
 		t.Errorf("FromContext got no error, wanted an error")
+	}
+}
+
+func TestUnmarshalJSON(t *testing.T) {
+	var tests = []struct {
+		name string
+		data []byte
+	}{
+		{
+			name: "MetadataWithResource",
+			data: []byte(`{
+				"eventId": "1234567",
+				"timestamp": "2019-11-04T23:01:10.112Z",
+				"eventType": "google.pubsub.topic.publish",
+				"resource": {
+						"service": "pubsub.googleapis.com",
+						"named": "mytopic",
+						"type": "type.googleapis.com/google.pubsub.v1.PubsubMessage"
+				},
+				"data": {
+						"@type": "type.googleapis.com/google.pubsub.v1.PubsubMessage",
+						"attributes": null,
+						"data": "test data"
+						}
+				}`),
+		},
+		{
+			name: "MetadataWithString",
+			data: []byte(`{
+				"eventId": "1234567",
+				"timestamp": "2019-11-04T23:01:10.112Z",
+				"eventType": "google.pubsub.topic.publish",
+				"resource": "projects/myproject/mytopic",
+				"data": {
+						"@type": "type.googleapis.com/google.pubsub.v1.PubsubMessage",
+						"attributes": null,
+						"data": "test data"
+						}
+				}`),
+		},
+	}
+
+	for _, tc := range tests {
+		var m Metadata
+		if err := json.Unmarshal(tc.data, &m); err != nil {
+			t.Errorf("UnmarshalJSON(%s) error: %v", tc.name, err)
+		}
 	}
 }


### PR DESCRIPTION
Some legacy events arrive with the `resource` field of the metadata as a
string value in the JSON, rather than the struct. Handle these appropriately
in a custom JSON unmarshaller.