### PR TITLE
test(speech): skip tests that rely on deleted bucket

### DIFF
--- a/speech/apiv1/Recognize_smoke_test.go
+++ b/speech/apiv1/Recognize_smoke_test.go
@@ -35,6 +35,7 @@ var _ = strconv.FormatUint
 var _ = time.Now
 
 func TestSpeechSmoke(t *testing.T) {
+	t.Skip("https://github.com/googleapis/google-cloud-go/issues/2702")
 	if testing.Short() {
 		t.Skip("skipping smoke test in short mode")
 	}

--- a/speech/apiv1p1beta1/Recognize_smoke_test.go
+++ b/speech/apiv1p1beta1/Recognize_smoke_test.go
@@ -35,6 +35,7 @@ var _ = strconv.FormatUint
 var _ = time.Now
 
 func TestSpeechSmoke(t *testing.T) {
+	t.Skip("https://github.com/googleapis/google-cloud-go/issues/2702")
 	if testing.Short() {
 		t.Skip("skipping smoke test in short mode")
 	}


### PR DESCRIPTION
A bucket that we rely on was accidentally deleted. Until these
assets find a new home, we should skip these tests. This affected
client libraries in other languages as well.

Fixes: #2697
Fixes: #2698
Updates: #2702