### PR TITLE
test(spanner): return err from tx

### DIFF
--- a/spanner/integration_test.go
+++ b/spanner/integration_test.go
@@ -2181,7 +2181,7 @@ func TestIntegration_DML(t *testing.T) {
 			SQL: `Insert INTO Singers (SingerId, FirstName, LastName) VALUES (2, "Eduard", "Khil")`,
 		})
 		if err != nil {
-			t.Fatal(err)
+			return err
 		}
 		if count != 1 {
 			t.Errorf("row count: got %d, want 1", count)


### PR DESCRIPTION
A read/write transaction should always return any error to the transaction runner and let it determine whether it should be returned to the user application, or it should cause a transaction retry. Failing to do so, can cause the transaction to fail sometimes with an Aborted error.

Fixes #2486