### PR TITLE
feat(pubsublite): Basic types for the Pub/Sub Lite client library

### DIFF
--- a/pubsublite/doc.go
+++ b/pubsublite/doc.go
@@ -1,0 +1,24 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+
+/*
+Package pubsublite provides an interface for publishing and receiving messages
+using Google Pub/Sub Lite.
+
+More information about Google Pub/Sub Lite is available at
+https://cloud.google.com/pubsub/lite.
+
+This library is under development and should not be used until v1.0.0 has been
+released.
+*/
+package pubsublite // import "cloud.google.com/go/pubsublite"

--- a/pubsublite/types.go
+++ b/pubsublite/types.go
@@ -1,0 +1,136 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+
+package pubsublite
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// CloudRegion identifies a geographical location where resources are hosted. An
+// example region is "us-central1".
+// See https://cloud.google.com/compute/docs/regions-zones for more information.
+type CloudRegion string
+
+func (r CloudRegion) String() string {
+	return string(r)
+}
+
+// CloudZone identifies a subset of a Google Cloud region. An example zone is
+// "us-central1-a".
+// See https://cloud.google.com/compute/docs/regions-zones for more information.
+type CloudZone string
+
+// ParseZone verifies that the `input` string has the format of a valid zone and
+// returns it as a CloudZone type. If `input` is guaranteed to be a valid zone,
+// the type conversion `CloudZone(input)` can be used instead.
+func ParseZone(input string) (CloudZone, error) {
+	parts := strings.Split(input, "-")
+	if len(parts) != 3 {
+		return CloudZone(""), fmt.Errorf("pubsublite: invalid zone %q", input)
+	}
+	return CloudZone(input), nil
+}
+
+func (z CloudZone) String() string {
+	return string(z)
+}
+
+// Region returns the region that this zone is in.
+func (z CloudZone) Region() CloudRegion {
+	return CloudRegion(z[0:strings.LastIndex(z.String(), "-")])
+}
+
+// Project identifies a Google Cloud project. The project ID (e.g. "my-project")
+// or the project number (e.g. 987654321) can be provided.
+// See https://cloud.google.com/resource-manager/docs/creating-managing-projects
+// for more information about project identifiers.
+type Project string
+
+func (p Project) String() string {
+	return string(p)
+}
+
+// TopicID identifies a Google Pub/Sub Lite topic.
+// See https://cloud.google.com/pubsub/lite/docs/topics for more information.
+type TopicID string
+
+func (t TopicID) String() string {
+	return string(t)
+}
+
+// TopicPath stores the full path of a Google Pub/Sub Lite topic.
+type TopicPath struct {
+	Project Project
+	Zone    CloudZone
+	ID      TopicID
+}
+
+var topicPathRE = regexp.MustCompile(`^projects/([^/]+)/locations/([^/]+)/topics/([^/]+)`)
+
+// ParseTopicPath parses the full path of a Google Pub/Sub Lite topic, which
+// should have the format: `projects/{project}/locations/{zone}/topics/{id}`.
+func ParseTopicPath(input string) (TopicPath, error) {
+	parts := topicPathRE.FindStringSubmatch(input)
+	if len(parts) < 4 {
+		return TopicPath{}, fmt.Errorf("pubsublite: invalid topic path %q", input)
+	}
+	zone, err := ParseZone(parts[2])
+	if err != nil {
+		return TopicPath{}, fmt.Errorf("pubsublite: topic path %q contains an invalid zone", input)
+	}
+	return TopicPath{Project(parts[1]), zone, TopicID(parts[3])}, nil
+}
+
+func (t TopicPath) String() string {
+	return fmt.Sprintf("projects/%s/locations/%s/topics/%s", t.Project, t.Zone, t.ID)
+}
+
+// SubscriptionID identifies a Google Pub/Sub Lite subscription.
+// See https://cloud.google.com/pubsub/lite/docs/subscriptions for more
+// information.
+type SubscriptionID string
+
+func (s SubscriptionID) String() string {
+	return string(s)
+}
+
+// SubscriptionPath stores the full path of a Google Pub/Sub Lite subscription.
+type SubscriptionPath struct {
+	Project Project
+	Zone    CloudZone
+	ID      SubscriptionID
+}
+
+var subsPathRE = regexp.MustCompile(`^projects/([^/]+)/locations/([^/]+)/subscriptions/([^/]+)`)
+
+// ParseSubscriptionPath parses the full path of a Google Pub/Sub Lite
+// subscription, which should have the format:
+// `projects/{project}/locations/{zone}/subscriptions/{id}`.
+func ParseSubscriptionPath(input string) (SubscriptionPath, error) {
+	parts := subsPathRE.FindStringSubmatch(input)
+	if len(parts) < 4 {
+		return SubscriptionPath{}, fmt.Errorf("pubsublite: invalid subscription path %q", input)
+	}
+	zone, err := ParseZone(parts[2])
+	if err != nil {
+		return SubscriptionPath{}, fmt.Errorf("pubsublite: subscription path %q contains an invalid zone", input)
+	}
+	return SubscriptionPath{Project(parts[1]), zone, SubscriptionID(parts[3])}, nil
+}
+
+func (s SubscriptionPath) String() string {
+	return fmt.Sprintf("projects/%s/locations/%s/subscriptions/%s", s.Project, s.Zone, s.ID)
+}

--- a/pubsublite/types.go
+++ b/pubsublite/types.go
@@ -63,6 +63,16 @@ func (p Project) String() string {
 	return string(p)
 }
 
+// LocationPath stores a path consisting of a project and zone.
+type LocationPath struct {
+	Project Project
+	Zone    CloudZone
+}
+
+func (l LocationPath) String() string {
+	return fmt.Sprintf("projects/%s/locations/%s", l.Project, l.Zone)
+}
+
 // TopicID identifies a Google Pub/Sub Lite topic.
 // See https://cloud.google.com/pubsub/lite/docs/topics for more information.
 type TopicID string
@@ -96,6 +106,10 @@ func ParseTopicPath(input string) (TopicPath, error) {
 
 func (t TopicPath) String() string {
 	return fmt.Sprintf("projects/%s/locations/%s/topics/%s", t.Project, t.Zone, t.ID)
+}
+
+func (t TopicPath) Location() LocationPath {
+	return LocationPath{t.Project, t.Zone}
 }
 
 // SubscriptionID identifies a Google Pub/Sub Lite subscription.
@@ -133,4 +147,8 @@ func ParseSubscriptionPath(input string) (SubscriptionPath, error) {
 
 func (s SubscriptionPath) String() string {
 	return fmt.Sprintf("projects/%s/locations/%s/subscriptions/%s", s.Project, s.Zone, s.ID)
+}
+
+func (s SubscriptionPath) Location() LocationPath {
+	return LocationPath{s.Project, s.Zone}
 }

--- a/pubsublite/types_test.go
+++ b/pubsublite/types_test.go
@@ -1,0 +1,171 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+
+package pubsublite
+
+import "testing"
+
+func TestZoneToRegion(t *testing.T) {
+	zone := CloudZone("europe-west1-d")
+	got := zone.Region()
+	want := CloudRegion("europe-west1")
+	if got != want {
+		t.Errorf("CloudZone(%q).Region() = %v, want %v", zone, got, want)
+	}
+}
+
+func TestParseZone(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		input    string
+		wantZone CloudZone
+		wantErr  bool
+	}{
+		{
+			name:     "valid",
+			input:    "us-central1-a",
+			wantZone: CloudZone("us-central1-a"),
+		},
+		{
+			name:    "invalid: insufficient dashes",
+			input:   "us-central1",
+			wantErr: true,
+		},
+		{
+			name:    "invalid: excess dashes",
+			input:   "us-central1-a-b",
+			wantErr: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			gotZone, gotErr := ParseZone(tc.input)
+			if gotZone != tc.wantZone || (gotErr != nil) != tc.wantErr {
+				t.Errorf("ParseZone(%q) = (%v, %v), want (%v, err=%v)", tc.input, gotZone, gotErr, tc.wantZone, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestParseTopicPath(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		input    string
+		wantPath TopicPath
+		wantErr  bool
+	}{
+		{
+			name:     "valid: topic path",
+			input:    "projects/987654321/locations/europe-west1-d/topics/my-topic",
+			wantPath: TopicPath{Project("987654321"), CloudZone("europe-west1-d"), TopicID("my-topic")},
+		},
+		{
+			name:     "valid: sub-resource path",
+			input:    "projects/my-project/locations/us-west1-b/topics/my-topic/subresource/name",
+			wantPath: TopicPath{Project("my-project"), CloudZone("us-west1-b"), TopicID("my-topic")},
+		},
+		{
+			name:    "invalid: zone",
+			input:   "europe-west1-d",
+			wantErr: true,
+		},
+		{
+			name:    "invalid: subscription path",
+			input:   "projects/987654321/locations/europe-west1-d/subscriptions/my-subs",
+			wantErr: true,
+		},
+		{
+			name:    "invalid: invalid zone component",
+			input:   "projects/987654321/locations/not_a_zone/topics/my-topic",
+			wantErr: true,
+		},
+		{
+			name:    "invalid: missing topic id",
+			input:   "projects/987654321/locations/europe-west1-d/topics/",
+			wantErr: true,
+		},
+		{
+			name:    "invalid: missing project",
+			input:   "projects//locations/europe-west1-d/topics/my-topic",
+			wantErr: true,
+		},
+		{
+			name:    "invalid: prefix",
+			input:   "prefix/projects/987654321/locations/europe-west1-d/topics/my-topic",
+			wantErr: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			gotPath, gotErr := ParseTopicPath(tc.input)
+			if gotPath != tc.wantPath || (gotErr != nil) != tc.wantErr {
+				t.Errorf("ParseTopicPath(%q) = (%v, %v), want (%v, err=%v)", tc.input, gotPath, gotErr, tc.wantPath, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestParseSubscriptionPath(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		input    string
+		wantPath SubscriptionPath
+		wantErr  bool
+	}{
+		{
+			name:     "valid: subscription path",
+			input:    "projects/987654321/locations/europe-west1-d/subscriptions/my-subs",
+			wantPath: SubscriptionPath{Project("987654321"), CloudZone("europe-west1-d"), SubscriptionID("my-subs")},
+		},
+		{
+			name:     "valid: sub-resource path",
+			input:    "projects/my-project/locations/us-west1-b/subscriptions/my-subs/subresource/name",
+			wantPath: SubscriptionPath{Project("my-project"), CloudZone("us-west1-b"), SubscriptionID("my-subs")},
+		},
+		{
+			name:    "invalid: zone",
+			input:   "europe-west1-d",
+			wantErr: true,
+		},
+		{
+			name:    "invalid: topic path",
+			input:   "projects/987654321/locations/europe-west1-d/topics/my-topic",
+			wantErr: true,
+		},
+		{
+			name:    "invalid: invalid zone component",
+			input:   "projects/987654321/locations/not_a_zone/subscriptions/my-subs",
+			wantErr: true,
+		},
+		{
+			name:    "invalid: missing subscription id",
+			input:   "projects/987654321/locations/europe-west1-d/subscriptions/",
+			wantErr: true,
+		},
+		{
+			name:    "invalid: missing project",
+			input:   "projects//locations/europe-west1-d/subscriptions/my-subs",
+			wantErr: true,
+		},
+		{
+			name:    "invalid: prefix",
+			input:   "prefix/projects/987654321/locations/europe-west1-d/subscriptions/my-subs",
+			wantErr: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			gotPath, gotErr := ParseSubscriptionPath(tc.input)
+			if gotPath != tc.wantPath || (gotErr != nil) != tc.wantErr {
+				t.Errorf("ParseSubscriptionPath(%q) = (%v, %v), want (%v, err=%v)", tc.input, gotPath, gotErr, tc.wantPath, tc.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Doc containing proposed interface of the Pub/Sub Lite Go client library: http://go/pubsublite-go-clientlib-interface.

Sending this out for review, but I don't intend to merge this PR until the pubsublite submodule has been created.

If helpful, this branch contains more progress on the pubsublite client library and shows how these types would be used:
https://github.com/tmdiep/google-cloud-go/tree/working/pubsublite