### PR TITLE
feat(spannertest): support unnest and multi-join

### DIFF
--- a/spanner/spannertest/db_query.go
+++ b/spanner/spannertest/db_query.go
@@ -221,7 +221,13 @@ func (si *selIter) next() (row, error) {
 	var out row
 	for _, e := range si.list {
 		if e == spansql.Star {
-			out = append(out, r...)
+			if len(si.ec.starCols) > 0 {
+				for _, j := range si.ec.starCols {
+					out = append(out, r[j])
+				}
+			} else {
+				out = append(out, r...)
+			}
 		} else {
 			v, err := si.ec.evalExpr(e)
 			if err != nil {
@@ -405,6 +411,13 @@ func (d *database) queryContext(q spansql.Query, params queryParams) (*queryCont
 		switch sf := sf.(type) {
 		default:
 			return fmt.Errorf("can't prepare query context for SelectFrom of type %T", sf)
+		case spansql.SelectFromList:
+			for j := range sf {
+				if err := findTables(sf[j]); err != nil {
+					return err
+				}
+			}
+			return nil
 		case spansql.SelectFromTable:
 			return addTable(sf.Table)
 		case spansql.SelectFromJoin:
@@ -436,23 +449,197 @@ func (d *database) queryContext(q spansql.Query, params queryParams) (*queryCont
 	return qc, nil
 }
 
+func (d *database) evalCartesian(qc *queryContext, ff []evalContext, rr []rowIter) (evalContext, rowIter, error) {
+	if len(ff) != len(rr) {
+		return evalContext{}, nil, fmt.Errorf("mismatched context and iterator sizes")
+	}
+	for len(rr) > 0 {
+		if _, ok := rr[0].(*nullIter); !ok {
+			break
+		}
+		params := ff[0].params
+		ff, rr = ff[1:], rr[1:]
+		if len(ff) > 0 {
+			if ff[0].params == nil {
+				ff[0].params = params
+			} else {
+				for k, v := range params {
+					ff[0].params[k] = v
+				}
+			}
+		}
+	}
+	if len(ff) == 0 {
+		return evalContext{}, &nullIter{}, nil
+	}
+	if len(ff) == 1 {
+		return ff[0], rr[0], nil
+	}
+	rows := make([][]row, len(ff))
+	var cols []colInfo
+	mergedEC := evalContext{}
+	for j := range ff {
+		raw, err := toRawIter(rr[j])
+		if err != nil {
+			return evalContext{}, nil, err
+		}
+		rows[j] = raw.rows
+		cols = append(cols, raw.cols...)
+		mergedEC, err = mergedEC.merge(ff[j])
+		if err != nil {
+			return evalContext{}, nil, err
+		}
+	}
+	return mergedEC, &cartesianIterator{
+		rows: rows,
+		cols: cols,
+	}, nil
+}
+
+type cartesianIterator struct {
+	rows [][]row
+	cols []colInfo
+
+	loop     int
+	counters []int
+}
+
+func (ci *cartesianIterator) Cols() []colInfo { return ci.cols }
+func (ci *cartesianIterator) Next() (row, error) {
+	if len(ci.rows) == 0 {
+		return nil, io.EOF
+	}
+	if len(ci.counters) != len(ci.rows) {
+		ci.counters = make([]int, len(ci.rows))
+		ci.loop = len(ci.rows) - 1
+	}
+	if ci.loop < 0 {
+		return nil, io.EOF
+	}
+	res := make(row, 0, len(ci.cols))
+	for j := range ci.rows {
+		if ci.counters[j] < len(ci.rows[j]) {
+			r := ci.rows[j][ci.counters[j]]
+			res = append(res, r...)
+		}
+	}
+	ci.increment()
+	return res, nil
+}
+
+func (ci *cartesianIterator) increment() bool {
+	if ci.loop < 0 {
+		return false
+	}
+
+	ci.counters[ci.loop]++
+	res := true
+	if ci.counters[ci.loop] >= len(ci.rows[ci.loop]) {
+		ci.counters[ci.loop] = 0
+		ci.loop--
+		res = ci.increment()
+		if res {
+			ci.loop++
+		}
+	}
+	return res
+}
+
+// unnestIter is a rowIter that processes an unnest operation per input row
+type unnestIter struct {
+	vals []interface{}
+	cols []colInfo
+	pos  int
+
+	ec   evalContext
+	sf   spansql.SelectFromUnnest
+	iter rowIter
+	err  error
+}
+
+func (u *unnestIter) Bind(ec evalContext) error {
+	u.ec = ec
+	// TODO: Do all relevant types flow through here? Path expressions might be tricky here.
+	col, err := u.ec.colInfo(u.sf.Expr)
+	if err != nil {
+		return fmt.Errorf("evaluating type of UNNEST arg: %v", err)
+	}
+	if !col.Type.Array {
+		return fmt.Errorf("type of UNNEST arg is non-array %s", col.Type.SQL())
+	}
+	// The output of this UNNEST is the non-array version.
+	col.Name = u.sf.Alias // may be empty
+	col.Type.Array = false
+	col.Alias = nil
+
+	offsetName := u.sf.OffsetAlias
+	if offsetName == "" {
+		offsetName = "offset"
+	}
+	offsetCol := colInfo{
+		Type:    int64Type,
+		Name:    offsetName,
+		NotNull: true,
+	}
+
+	cols := []colInfo{col, offsetCol}
+	u.cols = cols
+	return nil
+}
+
+func (u *unnestIter) Cols() []colInfo {
+	var res []colInfo
+	res = append(res, u.iter.Cols()...)
+	res = append(res, u.cols...)
+	return res
+}
+
+func (u *unnestIter) Next() (row, error) {
+	if u.err != nil {
+		return nil, u.err
+	}
+	for u.pos >= len(u.vals) {
+		r, err := u.iter.Next()
+		if err != nil {
+			u.err = err
+			return nil, err
+		}
+
+		u.ec.row = r
+		u.pos = 0
+
+		// Evaluate the expression, and yield a virtual table with one column.
+		e, err := u.ec.evalExpr(u.sf.Expr)
+		if err != nil {
+			return nil, fmt.Errorf("evaluating UNNEST arg: %v", err)
+		}
+		if e == nil {
+			u.vals = nil
+			continue
+		}
+		arr, ok := e.([]interface{})
+		if !ok {
+			return nil, fmt.Errorf("evaluating UNNEST arg with %+v from %+v gave %t, want array", u.ec, u.iter, e)
+		}
+		u.vals = arr
+	}
+	var r row
+	r = append(r, u.ec.row...)
+	r = append(r, row{u.vals[u.pos], int64(u.pos)}...)
+	u.pos++
+	return r, nil
+}
+
 func (d *database) evalSelect(sel spansql.Select, qc *queryContext) (si *selIter, evalErr error) {
-	var ri rowIter = &nullIter{}
 	ec := evalContext{
 		params: qc.params,
 	}
 
 	// First stage is to identify the data source.
 	// If there's a FROM then that names a table to use.
-	if len(sel.From) > 1 {
-		return nil, fmt.Errorf("selecting with more than one FROM clause not yet supported")
-	}
-	if len(sel.From) == 1 {
-		var err error
-		ec, ri, err = d.evalSelectFrom(qc, ec, sel.From[0])
-		if err != nil {
-			return nil, err
-		}
+	ec, ri, err := d.evalSelectFrom(qc, ec, spansql.SelectFromList(sel.From), &nullIter{})
+	if err != nil {
+		return nil, err
 	}
 
 	// Apply WHERE.
@@ -638,7 +825,13 @@ func (d *database) evalSelect(sel spansql.Select, qc *queryContext) (si *selIter
 	var colInfos []colInfo
 	for i, e := range sel.List {
 		if e == spansql.Star {
-			colInfos = append(colInfos, ec.cols...)
+			if len(ec.starCols) > 0 {
+				for _, j := range ec.starCols {
+					colInfos = append(colInfos, ec.cols[j])
+				}
+			} else {
+				colInfos = append(colInfos, ec.cols...)
+			}
 		} else {
 			ci, err := ec.colInfo(e)
 			if err != nil {
@@ -665,10 +858,22 @@ func (d *database) evalSelect(sel spansql.Select, qc *queryContext) (si *selIter
 	}, nil
 }
 
-func (d *database) evalSelectFrom(qc *queryContext, ec evalContext, sf spansql.SelectFrom) (evalContext, rowIter, error) {
+func (d *database) evalSelectFrom(qc *queryContext, ec evalContext, sf spansql.SelectFrom, iter rowIter) (evalContext, rowIter, error) {
 	switch sf := sf.(type) {
 	default:
 		return ec, nil, fmt.Errorf("selecting with FROM clause of type %T not yet supported", sf)
+	case spansql.SelectFromList:
+		ri := iter
+		for j := range sf {
+			fec, fri, err := d.evalSelectFrom(qc, ec, sf[j], ri)
+			if err != nil {
+				return ec, nil, err
+			}
+
+			ri = fri
+			ec = fec
+		}
+		return ec, ri, nil
 	case spansql.SelectFromTable:
 		t, ok := qc.tableIndex[sf.Table]
 		if !ok {
@@ -683,12 +888,28 @@ func (d *database) evalSelectFrom(qc *queryContext, ec evalContext, sf spansql.S
 			// https://cloud.google.com/spanner/docs/query-syntax#implicit_aliases
 			ti.alias = sf.Table
 		}
-		ec.cols = ti.Cols()
-		return ec, ti, nil
+		cols := ti.Cols()
+		starCols := make([]int, len(cols))
+		for j := range starCols {
+			starCols[j] = j
+		}
+
+		fec := evalContext{
+			cols:     cols,
+			starCols: starCols,
+		}
+		return d.evalCartesian(qc, []evalContext{ec, fec}, []rowIter{iter, ti})
 	case spansql.SelectFromJoin:
 		// TODO: Avoid the toRawIter calls here by doing the RHS recursive evalSelectFrom in joinIter.Next on demand.
 
-		lhsEC, lhs, err := d.evalSelectFrom(qc, ec, sf.LHS)
+		var lhsEC evalContext
+		var lhs rowIter
+		var err error
+		if sf.LHS == nil {
+			lhsEC, lhs = ec, iter
+		} else {
+			lhsEC, lhs, err = d.evalSelectFrom(qc, ec, sf.LHS, iter)
+		}
 		if err != nil {
 			return ec, nil, err
 		}
@@ -697,7 +918,7 @@ func (d *database) evalSelectFrom(qc *queryContext, ec evalContext, sf spansql.S
 			return ec, nil, err
 		}
 
-		rhsEC, rhs, err := d.evalSelectFrom(qc, ec, sf.RHS)
+		rhsEC, rhs, err := d.evalSelectFrom(qc, ec, sf.RHS, iter)
 		if err != nil {
 			return ec, nil, err
 		}
@@ -706,44 +927,28 @@ func (d *database) evalSelectFrom(qc *queryContext, ec evalContext, sf spansql.S
 			return ec, nil, err
 		}
 
-		ji, ec, err := newJoinIter(lhsRaw, rhsRaw, lhsEC, rhsEC, sf)
+		ji, jec, err := newJoinIter(lhsRaw, rhsRaw, lhsEC, rhsEC, sf)
 		if err != nil {
 			return ec, nil, err
 		}
-		return ec, ji, nil
+		//return d.evalCartesian(qc, []evalContext{ec, jec}, []rowIter{iter, ji})
+		return jec, ji, nil
 	case spansql.SelectFromUnnest:
-		// TODO: Do all relevant types flow through here? Path expressions might be tricky here.
-		col, err := ec.colInfo(sf.Expr)
+		u := &unnestIter{
+			sf:   sf,
+			iter: iter,
+		}
+		if err := u.Bind(ec); err != nil {
+			return ec, nil, err
+		}
+		uec, err := ec.merge(evalContext{
+			cols:     u.cols,
+			starCols: []int{0},
+		})
 		if err != nil {
-			return ec, nil, fmt.Errorf("evaluating type of UNNEST arg: %v", err)
+			return ec, nil, err
 		}
-		if !col.Type.Array {
-			return ec, nil, fmt.Errorf("type of UNNEST arg is non-array %s", col.Type.SQL())
-		}
-		// The output of this UNNEST is the non-array version.
-		col.Name = sf.Alias // may be empty
-		col.Type.Array = false
-
-		// Evaluate the expression, and yield a virtual table with one column.
-		e, err := ec.evalExpr(sf.Expr)
-		if err != nil {
-			return ec, nil, fmt.Errorf("evaluating UNNEST arg: %v", err)
-		}
-		arr, ok := e.([]interface{})
-		if !ok {
-			return ec, nil, fmt.Errorf("evaluating UNNEST arg gave %t, want array", e)
-		}
-		var rows []row
-		for _, v := range arr {
-			rows = append(rows, row{v})
-		}
-
-		ri := &rawIter{
-			cols: []colInfo{col},
-			rows: rows,
-		}
-		ec.cols = ri.cols
-		return ec, ri, nil
+		return uec, u, nil
 	}
 }
 
@@ -803,9 +1008,18 @@ func newJoinIter(lhs, rhs *rawIter, lhsEC, rhsEC evalContext, sfj spansql.Select
 func (ji *joinIter) prepNonUsing(on spansql.BoolExpr, lhsEC, rhsEC evalContext) {
 	// Having ON or no clause results in the full set of columns from both sides.
 	// Force a copy.
+	lhsOffset := len(ji.ec.cols)
 	ji.ec.cols = append(ji.ec.cols, lhsEC.cols...)
+	rhsOffset := len(ji.ec.cols)
 	ji.ec.cols = append(ji.ec.cols, rhsEC.cols...)
 	ji.ec.row = make(row, len(ji.ec.cols))
+	ji.ec.starCols = make([]int, 0, len(lhsEC.starCols)+len(rhsEC.starCols))
+	for j := range lhsEC.starCols {
+		ji.ec.starCols = append(ji.ec.starCols, lhsEC.starCols[j]+lhsOffset)
+	}
+	for j := range rhsEC.starCols {
+		ji.ec.starCols = append(ji.ec.starCols, rhsEC.starCols[j]+rhsOffset)
+	}
 
 	ji.cond = func(primary, secondary row) (bool, error) {
 		copy(ji.ec.row[ji.primaryOffset:], primary)
@@ -837,9 +1051,11 @@ func (ji *joinIter) prepUsing(using []spansql.ID, lhsEC, rhsEC evalContext, flip
 	// rhsUsing is similar.
 	// lhsNotUsing/rhsNotUsing are the complement.
 	var lhsUsing, rhsUsing []int
-	var lhsNotUsing, rhsNotUsing []int
 	// lhsUsed, rhsUsed are the set of column indexes in lhsUsing/rhsUsing.
 	lhsUsed, rhsUsed := make(map[int]bool), make(map[int]bool)
+	primaryLength, secondaryLength := len(lhsEC.cols), len(rhsEC.cols)
+	ji.ec.cols = nil
+	ji.ec.starCols = nil
 	for _, id := range using {
 		lhsi, err := lhsEC.resolveColumnIndex(id)
 		if err != nil {
@@ -854,59 +1070,68 @@ func (ji *joinIter) prepUsing(using []spansql.ID, lhsEC, rhsEC evalContext, flip
 		}
 		rhsUsing = append(rhsUsing, rhsi)
 		rhsUsed[rhsi] = true
+		ji.ec.starCols = append(ji.ec.starCols, len(ji.ec.cols))
+		col := lhsEC.cols[lhsi]
+		if flipped {
+			col = rhsEC.cols[rhsi]
+		}
+		col.Alias = nil
+		col.AggIndex = 0
+		ji.ec.cols = append(ji.ec.cols, col)
+	}
 
-		// TODO: Should this hide or merge column aliases?
-		ji.ec.cols = append(ji.ec.cols, lhsEC.cols[lhsi])
-	}
-	for i, col := range lhsEC.cols {
+	for i := range lhsEC.cols {
 		if !lhsUsed[i] {
-			ji.ec.cols = append(ji.ec.cols, col)
-			lhsNotUsing = append(lhsNotUsing, i)
+			ji.ec.starCols = append(ji.ec.starCols, len(ji.ec.cols))
 		}
+		ji.ec.cols = append(ji.ec.cols, lhsEC.cols[i])
 	}
-	for i, col := range rhsEC.cols {
+	for i := range rhsEC.cols {
 		if !rhsUsed[i] {
-			ji.ec.cols = append(ji.ec.cols, col)
-			rhsNotUsing = append(rhsNotUsing, i)
+			ji.ec.starCols = append(ji.ec.starCols, len(ji.ec.cols))
 		}
+		ji.ec.cols = append(ji.ec.cols, rhsEC.cols[i])
 	}
-	ji.ec.row = make(row, len(ji.ec.cols))
 
 	primaryUsing, secondaryUsing := lhsUsing, rhsUsing
+	primaryUsed, secondaryUsed := lhsUsed, rhsUsed
 	if flipped {
 		primaryUsing, secondaryUsing = secondaryUsing, primaryUsing
+		primaryUsed, secondaryUsed = secondaryUsed, primaryUsed
 	}
 
+	ji.ec.row = make(row, len(ji.ec.cols))
+
 	orNil := func(r row, i int) interface{} {
-		if r == nil {
+		if len(r) == 0 {
 			return nil
 		}
 		return r[i]
 	}
+
 	// populate writes the data to ji.ec.row in the correct positions.
 	populate := func(primary, secondary row) { // either may be nil
 		j := 0
 		if primary != nil {
-			for _, pi := range primaryUsing {
-				ji.ec.row[j] = primary[pi]
+			for _, i := range primaryUsing {
+				ji.ec.row[j] = orNil(primary, i)
 				j++
 			}
 		} else {
-			for _, si := range secondaryUsing {
-				ji.ec.row[j] = secondary[si]
+			for _, i := range secondaryUsing {
+				ji.ec.row[j] = orNil(secondary, i)
 				j++
 			}
 		}
-		lhs, rhs := primary, secondary
 		if flipped {
-			rhs, lhs = lhs, rhs
+			primary, secondary = secondary, primary
 		}
-		for _, i := range lhsNotUsing {
-			ji.ec.row[j] = orNil(lhs, i)
+		for i := 0; i < primaryLength; i++ {
+			ji.ec.row[j] = orNil(primary, i)
 			j++
 		}
-		for _, i := range rhsNotUsing {
-			ji.ec.row[j] = orNil(rhs, i)
+		for i := 0; i < secondaryLength; i++ {
+			ji.ec.row[j] = orNil(secondary, i)
 			j++
 		}
 	}

--- a/spanner/spannertest/db_test.go
+++ b/spanner/spannertest/db_test.go
@@ -375,10 +375,13 @@ func slurp(t *testing.T, ri rowIter) (all [][]interface{}) {
 }
 
 func listV(vs ...*structpb.Value) *structpb.ListValue { return &structpb.ListValue{Values: vs} }
-func stringV(s string) *structpb.Value                { return &structpb.Value{Kind: &structpb.Value_StringValue{s}} }
-func floatV(f float64) *structpb.Value                { return &structpb.Value{Kind: &structpb.Value_NumberValue{f}} }
-func boolV(b bool) *structpb.Value                    { return &structpb.Value{Kind: &structpb.Value_BoolValue{b}} }
-func nullV() *structpb.Value                          { return &structpb.Value{Kind: &structpb.Value_NullValue{}} }
+func listVV(vs ...*structpb.Value) *structpb.Value {
+	return &structpb.Value{Kind: &structpb.Value_ListValue{listV(vs...)}}
+}
+func stringV(s string) *structpb.Value { return &structpb.Value{Kind: &structpb.Value_StringValue{s}} }
+func floatV(f float64) *structpb.Value { return &structpb.Value{Kind: &structpb.Value_NumberValue{f}} }
+func boolV(b bool) *structpb.Value     { return &structpb.Value{Kind: &structpb.Value_BoolValue{b}} }
+func nullV() *structpb.Value           { return &structpb.Value{Kind: &structpb.Value_NullValue{}} }
 
 func boolParam(b bool) queryParam     { return queryParam{Value: b, Type: boolType} }
 func stringParam(s string) queryParam { return queryParam{Value: s, Type: stringType} }

--- a/spanner/spannertest/integration_test.go
+++ b/spanner/spannertest/integration_test.go
@@ -453,7 +453,8 @@ func TestIntegration_ReadsAndQueries(t *testing.T) {
 	allTables := []string{
 		"Staff",
 		"PlayerStats",
-		"JoinA", "JoinB", "JoinC", "JoinD", "JoinE", "JoinF",
+		"Episodes",
+		"JoinA", "JoinB", "JoinC", "JoinD", "JoinE", "JoinF", "JoinG",
 		"SomeStrings", "Updateable",
 	}
 	errc := make(chan error)
@@ -658,6 +659,7 @@ func TestIntegration_ReadsAndQueries(t *testing.T) {
 		`CREATE TABLE JoinD ( x INT64, z STRING(MAX) ) PRIMARY KEY (x, z)`,
 		`CREATE TABLE JoinE ( w INT64, x STRING(MAX) ) PRIMARY KEY (w, x)`,
 		`CREATE TABLE JoinF ( y INT64, z STRING(MAX) ) PRIMARY KEY (y, z)`,
+		`CREATE TABLE JoinG ( x INT64, a STRING(MAX), b STRING(MAX) ) PRIMARY KEY (x, a, b)`,
 		// Some other test tables.
 		`CREATE TABLE SomeStrings ( i INT64, str STRING(MAX) ) PRIMARY KEY (i)`,
 		`CREATE TABLE Updateable (
@@ -665,6 +667,11 @@ func TestIntegration_ReadsAndQueries(t *testing.T) {
 			first STRING(MAX),
 			last STRING(MAX),
 		) PRIMARY KEY (id)`,
+		`CREATE TABLE Episodes (
+			EpisodeID INT64,
+			StaffNames ARRAY<STRING(MAX)>,
+			StaffIDs ARRAY<INT64>,
+		) PRIMARY KEY (EpisodeID)`,
 	)
 	if err != nil {
 		t.Fatalf("Creating sample tables: %v", err)
@@ -704,6 +711,9 @@ func TestIntegration_ReadsAndQueries(t *testing.T) {
 		spanner.Insert("JoinF", []string{"y", "z"}, []interface{}{2, "c"}),
 		spanner.Insert("JoinF", []string{"y", "z"}, []interface{}{3, "d"}),
 
+		spanner.Insert("JoinG", []string{"x", "a", "b"}, []interface{}{3, "c", "x"}),
+		spanner.Insert("JoinG", []string{"x", "a", "b"}, []interface{}{3, "d", "y"}),
+
 		spanner.Insert("SomeStrings", []string{"i", "str"}, []interface{}{0, "afoo"}),
 		spanner.Insert("SomeStrings", []string{"i", "str"}, []interface{}{1, "abar"}),
 		spanner.Insert("SomeStrings", []string{"i", "str"}, []interface{}{2, nil}),
@@ -712,6 +722,11 @@ func TestIntegration_ReadsAndQueries(t *testing.T) {
 		spanner.Insert("Updateable", []string{"id", "first", "last"}, []interface{}{0, "joe", nil}),
 		spanner.Insert("Updateable", []string{"id", "first", "last"}, []interface{}{1, "doe", "joan"}),
 		spanner.Insert("Updateable", []string{"id", "first", "last"}, []interface{}{2, "wong", "wong"}),
+
+		spanner.Insert("Episodes", []string{"EpisodeID", "StaffNames", "StaffIDs"}, []interface{}{1, []string{"Jack", "Daniel"}, []int64{1, 2}}),
+		spanner.Insert("Episodes", []string{"EpisodeID", "StaffNames", "StaffIDs"}, []interface{}{2, []string{"Jack", "Daniel", "Sam"}, []int64{1, 2, 3}}),
+		spanner.Insert("Episodes", []string{"EpisodeID", "StaffNames", "StaffIDs"}, []interface{}{3, []string{"Teal'c"}, []int64{4}}),
+		spanner.Insert("Episodes", []string{"EpisodeID", "StaffNames", "StaffIDs"}, []interface{}{4, []string{"Jack", "Daniel", "Sam", "Teal'c", "George"}, []int64{1,2,3,4,5}}),
 	})
 	if err != nil {
 		t.Fatalf("Inserting sample data: %v", err)
@@ -1143,6 +1158,31 @@ func TestIntegration_ReadsAndQueries(t *testing.T) {
 			[][]interface{}{
 				{"Jack"},
 				{"Daniel"},
+			},
+		},
+		{
+			`SELECT JoinC.x, JoinD.z FROM JoinC JOIN JoinD USING (x) WHERE z != 'n' ORDER BY x`,
+			nil,
+			[][]interface{}{
+				{int64(2), "k"},
+				{int64(3), "m"},
+				{int64(3), "m"},
+			},
+		},
+		{
+			`SELECT * FROM JoinG RIGHT OUTER JOIN JoinD USING (x) WHERE JoinG.x IS NULL ORDER BY x, z, a, b`,
+			nil,
+			[][]interface{}{
+				{int64(2), nil, nil, "k"},
+				{int64(4), nil, nil, "p"},
+			},
+		},
+		{
+			`SELECT EpisodeID, offset, Cool FROM Episodes AS e, UNNEST(e.StaffIDs) as id WITH OFFSET as offset JOIN Staff AS s ON id = s.ID LEFT JOIN Staff as taller ON s.Height < taller.Height WHERE taller.ID IS NULL ORDER BY offset`,
+			nil,
+			[][]interface{}{
+				{int64(3), int64(0), true},
+				{int64(4), int64(3), true},
 			},
 		},
 	}

--- a/spanner/spansql/parser_test.go
+++ b/spanner/spansql/parser_test.go
@@ -208,6 +208,39 @@ func TestParseQuery(t *testing.T) {
 				},
 			},
 		},
+		{`SELECT c.Alias FROM Characters AS c` + "\n\t",
+			Query{
+				Select: Select{
+					List: []Expr{PathExp{
+						"c",
+						"Alias",
+					}},
+					From: []SelectFrom{SelectFromTable{
+						Table: "Characters",
+						Alias: "c",
+					}},
+				},
+			},
+		},
+		// Joins with hints.
+		{`SELECT * FROM A JOIN B USING (x) JOIN C USING (x)`,
+			Query{
+				Select: Select{
+					List: []Expr{Star},
+					From: []SelectFrom{SelectFromJoin{
+						Type: InnerJoin,
+						LHS: SelectFromJoin{
+							Type:  InnerJoin,
+							LHS:   SelectFromTable{Table: "A"},
+							RHS:   SelectFromTable{Table: "B"},
+							Using: []ID{"x"},
+						},
+						RHS:   SelectFromTable{Table: "C"},
+						Using: []ID{"x"},
+					}},
+				},
+			},
+		},
 	}
 	for _, test := range tests {
 		got, err := ParseQuery(test.in)

--- a/spanner/spansql/sql.go
+++ b/spanner/spansql/sql.go
@@ -351,6 +351,9 @@ func (sfu SelectFromUnnest) SQL() string {
 	if sfu.Alias != "" {
 		str += " AS " + sfu.Alias.SQL()
 	}
+	if sfu.OffsetAlias != "" {
+		str += " WITH OFFSET " + sfu.OffsetAlias.SQL()
+	}
 	return str
 }
 

--- a/spanner/spansql/types.go
+++ b/spanner/spansql/types.go
@@ -398,13 +398,25 @@ const (
 // SelectFromUnnest is a SelectFrom that yields a virtual table from an array.
 // https://cloud.google.com/spanner/docs/query-syntax#unnest
 type SelectFromUnnest struct {
-	Expr  Expr
-	Alias ID // empty if not aliased
-
+	Expr        Expr
+	Alias       ID // empty if not aliased
+	OffsetAlias ID // empty if no offset
 	// TODO: Implicit
 }
 
 func (SelectFromUnnest) isSelectFrom() {}
+
+type SelectFromList []SelectFrom
+
+func (SelectFromList) isSelectFrom() {}
+
+func (sfl SelectFromList) SQL() string {
+	sqls := make([]string, len(sfl))
+	for j := range sfl {
+		sqls[j] = sfl[j].SQL()
+	}
+	return strings.Join(sqls, ", ")
+}
 
 // TODO: SelectFromSubquery, etc.
 


### PR DESCRIPTION
Adds support to spannertest for various complex joins:
- `UNNEST` in a `FROM` clause: `SELECT * FROM a, UNNEST(a.ArrayColumn)`.
- Multi-table cartesian product: `SELECT * FROM a, b`.
- Multiple `JOIN` clauses: `SELECT * FROM a JOIN b USING(x) JOIN c USING(x)`.

Split from #3937