### PR TITLE
fix(pubsublite): increase default timeouts for publish and subscribe stream connections

### DIFF
--- a/pubsublite/internal/wire/settings.go
+++ b/pubsublite/internal/wire/settings.go
@@ -82,7 +82,7 @@ var DefaultPublishSettings = PublishSettings{
 	DelayThreshold: 10 * time.Millisecond,
 	CountThreshold: 100,
 	ByteThreshold:  1e6,
-	Timeout:        10 * time.Minute,
+	Timeout:        30 * time.Minute,
 	// By default set to a high limit that is not likely to occur, but prevents
 	// OOM errors in clients.
 	BufferedByteLimit: 1 << 30, // 1 GiB
@@ -146,7 +146,7 @@ type ReceiveSettings struct {
 var DefaultReceiveSettings = ReceiveSettings{
 	MaxOutstandingMessages: 1000,
 	MaxOutstandingBytes:    1e9,
-	Timeout:                10 * time.Minute,
+	Timeout:                30 * time.Minute,
 }
 
 func validateReceiveSettings(settings ReceiveSettings) error {

--- a/pubsublite/internal/wire/settings.go
+++ b/pubsublite/internal/wire/settings.go
@@ -82,7 +82,7 @@ var DefaultPublishSettings = PublishSettings{
 	DelayThreshold: 10 * time.Millisecond,
 	CountThreshold: 100,
 	ByteThreshold:  1e6,
-	Timeout:        30 * time.Minute,
+	Timeout:        60 * time.Minute,
 	// By default set to a high limit that is not likely to occur, but prevents
 	// OOM errors in clients.
 	BufferedByteLimit: 1 << 30, // 1 GiB
@@ -146,7 +146,7 @@ type ReceiveSettings struct {
 var DefaultReceiveSettings = ReceiveSettings{
 	MaxOutstandingMessages: 1000,
 	MaxOutstandingBytes:    1e9,
-	Timeout:                30 * time.Minute,
+	Timeout:                60 * time.Minute,
 }
 
 func validateReceiveSettings(settings ReceiveSettings) error {

--- a/pubsublite/pscompat/settings.go
+++ b/pubsublite/pscompat/settings.go
@@ -106,7 +106,7 @@ var DefaultPublishSettings = PublishSettings{
 	DelayThreshold:    10 * time.Millisecond,
 	CountThreshold:    100,
 	ByteThreshold:     1e6,
-	Timeout:           60 * time.Second,
+	Timeout:           30 * time.Minute,
 	BufferedByteLimit: 1e8,
 }
 
@@ -206,7 +206,7 @@ type ReceiveSettings struct {
 var DefaultReceiveSettings = ReceiveSettings{
 	MaxOutstandingMessages: 1000,
 	MaxOutstandingBytes:    1e9,
-	Timeout:                60 * time.Second,
+	Timeout:                30 * time.Minute,
 }
 
 func (s *ReceiveSettings) toWireSettings() wire.ReceiveSettings {

--- a/pubsublite/pscompat/settings.go
+++ b/pubsublite/pscompat/settings.go
@@ -106,7 +106,7 @@ var DefaultPublishSettings = PublishSettings{
 	DelayThreshold:    10 * time.Millisecond,
 	CountThreshold:    100,
 	ByteThreshold:     1e6,
-	Timeout:           30 * time.Minute,
+	Timeout:           60 * time.Minute,
 	BufferedByteLimit: 1e8,
 }
 
@@ -206,7 +206,7 @@ type ReceiveSettings struct {
 var DefaultReceiveSettings = ReceiveSettings{
 	MaxOutstandingMessages: 1000,
 	MaxOutstandingBytes:    1e9,
-	Timeout:                30 * time.Minute,
+	Timeout:                60 * time.Minute,
 }
 
 func (s *ReceiveSettings) toWireSettings() wire.ReceiveSettings {


### PR DESCRIPTION
The default is currently 1 minute, which may be too short and causes publishers and subscribers to permanently shut down.