### PR TITLE
feat(storage): allow CustomTime to be updated

### DIFF
--- a/storage/integration_test.go
+++ b/storage/integration_test.go
@@ -2686,7 +2686,7 @@ func TestIntegration_CustomTime(t *testing.T) {
 
 	// Update CustomTime to the future should succeed.
 	laterTime := ct.Add(10 * time.Hour)
-	if _, err := obj.Update(ctx, ObjectAttrsToUpdate{CustomTime:laterTime}); err != nil {
+	if _, err := obj.Update(ctx, ObjectAttrsToUpdate{CustomTime: laterTime}); err != nil {
 		t.Fatalf("updating CustomTime: %v", err)
 	}
 

--- a/storage/integration_test.go
+++ b/storage/integration_test.go
@@ -2691,7 +2691,7 @@ func TestIntegration_CustomTime(t *testing.T) {
 	}
 
 	// Update CustomTime to the past should give error.
-	// This doesn't work currently!
+	// TODO(tritone): uncomment once internal bug is fixed.
 	//earlierTime := ct.Add(5*time.Hour)
 	//if _, err := obj.Update(ctx, ObjectAttrsToUpdate{CustomTime:earlierTime}); err == nil {
 	//	t.Fatalf("backdating CustomTime: expected error, got none")

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -872,6 +872,10 @@ func (o *ObjectHandle) Update(ctx context.Context, uattrs ObjectAttrsToUpdate) (
 		attrs.TemporaryHold = optional.ToBool(uattrs.TemporaryHold)
 		forceSendFields = append(forceSendFields, "TemporaryHold")
 	}
+	if !uattrs.CustomTime.IsZero() {
+		attrs.CustomTime = uattrs.CustomTime
+		forceSendFields = append(forceSendFields, "CustomTime")
+	}
 	if uattrs.Metadata != nil {
 		attrs.Metadata = uattrs.Metadata
 		if len(attrs.Metadata) == 0 {
@@ -944,6 +948,7 @@ type ObjectAttrsToUpdate struct {
 	ContentEncoding    optional.String
 	ContentDisposition optional.String
 	CacheControl       optional.String
+	CustomTime         time.Time
 	Metadata           map[string]string // set to map[string]string{} to delete
 	ACL                []ACLRule
 


### PR DESCRIPTION
This metadata field should be mutable via
ObjectHandle.Update.

One part of the integration test is commented out as part of a bug that @frankyn and I are investigating.