### PR TITLE
build: switch release-please type to go-yoshi

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,7 @@ jobs:
         with:
           # token: ${{ secrets.FORKING_TOKEN }}
           token: ${{ secrets.FORKING_TOKEN }}
-          release-type: go
+          release-type: go-yoshi
           bump-minor-pre-major: true
           fork: true
           package-name: google-cloud-go
@@ -40,7 +40,7 @@ jobs:
         id: tag-release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          release-type: go
+          release-type: go-yoshi
           package-name: google-cloud-go
           command: github-release
           changelog-path: CHANGES.md


### PR DESCRIPTION
`go` was an alias to the `GoYoshi` release strategy (https://github.com/googleapis/release-please/blob/c80f8a096178fcf355579a3e70a255aac82c725a/src/releasers/index.ts#L54-L55). `GoYoshi` is also available via the `go-yoshi` release type config.

We will be replacing `go` with a generic golang releaser that only updates the `CHANGES.md` and handles tagging.