### PR TITLE
fix(internal/kokoro): remove install of staticcheck

### DIFF
--- a/internal/kokoro/vet.sh
+++ b/internal/kokoro/vet.sh
@@ -30,8 +30,7 @@ fi
 go install \
   github.com/golang/protobuf/protoc-gen-go \
   golang.org/x/lint/golint \
-  golang.org/x/tools/cmd/goimports \
-  honnef.co/go/tools/cmd/staticcheck
+  golang.org/x/tools/cmd/goimports
 
 # Fail if a dependency was added without the necessary go.mod/go.sum change
 # being part of the commit.


### PR DESCRIPTION
This is already in the image. Unblocks #2564.