### PR TITLE
feat(pubsublite): set initial cursor when reconnecting subscribe streams

### DIFF
--- a/pubsublite/internal/wire/flow_control.go
+++ b/pubsublite/internal/wire/flow_control.go
@@ -147,18 +147,14 @@ type subscriberOffsetTracker struct {
 	minNextOffset int64
 }
 
-// RequestForRestart returns the seek request to send when a new subscribe
+// CursorForRestart returns the initial cursor to use when a new subscribe
 // stream reconnects. Returns nil if the subscriber has just started, in which
-// case the server returns the offset of the last committed cursor.
-func (ot *subscriberOffsetTracker) RequestForRestart() *pb.SeekRequest {
+// case the server uses the offset of the last committed cursor.
+func (ot *subscriberOffsetTracker) CursorForRestart() *pb.Cursor {
 	if ot.minNextOffset <= 0 {
 		return nil
 	}
-	return &pb.SeekRequest{
-		Target: &pb.SeekRequest_Cursor{
-			Cursor: &pb.Cursor{Offset: ot.minNextOffset},
-		},
-	}
+	return &pb.Cursor{Offset: ot.minNextOffset}
 }
 
 // OnMessages verifies that messages are delivered in order and updates the next

--- a/pubsublite/internal/wire/flow_control_test.go
+++ b/pubsublite/internal/wire/flow_control_test.go
@@ -222,11 +222,11 @@ func TestFlowControlBatcher(t *testing.T) {
 	})
 }
 
-func TestOffsetTrackerRequestForRestart(t *testing.T) {
+func TestOffsetTrackerCursorForRestart(t *testing.T) {
 	for _, tc := range []struct {
 		desc    string
 		tracker subscriberOffsetTracker
-		want    *pb.SeekRequest
+		want    *pb.Cursor
 	}{
 		{
 			desc:    "Uninitialized tracker",
@@ -236,17 +236,13 @@ func TestOffsetTrackerRequestForRestart(t *testing.T) {
 		{
 			desc:    "Next offset positive",
 			tracker: subscriberOffsetTracker{minNextOffset: 1},
-			want: &pb.SeekRequest{
-				Target: &pb.SeekRequest_Cursor{
-					Cursor: &pb.Cursor{Offset: 1},
-				},
-			},
+			want:    &pb.Cursor{Offset: 1},
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
-			got := tc.tracker.RequestForRestart()
+			got := tc.tracker.CursorForRestart()
 			if !proto.Equal(got, tc.want) {
-				t.Errorf("subscriberOffsetTracker(%v).RequestForRestart(): got %v, want %v", tc.tracker, got, tc.want)
+				t.Errorf("subscriberOffsetTracker(%v).CursorForRestart(): got %v, want %v", tc.tracker, got, tc.want)
 			}
 		})
 	}

--- a/pubsublite/internal/wire/requests_test.go
+++ b/pubsublite/internal/wire/requests_test.go
@@ -145,22 +145,22 @@ func initSubReq(subscription subscriptionPartition) *pb.SubscribeRequest {
 	}
 }
 
-func initSubResp() *pb.SubscribeResponse {
-	return &pb.SubscribeResponse{
-		Response: &pb.SubscribeResponse_Initial{
-			Initial: &pb.InitialSubscribeResponse{},
+func initSubReqWithOffset(subscription subscriptionPartition, init_offset int64) *pb.SubscribeRequest {
+	return &pb.SubscribeRequest{
+		Request: &pb.SubscribeRequest_Initial{
+			Initial: &pb.InitialSubscribeRequest{
+				Subscription:  subscription.Path,
+				Partition:     int64(subscription.Partition),
+				InitialCursor: &pb.Cursor{Offset: init_offset},
+			},
 		},
 	}
 }
 
-func seekReq(offset int64) *pb.SubscribeRequest {
-	return &pb.SubscribeRequest{
-		Request: &pb.SubscribeRequest_Seek{
-			Seek: &pb.SeekRequest{
-				Target: &pb.SeekRequest_Cursor{
-					Cursor: &pb.Cursor{Offset: offset},
-				},
-			},
+func initSubResp() *pb.SubscribeResponse {
+	return &pb.SubscribeResponse{
+		Response: &pb.SubscribeResponse_Initial{
+			Initial: &pb.InitialSubscribeResponse{},
 		},
 	}
 }

--- a/pubsublite/internal/wire/requests_test.go
+++ b/pubsublite/internal/wire/requests_test.go
@@ -145,13 +145,13 @@ func initSubReq(subscription subscriptionPartition) *pb.SubscribeRequest {
 	}
 }
 
-func initSubReqWithOffset(subscription subscriptionPartition, init_offset int64) *pb.SubscribeRequest {
+func initSubReqWithOffset(subscription subscriptionPartition, initOffset int64) *pb.SubscribeRequest {
 	return &pb.SubscribeRequest{
 		Request: &pb.SubscribeRequest_Initial{
 			Initial: &pb.InitialSubscribeRequest{
 				Subscription:  subscription.Path,
 				Partition:     int64(subscription.Partition),
-				InitialCursor: &pb.Cursor{Offset: init_offset},
+				InitialCursor: &pb.Cursor{Offset: initOffset},
 			},
 		},
 	}


### PR DESCRIPTION
Instead of sending a seek request, set the new `InitialSubscribeRequest.InitialCursor` field to set the cursor for a reconnected subscribe stream.