### PR TITLE
docs: update CONTRIBUTING.md with some PR setup info

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@
     `cd google-cloud-go`
 
 1. Fork the repo.
-   
+
 1. Set your fork as a remote:
     `git remote add fork git@github.com:GITHUB_USERNAME/google-cloud-go.git`
 
@@ -35,6 +35,9 @@
    ```
 
 1. Send a pull request with your changes.
+
+   To minimize friction, consider setting `Allow edits from maintainers` on the
+   PR, which will enable project committers and automation to update your PR.
 
 1. A maintainer will review the pull request and make comments.
 


### PR DESCRIPTION
Adds an explicit mention to enable "Allow edits by maintainers" when
setting up the pull request.  In PR #2574 (external contribution) it was
discovered this cannot be added after the fact for org-based forks, only
user-based.

As there's not a great reference link for this in the github docs that
doesn't descend into a bunch of organization permissions management, I'm
not calling this specific circumstance explicitly.