### PR TITLE
build: typo on if line was issue

### DIFF
--- a/.github/workflows/release-submodule.yaml
+++ b/.github/workflows/release-submodule.yaml
@@ -77,7 +77,7 @@ jobs:
            command: release-pr
       - uses: actions/github-script@v3
         id: label # Adds the "autorelease: pending" label.
-        if: ${{steps.release-please.outputs.pr}})
+        if: ${{steps.release-please.outputs.pr}}
         with:
             github-token: ${{secrets.GITHUB_TOKEN}}
             script: |


### PR DESCRIPTION
I believe this darn typo is why the step wasn't aborting, the string ')' evaluates to `true`.