### PR TITLE
chore(internal/gapicgen): update microgen to v0.20.0

### DIFF
--- a/internal/gapicgen/cmd/genbot/Dockerfile
+++ b/internal/gapicgen/cmd/genbot/Dockerfile
@@ -28,7 +28,7 @@ RUN GO111MODULE=on go get \
     golang.org/x/lint/golint@latest \
     golang.org/x/tools/cmd/goimports@latest \
     honnef.co/go/tools/cmd/staticcheck@latest \
-    github.com/googleapis/gapic-generator-go/cmd/protoc-gen-go_gapic@v0.18.3
+    github.com/googleapis/gapic-generator-go/cmd/protoc-gen-go_gapic@v0.20.0
 ENV PATH="${PATH}:/root/go/bin"
 
 # Source: http://debuggable.com/posts/disable-strict-host-checking-for-git-clone:49896ff3-0ac0-4263-9703-1eae4834cda3

--- a/internal/gapicgen/cmd/genbot/Dockerfile
+++ b/internal/gapicgen/cmd/genbot/Dockerfile
@@ -24,7 +24,7 @@ RUN go version
 
 # Install Go tools.
 RUN GO111MODULE=on go get \
-    github.com/golang/protobuf/protoc-gen-go@v1.4.3 \
+    github.com/golang/protobuf/protoc-gen-go@v1.5.2 \
     golang.org/x/lint/golint@latest \
     golang.org/x/tools/cmd/goimports@latest \
     honnef.co/go/tools/cmd/staticcheck@latest \


### PR DESCRIPTION
Introduces a number of documentation/comment fixes as well a refactor of the generated code that moves the transport specific (i.e. gRPC) client implementation behind a generated interface used within a generic client. This results in a few breakages to manual code that reference internal attributes. The following diff represents the changes that should be made to fix the build:

```
diff --git a/secretmanager/apiv1/iam.go b/secretmanager/apiv1/iam.go
index e3d78a54c..948ffe3cd 100644
--- a/secretmanager/apiv1/iam.go
+++ b/secretmanager/apiv1/iam.go
@@ -22,5 +22,10 @@ import (
 // indicated by the given resource path. Name should be of the format
 // `projects/my-project/secrets/my-secret`.
 func (c *Client) IAM(name string) *iam.Handle {
-	return iam.InternalNewHandleGRPCClient(c.client, name)
+	// Until a REST transport is generated, it will always be a gRPC client
+	// under the hood.
+	if gc, ok := c.internalClient.(*gRPCClient); ok {
+		return iam.InternalNewHandleGRPCClient(gc.client, name)
+	}
+	return iam.InternalNewHandle(nil, name)
 }
diff --git a/secretmanager/apiv1beta1/iam.go b/secretmanager/apiv1beta1/iam.go
index 9d5fd4bf7..e6281f53b 100644
--- a/secretmanager/apiv1beta1/iam.go
+++ b/secretmanager/apiv1beta1/iam.go
@@ -22,5 +22,10 @@ import (
 // indicated by the given resource path. Name should be of the format
 // `projects/my-project/secrets/my-secret`.
 func (c *Client) IAM(name string) *iam.Handle {
-	return iam.InternalNewHandleGRPCClient(c.client, name)
+	// Until a REST transport is generated, it will always be a gRPC client
+	// under the hood.
+	if gc, ok := c.internalClient.(*gRPCClient); ok {
+		return iam.InternalNewHandleGRPCClient(gc.client, name)
+	}
+	return iam.InternalNewHandle(nil, name)
 }
diff --git a/spanner/apiv1/spanner_client_options.go b/spanner/apiv1/spanner_client_options.go
index 639e890d4..5b924b5d1 100644
--- a/spanner/apiv1/spanner_client_options.go
+++ b/spanner/apiv1/spanner_client_options.go
@@ -21,5 +21,5 @@ import "google.golang.org/api/option"
 // This function is only intended for use by the client library, and may be
 // removed at any time without any warning.
 func DefaultClientOptions() []option.ClientOption {
-	return defaultClientOptions()
+	return defaultGRPCClientOptions()
 }

```

Also update `protoc-gen-go` to `v1.5.2` in the Docker image.