### PR TITLE
improve PutMultiError messages to be more descriptive

### DIFF
--- a/bigquery/error.go
+++ b/bigquery/error.go
@@ -16,6 +16,7 @@ package bigquery
 
 import (
 	"fmt"
+	"strings"
 
 	bq "google.golang.org/api/bigquery/v2"
 )
@@ -79,5 +80,15 @@ func (pme PutMultiError) Error() string {
 		plural = ""
 	}
 
-	return fmt.Sprintf("%v row insertion%s failed", len(pme), plural)
+	es := make([]string, len(pme))
+	for i, e := range pme {
+		es[i] = e.Error()
+	}
+
+	details := ""
+	if len(es) > 0 {
+		details = fmt.Sprintf(" (%s)", strings.Join(es, ", "))
+	}
+
+	return fmt.Sprintf("%v row insertion%s failed%s", len(pme), plural, details)
 }

--- a/bigquery/error_test.go
+++ b/bigquery/error_test.go
@@ -38,11 +38,11 @@ func TestPutMultiErrorString(t *testing.T) {
 		},
 		{
 			errs: PutMultiError{rowInsertionError("a")},
-			want: "1 row insertion failed",
+			want: "1 row insertion failed (insertion of row [insertID: \"\"; insertIndex: 0] failed with error: a)",
 		},
 		{
 			errs: PutMultiError{rowInsertionError("a"), rowInsertionError("b")},
-			want: "2 row insertions failed",
+			want: "2 row insertions failed (insertion of row [insertID: \"\"; insertIndex: 0] failed with error: a, insertion of row [insertID: \"\"; insertIndex: 0] failed with error: b)",
 		},
 	}
 


### PR DESCRIPTION
I've found that I can't see the details of `bigquery.PutMultiError`, instead it just says "N row insersion(s) failed", which makes us difficult to investigate errors.

This PR improves its error messages to show each error's `Error()`, for example:

before:

```
1 row insertion failed
```

after:

```
1 row insertion failed (insertion of row [insertID: "8rVP48BCVKPPli7IXmBrB7RVFJO"; insertIndex: 0] failed with error: {Location: ""; Message: ""; Reason: "invalid"})
```

Unit tests are included.