### PR TITLE
chore(internal/gapicgen): enable metadata gen

### DIFF
--- a/internal/gapicgen/cmd/genbot/Dockerfile
+++ b/internal/gapicgen/cmd/genbot/Dockerfile
@@ -33,7 +33,7 @@ RUN GO111MODULE=on go get \
     golang.org/x/lint/golint@latest \
     golang.org/x/tools/cmd/goimports@latest \
     honnef.co/go/tools/cmd/staticcheck@latest \
-    github.com/googleapis/gapic-generator-go/cmd/protoc-gen-go_gapic@v0.17.0
+    github.com/googleapis/gapic-generator-go/cmd/protoc-gen-go_gapic@v0.18.2
 ENV PATH="${PATH}:/root/go/bin"
 
 # Source: http://debuggable.com/posts/disable-strict-host-checking-for-git-clone:49896ff3-0ac0-4263-9703-1eae4834cda3

--- a/internal/gapicgen/generator/config.go
+++ b/internal/gapicgen/generator/config.go
@@ -42,6 +42,10 @@ type microgenConfig struct {
 	// useful if a client needs to be deprecated, but retained in the repo
 	// metadata.
 	stopGeneration bool
+
+	// disableMetadata is used to toggle generation of the gapic_metadata.json
+	// file for the client library.
+	disableMetadata bool
 }
 
 var microgenGapicConfigs = []*microgenConfig{

--- a/internal/gapicgen/generator/gapics.go
+++ b/internal/gapicgen/generator/gapics.go
@@ -178,6 +178,9 @@ func (g *GapicGenerator) microgen(conf *microgenConfig) error {
 	if conf.gRPCServiceConfigPath != "" {
 		args = append(args, "--go_gapic_opt", fmt.Sprintf("grpc-service-config=%s", conf.gRPCServiceConfigPath))
 	}
+	if !conf.disableMetadata {
+		args = append(args, "--go_gapic_opt", "metadata")
+	}
 	args = append(args, protoFiles...)
 	c := command("protoc", args...)
 	c.Dir = g.googleapisDir


### PR DESCRIPTION
* add metadata flag to configs
* update gapic-generator-go to v0.18.2
* gen code changes include:
  * generation of gapic_metadata.json
  * removal of stuttering import aliases for `*pb` packages like `structpb`