### PR TITLE
fix(bigquery): address fastpath iteration with iterator.Pager

### DIFF
--- a/bigquery/iterator.go
+++ b/bigquery/iterator.go
@@ -268,11 +268,11 @@ func fetchJobResultPage(ctx context.Context, src *rowSource, schema Schema, star
 	// reduce data transfered by leveraging api projections
 	projectedFields := []googleapi.Field{"rows", "pageToken", "totalRows"}
 	call := src.j.c.bqs.Jobs.GetQueryResults(src.j.projectID, src.j.jobID).Location(src.j.location)
-	call = call.Fields(projectedFields...)
 	if schema == nil {
 		// only project schema if we weren't supplied one.
-		call = call.Fields("schema")
+		projectedFields = append(projectedFields, "schema")
 	}
+	call = call.Fields(projectedFields...)
 	setClientHeader(call.Header())
 	if pageToken != "" {
 		call.PageToken(pageToken)
@@ -294,7 +294,6 @@ func fetchJobResultPage(ctx context.Context, src *rowSource, schema Schema, star
 	if schema == nil {
 		schema = bqToSchema(res.Schema)
 	}
-
 	rows, err := convertRows(res.Rows, schema)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Iterating query results from the fastpath with an iterator.Pager
forces a cache miss if the pager size is misaligned with the cached
page size.

Logic to reduce the size of the getQueryResults payload by dictating
the projected fields was yielding an empty pageToken and no rows, which
is equivalent to an empty page response.

This PR corrects the projection logic, and adds an integration test to
exercise the use of misaligned paging.

Fixes: #2946 