### PR TITLE
test(spanner): check for Aborted error

### DIFF
--- a/spanner/integration_test.go
+++ b/spanner/integration_test.go
@@ -2314,7 +2314,11 @@ func TestIntegration_DML(t *testing.T) {
 			SQL: `INSERT INTO Singers (SingerId, FirstName, LastName) VALUES (1, "Umm", "Kulthum")`,
 		})
 		defer iter.Stop()
-		if row, err := iter.Next(); err != iterator.Done {
+		row, err := iter.Next()
+		if ErrCode(err) == codes.Aborted {
+			return err
+		}
+		if err != iterator.Done {
 			t.Fatalf("got results from iterator, want none: %#v, err = %v\n", row, err)
 		}
 		if iter.RowCount != 1 {


### PR DESCRIPTION
The test did not check whether the query returned an Aborted error. If the transaction was aborted by Spanner, the Aborted error should be propagated to the transaction runner, which will automatically retry the transaction.

Fixes #3029