### PR TITLE
ci(all): continuous job to only run root & changed submodule tests

### DIFF
--- a/cmd/go-cloud-debug-agent/internal/debug/dwarf/frame_test.go
+++ b/cmd/go-cloud-debug-agent/internal/debug/dwarf/frame_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build linux
+
 package dwarf_test
 
 import (

--- a/cmd/go-cloud-debug-agent/internal/debug/dwarf/pclntab_test.go
+++ b/cmd/go-cloud-debug-agent/internal/debug/dwarf/pclntab_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build go1.10
+// +build linux,go1.10
 
 package dwarf_test
 

--- a/cmd/go-cloud-debug-agent/internal/debug/gosym/pclntab_test.go
+++ b/cmd/go-cloud-debug-agent/internal/debug/gosym/pclntab_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build linux
+
 package gosym
 
 import (

--- a/cmd/go-cloud-debug-agent/internal/debug/remote/remote.go
+++ b/cmd/go-cloud-debug-agent/internal/debug/remote/remote.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build linux
+
 // Package remote provides remote access to a debugproxy server.
 package remote
 

--- a/httpreplay/cmd/httpr/integration_test.go
+++ b/httpreplay/cmd/httpr/integration_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build linux
+
 package main_test
 
 import (

--- a/internal/gapicgen/cmd/genbot/Dockerfile
+++ b/internal/gapicgen/cmd/genbot/Dockerfile
@@ -33,7 +33,7 @@ RUN GO111MODULE=on go get \
     golang.org/x/lint/golint@latest \
     golang.org/x/tools/cmd/goimports@latest \
     honnef.co/go/tools/cmd/staticcheck@latest \
-    github.com/googleapis/gapic-generator-go/cmd/protoc-gen-go_gapic@v0.16.0
+    github.com/googleapis/gapic-generator-go/cmd/protoc-gen-go_gapic@v0.17.0
 ENV PATH="${PATH}:/root/go/bin"
 
 # Source: http://debuggable.com/posts/disable-strict-host-checking-for-git-clone:49896ff3-0ac0-4263-9703-1eae4834cda3

--- a/internal/gapicgen/cmd/genbot/README.md
+++ b/internal/gapicgen/cmd/genbot/README.md
@@ -16,8 +16,10 @@ information on how that's done can be found here:
 Note: this may change your `~/.gitconfig`, `~/.gitcookies`, and use up
 non-trivial amounts of space on your computer.
 
-1. Make sure you have all the tools installed listed in genlocal's README.md
-2. Run:
+1. Make sure you are on a non-Windows platform. If you are using windows
+   continue on to the docker instructions.
+2. Make sure you have all the tools installed listed in genlocal's README.md
+3. Run:
 
 ```shell
 cd /path/to/internal/gapicgen

--- a/internal/gapicgen/cmd/genbot/generate.go
+++ b/internal/gapicgen/cmd/genbot/generate.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build !windows
+
 package main
 
 import (

--- a/internal/gapicgen/cmd/genbot/github.go
+++ b/internal/gapicgen/cmd/genbot/github.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build !windows
+
 package main
 
 import (

--- a/internal/gapicgen/cmd/genbot/main.go
+++ b/internal/gapicgen/cmd/genbot/main.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build !windows
+
 // genbot is a binary for generating gapics and creating CLs/PRs with the results.
 // It is intended to be used as a bot, though it can be run locally too.
 package main

--- a/internal/gapicgen/cmd/genbot/update.go
+++ b/internal/gapicgen/cmd/genbot/update.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build !windows
+
 package main
 
 import (

--- a/internal/gapicgen/cmd/genlocal/README.md
+++ b/internal/gapicgen/cmd/genlocal/README.md
@@ -6,25 +6,29 @@ run generators against googleapis-private, and various other local tasks.
 
 ## Required tools
 
-1. Install [docker](https://www.docker.com/get-started)
-1. Install [protoc](https://github.com/protocolbuffers/protobuf/releases)
-1. Install [Go](http://golang.org/dl)
-1. Install python3, pip3
-1. Install virtualenv `pip3 install virtualenv`
-1. Install Go tools:
+*Note*: If you are on a Windows platform you will need to install these tools
+in a linux docker container: [Install docker](https://www.docker.com/get-started)
 
-    ```
-    go get \
-        github.com/golang/protobuf/protoc-gen-go \
-        golang.org/x/lint/golint \
-        golang.org/x/tools/cmd/goimports \
-        honnef.co/go/tools/cmd/staticcheck \
-        github.com/googleapis/gapic-generator-go/cmd/protoc-gen-go_gapic
-    ```
+1. Install [protoc](https://github.com/protocolbuffers/protobuf/releases)
+2. Install [Go](http://golang.org/dl)
+3. Install python3, pip3
+4. Install virtualenv `pip3 install virtualenv`
+5. Install Go tools:
+
+```bash
+go get \
+    github.com/golang/protobuf/protoc-gen-go \
+    golang.org/x/lint/golint \
+    golang.org/x/tools/cmd/goimports \
+    honnef.co/go/tools/cmd/staticcheck \
+    github.com/googleapis/gapic-generator-go/cmd/protoc-gen-go_gapic
+```
 
 ## Running
 
-```
-cd /path/to/internal/gapicgen
+`git clone` this project if you don't already have it checked-out locally.
+
+```bash
+cd /path/to/google-cloud-go/internal/gapicgen
 go run cloud.google.com/go/internal/gapicgen/cmd/genlocal
 ```

--- a/internal/gapicgen/cmd/genlocal/main.go
+++ b/internal/gapicgen/cmd/genlocal/main.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build !windows
+
 // genlocal is a binary for generating gapics locally. It may be used to test out
 // new changes, test the generation of a new library, test new generator tweaks,
 // run generators against googleapis-private, and various other local tasks.

--- a/internal/gapicgen/generator/generator.go
+++ b/internal/gapicgen/generator/generator.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build !windows
+
 // Package generator provides tools for generating clients.
 package generator
 

--- a/internal/gapicgen/tools.go
+++ b/internal/gapicgen/tools.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build !windows
+
 // Package gapicgen provides some helpers for gapicgen binaries.
 package gapicgen
 

--- a/internal/godocfx/main.go
+++ b/internal/godocfx/main.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build go1.15
+// +build linux,go1.15
 
 /*Command godocfx generates DocFX YAML for Go code.
 

--- a/internal/kokoro/continuous.sh
+++ b/internal/kokoro/continuous.sh
@@ -17,6 +17,7 @@ export GOOGLE_APPLICATION_CREDENTIALS=$KOKORO_KEYSTORE_DIR/72523_go_integration_
 # Removing the GCLOUD_TESTS_GOLANG_PROJECT_ID setting may make some integration
 # tests (like profiler's) silently skipped, so make sure you know what you are
 # doing when changing / removing the next line.
+
 export GCLOUD_TESTS_GOLANG_PROJECT_ID=dulcet-port-762
 export GCLOUD_TESTS_GOLANG_KEY=$GOOGLE_APPLICATION_CREDENTIALS
 export GCLOUD_TESTS_GOLANG_FIRESTORE_PROJECT_ID=gcloud-golang-firestore-tests
@@ -53,23 +54,88 @@ try3 go mod download
 go install github.com/jstemmer/go-junit-report
 ./internal/kokoro/vet.sh
 
+# Continuous jobs only run root tests & tests in submodules changed by the PR
+# Nightly jobs run all tests in all submodules
+SIGNIFICANT_CHANGES=$(git --no-pager diff --name-only master..HEAD | grep -Ev '(\.md$|^\.github)' || true)
+# CHANGED_DIRS is the list of significant top-level directories that changed,
+# but weren't deleted by the current PR.
+# CHANGED_DIRS will be empty when run on master.
+CHANGED_DIRS=$(echo "$SIGNIFICANT_CHANGES" | tr ' ' '\n' | grep "/" | cut -d/ -f1 | sort -u | tr '\n' ' ' | xargs ls -d 2>/dev/null || true)
+
+# List all modules in changed directories.
+# If running on master will collect all modules in the repo, including the root module.
+# shellcheck disable=SC2086
+GO_CHANGED_MODULES="$(find ${CHANGED_DIRS:-.} -name go.mod)"
+# If we didn't find any modules, use the root module.
+GO_CHANGED_MODULES=${GO_CHANGED_MODULES:-./go.mod}
+# Exclude the root module, if present, from the list of sub-modules.
+GO_CHANGED_SUBMODULES=${GO_CHANGED_MODULES#./go.mod}
+
+# Override to determine if all go tests should be run.
+# Does not include static analysis checks.
+RUN_ALL_TESTS="0"
+# If this is a nightly test (not a PR), run all tests.
+if [ -z "${KOKORO_GITHUB_PULL_REQUEST_NUMBER:-}" ]; then
+  RUN_ALL_TESTS="0"
+# If the change touches a repo-spanning file or directory of significance, run all tests.
+elif echo "$SIGNIFICANT_CHANGES" | tr ' ' '\n' | grep "^go.mod$" || [[ $CHANGED_DIRS =~ "internal" ]]; then
+  RUN_ALL_TESTS="1"
+fi
+
+# runTests runs the tests in the current directory. If an argument is specified,
+# it is used as the argument to `go test`.
+runTests() {
+  go test -race -v -timeout 45m "${1:-./...}" 2>&1 \
+    | tee sponge_log.log
+  # Takes the kokoro output log (raw stdout) and creates a machine-parseable
+  # xUnit XML file.
+  cat sponge_log.log \
+    | go-junit-report -set-exit-code > sponge_log.xml
+  # Add the exit codes together so we exit non-zero if any module fails.
+  exit_code=$(($exit_code + $?))
+}
+
 set +e # Run all tests, don't stop after the first failure.
 exit_code=0
-# Run tests and tee output to log file, to be pushed to GCS as artifact.
-for i in `find . -name go.mod`; do
-  pushd `dirname $i`;
-    go test -race -v -timeout 45m ./... 2>&1 \
-      | tee sponge_log.log
-    # Takes the kokoro output log (raw stdout) and creates a machine-parseable
-    # xUnit XML file.
-    cat sponge_log.log \
-      | go-junit-report -set-exit-code > sponge_log.xml
-    # Add the exit codes together so we exit non-zero if any module fails.
-    exit_code=$(($exit_code + $?))
-  popd;
-done
 
-if [[ $KOKORO_BUILD_ARTIFACTS_SUBDIR = *"continuous"* ]]; then
+if [[ $RUN_ALL_TESTS = "1" ]]; then
+  echo "Running all tests"
+  # shellcheck disable=SC2044
+  for i in $(find . -name go.mod); do
+    pushd "$(dirname "$i")" > /dev/null;
+      runTests
+    popd > /dev/null;
+  done
+elif [[ -z "${CHANGED_DIRS// }" ]]; then
+  echo "Only running root tests"
+  runTests .
+else
+  runTests . # Always run root tests.
+  echo "Running tests in modified directories: $CHANGED_DIRS"
+  for d in $CHANGED_DIRS; do
+    mods=$(find "$d" -name go.mod)
+    # If there are no modules, just run the tests directly.
+    if [[ -z "$mods" ]]; then
+      pushd "$d" > /dev/null;
+        runTests
+      popd > /dev/null;
+    # Otherwise, run the tests in all Go directories. This way, we don't have to
+    # check to see if there are tests that aren't in a sub-module.
+    else
+      goDirectories="$(find "$d" -name "*.go" -printf "%h\n" | sort -u)"
+      goDirectories=""
+      if [[ -n "$goDirectories" ]]; then
+        for gd in $goDirectories; do
+          pushd "$gd" > /dev/null;
+            runTests .
+          popd > /dev/null;
+        done
+      fi
+    fi
+  done
+fi
+
+if [[ $KOKORO_BUILD_ARTIFACTS_SUBDIR = *"continuous"* ]] || [[ $KOKORO_BUILD_ARTIFACTS_SUBDIR = *"nightly"* ]]; then
   chmod +x $KOKORO_GFILE_DIR/linux_amd64/buildcop
   $KOKORO_GFILE_DIR/linux_amd64/buildcop -logs_dir=$GOCLOUD_HOME \
     -repo=googleapis/google-cloud-go \

--- a/internal/pretty/diff.go
+++ b/internal/pretty/diff.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build linux
+
 package pretty
 
 import (

--- a/profiler/integration_test.go
+++ b/profiler/integration_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build linux
+
 package profiler
 
 import (

--- a/pubsublite/CHANGES.md
+++ b/pubsublite/CHANGES.md
@@ -1,5 +1,20 @@
 # Changes
 
+## [0.5.0](https://www.github.com/googleapis/google-cloud-go/compare/v0.4.0...v0.5.0) (2021-01-07)
+
+
+### Features
+
+* **pubsublite:** add client library metadata to headers ([#3458](https://www.github.com/googleapis/google-cloud-go/issues/3458)) ([8226811](https://www.github.com/googleapis/google-cloud-go/commit/822681105bc13f1e1f0784c4557faf849c1110b4))
+* **pubsublite:** publisher client ([#3303](https://www.github.com/googleapis/google-cloud-go/issues/3303)) ([1648ea0](https://www.github.com/googleapis/google-cloud-go/commit/1648ea06bbb08c3452f79551a9d45147379f13e4))
+* **pubsublite:** settings and message transforms for Cloud Pub/Sub shim ([#3281](https://www.github.com/googleapis/google-cloud-go/issues/3281)) ([74923c2](https://www.github.com/googleapis/google-cloud-go/commit/74923c27efd7936b3e18cd8ccb72882a40c7ff42))
+* **pubsublite:** subscriber client ([#3442](https://www.github.com/googleapis/google-cloud-go/issues/3442)) ([221bfba](https://www.github.com/googleapis/google-cloud-go/commit/221bfbae54107486ab9060b950081faa27489d1c))
+
+
+### Bug Fixes
+
+* **pubsublite:** return an error if no topic or subscription fields were updated ([#3502](https://www.github.com/googleapis/google-cloud-go/issues/3502)) ([a875969](https://www.github.com/googleapis/google-cloud-go/commit/a87596942d39fbfe47427c007e4029bd9be2ca0e))
+
 ## [0.4.0](https://www.github.com/googleapis/google-cloud-go/compare/pubsublite/v0.3.0...v0.4.0) (2020-12-09)
 
 

--- a/pubsublite/README.md
+++ b/pubsublite/README.md
@@ -1,6 +1,76 @@
-## Cloud Pub/Sub Lite [![GoDoc](https://godoc.org/cloud.google.com/go/pubsublite?status.svg)](https://godoc.org/cloud.google.com/go/pubsublite)
+## Cloud Pub/Sub Lite [![GoDoc](https://godoc.org/cloud.google.com/go/pubsublite?status.svg)](https://pkg.go.dev/cloud.google.com/go/pubsublite)
 
-- [About Cloud Pub/Sub Lite](https://cloud.google.com/pubsub/lite/docs)
+- [About Cloud Pub/Sub Lite](https://cloud.google.com/pubsub/lite)
+- [Client library documentation](https://cloud.google.com/pubsub/lite/docs/reference/libraries)
+- [API documentation](https://cloud.google.com/pubsub/lite/docs/apis)
+- [Go client documentation](https://pkg.go.dev/cloud.google.com/go/pubsublite)
 
-*This library is under development and will not provide a delightful user
-experience until v1.0.0 has been released.*
+*This library is in ALPHA. Backwards-incompatible changes may be made before
+ stable v1.0.0 is released.*
+
+### Example Usage
+
+[snip]:# (imports)
+```go
+import (
+	"cloud.google.com/go/pubsub"
+	"cloud.google.com/go/pubsublite"
+	"cloud.google.com/go/pubsublite/ps"
+)
+```
+
+To publish messages to a topic:
+
+[snip]:# (publish)
+```go
+// Create a PublisherClient for topic1.
+// See https://cloud.google.com/pubsub/lite/docs/locations for available zones.
+topic := pubsublite.TopicPath{
+    Project: "project-id",
+    Zone:    "us-central1-b",
+    TopicID: "topic1",
+}
+publisher, err := ps.NewPublisherClient(ctx, ps.DefaultPublishSettings, topic)
+if err != nil {
+    log.Fatal(err)
+}
+
+// Publish "hello world".
+res := publisher.Publish(ctx, &pubsub.Message{
+	Data: []byte("hello world"),
+})
+// The publish happens asynchronously.
+// Later, you can get the result from res:
+...
+msgID, err := res.Get(ctx)
+if err != nil {
+	log.Fatal(err)
+}
+```
+
+To receive messages for a subscription:
+
+[snip]:# (subscribe)
+```go
+// Create a SubscriberClient for subscription1.
+subscription := pubsublite.SubscriptionPath{
+    Project:        "project-id",
+    Zone:           "us-central1-b",
+    SubscriptionID: "subscription1",
+}
+subscriber, err := ps.NewSubscriberClient(ctx, ps.DefaultReceiveSettings, subscription)
+if err != nil {
+	log.Fatal(err)
+}
+
+// Use a callback to receive messages.
+// Call cancel() to stop receiving messages.
+cctx, cancel := context.WithCancel(ctx)
+err = subscriber.Receive(cctx, func(ctx context.Context, m *pubsub.Message) {
+	fmt.Println(m.Data)
+	m.Ack() // Acknowledge that we've consumed the message.
+})
+if err != nil {
+	log.Println(err)
+}
+```

--- a/pubsublite/admin_test.go
+++ b/pubsublite/admin_test.go
@@ -95,6 +95,10 @@ func TestAdminTopicCRUD(t *testing.T) {
 		t.Errorf("UpdateTopic() got: %v\nwant: %v", gotConfig, topicConfig)
 	}
 
+	if _, err := admin.UpdateTopic(ctx, TopicConfigToUpdate{}); !test.ErrorEqual(err, errNoTopicFieldsUpdated) {
+		t.Errorf("UpdateTopic() got err: (%v), want err: (%v)", err, errNoTopicFieldsUpdated)
+	}
+
 	if gotConfig, err := admin.Topic(ctx, topicPath); err != nil {
 		t.Errorf("Topic() got err: %v", err)
 	} else if !testutil.Equal(gotConfig, &topicConfig) {
@@ -294,6 +298,10 @@ func TestAdminSubscriptionCRUD(t *testing.T) {
 		t.Errorf("UpdateSubscription() got err: %v", err)
 	} else if !testutil.Equal(gotConfig, &subscriptionConfig) {
 		t.Errorf("UpdateSubscription() got: %v\nwant: %v", gotConfig, subscriptionConfig)
+	}
+
+	if _, err := admin.UpdateSubscription(ctx, SubscriptionConfigToUpdate{}); !test.ErrorEqual(err, errNoSubscriptionFieldsUpdated) {
+		t.Errorf("UpdateSubscription() got err: (%v), want err: (%v)", err, errNoSubscriptionFieldsUpdated)
 	}
 
 	if gotConfig, err := admin.Subscription(ctx, subscriptionPath); err != nil {

--- a/pubsublite/doc.go
+++ b/pubsublite/doc.go
@@ -12,13 +12,145 @@
 // See the License for the specific language governing permissions and
 
 /*
-Package pubsublite provides an interface for publishing and receiving messages
-using Google Pub/Sub Lite.
+Package pubsublite provides an easy way to publish and receive messages using
+Google Cloud Pub/Sub Lite.
 
-More information about Google Pub/Sub Lite is available at
+Google Cloud Pub/Sub is designed to provide reliable, many-to-many, asynchronous
+messaging between applications. Publisher applications can send messages to a
+topic and other applications can subscribe to that topic to receive the
+messages. By decoupling senders and receivers, Google Cloud Pub/Sub allows
+developers to communicate between independently written applications.
+
+Compared to Google Cloud Pub/Sub, Pub/Sub Lite provides partitioned zonal data
+storage with predefined throughput and storage capacity. Guidance on how to
+choose between Google Cloud Pub/Sub and Pub/Sub Lite is available at
+https://cloud.google.com/pubsub/docs/choosing-pubsub-or-lite.
+
+More information about Google Cloud Pub/Sub Lite is available at
 https://cloud.google.com/pubsub/lite.
 
-This library is under development and will not provdie a delightful user
-experience until v1.0.0 has been released.
+See https://godoc.org/cloud.google.com/go for authentication, timeouts,
+connection pooling and similar aspects of this package.
+
+Note: This library is in ALPHA. Backwards-incompatible changes may be made
+before stable v1.0.0 is released.
+
+
+Creating Topics
+
+Messages are published to topics. Cloud Pub/Sub Lite topics may be created like
+so (error handling omitted for brevity):
+
+  topicPath := pubsublite.TopicPath{
+    Project: "project-id",
+    Zone:    "zone",
+    TopicID: "topic-id",
+  }
+  topicConfig := pubsublite.TopicConfig{
+    Name:                       topicPath,
+    PartitionCount:             1,
+    PublishCapacityMiBPerSec:   4,
+    SubscribeCapacityMiBPerSec: 4,
+    PerPartitionBytes:          30 * 1024 * 1024 * 1024,  // 30 GiB
+    RetentionDuration:          pubsublite.InfiniteRetention,
+  }
+
+  region, err := pubsublite.ZoneToRegion(topicPath.Zone)
+  adminClient, err := pubsublite.NewAdminClient(ctx, region)
+  _, err = adminClient.CreateTopic(ctx, topicConfig)
+
+See https://cloud.google.com/pubsub/lite/docs/topics for more information about
+how Cloud Pub/Sub Lite topics are configured.
+
+
+Publishing
+
+The pubsublite/ps subpackage contains clients for publishing and receiving
+messages, which have similar interfaces to their Topic and Subscription
+counterparts in the pubsub package. Cloud Pub/Sub Lite uses gRPC streams
+extensively for high throughput. For more differences, see
+https://godoc.org/cloud.google.com/go/pubsublite/ps.
+
+To publish messages to a topic, first create a PublisherClient:
+
+  publisher, err := ps.NewPublisherClient(ctx, ps.DefaultPublishSettings, topicPath)
+
+Then call Publish:
+
+  // Note: result is a pubsub.PublishResult
+  result := publisher.Publish(ctx, &pubsub.Message{Data: []byte("payload")})
+
+Publish queues the message for publishing and returns immediately. When enough
+messages have accumulated, or enough time has elapsed, the batch of messages is
+sent to the Cloud Pub/Sub Lite service. Thresholds for batching can be
+configured in PublishSettings.
+
+Publish returns a PublishResult, which behaves like a future: its Get method
+blocks until the message has been sent (or has failed to be sent) to the
+service. Once you've finishing publishing, call Stop to flush all messages to
+the service and close gRPC streams:
+
+  publisher.Stop()
+
+See https://cloud.google.com/pubsub/lite/docs/publishing for more information
+about publishing.
+
+
+Creating Subscriptions
+
+To receive messages published to a topic, clients create subscriptions to the
+topic. There may be more than one subscription per topic; each message that is
+published to the topic will be delivered to all of its subscriptions.
+
+Cloud Pub/Sub Lite subscriptions may be created like so:
+
+  subscriptionPath := pubsublite.SubscriptionPath{
+    Project:        "project-id",
+    Zone:           "zone",
+    SubscriptionID: "subscription-id",
+  }
+  subscriptionConfig := pubsublite.SubscriptionConfig{
+    Name:                subscriptionPath,
+    Topic:               topicPath,
+    DeliveryRequirement: pubsublite.DeliverImmediately,
+  }
+  _, err = admin.CreateSubscription(ctx, subscriptionConfig)
+
+See https://cloud.google.com/pubsub/lite/docs/subscriptions for more information
+about how subscriptions are configured.
+
+
+Receiving
+
+To receive messages for a subscription, first create a SubscriberClient:
+
+  subscriber, err := ps.NewSubscriberClient(ctx, ps.DefaultReceiveSettings, subscriptionPath)
+
+Messages are then consumed from a subscription via callback.
+
+  cctx, cancel := context.WithCancel(ctx)
+  err = subscriber.Receive(cctx, func(ctx context.Context, m *pubsub.Message) {
+    log.Printf("Got message: %s", m.Data)
+    m.Ack()
+  })
+  if err != nil {
+    // Handle error.
+  }
+
+The callback may be invoked concurrently by multiple goroutines (one per
+partition that the subscriber client is connected to). To terminate a call to
+Receive, cancel its context:
+
+  cancel()
+
+Clients must call pubsub.Message.Ack() or pubsub.Message.Nack() for every
+message received. Cloud Pub/Sub Lite does not have ACK deadlines. Cloud Pub/Sub
+Lite also does not actually have the concept of NACK. The default behavior
+terminates the SubscriberClient. In Cloud Pub/Sub Lite, only a single subscriber
+for a given subscription is connected to any partition at a time, and there is
+no other client that may be able to handle messages.
+
+See https://cloud.google.com/pubsub/lite/docs/subscribing for more information
+about receiving messages.
 */
 package pubsublite // import "cloud.google.com/go/pubsublite"

--- a/pubsublite/example_test.go
+++ b/pubsublite/example_test.go
@@ -1,0 +1,229 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+
+package pubsublite_test
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"cloud.google.com/go/pubsublite"
+	"google.golang.org/api/iterator"
+)
+
+func ExampleAdminClient_CreateTopic() {
+	ctx := context.Background()
+	admin, err := pubsublite.NewAdminClient(ctx, "region")
+	if err != nil {
+		// TODO: Handle error.
+	}
+
+	const gib = 1 << 30
+	topicConfig := pubsublite.TopicConfig{
+		Name: pubsublite.TopicPath{
+			Project: "project-id",
+			Zone:    "zone",
+			TopicID: "topic-id",
+		},
+		PartitionCount:             2,        // Must be at least 1.
+		PublishCapacityMiBPerSec:   4,        // Must be 4-16 MiB/s.
+		SubscribeCapacityMiBPerSec: 8,        // Must be 4-32 MiB/s.
+		PerPartitionBytes:          30 * gib, // Must be 30 GiB-10 TiB.
+		// Retain messages indefinitely as long as there is available storage.
+		RetentionDuration: pubsublite.InfiniteRetention,
+	}
+	_, err = admin.CreateTopic(ctx, topicConfig)
+	if err != nil {
+		// TODO: Handle error.
+	}
+}
+
+func ExampleAdminClient_UpdateTopic() {
+	ctx := context.Background()
+	admin, err := pubsublite.NewAdminClient(ctx, "region")
+	if err != nil {
+		// TODO: Handle error.
+	}
+
+	updateConfig := pubsublite.TopicConfigToUpdate{
+		Name: pubsublite.TopicPath{
+			Project: "project-id",
+			Zone:    "zone",
+			TopicID: "topic-id",
+		},
+		PublishCapacityMiBPerSec:   8,
+		SubscribeCapacityMiBPerSec: 16,
+		// Garbage collect messages older than 24 hours.
+		RetentionDuration: 24 * time.Hour,
+	}
+	_, err = admin.UpdateTopic(ctx, updateConfig)
+	if err != nil {
+		// TODO: Handle error.
+	}
+}
+
+func ExampleAdminClient_DeleteTopic() {
+	ctx := context.Background()
+	admin, err := pubsublite.NewAdminClient(ctx, "region")
+	if err != nil {
+		// TODO: Handle error.
+	}
+
+	topic := pubsublite.TopicPath{
+		Project: "project-id",
+		Zone:    "zone",
+		TopicID: "topic-id",
+	}
+	if err := admin.DeleteTopic(ctx, topic); err != nil {
+		// TODO: Handle error.
+	}
+}
+
+func ExampleAdminClient_Topics() {
+	ctx := context.Background()
+	admin, err := pubsublite.NewAdminClient(ctx, "region")
+	if err != nil {
+		// TODO: Handle error.
+	}
+
+	// List the configs of all topics in the given zone for the project.
+	location := pubsublite.LocationPath{Project: "project-id", Zone: "zone"}
+	it := admin.Topics(ctx, location)
+	for {
+		topicConfig, err := it.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			// TODO: Handle error.
+		}
+		fmt.Println(topicConfig)
+	}
+}
+
+func ExampleAdminClient_TopicSubscriptions() {
+	ctx := context.Background()
+	admin, err := pubsublite.NewAdminClient(ctx, "region")
+	if err != nil {
+		// TODO: Handle error.
+	}
+
+	// List the paths of all subscriptions of a topic.
+	topic := pubsublite.TopicPath{
+		Project: "project-id",
+		Zone:    "zone",
+		TopicID: "topic-id",
+	}
+	it := admin.TopicSubscriptions(ctx, topic)
+	for {
+		subscriptionPath, err := it.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			// TODO: Handle error.
+		}
+		fmt.Println(subscriptionPath)
+	}
+}
+
+func ExampleAdminClient_CreateSubscription() {
+	ctx := context.Background()
+	admin, err := pubsublite.NewAdminClient(ctx, "region")
+	if err != nil {
+		// TODO: Handle error.
+	}
+
+	subscriptionConfig := pubsublite.SubscriptionConfig{
+		Name: pubsublite.SubscriptionPath{
+			Project:        "project-id",
+			Zone:           "zone",
+			SubscriptionID: "subscription-id",
+		},
+		Topic: pubsublite.TopicPath{
+			Project: "project-id",
+			Zone:    "zone",
+			TopicID: "topic-id",
+		},
+		// Do not wait for a published message to be successfully written to storage
+		// before delivering it to subscribers.
+		DeliveryRequirement: pubsublite.DeliverImmediately,
+	}
+	_, err = admin.CreateSubscription(ctx, subscriptionConfig)
+	if err != nil {
+		// TODO: Handle error.
+	}
+}
+
+func ExampleAdminClient_UpdateSubscription() {
+	ctx := context.Background()
+	admin, err := pubsublite.NewAdminClient(ctx, "region")
+	if err != nil {
+		// TODO: Handle error.
+	}
+
+	updateConfig := pubsublite.SubscriptionConfigToUpdate{
+		Name: pubsublite.SubscriptionPath{
+			Project:        "project-id",
+			Zone:           "zone",
+			SubscriptionID: "subscription-id",
+		},
+		// Deliver a published message to subscribers after it has been successfully
+		// written to storage.
+		DeliveryRequirement: pubsublite.DeliverAfterStored,
+	}
+	_, err = admin.UpdateSubscription(ctx, updateConfig)
+	if err != nil {
+		// TODO: Handle error.
+	}
+}
+
+func ExampleAdminClient_DeleteSubscription() {
+	ctx := context.Background()
+	admin, err := pubsublite.NewAdminClient(ctx, "region")
+	if err != nil {
+		// TODO: Handle error.
+	}
+
+	subscription := pubsublite.SubscriptionPath{
+		Project:        "project-id",
+		Zone:           "zone",
+		SubscriptionID: "subscription-id",
+	}
+	if err := admin.DeleteSubscription(ctx, subscription); err != nil {
+		// TODO: Handle error.
+	}
+}
+
+func ExampleAdminClient_Subscriptions() {
+	ctx := context.Background()
+	admin, err := pubsublite.NewAdminClient(ctx, "region")
+	if err != nil {
+		// TODO: Handle error.
+	}
+
+	// List the configs of all subscriptions in the given zone for the project.
+	location := pubsublite.LocationPath{Project: "project-id", Zone: "zone"}
+	it := admin.Subscriptions(ctx, location)
+	for {
+		subscriptionConfig, err := it.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			// TODO: Handle error.
+		}
+		fmt.Println(subscriptionConfig)
+	}
+}

--- a/pubsublite/internal/wire/assigner.go
+++ b/pubsublite/internal/wire/assigner.go
@@ -65,6 +65,7 @@ type assigner struct {
 	assignmentClient  *vkit.PartitionAssignmentClient
 	initialReq        *pb.PartitionAssignmentRequest
 	receiveAssignment partitionAssignmentReceiver
+	metadata          pubsubMetadata
 
 	// Fields below must be guarded with mu.
 	stream *retryableStream
@@ -89,8 +90,10 @@ func newAssigner(ctx context.Context, assignmentClient *vkit.PartitionAssignment
 			},
 		},
 		receiveAssignment: receiver,
+		metadata:          newPubsubMetadata(),
 	}
 	a.stream = newRetryableStream(ctx, a, settings.Timeout, reflect.TypeOf(pb.PartitionAssignment{}))
+	a.metadata.AddClientInfo(settings.Framework)
 	return a, nil
 }
 
@@ -109,7 +112,7 @@ func (a *assigner) Stop() {
 }
 
 func (a *assigner) newStream(ctx context.Context) (grpc.ClientStream, error) {
-	return a.assignmentClient.AssignPartitions(ctx)
+	return a.assignmentClient.AssignPartitions(a.metadata.AddToContext(ctx))
 }
 
 func (a *assigner) initialRequest() (interface{}, initialResponseRequired) {

--- a/pubsublite/internal/wire/rpc.go
+++ b/pubsublite/internal/wire/rpc.go
@@ -15,6 +15,7 @@ package wire
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"net/url"
 	"time"
@@ -24,6 +25,8 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/structpb"
 
 	vkit "cloud.google.com/go/pubsublite/apiv1"
 	gax "github.com/googleapis/gax-go/v2"
@@ -127,10 +130,7 @@ func retryableReadOnlyCallOption() gax.CallOption {
 	})
 }
 
-const (
-	pubsubLiteDefaultEndpoint = "-pubsublite.googleapis.com:443"
-	routingMetadataHeader     = "x-goog-request-params"
-)
+const pubsubLiteDefaultEndpoint = "-pubsublite.googleapis.com:443"
 
 func defaultClientOptions(region string) []option.ClientOption {
 	return []option.ClientOption{
@@ -164,18 +164,64 @@ func newPartitionAssignmentClient(ctx context.Context, region string, opts ...op
 	return vkit.NewPartitionAssignmentClient(ctx, options...)
 }
 
-func addTopicRoutingMetadata(ctx context.Context, topic topicPartition) context.Context {
-	md, _ := metadata.FromOutgoingContext(ctx)
-	md = md.Copy()
-	val := fmt.Sprintf("partition=%d&topic=%s", topic.Partition, url.QueryEscape(topic.Path))
-	md[routingMetadataHeader] = append(md[routingMetadataHeader], val)
-	return metadata.NewOutgoingContext(ctx, md)
+const (
+	routingMetadataHeader    = "x-goog-request-params"
+	clientInfoMetadataHeader = "x-goog-pubsub-context"
+
+	languageKey     = "language"
+	languageValue   = "GOLANG"
+	frameworkKey    = "framework"
+	majorVersionKey = "major_version"
+	minorVersionKey = "minor_version"
+)
+
+func stringValue(str string) *structpb.Value {
+	return &structpb.Value{
+		Kind: &structpb.Value_StringValue{StringValue: str},
+	}
 }
 
-func addSubscriptionRoutingMetadata(ctx context.Context, subscription subscriptionPartition) context.Context {
+// pubsubMetadata stores key/value pairs that should be added to gRPC metadata.
+type pubsubMetadata map[string]string
+
+func newPubsubMetadata() pubsubMetadata {
+	return make(map[string]string)
+}
+
+func (pm pubsubMetadata) AddTopicRoutingMetadata(topic topicPartition) {
+	pm[routingMetadataHeader] = fmt.Sprintf("partition=%d&topic=%s", topic.Partition, url.QueryEscape(topic.Path))
+}
+
+func (pm pubsubMetadata) AddSubscriptionRoutingMetadata(subscription subscriptionPartition) {
+	pm[routingMetadataHeader] = fmt.Sprintf("partition=%d&subscription=%s", subscription.Partition, url.QueryEscape(subscription.Path))
+}
+
+func (pm pubsubMetadata) AddClientInfo(framework FrameworkType) {
+	pm.doAddClientInfo(framework, libraryVersion)
+}
+
+func (pm pubsubMetadata) doAddClientInfo(framework FrameworkType, getVersion func() (version, bool)) {
+	s := &structpb.Struct{
+		Fields: make(map[string]*structpb.Value),
+	}
+	s.Fields[languageKey] = stringValue(languageValue)
+	if len(framework) > 0 {
+		s.Fields[frameworkKey] = stringValue(string(framework))
+	}
+	if version, ok := getVersion(); ok {
+		s.Fields[majorVersionKey] = stringValue(version.Major)
+		s.Fields[minorVersionKey] = stringValue(version.Minor)
+	}
+	if bytes, err := proto.Marshal(s); err == nil {
+		pm[clientInfoMetadataHeader] = base64.StdEncoding.EncodeToString(bytes)
+	}
+}
+
+func (pm pubsubMetadata) AddToContext(ctx context.Context) context.Context {
 	md, _ := metadata.FromOutgoingContext(ctx)
 	md = md.Copy()
-	val := fmt.Sprintf("partition=%d&subscription=%s", subscription.Partition, url.QueryEscape(subscription.Path))
-	md[routingMetadataHeader] = append(md[routingMetadataHeader], val)
+	for key, val := range pm {
+		md[key] = append(md[key], val)
+	}
 	return metadata.NewOutgoingContext(ctx, md)
 }

--- a/pubsublite/internal/wire/rpc_test.go
+++ b/pubsublite/internal/wire/rpc_test.go
@@ -1,0 +1,91 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+
+package wire
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"cloud.google.com/go/internal/testutil"
+	"github.com/golang/protobuf/proto"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+func TestPubsubMetadataAddClientInfo(t *testing.T) {
+	for _, tc := range []struct {
+		desc           string
+		framework      FrameworkType
+		libraryVersion func() (version, bool)
+		wantClientInfo *structpb.Struct
+	}{
+		{
+			desc: "minimal",
+			libraryVersion: func() (version, bool) {
+				return version{}, false
+			},
+			wantClientInfo: &structpb.Struct{
+				Fields: map[string]*structpb.Value{
+					"language": stringValue("GOLANG"),
+				},
+			},
+		},
+		{
+			desc:      "cps shim",
+			framework: FrameworkCloudPubSubShim,
+			libraryVersion: func() (version, bool) {
+				return version{}, false
+			},
+			wantClientInfo: &structpb.Struct{
+				Fields: map[string]*structpb.Value{
+					"language":  stringValue("GOLANG"),
+					"framework": stringValue("CLOUD_PUBSUB_SHIM"),
+				},
+			},
+		},
+		{
+			desc:      "version valid",
+			framework: FrameworkCloudPubSubShim,
+			libraryVersion: func() (version, bool) {
+				return version{Major: "1", Minor: "2"}, true
+			},
+			wantClientInfo: &structpb.Struct{
+				Fields: map[string]*structpb.Value{
+					"language":      stringValue("GOLANG"),
+					"framework":     stringValue("CLOUD_PUBSUB_SHIM"),
+					"major_version": stringValue("1"),
+					"minor_version": stringValue("2"),
+				},
+			},
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			metadata := newPubsubMetadata()
+			metadata.doAddClientInfo(tc.framework, tc.libraryVersion)
+
+			b, err := base64.StdEncoding.DecodeString(metadata["x-goog-pubsub-context"])
+			if err != nil {
+				t.Errorf("Failed to decode base64 pubsub context header: %v", err)
+				return
+			}
+			gotClientInfo := new(structpb.Struct)
+			if err := proto.Unmarshal(b, gotClientInfo); err != nil {
+				t.Errorf("Failed to unmarshal pubsub context structpb: %v", err)
+				return
+			}
+			if diff := testutil.Diff(gotClientInfo, tc.wantClientInfo); diff != "" {
+				t.Errorf("Pubsub context structpb: got: -, want: +\n%s", diff)
+			}
+		})
+	}
+}

--- a/pubsublite/internal/wire/subscriber.go
+++ b/pubsublite/internal/wire/subscriber.go
@@ -44,8 +44,6 @@ type ReceivedMessage struct {
 // MessageReceiverFunc receives a Pub/Sub message from a topic partition.
 type MessageReceiverFunc func(*ReceivedMessage)
 
-const maxMessageBufferSize = 10000
-
 // messageDeliveryQueue delivers received messages to the client-provided
 // MessageReceiverFunc sequentially.
 type messageDeliveryQueue struct {
@@ -57,12 +55,6 @@ type messageDeliveryQueue struct {
 }
 
 func newMessageDeliveryQueue(acks *ackTracker, receiver MessageReceiverFunc, bufferSize int) *messageDeliveryQueue {
-	// The buffer size is based on ReceiveSettings.MaxOutstandingMessages. But
-	// ensure there's a reasonable limit as channel buffer capacity is allocated
-	// on creation.
-	if bufferSize > maxMessageBufferSize {
-		bufferSize = maxMessageBufferSize
-	}
 	return &messageDeliveryQueue{
 		acks:      acks,
 		receiver:  receiver,
@@ -85,11 +77,9 @@ func (mq *messageDeliveryQueue) Stop() {
 	}
 }
 
-func (mq *messageDeliveryQueue) Add(messages []*ReceivedMessage) {
+func (mq *messageDeliveryQueue) Add(msg *ReceivedMessage) {
 	if mq.status == serviceActive {
-		for _, msg := range messages {
-			mq.messagesC <- msg
-		}
+		mq.messagesC <- msg
 	}
 }
 
@@ -129,10 +119,10 @@ type subscribeStream struct {
 	settings     ReceiveSettings
 	subscription subscriptionPartition
 	initialReq   *pb.SubscribeRequest
-	messageQueue *messageDeliveryQueue
 	metadata     pubsubMetadata
 
 	// Fields below must be guarded with mu.
+	messageQueue    *messageDeliveryQueue
 	stream          *retryableStream
 	offsetTracker   subscriberOffsetTracker
 	flowControl     flowControlBatcher
@@ -285,12 +275,10 @@ func (s *subscribeStream) unsafeOnMessageResponse(response *pb.MessageResponse) 
 		return err
 	}
 
-	var receivedMsgs []*ReceivedMessage
 	for _, msg := range response.Messages {
 		ack := newAckConsumer(msg.GetCursor().GetOffset(), msg.GetSizeBytes(), s.onAck)
-		receivedMsgs = append(receivedMsgs, &ReceivedMessage{Msg: msg, Ack: ack})
+		s.messageQueue.Add(&ReceivedMessage{Msg: msg, Ack: ack})
 	}
-	s.messageQueue.Add(receivedMsgs)
 	return nil
 }
 

--- a/pubsublite/internal/wire/subscriber_test.go
+++ b/pubsublite/internal/wire/subscriber_test.go
@@ -145,7 +145,7 @@ func TestMessageDeliveryQueue(t *testing.T) {
 	t.Run("Add before start", func(t *testing.T) {
 		msg1 := seqMsgWithOffset(1)
 		ack1 := newAckConsumer(1, 0, nil)
-		messageQueue.Add([]*ReceivedMessage{{Msg: msg1, Ack: ack1}})
+		messageQueue.Add(&ReceivedMessage{Msg: msg1, Ack: ack1})
 
 		receiver.VerifyNoMsgs()
 	})
@@ -158,10 +158,8 @@ func TestMessageDeliveryQueue(t *testing.T) {
 
 		messageQueue.Start()
 		messageQueue.Start() // Check duplicate starts
-		messageQueue.Add([]*ReceivedMessage{
-			{Msg: msg2, Ack: ack2},
-			{Msg: msg3, Ack: ack3},
-		})
+		messageQueue.Add(&ReceivedMessage{Msg: msg2, Ack: ack2})
+		messageQueue.Add(&ReceivedMessage{Msg: msg3, Ack: ack3})
 
 		receiver.ValidateMsg(msg2)
 		receiver.ValidateMsg(msg3)
@@ -173,7 +171,7 @@ func TestMessageDeliveryQueue(t *testing.T) {
 
 		messageQueue.Stop()
 		messageQueue.Stop() // Check duplicate stop
-		messageQueue.Add([]*ReceivedMessage{{Msg: msg4, Ack: ack4}})
+		messageQueue.Add(&ReceivedMessage{Msg: msg4, Ack: ack4})
 
 		receiver.VerifyNoMsgs()
 	})

--- a/pubsublite/internal/wire/version.go
+++ b/pubsublite/internal/wire/version.go
@@ -1,0 +1,66 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+
+// +build go1.12
+
+package wire
+
+import (
+	"runtime/debug"
+	"strconv"
+	"strings"
+)
+
+const pubsubLiteModulePath = "cloud.google.com/go/pubsublite"
+
+type version struct {
+	Major string
+	Minor string
+}
+
+// libraryVersion attempts to determine the pubsublite module version.
+func libraryVersion() (version, bool) {
+	if buildInfo, ok := debug.ReadBuildInfo(); ok {
+		return pubsubliteModuleVersion(buildInfo)
+	}
+	return version{}, false
+}
+
+// pubsubliteModuleVersion extracts the module version from BuildInfo embedded
+// in the binary. Only applies to binaries built with module support.
+func pubsubliteModuleVersion(buildInfo *debug.BuildInfo) (version, bool) {
+	for _, dep := range buildInfo.Deps {
+		if dep.Path == pubsubLiteModulePath {
+			return parseModuleVersion(dep.Version)
+		}
+	}
+	return version{}, false
+}
+
+func parseModuleVersion(value string) (v version, ok bool) {
+	if strings.HasPrefix(value, "v") {
+		value = value[1:]
+	}
+	components := strings.Split(value, ".")
+	if len(components) >= 2 {
+		if _, err := strconv.ParseInt(components[0], 10, 32); err != nil {
+			return
+		}
+		if _, err := strconv.ParseInt(components[1], 10, 32); err != nil {
+			return
+		}
+		v = version{Major: components[0], Minor: components[1]}
+		ok = true
+	}
+	return
+}

--- a/pubsublite/internal/wire/version_not112.go
+++ b/pubsublite/internal/wire/version_not112.go
@@ -1,0 +1,26 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+
+// TODO: Remove file when the minimum supported version is Go1.12.
+// +build !go1.12
+
+package wire
+
+type version struct {
+	Major string
+	Minor string
+}
+
+func libraryVersion() (version, bool) {
+	return version{}, false
+}

--- a/pubsublite/internal/wire/version_test.go
+++ b/pubsublite/internal/wire/version_test.go
@@ -1,0 +1,96 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+
+// +build go1.12
+
+package wire
+
+import (
+	"runtime/debug"
+	"testing"
+
+	"cloud.google.com/go/internal/testutil"
+)
+
+func TestPubsubliteModuleVersion(t *testing.T) {
+	for _, tc := range []struct {
+		desc        string
+		buildInfo   *debug.BuildInfo
+		wantVersion version
+		wantOk      bool
+	}{
+		{
+			desc: "version valid",
+			buildInfo: &debug.BuildInfo{
+				Deps: []*debug.Module{
+					{Path: "cloud.google.com/go/pubsublite", Version: "v1.2.2"},
+					{Path: "cloud.google.com/go/pubsub", Version: "v1.8.3"},
+				},
+			},
+			wantVersion: version{Major: "1", Minor: "2"},
+			wantOk:      true,
+		},
+		{
+			desc: "version corner case",
+			buildInfo: &debug.BuildInfo{
+				Deps: []*debug.Module{
+					{Path: "cloud.google.com/go/pubsublite", Version: "2.3"},
+				},
+			},
+			wantVersion: version{Major: "2", Minor: "3"},
+			wantOk:      true,
+		},
+		{
+			desc: "version missing",
+			buildInfo: &debug.BuildInfo{
+				Deps: []*debug.Module{
+					{Path: "cloud.google.com/go/pubsub", Version: "v1.8.3"},
+				},
+			},
+			wantOk: false,
+		},
+		{
+			desc: "minor version invalid",
+			buildInfo: &debug.BuildInfo{
+				Deps: []*debug.Module{
+					{Path: "cloud.google.com/go/pubsublite", Version: "v1.a.2"},
+				},
+			},
+			wantOk: false,
+		},
+		{
+			desc: "major version invalid",
+			buildInfo: &debug.BuildInfo{
+				Deps: []*debug.Module{
+					{Path: "cloud.google.com/go/pubsublite", Version: "vb.1.2"},
+				},
+			},
+			wantOk: false,
+		},
+		{
+			desc: "minor version missing",
+			buildInfo: &debug.BuildInfo{
+				Deps: []*debug.Module{
+					{Path: "cloud.google.com/go/pubsublite", Version: "v4"},
+				},
+			},
+			wantOk: false,
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			if gotVersion, gotOk := pubsubliteModuleVersion(tc.buildInfo); !testutil.Equal(gotVersion, tc.wantVersion) || gotOk != tc.wantOk {
+				t.Errorf("pubsubliteModuleVersion(): got (%v, %v), want (%v, %v)", gotVersion, gotOk, tc.wantVersion, tc.wantOk)
+			}
+		})
+	}
+}

--- a/pubsublite/ps/doc.go
+++ b/pubsublite/ps/doc.go
@@ -20,16 +20,19 @@ substitutions for pubsub.Topic.Publish() and pubsub.Subscription.Receive(),
 respectively, from the pubsub package.
 
 As noted in comments, the two services have some differences:
-  - Pub/Sub Lite does not support nack for messages. By default, this will
+  - Pub/Sub Lite does not support NACK for messages. By default, this will
     terminate the SubscriberClient. A custom function can be provided for
-    ReceiveSettings.NackHandler to handle nacked messages.
-  - Pub/Sub Lite has no concept of ack expiration. Subscribers must ack or nack
-    every message received.
-  - Pub/Sub Lite PublisherClients can terminate when an unretryable error
-    occurs.
+    ReceiveSettings.NackHandler to handle NACKed messages.
+  - Pub/Sub Lite has no concept of ack deadlines. Subscribers must ACK or NACK
+    every message received and can take as much time as they need to process the
+    message.
+  - Pub/Sub Lite PublisherClients and SubscriberClients can terminate when an
+    unretryable error occurs.
   - Publishers and subscribers will be throttled if Pub/Sub Lite publish or
     subscribe throughput limits are exceeded. Thus publishing can be more
     sensitive to buffer overflow than Cloud Pub/Sub.
+  - Pub/Sub Lite utilizes bidirectional gRPC streams extensively to maximize
+    publish and subscribe throughput.
 
 More information about Google Cloud Pub/Sub Lite is available at
 https://cloud.google.com/pubsub/lite.

--- a/storage/bucket.go
+++ b/storage/bucket.go
@@ -134,7 +134,7 @@ func (b *BucketHandle) DefaultObjectACL() *ACLHandle {
 //
 // name must consist entirely of valid UTF-8-encoded runes. The full specification
 // for valid object names can be found at:
-//   https://cloud.google.com/storage/docs/bucket-naming
+//   https://cloud.google.com/storage/docs/naming-objects
 func (b *BucketHandle) Object(name string) *ObjectHandle {
 	return &ObjectHandle{
 		c:      b.c,


### PR DESCRIPTION
Here's a draft PR for #3454
I don't believe I've accounted for all the edge cases needed by this CI change. Feedback please! 😄 

**Changes**
- Adapts code from [golang-samples](https://github.com/GoogleCloudPlatform/golang-samples/blob/master/testing/kokoro/system_tests.sh) to only run tests in submodules changed by a PR during continuous jobs.
- Accounts for the new `nightly` [job here](https://fusion.corp.google.com/projectanalysis/summary/KOKORO/prod:cloud-devrel%2Fclient-libraries%2Fgo%2Fgoogle-cloud-go%2Fnightly%2Fmaster?search_pattern=google-cloud-go&include_inactive_projects=false), s.t. all submodules tests still run during the nightly check.
_Here's a [one pager summary](https://docs.google.com/document/d/1ZWLb85kkjcnHwUOqnJCexEx_GNf-UVSEAbdfL8A5NGo/edit?resourcekey=0-LO2alh3JcP1DEWFJLshMUA#heading=h.tdx2ho1d7dsd) in case my approach is confusing._

**Open questions:** 
- What are other directories in this repo that, upon being changed in a PR, should trigger CI on ALL submodules? There's `internal` but what else? longrunning?
- Should we keep the `perf-bench` tests e.g. [pubsub](https://fusion.corp.google.com/projectanalysis/summary/KOKORO/prod:cloud-devrel%2Fclient-libraries%2Fgo%2Fgoogle-cloud-go%2Fcontinuous%2Fpubsub_perf_bench?search_pattern=google-cloud-go&include_inactive_projects=false) within the continuous job configs, or should I move them over to nightly? We'll save a bit of compute as these tests are already scheduled to run nightly. 

