### PR TITLE
fix(bigtable/bttest): fix locking bug in DropRowRange

### DIFF
--- a/bigtable/bttest/inmem.go
+++ b/bigtable/bttest/inmem.go
@@ -252,11 +252,14 @@ func (s *server) ModifyColumnFamilies(ctx context.Context, req *btapb.ModifyColu
 
 func (s *server) DropRowRange(ctx context.Context, req *btapb.DropRowRangeRequest) (*emptypb.Empty, error) {
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	tbl, ok := s.tables[req.Name]
+	s.mu.Unlock()
 	if !ok {
 		return nil, status.Errorf(codes.NotFound, "table %q not found", req.Name)
 	}
+
+	tbl.mu.Lock()
+	defer tbl.mu.Unlock()
 
 	if req.GetDeleteAllDataFromTable() {
 		tbl.rows = btree.New(btreeDegree)


### PR DESCRIPTION
DropRowRange's locking is inconsistent with the rest of bttest
https://github.com/googleapis/google-cloud-go/issues/2600

ModifyColumnFamilies demonstrates the correct pattern:
- Use the server global mutex to reference the table by name
- Use the table's mutex to guard data reads and writes.

The existing implementation can data race if another concurrently running method (such as SampleRowKeys)
has already dropped the server mutex and acquired the table mutex.  Nothing then prevents DropRowRange
from mutating table data during a Sample or Scan.