### PR TITLE
chore(internal/gapicgen): add regen-only flag

### DIFF
--- a/internal/gapicgen/cmd/genbot/local.go
+++ b/internal/gapicgen/cmd/genbot/local.go
@@ -35,6 +35,7 @@ type localConfig struct {
 	protoDir        string
 	gapicToGenerate string
 	onlyGapics      bool
+	regenOnly       bool
 }
 
 func genLocal(ctx context.Context, c localConfig) error {
@@ -68,6 +69,7 @@ func genLocal(ctx context.Context, c localConfig) error {
 		GapicToGenerate:   c.gapicToGenerate,
 		OnlyGenerateGapic: c.onlyGapics,
 		LocalMode:         true,
+		RegenOnly:         c.regenOnly,
 	}
 	if _, err := generator.Generate(ctx, conf); err != nil {
 		log.Printf("Generator ran (and failed) in %s\n", tmpDir)

--- a/internal/gapicgen/cmd/genbot/main.go
+++ b/internal/gapicgen/cmd/genbot/main.go
@@ -49,6 +49,7 @@ func main() {
 	protoDir := flag.String("proto-dir", os.Getenv("PROTO_DIR"), "Directory where sources of google/protobuf resides. If unset the sources will be cloned to a temporary directory that is not cleaned up.")
 	gapicToGenerate := flag.String("gapic", os.Getenv("GAPIC_TO_GENERATE"), `Specifies which gapic to generate. The value should be in the form of an import path (Ex: cloud.google.com/go/pubsub/apiv1). The default "" generates all gapics.`)
 	onlyGapics := flag.Bool("only-gapics", strToBool(os.Getenv("ONLY_GAPICS")), "Enabling stops regenerating genproto.")
+	regenOnly := flag.Bool("regen-only", strToBool(os.Getenv("SKIP_COMPILATION")), "Enabling means no vetting, manifest updates, or compilation.")
 
 	flag.Parse()
 
@@ -60,6 +61,7 @@ func main() {
 			protoDir:        *protoDir,
 			gapicToGenerate: *gapicToGenerate,
 			onlyGapics:      *onlyGapics,
+			regenOnly:       *regenOnly,
 		}); err != nil {
 			log.Fatal(err)
 		}

--- a/internal/gapicgen/cmd/genbot/main.go
+++ b/internal/gapicgen/cmd/genbot/main.go
@@ -49,7 +49,7 @@ func main() {
 	protoDir := flag.String("proto-dir", os.Getenv("PROTO_DIR"), "Directory where sources of google/protobuf resides. If unset the sources will be cloned to a temporary directory that is not cleaned up.")
 	gapicToGenerate := flag.String("gapic", os.Getenv("GAPIC_TO_GENERATE"), `Specifies which gapic to generate. The value should be in the form of an import path (Ex: cloud.google.com/go/pubsub/apiv1). The default "" generates all gapics.`)
 	onlyGapics := flag.Bool("only-gapics", strToBool(os.Getenv("ONLY_GAPICS")), "Enabling stops regenerating genproto.")
-	regenOnly := flag.Bool("regen-only", strToBool(os.Getenv("SKIP_COMPILATION")), "Enabling means no vetting, manifest updates, or compilation.")
+	regenOnly := flag.Bool("regen-only", strToBool(os.Getenv("REGEN_ONLY")), "Enabling means no vetting, manifest updates, or compilation.")
 
 	flag.Parse()
 

--- a/internal/gapicgen/generator/generator.go
+++ b/internal/gapicgen/generator/generator.go
@@ -38,6 +38,7 @@ type Config struct {
 	GapicToGenerate   string
 	OnlyGenerateGapic bool
 	LocalMode         bool
+	RegenOnly         bool
 }
 
 // Generate generates genproto and gapics.
@@ -48,9 +49,14 @@ func Generate(ctx context.Context, conf *Config) ([]*git.ChangeInfo, error) {
 			return nil, fmt.Errorf("error generating genproto (may need to check logs for more errors): %v", err)
 		}
 	}
-	gapicGenerator := NewGapicGenerator(conf.GoogleapisDir, conf.ProtoDir, conf.GapicDir, conf.GenprotoDir, conf.GapicToGenerate)
+	gapicGenerator := NewGapicGenerator(conf.GoogleapisDir, conf.ProtoDir, conf.GapicDir, conf.GenprotoDir, conf.GapicToGenerate, conf.RegenOnly)
 	if err := gapicGenerator.Regen(ctx); err != nil {
 		return nil, fmt.Errorf("error generating gapics (may need to check logs for more errors): %v", err)
+	}
+	if !conf.OnlyGenerateGapic {
+		if err := gapicGenerator.RegenSnippets(ctx); err != nil {
+			return nil, fmt.Errorf("error generating snippets (may need to check logs for more errors): %v", err)
+		}
 	}
 
 	var changes []*git.ChangeInfo


### PR DESCRIPTION
Adds a `regen-only` flag to local mode that disables generation version updates, manifest updates, and vetting/compilation. This is useful for iterating on generator changes or just fiddling. 

This also makes `gensnippets` respect the `only-gapics` flag, disabling snippet regen when that flag is enabled.

Finally, it optionally supplies the `release-level` option to the generator depending on if it is empty or not in the `microgenConfig`, and uses the flag name `api-service-config` instead of `gapic-service-config`, because that is the more accurate name.