### PR TITLE
fix(internal/gapicgen): don't create genproto pr as draft

### DIFF
--- a/internal/gapicgen/cmd/genbot/github.go
+++ b/internal/gapicgen/cmd/genbot/github.go
@@ -225,7 +225,6 @@ git push origin $BRANCH_NAME
 		Body:  &body,
 		Head:  &head,
 		Base:  &base,
-		Draft: github.Bool(true),
 	})
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
This flag was not intended to be commited and was used for
testing.