### PR TITLE
fix(pubsub): use grpc conn pool option for subscriber client

### DIFF
--- a/pubsub/pubsub.go
+++ b/pubsub/pubsub.go
@@ -80,7 +80,7 @@ func NewClient(ctx context.Context, projectID string, opts ...option.ClientOptio
 	if err != nil {
 		return nil, fmt.Errorf("pubsub: %v", err)
 	}
-	subc, err := vkit.NewSubscriberClient(ctx, option.WithGRPCConn(pubc.Connection()))
+	subc, err := vkit.NewSubscriberClient(ctx, o...)
 	if err != nil {
 		// Should never happen, since we are passing in the connection.
 		// If it does, we cannot close, because the user may have passed in their


### PR DESCRIPTION
Back in February 2020, `google.golang.org/api/transport/grpc` switched to using a single grpc connection for `Dial` starting in [v0.20.0](https://github.com/googleapis/google-api-go-client/blob/v0.20.0/transport/grpc/dial.go#L46). While the publisher client started to use `DialPool`, the subscriber client did not switch to connection pooling. This was causing an issue where number of open streams was being capped at about 100.

This change has the additional effect of separating the previously shared connection between publisher and subscriber, which should have a minimal effect on most uers.

Fixes #2593 