### PR TITLE
internal/gapicgen: add more logging and fix pr status bug

### DIFF
--- a/internal/gapicgen/cmd/genbot/github.go
+++ b/internal/gapicgen/cmd/genbot/github.go
@@ -126,13 +126,13 @@ func setGitCreds(githubName, githubEmail string) error {
 // GetRegenPR finds the first regen pull request with the given status. Accepted
 // statues are: open, closed, or all.
 func (gc *GithubClient) GetRegenPR(ctx context.Context, repo string, status string) (*PullRequest, error) {
-	log.Printf("getting %v pull requests", repo)
+	log.Printf("getting %v pull requests with status %q", repo, status)
 
 	// We don't bother paginating, because it hurts our requests quota and makes
 	// the page slower without a lot of value.
 	opt := &github.PullRequestListOptions{
 		ListOptions: github.ListOptions{PerPage: 50},
-		State:       "open",
+		State:       status,
 	}
 	prs, _, err := gc.c.PullRequests.List(ctx, "googleapis", repo, opt)
 	if err != nil {

--- a/internal/gapicgen/cmd/genbot/main.go
+++ b/internal/gapicgen/cmd/genbot/main.go
@@ -100,6 +100,7 @@ func main() {
 	if pr, err := githubClient.GetRegenPR(ctx, "go-genproto", "open"); err != nil {
 		log.Fatal(err)
 	} else if pr != nil {
+		log.Println("There is already a re-generation in progress")
 		return
 	}
 	if pr, err := githubClient.GetRegenPR(ctx, "google-cloud-go", "open"); err != nil {
@@ -116,6 +117,7 @@ func main() {
 	} else if pr != nil {
 		now := time.Now()
 		today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Local().Location())
+		log.Printf("Times -- Now: %v\tToday: %v\tPR: %v", now, today, pr)
 		if pr.Created.After(today) {
 			log.Println("skipping generation, already ran today")
 			return


### PR DESCRIPTION
Trying to figure out why the pull requests are happening with every
re-generation. I am guessing something is wrong with the time
check, but I don't know what yet. Adding more logging to debug.

Also, fixed a bug where the status of a PR being searched for was
not being accounted for.