### PR TITLE
fix(spanner): fix flaky numeric tests

### DIFF
--- a/spanner/integration_test.go
+++ b/spanner/integration_test.go
@@ -1369,8 +1369,10 @@ func TestIntegration_BasicTypes(t *testing.T) {
 	d3, _ := civil.ParseDate("9999-12-31")
 
 	n0 := big.Rat{}
-	n1 := *big.NewRat(123456789, 1)
-	n2 := *big.NewRat(123456789, 1000000000)
+	n1p, _ := (&big.Rat{}).SetString("123456789")
+	n2p, _ := (&big.Rat{}).SetString("123456789/1000000000")
+	n1 := *n1p
+	n2 := *n2p
 
 	tests := []struct {
 		col  string


### PR DESCRIPTION
The problem is that sometimes we got `big.nat(nil)` but want `big.nat{}`. This happens occasionally and I couldn't reproduce it on my local env. 

One of the errors: 

```bash
    integration_test.go:1524: 83: col:Numeric val:big.Rat{a:big.Int{neg:false, abs:big.nat{0x75bcd15}}, b:big.Int{neg:false, abs:big.nat{}}}, got big.Rat{a:big.Int{neg:false, abs:big.nat{0x75bcd15}}, b:big.Int{neg:false, abs:big.nat(nil)}}, want big.Rat{a:big.Int{neg:false, abs:big.nat{0x75bcd15}}, b:big.Int{neg:false, abs:big.nat{}}}
```

So I suspect that we should use `big.Rat.Cmp` for checking equality instead of using `cmp`. 

Fixes #2828 