### PR TITLE
ci(all): fix incorrect reference to job name in nightly

### DIFF
--- a/internal/kokoro/continuous.sh
+++ b/internal/kokoro/continuous.sh
@@ -121,7 +121,7 @@ if [[ $KOKORO_JOB_NAME == *"continuous"* ]]; then
   fi
 elif [[ $KOKORO_JOB_NAME == *"nightly"* ]]; then
   # Expected job name format: "/nightly/[OPTIONAL_MODULE_NAME]/[OPTIONAL_JOB_NAMES...]"
-  ARR=(${JOBNAME//// }) # Splits job name by "/" where ARR[0] is expected to be "nightly".
+  ARR=(${KOKORO_JOB_NAME//// }) # Splits job name by "/" where ARR[0] is expected to be "nightly".
   SUBMODULE_NAME=${ARR[1]} # Gets the token after "nightly/".
   if [[ -n $SUBMODULE_NAME ]] && [[ -d "./$SUBMODULE_NAME" ]]; then
     # Only run tests in the submodule designated in the Kokoro job name.


### PR DESCRIPTION
I caught my error with this test: https://fusion.corp.google.com/projectanalysis/summary/KOKORO/prod:cloud-devrel%2Fclient-libraries%2Fgo%2Fgoogle-cloud-go%2Fnightly%2Flogging%2Fgo115?search_pattern=google-cloud-go%2Fnightly&include_inactive_projects=false

I updated the script to reference the correct kokoro job name. 

Thanks for all the PR reviews on this! I appreciate the patience on this :) 