### PR TITLE
chore: have release please bump minor pre major

### DIFF
--- a/.github/workflows/release-submodule.yaml
+++ b/.github/workflows/release-submodule.yaml
@@ -72,6 +72,7 @@ jobs:
            token: ${{ secrets.FORKING_TOKEN }}
            fork: true
            release-type: go
+           bump-minor-pre-major: true
            package-name: ${{ matrix.package }}
            monorepo-tags: true
            command: release-pr

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,6 +15,7 @@ jobs:
           # token: ${{ secrets.FORKING_TOKEN }}
           token: ${{ secrets.FORKING_TOKEN }}
           release-type: go
+          bump-minor-pre-major: true
           fork: true
           package-name: google-cloud-go
           command: release-pr


### PR DESCRIPTION
This will make cutting a v1.0.0 a more explicit process rather
than default to bump to v1.0.0 if a breaking change occurs.