### PR TITLE
chore: release bigquery/v1.11.1

### DIFF
--- a/bigquery/CHANGES.md
+++ b/bigquery/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## v1.11.1
+
+* Addresses issue with optimized query path changes, released
+  in v1.11.0
+
 ## v1.11.0
 
 * Add support for optimized query path.

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -26,7 +26,7 @@ import (
 
 // Repo is the current version of the client libraries in this
 // repo. It should be a date in YYYYMMDD format.
-const Repo = "20200928"
+const Repo = "20200930"
 
 // Go returns the Go runtime version. The returned string
 // has no whitespace.


### PR DESCRIPTION
This PR will be tagged as bigquery/v1.11.1.