### PR TITLE
feat(spanner): support of client-level custom retry settings

### DIFF
--- a/spanner/client.go
+++ b/spanner/client.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/internal/trace"
+	vkit "cloud.google.com/go/spanner/apiv1"
 	"google.golang.org/api/option"
 	gtransport "google.golang.org/api/transport/grpc"
 	sppb "google.golang.org/genproto/googleapis/spanner/v1"
@@ -103,6 +104,10 @@ type ClientConfig struct {
 
 	// QueryOptions is the configuration for executing a sql query.
 	QueryOptions QueryOptions
+
+	// CallOptions is the configuration for providing custom retry settings that
+	// override the default values.
+	CallOptions *vkit.CallOptions
 
 	// logger is the logger to use for this client. If it is nil, all logging
 	// will be directed to the standard logger.
@@ -200,7 +205,7 @@ func NewClientWithConfig(ctx context.Context, database string, config ClientConf
 		config.incStep = DefaultSessionPoolConfig.incStep
 	}
 	// Create a session client.
-	sc := newSessionClient(pool, database, sessionLabels, metadata.Pairs(resourcePrefixHeader, database), config.logger)
+	sc := newSessionClient(pool, database, sessionLabels, metadata.Pairs(resourcePrefixHeader, database), config.logger, config.CallOptions)
 	// Create a session pool.
 	config.SessionPoolConfig.sessionLabels = sessionLabels
 	sp, err := newSessionPool(sc, config.SessionPoolConfig)

--- a/spanner/client_test.go
+++ b/spanner/client_test.go
@@ -27,8 +27,10 @@ import (
 
 	"cloud.google.com/go/civil"
 	itestutil "cloud.google.com/go/internal/testutil"
+	vkit "cloud.google.com/go/spanner/apiv1"
 	. "cloud.google.com/go/spanner/internal/testutil"
 	structpb "github.com/golang/protobuf/ptypes/struct"
+	gax "github.com/googleapis/gax-go/v2"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
 	sppb "google.golang.org/genproto/googleapis/spanner/v1"
@@ -1757,6 +1759,43 @@ func TestClient_WithGRPCConnectionPoolAndNumChannels_Misconfigured(t *testing.T)
 	}
 	if !strings.Contains(se.Error(), msg) {
 		t.Fatalf("Error message mismatch\nGot: %s\nWant: %s", se.Error(), msg)
+	}
+}
+
+func TestClient_WithCallOptions(t *testing.T) {
+	co := &vkit.CallOptions{
+		CreateSession: []gax.CallOption{
+			gax.WithRetry(func() gax.Retryer {
+				return gax.OnCodes([]codes.Code{
+					codes.Unavailable, codes.DeadlineExceeded,
+				}, gax.Backoff{
+					Initial:    200 * time.Millisecond,
+					Max:        30000 * time.Millisecond,
+					Multiplier: 1.25,
+				})
+			}),
+		},
+	}
+
+	_, client, teardown := setupMockedTestServerWithConfig(t, ClientConfig{CallOptions: co})
+	defer teardown()
+
+	c, err := client.sc.nextClient()
+	if err != nil {
+		t.Fatalf("failed to get a session client: %v", err)
+	}
+
+	cs := &gax.CallSettings{}
+	// This is the default retry setting.
+	c.CallOptions.CreateSession[0].Resolve(cs)
+	if got, want := fmt.Sprintf("%v", cs.Retry()), "&{{250000000 32000000000 1.3 0} [14]}"; got != want {
+		t.Fatalf("merged CallOptions is incorrect: got %v, want %v", got, want)
+	}
+
+	// This is the custom retry setting.
+	c.CallOptions.CreateSession[1].Resolve(cs)
+	if got, want := fmt.Sprintf("%v", cs.Retry()), "&{{200000000 30000000000 1.25 0} [14 4]}"; got != want {
+		t.Fatalf("merged CallOptions is incorrect: got %v, want %v", got, want)
 	}
 }
 

--- a/spanner/sessionclient.go
+++ b/spanner/sessionclient.go
@@ -286,22 +286,21 @@ func (sc *sessionClient) nextClient() (*vkit.Client, error) {
 
 // mergeCallOptions merges two CallOptions into one and the first argument has
 // a lower order of precedence than the second one.
-func mergeCallOptions(low *vkit.CallOptions, high *vkit.CallOptions) *vkit.CallOptions {
+func mergeCallOptions(a *vkit.CallOptions, b *vkit.CallOptions) *vkit.CallOptions {
 	res := &vkit.CallOptions{}
-
 	resVal := reflect.ValueOf(res).Elem()
-	lowVal := reflect.ValueOf(low).Elem()
-	highVal := reflect.ValueOf(high).Elem()
+	aVal := reflect.ValueOf(a).Elem()
+	bVal := reflect.ValueOf(b).Elem()
 
-	t := lowVal.Type()
+	t := aVal.Type()
 
-	for i := 0; i < lowVal.NumField(); i++ {
+	for i := 0; i < aVal.NumField(); i++ {
 		fieldName := t.Field(i).Name
 
-		lowFieldVal := lowVal.Field(i).Interface().([]gax.CallOption)
-		highFieldVal := highVal.Field(i).Interface().([]gax.CallOption)
+		aFieldVal := aVal.Field(i).Interface().([]gax.CallOption)
+		bFieldVal := bVal.Field(i).Interface().([]gax.CallOption)
 
-		merged := append(lowFieldVal, highFieldVal...)
+		merged := append(aFieldVal, bFieldVal...)
 		resVal.FieldByName(fieldName).Set(reflect.ValueOf(merged))
 	}
 	return res

--- a/spanner/sessionclient.go
+++ b/spanner/sessionclient.go
@@ -20,12 +20,14 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"reflect"
 	"sync"
 	"time"
 
 	"cloud.google.com/go/internal/trace"
 	"cloud.google.com/go/internal/version"
 	vkit "cloud.google.com/go/spanner/apiv1"
+	"github.com/googleapis/gax-go/v2"
 	"google.golang.org/api/option"
 	gtransport "google.golang.org/api/transport/grpc"
 	sppb "google.golang.org/genproto/googleapis/spanner/v1"
@@ -90,10 +92,11 @@ type sessionClient struct {
 	md            metadata.MD
 	batchTimeout  time.Duration
 	logger        *log.Logger
+	callOptions   *vkit.CallOptions
 }
 
 // newSessionClient creates a session client to use for a database.
-func newSessionClient(connPool gtransport.ConnPool, database string, sessionLabels map[string]string, md metadata.MD, logger *log.Logger) *sessionClient {
+func newSessionClient(connPool gtransport.ConnPool, database string, sessionLabels map[string]string, md metadata.MD, logger *log.Logger, callOptions *vkit.CallOptions) *sessionClient {
 	return &sessionClient{
 		connPool:      connPool,
 		database:      database,
@@ -102,6 +105,7 @@ func newSessionClient(connPool gtransport.ConnPool, database string, sessionLabe
 		md:            md,
 		batchTimeout:  time.Minute,
 		logger:        logger,
+		callOptions:   callOptions,
 	}
 }
 
@@ -274,5 +278,32 @@ func (sc *sessionClient) nextClient() (*vkit.Client, error) {
 		return nil, err
 	}
 	client.SetGoogleClientInfo("gccl", version.Repo)
+	if sc.callOptions != nil {
+		client.CallOptions = mergeCallOptions(client.CallOptions, sc.callOptions)
+	}
 	return client, nil
+}
+
+func mergeCallOptions(low *vkit.CallOptions, high *vkit.CallOptions) *vkit.CallOptions {
+	res := &vkit.CallOptions{}
+
+	resVal := reflect.ValueOf(res).Elem()
+	lowVal := reflect.ValueOf(low).Elem()
+	highVal := reflect.ValueOf(high).Elem()
+
+	t := lowVal.Type()
+
+	for i := 0; i < lowVal.NumField(); i++ {
+		fieldName := t.Field(i).Name
+
+		lowFieldVal := lowVal.Field(i)
+		highFieldVal := highVal.Field(i)
+
+		h := highFieldVal.Interface().([]gax.CallOption)
+		l := lowFieldVal.Interface().([]gax.CallOption)
+
+		merged := append(l, h...)
+		resVal.FieldByName(fieldName).Set(reflect.ValueOf(merged))
+	}
+	return res
 }

--- a/spanner/sessionclient.go
+++ b/spanner/sessionclient.go
@@ -298,13 +298,10 @@ func mergeCallOptions(low *vkit.CallOptions, high *vkit.CallOptions) *vkit.CallO
 	for i := 0; i < lowVal.NumField(); i++ {
 		fieldName := t.Field(i).Name
 
-		lowFieldVal := lowVal.Field(i)
-		highFieldVal := highVal.Field(i)
+		lowFieldVal := lowVal.Field(i).Interface().([]gax.CallOption)
+		highFieldVal := highVal.Field(i).Interface().([]gax.CallOption)
 
-		h := highFieldVal.Interface().([]gax.CallOption)
-		l := lowFieldVal.Interface().([]gax.CallOption)
-
-		merged := append(l, h...)
+		merged := append(lowFieldVal, highFieldVal...)
 		resVal.FieldByName(fieldName).Set(reflect.ValueOf(merged))
 	}
 	return res

--- a/spanner/sessionclient.go
+++ b/spanner/sessionclient.go
@@ -284,6 +284,8 @@ func (sc *sessionClient) nextClient() (*vkit.Client, error) {
 	return client, nil
 }
 
+// mergeCallOptions merges two CallOptions into one and the first argument has
+// a lower order of precedence than the second one.
 func mergeCallOptions(low *vkit.CallOptions, high *vkit.CallOptions) *vkit.CallOptions {
 	res := &vkit.CallOptions{}
 


### PR DESCRIPTION
Changes included are: 

- Add a field `CallOptions` in `ClientConfig`.
- Add a field `callOptions` in `sessionClient`.
- Add a method `mergeCallOptions` to merge two CallOptions.
- Update `nextClient` in sessionclient.go so that if a custom CallOptions is provided, merge it with the default one. 

Fixes #2594