### PR TITLE
fix(spanner): call ctx.cancel after stats have been recorded

### DIFF
--- a/spanner/session.go
+++ b/spanner/session.go
@@ -1501,7 +1501,6 @@ func (hc *healthChecker) worker(i int) {
 		if ws != nil {
 			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 			err := ws.prepareForWrite(ctx)
-			cancel()
 			if err != nil {
 				// Skip handling prepare error, session can be prepared in next
 				// cycle.
@@ -1516,6 +1515,7 @@ func (hc *healthChecker) worker(i int) {
 			hc.pool.mu.Lock()
 			hc.pool.decNumBeingPreparedLocked(ctx)
 			hc.pool.mu.Unlock()
+			cancel()
 			hc.markDone(ws)
 		}
 		rs := getNextForPing()


### PR DESCRIPTION
The `cancel()` method should be called once all code that is executing in the given context have finished. In this case, that also means after the stats recording that uses the same context has finished.

Fixes #2660