### PR TITLE
feat(spanner): support RPC priority for partition query

### DIFF
--- a/spanner/batch.go
+++ b/spanner/batch.go
@@ -183,6 +183,7 @@ func (t *BatchReadOnlyTransaction) partitionQuery(ctx context.Context, statement
 		Params:       params,
 		ParamTypes:   paramTypes,
 		QueryOptions: qOpts.Options,
+		RequestOptions: createRequestOptions(&qOpts),
 	}
 
 	// generate Partitions
@@ -282,6 +283,7 @@ func (t *BatchReadOnlyTransaction) Execute(ctx context.Context, p *Partition) *R
 				Params:         p.qreq.Params,
 				ParamTypes:     p.qreq.ParamTypes,
 				QueryOptions:   p.qreq.QueryOptions,
+				RequestOptions: p.qreq.RequestOptions,
 				PartitionToken: p.pt,
 				ResumeToken:    resumeToken,
 			})


### PR DESCRIPTION
RPC priority was added by #3341, but it looks like the partition (batch) query was not supported in that PR.

This PR is for supporting RPC priority for the partition query.

This graph shows the CPU usage for low priority when I used this fix for running a partition query.
![image](https://user-images.githubusercontent.com/1595215/113854516-e7f19a00-97d9-11eb-90d1-57d7337d837e.png)