### PR TITLE
fix(internal/kokoro): install the right version of docuploader

### DIFF
--- a/internal/kokoro/publish_docs.sh
+++ b/internal/kokoro/publish_docs.sh
@@ -19,7 +19,7 @@ set -eo pipefail
 # Display commands being run.
 set -x
 
-python3 -m pip install gcp-docuploader
+python3 -m pip install "gcp-docuploader<2019.0.0"
 
 cd github/google-cloud-go/internal/godocfx
 go install


### PR DESCRIPTION
docuploader used to be "calendar" versioned. Now, it's normally versioned. This will work until we get to major version 2019. :wink: 