### PR TITLE
Duration order consistency when multiplying number by time unit

### DIFF
--- a/compute/metadata/metadata.go
+++ b/compute/metadata/metadata.go
@@ -476,7 +476,7 @@ func (c *Client) Scopes(serviceAccount string) ([]string, error) {
 // is deleted. Subscribe returns the error value returned from the last call to
 // fn, which may be nil when ok == false.
 func (c *Client) Subscribe(suffix string, fn func(v string, ok bool) error) error {
-	const failedSubscribeSleep = time.Second * 5
+	const failedSubscribeSleep = 5 * time.Second
 
 	// First check to see if the metadata value exists at all.
 	val, lastETag, err := c.getETag(suffix)


### PR DESCRIPTION
### What does this PR do?
Fix duration order consistency when multiplying number by time unit

### Motivation

I saw some inconsistency in the code and wanna fix it :)

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation
