### PR TITLE
chore(internal/gapicgen): upgrade gapic generator to v0.16.0

### DIFF
--- a/internal/gapicgen/cmd/genbot/Dockerfile
+++ b/internal/gapicgen/cmd/genbot/Dockerfile
@@ -33,7 +33,7 @@ RUN GO111MODULE=on go get \
     golang.org/x/lint/golint@latest \
     golang.org/x/tools/cmd/goimports@latest \
     honnef.co/go/tools/cmd/staticcheck@latest \
-    github.com/googleapis/gapic-generator-go/cmd/protoc-gen-go_gapic@v0.15.3
+    github.com/googleapis/gapic-generator-go/cmd/protoc-gen-go_gapic@v0.16.0
 ENV PATH="${PATH}:/root/go/bin"
 
 # Source: http://debuggable.com/posts/disable-strict-host-checking-for-git-clone:49896ff3-0ac0-4263-9703-1eae4834cda3


### PR DESCRIPTION
This most notably will start passing a new internaloption in all
apis to enable them to authenticate with self-signed JWTs if
applicable.