### PR TITLE
feat(datastore): accept pb.Value in interfaceToProto

### DIFF
--- a/datastore/save.go
+++ b/datastore/save.go
@@ -427,6 +427,12 @@ func interfaceToProto(iv interface{}, noIndex bool) (*pb.Value, error) {
 			return nil, err
 		}
 		val.ValueType = &pb.Value_EntityValue{EntityValue: e}
+	case *pb.Value:
+		if v != nil {
+			return v, nil
+		}
+		val.ValueType = &pb.Value_NullValue{}
+		return val, nil
 	case []interface{}:
 		arr := make([]*pb.Value, 0, len(v))
 		for i, v := range v {

--- a/datastore/save_test.go
+++ b/datastore/save_test.go
@@ -32,6 +32,7 @@ func TestInterfaceToProtoNil(t *testing.T) {
 		(*float64)(nil),
 		(*GeoPoint)(nil),
 		(*time.Time)(nil),
+		(*pb.Value)(nil),
 	} {
 		got, err := interfaceToProto(in, false)
 		if err != nil {


### PR DESCRIPTION
Modifies the `interfaceToProto` function to allow end users to pass in an existing protobuf `Value`. This is to support querying for entities that need the `meaning` field to be set.

Resolves #3078.