### PR TITLE
profiler: fix integration test

### DIFF
--- a/profiler/integration_test.go
+++ b/profiler/integration_test.go
@@ -82,6 +82,9 @@ gimme_retrier() {
 }
 retry gimme_retrier
 
+# Use go modules
+export GO111MODULE="on"
+
 # Set $GOPATH
 export GOPATH="$HOME/go"
 
@@ -89,7 +92,7 @@ export GOCLOUD_HOME=$GOPATH/src/cloud.google.com/go
 mkdir -p $GOCLOUD_HOME
 
 # Install agent
-retry git clone https://code.googlesource.com/gocloud $GOCLOUD_HOME >/dev/null
+retry git clone https://github.com/googleapis/google-cloud-go.git $GOCLOUD_HOME >/dev/null
 cd $GOCLOUD_HOME
 retry git fetch origin {{.Commit}}
 git reset --hard {{.Commit}}


### PR DESCRIPTION
This change switches to using go modules consistently and switches to pulling profiler agent from https://github.com/googleapis/google-cloud-go.git rather than https://code.googlesource.com/gocloud.

TESTED= When running e2e test with go1.12, there were failures before this change and no failure with this change.