### PR TITLE
unset ResponseHeaderTimeout in defaultClient

### DIFF
--- a/compute/metadata/metadata.go
+++ b/compute/metadata/metadata.go
@@ -68,7 +68,6 @@ var (
 				Timeout:   2 * time.Second,
 				KeepAlive: 30 * time.Second,
 			}).Dial,
-			ResponseHeaderTimeout: 2 * time.Second,
 		},
 	}}
 	subscribeClient = &Client{hc: &http.Client{


### PR DESCRIPTION
for customers who use workload identity, this argument will prevent them from getting metadata credentials because it will timeout and cancel the request. the roundtrip to mds usually takes longer than 2 seconds.

we probably need to do the same thing to packages in java, c++, etc.. if there is such timeout parameter set.