### PR TITLE
feat(pubsub/pstest)!: Add status code to error injection.

### DIFF
--- a/pubsub/pstest/fake.go
+++ b/pubsub/pstest/fake.go
@@ -1171,20 +1171,22 @@ func (s *GServer) runReactor(req interface{}, funcName string, defaultObj interf
 	return false, nil, nil
 }
 
-// ErrorInjectionReactor is a reactor to inject an error message
-type ErrorInjectionReactor struct {
-	errMsg string
+// errorInjectionReactor is a reactor to inject an error message with status code.
+type errorInjectionReactor struct {
+	code codes.Code
+	msg  string
 }
 
-// React simply returns an error with defined error message.
-func (e *ErrorInjectionReactor) React(_ interface{}) (handled bool, ret interface{}, err error) {
-	return true, nil, fmt.Errorf(e.errMsg)
+// React simply returns an error with defined error message and status code.
+func (e *errorInjectionReactor) React(_ interface{}) (handled bool, ret interface{}, err error) {
+	return true, nil, status.Errorf(e.code, e.msg)
 }
 
-// WithErrorInjection creates a ServerReactorOption that injects error for a certain function.
-func WithErrorInjection(funcName string, errMsg string) ServerReactorOption {
+// WithErrorInjection creates a ServerReactorOption that injects error with defined status code and
+// message for a certain function.
+func WithErrorInjection(funcName string, code codes.Code, msg string) ServerReactorOption {
 	return ServerReactorOption{
 		FuncName: funcName,
-		Reactor:  &ErrorInjectionReactor{errMsg: errMsg},
+		Reactor:  &errorInjectionReactor{code: code, msg: msg},
 	}
 }


### PR DESCRIPTION
A status code is added into errorInjectionReactor, this is necessary
as the retry setting for some calls depends on the error code. Also
the errorInjectionReactor is not exported. Note that the previous
version is same as having an Unknown code as the server will always
wrap the error to a proper status error.

BREAKING CHANGE: this will invalidate the previous exported
`ErrorInjectionReactor` struct and `WithErrorInjection` function.