### PR TITLE
storage: make empty lifecycle clear existing rules

### DIFF
--- a/storage/bucket.go
+++ b/storage/bucket.go
@@ -750,6 +750,7 @@ func (ua *BucketAttrsToUpdate) toRawBucket() *raw.Bucket {
 	}
 	if ua.Lifecycle != nil {
 		rb.Lifecycle = toRawLifecycle(*ua.Lifecycle)
+		rb.ForceSendFields = append(rb.ForceSendFields, "lifecycle")
 	}
 	if ua.Logging != nil {
 		if *ua.Logging == (BucketLogging{}) {
@@ -935,9 +936,6 @@ func toCORS(rc []*raw.BucketCors) []CORS {
 
 func toRawLifecycle(l Lifecycle) *raw.BucketLifecycle {
 	var rl raw.BucketLifecycle
-	if len(l.Rules) == 0 {
-		return nil
-	}
 	for _, r := range l.Rules {
 		rr := &raw.BucketLifecycleRule{
 			Action: &raw.BucketLifecycleRuleAction{

--- a/storage/bucket_test.go
+++ b/storage/bucket_test.go
@@ -284,7 +284,7 @@ func TestBucketAttrsToUpdateToRawBucket(t *testing.T) {
 		},
 		Logging:         &raw.BucketLogging{LogBucket: "lb", LogObjectPrefix: "p"},
 		Website:         &raw.BucketWebsite{MainPageSuffix: "mps", NotFoundPage: "404"},
-		ForceSendFields: []string{"DefaultEventBasedHold"},
+		ForceSendFields: []string{"DefaultEventBasedHold", "lifecycle"},
 	}
 	if msg := testutil.Diff(got, want); msg != "" {
 		t.Error(msg)
@@ -407,6 +407,19 @@ func TestBucketAttrsToUpdateToRawBucket(t *testing.T) {
 				ForceSendFields: []string{"Enabled"},
 			},
 		},
+	}
+	if msg := testutil.Diff(got, want); msg != "" {
+		t.Errorf(msg)
+	}
+
+	// Set an empty Lifecycle and verify that it will be sent.
+	au9 := &BucketAttrsToUpdate{
+		Lifecycle: &Lifecycle{},
+	}
+	got = au9.toRawBucket()
+	want = &raw.Bucket{
+		Lifecycle: &raw.BucketLifecycle{},
+		ForceSendFields: []string{"lifecycle"},
 	}
 	if msg := testutil.Diff(got, want); msg != "" {
 		t.Errorf(msg)


### PR DESCRIPTION
If the caller provides an empty bucket lifecycle (as opposed
to nil, which is the default), it should be force sent in
the request. This allows the caller to clear existing rules
for a bucket.

Fixes #2450