### PR TITLE
storage: make Writer.CloseWithError block until writer exits

### DIFF
--- a/storage/writer.go
+++ b/storage/writer.go
@@ -258,7 +258,9 @@ func (w *Writer) CloseWithError(err error) error {
 	if !w.opened {
 		return nil
 	}
-	return w.pw.CloseWithError(err)
+	err = w.pw.CloseWithError(err)
+	<-w.donec
+	return err
 }
 
 // Attrs returns metadata about a successfully-written object.


### PR DESCRIPTION
Writer.Close blocks on w.donec to return only after the spawned writer goroutine
has exited. Previously CloseWithError did not block on this channel however, meaning
it could return while the writer goroutine was still running, which could then lead
to a caller e.g. closing the underlying Client, leading to a crash in the still-running
goroutine.

This adds the same block on the channel to CloseWithError to ensure that however a
caller closes a Writer, it is fully closed when the close method returns and that
caller can safely Close the client.

Fixes #4167.