### PR TITLE
chore: release bigquery/v1.11.2

### DIFF
--- a/bigquery/CHANGES.md
+++ b/bigquery/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes
 
+## v1.11.2
+
+* Addresses issue with consuming query results using an iterator.Pager
+
 ## v1.11.1
 
 * Addresses issue with optimized query path changes, released

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -26,7 +26,7 @@ import (
 
 // Repo is the current version of the client libraries in this
 // repo. It should be a date in YYYYMMDD format.
-const Repo = "20200930"
+const Repo = "20201001"
 
 // Go returns the Go runtime version. The returned string
 // has no whitespace.


### PR DESCRIPTION
This PR will be tagged bigquery/v1.11.2