### PR TITLE
fix(profiler): fix order of units in regexp used to parse backoff duration

### DIFF
--- a/profiler/proftest/proftest.go
+++ b/profiler/proftest/proftest.go
@@ -44,7 +44,10 @@ const (
 )
 
 var (
-	logtimeRE     = regexp.MustCompile(`[A-Z][a-z]{2} [A-Z][a-z]{2}  ?\d+ \d\d:\d\d:\d\d [A-Z]{3} \d{4}`)
+	logtimeRE = regexp.MustCompile(`[A-Z][a-z]{2} [A-Z][a-z]{2}  ?\d+ \d\d:\d\d:\d\d [A-Z]{3} \d{4}`)
+
+	// "ms" must be specified before "m" in the regexp, to ensure "ms" is fully
+	// matched.
 	backoffTimeRE = regexp.MustCompile(`(\d+(\.\d+)?(ms|h|m|s|us))+`)
 )
 

--- a/profiler/proftest/proftest.go
+++ b/profiler/proftest/proftest.go
@@ -45,7 +45,7 @@ const (
 
 var (
 	logtimeRE     = regexp.MustCompile(`[A-Z][a-z]{2} [A-Z][a-z]{2}  ?\d+ \d\d:\d\d:\d\d [A-Z]{3} \d{4}`)
-	backoffTimeRE = regexp.MustCompile(`(\d+(\.\d+)?(h|m|s|ms|us))+`)
+	backoffTimeRE = regexp.MustCompile(`(\d+(\.\d+)?(ms|h|m|s|us))+`)
 )
 
 // BaseStartupTmpl is the common part of the startup script that

--- a/profiler/proftest/proftest_test.go
+++ b/profiler/proftest/proftest_test.go
@@ -134,6 +134,11 @@ func TestParseBackoffDuration(t *testing.T) {
 			line:    "Fri May 15 22:05:01 UTC 2020: benchmark 0: failed to create profile, will retry: rpc error: code = Aborted desc = generic::aborted: action throttled, backoff for 32..0.s",
 			wantErr: true,
 		},
+		{
+			desc:           "a backoff duration specifying hours, minutes, seconds, milliseconds and microseconds is parsed correctly.",
+			line:           "Fri May 15 22:05:01 UTC 2020: benchmark 0: failed to create profile, will retry: rpc error: code = Aborted desc = generic::aborted: action throttled, backoff for 1h1m1s1ms1us",
+			wantBackoffDur: time.Hour + time.Minute + time.Second + time.Millisecond + time.Microsecond,
+		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
 			backoffDur, err := parseBackoffDuration(tc.line)


### PR DESCRIPTION
Without this change,  milliseconds are parsed as minutes.