### PR TITLE
feat(spanner/spannertest): implement SELECT ... FROM UNNEST(...)

### DIFF
--- a/spanner/spannertest/integration_test.go
+++ b/spanner/spannertest/integration_test.go
@@ -890,10 +890,12 @@ func TestIntegration_ReadsAndQueries(t *testing.T) {
 			},
 		},
 		{
-			`SELECT AVG(Height) FROM Staff WHERE ID <= 2`,
-			nil,
+			// From https://cloud.google.com/spanner/docs/aggregate_functions#avg
+			// but using a param for the array since array literals aren't supported yet.
+			`SELECT AVG(x) AS avg FROM UNNEST(@p) AS x`,
+			map[string]interface{}{"p": []int64{0, 2, 4, 4, 5}},
 			[][]interface{}{
-				{float64(1.84)},
+				{float64(3)},
 			},
 		},
 		{

--- a/spanner/spansql/parser_test.go
+++ b/spanner/spansql/parser_test.go
@@ -190,6 +190,17 @@ func TestParseQuery(t *testing.T) {
 				},
 			},
 		},
+		{`SELECT * FROM UNNEST (@p) AS data`, // array literals aren't yet supported
+			Query{
+				Select: Select{
+					List: []Expr{Star},
+					From: []SelectFrom{SelectFromUnnest{
+						Expr:  Param("p"),
+						Alias: ID("data"),
+					}},
+				},
+			},
+		},
 	}
 	for _, test := range tests {
 		got, err := ParseQuery(test.in)

--- a/spanner/spansql/sql.go
+++ b/spanner/spansql/sql.go
@@ -345,6 +345,14 @@ var joinTypes = map[JoinType]string{
 	RightJoin: "RIGHT",
 }
 
+func (sfu SelectFromUnnest) SQL() string {
+	str := "UNNEST(" + sfu.Expr.SQL() + ")"
+	if sfu.Alias != "" {
+		str += " AS " + sfu.Alias.SQL()
+	}
+	return str
+}
+
 func (o Order) SQL() string { return buildSQL(o) }
 func (o Order) addSQL(sb *strings.Builder) {
 	o.Expr.addSQL(sb)

--- a/spanner/spansql/types.go
+++ b/spanner/spansql/types.go
@@ -392,6 +392,17 @@ const (
 	RightJoin
 )
 
+// SelectFromUnnest is a SelectFrom that yields a virtual table from an array.
+// https://cloud.google.com/spanner/docs/query-syntax#unnest
+type SelectFromUnnest struct {
+	Expr  Expr
+	Alias ID // empty if not aliased
+
+	// TODO: Implicit
+}
+
+func (SelectFromUnnest) isSelectFrom() {}
+
 // TODO: SelectFromSubquery, etc.
 
 type Order struct {


### PR DESCRIPTION
This does not implement array literals, but now arrays provided as query
parameters may be used as SELECT targets.

Fixes #3296.