### PR TITLE
feat(spanner/spannertest): evaluate path expressions

### DIFF
--- a/spanner/spannertest/README.md
+++ b/spanner/spannertest/README.md
@@ -25,7 +25,6 @@ by ascending esotericism:
 - joins
 - transaction simulation
 - expression type casting, coercion
-- SELECT aliases in FROM clause, ORDER BY
 - subselects
 - set operations (UNION, INTERSECT, EXCEPT)
 - partition support

--- a/spanner/spannertest/db.go
+++ b/spanner/spannertest/db.go
@@ -67,7 +67,8 @@ type table struct {
 type colInfo struct {
 	Name     spansql.ID
 	Type     spansql.Type
-	AggIndex int // Index+1 of SELECT list for which this is an aggregate value.
+	AggIndex int             // Index+1 of SELECT list for which this is an aggregate value.
+	Alias    spansql.PathExp // an alternate name for this column (result sets only)
 }
 
 // commitTimestampSentinel is a sentinel value for TIMESTAMP fields with allow_commit_timestamp=true.

--- a/spanner/spannertest/db_test.go
+++ b/spanner/spannertest/db_test.go
@@ -548,6 +548,14 @@ func TestTableData(t *testing.T) {
 				{[]interface{}{false, nil, nil, false, true}},
 			},
 		},
+		// SELECT with aliases.
+		{
+			`SELECT s.Name FROM Staff AS s WHERE s.ID = 3 ORDER BY s.Tenure`,
+			nil,
+			[][]interface{}{
+				{"Sam"},
+			},
+		},
 		// Regression test for aggregating no rows; it used to return an empty row.
 		// https://github.com/googleapis/google-cloud-go/issues/2793
 		{


### PR DESCRIPTION
This adds support for aliases in SELECT statements, and in particular
table aliases that can then be referenced from other places in the query
evaluation.

Fixes #2463.