### PR TITLE
feat(bigquery): add reservation usage stats to query statistics

### DIFF
--- a/bigquery/integration_test.go
+++ b/bigquery/integration_test.go
@@ -1630,6 +1630,63 @@ func TestIntegration_TableUpdate(t *testing.T) {
 	}
 }
 
+func TestIntegration_QueryStatistics(t *testing.T) {
+	// Make a bunch of assertions on a simple query.
+	if client == nil {
+		t.Skip("Integration tests skipped")
+	}
+	ctx := context.Background()
+
+	q := client.Query("SELECT 17 as foo, 3.14 as bar")
+	// disable cache to ensure we have query statistics
+	q.DisableQueryCache = true
+
+	job, err := q.Run(ctx)
+	if err != nil {
+		t.Fatalf("job Run failure: %v", err)
+	}
+	status, err := job.Wait(ctx)
+	if err != nil {
+		t.Fatalf("job Wait failure: %v", err)
+	}
+	if status.Statistics == nil {
+		t.Fatal("expected job statistics, none found")
+	}
+
+	if status.Statistics.NumChildJobs != 0 {
+		t.Errorf("expected no children, %d reported", status.Statistics.NumChildJobs)
+	}
+
+	if status.Statistics.ParentJobID != "" {
+		t.Errorf("expected no parent, but parent present: %s", status.Statistics.ParentJobID)
+	}
+
+	if status.Statistics.Details == nil {
+		t.Fatal("expected job details, none present")
+	}
+
+	qStats, ok := status.Statistics.Details.(*QueryStatistics)
+	if !ok {
+		t.Fatalf("expected query statistics not present")
+	}
+
+	if qStats.CacheHit {
+		t.Error("unexpected cache hit")
+	}
+
+	if qStats.StatementType != "SELECT" {
+		t.Errorf("expected SELECT statement type, got: %s", qStats.StatementType)
+	}
+
+	if len(qStats.QueryPlan) == 0 {
+		t.Errorf("expected query plan, none present")
+	}
+
+	if len(qStats.Timeline) == 0 {
+		t.Errorf("expected query timeline, none present")
+	}
+}
+
 func TestIntegration_Load(t *testing.T) {
 	if client == nil {
 		t.Skip("Integration tests skipped")

--- a/bigquery/integration_test.go
+++ b/bigquery/integration_test.go
@@ -1679,11 +1679,11 @@ func TestIntegration_QueryStatistics(t *testing.T) {
 	}
 
 	if len(qStats.QueryPlan) == 0 {
-		t.Errorf("expected query plan, none present")
+		t.Error("expected query plan, none present")
 	}
 
 	if len(qStats.Timeline) == 0 {
-		t.Errorf("expected query timeline, none present")
+		t.Error("expected query timeline, none present")
 	}
 }
 

--- a/bigquery/job.go
+++ b/bigquery/job.go
@@ -440,7 +440,7 @@ type QueryStatistics struct {
 	// The DDL target table, present only for CREATE/DROP FUNCTION/PROCEDURE queries.
 	DDLTargetRoutine *Routine
 
-	// Information about reservation usage.
+	// ReservationUsage details slot consumption by reservation.
 	ReservationUsage []*ReservationUsage
 }
 
@@ -566,7 +566,7 @@ type QueryTimelineSample struct {
 
 // ReservationUsage contains information about a job's usage of a single reservation.
 type ReservationUsage struct {
-	// Slot-milliseconds the job spent in the given reservation.
+	// SlotMillis reports the slot milliseconds utilized within in the given reservation.
 	SlotMillis int64
 	// Name indicates the utilized reservation name, or "unreserved" for ondemand usage.
 	Name string


### PR DESCRIPTION
This PR plumbs through reservation usage stats reported per-job.

Also added a small integration test for testing query statistics,
as we didn't have one previously.