### PR TITLE
chore(profiler): remove comment indicating profiler library is experimental

### DIFF
--- a/profiler/profiler.go
+++ b/profiler/profiler.go
@@ -14,8 +14,6 @@
 
 // Package profiler is a client for the Stackdriver Profiler service.
 //
-// This package is still experimental and subject to change.
-//
 // Usage example:
 //
 //   import "cloud.google.com/go/profiler"


### PR DESCRIPTION
We've considered Profiler's go agent to be GA for a while now on Profiler's documentation ([see here](https://cloud.google.com/profiler/docs/about-profiler)). 

This change removes the comment indicating this agent is experimental to match up with docs at cloud.google.com