### PR TITLE
chore(all): un-gitignore file not in repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,3 @@ coverage.txt
 
 # Other
 .DS_Store
-internal/env-tests-logging


### PR DESCRIPTION
I accidentally merged this file, but only needed it locally and it breaks our CI if merged in master :[