### PR TITLE
fix(logging): allow X-Cloud-Trace-Context fields to be optional

### DIFF
--- a/logging/logging.go
+++ b/logging/logging.go
@@ -886,7 +886,7 @@ func deconstructXCloudTraceContext(s string) (traceID, spanID string, traceSampl
 	//   * spanID (optional):          "0"
 	//   * traceSampled (optional):    1 (defaults to false)
 	matches := reCloudTraceContext.FindStringSubmatch(s)
-	
+
 	traceID, spanID, traceSampled = matches[1], matches[3], (matches[5] == "1")
 
 	if spanID == "0" {

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -879,12 +879,12 @@ func deconstructXCloudTraceContext(s string) (traceID, spanID string, traceSampl
 	// As per the format described at https://cloud.google.com/trace/docs/setup#force-trace
 	//    "X-Cloud-Trace-Context: TRACE_ID/SPAN_ID;o=TRACE_TRUE"
 	// for example:
-	//    "X-Cloud-Trace-Context: 105445aa7843bc8bf206b120001000/0;o=1"
+	//    "X-Cloud-Trace-Context: 105445aa7843bc8bf206b120001000/1;o=1"
 	//
 	// We expect:
-	//   * traceID (optional):         "105445aa7843bc8bf206b120001000"
-	//   * spanID (optional):          "0"
-	//   * traceSampled (optional):    1 (defaults to false)
+	//   * traceID (optional): 			"105445aa7843bc8bf206b120001000"
+	//   * spanID (optional):       	"1"
+	//   * traceSampled (optional): 	true
 	matches := reCloudTraceContext.FindStringSubmatch(s)
 
 	traceID, spanID, traceSampled = matches[1], matches[3], (matches[5] == "1")

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -876,7 +876,7 @@ func (l *Logger) StandardLogger(s Severity) *log.Logger { return l.stdLoggers[s]
 var reCloudTraceContext = regexp.MustCompile(`([a-f\d]+)/([a-f\d]+);o=(\d)`)
 
 func deconstructXCloudTraceContext(s string) (traceID, spanID string, traceSampled bool) {
-	// As per the format described at https://cloud.google.com/trace/docs/troubleshooting#force-trace
+	// As per the format described at https://cloud.google.com/trace/docs/setup#force-trace
 	//    "X-Cloud-Trace-Context: TRACE_ID/SPAN_ID;o=TRACE_TRUE"
 	// for example:
 	//    "X-Cloud-Trace-Context: 105445aa7843bc8bf206b120001000/0;o=1"
@@ -884,7 +884,7 @@ func deconstructXCloudTraceContext(s string) (traceID, spanID string, traceSampl
 	// We expect:
 	//   * traceID:         "105445aa7843bc8bf206b120001000"
 	//   * spanID:          ""
-	//   * traceSampled:    true
+	//   * traceSampled:    true (defaults to false, if not user specified)
 	matches := reCloudTraceContext.FindAllStringSubmatch(s, -1)
 	if len(matches) != 1 {
 		return

--- a/logging/logging_unexported_test.go
+++ b/logging/logging_unexported_test.go
@@ -289,16 +289,52 @@ func TestToLogEntryTrace(t *testing.T) {
 			logging.LogEntry{Trace: "projects/P/traces/105445aa7843bc8bf206b120001000", SpanId: "000000000000004a", TraceSampled: true},
 		},
 		{
+			"X-Trace-Context header with blank trace",
+			Entry{
+				HTTPRequest: &HTTPRequest{
+					Request: &http.Request{
+						URL:    u,
+						Header: http.Header{"X-Cloud-Trace-Context": {"/0;o=1"}},
+					},
+				},
+			},
+			logging.LogEntry{TraceSampled: true},
+		},
+		{
 			"X-Trace-Context header with blank span",
 			Entry{
 				HTTPRequest: &HTTPRequest{
 					Request: &http.Request{
 						URL:    u,
-						Header: http.Header{"X-Cloud-Trace-Context": {"105445aa7843bc8bf206b120001000/0;o=0"}},
+						Header: http.Header{"X-Cloud-Trace-Context": {"105445aa7843bc8bf206b120001000/;o=0"}},
 					},
 				},
 			},
 			logging.LogEntry{Trace: "projects/P/traces/105445aa7843bc8bf206b120001000"},
+		},
+		{
+			"X-Trace-Context header with blank TraceSampled",
+			Entry{
+				HTTPRequest: &HTTPRequest{
+					Request: &http.Request{
+						URL:    u,
+						Header: http.Header{"X-Cloud-Trace-Context": {"105445aa7843bc8bf206b120001000/0"}},
+					},
+				},
+			},
+			logging.LogEntry{Trace: "projects/P/traces/105445aa7843bc8bf206b120001000"},
+		},
+		{
+			"X-Trace-Context header with all blank fields",
+			Entry{
+				HTTPRequest: &HTTPRequest{
+					Request: &http.Request{
+						URL:    u,
+						Header: http.Header{"X-Cloud-Trace-Context": {""}},
+					},
+				},
+			},
+			logging.LogEntry{},
 		},
 		{
 			"Invalid X-Trace-Context header but already set TraceID",

--- a/logging/logging_unexported_test.go
+++ b/logging/logging_unexported_test.go
@@ -313,7 +313,7 @@ func TestToLogEntryTrace(t *testing.T) {
 			logging.LogEntry{Trace: "projects/P/traces/105445aa7843bc8bf206b120001000"},
 		},
 		{
-			"X-Trace-Context header with blank TraceSampled",
+			"X-Trace-Context header with missing traceSampled aka ?o=*",
 			Entry{
 				HTTPRequest: &HTTPRequest{
 					Request: &http.Request{


### PR DESCRIPTION
Fixes: #1590 

**Changes according to spec:**
1.  `trace`, `spanID` and `traceSampled` fields in X-Cloud-Trace-Context can be optional (see context/trace_context.proto)
2. TraceSample should default to false (verified with nwang@)
3. Trace/span IDs should still be included in log contexts even when traceSampled is false, because "A non-sampled trace value is still useful as a request correlation identifier." ([LogEntry spec](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry))

**Details:**
[Intended Use case](https://cloud.google.com/trace/docs/setup#force-trace)

The following header specifications by users are now recognized: 
![Screen Shot 2020-10-21 at 12 30 23 PM](https://user-images.githubusercontent.com/69952136/96778468-99be1b00-13a0-11eb-92c2-ce40f0d10ced.png)