### PR TITLE
chore(internal/gapicgen): use protoc 3.12.2

### DIFF
--- a/internal/gapicgen/cmd/genbot/Dockerfile
+++ b/internal/gapicgen/cmd/genbot/Dockerfile
@@ -11,11 +11,6 @@ RUN which bash
 # Install libc compatibility (required by protoc and go)
 RUN apk add libc6-compat
 
-# Use edge for protoc 3.12.x
-# Remove when main upgrades from 3.11.x
-RUN sed -i -e 's/v[[:digit:]]\..*\//edge\//g' /etc/apk/repositories
-RUN apk update
-
 # Install protoc and protobuf-dev (common protos).
 RUN apk add protoc protobuf-dev
 RUN protoc --version


### PR DESCRIPTION
protoc 3.11.X is no longer the default on stable.