### PR TITLE
fix(pubsub): suppress connection is closing error

### DIFF
--- a/pubsub/streaming_pull_test.go
+++ b/pubsub/streaming_pull_test.go
@@ -315,12 +315,9 @@ func TestStreamingPull_ClosedClient(t *testing.T) {
 	// wait for receives to happen
 	time.Sleep(100 * time.Millisecond)
 
-	// Intentionally don't check the returned err here. In the fake,
-	// closing either the publisher/subscriber client will cause the
-	// server to clean up resources, which is different than in the
-	// live service. With the fake, client.Close() will return a
-	// "the client connection is closing" error with the second Close.
-	client.Close()
+	if err := client.Close(); err != nil {
+		t.Fatalf("Got error while closing client: %v", err)
+	}
 
 	// wait for things to close
 	time.Sleep(100 * time.Millisecond)


### PR DESCRIPTION
Fix an issue where calling `client.Close()` will return a "the client connection
is closing" error on subscriber closing. This previously only happened in
non-live service environments (e.g. using the emulator or fake).

Also fix a typo where publisher and subscriber client close errors were swapped.

Fixes #2950
