### PR TITLE
chore(profiler): fix Kokoro configurations

### DIFF
--- a/profiler/kokoro/continuous_backoff.cfg
+++ b/profiler/kokoro/continuous_backoff.cfg
@@ -21,4 +21,4 @@ before_action {
   }
 }
 
-build: "google-cloud-go/profiler/kokoro/integration_test.sh"
+build_file: "google-cloud-go/profiler/kokoro/integration_test.sh"


### PR DESCRIPTION
I used "build" where I should have used "build_file".
