### PR TITLE
test(storage): unskip UpdateRetentionPolicy test

### DIFF
--- a/storage/integration_test.go
+++ b/storage/integration_test.go
@@ -2644,7 +2644,6 @@ func TestIntegration_UpdateRetentionExpirationTime(t *testing.T) {
 }
 
 func TestIntegration_UpdateRetentionPolicy(t *testing.T) {
-	t.Skip("https://github.com/googleapis/google-cloud-go/issues/1632")
 	ctx := context.Background()
 	client := testConfig(ctx, t)
 	defer client.Close()


### PR DESCRIPTION
This test was skipped b/c of a rate limit issue, but we
were able to waive this rate limit for the testing project
via an internal change.

Fixes #1632