### PR TITLE
feat(internal/godocfx): keep some cross links on same domain

### DIFF
--- a/internal/godocfx/godocfx_test.go
+++ b/internal/godocfx/godocfx_test.go
@@ -168,3 +168,33 @@ func TestGoldens(t *testing.T) {
 		}
 	}
 }
+
+func TestHasPrefix(t *testing.T) {
+	tests := []struct {
+		s        string
+		prefixes []string
+		want     bool
+	}{
+		{
+			s:        "abc",
+			prefixes: []string{"1", "a"},
+			want:     true,
+		},
+		{
+			s:        "abc",
+			prefixes: []string{"1"},
+			want:     false,
+		},
+		{
+			s:        "abc",
+			prefixes: []string{"1", "2"},
+			want:     false,
+		},
+	}
+
+	for _, test := range tests {
+		if got := hasPrefix(test.s, test.prefixes); got != test.want {
+			t.Errorf("hasPrefix(%q, %q) got %v, want %v", test.s, test.prefixes, got, test.want)
+		}
+	}
+}

--- a/internal/godocfx/testdata/golden/index.yml
+++ b/internal/godocfx/testdata/golden/index.yml
@@ -793,7 +793,8 @@ items:
   - go
   syntax:
     content: func (b *<a href="#cloud_google_com_go_storage_BucketHandle">BucketHandle</a>)
-      IAM() *<a href="https://pkg.go.dev/cloud.google.com/go/iam">iam</a>.<a href="https://pkg.go.dev/cloud.google.com/go/iam#Handle">Handle</a>
+      IAM() *<a href="/go/docs/reference/cloud.google.com/go/latest/iam">iam</a>.<a
+      href="/go/docs/reference/cloud.google.com/go/latest/iam#cloud_google_com_go_iam_Handle">Handle</a>
 - uid: cloud.google.com/go/storage.BucketHandle.If
   name: |
     func (*BucketHandle) If


### PR DESCRIPTION
The magic of this PR (that took me way too long to figure out) comes from adding `| packages.NeedDeps` to the `packages.Load` `Config`. That lets us get the `Fset` and `Syntax` of all packages the current package imports. We can then use that information to pull out the anchors for every element we link to.

This also fixes an issue where we were handling some packages that didn't have the Module field set -- we can ignore them. It appears to be a new package gets returned with the ID of the glob you asked for. For example, `cloud.google.com/go/...`. We don't seem to need that.

Fixes #3739.