### PR TITLE
fix(pubsub): fix default stream ack deadline seconds

### DIFF
--- a/pubsub/pullstream.go
+++ b/pubsub/pullstream.go
@@ -48,7 +48,7 @@ func newPullStream(ctx context.Context, streamingPull streamingPullFunc, subName
 			if err == nil {
 				recordStat(ctx, StreamRequestCount, 1)
 				streamAckDeadline := int32(maxDurationPerLeaseExtension / time.Second)
-				// By default, maxDurationPerLeaseExtension (aka MaxExtensionPeriod) is 0 (off),
+				// By default, maxDurationPerLeaseExtension, aka MaxExtensionPeriod, is disabled,
 				// so in these cases, use a healthy default of 60 seconds.
 				if streamAckDeadline <= 0 {
 					streamAckDeadline = 60

--- a/pubsub/pullstream.go
+++ b/pubsub/pullstream.go
@@ -54,8 +54,7 @@ func newPullStream(ctx context.Context, streamingPull streamingPullFunc, subName
 					streamAckDeadline = 60
 				}
 				err = spc.Send(&pb.StreamingPullRequest{
-					Subscription: subName,
-					// We modack messages when we receive them, so this value doesn't matter too much.
+					Subscription:             subName,
 					StreamAckDeadlineSeconds: streamAckDeadline,
 					MaxOutstandingMessages:   int64(maxOutstandingMessages),
 					MaxOutstandingBytes:      int64(maxOutstandingBytes),

--- a/pubsub/pullstream.go
+++ b/pubsub/pullstream.go
@@ -47,10 +47,16 @@ func newPullStream(ctx context.Context, streamingPull streamingPullFunc, subName
 			spc, err := streamingPull(ctx, gax.WithGRPCOptions(grpc.MaxCallRecvMsgSize(maxSendRecvBytes)))
 			if err == nil {
 				recordStat(ctx, StreamRequestCount, 1)
+				streamAckDeadline := int32(maxDurationPerLeaseExtension / time.Second)
+				// By default, maxDurationPerLeaseExtension (aka MaxExtensionPeriod) is 0 (off),
+				// so in these cases, use a healthy default of 60 seconds.
+				if streamAckDeadline <= 0 {
+					streamAckDeadline = 60
+				}
 				err = spc.Send(&pb.StreamingPullRequest{
 					Subscription: subName,
 					// We modack messages when we receive them, so this value doesn't matter too much.
-					StreamAckDeadlineSeconds: int32(maxDurationPerLeaseExtension / time.Second),
+					StreamAckDeadlineSeconds: streamAckDeadline,
 					MaxOutstandingMessages:   int64(maxOutstandingMessages),
 					MaxOutstandingBytes:      int64(maxOutstandingBytes),
 				})


### PR DESCRIPTION
A error was made in #3367 when using the default MaxExtensionPeriod of 0 seconds. This also made the default stream ack deadline seconds 0, which means messages will always expire and messages will never be successfully delivered. This PR reverts to the previous default of 60 seconds if MaxExtensionPeriod is disabled.

This issue fixes #3397, fixes #3398, fixes #3399 

