### PR TITLE
.github: remove pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,0 @@
-# Wait!
-
-**This project does not accept pull requests.**
-
-Please see [CONTRIBUTING.md](https://github.com/googleapis/google-cloud-go/blob/master/CONTRIBUTING.md) for instructions for how to contribute.
-
-Thank you for contributing!


### PR DESCRIPTION
We now accept pull requests. This template is obsolete.