### PR TITLE
metadata: set Metadata-Flavor header in OnGCE

### DIFF
--- a/compute/metadata/metadata.go
+++ b/compute/metadata/metadata.go
@@ -130,6 +130,7 @@ func testOnGCE() bool {
 	go func() {
 		req, _ := http.NewRequest("GET", "http://"+metadataIP, nil)
 		req.Header.Set("User-Agent", userAgent)
+		req.Header.Set("Metadata-Flavor", "Google")
 		res, err := defaultClient.hc.Do(req.WithContext(ctx))
 		if err != nil {
 			resc <- false


### PR DESCRIPTION
I'll close this after filing, but I believe that this library suffers from the same issue with Workload Identity on GKE as both the Java and .Net SDKs.
https://github.com/googleapis/google-auth-library-java/pull/283
https://github.com/googleapis/google-api-dotnet-client/issues/1409