### PR TITLE
feat(spanner/spansql): parse join hints

### DIFF
--- a/spanner/spannertest/README.md
+++ b/spanner/spannertest/README.md
@@ -30,4 +30,3 @@ by ascending esotericism:
 - partition support
 - conditional expressions
 - table sampling (implementation)
-- hints for table/joins

--- a/spanner/spansql/parser_test.go
+++ b/spanner/spansql/parser_test.go
@@ -161,6 +161,35 @@ func TestParseQuery(t *testing.T) {
 				},
 			},
 		},
+		// Joins with hints.
+		{`SELECT * FROM A HASH JOIN B USING (x)`,
+			Query{
+				Select: Select{
+					List: []Expr{Star},
+					From: []SelectFrom{SelectFromJoin{
+						Type:  InnerJoin,
+						LHS:   SelectFromTable{Table: "A"},
+						RHS:   SelectFromTable{Table: "B"},
+						Using: []ID{"x"},
+						Hints: map[string]string{"JOIN_METHOD": "HASH_JOIN"},
+					}},
+				},
+			},
+		},
+		{`SELECT * FROM A JOIN @{ JOIN_METHOD=HASH_JOIN } B USING (x)`,
+			Query{
+				Select: Select{
+					List: []Expr{Star},
+					From: []SelectFrom{SelectFromJoin{
+						Type:  InnerJoin,
+						LHS:   SelectFromTable{Table: "A"},
+						RHS:   SelectFromTable{Table: "B"},
+						Using: []ID{"x"},
+						Hints: map[string]string{"JOIN_METHOD": "HASH_JOIN"},
+					}},
+				},
+			},
+		},
 	}
 	for _, test := range tests {
 		got, err := ParseQuery(test.in)

--- a/spanner/spansql/types.go
+++ b/spanner/spansql/types.go
@@ -327,7 +327,9 @@ type SelectFromJoin struct {
 	On    BoolExpr
 	Using []ID
 
-	// TODO: hint keys (this will cover `X HASH JOIN Y` too).
+	// Hints are suggestions for how to evaluate a join.
+	// https://cloud.google.com/spanner/docs/query-syntax#join-hints
+	Hints map[string]string
 }
 
 func (SelectFromJoin) isSelectFrom() {}


### PR DESCRIPTION
This includes both the special case "HASH JOIN" syntax and the "JOIN@{...}" syntax.

Initial work towards #2462.