### PR TITLE
chore(internal/gapicgen): remove manual trace from manifest

### DIFF
--- a/internal/gapicgen/generator/gapics.go
+++ b/internal/gapicgen/generator/gapics.go
@@ -297,14 +297,6 @@ var manualEntries = []manifestEntry{
 		DocsURL:           "https://pkg.go.dev/cloud.google.com/go/spanner",
 		ReleaseLevel:      "ga",
 	},
-	{
-		DistributionName:  "cloud.google.com/go/trace",
-		Description:       "Stackdriver Trace",
-		Language:          "Go",
-		ClientLibraryType: "manual",
-		DocsURL:           "https://pkg.go.dev/cloud.google.com/go/trace",
-		ReleaseLevel:      "ga",
-	},
 }
 
 // manifest writes a manifest file with info about all of the confs.


### PR DESCRIPTION
There is an entry for a manual `trace` client in the `.repo-metadatafull.json`, but there is no such package. There are two generated clients, however, `apiv1` & `apiv2` which are included in the manifest when generated.