### PR TITLE
feat(logging): add localIP and Cache fields to HTTPRequest conversion from proto

### DIFF
--- a/logging/logadmin/logadmin.go
+++ b/logging/logadmin/logadmin.go
@@ -161,9 +161,12 @@ func toHTTPRequest(p *logtypepb.HttpRequest) (*logging.HTTPRequest, error) {
 		Status:                         int(p.Status),
 		ResponseSize:                   p.ResponseSize,
 		Latency:                        dur,
+		LocalIP:                        p.ServerIp,
 		RemoteIP:                       p.RemoteIp,
 		CacheHit:                       p.CacheHit,
 		CacheValidatedWithOriginServer: p.CacheValidatedWithOriginServer,
+		CacheFillBytes:                 p.CacheFillBytes,
+		CacheLookup:                    p.CacheLookup,
 	}, nil
 }
 

--- a/logging/logadmin/logadmin_test.go
+++ b/logging/logadmin/logadmin_test.go
@@ -80,9 +80,6 @@ func TestMain(m *testing.M) {
 			return c
 		}
 	} else {
-		// TODO(enocom): Delete this once we can get these tests to reliably pass.
-		return
-
 		integrationTest = true
 		ts := testutil.TokenSource(ctx, logging.AdminScope)
 		if ts == nil {
@@ -139,9 +136,12 @@ func TestFromLogEntry(t *testing.T) {
 			Latency:                        &durpb.Duration{Seconds: 100},
 			UserAgent:                      "user-agent",
 			RemoteIp:                       "127.0.0.1",
+			ServerIp:                       "127.0.0.1",
 			Referer:                        "referer",
+			CacheLookup:                    true,
 			CacheHit:                       true,
 			CacheValidatedWithOriginServer: true,
+			CacheFillBytes:                 2048,
 		},
 		Labels: map[string]string{
 			"a": "1",
@@ -183,9 +183,12 @@ func TestFromLogEntry(t *testing.T) {
 			Status:                         200,
 			ResponseSize:                   25,
 			Latency:                        100 * time.Second,
+			LocalIP:                        "127.0.0.1",
 			RemoteIP:                       "127.0.0.1",
+			CacheLookup:                    true,
 			CacheHit:                       true,
 			CacheValidatedWithOriginServer: true,
+			CacheFillBytes:                 2048,
 		},
 		SourceLocation: &logpb.LogEntrySourceLocation{
 			File:     "some_file.go",


### PR DESCRIPTION
Fix #3588 

Changes: 
- Turned integration test back on for `logadmin`. According to previous comments, this may be flakey so I will closely monitor and debug. 
- Added fields LocalIP, CacheLookup, and CacheFillBytes back to httprequest conversion from proto to logging.httprequest