### PR TITLE
fix(pubsublite)!: rename TopicPartitions to TopicPartitionCount

### DIFF
--- a/pubsublite/admin.go
+++ b/pubsublite/admin.go
@@ -110,9 +110,10 @@ func (ac *AdminClient) Topic(ctx context.Context, topic string) (*TopicConfig, e
 	return protoToTopicConfig(topicpb)
 }
 
-// TopicPartitions returns the number of partitions for a topic. A valid topic
-// path has the format: "projects/PROJECT_ID/locations/ZONE/topics/TOPIC_ID".
-func (ac *AdminClient) TopicPartitions(ctx context.Context, topic string) (int, error) {
+// TopicPartitionCount returns the number of partitions for a topic. A valid
+// topic path has the format:
+// "projects/PROJECT_ID/locations/ZONE/topics/TOPIC_ID".
+func (ac *AdminClient) TopicPartitionCount(ctx context.Context, topic string) (int, error) {
 	if _, err := wire.ParseTopicPath(topic); err != nil {
 		return 0, err
 	}

--- a/pubsublite/admin_test.go
+++ b/pubsublite/admin_test.go
@@ -108,10 +108,10 @@ func TestAdminTopicCRUD(t *testing.T) {
 		t.Errorf("Topic() got: %v\nwant: %v", gotConfig, topicConfig)
 	}
 
-	if gotPartitions, err := admin.TopicPartitions(ctx, topicPath); err != nil {
-		t.Errorf("TopicPartitions() got err: %v", err)
+	if gotPartitions, err := admin.TopicPartitionCount(ctx, topicPath); err != nil {
+		t.Errorf("TopicPartitionCount() got err: %v", err)
 	} else if wantPartitions := 3; gotPartitions != wantPartitions {
-		t.Errorf("TopicPartitions() got: %v\nwant: %v", gotPartitions, wantPartitions)
+		t.Errorf("TopicPartitionCount() got: %v\nwant: %v", gotPartitions, wantPartitions)
 	}
 
 	if err := admin.DeleteTopic(ctx, topicPath); err != nil {
@@ -397,8 +397,8 @@ func TestAdminValidateResourcePaths(t *testing.T) {
 	if _, err := admin.Topic(ctx, "INVALID"); err == nil {
 		t.Errorf("Topic() should fail")
 	}
-	if _, err := admin.TopicPartitions(ctx, "INVALID"); err == nil {
-		t.Errorf("TopicPartitions() should fail")
+	if _, err := admin.TopicPartitionCount(ctx, "INVALID"); err == nil {
+		t.Errorf("TopicPartitionCount() should fail")
 	}
 	if err := admin.DeleteTopic(ctx, "INVALID"); err == nil {
 		t.Errorf("DeleteTopic() should fail")

--- a/pubsublite/integration_test.go
+++ b/pubsublite/integration_test.go
@@ -163,10 +163,10 @@ func TestIntegration_ResourceAdminOperations(t *testing.T) {
 		t.Errorf("Topic() got: -, want: +\n%s", diff)
 	}
 
-	if gotTopicPartitions, err := admin.TopicPartitions(ctx, topicPath); err != nil {
+	if gotTopicPartitions, err := admin.TopicPartitionCount(ctx, topicPath); err != nil {
 		t.Errorf("Failed to get topic partitions: %v", err)
 	} else if gotTopicPartitions != newTopicConfig.PartitionCount {
-		t.Errorf("TopicPartitions() got: %v, want: %v", gotTopicPartitions, newTopicConfig.PartitionCount)
+		t.Errorf("TopicPartitionCount() got: %v, want: %v", gotTopicPartitions, newTopicConfig.PartitionCount)
 	}
 
 	topicIt := admin.Topics(ctx, locationPath)


### PR DESCRIPTION
For consistency with the Java and Python libraries.