### PR TITLE
fix(pubsublite): change pubsub.Message.ID to an encoded publish.Metadata

### DIFF
--- a/pubsublite/internal/wire/subscriber.go
+++ b/pubsublite/internal/wire/subscriber.go
@@ -37,8 +37,9 @@ var (
 // ReceivedMessage stores a received Pub/Sub message and AckConsumer for
 // acknowledging the message.
 type ReceivedMessage struct {
-	Msg *pb.SequencedMessage
-	Ack AckConsumer
+	Msg       *pb.SequencedMessage
+	Ack       AckConsumer
+	Partition int
 }
 
 // MessageReceiverFunc receives a Pub/Sub message from a topic partition.
@@ -277,7 +278,7 @@ func (s *subscribeStream) unsafeOnMessageResponse(response *pb.MessageResponse) 
 
 	for _, msg := range response.Messages {
 		ack := newAckConsumer(msg.GetCursor().GetOffset(), msg.GetSizeBytes(), s.onAck)
-		s.messageQueue.Add(&ReceivedMessage{Msg: msg, Ack: ack})
+		s.messageQueue.Add(&ReceivedMessage{Msg: msg, Ack: ack, Partition: s.subscription.Partition})
 	}
 	return nil
 }

--- a/pubsublite/pscompat/message.go
+++ b/pubsublite/pscompat/message.go
@@ -104,9 +104,6 @@ func transformReceivedMessage(from *pb.SequencedMessage, to *pubsub.Message) err
 			return fmt.Errorf("%s: %s", errInvalidMessage.Error(), err)
 		}
 	}
-	if from.GetCursor() != nil {
-		to.ID = fmt.Sprintf("%d", from.GetCursor().GetOffset())
-	}
 	if len(msg.GetKey()) > 0 {
 		to.OrderingKey = string(msg.GetKey())
 	}

--- a/pubsublite/pscompat/message_test.go
+++ b/pubsublite/pscompat/message_test.go
@@ -66,7 +66,6 @@ func TestMessageTransforms(t *testing.T) {
 				},
 			},
 			wantMsg: &pubsub.Message{
-				ID:          "10",
 				PublishTime: time.Unix(1577836800, 900800700),
 				Data:        []byte("foo"),
 				OrderingKey: "bar",

--- a/pubsublite/pscompat/settings.go
+++ b/pubsublite/pscompat/settings.go
@@ -146,8 +146,10 @@ func (s *PublishSettings) toWireSettings() wire.PublishSettings {
 type NackHandler func(*pubsub.Message) error
 
 // ReceiveMessageTransformerFunc transforms a Pub/Sub Lite SequencedMessage API
-// proto to a pubsub.Message. If this returns an error, the SubscriberClient
-// will consider this a fatal error and terminate.
+// proto to a pubsub.Message. The implementation must not set pubsub.Message.ID.
+//
+// If this returns an error, the SubscriberClient will consider this a fatal
+// error and terminate.
 type ReceiveMessageTransformerFunc func(*pb.SequencedMessage, *pubsub.Message) error
 
 // ReceiveSettings configure the SubscriberClient. Flow control settings

--- a/pubsublite/publish/example_test.go
+++ b/pubsublite/publish/example_test.go
@@ -1,0 +1,65 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+
+package publish_test
+
+import (
+	"context"
+	"fmt"
+
+	"cloud.google.com/go/pubsub"
+	"cloud.google.com/go/pubsublite/pscompat"
+	"cloud.google.com/go/pubsublite/publish"
+)
+
+func ExampleParseMetadata_publisher() {
+	ctx := context.Background()
+	const topic = "projects/my-project/locations/zone/topics/my-topic"
+	publisher, err := pscompat.NewPublisherClient(ctx, topic)
+	if err != nil {
+		// TODO: Handle error.
+	}
+	defer publisher.Stop()
+
+	result := publisher.Publish(ctx, &pubsub.Message{Data: []byte("payload")})
+	id, err := result.Get(ctx)
+	if err != nil {
+		// TODO: Handle error.
+	}
+	metadata, err := publish.ParseMetadata(id)
+	if err != nil {
+		// TODO: Handle error.
+	}
+	fmt.Printf("Published message to partition %d with offset %d\n", metadata.Partition, metadata.Offset)
+}
+
+func ExampleParseMetadata_subscriber() {
+	ctx := context.Background()
+	const subscription = "projects/my-project/locations/zone/subscriptions/my-subscription"
+	subscriber, err := pscompat.NewSubscriberClient(ctx, subscription)
+	if err != nil {
+		// TODO: Handle error.
+	}
+	err = subscriber.Receive(ctx, func(ctx context.Context, m *pubsub.Message) {
+		// TODO: Handle message.
+		m.Ack()
+		metadata, err := publish.ParseMetadata(m.ID)
+		if err != nil {
+			// TODO: Handle error.
+		}
+		fmt.Printf("Received message from partition %d with offset %d\n", metadata.Partition, metadata.Offset)
+	})
+	if err != nil {
+		// TODO: Handle error.
+	}
+}

--- a/pubsublite/publish/metadata.go
+++ b/pubsublite/publish/metadata.go
@@ -34,18 +34,9 @@ func (m *Metadata) String() string {
 	return fmt.Sprintf("%d:%d", m.Partition, m.Offset)
 }
 
-// ParseMetadata converts the ID string of a pubsub.PublishResult to Metadata.
-//
-// Example:
-//   result := publisher.Publish(ctx, &pubsub.Message{Data: []byte("payload")})
-//   id, err := result.Get(ctx)
-//   if err != nil {
-//     // TODO: Handle error.
-//   }
-//   metadata, err := publish.ParseMetadata(id)
-//   if err != nil {
-//     // TODO: Handle error.
-//   }
+// ParseMetadata creates Metadata from the ID string of a pubsub.PublishResult
+// returned by pscompat.PublisherClient or pubsub.Message.ID received from
+// pscompat.SubscriberClient.
 func ParseMetadata(id string) (*Metadata, error) {
 	parts := strings.Split(id, ":")
 	if len(parts) != 2 {


### PR DESCRIPTION
This mirrors the Java implementation: https://github.com/googleapis/java-pubsublite/pull/482. If the user's custom message transformer sets the `pubsub.Message.ID`, the `SubscriberClient` will terminate with error. The internal wire subscriber needs to pass the partition number to the CPS subscriber shim via `ReceivedMessage`.

Updated tests and documentation. Changed the comments for `publish.ParseMetadata` to inline documentation examples.