### PR TITLE
fix(pubsublite): deliver messages sequentially

### DIFF
--- a/pubsublite/internal/wire/periodic_task.go
+++ b/pubsublite/internal/wire/periodic_task.go
@@ -59,10 +59,16 @@ func (pt *periodicTask) Stop() {
 
 func (pt *periodicTask) poll(ticker *time.Ticker, stop chan struct{}) {
 	for {
+		// stop has higher priority.
 		select {
 		case <-stop:
-			// Ends the goroutine.
-			return
+			return // Ends the goroutine.
+		default:
+		}
+
+		select {
+		case <-stop:
+			return // Ends the goroutine.
 		case <-ticker.C:
 			pt.task()
 		}

--- a/pubsublite/internal/wire/streams.go
+++ b/pubsublite/internal/wire/streams.go
@@ -47,6 +47,9 @@ const (
 // streamHandler methods must not be called while holding retryableStream.mu in
 // order to prevent the streamHandler calling back into the retryableStream and
 // deadlocking.
+//
+// If any streamHandler method implementations block, this will block the
+// retryableStream.connectStream goroutine processing the underlying stream.
 type streamHandler interface {
 	// newStream implementations must create the client stream with the given
 	// (cancellable) context.

--- a/pubsublite/internal/wire/subscriber.go
+++ b/pubsublite/internal/wire/subscriber.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"errors"
 	"reflect"
+	"sync"
 	"time"
 
 	"google.golang.org/grpc"
@@ -43,6 +44,81 @@ type ReceivedMessage struct {
 // partition.
 type MessageReceiverFunc func([]*ReceivedMessage)
 
+const maxMessagesBufferSize = 1000
+
+// messageDeliveryQueue delivers received messages to the client-provided
+// MessageReceiverFunc sequentially.
+type messageDeliveryQueue struct {
+	receiver  MessageReceiverFunc
+	messagesC chan []*ReceivedMessage
+	stopC     chan struct{}
+
+	// Fields below must be guarded with mu.
+	mu     sync.Mutex
+	status serviceStatus
+}
+
+func newMessageDeliveryQueue(receiver MessageReceiverFunc, bufferSize int) *messageDeliveryQueue {
+	// The buffer size is based on ReceiveSettings.MaxOutstandingMessages to
+	// handle the worst case of single messages. But ensure there's a reasonable
+	// limit as channel buffer capacity is allocated on creation.
+	if bufferSize > maxMessagesBufferSize {
+		bufferSize = maxMessagesBufferSize
+	}
+	return &messageDeliveryQueue{
+		receiver:  receiver,
+		messagesC: make(chan []*ReceivedMessage, bufferSize),
+		stopC:     make(chan struct{}),
+	}
+}
+
+func (mq *messageDeliveryQueue) Start() {
+	mq.mu.Lock()
+	defer mq.mu.Unlock()
+
+	if mq.status == serviceUninitialized {
+		go mq.deliverMessages()
+		mq.status = serviceActive
+	}
+}
+
+func (mq *messageDeliveryQueue) Stop() {
+	mq.mu.Lock()
+	defer mq.mu.Unlock()
+
+	if mq.status < serviceTerminated {
+		close(mq.stopC)
+		mq.status = serviceTerminated
+	}
+}
+
+func (mq *messageDeliveryQueue) Add(messages []*ReceivedMessage) {
+	mq.mu.Lock()
+	defer mq.mu.Unlock()
+
+	if mq.status == serviceActive {
+		mq.messagesC <- messages
+	}
+}
+
+func (mq *messageDeliveryQueue) deliverMessages() {
+	for {
+		// stopC has higher priority.
+		select {
+		case <-mq.stopC:
+			return // Ends the goroutine.
+		default:
+		}
+
+		select {
+		case <-mq.stopC:
+			return // Ends the goroutine.
+		case msgs := <-mq.messagesC:
+			mq.receiver(msgs)
+		}
+	}
+}
+
 // The frequency of sending batch flow control requests.
 const batchFlowControlPeriod = 100 * time.Millisecond
 
@@ -58,9 +134,9 @@ type subscribeStream struct {
 	settings     ReceiveSettings
 	subscription subscriptionPartition
 	initialReq   *pb.SubscribeRequest
-	receiver     MessageReceiverFunc
+	messageQueue *messageDeliveryQueue
 
-	// Fields below must be guarded with mutex.
+	// Fields below must be guarded with mu.
 	stream          *retryableStream
 	acks            *ackTracker
 	offsetTracker   subscriberOffsetTracker
@@ -86,8 +162,8 @@ func newSubscribeStream(ctx context.Context, subClient *vkit.SubscriberClient, s
 				},
 			},
 		},
-		receiver: receiver,
-		acks:     acks,
+		messageQueue: newMessageDeliveryQueue(receiver, settings.MaxOutstandingMessages),
+		acks:         acks,
 	}
 	s.stream = newRetryableStream(ctx, s, settings.Timeout, reflect.TypeOf(pb.SubscribeResponse{}))
 
@@ -108,6 +184,7 @@ func (s *subscribeStream) Start() {
 	if s.unsafeUpdateStatus(serviceStarting, nil) {
 		s.stream.Start()
 		s.pollFlowControl.Start()
+		s.messageQueue.Start()
 
 		s.flowControl.OnClientFlow(flowControlTokens{
 			Bytes:    int64(s.settings.MaxOutstandingBytes),
@@ -150,13 +227,12 @@ func (s *subscribeStream) onStreamStatusChange(status streamStatus) {
 		// Reinitialize the offset and flow control tokens when a new subscribe
 		// stream instance is connected.
 		if seekReq := s.offsetTracker.RequestForRestart(); seekReq != nil {
-			// Note: If Send() returns false, the subscriber will either terminate or
-			// the stream will be reconnected.
-			if s.stream.Send(&pb.SubscribeRequest{
+			if !s.stream.Send(&pb.SubscribeRequest{
 				Request: &pb.SubscribeRequest_Seek{Seek: seekReq},
 			}) {
-				s.seekInFlight = true
+				return
 			}
+			s.seekInFlight = true
 		}
 		s.unsafeSendFlowControl(s.flowControl.RequestForRestart())
 		s.pollFlowControl.Start()
@@ -171,30 +247,26 @@ func (s *subscribeStream) onStreamStatusChange(status streamStatus) {
 }
 
 func (s *subscribeStream) onResponse(response interface{}) {
-	var receivedMsgs []*ReceivedMessage
-	var err error
 	s.mu.Lock()
+	defer s.mu.Unlock()
 
+	if s.status >= serviceTerminating {
+		return
+	}
+
+	var err error
 	subscribeResponse, _ := response.(*pb.SubscribeResponse)
 	switch {
 	case subscribeResponse.GetMessages() != nil:
-		receivedMsgs, err = s.unsafeOnMessageResponse(subscribeResponse.GetMessages())
+		err = s.unsafeOnMessageResponse(subscribeResponse.GetMessages())
 	case subscribeResponse.GetSeek() != nil:
 		err = s.unsafeOnSeekResponse(subscribeResponse.GetSeek())
 	default:
 		err = errInvalidSubscribeResponse
 	}
-
-	if receivedMsgs != nil {
-		// Deliver messages without holding the mutex to prevent deadlocks.
-		s.mu.Unlock()
-		s.receiver(receivedMsgs)
-		return
-	}
 	if err != nil {
 		s.unsafeInitiateShutdown(serviceTerminated, err)
 	}
-	s.mu.Unlock()
 }
 
 func (s *subscribeStream) unsafeOnSeekResponse(response *pb.SeekResponse) error {
@@ -205,15 +277,15 @@ func (s *subscribeStream) unsafeOnSeekResponse(response *pb.SeekResponse) error 
 	return nil
 }
 
-func (s *subscribeStream) unsafeOnMessageResponse(response *pb.MessageResponse) ([]*ReceivedMessage, error) {
+func (s *subscribeStream) unsafeOnMessageResponse(response *pb.MessageResponse) error {
 	if len(response.Messages) == 0 {
-		return nil, errServerNoMessages
+		return errServerNoMessages
 	}
 	if err := s.offsetTracker.OnMessages(response.Messages); err != nil {
-		return nil, err
+		return err
 	}
 	if err := s.flowControl.OnMessages(response.Messages); err != nil {
-		return nil, err
+		return err
 	}
 
 	var receivedMsgs []*ReceivedMessage
@@ -222,11 +294,12 @@ func (s *subscribeStream) unsafeOnMessageResponse(response *pb.MessageResponse) 
 		// `committer`.
 		ack := newAckConsumer(msg.GetCursor().GetOffset(), msg.GetSizeBytes(), s.onAck)
 		if err := s.acks.Push(ack); err != nil {
-			return nil, err
+			return err
 		}
 		receivedMsgs = append(receivedMsgs, &ReceivedMessage{Msg: msg, Ack: ack})
 	}
-	return receivedMsgs, nil
+	s.messageQueue.Add(receivedMsgs)
+	return nil
 }
 
 func (s *subscribeStream) onAck(ac *ackConsumer) {
@@ -276,6 +349,7 @@ func (s *subscribeStream) unsafeInitiateShutdown(targetStatus serviceStatus, err
 	}
 
 	// No data to send. Immediately terminate the stream.
+	s.messageQueue.Stop()
 	s.pollFlowControl.Stop()
 	s.stream.Stop()
 }

--- a/pubsublite/internal/wire/subscriber_test.go
+++ b/pubsublite/internal/wire/subscriber_test.go
@@ -108,6 +108,37 @@ func (tr *testMessageReceiver) VerifyNoMsgs() {
 	}
 }
 
+// testBlockingMessageReceiver can be used to simulate a client message receiver
+// func that is blocking due to slow message processing.
+type testBlockingMessageReceiver struct {
+	blockReceive chan struct{}
+
+	testMessageReceiver
+}
+
+func newTestBlockingMessageReceiver(t *testing.T) *testBlockingMessageReceiver {
+	return &testBlockingMessageReceiver{
+		testMessageReceiver: testMessageReceiver{
+			t:        t,
+			received: make(chan *ReceivedMessage, 5),
+		},
+		blockReceive: make(chan struct{}),
+	}
+}
+
+// onMessages is the message receiver func and blocks until there is a call to
+// Return().
+func (tr *testBlockingMessageReceiver) onMessages(msgs []*ReceivedMessage) {
+	tr.testMessageReceiver.onMessages(msgs)
+	<-tr.blockReceive
+}
+
+// Return signals onMessages to return.
+func (tr *testBlockingMessageReceiver) Return() {
+	var void struct{}
+	tr.blockReceive <- void
+}
+
 func TestNewMessageDeliveryQueue(t *testing.T) {
 	receiver := newTestMessageReceiver(t)
 	messageQueue := newMessageDeliveryQueue(receiver.onMessages, 10)
@@ -497,6 +528,102 @@ func TestSinglePartitionSubscriberSimpleMsgAck(t *testing.T) {
 	if gotErr := sub.WaitStopped(); gotErr != nil {
 		t.Errorf("Stop() got err: (%v)", gotErr)
 	}
+}
+
+func TestSinglePartitionSubscriberMessageQueue(t *testing.T) {
+	subscription := subscriptionPartition{"projects/123456/locations/us-central1-b/subscriptions/my-sub", 0}
+	receiver := newTestBlockingMessageReceiver(t)
+	msg1 := seqMsgWithOffsetAndSize(1, 100)
+	msg2 := seqMsgWithOffsetAndSize(2, 100)
+	msg3 := seqMsgWithOffsetAndSize(3, 100)
+	retryableErr := status.Error(codes.Unavailable, "should retry")
+
+	verifiers := test.NewVerifiers(t)
+
+	subStream1 := test.NewRPCVerifier(t)
+	subStream1.Push(initSubReq(subscription), initSubResp(), nil)
+	subStream1.Push(initFlowControlReq(), msgSubResp(msg1), nil)
+	subStream1.Push(nil, msgSubResp(msg2), nil)
+	subStream1.Push(nil, nil, retryableErr)
+	verifiers.AddSubscribeStream(subscription.Path, subscription.Partition, subStream1)
+
+	// When reconnected, the subscribeStream should seek to msg3 and have
+	// subtracted flow control tokens for msg1 and msg2.
+	subStream2 := test.NewRPCVerifier(t)
+	subStream2.Push(initSubReq(subscription), initSubResp(), nil)
+	subStream2.Push(seekReq(3), nil, nil)
+	subStream2.Push(flowControlSubReq(flowControlTokens{Bytes: 800, Messages: 8}), msgSubResp(msg3), nil)
+	verifiers.AddSubscribeStream(subscription.Path, subscription.Partition, subStream2)
+
+	cmtStream := test.NewRPCVerifier(t)
+	cmtStream.Push(initCommitReq(subscription), initCommitResp(), nil)
+	verifiers.AddCommitStream(subscription.Path, subscription.Partition, cmtStream)
+
+	mockServer.OnTestStart(verifiers)
+	defer mockServer.OnTestEnd()
+
+	sub := newTestSinglePartitionSubscriber(t, receiver.onMessages, subscription)
+	if gotErr := sub.WaitStarted(); gotErr != nil {
+		t.Errorf("Start() got err: (%v)", gotErr)
+	}
+
+	// Verifies that messageDeliveryQueue delivers messages sequentially and waits
+	// for the client message receiver func to return.
+	receiver.ValidateMsg(msg1)
+	receiver.VerifyNoMsgs()
+	receiver.Return()
+
+	receiver.ValidateMsg(msg2)
+	receiver.VerifyNoMsgs()
+	receiver.Return()
+
+	receiver.ValidateMsg(msg3)
+	receiver.VerifyNoMsgs()
+	receiver.Return()
+
+	sub.Stop()
+	if gotErr := sub.WaitStopped(); gotErr != nil {
+		t.Errorf("Stop() got err: (%v)", gotErr)
+	}
+}
+
+func TestSinglePartitionSubscriberStopDuringReceive(t *testing.T) {
+	subscription := subscriptionPartition{"projects/123456/locations/us-central1-b/subscriptions/my-sub", 0}
+	receiver := newTestBlockingMessageReceiver(t)
+	msg1 := seqMsgWithOffsetAndSize(1, 100)
+	msg2 := seqMsgWithOffsetAndSize(2, 100)
+
+	verifiers := test.NewVerifiers(t)
+
+	subStream := test.NewRPCVerifier(t)
+	subStream.Push(initSubReq(subscription), initSubResp(), nil)
+	subStream.Push(initFlowControlReq(), msgSubResp(msg1), nil)
+	subStream.Push(nil, msgSubResp(msg2), nil)
+	verifiers.AddSubscribeStream(subscription.Path, subscription.Partition, subStream)
+
+	cmtStream := test.NewRPCVerifier(t)
+	cmtStream.Push(initCommitReq(subscription), initCommitResp(), nil)
+	verifiers.AddCommitStream(subscription.Path, subscription.Partition, cmtStream)
+
+	mockServer.OnTestStart(verifiers)
+	defer mockServer.OnTestEnd()
+
+	sub := newTestSinglePartitionSubscriber(t, receiver.onMessages, subscription)
+	if gotErr := sub.WaitStarted(); gotErr != nil {
+		t.Errorf("Start() got err: (%v)", gotErr)
+	}
+
+	receiver.ValidateMsg(msg1)
+	receiver.VerifyNoMsgs()
+
+	// Stop the subscriber before returning from the message receiver func.
+	sub.Stop()
+	receiver.Return()
+
+	if gotErr := sub.WaitStopped(); gotErr != nil {
+		t.Errorf("Stop() got err: (%v)", gotErr)
+	}
+	receiver.VerifyNoMsgs() // msg2 should not be received
 }
 
 func newTestMultiPartitionSubscriber(t *testing.T, receiverFunc MessageReceiverFunc, subscriptionPath string, partitions []int) *multiPartitionSubscriber {


### PR DESCRIPTION
Motivation: we want to match the Java Lite implementation, that delivers messages for a partition sequentially and block progress if the user's message receiver func blocks.

Messages were previously delivered to the user receiver func from the goroutine that processes the underlying Subscribe gRPC stream. If the Subscribe stream breaks, a new goroutine is started to handle a new stream instance, so the user's receiver func may be invoked while concurrently processing a previous invocation.

`messageDeliveryQueue` uses a channel to ensure that messages are delivered sequentially for a partition.