### PR TITLE
spanner/spannertest: fix evaluation on IN

### DIFF
--- a/spanner/spannertest/db_eval.go
+++ b/spanner/spannertest/db_eval.go
@@ -419,7 +419,8 @@ func (ec evalContext) evalExpr(e spansql.Expr) (interface{}, error) {
 					return nil, fmt.Errorf("UNNEST argument evaluated as %T, want array", rhs)
 				}
 				for _, rhs := range arr {
-					if lhs == rhs {
+					// == isn't okay here.
+					if compareVals(lhs, rhs) == 0 {
 						b = true
 					}
 				}

--- a/spanner/spannertest/db_test.go
+++ b/spanner/spannertest/db_test.go
@@ -541,6 +541,21 @@ func TestTableData(t *testing.T) {
 				{[]interface{}{false, nil, nil, false, true}},
 			},
 		},
+		// Regression test for evaluating `IN` incorrectly using ==.
+		// https://github.com/googleapis/google-cloud-go/issues/2458
+		{
+			`SELECT COUNT(*) FROM Staff WHERE RawBytes IN UNNEST(@arg)`,
+			queryParams{"arg": queryParam{
+				Type: spansql.Type{Array: true, Base: spansql.Bytes},
+				Value: []interface{}{
+					[]byte{0x02},
+					[]byte{0x01, 0x00, 0x01}, // only one present
+				},
+			}},
+			[][]interface{}{
+				{int64(1)},
+			},
+		},
 	}
 	for _, test := range tests {
 		q, err := spansql.ParseQuery(test.q)


### PR DESCRIPTION
This was broken for BYTES, DATE and TIMESTAMP types.

Fixes #2458.