### PR TITLE
spanner: unskip tests for emulator 0.8.0.

### DIFF
--- a/spanner/emulator_test.sh
+++ b/spanner/emulator_test.sh
@@ -24,7 +24,7 @@ export GCLOUD_TESTS_GOLANG_PROJECT_ID=emulator-test-project
 echo "Running the Cloud Spanner emulator: $SPANNER_EMULATOR_HOST";
 
 # Download the emulator
-EMULATOR_VERSION=0.7.3
+EMULATOR_VERSION=0.8.0
 wget https://storage.googleapis.com/cloud-spanner-emulator/releases/${EMULATOR_VERSION}/cloud-spanner-emulator_linux_amd64-${EMULATOR_VERSION}.tar.gz
 tar zxvf cloud-spanner-emulator_linux_amd64-${EMULATOR_VERSION}.tar.gz
 chmod u+x emulator_main

--- a/spanner/integration_test.go
+++ b/spanner/integration_test.go
@@ -1828,7 +1828,6 @@ func TestIntegration_TransactionRunner(t *testing.T) {
 // serialize and deserialize both transaction and partition to be used in
 // execution on another client, and compare results.
 func TestIntegration_BatchQuery(t *testing.T) {
-	skipEmulatorTest(t)
 	t.Parallel()
 
 	// Set up testing environment.
@@ -1915,7 +1914,6 @@ func TestIntegration_BatchQuery(t *testing.T) {
 
 // Test PartitionRead of BatchReadOnlyTransaction, similar to TestBatchQuery
 func TestIntegration_BatchRead(t *testing.T) {
-	skipEmulatorTest(t)
 	t.Parallel()
 
 	// Set up testing environment.
@@ -2445,7 +2443,6 @@ func TestIntegration_StructParametersBind(t *testing.T) {
 }
 
 func TestIntegration_PDML(t *testing.T) {
-	skipEmulatorTest(t)
 	t.Parallel()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)


### PR DESCRIPTION
Changes:
- Skip tests that are supported in emulator 0.8.0. 
- Upgrade the emulator version in presubmit to 0.8.0. 