### PR TITLE
spanner/spansql: restructure types and parsing for column options

### DIFF
--- a/spanner/spannertest/db_test.go
+++ b/spanner/spannertest/db_test.go
@@ -666,7 +666,8 @@ func TestTableSchemaConvertNull(t *testing.T) {
 	st = db.ApplyDDL(&spansql.AlterTable{
 		Name: "Songwriters",
 		Alteration: spansql.AlterColumn{
-			Def: spansql.ColumnDef{Name: "Nickname", Type: spansql.Type{Base: spansql.Bytes}},
+			Name:       "Nickname",
+			Alteration: spansql.SetColumnType{Type: spansql.Type{Base: spansql.Bytes}},
 		},
 	})
 	if err := st.Err(); err != nil {
@@ -675,7 +676,8 @@ func TestTableSchemaConvertNull(t *testing.T) {
 	st = db.ApplyDDL(&spansql.AlterTable{
 		Name: "Songwriters",
 		Alteration: spansql.AlterColumn{
-			Def: spansql.ColumnDef{Name: "Nickname", Type: spansql.Type{Base: spansql.String}},
+			Name:       "Nickname",
+			Alteration: spansql.SetColumnType{Type: spansql.Type{Base: spansql.String}},
 		},
 	})
 	if err := st.Err(); err != nil {

--- a/spanner/spansql/parser_test.go
+++ b/spanner/spansql/parser_test.go
@@ -301,7 +301,7 @@ func TestParseDDL(t *testing.T) {
 					{Name: "System", Type: Type{Base: String, Len: MaxLen}, NotNull: true, Position: line(2)},
 					{Name: "RepoPath", Type: Type{Base: String, Len: MaxLen}, NotNull: true, Position: line(3)},
 					{Name: "Count", Type: Type{Base: Int64}, Position: line(4)},
-					{Name: "UpdatedAt", Type: Type{Base: Timestamp}, AllowCommitTimestamp: boolAddr(true), Position: line(6)},
+					{Name: "UpdatedAt", Type: Type{Base: Timestamp}, Options: ColumnOptions{AllowCommitTimestamp: boolAddr(true)}, Position: line(6)},
 				},
 				PrimaryKey: []KeyPart{
 					{Column: "System"},
@@ -394,12 +394,13 @@ func TestParseDDL(t *testing.T) {
 			},
 			&AlterTable{
 				Name: "FooBar",
-				Alteration: AlterColumn{Def: ColumnDef{
-					Name:     "Author",
-					Type:     Type{Base: String, Len: MaxLen},
-					NotNull:  true,
-					Position: line(26),
-				}},
+				Alteration: AlterColumn{
+					Name: "Author",
+					Alteration: SetColumnType{
+						Type:    Type{Base: String, Len: MaxLen},
+						NotNull: true,
+					},
+				},
 				Position: line(26),
 			},
 			&DropIndex{Name: "MyFirstIndex", Position: line(28)},

--- a/spanner/spansql/sql.go
+++ b/spanner/spansql/sql.go
@@ -114,7 +114,33 @@ func (od OnDelete) SQL() string {
 }
 
 func (ac AlterColumn) SQL() string {
-	return "ALTER COLUMN " + ac.Def.SQL()
+	return "ALTER COLUMN " + ID(ac.Name).SQL() + " " + ac.Alteration.SQL()
+}
+
+func (sct SetColumnType) SQL() string {
+	str := sct.Type.SQL()
+	if sct.NotNull {
+		str += " NOT NULL"
+	}
+	return str
+}
+
+func (sco SetColumnOptions) SQL() string {
+	// TODO: not clear what to do for no options.
+	return "SET " + sco.Options.SQL()
+}
+
+func (co ColumnOptions) SQL() string {
+	str := "OPTIONS ("
+	if co.AllowCommitTimestamp != nil {
+		if *co.AllowCommitTimestamp {
+			str += "allow_commit_timestamp = true"
+		} else {
+			str += "allow_commit_timestamp = null"
+		}
+	}
+	str += ")"
+	return str
 }
 
 func (d *Delete) SQL() string {
@@ -126,12 +152,8 @@ func (cd ColumnDef) SQL() string {
 	if cd.NotNull {
 		str += " NOT NULL"
 	}
-	if cd.Type.Base == Timestamp && cd.AllowCommitTimestamp != nil {
-		if *cd.AllowCommitTimestamp {
-			str += " OPTIONS (allow_commit_timestamp = true)"
-		} else {
-			str += " OPTIONS (allow_commit_timestamp = null)"
-		}
+	if cd.Options != (ColumnOptions{}) {
+		str += " " + cd.Options.SQL()
 	}
 	return str
 }

--- a/spanner/spansql/sql_test.go
+++ b/spanner/spansql/sql_test.go
@@ -71,10 +71,10 @@ func TestSQL(t *testing.T) {
 					{Name: "Cf", Type: Type{Base: Bytes, Len: 4711}, Position: line(7)},
 					{Name: "Cg", Type: Type{Base: Bytes, Len: MaxLen}, Position: line(8)},
 					{Name: "Ch", Type: Type{Base: Date}, Position: line(9)},
-					{Name: "Ci", Type: Type{Base: Timestamp}, AllowCommitTimestamp: boolAddr(true), Position: line(10)},
+					{Name: "Ci", Type: Type{Base: Timestamp}, Options: ColumnOptions{AllowCommitTimestamp: boolAddr(true)}, Position: line(10)},
 					{Name: "Cj", Type: Type{Array: true, Base: Int64}, Position: line(11)},
 					{Name: "Ck", Type: Type{Array: true, Base: String, Len: MaxLen}, Position: line(12)},
-					{Name: "Cl", Type: Type{Base: Timestamp}, AllowCommitTimestamp: boolAddr(false), Position: line(13)},
+					{Name: "Cl", Type: Type{Base: Timestamp}, Options: ColumnOptions{AllowCommitTimestamp: boolAddr(false)}, Position: line(13)},
 				},
 				PrimaryKey: []KeyPart{
 					{Column: "Ca"},
@@ -188,6 +188,36 @@ func TestSQL(t *testing.T) {
 				Position:   line(1),
 			},
 			"ALTER TABLE Ta SET ON DELETE CASCADE",
+			reparseDDL,
+		},
+		{
+			&AlterTable{
+				Name: "Ta",
+				Alteration: AlterColumn{
+					Name: "Cg",
+					Alteration: SetColumnType{
+						Type: Type{Base: String, Len: MaxLen},
+					},
+				},
+				Position: line(1),
+			},
+			"ALTER TABLE Ta ALTER COLUMN Cg STRING(MAX)",
+			reparseDDL,
+		},
+		{
+			&AlterTable{
+				Name: "Ta",
+				Alteration: AlterColumn{
+					Name: "Ci",
+					Alteration: SetColumnOptions{
+						Options: ColumnOptions{
+							AllowCommitTimestamp: boolAddr(false),
+						},
+					},
+				},
+				Position: line(1),
+			},
+			"ALTER TABLE Ta ALTER COLUMN Ci SET OPTIONS (allow_commit_timestamp = null)",
 			reparseDDL,
 		},
 		{

--- a/spanner/spansql/types.go
+++ b/spanner/spansql/types.go
@@ -141,9 +141,6 @@ func (at *AlterTable) clearOffset() {
 	case AddConstraint:
 		alt.Constraint.clearOffset()
 		at.Alteration = alt
-	case AlterColumn:
-		alt.Def.clearOffset()
-		at.Alteration = alt
 	}
 	at.Position.Offset = 0
 }
@@ -166,7 +163,25 @@ type DropColumn struct{ Name string }
 type AddConstraint struct{ Constraint TableConstraint }
 type DropConstraint struct{ Name string }
 type SetOnDelete struct{ Action OnDelete }
-type AlterColumn struct{ Def ColumnDef }
+type AlterColumn struct {
+	Name       string
+	Alteration ColumnAlteration
+}
+
+type ColumnAlteration interface {
+	isColumnAlteration()
+	SQL() string
+}
+
+func (SetColumnType) isColumnAlteration()    {}
+func (SetColumnOptions) isColumnAlteration() {}
+
+type SetColumnType struct {
+	Type    Type
+	NotNull bool
+}
+
+type SetColumnOptions struct{ Options ColumnOptions }
 
 type OnDelete int
 
@@ -196,17 +211,23 @@ type ColumnDef struct {
 	Type    Type
 	NotNull bool
 
-	// AllowCommitTimestamp represents a column OPTIONS.
-	// `true` if query is `OPTIONS (allow_commit_timestamp = true)`
-	// `false` if query is `OPTIONS (allow_commit_timestamp = null)`
-	// `nil` if there are no OPTIONS
-	AllowCommitTimestamp *bool
+	Options ColumnOptions
 
 	Position Position // position of the column name
 }
 
 func (cd ColumnDef) Pos() Position { return cd.Position }
 func (cd *ColumnDef) clearOffset() { cd.Position.Offset = 0 }
+
+// ColumnOptions represents options on a column as part of a
+// CREATE TABLE or ALTER TABLE statement.
+type ColumnOptions struct {
+	// AllowCommitTimestamp represents a column OPTIONS.
+	// `true` if query is `OPTIONS (allow_commit_timestamp = true)`
+	// `false` if query is `OPTIONS (allow_commit_timestamp = null)`
+	// `nil` if there are no OPTIONS
+	AllowCommitTimestamp *bool
+}
 
 // ForeignKey represents a foreign key definition as part of a CREATE TABLE
 // or ALTER TABLE statement.


### PR DESCRIPTION
Column options appear in a few different places:
	CREATE TABLE
        ALTER TABLE ... ADD COLUMN
        ALTER TABLE ... ALTER COLUMN

In the first two places, the entire column is being defined, and the
options may appear without a leading "SET". The third place may
explicitly set options using "SET". In all cases, the options
specification is itself the same, so extract that into its own type,
ColumnOptions, and add distinguished ColumnAlteration types so the
`ALTER TABLE ... ALTER COLUMN` form may be correctly parsed and
formatted.

This change is backward incompatible, but should only affect those using
(defining or parsing) column options.

Fixes #2621.