### PR TITLE
chore(internal/kokoro): tidy up static check

### DIFF
--- a/container/container.go
+++ b/container/container.go
@@ -79,7 +79,7 @@ func NewClient(ctx context.Context, projectID string, opts ...option.ClientOptio
 		return nil, fmt.Errorf("dialing: %v", err)
 	}
 
-	svc, err := raw.New(httpClient)
+	svc, err := raw.NewService(ctx, option.WithHTTPClient(httpClient))
 	if err != nil {
 		return nil, fmt.Errorf("constructing container client: %v", err)
 	}

--- a/internal/fields/fold.go
+++ b/internal/fields/fold.go
@@ -109,10 +109,7 @@ func equalFoldRight(s, t []byte) bool {
 		t = t[size:]
 
 	}
-	if len(t) > 0 {
-		return false
-	}
-	return true
+	return len(t) <= 0
 }
 
 // asciiEqualFold is a specialization of bytes.EqualFold for use when

--- a/internal/kokoro/vet.sh
+++ b/internal/kokoro/vet.sh
@@ -86,23 +86,17 @@ golint ./... 2>&1 | ( \
   tee /dev/stderr | (! read)
 
 staticcheck -go 1.11 ./... 2>&1 | ( \
-  grep -v S1007 | \
+  # Ignore deprecation warnings
   grep -v SA1019 | \
-  grep -v firestore/internal/doc-snippets.go | \
+  # Passing nil as context is a valid test.
   grep -v functions/metadata/metadata_test.go | \
-  grep -v spanner/value.go | \
+  # This includes old vendored code. This code is not being updated.
   grep -v go-cloud-debug-agent | \
-  grep -v pubsub/integration_test.go | \
-  grep -v internal/fields/fold.go | \
+  # This code is internal and is just meant to be a reference for debugging.
   grep -v httpreplay/internal/proxy/debug.go | \
-  grep -v bigtable/internal/cbtconfig/cbtconfig.go | \
-  grep -v bigtable/cmd/cbt/cbt.go | \
-  grep -v asset/v1beta1/doc.go | \
-  grep -v asset/v1beta1/mock_test.go | \
-  grep -v spanner/value_test.go | \
-  grep -v bigtable/reader.go | \
-  grep -v internal/btree/btree.go | \
-  grep -v container/apiv1/mock_test.go) | \
+  # The byte field is used to determine if pointers to the same node are
+  # really the same node.
+  grep -v internal/btree/btree.go) | \
   tee /dev/stderr | (! read)
 
 echo "Done vetting!"

--- a/longrunning/longrunning_test.go
+++ b/longrunning/longrunning_test.go
@@ -29,7 +29,6 @@ import (
 	gax "github.com/googleapis/gax-go/v2"
 	pb "google.golang.org/genproto/googleapis/longrunning"
 	rpcstatus "google.golang.org/genproto/googleapis/rpc/status"
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -166,7 +165,7 @@ func TestPollErrorResult(t *testing.T) {
 	if got := status.Code(err); got != errCode {
 		t.Errorf("error code, want %s, got %s", errCode, got)
 	}
-	if got := grpc.ErrorDesc(err); got != errMsg {
+	if got := status.Convert(err).Message(); got != errMsg {
 		t.Errorf("error code, want %s, got %s", errMsg, got)
 	}
 	if !op.Done() {

--- a/profiler/integration_test.go
+++ b/profiler/integration_test.go
@@ -30,6 +30,7 @@ import (
 	"cloud.google.com/go/profiler/proftest"
 	"golang.org/x/oauth2/google"
 	compute "google.golang.org/api/compute/v1"
+	"google.golang.org/api/option"
 )
 
 var runBackoffTest = flag.Bool("run_only_profiler_backoff_test", false, "Enables only the backoff integration test. This integration test requires over 45 mins to run, so it is not run by default.")
@@ -237,7 +238,7 @@ func TestAgentIntegration(t *testing.T) {
 		t.Fatalf("failed to get default client: %v", err)
 	}
 
-	computeService, err := compute.New(client)
+	computeService, err := compute.NewService(ctx, option.WithHTTPClient(client))
 	if err != nil {
 		t.Fatalf("failed to initialize compute service: %v", err)
 	}

--- a/profiler/proftest/proftest_test.go
+++ b/profiler/proftest/proftest_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestParseBenchmarkNumber(t *testing.T) {
-	benchNumRE, err := regexp.Compile("benchmark (\\d+):")
+	benchNumRE, err := regexp.Compile(`benchmark (\d+):`)
 	if err != nil {
 		t.Fatalf("failed to get benchmark regexp: %v", err)
 	}

--- a/translate/translate.go
+++ b/translate/translate.go
@@ -59,7 +59,7 @@ func NewClient(ctx context.Context, opts ...option.ClientOption) (*Client, error
 	if err != nil {
 		return nil, fmt.Errorf("dialing: %v", err)
 	}
-	rawService, err := raw.New(httpClient)
+	rawService, err := raw.NewService(ctx, option.WithHTTPClient(httpClient))
 	if err != nil {
 		return nil, fmt.Errorf("translate client: %v", err)
 	}

--- a/vision/apiv1/client_test.go
+++ b/vision/apiv1/client_test.go
@@ -23,8 +23,8 @@ import (
 	"github.com/golang/protobuf/proto"
 	pb "google.golang.org/genproto/googleapis/cloud/vision/v1"
 	"google.golang.org/genproto/googleapis/rpc/status"
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
 )
 
 var batchResponse = &pb.BatchAnnotateImagesResponse{
@@ -204,7 +204,7 @@ func TestAnnotateOneError(t *testing.T) {
 	_, err = c.annotateOne(ctx,
 		&pb.Image{Source: &pb.ImageSource{ImageUri: "http://foo.jpg"}},
 		nil, pb.Feature_LOGO_DETECTION, 1, nil)
-	if c := grpc.Code(err); c != codes.NotFound {
+	if c := grpcstatus.Code(err); c != codes.NotFound {
 		t.Errorf("got %v, want NotFound", c)
 	}
 }


### PR DESCRIPTION
Remove many of the static check entries that are no longer needed.
Also, provide a snippet for each that we want to keep around.