### PR TITLE
Dp release

### DIFF
--- a/spanner/client.go
+++ b/spanner/client.go
@@ -178,6 +178,7 @@ func NewClientWithConfig(ctx context.Context, database string, config ClientConf
 		),
 		option.WithGRPCConnectionPool(config.NumChannels),
 		option.WithUserAgent(clientUserAgent),
+		internaloption.EnableDirectPath(true),
 	}
 	// opts will take precedence above allOpts, as the values in opts will be
 	// applied after the values in allOpts.

--- a/spanner/integration_test.go
+++ b/spanner/integration_test.go
@@ -40,7 +40,6 @@ import (
 	instance "cloud.google.com/go/spanner/admin/instance/apiv1"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
-	"google.golang.org/api/option/internaloption"
 	adminpb "google.golang.org/genproto/googleapis/spanner/admin/database/v1"
 	instancepb "google.golang.org/genproto/googleapis/spanner/admin/instance/v1"
 	sppb "google.golang.org/genproto/googleapis/spanner/v1"
@@ -239,8 +238,6 @@ func initIntegrationTests() (cleanup func()) {
 		opts = append(opts, option.WithEndpoint(spannerHost))
 	}
 	if dpConfig.attemptDirectPath {
-		// TODO(mohanli): Move EnableDirectPath internal option to client.go when DirectPath is ready for public beta.
-		opts = append(opts, internaloption.EnableDirectPath(true))
 		opts = append(opts, option.WithGRPCDialOption(grpc.WithDefaultCallOptions(grpc.Peer(peerInfo))))
 	}
 	var err error
@@ -3211,8 +3208,6 @@ func createClient(ctx context.Context, dbPath string, spc SessionPoolConfig) (cl
 		opts = append(opts, option.WithEndpoint(spannerHost))
 	}
 	if dpConfig.attemptDirectPath {
-		// TODO(mohanli): Move EnableDirectPath internal option to client.go when DirectPath is ready for public beta.
-		opts = append(opts, internaloption.EnableDirectPath(true))
 		opts = append(opts, option.WithGRPCDialOption(grpc.WithDefaultCallOptions(grpc.Peer(peerInfo))))
 	}
 	client, err = NewClientWithConfig(ctx, dbPath, ClientConfig{SessionPoolConfig: spc}, opts...)
@@ -3353,6 +3348,7 @@ func verifyDirectPathRemoteAddress(t *testing.T) {
 
 func isDirectPathRemoteAddress() (_ string, _ bool) {
 	remoteIP := peerInfo.Addr.String()
+	fmt.Println("Peer IP = " + remoteIP)
 	// DirectPath ipv4-only can only use ipv4 traffic.
 	if dpConfig.directPathIPv4Only {
 		return remoteIP, strings.HasPrefix(remoteIP, directPathIPV4Prefix)

--- a/spanner/integration_test.go
+++ b/spanner/integration_test.go
@@ -3348,7 +3348,6 @@ func verifyDirectPathRemoteAddress(t *testing.T) {
 
 func isDirectPathRemoteAddress() (_ string, _ bool) {
 	remoteIP := peerInfo.Addr.String()
-	fmt.Println("Peer IP = " + remoteIP)
 	// DirectPath ipv4-only can only use ipv4 traffic.
 	if dpConfig.directPathIPv4Only {
 		return remoteIP, strings.HasPrefix(remoteIP, directPathIPV4Prefix)


### PR DESCRIPTION
Update client to attempt DirectPath by default.

Note that it doesn't mean that after this change client will just use DirectPath, but will call the DirectPath codepath by default.

The actually enablement of DirectPath is controlled by service owner via ACL config. For now, after this change, although all users will attempt DirectPath, but they will all just fallback to the original CFE path.