### PR TITLE
doc(storage): storage.Client should be reused

### DIFF
--- a/storage/doc.go
+++ b/storage/doc.go
@@ -39,7 +39,9 @@ To start working with this package, create a client:
         // TODO: Handle error.
     }
 
-The client will use your default application credentials.
+The client will use your default application credentials. Clients should be
+reused instead of created as needed. The methods of Client are safe for
+concurrent use by multiple goroutines.
 
 If you only wish to access public data, you can create
 an unauthenticated client with

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -97,7 +97,11 @@ type Client struct {
 }
 
 // NewClient creates a new Google Cloud Storage client.
-// The default scope is ScopeFullControl. To use a different scope, like ScopeReadOnly, use option.WithScopes.
+// The default scope is ScopeFullControl. To use a different scope, like
+// ScopeReadOnly, use option.WithScopes.
+//
+// Clients should be reused instead of created as needed. The methods of Client
+// are safe for concurrent use by multiple goroutines.
 func NewClient(ctx context.Context, opts ...option.ClientOption) (*Client, error) {
 	var host, readHost, scheme string
 


### PR DESCRIPTION
This is already indicated in the docs for the client type,
but we want to make sure this is emphasized by including it
in the package docs and docs for NewClient as well. This
becomes more important now that the transport is cloned
for each new client.

Updates #2688