### PR TITLE
chore(internal/gapicgen): update protoc-gen-go

### DIFF
--- a/internal/gapicgen/cmd/genbot/Dockerfile
+++ b/internal/gapicgen/cmd/genbot/Dockerfile
@@ -29,7 +29,7 @@ RUN go version
 
 # Install Go tools.
 RUN GO111MODULE=on go get \
-    github.com/golang/protobuf/protoc-gen-go@v1.4.2 \
+    github.com/golang/protobuf/protoc-gen-go@v1.4.3 \
     golang.org/x/lint/golint@latest \
     golang.org/x/tools/cmd/goimports@latest \
     honnef.co/go/tools/cmd/staticcheck@latest \


### PR DESCRIPTION
github.com/googleapis/gapic-generator-go@v0.15.3 from github.com/googleapis/gapic-generator-go/cmd/protoc-gen-go_gapic@v0.15.3 requires github.com/golang/protobuf@v1.4.3