### PR TITLE
chore(internal): stop generating Ads packages in genproto

### DIFF
--- a/internal/gapicgen/generator/genproto.go
+++ b/internal/gapicgen/generator/genproto.go
@@ -42,6 +42,19 @@ var denylist = map[string]bool{
 	"google.golang.org/genproto/googleapis/devtools/containeranalysis/v1": true,
 }
 
+var skipPrefixes = []string{
+	"google.golang.org/genproto/googleapis/ads",
+}
+
+func hasPrefix(s string, prefixes []string) bool {
+	for _, prefix := range prefixes {
+		if strings.HasPrefix(s, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
 // regenGenproto regenerates the genproto repository.
 //
 // regenGenproto recursively walks through each directory named by given
@@ -110,7 +123,7 @@ func regenGenproto(ctx context.Context, genprotoDir, googleapisDir, protoDir str
 	// Run protoc on all protos of all packages.
 	grp, _ := errgroup.WithContext(ctx)
 	for pkg, fnames := range pkgFiles {
-		if !strings.HasPrefix(pkg, "google.golang.org/genproto") || denylist[pkg] {
+		if !strings.HasPrefix(pkg, "google.golang.org/genproto") || denylist[pkg] || hasPrefix(pkg, skipPrefixes) {
 			continue
 		}
 		pk := pkg

--- a/internal/gapicgen/generator/genproto_test.go
+++ b/internal/gapicgen/generator/genproto_test.go
@@ -1,0 +1,65 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generator
+
+import "testing"
+
+func TestHasPrefix(t *testing.T) {
+	tests := []struct {
+		s        string
+		prefixes []string
+		want     bool
+	}{
+		{
+			s:        "abc",
+			prefixes: []string{"a"},
+			want:     true,
+		},
+		{
+			s:        "abc",
+			prefixes: []string{"ab"},
+			want:     true,
+		},
+		{
+			s:        "abc",
+			prefixes: []string{"abc"},
+			want:     true,
+		},
+		{
+			s:        "google.golang.org/genproto/googleapis/ads/googleads/v1/common",
+			prefixes: []string{"google.golang.org/genproto/googleapis/ads"},
+			want:     true,
+		},
+		{
+			s:        "abc",
+			prefixes: []string{"zzz"},
+			want:     false,
+		},
+		{
+			s:        "",
+			prefixes: []string{"zzz"},
+			want:     false,
+		},
+		{
+			s:    "abc",
+			want: false,
+		},
+	}
+	for _, test := range tests {
+		if got := hasPrefix(test.s, test.prefixes); got != test.want {
+			t.Errorf("hasPrefix(%q, %q) got %v, want %v", test.s, test.prefixes, got, test.want)
+		}
+	}
+}


### PR DESCRIPTION
These packages don't have a corresponding client library (in
cloud.google.com/go or another module). They aren't ready for production
use. So, we're going to stop generating them for now and will revisit
in the future when ready.

A go-genproto PR will remove the existing Ads packages.

If needed, these packages can be generated locally or as part of a build
process. However, we're not ready to generate and publish them
automatically.

@anashoommen @aohren