### PR TITLE
fix(spanner/spansql): fix parsing of NOT IN operator

### DIFF
--- a/spanner/spansql/parser_test.go
+++ b/spanner/spansql/parser_test.go
@@ -255,6 +255,7 @@ func TestParseExpr(t *testing.T) {
 		{`A AND NOT B`, LogicalOp{LHS: ID("A"), Op: And, RHS: LogicalOp{Op: Not, RHS: ID("B")}}},
 		{`X BETWEEN Y AND Z`, ComparisonOp{LHS: ID("X"), Op: Between, RHS: ID("Y"), RHS2: ID("Z")}},
 		{`@needle IN UNNEST(@haystack)`, InOp{LHS: Param("needle"), RHS: []Expr{Param("haystack")}, Unnest: true}},
+		{`@needle NOT IN UNNEST(@haystack)`, InOp{LHS: Param("needle"), Neg: true, RHS: []Expr{Param("haystack")}, Unnest: true}},
 
 		// String literal:
 		// Accept double quote and single quote.


### PR DESCRIPTION
The parsing of comparison operators was erroneously capturing any NOT
token assuming it would be followed by a LIKE or BETWEEN. Instead,
change that code to explicitly look ahead for the limited combinations
allowed, and do the same for parsing IN and NOT IN.

Fixes #3715.