### PR TITLE
feat(cloudbuild): Start generating apiv1/v3

### DIFF
--- a/internal/gapicgen/generator/config.go
+++ b/internal/gapicgen/generator/config.go
@@ -545,7 +545,7 @@ var microgenGapicConfigs = []*microgenConfig{
 	{
 		inputDirectoryPath:    "google/devtools/cloudbuild/v1",
 		pkg:                   "cloudbuild",
-		importPath:            "cloud.google.com/go/cloudbuild/apiv1/v2",
+		importPath:            "cloud.google.com/go/cloudbuild/apiv1/v3",
 		gRPCServiceConfigPath: "google/devtools/cloudbuild/v1/cloudbuild_grpc_service_config.json",
 		apiServiceConfigPath:  "google/devtools/cloudbuild/v1/cloudbuild_v1.yaml",
 		releaseLevel:          "ga",

--- a/internal/gapicgen/generator/config_test.go
+++ b/internal/gapicgen/generator/config_test.go
@@ -30,6 +30,7 @@ var apivExceptions = map[string]bool{
 	"cloud.google.com/go/firestore/apiv1/admin": true,
 	"cloud.google.com/go/cloudbuild/apiv1/v2":   true,
 	"cloud.google.com/go/monitoring/apiv3/v2":   true,
+	"cloud.google.com/go/cloudbuild/apiv1/v3":   true,
 }
 
 // TestMicrogenConfigs validates config entries.


### PR DESCRIPTION
A recent [change](https://github.com/googleapis/googleapis/commit/48ce8878cd4c54cf247de826ac53c1414b0345bd) has removed some apis from the surface of
apiv1/v2. As this is a breaking change, we need to start generating
sources under a new import path. A future commit will deprecated
the previous package.