### PR TITLE
test(pubsublite): fix flaky TestPeriodicTask

### DIFF
--- a/pubsublite/internal/wire/periodic_task_test.go
+++ b/pubsublite/internal/wire/periodic_task_test.go
@@ -20,26 +20,37 @@ import (
 )
 
 func TestPeriodicTask(t *testing.T) {
+	const pollInterval = 10 * time.Millisecond
 	var callCount int32
 	values := make(chan int32)
 	task := func() {
 		values <- atomic.AddInt32(&callCount, 1)
 	}
-	ptask := newPeriodicTask(10*time.Millisecond, task)
+	ptask := newPeriodicTask(pollInterval, task)
+	var lastValue int32
 
-	t.Run("Start1", func(t *testing.T) {
+	t.Run("Start", func(t *testing.T) {
 		ptask.Start()
 		ptask.Start() // Tests duplicate start
 
-		if got, want := <-values, int32(1); got != want {
+		lastValue = <-values
+		if got, want := lastValue, int32(1); got != want {
 			t.Errorf("got %d, want %d", got, want)
 		}
 	})
 
-	t.Run("Stop1", func(t *testing.T) {
+	t.Run("Stop", func(t *testing.T) {
+		// Flushes last value immediately before stopping.
+		// Note: if this test is still flaky, pollInterval can be increased.
+		select {
+		case lastValue = <-values:
+		default:
+		}
+
 		ptask.Stop()
 		ptask.Stop() // Tests duplicate stop
 
+		time.Sleep(2 * pollInterval)
 		select {
 		case got := <-values:
 			t.Errorf("got unexpected value %d", got)
@@ -47,21 +58,11 @@ func TestPeriodicTask(t *testing.T) {
 		}
 	})
 
-	t.Run("Start2", func(t *testing.T) {
+	t.Run("Restart", func(t *testing.T) {
 		ptask.Start()
 
-		if got, want := <-values, int32(2); got != want {
+		if got, want := <-values, lastValue+1; got != want {
 			t.Errorf("got %d, want %d", got, want)
-		}
-	})
-
-	t.Run("Stop2", func(t *testing.T) {
-		ptask.Stop()
-
-		select {
-		case got := <-values:
-			t.Errorf("got unexpected value %d", got)
-		default:
 		}
 	})
 }

--- a/pubsublite/internal/wire/periodic_task_test.go
+++ b/pubsublite/internal/wire/periodic_task_test.go
@@ -27,6 +27,7 @@ func TestPeriodicTask(t *testing.T) {
 		values <- atomic.AddInt32(&callCount, 1)
 	}
 	ptask := newPeriodicTask(pollInterval, task)
+	defer ptask.Stop()
 
 	t.Run("Start", func(t *testing.T) {
 		ptask.Start()


### PR DESCRIPTION
Two executions of the task can run before the first call to `Stop`. So we stop the task immediately after receiving the value. This doesn't guarantee no flakes in the future. If it occurs again, we can increase `pollInterval`.

Fixes: https://github.com/googleapis/google-cloud-go/issues/4064