### PR TITLE
refactor(errorreporting): debrand Stackdriver from Error Reporting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,7 +103,7 @@ Next, ensure the following APIs are enabled in the general project:
 - Google Compute Engine Instance Group Updater API
 - Google Compute Engine Instance Groups API
 - Kubernetes Engine API
-- Stackdriver Error Reporting API
+- Cloud Error Reporting API
 
 Next, create a Datastore database in the general project, and a Firestore
 database in the Firestore project.

--- a/errorreporting/errors.go
+++ b/errorreporting/errors.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package errorreporting is a Google Stackdriver Error Reporting library.
+// Package errorreporting is a Google Cloud Error Reporting library.
 //
 // Any provided stacktraces must match the format produced by https://golang.org/pkg/runtime/#Stack
 // or as per https://cloud.google.com/error-reporting/reference/rest/v1beta1/projects.events/report#ReportedErrorEvent

--- a/errorreporting/example_test.go
+++ b/errorreporting/example_test.go
@@ -34,7 +34,7 @@ func Example() {
 	}
 	defer func() {
 		if err := ec.Close(); err != nil {
-			log.Printf("failed to report errors to Stackdriver: %v", err)
+			log.Printf("failed to report errors to Cloud Error Reporting: %v", err)
 		}
 	}()
 

--- a/internal/.repo-metadata-full.json
+++ b/internal/.repo-metadata-full.json
@@ -321,7 +321,7 @@
   },
   "cloud.google.com/go/errorreporting": {
     "distribution_name": "cloud.google.com/go/errorreporting",
-    "description": "Stackdriver Error Reporting API",
+    "description": "Cloud Error Reporting API",
     "language": "Go",
     "client_library_type": "manual",
     "docs_url": "https://pkg.go.dev/cloud.google.com/go/errorreporting",
@@ -329,7 +329,7 @@
   },
   "cloud.google.com/go/errorreporting/apiv1beta1": {
     "distribution_name": "cloud.google.com/go/errorreporting/apiv1beta1",
-    "description": "Stackdriver Error Reporting API",
+    "description": "Cloud Error Reporting API",
     "language": "Go",
     "client_library_type": "generated",
     "docs_url": "https://pkg.go.dev/cloud.google.com/go/errorreporting/apiv1beta1",

--- a/internal/gapicgen/generator/gapics.go
+++ b/internal/gapicgen/generator/gapics.go
@@ -237,7 +237,7 @@ var manualEntries = []manifestEntry{
 	// Manuals with a GAPIC.
 	{
 		DistributionName:  "cloud.google.com/go/errorreporting",
-		Description:       "Stackdriver Error Reporting API",
+		Description:       "Cloud Error Reporting API",
 		Language:          "Go",
 		ClientLibraryType: "manual",
 		DocsURL:           "https://pkg.go.dev/cloud.google.com/go/errorreporting",


### PR DESCRIPTION
Debrand "Stackdriver" in favor of "Cloud" in Error Reporting. As a follow up to #3007.

It looks like I need to update upstream as well since there are mentions of Stackdriver in `errorreporting/apiv1beta1`