### PR TITLE
chore(internal/gapicgen): use API Service Config not gapic config

### DIFF
--- a/internal/gapicgen/generator/config.go
+++ b/internal/gapicgen/generator/config.go
@@ -706,7 +706,7 @@ var microgenGapicConfigs = []*microgenConfig{
 		pkg:                   "pubsublite",
 		importPath:            "cloud.google.com/go/pubsublite/apiv1",
 		gRPCServiceConfigPath: "google/cloud/pubsublite/v1/pubsublite_grpc_service_config.json",
-		apiServiceConfigPath:  "google/cloud/pubsublite/v1/gapic.yaml",
+		apiServiceConfigPath:  "google/cloud/pubsublite/v1/pubsublite_v1.yaml",
 		// Update to "ga" after the manual client (beta) for pubsublite is released.
 		// Also make sure the manual client is generated in .repo-metadata-full.json.
 		releaseLevel: "beta",

--- a/internal/gapicgen/generator/config.go
+++ b/internal/gapicgen/generator/config.go
@@ -682,7 +682,7 @@ var microgenGapicConfigs = []*microgenConfig{
 		pkg:                   "talent",
 		importPath:            "cloud.google.com/go/talent/apiv4",
 		gRPCServiceConfigPath: "google/cloud/talent/v4/talent_grpc_service_config.json",
-		apiServiceConfigPath:  "google/cloud/talent/v4/talent_gapic.yaml",
+		apiServiceConfigPath:  "google/cloud/talent/v4/jobs_v4.yaml",
 		releaseLevel:          "beta",
 	},
 	{
@@ -756,7 +756,7 @@ var microgenGapicConfigs = []*microgenConfig{
 		pkg:                   "gaming",
 		importPath:            "cloud.google.com/go/gaming/apiv1",
 		gRPCServiceConfigPath: "google/cloud/gaming/v1/gaming_grpc_service_config.json",
-		apiServiceConfigPath:  "google/cloud/gaming/v1/gaming_gapic.yaml",
+		apiServiceConfigPath:  "google/cloud/gaming/v1/gameservices_v1.yaml",
 		releaseLevel:          "ga",
 	},
 	{
@@ -764,7 +764,7 @@ var microgenGapicConfigs = []*microgenConfig{
 		pkg:                   "gaming",
 		importPath:            "cloud.google.com/go/gaming/apiv1beta",
 		gRPCServiceConfigPath: "google/cloud/gaming/v1beta/gaming_grpc_service_config.json",
-		apiServiceConfigPath:  "google/cloud/gaming/v1beta/gaming_gapic.yaml",
+		apiServiceConfigPath:  "google/cloud/gaming/v1beta/gameservices_v1beta.yaml",
 		releaseLevel:          "beta",
 	},
 	{
@@ -780,7 +780,7 @@ var microgenGapicConfigs = []*microgenConfig{
 		pkg:                   "dashboard",
 		importPath:            "cloud.google.com/go/monitoring/dashboard/apiv1",
 		gRPCServiceConfigPath: "google/monitoring/dashboard/v1/dashboards_grpc_service_config.json",
-		apiServiceConfigPath:  "google/monitoring/dashboard/v1/monitoring_gapic.yaml",
+		apiServiceConfigPath:  "google/monitoring/dashboard/v1/monitoring.yaml",
 		releaseLevel:          "ga",
 	},
 	{
@@ -788,7 +788,7 @@ var microgenGapicConfigs = []*microgenConfig{
 		pkg:                   "functions",
 		importPath:            "cloud.google.com/go/functions/apiv1",
 		gRPCServiceConfigPath: "google/cloud/functions/v1/functions_grpc_service_config.json",
-		apiServiceConfigPath:  "google/cloud/functions/v1/functions_gapic.yaml",
+		apiServiceConfigPath:  "google/cloud/functions/v1/cloudfunctions_v1.yaml",
 		releaseLevel:          "ga",
 	},
 	{
@@ -820,7 +820,7 @@ var microgenGapicConfigs = []*microgenConfig{
 		pkg:                   "budgets",
 		importPath:            "cloud.google.com/go/billing/budgets/apiv1beta1",
 		gRPCServiceConfigPath: "google/cloud/billing/budgets/v1beta1/billingbudgets_grpc_service_config.json",
-		apiServiceConfigPath:  "google/cloud/billing/budgets/v1beta1/billingbudgets_gapic.yaml",
+		apiServiceConfigPath:  "google/cloud/billing/budgets/v1beta1/billingbudgets.yaml",
 		releaseLevel:          "beta",
 	},
 	{
@@ -828,7 +828,7 @@ var microgenGapicConfigs = []*microgenConfig{
 		pkg:                   "transcoder",
 		importPath:            "cloud.google.com/go/video/transcoder/apiv1beta1",
 		gRPCServiceConfigPath: "google/cloud/video/transcoder/v1beta1/transcoder_grpc_service_config.json",
-		apiServiceConfigPath:  "google/cloud/video/transcoder/v1beta1/transcoder_gapic.yaml",
+		apiServiceConfigPath:  "google/cloud/video/transcoder/v1beta1/transcoder_v1beta1.yaml",
 		releaseLevel:          "beta",
 	},
 	{
@@ -836,7 +836,7 @@ var microgenGapicConfigs = []*microgenConfig{
 		pkg:                   "workflows",
 		importPath:            "cloud.google.com/go/workflows/apiv1beta",
 		gRPCServiceConfigPath: "google/cloud/workflows/v1beta/workflows_grpc_service_config.json",
-		apiServiceConfigPath:  "google/cloud/workflows/v1beta/workflows_gapic.yaml",
+		apiServiceConfigPath:  "google/cloud/workflows/v1beta/workflows_v1beta.yaml",
 		releaseLevel:          "beta",
 	},
 	{
@@ -844,7 +844,7 @@ var microgenGapicConfigs = []*microgenConfig{
 		pkg:                   "executions",
 		importPath:            "cloud.google.com/go/workflows/executions/apiv1beta",
 		gRPCServiceConfigPath: "google/cloud/workflows/executions/v1beta/executions_grpc_service_config.json",
-		apiServiceConfigPath:  "google/cloud/workflows/executions/v1beta/executions_gapic.yaml",
+		apiServiceConfigPath:  "google/cloud/workflows/executions/v1beta/workflowexecutions_v1beta.yaml",
 		releaseLevel:          "beta",
 	},
 	{
@@ -852,7 +852,7 @@ var microgenGapicConfigs = []*microgenConfig{
 		pkg:                   "privateca",
 		importPath:            "cloud.google.com/go/security/privateca/apiv1beta1",
 		gRPCServiceConfigPath: "google/cloud/security/privateca/v1beta1/privateca_grpc_service_config.json",
-		apiServiceConfigPath:  "google/cloud/security/privateca/v1beta1/privateca_gapic.yaml",
+		apiServiceConfigPath:  "google/cloud/security/privateca/v1beta1/privateca_v1beta1.yaml",
 		releaseLevel:          "beta",
 	},
 	{
@@ -860,7 +860,7 @@ var microgenGapicConfigs = []*microgenConfig{
 		pkg:                   "assuredworkloads",
 		importPath:            "cloud.google.com/go/assuredworkloads/apiv1beta1",
 		gRPCServiceConfigPath: "google/cloud/assuredworkloads/v1beta1/assuredworkloads_grpc_service_config.json",
-		apiServiceConfigPath:  "google/cloud/assuredworkloads/v1beta1/assuredworkloads_gapic.yaml",
+		apiServiceConfigPath:  "google/cloud/assuredworkloads/v1beta1/assuredworkloads_v1beta1.yaml",
 		releaseLevel:          "beta",
 	},
 	{
@@ -868,7 +868,7 @@ var microgenGapicConfigs = []*microgenConfig{
 		pkg:                   "accessapproval",
 		importPath:            "cloud.google.com/go/accessapproval/apiv1",
 		gRPCServiceConfigPath: "google/cloud/accessapproval/v1/accessapproval_grpc_service_config.json",
-		apiServiceConfigPath:  "google/cloud/accessapproval/v1/accessapproval_gapic.yaml",
+		apiServiceConfigPath:  "google/cloud/accessapproval/v1/accessapproval_v1.yaml",
 		releaseLevel:          "ga",
 	},
 	{
@@ -971,7 +971,7 @@ var microgenGapicConfigs = []*microgenConfig{
 		pkg:                   "servicemanagement",
 		importPath:            "cloud.google.com/go/servicemanagement/apiv1",
 		gRPCServiceConfigPath: "google/api/servicemanagement/v1/servicemanagement_grpc_service_config.json",
-		apiServiceConfigPath:  "google/api/servicemanagement/v1/servicemanagement_gapic.yaml",
+		apiServiceConfigPath:  "google/api/servicemanagement/v1/servicemanagement_v1.yaml",
 		releaseLevel:          "ga",
 	},
 	{
@@ -994,7 +994,7 @@ var microgenGapicConfigs = []*microgenConfig{
 		inputDirectoryPath:   "google/api/servicecontrol/v1",
 		pkg:                  "servicecontrol",
 		importPath:           "cloud.google.com/go/servicecontrol/apiv1",
-		apiServiceConfigPath: "google/api/servicecontrol/v1/servicecontrol_gapic.yaml",
+		apiServiceConfigPath: "google/api/servicecontrol/v1/servicecontrol.yaml",
 		releaseLevel:         "ga",
 	},
 	{
@@ -1061,7 +1061,7 @@ var microgenGapicConfigs = []*microgenConfig{
 		pkg:                   "admin",
 		importPath:            "cloud.google.com/go/analytics/admin/apiv1alpha",
 		gRPCServiceConfigPath: "google/analytics/admin/v1alpha/admin_grpc_service_config.json",
-		apiServiceConfigPath:  "google/analytics/admin/v1alpha/analyticsadmin_gapic.yaml",
+		apiServiceConfigPath:  "google/analytics/admin/v1alpha/analyticsadmin_v1alpha.yaml",
 		releaseLevel:          "alpha",
 	},
 	{
@@ -1069,7 +1069,7 @@ var microgenGapicConfigs = []*microgenConfig{
 		pkg:                   "data",
 		importPath:            "cloud.google.com/go/analytics/data/apiv1alpha",
 		gRPCServiceConfigPath: "google/analytics/data/v1alpha/analytics_data_grpc_service_config.json",
-		apiServiceConfigPath:  "google/analytics/data/v1alpha/analyticsdata_gapic.yaml",
+		apiServiceConfigPath:  "google/analytics/data/v1alpha/analyticsdata_v1alpha.yaml",
 		releaseLevel:          "alpha",
 	},
 	{

--- a/internal/gapicgen/generator/config_test.go
+++ b/internal/gapicgen/generator/config_test.go
@@ -58,6 +58,9 @@ func TestMicrogenConfigs(t *testing.T) {
 		if entry.apiServiceConfigPath == "" {
 			t.Errorf("config %q (#%d) expected non-empty apiServiceConfigPath", entry.importPath, k)
 		}
+		if p := entry.apiServiceConfigPath; p != "" && strings.HasSuffix(p, "gapic.yaml") {
+			t.Errorf("config %q (#%d) should not use GAPIC yaml for apiServiceConfigPath", entry.importPath, k)
+		}
 		// Internally, an empty release level means "ga" to the underlying tool, but we
 		// want to be explicit in this configuration.
 		if entry.releaseLevel == "" {


### PR DESCRIPTION
This fixes some generation configs that I noticed were using the GAPIC yaml for the `apiServiceConfig` param. These are actually different yaml files and the generator silently accepted them (gonna fix this https://github.com/googleapis/gapic-generator-go/issues/573). The Go microgenerator doesn't use the GAPIC yamls at all. 