### PR TITLE
feat(all): auto-regenerate gapics

### DIFF
--- a/accessapproval/apiv1/doc.go
+++ b/accessapproval/apiv1/doc.go
@@ -46,7 +46,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/analytics/admin/apiv1alpha/doc.go
+++ b/analytics/admin/apiv1alpha/doc.go
@@ -46,7 +46,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/analytics/data/apiv1alpha/doc.go
+++ b/analytics/data/apiv1alpha/doc.go
@@ -46,7 +46,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/area120/tables/apiv1alpha1/doc.go
+++ b/area120/tables/apiv1alpha1/doc.go
@@ -46,7 +46,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/asset/apiv1/doc.go
+++ b/asset/apiv1/doc.go
@@ -48,7 +48,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/asset/apiv1beta1/doc.go
+++ b/asset/apiv1beta1/doc.go
@@ -50,7 +50,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/asset/apiv1p2beta1/doc.go
+++ b/asset/apiv1p2beta1/doc.go
@@ -50,7 +50,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/asset/apiv1p5beta1/doc.go
+++ b/asset/apiv1p5beta1/doc.go
@@ -50,7 +50,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/assuredworkloads/apiv1beta1/doc.go
+++ b/assuredworkloads/apiv1beta1/doc.go
@@ -46,7 +46,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/automl/apiv1/doc.go
+++ b/automl/apiv1/doc.go
@@ -49,7 +49,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/automl/apiv1beta1/doc.go
+++ b/automl/apiv1beta1/doc.go
@@ -51,7 +51,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/bigquery/connection/apiv1/doc.go
+++ b/bigquery/connection/apiv1/doc.go
@@ -48,7 +48,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/bigquery/connection/apiv1beta1/doc.go
+++ b/bigquery/connection/apiv1beta1/doc.go
@@ -50,7 +50,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/bigquery/datatransfer/apiv1/doc.go
+++ b/bigquery/datatransfer/apiv1/doc.go
@@ -49,7 +49,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/bigquery/reservation/apiv1/doc.go
+++ b/bigquery/reservation/apiv1/doc.go
@@ -48,7 +48,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/bigquery/reservation/apiv1beta1/doc.go
+++ b/bigquery/reservation/apiv1beta1/doc.go
@@ -50,7 +50,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/bigquery/storage/apiv1/doc.go
+++ b/bigquery/storage/apiv1/doc.go
@@ -46,7 +46,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/bigquery/storage/apiv1alpha2/doc.go
+++ b/bigquery/storage/apiv1alpha2/doc.go
@@ -48,7 +48,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/bigquery/storage/apiv1beta1/doc.go
+++ b/bigquery/storage/apiv1beta1/doc.go
@@ -48,7 +48,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/bigquery/storage/apiv1beta2/doc.go
+++ b/bigquery/storage/apiv1beta2/doc.go
@@ -48,7 +48,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/billing/apiv1/doc.go
+++ b/billing/apiv1/doc.go
@@ -49,7 +49,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/billing/budgets/apiv1beta1/doc.go
+++ b/billing/budgets/apiv1beta1/doc.go
@@ -46,7 +46,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/cloudbuild/apiv1/v2/doc.go
+++ b/cloudbuild/apiv1/v2/doc.go
@@ -48,7 +48,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/cloudtasks/apiv2/doc.go
+++ b/cloudtasks/apiv2/doc.go
@@ -48,7 +48,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/cloudtasks/apiv2beta2/doc.go
+++ b/cloudtasks/apiv2beta2/doc.go
@@ -50,7 +50,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/cloudtasks/apiv2beta3/doc.go
+++ b/cloudtasks/apiv2beta3/doc.go
@@ -50,7 +50,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/container/apiv1/doc.go
+++ b/container/apiv1/doc.go
@@ -49,7 +49,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/containeranalysis/apiv1beta1/doc.go
+++ b/containeranalysis/apiv1beta1/doc.go
@@ -51,7 +51,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/datacatalog/apiv1/doc.go
+++ b/datacatalog/apiv1/doc.go
@@ -49,7 +49,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/datacatalog/apiv1beta1/doc.go
+++ b/datacatalog/apiv1beta1/doc.go
@@ -51,7 +51,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/dataproc/apiv1/doc.go
+++ b/dataproc/apiv1/doc.go
@@ -48,7 +48,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/dataproc/apiv1beta2/doc.go
+++ b/dataproc/apiv1beta2/doc.go
@@ -50,7 +50,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/datastore/admin/apiv1/doc.go
+++ b/datastore/admin/apiv1/doc.go
@@ -51,7 +51,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/debugger/apiv2/doc.go
+++ b/debugger/apiv2/doc.go
@@ -49,7 +49,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/dialogflow/apiv2/doc.go
+++ b/dialogflow/apiv2/doc.go
@@ -49,7 +49,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/dialogflow/cx/apiv3beta1/doc.go
+++ b/dialogflow/cx/apiv3beta1/doc.go
@@ -51,7 +51,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/dlp/apiv2/doc.go
+++ b/dlp/apiv2/doc.go
@@ -50,7 +50,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/errorreporting/apiv1beta1/doc.go
+++ b/errorreporting/apiv1beta1/doc.go
@@ -52,7 +52,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/firestore/apiv1/admin/doc.go
+++ b/firestore/apiv1/admin/doc.go
@@ -49,7 +49,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/firestore/apiv1/doc.go
+++ b/firestore/apiv1/doc.go
@@ -49,7 +49,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/functions/apiv1/doc.go
+++ b/functions/apiv1/doc.go
@@ -44,7 +44,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/gaming/apiv1/doc.go
+++ b/gaming/apiv1/doc.go
@@ -44,7 +44,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/gaming/apiv1beta/doc.go
+++ b/gaming/apiv1beta/doc.go
@@ -46,7 +46,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/iam/credentials/apiv1/doc.go
+++ b/iam/credentials/apiv1/doc.go
@@ -49,7 +49,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/internal/.repo-metadata-full.json
+++ b/internal/.repo-metadata-full.json
@@ -183,14 +183,6 @@
     "docs_url": "https://pkg.go.dev/cloud.google.com/go/billing/apiv1",
     "release_level": "ga"
   },
-  "cloud.google.com/go/billing/budgets/apiv1": {
-    "distribution_name": "cloud.google.com/go/billing/budgets/apiv1",
-    "description": "Cloud Billing Budget API",
-    "language": "Go",
-    "client_library_type": "generated",
-    "docs_url": "https://pkg.go.dev/cloud.google.com/go/billing/budgets/apiv1",
-    "release_level": "beta"
-  },
   "cloud.google.com/go/billing/budgets/apiv1beta1": {
     "distribution_name": "cloud.google.com/go/billing/budgets/apiv1beta1",
     "description": "",

--- a/iot/apiv1/doc.go
+++ b/iot/apiv1/doc.go
@@ -49,7 +49,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/kms/apiv1/doc.go
+++ b/kms/apiv1/doc.go
@@ -49,7 +49,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/language/apiv1/doc.go
+++ b/language/apiv1/doc.go
@@ -50,7 +50,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/language/apiv1beta2/doc.go
+++ b/language/apiv1beta2/doc.go
@@ -52,7 +52,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/logging/apiv2/doc.go
+++ b/logging/apiv2/doc.go
@@ -51,7 +51,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/longrunning/autogen/doc.go
+++ b/longrunning/autogen/doc.go
@@ -48,7 +48,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/managedidentities/apiv1/doc.go
+++ b/managedidentities/apiv1/doc.go
@@ -52,7 +52,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/memcache/apiv1beta2/doc.go
+++ b/memcache/apiv1beta2/doc.go
@@ -51,7 +51,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/monitoring/apiv3/v2/doc.go
+++ b/monitoring/apiv3/v2/doc.go
@@ -53,7 +53,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/monitoring/dashboard/apiv1/doc.go
+++ b/monitoring/dashboard/apiv1/doc.go
@@ -44,7 +44,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/notebooks/apiv1beta1/doc.go
+++ b/notebooks/apiv1beta1/doc.go
@@ -51,7 +51,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/osconfig/agentendpoint/apiv1/doc.go
+++ b/osconfig/agentendpoint/apiv1/doc.go
@@ -49,7 +49,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/osconfig/agentendpoint/apiv1beta/doc.go
+++ b/osconfig/agentendpoint/apiv1beta/doc.go
@@ -51,7 +51,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/osconfig/apiv1/doc.go
+++ b/osconfig/apiv1/doc.go
@@ -49,7 +49,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/osconfig/apiv1beta/doc.go
+++ b/osconfig/apiv1beta/doc.go
@@ -51,7 +51,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/oslogin/apiv1/doc.go
+++ b/oslogin/apiv1/doc.go
@@ -49,7 +49,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/oslogin/apiv1beta/doc.go
+++ b/oslogin/apiv1beta/doc.go
@@ -51,7 +51,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/phishingprotection/apiv1beta1/doc.go
+++ b/phishingprotection/apiv1beta1/doc.go
@@ -48,7 +48,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/policytroubleshooter/apiv1/doc.go
+++ b/policytroubleshooter/apiv1/doc.go
@@ -46,7 +46,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/pubsub/apiv1/doc.go
+++ b/pubsub/apiv1/doc.go
@@ -49,7 +49,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/pubsublite/apiv1/doc.go
+++ b/pubsublite/apiv1/doc.go
@@ -44,7 +44,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/recaptchaenterprise/apiv1/doc.go
+++ b/recaptchaenterprise/apiv1/doc.go
@@ -46,7 +46,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/recaptchaenterprise/apiv1beta1/doc.go
+++ b/recaptchaenterprise/apiv1beta1/doc.go
@@ -48,7 +48,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/recommender/apiv1/doc.go
+++ b/recommender/apiv1/doc.go
@@ -46,7 +46,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/recommender/apiv1beta1/doc.go
+++ b/recommender/apiv1beta1/doc.go
@@ -48,7 +48,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/redis/apiv1/doc.go
+++ b/redis/apiv1/doc.go
@@ -48,7 +48,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/redis/apiv1beta1/doc.go
+++ b/redis/apiv1beta1/doc.go
@@ -50,7 +50,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/scheduler/apiv1/doc.go
+++ b/scheduler/apiv1/doc.go
@@ -48,7 +48,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/scheduler/apiv1beta1/doc.go
+++ b/scheduler/apiv1beta1/doc.go
@@ -50,7 +50,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/secretmanager/apiv1/doc.go
+++ b/secretmanager/apiv1/doc.go
@@ -49,7 +49,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/secretmanager/apiv1beta1/doc.go
+++ b/secretmanager/apiv1beta1/doc.go
@@ -51,7 +51,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/security/privateca/apiv1beta1/doc.go
+++ b/security/privateca/apiv1beta1/doc.go
@@ -46,7 +46,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/securitycenter/apiv1/doc.go
+++ b/securitycenter/apiv1/doc.go
@@ -49,7 +49,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/securitycenter/apiv1beta1/doc.go
+++ b/securitycenter/apiv1beta1/doc.go
@@ -51,7 +51,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/securitycenter/apiv1p1beta1/doc.go
+++ b/securitycenter/apiv1p1beta1/doc.go
@@ -51,7 +51,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/securitycenter/settings/apiv1beta1/doc.go
+++ b/securitycenter/settings/apiv1beta1/doc.go
@@ -51,7 +51,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/servicedirectory/apiv1beta1/doc.go
+++ b/servicedirectory/apiv1beta1/doc.go
@@ -50,7 +50,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/spanner/admin/database/apiv1/doc.go
+++ b/spanner/admin/database/apiv1/doc.go
@@ -46,7 +46,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/spanner/admin/instance/apiv1/doc.go
+++ b/spanner/admin/instance/apiv1/doc.go
@@ -46,7 +46,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/spanner/apiv1/doc.go
+++ b/spanner/apiv1/doc.go
@@ -49,7 +49,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/speech/apiv1/doc.go
+++ b/speech/apiv1/doc.go
@@ -48,7 +48,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/speech/apiv1p1beta1/doc.go
+++ b/speech/apiv1p1beta1/doc.go
@@ -50,7 +50,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/talent/apiv4/doc.go
+++ b/talent/apiv4/doc.go
@@ -46,7 +46,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/talent/apiv4beta1/doc.go
+++ b/talent/apiv4beta1/doc.go
@@ -51,7 +51,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/texttospeech/apiv1/doc.go
+++ b/texttospeech/apiv1/doc.go
@@ -49,7 +49,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/trace/apiv1/doc.go
+++ b/trace/apiv1/doc.go
@@ -52,7 +52,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/trace/apiv2/doc.go
+++ b/trace/apiv2/doc.go
@@ -52,7 +52,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/translate/apiv3/doc.go
+++ b/translate/apiv3/doc.go
@@ -48,7 +48,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/video/transcoder/apiv1beta1/doc.go
+++ b/video/transcoder/apiv1beta1/doc.go
@@ -46,7 +46,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/videointelligence/apiv1/doc.go
+++ b/videointelligence/apiv1/doc.go
@@ -50,7 +50,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/videointelligence/apiv1beta2/doc.go
+++ b/videointelligence/apiv1beta2/doc.go
@@ -52,7 +52,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/vision/apiv1/doc.go
+++ b/vision/apiv1/doc.go
@@ -50,7 +50,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/vision/apiv1p1beta1/doc.go
+++ b/vision/apiv1p1beta1/doc.go
@@ -52,7 +52,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/webrisk/apiv1/doc.go
+++ b/webrisk/apiv1/doc.go
@@ -46,7 +46,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/webrisk/apiv1beta1/doc.go
+++ b/webrisk/apiv1beta1/doc.go
@@ -48,7 +48,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/websecurityscanner/apiv1/doc.go
+++ b/websecurityscanner/apiv1/doc.go
@@ -50,7 +50,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/workflows/apiv1beta/doc.go
+++ b/workflows/apiv1beta/doc.go
@@ -46,7 +46,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/workflows/executions/apiv1beta/doc.go
+++ b/workflows/executions/apiv1beta/doc.go
@@ -46,7 +46,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "20201106"
+const versionClient = "20201109"
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)


### PR DESCRIPTION

This is an auto-generated regeneration of the gapic clients by
cloud.google.com/go/internal/gapicgen. Once the corresponding genproto PR is
submitted, genbot will update this PR with a newer dependency to the newer
version of genproto and assign reviewers to this PR.

If you have been assigned to review this PR, please:

- Ensure that the version of genproto in go.mod has been updated.
- Ensure that CI is passing. If it's failing, it requires your manual attention.
- Approve and submit this PR if you believe it's ready to ship.


Corresponding genproto PR: https://github.com/googleapis/go-genproto/pull/486

Changes:
- feat!(spanner/admin/database): Update BUILD.bazel for spanner to use latest-gen python code generator.
  - Generated code no longer supports Python 2.7

  PiperOrigin-RevId: 341320404
  Source-Link: https://github.com/googleapis/googleapis/commit/3ad55bd69fcfcd011d81c05fb6dc7346275bcda4

- build(area120/tables): set package name

  PiperOrigin-RevId: 341146950
  Source-Link: https://github.com/googleapis/googleapis/commit/5359df5297982d551ac5dcc20c8a29de04c70090

- chore(analytics/data): use python microgenerator for analytics and billing budgtes

  PiperOrigin-RevId: 341060773
  Source-Link: https://github.com/googleapis/googleapis/commit/b036c69138b0cfde4e97bc4c9cf88959a1a8bf91

- fix(analytics/admin): 'requests' field of CreateUserLink, UpdateUserLink, DeleteUserLink methods is now required
  docs: minor documentation updates

  PiperOrigin-RevId: 340922897
  Source-Link: https://github.com/googleapis/googleapis/commit/b365fff50d84fbe03ea16d02cc73d72fa1fc864d

