### PR TITLE
chore(internal/apidiff): check for bang breaking change indicator

### DIFF
--- a/internal/apidiff/apidiff.go
+++ b/internal/apidiff/apidiff.go
@@ -51,8 +51,7 @@ func main() {
 	if err != nil {
 		log.Fatalln(err)
 	}
-	if strings.Contains(head, "BREAKING_CHANGE") {
-		log.Println("Not running apidiff because description contained tag BREAKING_CHANGE.")
+	if checkAllowBreakingChange(head) {
 		return
 	}
 
@@ -213,6 +212,23 @@ func diff(m manifest, modDir, imp, pkg, base string) (string, error) {
 	}
 
 	return out, err
+}
+
+func checkAllowBreakingChange(commit string) bool {
+	if strings.Contains(commit, "BREAKING_CHANGE") {
+		log.Println("Not running apidiff because description contained tag BREAKING_CHANGE.")
+		return true
+	}
+
+	split := strings.Split(commit, "\n")
+	for _, s := range split {
+		if strings.Contains(s, "!:") || strings.Contains(s, "!(") {
+			log.Println("Not running apidiff because description contained breaking change indicator '!'.")
+			return true
+		}
+	}
+
+	return false
 }
 
 func manualParent(m manifest, imp string) string {

--- a/internal/apidiff/apidiff.go
+++ b/internal/apidiff/apidiff.go
@@ -215,7 +215,7 @@ func diff(m manifest, modDir, imp, pkg, base string) (string, error) {
 }
 
 func checkAllowBreakingChange(commit string) bool {
-	if strings.Contains(commit, "BREAKING_CHANGE") {
+	if strings.Contains(commit, "BREAKING CHANGE:") {
 		log.Println("Not running apidiff because description contained tag BREAKING_CHANGE.")
 		return true
 	}

--- a/internal/apidiff/apidiff_test.go
+++ b/internal/apidiff/apidiff_test.go
@@ -1,0 +1,65 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build linux darwin
+
+package main
+
+import "testing"
+
+func TestCheckAllowBreakingChange(t *testing.T) {
+	for _, tst := range []struct {
+		name, msg string
+		want      bool
+	}{
+		{
+			name: "disallow - no indicator",
+			msg:  "feat: add foo",
+			want: false,
+		},
+		{
+			name: "allow - bang indicator",
+			msg:  "feat!: remove foo",
+			want: true,
+		},
+		{
+			name: "allow - bang indicator pre-scope",
+			msg:  "feat!(scope): remove foo",
+			want: true,
+		},
+		{
+			name: "allow - tag indicator",
+			msg:  "BREAKING CHANGE: remove foo",
+			want: true,
+		},
+		{
+			name: "allow - multiline bang indicator",
+			msg: `feat: add foo
+			feat!: remove bar
+			chore: update dep`,
+			want: true,
+		},
+		{
+			name: "allow - multiline tag indicator",
+			msg: `feat: add foo
+			BREAKING CHANGE: remove bar
+			chore: update dep`,
+			want: true,
+		},
+	} {
+		if got := checkAllowBreakingChange(tst.msg); got != tst.want {
+			t.Errorf("%s: got %v want %v", tst.name, got, tst.want)
+		}
+	}
+}


### PR DESCRIPTION
Allow breaking changes when either of the conventional commit breaking change indicators are available: `!` or `BREAKING CHANGE:`.

An example of the former is: `fix!(dialogflow): remove rpc or fields that are unintended to release`