### PR TITLE
refactor(pubsublite): committer discards outstanding acks when stopped

### DIFF
--- a/pubsublite/internal/wire/acks.go
+++ b/pubsublite/internal/wire/acks.go
@@ -77,7 +77,7 @@ func (ac *ackConsumer) Clear() {
 }
 
 // Represents an uninitialized cursor offset. A sentinel value is used instead
-// if an optional to simplify cursor comparisons (i.e. -1 works without the need
+// of an optional to simplify cursor comparisons (i.e. -1 works without the need
 // to check for nil and then convert to int64).
 const nilCursorOffset int64 = -1
 
@@ -127,21 +127,7 @@ func (at *ackTracker) CommitOffset() int64 {
 	at.mu.Lock()
 	defer at.mu.Unlock()
 
-	// Process outstanding acks and update `ackedPrefixOffset` until an unacked
-	// message is found.
-	for {
-		elem := at.outstandingAcks.Front()
-		if elem == nil {
-			break
-		}
-		ack, _ := elem.Value.(*ackConsumer)
-		if !ack.IsAcked() {
-			break
-		}
-		at.ackedPrefixOffset = ack.Offset
-		at.outstandingAcks.Remove(elem)
-		ack.Clear()
-	}
+	at.unsafeProcessAcks()
 
 	if at.ackedPrefixOffset == nilCursorOffset {
 		return nilCursorOffset
@@ -156,6 +142,8 @@ func (at *ackTracker) Release() {
 	at.mu.Lock()
 	defer at.mu.Unlock()
 
+	at.unsafeProcessAcks()
+
 	for elem := at.outstandingAcks.Front(); elem != nil; elem = elem.Next() {
 		ack, _ := elem.Value.(*ackConsumer)
 		ack.Clear()
@@ -163,11 +151,22 @@ func (at *ackTracker) Release() {
 	at.outstandingAcks.Init()
 }
 
-// Empty when there are no outstanding acks.
-func (at *ackTracker) Empty() bool {
-	at.mu.Lock()
-	defer at.mu.Unlock()
-	return at.outstandingAcks.Len() == 0
+// Process outstanding acks and update `ackedPrefixOffset` until an unacked
+// message is found.
+func (at *ackTracker) unsafeProcessAcks() {
+	for {
+		elem := at.outstandingAcks.Front()
+		if elem == nil {
+			break
+		}
+		ack, _ := elem.Value.(*ackConsumer)
+		if !ack.IsAcked() {
+			break
+		}
+		at.ackedPrefixOffset = ack.Offset
+		at.outstandingAcks.Remove(elem)
+		ack.Clear()
+	}
 }
 
 // commitCursorTracker tracks pending and last successful committed offsets.
@@ -241,7 +240,7 @@ func (ct *commitCursorTracker) ConfirmOffsets(numConfirmed int64) error {
 	return nil
 }
 
-// Done when the server has confirmed the desired commit offset.
-func (ct *commitCursorTracker) Done() bool {
+// UpToDate when the server has confirmed the desired commit offset.
+func (ct *commitCursorTracker) UpToDate() bool {
 	return ct.acks.CommitOffset() <= ct.lastConfirmedOffset
 }

--- a/pubsublite/internal/wire/committer_test.go
+++ b/pubsublite/internal/wire/committer_test.go
@@ -102,7 +102,6 @@ func TestCommitterStopFlushesCommits(t *testing.T) {
 	stream := test.NewRPCVerifier(t)
 	stream.Push(initCommitReq(subscription), initCommitResp(), nil)
 	stream.Push(commitReq(34), commitResp(1), nil)
-	stream.Push(commitReq(56), commitResp(1), nil)
 	verifiers.AddCommitStream(subscription.Path, subscription.Partition, stream)
 
 	mockServer.OnTestStart(verifiers)
@@ -115,8 +114,7 @@ func TestCommitterStopFlushesCommits(t *testing.T) {
 
 	ack1.Ack()
 	cmt.Stop() // Stop should flush the first offset
-	ack2.Ack() // Acks after Stop() are still processed
-	cmt.SendBatchCommit()
+	ack2.Ack() // Acks after Stop() are discarded
 	// Committer terminates when all acks are processed.
 	if gotErr := cmt.FinalError(); gotErr != nil {
 		t.Errorf("Final err: (%v), want: <nil>", gotErr)

--- a/pubsublite/internal/wire/committer_test.go
+++ b/pubsublite/internal/wire/committer_test.go
@@ -115,6 +115,7 @@ func TestCommitterStopFlushesCommits(t *testing.T) {
 	ack1.Ack()
 	cmt.Stop() // Stop should flush the first offset
 	ack2.Ack() // Acks after Stop() are discarded
+	cmt.SendBatchCommit()
 	// Committer terminates when all acks are processed.
 	if gotErr := cmt.FinalError(); gotErr != nil {
 		t.Errorf("Final err: (%v), want: <nil>", gotErr)


### PR DESCRIPTION
When stopped, the `committer` now sends the final commit offset only. Acks that arrive after Stop() are discarded to minimize complexity. Acks are best-effort anyway.