### PR TITLE
docs(spanner): fix godoc for default value of health check interval

### DIFF
--- a/spanner/session.go
+++ b/spanner/session.go
@@ -442,7 +442,7 @@ type SessionPoolConfig struct {
 
 	// HealthCheckInterval is how often the health checker pings a session.
 	//
-	// Defaults to 5m.
+	// Defaults to 50m.
 	HealthCheckInterval time.Duration
 
 	// TrackSessionHandles determines whether the session pool will keep track


### PR DESCRIPTION
The default value in the Godoc had not been updated to reflect a recent change that updated the actual default value to 50 minutes.