### PR TITLE
build: use the alternate CHANGELOG name

### DIFF
--- a/.github/workflows/release-submodule.yaml
+++ b/.github/workflows/release-submodule.yaml
@@ -101,6 +101,7 @@ jobs:
         id: tag-release
         with:
           path: ${{ matrix.package }}
+          changelog-path: CHANGES.md
           token: ${{ secrets.GITHUB_TOKEN }}
           release-type: go
           monorepo-tags: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,6 +42,7 @@ jobs:
           release-type: go
           package-name: google-cloud-go
           command: github-release
+          changelog-path: CHANGES.md
       # Add the "autorelease: published" and remove tagged, this allows
       # monitoring to be enabled that detects failed releases:
       - uses: actions/github-script@v3


### PR DESCRIPTION
Go uses the name `CHANGES.md` rather than `CHANGELOG.md`.