### PR TITLE
test(pubsublite): fix flaky subscriber stream tests

### DIFF
--- a/pubsublite/internal/wire/subscriber_test.go
+++ b/pubsublite/internal/wire/subscriber_test.go
@@ -346,16 +346,12 @@ func TestSubscribeStreamDuplicateInitialResponse(t *testing.T) {
 	defer mockServer.OnTestEnd()
 
 	sub := newTestSubscribeStream(t, subscription, testSubscriberSettings(), acks)
-	if gotErr := sub.StartError(); gotErr != nil {
-		t.Errorf("Start() got err: (%v)", gotErr)
-	}
 	if gotErr, wantErr := sub.FinalError(), errInvalidSubscribeResponse; !test.ErrorEqual(gotErr, wantErr) {
 		t.Errorf("Final err: (%v), want: (%v)", gotErr, wantErr)
 	}
 }
 
 func TestSubscribeStreamSpuriousSeekResponse(t *testing.T) {
-	t.Skip("https://github.com/googleapis/google-cloud-go/issues/3329")
 	subscription := subscriptionPartition{"projects/123456/locations/us-central1-b/subscriptions/my-sub", 0}
 	acks := newAckTracker()
 
@@ -369,9 +365,6 @@ func TestSubscribeStreamSpuriousSeekResponse(t *testing.T) {
 	defer mockServer.OnTestEnd()
 
 	sub := newTestSubscribeStream(t, subscription, testSubscriberSettings(), acks)
-	if gotErr := sub.StartError(); gotErr != nil {
-		t.Errorf("Start() got err: (%v)", gotErr)
-	}
 	if gotErr, wantErr := sub.FinalError(), errNoInFlightSeek; !test.ErrorEqual(gotErr, wantErr) {
 		t.Errorf("Final err: (%v), want: (%v)", gotErr, wantErr)
 	}
@@ -391,9 +384,6 @@ func TestSubscribeStreamNoMessages(t *testing.T) {
 	defer mockServer.OnTestEnd()
 
 	sub := newTestSubscribeStream(t, subscription, testSubscriberSettings(), acks)
-	if gotErr := sub.StartError(); gotErr != nil {
-		t.Errorf("Start() got err: (%v)", gotErr)
-	}
 	if gotErr, wantErr := sub.FinalError(), errServerNoMessages; !test.ErrorEqual(gotErr, wantErr) {
 		t.Errorf("Final err: (%v), want: (%v)", gotErr, wantErr)
 	}
@@ -416,9 +406,6 @@ func TestSubscribeStreamMessagesOutOfOrder(t *testing.T) {
 	defer mockServer.OnTestEnd()
 
 	sub := newTestSubscribeStream(t, subscription, testSubscriberSettings(), acks)
-	if gotErr := sub.StartError(); gotErr != nil {
-		t.Errorf("Start() got err: (%v)", gotErr)
-	}
 	sub.Receiver.ValidateMsg(msg1)
 	if gotErr, msg := sub.FinalError(), "start offset = 55, expected >= 57"; !test.ErrorHasMsg(gotErr, msg) {
 		t.Errorf("Final err: (%v), want msg: %q", gotErr, msg)
@@ -442,9 +429,6 @@ func TestSubscribeStreamFlowControlOverflow(t *testing.T) {
 	defer mockServer.OnTestEnd()
 
 	sub := newTestSubscribeStream(t, subscription, testSubscriberSettings(), acks)
-	if gotErr := sub.StartError(); gotErr != nil {
-		t.Errorf("Start() got err: (%v)", gotErr)
-	}
 	sub.Receiver.ValidateMsg(msg1)
 	if gotErr, wantErr := sub.FinalError(), errTokenCounterBytesNegative; !test.ErrorEqual(gotErr, wantErr) {
 		t.Errorf("Final err: (%v), want: (%v)", gotErr, wantErr)


### PR DESCRIPTION
Fixes https://github.com/googleapis/google-cloud-go/issues/3329 and other similar instances.

The subscribeStream transitions to the active state before it terminates, however the state change notifications are sent asynchronously, so they can be received by observers out of order. In these test cases, we expect the subscribeStream to terminate due to fatal error, so it is only necessary to check FinalError().