### PR TITLE
compute/metadata: pass cancelable context to DNS lookup

### DIFF
--- a/compute/metadata/metadata.go
+++ b/compute/metadata/metadata.go
@@ -140,7 +140,7 @@ func testOnGCE() bool {
 	}()
 
 	go func() {
-		addrs, err := net.LookupHost("metadata.google.internal")
+		addrs, err := net.DefaultResolver.LookupAddr(ctx, "metadata.google.internal")
 		if err != nil || len(addrs) == 0 {
 			resc <- false
 			return


### PR DESCRIPTION
Tested changes on GCE to make sure this fixed the leak.

Fixes: #2417