### PR TITLE
fix(spanner/spannertest): fix ORDER BY combined with SELECT aliases

### DIFF
--- a/spanner/spannertest/README.md
+++ b/spanner/spannertest/README.md
@@ -19,10 +19,10 @@ by ascending esotericism:
 
 - expression functions
 - more aggregation functions
-- more joins types (INNER, CROSS, FULL, RIGHT)
 - INSERT/UPDATE DML statements
 - SELECT HAVING
 - case insensitivity
+- FULL JOIN
 - alternate literal types (esp. strings)
 - STRUCT types
 - transaction simulation

--- a/spanner/spannertest/integration_test.go
+++ b/spanner/spannertest/integration_test.go
@@ -970,7 +970,7 @@ func TestIntegration_ReadsAndQueries(t *testing.T) {
 				{int64(1)},
 			},
 		},
-		// Regression TEST for mishandling NULLs with LIKE operator.
+		// Regression test for mishandling NULLs with LIKE operator.
 		{
 			`SELECT i, str FROM SomeStrings WHERE str LIKE "%bar"`,
 			nil,
@@ -986,6 +986,15 @@ func TestIntegration_ReadsAndQueries(t *testing.T) {
 			[][]interface{}{
 				// Does not include [1, "abar"], [2, nil] or [3, "bbar"].
 				{int64(0), "afoo"},
+			},
+		},
+		// Regression test for ORDER BY combined with SELECT aliases.
+		{
+			`SELECT Name AS nom FROM Staff ORDER BY ID LIMIT 2`,
+			nil,
+			[][]interface{}{
+				{"Jack"},
+				{"Daniel"},
 			},
 		},
 	}


### PR DESCRIPTION
This was broken due to the ORDER BY implementation that was a bit of a
hack. Replace that hack with a more explicit evaluation of the ORDER BY
sort keys, which also removed a duplicate chunk of row sorting code.

This also required a restructuring of how locking works during an
evaluation, which cleaned up some other code.

Also include a minor revision to README.md.