### PR TITLE
spanner: only retry certain types of internal errors.

### DIFF
--- a/spanner/read.go
+++ b/spanner/read.go
@@ -457,7 +457,7 @@ var (
 )
 
 func (d *resumableStreamDecoder) next() bool {
-	retryer := gax.OnCodes([]codes.Code{codes.Unavailable, codes.Internal}, d.backoff)
+	retryer := onCodes(d.backoff, codes.Unavailable, codes.Internal)
 	for {
 		switch d.state {
 		case unConnected:

--- a/spanner/retry.go
+++ b/spanner/retry.go
@@ -48,7 +48,8 @@ type spannerRetryer struct {
 }
 
 // onCodes returns a spannerRetryer that will retry on the specified error
-// codes.
+// codes. For Internal errors, only errors that have one of a list of known
+// descriptions should be retried.
 func onCodes(bo gax.Backoff, cc ...codes.Code) gax.Retryer {
 	return &spannerRetryer{
 		Retryer: gax.OnCodes(cc, bo),

--- a/spanner/retry.go
+++ b/spanner/retry.go
@@ -18,6 +18,7 @@ package spanner
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"cloud.google.com/go/internal/trace"
@@ -57,6 +58,16 @@ func onCodes(bo gax.Backoff, cc ...codes.Code) gax.Retryer {
 // Retry returns the retry delay returned by Cloud Spanner if that is present.
 // Otherwise it returns the retry delay calculated by the generic gax Retryer.
 func (r *spannerRetryer) Retry(err error) (time.Duration, bool) {
+	if status.Code(err) == codes.Internal &&
+		!strings.Contains(err.Error(), "stream terminated by RST_STREAM") &&
+		// See b/25451313.
+		!strings.Contains(err.Error(), "HTTP/2 error code: INTERNAL_ERROR") &&
+		// See b/27794742.
+		!strings.Contains(err.Error(), "Connection closed with unknown cause") &&
+		!strings.Contains(err.Error(), "Received unexpected EOS on DATA frame from server") {
+		return 0, false
+	}
+
 	delay, shouldRetry := r.Retryer.Retry(err)
 	if !shouldRetry {
 		return 0, false


### PR DESCRIPTION
Reference: https://github.com/googleapis/java-spanner/blob/f89da6a1f4f8a86c136a23dfd2f5b073dd65407a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerExceptionFactory.java#L257-L269

Fixes #2443