### PR TITLE
fix(spanner/spansql): fix parsing of adjacent inline and leading comments

### DIFF
--- a/spanner/spansql/parser.go
+++ b/spanner/spansql/parser.go
@@ -735,6 +735,12 @@ func (p *parser) skipSpace() bool {
 			p.line++
 		}
 		i += ti + len(term)
+
+		// A non-isolated comment is always complete and doesn't get
+		// combined with any future comment.
+		if !com.isolated {
+			com = nil
+		}
 	}
 	p.s = p.s[i:]
 	p.offset += i


### PR DESCRIPTION
These should be in separate Comment entries, not combined:
	Some INT64,  -- comment #1
        -- comment #2