### PR TITLE
feat(godocfx): add two levels of nesting to TOC

### DIFF
--- a/internal/godocfx/go.mod
+++ b/internal/godocfx/go.mod
@@ -4,6 +4,7 @@ go 1.15
 
 require (
 	cloud.google.com/go v0.67.0
+	cloud.google.com/go/bigquery v1.8.0
 	cloud.google.com/go/storage v1.11.0
 	github.com/kr/pretty v0.2.1 // indirect
 	golang.org/x/tools v0.0.0-20201005185003-576e169c3de7


### PR DESCRIPTION
The TOC is a bit unruly with every package in a single list. So, I added a couple levels of nesting: one for the module and one for the first part after the module. In other words, I split package names into `mod/mid/suffix` and nest shared `mod` and `mid` values. If there would only be one element in the nested list, it isn't nested. This is like a trie with only two levels.

The result looks like this:

```
- uid: cloud.google.com/go/bigquery
  name: cloud.google.com/go/bigquery
  items:
  - name: README
    href: README.md
  - name: connection
    items:
    - uid: cloud.google.com/go/bigquery/connection/apiv1
      name: apiv1
    - uid: cloud.google.com/go/bigquery/connection/apiv1beta1
      name: apiv1beta1
  - uid: cloud.google.com/go/bigquery/datatransfer/apiv1
    name: datatransfer/apiv1
```