### PR TITLE
fix(internal/godocfx): filter out test packages from other modules

### DIFF
--- a/internal/godocfx/parse.go
+++ b/internal/godocfx/parse.go
@@ -453,6 +453,17 @@ func loadPackages(glob, workingDir string) ([]pkgInfo, error) {
 	result := []pkgInfo{}
 
 	for _, pkgPath := range pkgNames {
+		// Check if pkgPath has prefix of skipped module.
+		skip := false
+		for skipModule := range skippedModules {
+			if strings.HasPrefix(pkgPath, skipModule) {
+				skip = true
+				break
+			}
+		}
+		if skip {
+			continue
+		}
 		parsedFiles := []*ast.File{}
 		fset := token.NewFileSet()
 		for _, f := range pkgFiles[pkgPath] {


### PR DESCRIPTION
Test packages don't have module set, so they aren't filtered out in the
existing check. The order of packages isn't defined as far as I can
tell. So, we may not know to skip a package when we first see it.