### PR TITLE
bigquery: address cached reference in rowiterator

### DIFF
--- a/bigquery/iterator.go
+++ b/bigquery/iterator.go
@@ -351,6 +351,7 @@ func fetchCachedPage(ctx context.Context, src *rowSource, schema Schema, startIn
 		}
 		// clear cache references and return response.
 		src.cachedRows = nil
+		src.cachedSchema = nil
 		src.cachedNextToken = ""
 		return result, nil
 	}


### PR DESCRIPTION
Refines the RowIterator to discard an extra schema reference that
doesn't need to be retained.