### PR TITLE
test(spanner): queries always return at least one partial result set

### DIFF
--- a/spanner/read_test.go
+++ b/spanner/read_test.go
@@ -929,6 +929,11 @@ func TestRsdBlockingStates(t *testing.T) {
 			name:         "unConnected -> queueingRetryable",
 			sql:          "SELECT t.key key, t.value value FROM t_mock t",
 			stateHistory: []resumableStreamDecoderState{queueingRetryable},
+			want: []*sppb.PartialResultSet{
+				{
+					Metadata: kvMeta,
+				},
+			},
 		},
 		{
 			// unConnected->queueingRetryable->queueingRetryable
@@ -1177,7 +1182,7 @@ func TestRsdBlockingStates(t *testing.T) {
 				mutex.Lock()
 				defer mutex.Unlock()
 				if !testEqual(rs, test.want) {
-					t.Fatalf("received PartialResultSets: \n%v\n, want \n%v\n", rs, test.want)
+					t.Fatalf("%s: received PartialResultSets: \n%v\n, want \n%v\n", test.name, rs, test.want)
 				}
 				// Verify that resumableStreamDecoder's internal buffering is also
 				// correct.


### PR DESCRIPTION
Queries will always return at least one partial result set containing the metadata of the query, even if the query does not return any rows. That was not taken into account in one of the test cases.

Fixes #3295