### PR TITLE
chore(internal/kokoro): enable apidiff

### DIFF
--- a/internal/kokoro/check_incompat_changes.sh
+++ b/internal/kokoro/check_incompat_changes.sh
@@ -13,14 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Skipped until https://github.com/golang/go/issues/34849 is resolved.
-exit 0
-
 # Display commands being run
 set -x
 
-# Only run apidiff checks on go1.12 (we only need it once).
-if [[ `go version` != *"go1.12"* ]]; then
+# Only run apidiff checks on go1.16 (we only need it once).
+if [[ `go version` != *"go1.16"* ]]; then
     exit 0
 fi
 
@@ -34,7 +31,7 @@ go install golang.org/x/exp/cmd/apidiff
 # working on an out-of-date branch, and master gets some new feature (that has
 # nothing to do with your work on your branch), you'll get an error message.
 # Thankfully the fix is quite simple: rebase your branch.
-git clone https://code.googlesource.com/gocloud /tmp/gocloud
+git clone https://github.com/googleapis/google-cloud-go /tmp/gocloud
 
 MANUALS="bigquery bigtable datastore firestore pubsub spanner storage logging"
 STABLE_GAPICS="container/apiv1 dataproc/apiv1 iam iam/admin/apiv1 iam/credentials/apiv1 kms/apiv1 language/apiv1 logging/apiv2 logging/logadmin pubsub/apiv1 spanner/apiv1 translate/apiv1 vision/apiv1"
@@ -46,11 +43,10 @@ for dir in $MANUALS $STABLE_GAPICS; do
   apidiff -w /tmp/pkg.master $pkg
   cd - > /dev/null
 
-  # TODO(deklerk): there's probably a nicer way to do this that doesn't require
-  # two invocations
-  if ! apidiff -incompatible /tmp/pkg.master $pkg | (! read); then
+  apidiff -incompatible /tmp/pkg.master $pkg > diff.txt
+  if [ -s diff.txt ]; then
     echo "Detected incompatible API changes between master@HEAD and current state:"
-    apidiff -incompatible /tmp/pkg.master $pkg
+    cat diff.txt
     exit 1
   fi
 done

--- a/internal/kokoro/check_incompat_changes.sh
+++ b/internal/kokoro/check_incompat_changes.sh
@@ -25,6 +25,7 @@ if git log -1 | grep BREAKING_CHANGE_ACCEPTABLE; then
   exit 0
 fi
 
+go mod download golang.org/x/exp
 go install golang.org/x/exp/cmd/apidiff
 
 # We compare against master@HEAD. This is unfortunate in some cases: if you're


### PR DESCRIPTION
* reenables `apidiff`
* update `go version` to target to be 1.16.x
* makes it compare against the new GitHub SoT
* tweaks it to only need a single execution of the incompat check by dumping the output to a file and checking if the file has content