### PR TITLE
feat(bigquery): support job-based timeout

### DIFF
--- a/bigquery/query_test.go
+++ b/bigquery/query_test.go
@@ -494,6 +494,7 @@ func TestConfiguringQuery(t *testing.T) {
 	}
 	query.DestinationEncryptionConfig = &EncryptionConfig{KMSKeyName: "keyName"}
 	query.SchemaUpdateOptions = []string{"ALLOW_FIELD_ADDITION"}
+	query.JobTimeout = time.Duration(5) * time.Second
 
 	// Note: Other configuration fields are tested in other tests above.
 	// A lot of that can be consolidated once Client.Copy is gone.
@@ -513,6 +514,7 @@ func TestConfiguringQuery(t *testing.T) {
 				DestinationEncryptionConfiguration: &bq.EncryptionConfiguration{KmsKeyName: "keyName"},
 				SchemaUpdateOptions:                []string{"ALLOW_FIELD_ADDITION"},
 			},
+			JobTimeoutMs: 5000,
 		},
 		JobReference: &bq.JobReference{
 			JobId:     "ajob",


### PR DESCRIPTION
Related: https://github.com/googleapis/google-cloud-go/issues/3613

This PR attempts to expose the concept of launching work with a timeout
that can cancel work on a best-effort basis.  I've marked the field as
experimental as I'm not confident in the approach.

Caveat:  Use of this feature effectively disables the fast query path
optimizations, as timeout is only applicable to jobs.insert and not
jobs.query API methods.