### PR TITLE
feat(pubsublite): allow committer to terminate when acks are canceled

### DIFF
--- a/pubsublite/internal/wire/acks_test.go
+++ b/pubsublite/internal/wire/acks_test.go
@@ -15,12 +15,20 @@ package wire
 
 import "testing"
 
+func emptyAckConsumer(_ *ackConsumer) {}
+
 func TestAckConsumerAck(t *testing.T) {
 	numAcks := 0
 	onAck := func(ac *ackConsumer) {
 		numAcks++
 	}
 	ackConsumer := newAckConsumer(0, 0, onAck)
+	if got, want := ackConsumer.IsAcked(), false; got != want {
+		t.Errorf("ackConsumer.IsAcked() got %v, want %v", got, want)
+	}
+	if got, want := ackConsumer.IsDone(), false; got != want {
+		t.Errorf("ackConsumer.IsDone() got %v, want %v", got, want)
+	}
 
 	// Test duplicate acks.
 	for i := 0; i < 3; i++ {
@@ -29,22 +37,41 @@ func TestAckConsumerAck(t *testing.T) {
 		if got, want := ackConsumer.IsAcked(), true; got != want {
 			t.Errorf("ackConsumer.IsAcked() got %v, want %v", got, want)
 		}
+		if got, want := ackConsumer.IsDone(), true; got != want {
+			t.Errorf("ackConsumer.IsDone() got %v, want %v", got, want)
+		}
 		if got, want := numAcks, 1; got != want {
 			t.Errorf("onAck func called %v times, expected %v call", got, want)
 		}
 	}
 }
 
-func TestAckConsumerClear(t *testing.T) {
+func TestAckConsumerCancel(t *testing.T) {
 	onAck := func(ac *ackConsumer) {
 		t.Error("onAck func should not have been called")
 	}
 	ackConsumer := newAckConsumer(0, 0, onAck)
-	ackConsumer.Clear()
-	ackConsumer.Ack()
+	if got, want := ackConsumer.IsAcked(), false; got != want {
+		t.Errorf("ackConsumer.IsAcked() got %v, want %v", got, want)
+	}
+	if got, want := ackConsumer.IsDone(), false; got != want {
+		t.Errorf("ackConsumer.IsDone() got %v, want %v", got, want)
+	}
 
+	ackConsumer.Cancel()
+	if got, want := ackConsumer.IsAcked(), false; got != want {
+		t.Errorf("ackConsumer.IsAcked() got %v, want %v", got, want)
+	}
+	if got, want := ackConsumer.IsDone(), true; got != want {
+		t.Errorf("ackConsumer.IsDone() got %v, want %v", got, want)
+	}
+
+	ackConsumer.Ack()
 	if got, want := ackConsumer.IsAcked(), true; got != want {
 		t.Errorf("ackConsumer.IsAcked() got %v, want %v", got, want)
+	}
+	if got, want := ackConsumer.IsDone(), true; got != want {
+		t.Errorf("ackConsumer.IsDone() got %v, want %v", got, want)
 	}
 }
 
@@ -56,12 +83,9 @@ func TestAckTrackerProcessing(t *testing.T) {
 		t.Errorf("ackTracker.CommitOffset() got %v, want %v", got, want)
 	}
 
-	onAck := func(ac *ackConsumer) {
-		// Nothing to do.
-	}
-	ack1 := newAckConsumer(1, 0, onAck)
-	ack2 := newAckConsumer(2, 0, onAck)
-	ack3 := newAckConsumer(3, 0, onAck)
+	ack1 := newAckConsumer(1, 0, emptyAckConsumer)
+	ack2 := newAckConsumer(2, 0, emptyAckConsumer)
+	ack3 := newAckConsumer(3, 0, emptyAckConsumer)
 	if err := ackTracker.Push(ack1); err != nil {
 		t.Errorf("ackTracker.Push() got err %v", err)
 	}
@@ -95,7 +119,7 @@ func TestAckTrackerProcessing(t *testing.T) {
 	}
 
 	// Newly received message.
-	ack4 := newAckConsumer(4, 0, onAck)
+	ack4 := newAckConsumer(4, 0, emptyAckConsumer)
 	if err := ackTracker.Push(ack4); err != nil {
 		t.Errorf("ackTracker.Push() got err %v", err)
 	}
@@ -131,6 +155,46 @@ func TestAckTrackerRelease(t *testing.T) {
 	ack3.Ack()
 }
 
+func TestAckTrackerCancelAcks(t *testing.T) {
+	ackTracker := newAckTracker()
+	ack1 := newAckConsumer(1, 0, emptyAckConsumer)
+	ack2 := newAckConsumer(2, 0, emptyAckConsumer)
+	ack3 := newAckConsumer(3, 0, emptyAckConsumer)
+
+	if err := ackTracker.Push(ack1); err != nil {
+		t.Errorf("ackTracker.Push() got err %v", err)
+	}
+	if err := ackTracker.Push(ack2); err != nil {
+		t.Errorf("ackTracker.Push() got err %v", err)
+	}
+	if err := ackTracker.Push(ack3); err != nil {
+		t.Errorf("ackTracker.Push() got err %v", err)
+	}
+	if got, want := ackTracker.CommitOffset(), nilCursorOffset; got != want {
+		t.Errorf("ackTracker.CommitOffset() got %v, want %v", got, want)
+	}
+	if got, want := ackTracker.Empty(), false; got != want {
+		t.Errorf("ackTracker.Empty() got %v, want %v", got, want)
+	}
+
+	ack1.Ack()
+	if got, want := ackTracker.CommitOffset(), int64(2); got != want {
+		t.Errorf("ackTracker.CommitOffset() got %v, want %v", got, want)
+	}
+	if got, want := ackTracker.Empty(), false; got != want {
+		t.Errorf("ackTracker.Empty() got %v, want %v", got, want)
+	}
+
+	ack2.Cancel()
+	ack3.Cancel()
+	if got, want := ackTracker.CommitOffset(), int64(2); got != want {
+		t.Errorf("ackTracker.CommitOffset() got %v, want %v", got, want)
+	}
+	if got, want := ackTracker.Empty(), true; got != want {
+		t.Errorf("ackTracker.Empty() got %v, want %v", got, want)
+	}
+}
+
 func TestCommitCursorTrackerProcessing(t *testing.T) {
 	ackTracker := newAckTracker()
 	commitTracker := newCommitCursorTracker(ackTracker)
@@ -140,12 +204,9 @@ func TestCommitCursorTrackerProcessing(t *testing.T) {
 		t.Errorf("commitCursorTracker.NextOffset() got %v, want %v", got, want)
 	}
 
-	onAck := func(ac *ackConsumer) {
-		// Nothing to do.
-	}
-	ack1 := newAckConsumer(1, 0, onAck)
-	ack2 := newAckConsumer(2, 0, onAck)
-	ack3 := newAckConsumer(3, 0, onAck)
+	ack1 := newAckConsumer(1, 0, emptyAckConsumer)
+	ack2 := newAckConsumer(2, 0, emptyAckConsumer)
+	ack3 := newAckConsumer(3, 0, emptyAckConsumer)
 	if err := ackTracker.Push(ack1); err != nil {
 		t.Errorf("ackTracker.Push() got err %v", err)
 	}
@@ -184,8 +245,8 @@ func TestCommitCursorTrackerProcessing(t *testing.T) {
 	if got, want := commitTracker.NextOffset(), nilCursorOffset; got != want {
 		t.Errorf("commitCursorTracker.NextOffset() got %v, want %v", got, want)
 	}
-	if got, want := commitTracker.Done(), false; got != want {
-		t.Errorf("commitCursorTracker.Done() got %v, want %v", got, want)
+	if got, want := commitTracker.UpToDate(), false; got != want {
+		t.Errorf("commitCursorTracker.UpToDate() got %v, want %v", got, want)
 	}
 
 	// First 2 pending commits acknowledged.
@@ -198,8 +259,8 @@ func TestCommitCursorTrackerProcessing(t *testing.T) {
 	if got, want := commitTracker.lastConfirmedOffset, int64(4); got != want {
 		t.Errorf("commitCursorTracker.lastConfirmedOffset got %v, want %v", got, want)
 	}
-	if got, want := commitTracker.Done(), true; got != want {
-		t.Errorf("commitCursorTracker.Done() got %v, want %v", got, want)
+	if got, want := commitTracker.UpToDate(), true; got != want {
+		t.Errorf("commitCursorTracker.UpToDate() got %v, want %v", got, want)
 	}
 }
 
@@ -207,12 +268,9 @@ func TestCommitCursorTrackerStreamReconnects(t *testing.T) {
 	ackTracker := newAckTracker()
 	commitTracker := newCommitCursorTracker(ackTracker)
 
-	onAck := func(ac *ackConsumer) {
-		// Nothing to do.
-	}
-	ack1 := newAckConsumer(1, 0, onAck)
-	ack2 := newAckConsumer(2, 0, onAck)
-	ack3 := newAckConsumer(3, 0, onAck)
+	ack1 := newAckConsumer(1, 0, emptyAckConsumer)
+	ack2 := newAckConsumer(2, 0, emptyAckConsumer)
+	ack3 := newAckConsumer(3, 0, emptyAckConsumer)
 	if err := ackTracker.Push(ack1); err != nil {
 		t.Errorf("ackTracker.Push() got err %v", err)
 	}
@@ -250,8 +308,8 @@ func TestCommitCursorTrackerStreamReconnects(t *testing.T) {
 
 	// Stream breaks and pending offsets are cleared.
 	commitTracker.ClearPending()
-	if got, want := commitTracker.Done(), false; got != want {
-		t.Errorf("commitCursorTracker.Done() got %v, want %v", got, want)
+	if got, want := commitTracker.UpToDate(), false; got != want {
+		t.Errorf("commitCursorTracker.UpToDate() got %v, want %v", got, want)
 	}
 	// When the stream reconnects the next offset should be 3 (offset 2 skipped).
 	if got, want := commitTracker.NextOffset(), int64(3); got != want {
@@ -282,8 +340,8 @@ func TestCommitCursorTrackerStreamReconnects(t *testing.T) {
 	if got, want := commitTracker.lastConfirmedOffset, int64(3); got != want {
 		t.Errorf("commitCursorTracker.lastConfirmedOffset got %v, want %v", got, want)
 	}
-	if got, want := commitTracker.Done(), false; got != want {
-		t.Errorf("commitCursorTracker.Done() got %v, want %v", got, want)
+	if got, want := commitTracker.UpToDate(), false; got != want {
+		t.Errorf("commitCursorTracker.UpToDate() got %v, want %v", got, want)
 	}
 
 	// Final pending commit confirmed.
@@ -293,17 +351,17 @@ func TestCommitCursorTrackerStreamReconnects(t *testing.T) {
 	if got, want := commitTracker.lastConfirmedOffset, int64(4); got != want {
 		t.Errorf("commitCursorTracker.lastConfirmedOffset got %v, want %v", got, want)
 	}
-	if got, want := commitTracker.Done(), true; got != want {
-		t.Errorf("commitCursorTracker.Done() got %v, want %v", got, want)
+	if got, want := commitTracker.UpToDate(), true; got != want {
+		t.Errorf("commitCursorTracker.UpToDate() got %v, want %v", got, want)
 	}
 
-	// Note: Done() returns true even though there are unacked messages.
-	ack4 := newAckConsumer(4, 0, onAck)
+	// Note: UpToDate() returns true even though there are unacked messages.
+	ack4 := newAckConsumer(4, 0, emptyAckConsumer)
 	if err := ackTracker.Push(ack4); err != nil {
 		t.Errorf("ackTracker.Push() got err %v", err)
 	}
-	if got, want := commitTracker.Done(), true; got != want {
-		t.Errorf("commitCursorTracker.Done() got %v, want %v", got, want)
+	if got, want := commitTracker.UpToDate(), true; got != want {
+		t.Errorf("commitCursorTracker.UpToDate() got %v, want %v", got, want)
 	}
 	if got, want := commitTracker.NextOffset(), nilCursorOffset; got != want {
 		t.Errorf("commitCursorTracker.NextOffset() got %v, want %v", got, want)

--- a/pubsublite/internal/wire/committer.go
+++ b/pubsublite/internal/wire/committer.go
@@ -207,7 +207,7 @@ func (c *committer) unsafeInitiateShutdown(targetStatus serviceStatus, err error
 func (c *committer) unsafeCheckDone() {
 	// If the user stops the subscriber, they will no longer receive messages, but
 	// the commit stream remains open to process acks for outstanding messages.
-	if c.status == serviceTerminating && c.cursorTracker.Done() && c.acks.Empty() {
+	if c.status == serviceTerminating && c.cursorTracker.UpToDate() && c.acks.Empty() {
 		c.unsafeTerminate()
 	}
 }


### PR DESCRIPTION
Allows an `AckConsumer` to be canceled from outside the `wire` package. For example, the CPS subscriber shim will receive a batch of messages from the wire subscriber (but deliver single messages to users), and will cancel remaining ack consumers for the batch if the user stops the subscriber midway.

This scenario is now handled by the `committer`, which terminates once all outstanding ack consumers have either been acked or canceled.

A couple of renames for clarity:

* `ackConsumer.Clear()` to `ackConsumer.Cancel()`
* `commitCursorTracker.Done()` to `commitCursorTracker.UpToDate()`