### PR TITLE
fix(spanner/spansql): fix parsing of unary minus

### DIFF
--- a/spanner/spansql/sql.go
+++ b/spanner/spansql/sql.go
@@ -351,6 +351,11 @@ func (ao ArithOp) addSQL(sb *strings.Builder) {
 		ao.RHS.addSQL(sb)
 		sb.WriteString(")")
 		return
+	case Plus:
+		sb.WriteString("+(")
+		ao.RHS.addSQL(sb)
+		sb.WriteString(")")
+		return
 	case BitNot:
 		sb.WriteString("~(")
 		ao.RHS.addSQL(sb)

--- a/spanner/spansql/types.go
+++ b/spanner/spansql/types.go
@@ -391,7 +391,7 @@ type LiteralOrParam interface {
 
 type ArithOp struct {
 	Op       ArithOperator
-	LHS, RHS Expr // only RHS is set for Neg, BitNot
+	LHS, RHS Expr // only RHS is set for Neg, Plus, BitNot
 }
 
 func (ArithOp) isExpr() {}
@@ -400,6 +400,7 @@ type ArithOperator int
 
 const (
 	Neg    ArithOperator = iota // unary -
+	Plus                        // unary +
 	BitNot                      // unary ~
 	Mul                         // *
 	Div                         // /
@@ -415,7 +416,7 @@ const (
 
 type LogicalOp struct {
 	Op       LogicalOperator
-	LHS, RHS BoolExpr // only RHS is set for Neg, BitNot
+	LHS, RHS BoolExpr // only RHS is set for Not
 }
 
 func (LogicalOp) isBoolExpr() {}


### PR DESCRIPTION
We cannot tokenise numbers with leading signs, because otherwise
`ID+100` is parsed as the identifier `ID` followed by the literal `+100`
instead of an arithmetic operation. This necessitates some rearrangement
of the parsing of int64 literals to accommodate that while also
preserving the ability to parse -INT_MAX.