### PR TITLE
test(spanner): fix test case using reflection

### DIFF
--- a/spanner/session_test.go
+++ b/spanner/session_test.go
@@ -1978,7 +1978,8 @@ func getSessionsPerChannel(sp *sessionPool) map[string]int {
 		// Get the pointer to the actual underlying gRPC ClientConn and use
 		// that as the key in the map.
 		val := reflect.ValueOf(s.client).Elem()
-		connPool := val.FieldByName("connPool").Elem().Elem()
+		internalClient := val.FieldByName("internalClient").Elem().Elem()
+		connPool := internalClient.FieldByName("connPool").Elem().Elem()
 		conn := connPool.Field(0).Pointer()
 		key := fmt.Sprintf("%v", conn)
 		sessionsPerChannel[key] = sessionsPerChannel[key] + 1


### PR DESCRIPTION
The refactoring of the generated gapic client had broken a test case that used reflection to get an internal value. This fixes the test
by first getting the (new) internalClient, and then getting the value from the internal client.

Fixes #4156