### PR TITLE
fix(pubsub): Remove NewMessage and NewPublishResult

### DIFF
--- a/pubsub/message.go
+++ b/pubsub/message.go
@@ -61,12 +61,6 @@ type Message struct {
 	ackh ackHandler
 }
 
-// NewMessage creates a message with a custom ack/nack handler, which should not
-// be nil.
-func NewMessage(ackh ackHandler) *Message {
-	return &Message{ackh: ackh}
-}
-
 func toMessage(resp *pb.ReceivedMessage) (*Message, error) {
 	if resp.Message == nil {
 		return &Message{ackh: &psAckHandler{ackID: resp.AckId}}, nil

--- a/pubsub/topic.go
+++ b/pubsub/topic.go
@@ -470,13 +470,6 @@ type PublishResult struct {
 	err      error
 }
 
-// NewPublishResult returns the set() function to enable callers from outside
-// this package to store and call it (e.g. unit tests).
-func NewPublishResult() (*PublishResult, func(string, error)) {
-	result := &PublishResult{ready: make(chan struct{})}
-	return result, result.set
-}
-
 // Ready returns a channel that is closed when the result is ready.
 // When the Ready channel is closed, Get is guaranteed not to block.
 func (r *PublishResult) Ready() <-chan struct{} { return r.ready }


### PR DESCRIPTION
Rolls back the public functions added in https://github.com/googleapis/google-cloud-go/pull/3200. We have decided not to expose these to users.