### PR TITLE
feat(spannertest): support index, unnest, multi-aggregate

### DIFF
--- a/spanner/go.mod
+++ b/spanner/go.mod
@@ -5,6 +5,7 @@ go 1.11
 require (
 	cloud.google.com/go v0.81.0
 	github.com/golang/protobuf v1.5.2
+	github.com/google/btree v1.0.1
 	github.com/google/go-cmp v0.5.5
 	github.com/googleapis/gax-go/v2 v2.0.5
 	go.opencensus.io v0.23.0

--- a/spanner/go.sum
+++ b/spanner/go.sum
@@ -91,6 +91,8 @@ github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
+github.com/google/btree v1.0.1 h1:gK4Kx5IaGY9CD5sPJ36FHiBJ6ZXl0kilRiiCj+jdYp4=
+github.com/google/btree v1.0.1/go.mod h1:xXMiIv4Fb/0kKde4SpL7qlzvu5cMJDRkFDxJfI9uaxA=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=

--- a/spanner/spannertest/db_query.go
+++ b/spanner/spannertest/db_query.go
@@ -519,7 +519,7 @@ func (d *database) evalSelect(sel spansql.Select, qc *queryContext) (si *selIter
 
 	// Handle aggregation.
 	// TODO: Support more than one aggregation function; does Spanner support that?
-	aggI := -1
+	var aggI []int
 	for i, e := range sel.List {
 		// Supported aggregate funcs have exactly one arg.
 		f, ok := e.(spansql.Func)
@@ -530,12 +530,9 @@ func (d *database) evalSelect(sel spansql.Select, qc *queryContext) (si *selIter
 		if !ok {
 			continue
 		}
-		if aggI > -1 {
-			return nil, fmt.Errorf("only one aggregate function is supported")
-		}
-		aggI = i
+		aggI = append(aggI, i)
 	}
-	if aggI > -1 {
+	if len(aggI) > 0 {
 		raw, err := toRawIter(ri)
 		if err != nil {
 			return nil, err
@@ -544,20 +541,6 @@ func (d *database) evalSelect(sel spansql.Select, qc *queryContext) (si *selIter
 			// No grouping, so aggregation applies to the entire table (e.g. COUNT(*)).
 			// This may result in a [0,0) entry for empty inputs.
 			rowGroups = [][2]int{{0, len(raw.rows)}}
-		}
-		fexpr := sel.List[aggI].(spansql.Func)
-		fn := aggregateFuncs[fexpr.Name]
-		starArg := fexpr.Args[0] == spansql.Star
-		if starArg && !fn.AcceptStar {
-			return nil, fmt.Errorf("aggregate function %s does not accept * as an argument", fexpr.Name)
-		}
-		var argType spansql.Type
-		if !starArg {
-			ci, err := ec.colInfo(fexpr.Args[0])
-			if err != nil {
-				return nil, fmt.Errorf("evaluating aggregate function %s arg type: %v", fexpr.Name, err)
-			}
-			argType = ci.Type
 		}
 
 		// Prepare output.
@@ -571,27 +554,6 @@ func (d *database) evalSelect(sel spansql.Select, qc *queryContext) (si *selIter
 
 		var aggType spansql.Type
 		for _, rg := range rowGroups {
-			// Compute aggregate value across this group.
-			var values []interface{}
-			for i := rg[0]; i < rg[1]; i++ {
-				ec.row = raw.rows[i]
-				if starArg {
-					// A non-NULL placeholder is sufficient for aggregation.
-					values = append(values, 1)
-				} else {
-					x, err := ec.evalExpr(fexpr.Args[0])
-					if err != nil {
-						return nil, err
-					}
-					values = append(values, x)
-				}
-			}
-			x, typ, err := fn.Eval(values, argType)
-			if err != nil {
-				return nil, err
-			}
-			aggType = typ
-
 			var outRow row
 			// Output for the row group is the first row of the group (arbitrary,
 			// but it should be representative), and the aggregate value.
@@ -609,27 +571,68 @@ func (d *database) evalSelect(sel spansql.Select, qc *queryContext) (si *selIter
 					outRow = append(outRow, nil)
 				}
 			}
-			outRow = append(outRow, x)
+
+			for _, aggI := range aggI {
+				fexpr := sel.List[aggI].(spansql.Func)
+				fn := aggregateFuncs[fexpr.Name]
+				starArg := fexpr.Args[0] == spansql.Star
+				if starArg && !fn.AcceptStar {
+					return nil, fmt.Errorf("aggregate function %s does not accept * as an argument", fexpr.Name)
+				}
+				var argType spansql.Type
+				if !starArg {
+					ci, err := ec.colInfo(fexpr.Args[0])
+					if err != nil {
+						return nil, fmt.Errorf("evaluating aggregate function %s arg type: %v", fexpr.Name, err)
+					}
+					argType = ci.Type
+				}
+
+				// Compute aggregate value across this group.
+				var values []interface{}
+				for i := rg[0]; i < rg[1]; i++ {
+					ec.row = raw.rows[i]
+					if starArg {
+						// A non-NULL placeholder is sufficient for aggregation.
+						values = append(values, 1)
+					} else {
+						x, err := ec.evalExpr(fexpr.Args[0])
+						if err != nil {
+							return nil, err
+						}
+						values = append(values, x)
+					}
+				}
+				x, typ, err := fn.Eval(values, argType)
+				if err != nil {
+					return nil, err
+				}
+				aggType = typ
+
+				outRow = append(outRow, x)
+			}
 			rawOut.rows = append(rawOut.rows, outRow)
 		}
 
-		if aggType == (spansql.Type{}) {
-			// Fallback; there might not be any groups.
-			// TODO: Should this be in aggregateFunc?
-			aggType = int64Type
+		for _, aggI := range aggI {
+			fexpr := sel.List[aggI].(spansql.Func)
+			if aggType == (spansql.Type{}) {
+				// Fallback; there might not be any groups.
+				// TODO: Should this be in aggregateFunc?
+				aggType = int64Type
+			}
+			rawOut.cols = append(rawOut.cols, colInfo{
+				Name:     spansql.ID(fexpr.SQL()), // TODO: this is a bit hokey, but it is output only
+				Type:     aggType,
+				AggIndex: aggI + 1,
+			})
+			sel.List[aggI] = aggSentinel{ // Mutate query so evalExpr in selIter picks out the new value.
+				Type:     aggType,
+				AggIndex: aggI + 1,
+			}
 		}
-		rawOut.cols = append(raw.cols, colInfo{
-			Name:     spansql.ID(fexpr.SQL()), // TODO: this is a bit hokey, but it is output only
-			Type:     aggType,
-			AggIndex: aggI + 1,
-		})
-
 		ri = rawOut
 		ec.cols = rawOut.cols
-		sel.List[aggI] = aggSentinel{ // Mutate query so evalExpr in selIter picks out the new value.
-			Type:     aggType,
-			AggIndex: aggI + 1,
-		}
 	}
 
 	// TODO: Support table sampling.

--- a/spanner/spannertest/db_test.go
+++ b/spanner/spannertest/db_test.go
@@ -375,10 +375,13 @@ func slurp(t *testing.T, ri rowIter) (all [][]interface{}) {
 }
 
 func listV(vs ...*structpb.Value) *structpb.ListValue { return &structpb.ListValue{Values: vs} }
-func stringV(s string) *structpb.Value                { return &structpb.Value{Kind: &structpb.Value_StringValue{s}} }
-func floatV(f float64) *structpb.Value                { return &structpb.Value{Kind: &structpb.Value_NumberValue{f}} }
-func boolV(b bool) *structpb.Value                    { return &structpb.Value{Kind: &structpb.Value_BoolValue{b}} }
-func nullV() *structpb.Value                          { return &structpb.Value{Kind: &structpb.Value_NullValue{}} }
+func listVV(vs ...*structpb.Value) *structpb.Value {
+	return &structpb.Value{Kind: &structpb.Value_ListValue{listV(vs...)}}
+}
+func stringV(s string) *structpb.Value { return &structpb.Value{Kind: &structpb.Value_StringValue{s}} }
+func floatV(f float64) *structpb.Value { return &structpb.Value{Kind: &structpb.Value_NumberValue{f}} }
+func boolV(b bool) *structpb.Value     { return &structpb.Value{Kind: &structpb.Value_BoolValue{b}} }
+func nullV() *structpb.Value           { return &structpb.Value{Kind: &structpb.Value_NullValue{}} }
 
 func boolParam(b bool) queryParam     { return queryParam{Value: b, Type: boolType} }
 func stringParam(s string) queryParam { return queryParam{Value: s, Type: stringType} }

--- a/spanner/spannertest/integration_test.go
+++ b/spanner/spannertest/integration_test.go
@@ -203,7 +203,9 @@ func TestIntegration_SpannerBasics(t *testing.T) {
 	}
 	err = updateDDL(t, adminClient,
 		`ALTER TABLE `+tableName+` ADD COLUMN Age INT64`,
-		`CREATE INDEX AgeIndex ON `+tableName+` (Age DESC)`)
+		`CREATE INDEX AgeIndexAsc ON `+tableName+` (Age)`,
+		`CREATE INDEX AgeIndexDesc ON `+tableName+` (Age DESC)`,
+		`CREATE INDEX AgeIndexStoring ON `+tableName+` (Age, FirstName) STORING (LastName)`)
 	if err != nil {
 		t.Fatalf("Adding new column: %v", err)
 	}
@@ -439,6 +441,214 @@ func TestIntegration_SpannerBasics(t *testing.T) {
 	if !reflect.DeepEqual(ages, wantAges) {
 		t.Errorf("Query with IN UNNEST gave wrong ages: got %+v, want %+v", ages, wantAges)
 	}
+	t.Run("Read all from index", func(t *testing.T) {
+		cases := []struct {
+			indexName string
+			want      []int64
+		}{
+			{
+				indexName: "AgeIndexAsc",
+				want:      []int64{0, 0, 35, 49, 102},
+			},
+			{
+				indexName: "AgeIndexDesc",
+				want:      []int64{102, 49, 35, 0, 0},
+			},
+			{
+				indexName: "AgeIndexStoring",
+				want:      []int64{0, 0, 35, 49, 102},
+			},
+		}
+
+		for _, tc := range cases {
+			ages := ages[:0]
+			if err := client.Single().ReadUsingIndex(ctx, tableName, tc.indexName, spanner.AllKeys(), []string{"Age"}).Do(func(row *spanner.Row) error {
+				var age spanner.NullInt64
+				if err := row.Column(0, &age); err != nil {
+					return err
+				}
+				ages = append(ages, age.Int64) // zero for NULL
+				return nil
+			}); err != nil {
+				t.Fatalf("Getting ages using index: %v", err)
+			}
+			if !reflect.DeepEqual(ages, tc.want) {
+				t.Fatalf("Read index %s gave wrong ages: got %+v, want %+v", tc.indexName, ages, tc.want)
+			}
+		}
+	})
+	t.Run("Read all from index desc", func(t *testing.T) {
+		ages := ages[:0]
+		if err := client.Single().ReadUsingIndex(ctx, tableName, "AgeIndexDesc", spanner.AllKeys(), []string{"Age"}).Do(func(row *spanner.Row) error {
+			var age spanner.NullInt64
+			if err := row.Column(0, &age); err != nil {
+				return err
+			}
+			ages = append(ages, age.Int64) // zero for NULL
+			return nil
+		}); err != nil {
+			t.Fatalf("Getting ages using index: %v", err)
+		}
+		wantAges = []int64{102, 49, 35, 0, 0}
+		if !reflect.DeepEqual(ages, wantAges) {
+			t.Fatalf("Read index gave wrong ages: got %+v, want %+v", ages, wantAges)
+		}
+	})
+	t.Run("Read ranges from index", func(t *testing.T) {
+		int64p := func(v int64) *int64 {
+			return &v
+		}
+		cases := []struct {
+			indexName   string
+			start       *int64
+			end         *int64
+			startClosed bool
+			endClosed   bool
+			want        []int64
+		}{
+			{
+				indexName:   "AgeIndexDesc",
+				start:       int64p(102),
+				end:         int64p(35),
+				startClosed: false,
+				endClosed:   false,
+				want:        []int64{49},
+			},
+			{
+				indexName:   "AgeIndexDesc",
+				start:       int64p(102),
+				end:         int64p(35),
+				startClosed: true,
+				endClosed:   false,
+				want:        []int64{102, 49},
+			},
+			{
+				indexName:   "AgeIndexDesc",
+				start:       int64p(102),
+				end:         int64p(35),
+				startClosed: false,
+				endClosed:   true,
+				want:        []int64{49, 35},
+			},
+			{
+				indexName:   "AgeIndexDesc",
+				start:       int64p(102),
+				end:         int64p(35),
+				startClosed: true,
+				endClosed:   true,
+				want:        []int64{102, 49, 35},
+			},
+			{
+				indexName:   "AgeIndexDesc",
+				start:       int64p(35),
+				end:         int64p(102),
+				startClosed: true,
+				endClosed:   true,
+				want:        []int64{},
+			},
+			{
+				indexName:   "AgeIndexDesc",
+				start:       int64p(102),
+				end:         nil,
+				startClosed: false,
+				endClosed:   false,
+				want:        []int64{49, 35, 0, 0},
+			},
+			{
+				indexName:   "AgeIndexDesc",
+				start:       int64p(102),
+				end:         int64p(0),
+				startClosed: true,
+				endClosed:   true,
+				want:        []int64{102, 49, 35},
+			},
+			{
+				indexName:   "AgeIndexAsc",
+				start:       int64p(35),
+				end:         int64p(102),
+				startClosed: false,
+				endClosed:   false,
+				want:        []int64{49},
+			},
+			{
+				indexName:   "AgeIndexAsc",
+				start:       int64p(35),
+				end:         int64p(102),
+				startClosed: true,
+				endClosed:   false,
+				want:        []int64{35, 49},
+			},
+			{
+				indexName:   "AgeIndexAsc",
+				start:       int64p(35),
+				end:         int64p(102),
+				startClosed: false,
+				endClosed:   true,
+				want:        []int64{49, 102},
+			},
+			{
+				indexName:   "AgeIndexAsc",
+				start:       int64p(35),
+				end:         int64p(102),
+				startClosed: true,
+				endClosed:   true,
+				want:        []int64{35, 49, 102},
+			},
+			{
+				indexName:   "AgeIndexAsc",
+				start:       int64p(102),
+				end:         int64p(35),
+				startClosed: true,
+				endClosed:   true,
+				want:        []int64{},
+			},
+			{
+				indexName:   "AgeIndexAsc",
+				start:       nil,
+				end:         int64p(102),
+				startClosed: false,
+				endClosed:   false,
+				want:        []int64{0, 0, 35, 49},
+			},
+		}
+		for j, tc := range cases {
+			ages := ages[:0]
+			rng := spanner.KeyRange{}
+
+			if tc.start != nil {
+				rng.Start = spanner.Key{*tc.start}
+			}
+			if tc.end != nil {
+				rng.End = spanner.Key{*tc.end}
+			}
+			if tc.startClosed {
+				if tc.endClosed {
+					rng.Kind = spanner.ClosedClosed
+				} else {
+					rng.Kind = spanner.ClosedOpen
+				}
+			} else {
+				if tc.endClosed {
+					rng.Kind = spanner.OpenClosed
+				} else {
+					rng.Kind = spanner.OpenOpen
+				}
+			}
+			if err := client.Single().ReadUsingIndex(ctx, tableName, tc.indexName, rng, []string{"Age"}).Do(func(row *spanner.Row) error {
+				var age spanner.NullInt64
+				if err := row.Column(0, &age); err != nil {
+					return err
+				}
+				ages = append(ages, age.Int64) // zero for NULL
+				return nil
+			}); err != nil {
+				t.Fatalf("Getting ages using index: %v", err)
+			}
+			if !reflect.DeepEqual(ages, tc.want) {
+				t.Fatalf("Read index case %d %s gave wrong ages: got %+v, want %+v", j, rng, ages, tc.want)
+			}
+		}
+	})
 }
 
 func TestIntegration_ReadsAndQueries(t *testing.T) {

--- a/spanner/spansql/parser_test.go
+++ b/spanner/spansql/parser_test.go
@@ -208,6 +208,39 @@ func TestParseQuery(t *testing.T) {
 				},
 			},
 		},
+		{`SELECT c.Alias FROM Characters AS c` + "\n\t",
+			Query{
+				Select: Select{
+					List: []Expr{PathExp{
+						"c",
+						"Alias",
+					}},
+					From: []SelectFrom{SelectFromTable{
+						Table: "Characters",
+						Alias: "c",
+					}},
+				},
+			},
+		},
+		// Joins with hints.
+		{`SELECT * FROM A JOIN B USING (x) JOIN C USING (x)`,
+			Query{
+				Select: Select{
+					List: []Expr{Star},
+					From: []SelectFrom{SelectFromJoin{
+						Type: InnerJoin,
+						LHS: SelectFromJoin{
+							Type:  InnerJoin,
+							LHS:   SelectFromTable{Table: "A"},
+							RHS:   SelectFromTable{Table: "B"},
+							Using: []ID{"x"},
+						},
+						RHS:   SelectFromTable{Table: "C"},
+						Using: []ID{"x"},
+					}},
+				},
+			},
+		},
 	}
 	for _, test := range tests {
 		got, err := ParseQuery(test.in)

--- a/spanner/spansql/sql.go
+++ b/spanner/spansql/sql.go
@@ -351,6 +351,9 @@ func (sfu SelectFromUnnest) SQL() string {
 	if sfu.Alias != "" {
 		str += " AS " + sfu.Alias.SQL()
 	}
+	if sfu.OffsetAlias != "" {
+		str += " WITH OFFSET " + sfu.OffsetAlias.SQL()
+	}
 	return str
 }
 

--- a/spanner/spansql/types.go
+++ b/spanner/spansql/types.go
@@ -398,13 +398,25 @@ const (
 // SelectFromUnnest is a SelectFrom that yields a virtual table from an array.
 // https://cloud.google.com/spanner/docs/query-syntax#unnest
 type SelectFromUnnest struct {
-	Expr  Expr
-	Alias ID // empty if not aliased
-
+	Expr        Expr
+	Alias       ID // empty if not aliased
+	OffsetAlias ID // empty if no offset
 	// TODO: Implicit
 }
 
 func (SelectFromUnnest) isSelectFrom() {}
+
+type SelectFromList []SelectFrom
+
+func (SelectFromList) isSelectFrom() {}
+
+func (sfl SelectFromList) SQL() string {
+	sqls := make([]string, len(sfl))
+	for j := range sfl {
+		sqls[j] = sfl[j].SQL()
+	}
+	return strings.Join(sqls, ", ")
+}
 
 // TODO: SelectFromSubquery, etc.
 


### PR DESCRIPTION
This adds several features to spannertest:
- `UNNEST` in a `FROM` clause: `SELECT * FROM a, UNNEST(a.ArrayColumn)`.
- Multi-table cartesian product: `SELECT * FROM a, b`.
- Multiple `JOIN` clauses: `SELECT * FROM a JOIN b USING(x) JOIN c USING(x)`.
- Multiple aggregations: `SELECT MIN(x), MAX(x) FROM a`.
- Secondary index reads: specifying `Index` in a `ReadRequest`.