### PR TITLE
perf(spanner/spansql): make fewer allocations during SQL

### DIFF
--- a/spanner/spansql/sql.go
+++ b/spanner/spansql/sql.go
@@ -18,11 +18,22 @@ package spansql
 
 // This file holds SQL methods for rendering the types in types.go
 // as the SQL dialect that this package parses.
+//
+// Every exported type has an SQL method that returns a string.
+// Some also have an addSQL method that efficiently builds that string
+// in a provided strings.Builder.
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 )
+
+func buildSQL(x interface{ addSQL(*strings.Builder) }) string {
+	var sb strings.Builder
+	x.addSQL(&sb)
+	return sb.String()
+}
 
 func (ct CreateTable) SQL() string {
 	str := "CREATE TABLE " + ct.Name.SQL() + " (\n"
@@ -219,65 +230,64 @@ func (kp KeyPart) SQL() string {
 	return str
 }
 
-func (q Query) SQL() string {
-	str := q.Select.SQL()
+func (q Query) SQL() string { return buildSQL(q) }
+func (q Query) addSQL(sb *strings.Builder) {
+	q.Select.addSQL(sb)
 	if len(q.Order) > 0 {
-		str += " ORDER BY "
+		sb.WriteString(" ORDER BY ")
 		for i, o := range q.Order {
 			if i > 0 {
-				str += ", "
+				sb.WriteString(", ")
 			}
-			str += o.SQL()
+			o.addSQL(sb)
 		}
 	}
 	if q.Limit != nil {
-		str += " LIMIT " + q.Limit.SQL()
+		sb.WriteString(" LIMIT ")
+		sb.WriteString(q.Limit.SQL())
 		if q.Offset != nil {
-			str += " OFFSET " + q.Offset.SQL()
+			sb.WriteString(" OFFSET ")
+			sb.WriteString(q.Offset.SQL())
 		}
 	}
-	return str
 }
 
-func (sel Select) SQL() string {
-	str := "SELECT "
+func (sel Select) SQL() string { return buildSQL(sel) }
+func (sel Select) addSQL(sb *strings.Builder) {
+	sb.WriteString("SELECT ")
 	if sel.Distinct {
-		str += "DISTINCT "
+		sb.WriteString("DISTINCT ")
 	}
 	for i, e := range sel.List {
 		if i > 0 {
-			str += ", "
+			sb.WriteString(", ")
 		}
-		str += e.SQL()
+		e.addSQL(sb)
 		if len(sel.ListAliases) > 0 {
 			alias := sel.ListAliases[i]
 			if alias != "" {
-				str += " AS " + alias.SQL()
+				sb.WriteString(" AS ")
+				sb.WriteString(alias.SQL())
 			}
 		}
 	}
 	if len(sel.From) > 0 {
-		str += " FROM "
+		sb.WriteString(" FROM ")
 		for i, f := range sel.From {
 			if i > 0 {
-				str += ", "
+				sb.WriteString(", ")
 			}
-			str += f.SQL()
+			sb.WriteString(f.SQL())
 		}
 	}
 	if sel.Where != nil {
-		str += " WHERE " + sel.Where.SQL()
+		sb.WriteString(" WHERE ")
+		sel.Where.addSQL(sb)
 	}
 	if len(sel.GroupBy) > 0 {
-		str += " GROUP BY "
-		for i, gb := range sel.GroupBy {
-			if i > 0 {
-				str += ", "
-			}
-			str += gb.SQL()
-		}
+		sb.WriteString(" GROUP BY ")
+		addExprList(sb, sel.GroupBy, ", ")
 	}
-	return str
 }
 
 func (sft SelectFromTable) SQL() string {
@@ -309,12 +319,12 @@ var joinTypes = map[JoinType]string{
 	RightJoin: "RIGHT",
 }
 
-func (o Order) SQL() string {
-	str := o.Expr.SQL()
+func (o Order) SQL() string { return buildSQL(o) }
+func (o Order) addSQL(sb *strings.Builder) {
+	o.Expr.addSQL(sb)
 	if o.Desc {
-		str += " DESC"
+		sb.WriteString(" DESC")
 	}
-	return str
 }
 
 var arithOps = map[ArithOperator]string{
@@ -331,33 +341,50 @@ var arithOps = map[ArithOperator]string{
 	BitOr:  "|",
 }
 
-func (ao ArithOp) SQL() string {
+func (ao ArithOp) SQL() string { return buildSQL(ao) }
+func (ao ArithOp) addSQL(sb *strings.Builder) {
 	// Extra parens inserted to ensure the correct precedence.
 
 	switch ao.Op {
 	case Neg:
-		return "-(" + ao.RHS.SQL() + ")"
+		sb.WriteString("-(")
+		ao.RHS.addSQL(sb)
+		sb.WriteString(")")
+		return
 	case BitNot:
-		return "~(" + ao.RHS.SQL() + ")"
+		sb.WriteString("~(")
+		ao.RHS.addSQL(sb)
+		sb.WriteString(")")
+		return
 	}
 	op, ok := arithOps[ao.Op]
 	if !ok {
 		panic("unknown ArithOp")
 	}
-	return "(" + ao.LHS.SQL() + ")" + op + "(" + ao.RHS.SQL() + ")"
+	sb.WriteString("(")
+	ao.LHS.addSQL(sb)
+	sb.WriteString(")")
+	sb.WriteString(op)
+	sb.WriteString("(")
+	ao.RHS.addSQL(sb)
+	sb.WriteString(")")
 }
 
-func (lo LogicalOp) SQL() string {
+func (lo LogicalOp) SQL() string { return buildSQL(lo) }
+func (lo LogicalOp) addSQL(sb *strings.Builder) {
 	switch lo.Op {
 	default:
 		panic("unknown LogicalOp")
 	case And:
-		return lo.LHS.SQL() + " AND " + lo.RHS.SQL()
+		lo.LHS.addSQL(sb)
+		sb.WriteString(" AND ")
 	case Or:
-		return lo.LHS.SQL() + " OR " + lo.RHS.SQL()
+		lo.LHS.addSQL(sb)
+		sb.WriteString(" OR ")
 	case Not:
-		return "NOT " + lo.RHS.SQL()
+		sb.WriteString("NOT ")
 	}
+	lo.RHS.addSQL(sb)
 }
 
 var compOps = map[ComparisonOperator]string{
@@ -373,57 +400,54 @@ var compOps = map[ComparisonOperator]string{
 	NotBetween: "NOT BETWEEN",
 }
 
-func (co ComparisonOp) SQL() string {
+func (co ComparisonOp) SQL() string { return buildSQL(co) }
+func (co ComparisonOp) addSQL(sb *strings.Builder) {
 	op, ok := compOps[co.Op]
 	if !ok {
 		panic("unknown ComparisonOp")
 	}
-	s := co.LHS.SQL() + " " + op + " " + co.RHS.SQL()
+	co.LHS.addSQL(sb)
+	sb.WriteString(" ")
+	sb.WriteString(op)
+	sb.WriteString(" ")
+	co.RHS.addSQL(sb)
 	if co.Op == Between || co.Op == NotBetween {
-		s += " AND " + co.RHS2.SQL()
+		sb.WriteString(" AND ")
+		co.RHS2.addSQL(sb)
 	}
-	return s
 }
 
-func (io InOp) SQL() string {
-	str := io.LHS.SQL()
+func (io InOp) SQL() string { return buildSQL(io) }
+func (io InOp) addSQL(sb *strings.Builder) {
+	io.LHS.addSQL(sb)
 	if io.Neg {
-		str += " NOT"
+		sb.WriteString(" NOT")
 	}
-	str += " IN "
+	sb.WriteString(" IN ")
 	if io.Unnest {
-		str += "UNNEST"
+		sb.WriteString("UNNEST")
 	}
-	str += "("
-	for i, e := range io.RHS {
-		if i > 0 {
-			str += ", "
-		}
-		str += e.SQL()
-	}
-	str += ")"
-	return str
+	sb.WriteString("(")
+	addExprList(sb, io.RHS, ", ")
+	sb.WriteString(")")
 }
 
-func (io IsOp) SQL() string {
-	str := io.LHS.SQL() + " IS "
+func (io IsOp) SQL() string { return buildSQL(io) }
+func (io IsOp) addSQL(sb *strings.Builder) {
+	io.LHS.addSQL(sb)
+	sb.WriteString(" IS ")
 	if io.Neg {
-		str += "NOT "
+		sb.WriteString("NOT ")
 	}
-	str += io.RHS.SQL()
-	return str
+	io.RHS.addSQL(sb)
 }
 
-func (f Func) SQL() string {
-	str := f.Name + "("
-	for i, e := range f.Args {
-		if i > 0 {
-			str += ", "
-		}
-		str += e.SQL()
-	}
-	str += ")"
-	return str
+func (f Func) SQL() string { return buildSQL(f) }
+func (f Func) addSQL(sb *strings.Builder) {
+	sb.WriteString(f.Name)
+	sb.WriteString("(")
+	addExprList(sb, f.Args, ", ")
+	sb.WriteString(")")
 }
 
 func idList(l []ID, join string) string {
@@ -434,39 +458,84 @@ func idList(l []ID, join string) string {
 	return strings.Join(ss, join)
 }
 
-func (pe PathExp) SQL() string { return idList([]ID(pe), ".") }
+func addExprList(sb *strings.Builder, l []Expr, join string) {
+	for i, s := range l {
+		if i > 0 {
+			sb.WriteString(join)
+		}
+		s.addSQL(sb)
+	}
+}
 
-func (p Paren) SQL() string { return "(" + p.Expr.SQL() + ")" }
+func addIDList(sb *strings.Builder, l []ID, join string) {
+	for i, s := range l {
+		if i > 0 {
+			sb.WriteString(join)
+		}
+		s.addSQL(sb)
+	}
+}
 
-func (id ID) SQL() string {
+func (pe PathExp) SQL() string { return buildSQL(pe) }
+func (pe PathExp) addSQL(sb *strings.Builder) {
+	addIDList(sb, []ID(pe), ".")
+}
+
+func (p Paren) SQL() string { return buildSQL(p) }
+func (p Paren) addSQL(sb *strings.Builder) {
+	sb.WriteString("(")
+	p.Expr.addSQL(sb)
+	sb.WriteString(")")
+}
+
+func (id ID) SQL() string { return buildSQL(id) }
+func (id ID) addSQL(sb *strings.Builder) {
 	// https://cloud.google.com/spanner/docs/lexical#identifiers
 
 	// TODO: If there are non-letters/numbers/underscores then this also needs quoting.
 
 	if IsKeyword(string(id)) {
 		// TODO: Escaping may be needed here.
-		return "`" + string(id) + "`"
+		sb.WriteString("`")
+		sb.WriteString(string(id))
+		sb.WriteString("`")
+		return
 	}
 
-	return string(id)
+	sb.WriteString(string(id))
 }
 
-func (p Param) SQL() string { return "@" + string(p) }
+func (p Param) SQL() string { return buildSQL(p) }
+func (p Param) addSQL(sb *strings.Builder) {
+	sb.WriteString("@")
+	sb.WriteString(string(p))
+}
 
-func (b BoolLiteral) SQL() string {
+func (b BoolLiteral) SQL() string { return buildSQL(b) }
+func (b BoolLiteral) addSQL(sb *strings.Builder) {
 	if b {
-		return "TRUE"
+		sb.WriteString("TRUE")
+	} else {
+		sb.WriteString("FALSE")
 	}
-	return "FALSE"
 }
 
-func (n NullLiteral) SQL() string { return "NULL" }
-func (StarExpr) SQL() string      { return "*" }
+func (NullLiteral) SQL() string                { return buildSQL(NullLiteral(0)) }
+func (NullLiteral) addSQL(sb *strings.Builder) { sb.WriteString("NULL") }
 
-func (il IntegerLiteral) SQL() string { return strconv.Itoa(int(il)) }
-func (fl FloatLiteral) SQL() string   { return strconv.FormatFloat(float64(fl), 'g', -1, 64) }
+func (StarExpr) SQL() string                { return buildSQL(StarExpr(0)) }
+func (StarExpr) addSQL(sb *strings.Builder) { sb.WriteString("*") }
+
+func (il IntegerLiteral) SQL() string                { return buildSQL(il) }
+func (il IntegerLiteral) addSQL(sb *strings.Builder) { fmt.Fprintf(sb, "%d", il) }
+
+func (fl FloatLiteral) SQL() string                { return buildSQL(fl) }
+func (fl FloatLiteral) addSQL(sb *strings.Builder) { fmt.Fprintf(sb, "%g", fl) }
 
 // TODO: provide correct string quote method and use it.
 
-func (sl StringLiteral) SQL() string { return strconv.Quote(string(sl)) }
-func (bl BytesLiteral) SQL() string  { return "B" + strconv.Quote(string(bl)) }
+func (sl StringLiteral) SQL() string                { return buildSQL(sl) }
+func (sl StringLiteral) addSQL(sb *strings.Builder) { fmt.Fprintf(sb, "%q", sl) }
+
+func (bl BytesLiteral) SQL() string                { return buildSQL(bl) }
+func (bl BytesLiteral) addSQL(sb *strings.Builder) { fmt.Fprintf(sb, "B%q", bl) }

--- a/spanner/spansql/types.go
+++ b/spanner/spansql/types.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"math"
 	"sort"
+	"strings"
 )
 
 // TODO: More Position fields throughout; maybe in Query/Select.
@@ -379,6 +380,7 @@ type BoolExpr interface {
 type Expr interface {
 	isExpr()
 	SQL() string
+	addSQL(*strings.Builder)
 }
 
 // LiteralOrParam is implemented by integer literal and parameter values.
@@ -477,8 +479,7 @@ func (IsOp) isExpr()     {}
 
 type IsExpr interface {
 	isIsExpr()
-	isExpr()
-	SQL() string
+	Expr
 }
 
 // PathExp represents a path expression.


### PR DESCRIPTION
Set up a parallel set of SQL-encoding methods called addSQL that build
the SQL result into a strings.Builder.

Fixes #2956.