### PR TITLE
feat(spanner/spansql): case insensitive parsing of keywords and functions

### DIFF
--- a/spanner/spannertest/README.md
+++ b/spanner/spannertest/README.md
@@ -21,12 +21,12 @@ by ascending esotericism:
 - NUMERIC
 - more aggregation functions
 - SELECT HAVING
-- case insensitivity
 - more literal types
 - generated columns
 - expression type casting, coercion
 - multiple joins
 - subselects
+- case insensitivity of table and column names and query aliases
 - transaction simulation
 - FOREIGN KEY and CHECK constraints
 - INSERT DML statements

--- a/spanner/spansql/parser_test.go
+++ b/spanner/spansql/parser_test.go
@@ -32,7 +32,7 @@ func TestParseQuery(t *testing.T) {
 		want Query
 	}{
 		{`SELECT 17`, Query{Select: Select{List: []Expr{IntegerLiteral(17)}}}},
-		{`SELECT Alias AS aka FROM Characters WHERE Age < @ageLimit AND Alias IS NOT NULL ORDER BY Age DESC LIMIT @limit OFFSET 3` + "\n\t",
+		{`SELECT Alias AS aka From Characters WHERE Age < @ageLimit AND Alias IS NOT NULL ORDER BY Age DESC LIMIT @limit OFFSET 3` + "\n\t",
 			Query{
 				Select: Select{
 					List: []Expr{ID("Alias")},
@@ -410,7 +410,7 @@ func TestParseDDL(t *testing.T) {
 		-- Table with generated column.
 		CREATE TABLE GenCol (
 			Name STRING(MAX) NOT NULL,
-			NameLen INT64 AS (CHAR_LENGTH(Name)) STORED,
+			NameLen INT64 AS (char_length(Name)) STORED,
 		) PRIMARY KEY (Name);
 
 		-- Trailing comment at end of file.


### PR DESCRIPTION
This handles the most important parts of the parser as it relates to
case insensitivity, namely permitting the lexical tokens for the grammar
(as opposed to elements like table/column names) to have arbitrary case.

This includes a complete audit of the parser to check all the lexical
token handling, and cleaned up a few places that were particularly
ancient.

The rendered output remains canonically uppercase.

Fixes #4032.