### PR TITLE
chore(internal/gapicgen): fix genbot

### DIFF
--- a/internal/gapicgen/cmd/genbot/Dockerfile
+++ b/internal/gapicgen/cmd/genbot/Dockerfile
@@ -29,7 +29,7 @@ RUN go version
 
 # Install Go tools.
 RUN GO111MODULE=on go get \
-    github.com/golang/protobuf/protoc-gen-go@v1.4.1 \
+    github.com/golang/protobuf/protoc-gen-go@v1.4.2 \
     golang.org/x/lint/golint@latest \
     golang.org/x/tools/cmd/goimports@latest \
     honnef.co/go/tools/cmd/staticcheck@latest \


### PR DESCRIPTION
Go tooling was failing due to inconsistencies between protoc-gen-go
versions. This was caused by #2715.

Tested locally and the Dockerfile now builds.