### PR TITLE
fix(spanner/spannertest): correct handling of tri-state boolean expre…

### DIFF
--- a/spanner/spannertest/db.go
+++ b/spanner/spannertest/db.go
@@ -972,7 +972,7 @@ func (d *database) Execute(stmt spansql.DMLStmt, params queryParams) (int, error
 			if err != nil {
 				return 0, err
 			}
-			if b {
+			if b != nil && *b {
 				copy(t.rows[i:], t.rows[i+1:])
 				t.rows = t.rows[:len(t.rows)-1]
 				n++

--- a/spanner/spannertest/db_query.go
+++ b/spanner/spannertest/db_query.go
@@ -171,10 +171,9 @@ func (wi whereIter) Next() (row, error) {
 		if err != nil {
 			return nil, err
 		}
-		if !b {
-			continue
+		if b != nil && *b {
+			return row, nil
 		}
-		return row, nil
 	}
 }
 
@@ -734,7 +733,11 @@ func (ji *joinIter) Next() (row, error) {
 
 func (ji *joinIter) evalCond() (bool, error) {
 	if ji.sfj.On != nil {
-		return ji.ec.evalBoolExpr(ji.sfj.On)
+		b, err := ji.ec.evalBoolExpr(ji.sfj.On)
+		if err != nil {
+			return false, err
+		}
+		return b != nil && *b, nil
 	}
 
 	if len(ji.sfj.Using) > 0 {


### PR DESCRIPTION
…ssion evaluation

NULL BOOLs need to be preserved beyond evalBoolExpr because NULLs sort
differently to FALSE/TRUE, and need special handling when evaluating
various operators. This was the cause of a couple of divergences from
production Spanner.