### PR TITLE
bigtable: Only test data operation for DirectPath integration tests

### DIFF
--- a/bigtable/integration_test.go
+++ b/bigtable/integration_test.go
@@ -2255,7 +2255,6 @@ func verifyDirectPathRemoteAddress(testEnv IntegrationEnv, t *testing.T) {
 
 func isDirectPathRemoteAddress(testEnv IntegrationEnv) (_ string, _ bool) {
 	remoteIP := testEnv.Peer().Addr.String()
-	fmt.Println("Peer IP = " + remoteIP)
 	// DirectPath ipv4-only can only use ipv4 traffic.
 	if testEnv.Config().DirectPathIPV4Only {
 		return remoteIP, strings.HasPrefix(remoteIP, directPathIPV4Prefix)

--- a/bigtable/integration_test.go
+++ b/bigtable/integration_test.go
@@ -2159,33 +2159,13 @@ func setupIntegration(ctx context.Context, t *testing.T) (_ IntegrationEnv, _ *C
 		return nil, nil, nil, nil, "", "", nil, err
 	}
 
-	//if err := adminClient.CreateTable(ctx, testEnv.Config().Table); err != nil {
-	//  cancel()
-	//  return nil, nil, nil, nil, "", nil, err
-	//}
-	//if err := adminClient.CreateColumnFamily(ctx, testEnv.Config().Table, directPathFamilyID); err != nil {
-	//  cancel()
-	//  return nil, nil, nil, nil, "", nil, err
-	//}
-
-	// Do some check here
-	//aaa, _ := adminClient.Tables(ctx)
-	//for _, s := range aaa {
-	//  fmt.Println("table = " + s)
-	//}
-
-	//tableinfo, _ := adminClient.TableInfo(ctx, testEnv.Config().Table)
-	//for _, s := range tableinfo.Families {
-	//  fmt.Println("family = " + s)
-	//}
-
 	// DirectPath integration test must ben run with a pre-existing table with a pre-existing column family "cf"
 	if testEnv.Config().AttemptDirectPath {
 		tableName = testEnv.Config().Table
 		return testEnv, client, adminClient, client.Open(tableName), tableName, directPathFamilyID, func() {
-      if err := adminClient.DropAllRows(ctx, tableName); err != nil {
-        t.Errorf("DropAllRoes got error %v", err)
-      }
+			if err := adminClient.DropAllRows(ctx, tableName); err != nil {
+				t.Errorf("DropAllRoes got error %v", err)
+			}
 			client.Close()
 			adminClient.Close()
 		}, nil

--- a/bigtable/integration_test.go
+++ b/bigtable/integration_test.go
@@ -2183,6 +2183,9 @@ func setupIntegration(ctx context.Context, t *testing.T) (_ IntegrationEnv, _ *C
 	if testEnv.Config().AttemptDirectPath {
 		tableName = testEnv.Config().Table
 		return testEnv, client, adminClient, client.Open(tableName), tableName, directPathFamilyID, func() {
+      if err := adminClient.DropAllRows(ctx, tableName); err != nil {
+        t.Errorf("DropAllRoes got error %v", err)
+      }
 			client.Close()
 			adminClient.Close()
 		}, nil


### PR DESCRIPTION
Because bigtable resources on TEST environment is very limited, we have to use bigtable instances on project "autonomous-mote-782". At the same time, VMs used for directpath auto tests must belong to project "directpath-pilot-testing". As a result, currently we are only able to test bigtable data client operations. This PR updates the integration test to run DirectPath tests without creating Table or ColumnFamily.