### PR TITLE
fix(internal/kokoro): remove extra dash in doc tarball

### DIFF
--- a/internal/kokoro/publish_docs.sh
+++ b/internal/kokoro/publish_docs.sh
@@ -43,6 +43,6 @@ cd obj/api || exit 4
 
 python3 -m docuploader upload \
   --staging-bucket docs-staging-v2-staging \
-  --destination-prefix docfx- \
+  --destination-prefix docfx \
   --credentials "$KOKORO_KEYSTORE_DIR/73713_docuploader_service_account" \
   .


### PR DESCRIPTION
Before, this would be uploaded as `docfx--go-...`.