### PR TITLE
build: configure alternate CHANGELOG path

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -1,2 +1,3 @@
 releaseType: go-yoshi
 handleGHRelease: true
+changelogPath: CHANGES.md


### PR DESCRIPTION
An alternate CHANGELOG path is now supported by the release tool.
