### PR TITLE
feat(spanner): add the Mutex lock in the beginning func of ReadWriteTransaction

### DIFF
--- a/spanner/transaction.go
+++ b/spanner/transaction.go
@@ -946,6 +946,8 @@ func beginTransaction(ctx context.Context, sid string, client *vkit.Client) (tra
 // begin starts a read-write transacton on Cloud Spanner, it is always called
 // before any of the public APIs.
 func (t *ReadWriteTransaction) begin(ctx context.Context) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
 	if t.tx != nil {
 		t.state = txActive
 		return nil


### PR DESCRIPTION
I suppose there is no reason not to add the Mutex lock here even though the other functions mutating the same field with this func    having the Mutex lock.
If it's intentional, please close this PR.