### PR TITLE
Test Vector for compareVal

### DIFF
--- a/spanner/spannertest/db_test.go
+++ b/spanner/spannertest/db_test.go
@@ -980,6 +980,19 @@ func TestKeyRange(t *testing.T) {
 				r("Doris", "1999-11-07"),
 			},
 		},
+		{
+			kr: closedClosed(r("A", "2020-01-02T00:03:04.000001Z"), r("A", "2020-01-02T00:03:04.100001Z")),
+			include: [][]interface{}{
+				r("A", "2020-01-02T00:03:04.000001Z"),
+				r("A", "2020-01-02T00:03:04.1Z"),
+				r("A", "2020-01-02T00:03:04.100001Z"),
+			},
+			exclude: [][]interface{}{
+				r("A", "2020-01-02T00:03:03Z"),
+				r("A", "2020-01-02T00:03:04.100002Z"),
+				r("A", "2020-01-02T00:03:04.2Z"),
+			},
+		},
 		// Exercise descending primary key ordering.
 		{
 			kr:   halfOpen(r("Alpha"), r("Charlie")),


### PR DESCRIPTION
[`compareVals`](https://github.com/googleapis/google-clou-go/blob/master/spanner/spannertest/db_eval.go#L496) uses strings.Compare for TIMESTAMP types.

Unfortunately, this incorrectly sorts timestamps with trailing zeros in
the nanosecond position: [Go Playground](https://play.golang.org/p/OODsktN8L_7)
```
Sorted strings: [2020-01-02T00:03:04.100001Z 2020-01-02T00:03:04Z]
Sorted times:   [2020-01-02T00:03:04Z 2020-01-02T00:03:04.100001Z]
```