### PR TITLE
chore(internal/gapicgen): update gapic generator v0.15.3

### DIFF
--- a/internal/gapicgen/cmd/genbot/Dockerfile
+++ b/internal/gapicgen/cmd/genbot/Dockerfile
@@ -33,7 +33,7 @@ RUN GO111MODULE=on go get \
     golang.org/x/lint/golint@latest \
     golang.org/x/tools/cmd/goimports@latest \
     honnef.co/go/tools/cmd/staticcheck@latest \
-    github.com/googleapis/gapic-generator-go/cmd/protoc-gen-go_gapic@v0.15.1
+    github.com/googleapis/gapic-generator-go/cmd/protoc-gen-go_gapic@v0.15.3
 ENV PATH="${PATH}:/root/go/bin"
 
 # Source: http://debuggable.com/posts/disable-strict-host-checking-for-git-clone:49896ff3-0ac0-4263-9703-1eae4834cda3


### PR DESCRIPTION
Updates `gapic-generator-go` to `v0.15.3`. Notable changes include:

* use DefaultEndpoint and DefaultMTLSEndpoint for default options (https://github.com/googleapis/gapic-generator-go/pull/465)