### PR TITLE
chore: update CODEOWNERS to include admins for all

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,12 +1,12 @@
 # Default owner for all directories not owned by others
 *                   @googleapis/yoshi-go-admins
 
-/bigtable/          @tritone
-/bigquery/          @googleapis/api-bigquery
-/datastore/         @tritone
-/firestore/         @tritone
-/pubsub/            @googleapis/api-pubsub
-/spanner/           @skuruppu
-/storage/           @tritone
-/errorreporting/    @googleapis/api-logging 
-/logging/           @googleapis/api-logging
+/bigtable/          @tritone @googleapis/yoshi-go-admins
+/bigquery/          @googleapis/api-bigquery @googleapis/yoshi-go-admins
+/datastore/         @tritone @googleapis/yoshi-go-admins
+/firestore/         @tritone @googleapis/yoshi-go-admins
+/pubsub/            @googleapis/api-pubsub @googleapis/yoshi-go-admins
+/spanner/           @skuruppu @googleapis/yoshi-go-admins
+/storage/           @tritone @googleapis/yoshi-go-admins
+/errorreporting/    @googleapis/api-logging @googleapis/yoshi-go-admins
+/logging/           @googleapis/api-logging @googleapis/yoshi-go-admins


### PR DESCRIPTION
We will soon be switching to require review from CODEOWNERS. In
order for admins to have the power to merge regen PRs with no other
reviews they need to be owners for all directories.