### PR TITLE
feat(spanner/spansql): support NUMERIC data type

### DIFF
--- a/spanner/spannertest/README.md
+++ b/spanner/spannertest/README.md
@@ -18,6 +18,7 @@ Here's a list of features that are missing or incomplete. It is roughly ordered
 by ascending esotericism:
 
 - expression functions
+- NUMERIC
 - more aggregation functions
 - SELECT HAVING
 - case insensitivity

--- a/spanner/spansql/parser.go
+++ b/spanner/spansql/parser.go
@@ -1650,6 +1650,7 @@ var baseTypes = map[string]TypeBase{
 	"BOOL":      Bool,
 	"INT64":     Int64,
 	"FLOAT64":   Float64,
+	"NUMERIC":   Numeric,
 	"STRING":    String,
 	"BYTES":     Bytes,
 	"DATE":      Date,
@@ -1664,7 +1665,7 @@ func (p *parser) parseType() (Type, *parseError) {
 			ARRAY< scalar_type >
 
 		scalar_type:
-			{ BOOL | INT64 | FLOAT64 | STRING( length ) | BYTES( length ) | DATE | TIMESTAMP }
+			{ BOOL | INT64 | FLOAT64 | NUMERIC | STRING( length ) | BYTES( length ) | DATE | TIMESTAMP }
 		length:
 			{ int64_value | MAX }
 	*/

--- a/spanner/spansql/sql.go
+++ b/spanner/spansql/sql.go
@@ -234,6 +234,8 @@ func (tb TypeBase) SQL() string {
 		return "INT64"
 	case Float64:
 		return "FLOAT64"
+	case Numeric:
+		return "NUMERIC"
 	case String:
 		return "STRING"
 	case Bytes:

--- a/spanner/spansql/types.go
+++ b/spanner/spansql/types.go
@@ -293,7 +293,7 @@ func (Check) isConstraint()   {}
 // Type represents a column type.
 type Type struct {
 	Array bool
-	Base  TypeBase // Bool, Int64, Float64, String, Bytes, Date, Timestamp
+	Base  TypeBase // Bool, Int64, Float64, Numeric, String, Bytes, Date, Timestamp
 	Len   int64    // if Base is String or Bytes; may be MaxLen
 }
 
@@ -306,6 +306,7 @@ const (
 	Bool TypeBase = iota
 	Int64
 	Float64
+	Numeric
 	String
 	Bytes
 	Date


### PR DESCRIPTION
This adds support for NUMERIC as a column data type in CREATE TABLE and
similar constructions. Its support in spannertest remains a TODO.

Fixes #3395.