### PR TITLE
feat(bigquery): augment retry predicate to support additional errors

### DIFF
--- a/bigquery/bigquery.go
+++ b/bigquery/bigquery.go
@@ -171,6 +171,9 @@ func retryableError(err error) bool {
 	if err == nil {
 		return false
 	}
+	if err == io.ErrUnexpectedEOF {
+		return true
+	}
 	// Special case due to http2: https://github.com/googleapis/google-cloud-go/issues/1793
 	// Due to Go's default being higher for streams-per-connection than is accepted by the
 	// BQ backend, it's possible to get streams refused immediately after a connection is

--- a/bigquery/bigquery_test.go
+++ b/bigquery/bigquery_test.go
@@ -16,6 +16,7 @@ package bigquery
 
 import (
 	"errors"
+	"io"
 	"net/http"
 	"net/url"
 	"testing"
@@ -38,6 +39,11 @@ func TestRetryableErrors(t *testing.T) {
 		{
 			"http stream closed",
 			errors.New("http2: stream closed"),
+			true,
+		},
+		{
+			"io ErrUnexpectedEOF",
+			io.ErrUnexpectedEOF,
 			true,
 		},
 		{

--- a/bigquery/bigquery_test.go
+++ b/bigquery/bigquery_test.go
@@ -17,8 +17,10 @@ package bigquery
 import (
 	"errors"
 	"net/http"
+	"net/url"
 	"testing"
 
+	"golang.org/x/xerrors"
 	"google.golang.org/api/googleapi"
 )
 
@@ -45,6 +47,32 @@ func TestRetryableErrors(t *testing.T) {
 				Message: "foo",
 			},
 			true,
+		},
+		{
+			"url connection error",
+			&url.Error{Op: "blah", URL: "blah", Err: errors.New("connection refused")},
+			true,
+		},
+		{
+			"url other error",
+			&url.Error{Op: "blah", URL: "blah", Err: errors.New("blah")},
+			false,
+		},
+		{
+			"wrapped retryable",
+			xerrors.Errorf("test of wrapped retryable: %w", &googleapi.Error{
+				Code:    http.StatusServiceUnavailable,
+				Message: "foo",
+				Errors: []googleapi.ErrorItem{
+					{Reason: "backendError", Message: "foo"},
+				},
+			}),
+			true,
+		},
+		{
+			"wrapped non-retryable",
+			xerrors.Errorf("test of wrapped retryable: %w", errors.New("blah")),
+			false,
 		},
 		{
 			// not retried per https://google.aip.dev/194

--- a/bigquery/go.mod
+++ b/bigquery/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/golang/protobuf v1.5.2
 	github.com/google/go-cmp v0.5.5
 	github.com/googleapis/gax-go/v2 v2.0.5
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 	google.golang.org/api v0.46.0
 	google.golang.org/genproto v0.0.0-20210503173045-b96a97608f20
 	google.golang.org/grpc v1.37.0


### PR DESCRIPTION
Based on similar refactor in storage:
https://github.com/googleapis/google-cloud-go/pull/4019

Fixes: https://github.com/googleapis/google-cloud-go/issues/4021