### PR TITLE
Revert "feat(firestore): support "!=" and "not-in" query operators (#…

### DIFF
--- a/firestore/integration_test.go
+++ b/firestore/integration_test.go
@@ -651,13 +651,6 @@ func TestIntegration_QueryDocuments(t *testing.T) {
 	}{
 		{q, wants},
 		{q.Where("q", ">", 1), wants[2:]},
-		{q.Where("q", "<", 1), wants[:1]},
-		{q.Where("q", "==", 1), wants[1:2]},
-		{q.Where("q", "!=", 0), wants[1:]},
-		{q.Where("q", ">=", 1), wants[1:]},
-		{q.Where("q", "<=", 1), wants[:2]},
-		{q.Where("q", "in", []int{0, 1}), wants[:2]},
-		{q.Where("q", "not-in", []int{0, 1}), wants[2:]},
 		{q.WherePath([]string{"q"}, ">", 1), wants[2:]},
 		{q.Offset(1).Limit(1), wants[1:2]},
 		{q.StartAt(1), wants[1:]},

--- a/firestore/query.go
+++ b/firestore/query.go
@@ -500,12 +500,8 @@ func (f filter) toProto() (*pb.StructuredQuery_Filter, error) {
 		op = pb.StructuredQuery_FieldFilter_GREATER_THAN_OR_EQUAL
 	case "==":
 		op = pb.StructuredQuery_FieldFilter_EQUAL
-	case "!=":
-		op = pb.StructuredQuery_FieldFilter_NOT_EQUAL
 	case "in":
 		op = pb.StructuredQuery_FieldFilter_IN
-	case "not-in":
-		op = pb.StructuredQuery_FieldFilter_NOT_IN
 	case "array-contains":
 		op = pb.StructuredQuery_FieldFilter_ARRAY_CONTAINS
 	case "array-contains-any":

--- a/firestore/query_test.go
+++ b/firestore/query_test.go
@@ -144,19 +144,9 @@ func TestQueryToProto(t *testing.T) {
 			want: &pb.StructuredQuery{Where: filtr([]string{"a"}, "==", math.NaN())},
 		},
 		{
-			desc: `q.Where("a", "!=", 3)`,
-			in:   q.Where("a", "!=", 3),
-			want: &pb.StructuredQuery{Where: filtr([]string{"a"}, "!=", 3)},
-		},
-		{
 			desc: `q.Where("a", "in", []int{7, 8})`,
 			in:   q.Where("a", "in", []int{7, 8}),
 			want: &pb.StructuredQuery{Where: filtr([]string{"a"}, "in", []int{7, 8})},
-		},
-		{
-			desc: `q.Where("a", "not-in", []int{9})`,
-			in:   q.Where("a", "not-in", []int{9}),
-			want: &pb.StructuredQuery{Where: filtr([]string{"a"}, "not-in", []int{9})},
 		},
 		{
 			desc: `q.Where("c", "array-contains", 1)`,
@@ -466,7 +456,7 @@ func TestQueryToProtoErrors(t *testing.T) {
 	q := coll.Query
 	for i, query := range []Query{
 		{},                                     // no collection ID
-		q.Where("x", "<>", 1),                  // invalid operator
+		q.Where("x", "!=", 1),                  // invalid operator
 		q.Where("~", ">", 1),                   // invalid path
 		q.WherePath([]string{"*", ""}, ">", 1), // invalid path
 		q.StartAt(1),                           // no OrderBy


### PR DESCRIPTION
…3207)"

This reverts commit 5c440192105fe3e9b5dd1b584118b309113935e3.

Reverting due to integration test failure.

Fixes #3223
Updates #3207 