### PR TITLE
chore(spanner): source default opts from gapic client

### DIFF
--- a/spanner/apiv1/spanner_client_options.go
+++ b/spanner/apiv1/spanner_client_options.go
@@ -1,0 +1,25 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spanner
+
+import "google.golang.org/api/option"
+
+// Returns the default client options used by the generated Spanner client.
+//
+// This function is only intended for use by the client library, and may be
+// removed at any time without any warning.
+func DefaultClientOptions() []option.ClientOption {
+	return defaultClientOptions()
+}

--- a/spanner/client.go
+++ b/spanner/client.go
@@ -205,8 +205,6 @@ func allClientOpts(numChannels int, userOpts ...option.ClientOption) []option.Cl
 		internaloption.EnableDirectPath(true),
 	}
 	allDefaultOpts := append(generatedDefaultOpts, clientDefaultOpts...)
-	// userOpts will take precedence above allDefaultOpts, as the values in
-	// userOpts will be applied after the values in allDefaultOpts.
 	return append(allDefaultOpts, userOpts...)
 }
 

--- a/spanner/client.go
+++ b/spanner/client.go
@@ -36,23 +36,12 @@ import (
 )
 
 const (
-	endpoint     = "spanner.googleapis.com:443"
-	mtlsEndpoint = "spanner.mtls.googleapis.com:443"
-
 	// resourcePrefixHeader is the name of the metadata header used to indicate
 	// the resource being operated on.
 	resourcePrefixHeader = "google-cloud-resource-prefix"
 
 	// numChannels is the default value for NumChannels of client.
 	numChannels = 4
-)
-
-const (
-	// Scope is the scope for Cloud Spanner Data API.
-	Scope = "https://www.googleapis.com/auth/spanner.data"
-
-	// AdminScope is the scope for Cloud Spanner Admin APIs.
-	AdminScope = "https://www.googleapis.com/auth/spanner.admin"
 )
 
 var (
@@ -116,13 +105,6 @@ type ClientConfig struct {
 	logger *log.Logger
 }
 
-// errDial returns error for dialing to Cloud Spanner.
-func errDial(ci int, err error) error {
-	e := ToSpannerError(err).(*Error)
-	e.decorate(fmt.Sprintf("dialing fails for channel[%v]", ci))
-	return e
-}
-
 func contextWithOutgoingMetadata(ctx context.Context, md metadata.MD) context.Context {
 	existing, ok := metadata.FromOutgoingContext(ctx)
 	if ok {
@@ -166,23 +148,7 @@ func NewClientWithConfig(ctx context.Context, database string, config ClientConf
 		config.NumChannels = numChannels
 	}
 	// gRPC options.
-	allOpts := []option.ClientOption{
-		internaloption.WithDefaultEndpoint(endpoint),
-		internaloption.WithDefaultMTLSEndpoint(mtlsEndpoint),
-		option.WithScopes(Scope),
-		option.WithGRPCDialOption(
-			grpc.WithDefaultCallOptions(
-				grpc.MaxCallSendMsgSize(100<<20),
-				grpc.MaxCallRecvMsgSize(100<<20),
-			),
-		),
-		option.WithGRPCConnectionPool(config.NumChannels),
-		option.WithUserAgent(clientUserAgent),
-		internaloption.EnableDirectPath(true),
-	}
-	// opts will take precedence above allOpts, as the values in opts will be
-	// applied after the values in allOpts.
-	allOpts = append(allOpts, opts...)
+	allOpts := allClientOpts(config.NumChannels, opts...)
 	pool, err := gtransport.DialPool(ctx, allOpts...)
 	if err != nil {
 		return nil, err
@@ -226,6 +192,22 @@ func NewClientWithConfig(ctx context.Context, database string, config ClientConf
 		qo:           getQueryOptions(config.QueryOptions),
 	}
 	return c, nil
+}
+
+// Combines the default options from the generated client, the default options
+// of the hand-written client and the user options to one list of options.
+// Precedence: userOpts > clientDefaultOpts > generatedDefaultOpts
+func allClientOpts(numChannels int, userOpts ...option.ClientOption) []option.ClientOption {
+	generatedDefaultOpts := vkit.DefaultClientOptions()
+	clientDefaultOpts := []option.ClientOption{
+		option.WithGRPCConnectionPool(numChannels),
+		option.WithUserAgent(clientUserAgent),
+		internaloption.EnableDirectPath(true),
+	}
+	allDefaultOpts := append(generatedDefaultOpts, clientDefaultOpts...)
+	// userOpts will take precedence above allDefaultOpts, as the values in
+	// userOpts will be applied after the values in allDefaultOpts.
+	return append(allDefaultOpts, userOpts...)
 }
 
 // getQueryOptions returns the query options overwritten by the environment


### PR DESCRIPTION
Sources the default client options from the generated client instead of the hand-written client. This makes sure that new default options that are introduced in the future will automatically be picked up by the Spanner client.

Fixes #3532