### PR TITLE
storage: remove retry for write integration test

### DIFF
--- a/storage/integration_test.go
+++ b/storage/integration_test.go
@@ -3391,20 +3391,16 @@ func (h testHelper) mustNewReader(obj *ObjectHandle) *Reader {
 }
 
 func writeObject(ctx context.Context, obj *ObjectHandle, contentType string, contents []byte) error {
-	// TODO: remove retry once retry logic in the client has been improved.
-	// https://github.com/googleapis/google-cloud-go/issues/2395
-	return retry(ctx, func() error {
-		w := obj.NewWriter(ctx)
-		w.ContentType = contentType
-		w.CacheControl = "public, max-age=60"
-		if contents != nil {
-			if _, err := w.Write(contents); err != nil {
-				_ = w.Close()
-				return err
-			}
+	w := obj.NewWriter(ctx)
+	w.ContentType = contentType
+	w.CacheControl = "public, max-age=60"
+	if contents != nil {
+		if _, err := w.Write(contents); err != nil {
+			_ = w.Close()
+			return err
 		}
-		return w.Close()
-	}, nil)
+	}
+	return w.Close()
 }
 
 // loc returns a string describing the file and line of its caller's call site. In


### PR DESCRIPTION
This should no longer be necessary to retry now that we have
addressed gaps in retries for the write operation.

Fixes #2395