### PR TITLE
refactor(pubsublite): remove messageDeliveryQueue buffer limit

### DIFF
--- a/pubsublite/internal/wire/subscriber.go
+++ b/pubsublite/internal/wire/subscriber.go
@@ -44,8 +44,6 @@ type ReceivedMessage struct {
 // MessageReceiverFunc receives a Pub/Sub message from a topic partition.
 type MessageReceiverFunc func(*ReceivedMessage)
 
-const maxMessageBufferSize = 10000
-
 // messageDeliveryQueue delivers received messages to the client-provided
 // MessageReceiverFunc sequentially.
 type messageDeliveryQueue struct {
@@ -57,12 +55,6 @@ type messageDeliveryQueue struct {
 }
 
 func newMessageDeliveryQueue(acks *ackTracker, receiver MessageReceiverFunc, bufferSize int) *messageDeliveryQueue {
-	// The buffer size is based on ReceiveSettings.MaxOutstandingMessages. But
-	// ensure there's a reasonable limit as channel buffer capacity is allocated
-	// on creation.
-	if bufferSize > maxMessageBufferSize {
-		bufferSize = maxMessageBufferSize
-	}
 	return &messageDeliveryQueue{
 		acks:      acks,
 		receiver:  receiver,
@@ -85,11 +77,9 @@ func (mq *messageDeliveryQueue) Stop() {
 	}
 }
 
-func (mq *messageDeliveryQueue) Add(messages []*ReceivedMessage) {
+func (mq *messageDeliveryQueue) Add(msg *ReceivedMessage) {
 	if mq.status == serviceActive {
-		for _, msg := range messages {
-			mq.messagesC <- msg
-		}
+		mq.messagesC <- msg
 	}
 }
 
@@ -129,9 +119,9 @@ type subscribeStream struct {
 	settings     ReceiveSettings
 	subscription subscriptionPartition
 	initialReq   *pb.SubscribeRequest
-	messageQueue *messageDeliveryQueue
 
 	// Fields below must be guarded with mu.
+	messageQueue    *messageDeliveryQueue
 	stream          *retryableStream
 	offsetTracker   subscriberOffsetTracker
 	flowControl     flowControlBatcher
@@ -281,12 +271,10 @@ func (s *subscribeStream) unsafeOnMessageResponse(response *pb.MessageResponse) 
 		return err
 	}
 
-	var receivedMsgs []*ReceivedMessage
 	for _, msg := range response.Messages {
 		ack := newAckConsumer(msg.GetCursor().GetOffset(), msg.GetSizeBytes(), s.onAck)
-		receivedMsgs = append(receivedMsgs, &ReceivedMessage{Msg: msg, Ack: ack})
+		s.messageQueue.Add(&ReceivedMessage{Msg: msg, Ack: ack})
 	}
-	s.messageQueue.Add(receivedMsgs)
 	return nil
 }
 

--- a/pubsublite/internal/wire/subscriber_test.go
+++ b/pubsublite/internal/wire/subscriber_test.go
@@ -145,7 +145,7 @@ func TestMessageDeliveryQueue(t *testing.T) {
 	t.Run("Add before start", func(t *testing.T) {
 		msg1 := seqMsgWithOffset(1)
 		ack1 := newAckConsumer(1, 0, nil)
-		messageQueue.Add([]*ReceivedMessage{{Msg: msg1, Ack: ack1}})
+		messageQueue.Add(&ReceivedMessage{Msg: msg1, Ack: ack1})
 
 		receiver.VerifyNoMsgs()
 	})
@@ -158,10 +158,8 @@ func TestMessageDeliveryQueue(t *testing.T) {
 
 		messageQueue.Start()
 		messageQueue.Start() // Check duplicate starts
-		messageQueue.Add([]*ReceivedMessage{
-			{Msg: msg2, Ack: ack2},
-			{Msg: msg3, Ack: ack3},
-		})
+		messageQueue.Add(&ReceivedMessage{Msg: msg2, Ack: ack2})
+		messageQueue.Add(&ReceivedMessage{Msg: msg3, Ack: ack3})
 
 		receiver.ValidateMsg(msg2)
 		receiver.ValidateMsg(msg3)
@@ -173,7 +171,7 @@ func TestMessageDeliveryQueue(t *testing.T) {
 
 		messageQueue.Stop()
 		messageQueue.Stop() // Check duplicate stop
-		messageQueue.Add([]*ReceivedMessage{{Msg: msg4, Ack: ack4}})
+		messageQueue.Add(&ReceivedMessage{Msg: msg4, Ack: ack4})
 
 		receiver.VerifyNoMsgs()
 	})


### PR DESCRIPTION
If the `messageDeliveryQueue` channel buffer is full, adding more messages to the channel will block while holding the `subscriberStream` mutex. The only potential problem is that subscriber client shut down is delayed until the mutex can be acquired.

This can only occur if the user sets MaxOutstandingMessages to be greater than 10000 (default value is 1000). So we'll just remove the clipping of the message buffer size, so that it's guaranteed to hold all MaxOutstandingMessages and not block.

The downside is that if users do set a very large MaxOutstandingMessages value (which is unlikely), channel buffer capacity will be preallocated. Otherwise we can introduce a second mutex, at the cost of additional code complexity.

Also minor: removed a pointless intermediate `ReceivedMessage` slice leftover from refactoring.