### PR TITLE
spanner/spannertest: fix aggregation in query evaluation for empty in…

### DIFF
--- a/spanner/spannertest/db_query.go
+++ b/spanner/spannertest/db_query.go
@@ -441,7 +441,7 @@ func (d *database) evalSelect(sel spansql.Select, params queryParams) (ri rowIte
 		if err != nil {
 			return nil, err
 		}
-		if len(rowGroups) == 0 {
+		if len(sel.GroupBy) == 0 {
 			// No grouping, so aggregation applies to the entire table (e.g. COUNT(*)).
 			// This may result in a [0,0) entry for empty inputs.
 			rowGroups = [][2]int{{0, len(raw.rows)}}

--- a/spanner/spannertest/db_test.go
+++ b/spanner/spannertest/db_test.go
@@ -541,6 +541,13 @@ func TestTableData(t *testing.T) {
 				{[]interface{}{false, nil, nil, false, true}},
 			},
 		},
+		// Regression test for aggregating no rows; it used to return an empty row.
+		// https://github.com/googleapis/google-cloud-go/issues/2793
+		{
+			`SELECT Cool, ARRAY_AGG(Name) FROM Staff WHERE Name > "zzz" GROUP BY Cool`,
+			nil,
+			nil,
+		},
 		// Regression test for evaluating `IN` incorrectly using ==.
 		// https://github.com/googleapis/google-cloud-go/issues/2458
 		{


### PR DESCRIPTION
…puts

The aggregation was applying grouping to the entire table if no grouping
was found, but that should only apply if there isn't a GROUP BY clause,
not if a GROUP BY clause found no rows (e.g. for an empty table).

Fixes #2793