### PR TITLE
revert(cloudbuild): "feat(cloudbuild): Start generating apiv1/v3"

### DIFF
--- a/internal/gapicgen/generator/config.go
+++ b/internal/gapicgen/generator/config.go
@@ -545,7 +545,7 @@ var microgenGapicConfigs = []*microgenConfig{
 	{
 		inputDirectoryPath:    "google/devtools/cloudbuild/v1",
 		pkg:                   "cloudbuild",
-		importPath:            "cloud.google.com/go/cloudbuild/apiv1/v3",
+		importPath:            "cloud.google.com/go/cloudbuild/apiv1/v2",
 		gRPCServiceConfigPath: "google/devtools/cloudbuild/v1/cloudbuild_grpc_service_config.json",
 		apiServiceConfigPath:  "google/devtools/cloudbuild/v1/cloudbuild_v1.yaml",
 		releaseLevel:          "ga",

--- a/internal/gapicgen/generator/config_test.go
+++ b/internal/gapicgen/generator/config_test.go
@@ -30,7 +30,6 @@ var apivExceptions = map[string]bool{
 	"cloud.google.com/go/firestore/apiv1/admin": true,
 	"cloud.google.com/go/cloudbuild/apiv1/v2":   true,
 	"cloud.google.com/go/monitoring/apiv3/v2":   true,
-	"cloud.google.com/go/cloudbuild/apiv1/v3":   true,
 }
 
 // TestMicrogenConfigs validates config entries.


### PR DESCRIPTION
The breaking changes have been rolled back, there is no need to
generate under a new package.

This reverts commit 358a5368da64cf4868551652e852ceb453504f64.