### PR TITLE
pubsub: fix panic on Topic.ResumePublish

### DIFF
--- a/pubsub/topic.go
+++ b/pubsub/topic.go
@@ -584,5 +584,12 @@ func (t *Topic) publishMessageBundle(ctx context.Context, bms []*bundledMessage)
 // encountered while publishing, to prevent messages from being published
 // out of order.
 func (t *Topic) ResumePublish(orderingKey string) {
+	t.mu.RLock()
+	noop := t.scheduler == nil
+	t.mu.RUnlock()
+	if noop {
+		return
+	}
+
 	t.scheduler.Resume(orderingKey)
 }


### PR DESCRIPTION
When Topic.ResumePublish is called before Publish,
the underlying scheduler is not initialized yet, leading to a panic.

This patch makes sure the scheduler is initialized by calling initBundler.