### PR TITLE
fix(pubsub): honor option.WithTelemetryDisabled

### DIFF
--- a/pubsub/pubsub.go
+++ b/pubsub/pubsub.go
@@ -61,6 +61,7 @@ func NewClient(ctx context.Context, projectID string, opts ...option.ClientOptio
 			return nil, fmt.Errorf("grpc.Dial: %v", err)
 		}
 		o = []option.ClientOption{option.WithGRPCConn(conn)}
+		o = append(o, option.WithTelemetryDisabled())
 	} else {
 		numConns := runtime.GOMAXPROCS(0)
 		if numConns > 4 {
@@ -73,7 +74,6 @@ func NewClient(ctx context.Context, projectID string, opts ...option.ClientOptio
 				Time: 5 * time.Minute,
 			})),
 		}
-		o = append(o, openCensusOptions()...)
 	}
 	o = append(o, opts...)
 	pubc, err := vkit.NewPublisherClient(ctx, o...)

--- a/pubsub/trace.go
+++ b/pubsub/trace.go
@@ -19,19 +19,10 @@ import (
 	"log"
 	"sync"
 
-	"go.opencensus.io/plugin/ocgrpc"
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
-	"google.golang.org/api/option"
-	"google.golang.org/grpc"
 )
-
-func openCensusOptions() []option.ClientOption {
-	return []option.ClientOption{
-		option.WithGRPCDialOption(grpc.WithStatsHandler(&ocgrpc.ClientHandler{})),
-	}
-}
 
 // The following keys are used to tag requests with a specific topic/subscription ID.
 var (


### PR DESCRIPTION
It seem that the telemetry options added here predate general
telemetry handling. There is no need to explicitly enable such
options here as it is taken care of grpc.DialPool:
https://pkg.go.dev/google.golang.org/api/transport/grpc?#DialPool.
The stats handler is only added if option.WithTelemetryDisabled is
not passed in.

Fixes: #2751