### PR TITLE
feat(pubsublite): optional logging settings for publisher and subscriber clients

### DIFF
--- a/pubsublite/pscompat/settings.go
+++ b/pubsublite/pscompat/settings.go
@@ -41,7 +41,8 @@ type KeyExtractorFunc func(*pubsub.Message) []byte
 // terminate.
 type PublishMessageTransformerFunc func(*pubsub.Message, *pb.PubSubMessage) error
 
-// LogFunc is a function to log informational messages.
+// LogFunc is a function to log informational messages. It may be called
+// concurrently from multiple goroutines and is expected to return quickly.
 type LogFunc func(v ...interface{})
 
 // PublishSettings configure the PublisherClient. Batching settings

--- a/pubsublite/pscompat/settings.go
+++ b/pubsublite/pscompat/settings.go
@@ -41,6 +41,9 @@ type KeyExtractorFunc func(*pubsub.Message) []byte
 // terminate.
 type PublishMessageTransformerFunc func(*pubsub.Message, *pb.PubSubMessage) error
 
+// LogFunc is a function to log informational messages.
+type LogFunc func(v ...interface{})
+
 // PublishSettings configure the PublisherClient. Batching settings
 // (DelayThreshold, CountThreshold, ByteThreshold, BufferedByteLimit) apply per
 // partition.
@@ -95,6 +98,11 @@ type PublishSettings struct {
 	// Optional custom function that transforms a pubsub.Message to a
 	// PubSubMessage API proto.
 	MessageTransformer PublishMessageTransformerFunc
+
+	// Optional function to log informational messages that may be useful for
+	// debugging. For example, this can be set to log.Println. If not set,
+	// messages will not be logged.
+	OnLog LogFunc
 }
 
 // DefaultPublishSettings holds the default values for PublishSettings.
@@ -191,6 +199,11 @@ type ReceiveSettings struct {
 	// Optional custom function that transforms a SequencedMessage API proto to a
 	// pubsub.Message.
 	MessageTransformer ReceiveMessageTransformerFunc
+
+	// Optional function to log informational messages that may be useful for
+	// debugging. For example, this can be set to log.Println. If not set,
+	// messages will not be logged.
+	OnLog LogFunc
 }
 
 // DefaultReceiveSettings holds the default values for ReceiveSettings.


### PR DESCRIPTION
The pubsublite library handles a number of events automatically and most of this is opaque to users. We would like to log some key information/warning messages to help users troubleshoot issues. The logs are not intended to be verbose.

The first usages are:
* The [set of partitions](https://github.com/googleapis/google-cloud-go/blob/89ad55d72f79995a68f9c2ed1cd9b5ba50009d6d/pubsublite/internal/wire/assigner.go#L153) that a subscriber client was assigned by the server. We considered adding hooks to notify user code of assignment updates, but ultimately decided to just log this information. Users need to know the partition numbers to filter metrics in order to troubleshoot issues.
* Warning when a [partition count decrease](https://github.com/googleapis/google-cloud-go/blob/89ad55d72f79995a68f9c2ed1cd9b5ba50009d6d/pubsublite/internal/wire/publisher.go#L317) was ignored.

This initial PR just introduces the setting.

There are not many precedents for logging in other Go client libraries. This setting is similar to the `OnError` func in [logging.Client](https://pkg.go.dev/cloud.google.com/go/logging#Client). The only other non-test example of logging was the warning messages in [datastore.NewClient](https://github.com/googleapis/google-cloud-go/blob/7f8e434b6a614de1a0dc2b66890db1888cd079af/datastore/datastore.go#L94).