### PR TITLE
fix(bttest): fix race condition in SampleRowKeys

### DIFF
--- a/bigtable/bttest/inmem.go
+++ b/bigtable/bttest/inmem.go
@@ -252,12 +252,14 @@ func (s *server) ModifyColumnFamilies(ctx context.Context, req *btapb.ModifyColu
 
 func (s *server) DropRowRange(ctx context.Context, req *btapb.DropRowRangeRequest) (*emptypb.Empty, error) {
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	tbl, ok := s.tables[req.Name]
+	s.mu.Unlock()
 	if !ok {
 		return nil, status.Errorf(codes.NotFound, "table %q not found", req.Name)
 	}
 
+	tbl.mu.Lock()
+	defer tbl.mu.Unlock()
 	if req.GetDeleteAllDataFromTable() {
 		tbl.rows = btree.New(btreeDegree)
 	} else {

--- a/bigtable/bttest/inmem_test.go
+++ b/bigtable/bttest/inmem_test.go
@@ -273,6 +273,71 @@ func TestSampleRowKeys(t *testing.T) {
 	}
 }
 
+func TestTableRowsConcurrent(t *testing.T) {
+	s := &server{
+		tables: make(map[string]*table),
+	}
+	ctx := context.Background()
+	newTbl := btapb.Table{
+		ColumnFamilies: map[string]*btapb.ColumnFamily{
+			"cf": {GcRule: &btapb.GcRule{Rule: &btapb.GcRule_MaxNumVersions{MaxNumVersions: 1}}},
+		},
+	}
+	tbl, err := s.CreateTable(ctx, &btapb.CreateTableRequest{Parent: "cluster", TableId: "t", Table: &newTbl})
+	if err != nil {
+		t.Fatalf("Creating table: %v", err)
+	}
+
+	// Populate the table
+	populate := func() {
+		rowCount := 100
+		for i := 0; i < rowCount; i++ {
+			req := &btpb.MutateRowRequest{
+				TableName: tbl.Name,
+				RowKey:    []byte("row-" + strconv.Itoa(i)),
+				Mutations: []*btpb.Mutation{{
+					Mutation: &btpb.Mutation_SetCell_{SetCell: &btpb.Mutation_SetCell{
+						FamilyName:      "cf",
+						ColumnQualifier: []byte("col"),
+						TimestampMicros: 1000,
+						Value:           []byte("value"),
+					}},
+				}},
+			}
+			if _, err := s.MutateRow(ctx, req); err != nil {
+				t.Fatalf("Populating table: %v", err)
+			}
+		}
+	}
+
+	attempts := 500
+	finished := make(chan bool)
+	go func() {
+		populate()
+		mock := &MockSampleRowKeysServer{}
+		for i := 0; i < attempts; i++ {
+			if err := s.SampleRowKeys(&btpb.SampleRowKeysRequest{TableName: tbl.Name}, mock); err != nil {
+				t.Errorf("SampleRowKeys error: %v", err)
+			}
+		}
+		finished <- true
+	}()
+	go func() {
+		for i := 0; i < attempts; i++ {
+			req := &btapb.DropRowRangeRequest{
+				Name:   tbl.Name,
+				Target: &btapb.DropRowRangeRequest_DeleteAllDataFromTable{DeleteAllDataFromTable: true},
+			}
+			if _, err = s.DropRowRange(ctx, req); err != nil {
+				t.Fatalf("Dropping all rows: %v", err)
+			}
+		}
+		finished <- true
+	}()
+	<-finished
+	<-finished
+}
+
 func TestDropRowRange(t *testing.T) {
 	s := &server{
 		tables: make(map[string]*table),

--- a/bigtable/bttest/inmem_test.go
+++ b/bigtable/bttest/inmem_test.go
@@ -334,8 +334,13 @@ func TestTableRowsConcurrent(t *testing.T) {
 		}
 		finished <- true
 	}()
-	<-finished
-	<-finished
+	for i := 0; i < 2; i++ {
+		select {
+		case <-finished:
+		case <-time.After(2 * time.Second):
+			t.Fatalf("Timeout waiting for task %d\n", i)
+		}
+	}
 }
 
 func TestDropRowRange(t *testing.T) {


### PR DESCRIPTION
Fixes #2600.

After this change running `go test -race .` passes cleanly. Before this change running with `go test -race` I got:

```
==================
WARNING: DATA RACE
Write at 0x00c001112b98 by goroutine 243:
  cloud.google.com/go/bigtable/bttest.(*server).DropRowRange()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem.go:264 +0x7b1
  cloud.google.com/go/bigtable/bttest.TestTableRowsConcurrent.func3()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem_test.go:331 +0x14c

Previous read at 0x00c001112b98 by goroutine 237:
  cloud.google.com/go/bigtable/bttest.(*table).mutableRow()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem.go:1222 +0x21d
  cloud.google.com/go/bigtable/bttest.(*server).MutateRow()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem.go:795 +0x1bd
  cloud.google.com/go/bigtable/bttest.TestTableRowsConcurrent.func1()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem_test.go:307 +0x564
  cloud.google.com/go/bigtable/bttest.TestTableRowsConcurrent.func2()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem_test.go:316 +0x51

Goroutine 243 (running) created at:
  cloud.google.com/go/bigtable/bttest.TestTableRowsConcurrent()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem_test.go:325 +0x664
  testing.tRunner()
      /usr/lib/google-golang/src/testing/testing.go:1193 +0x202

Goroutine 237 (running) created at:
  cloud.google.com/go/bigtable/bttest.TestTableRowsConcurrent()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem_test.go:315 +0x5f0
  testing.tRunner()
      /usr/lib/google-golang/src/testing/testing.go:1193 +0x202
==================
==================
WARNING: DATA RACE
Read at 0x00c000517810 by goroutine 237:
  github.com/google/btree.(*BTree).Get()
      /usr/local/google/home/coryan/go/pkg/mod/github.com/google/btree@v1.0.1/btree.go:819 +0x248
  cloud.google.com/go/bigtable/bttest.(*table).mutableRow()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem.go:1222 +0x20d
  cloud.google.com/go/bigtable/bttest.(*server).MutateRow()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem.go:795 +0x1bd
  cloud.google.com/go/bigtable/bttest.TestTableRowsConcurrent.func1()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem_test.go:307 +0x564
  cloud.google.com/go/bigtable/bttest.TestTableRowsConcurrent.func2()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem_test.go:316 +0x51

Previous write at 0x00c000517810 by goroutine 243:
  github.com/google/btree.NewWithFreeList()
      /usr/local/google/home/coryan/go/pkg/mod/github.com/google/btree@v1.0.1/btree.go:136 +0x6e4
  github.com/google/btree.New()
      /usr/local/google/home/coryan/go/pkg/mod/github.com/google/btree@v1.0.1/btree.go:128 +0x6b6
  cloud.google.com/go/bigtable/bttest.(*server).DropRowRange()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem.go:264 +0x793
  cloud.google.com/go/bigtable/bttest.TestTableRowsConcurrent.func3()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem_test.go:331 +0x14c

Goroutine 237 (running) created at:
  cloud.google.com/go/bigtable/bttest.TestTableRowsConcurrent()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem_test.go:315 +0x5f0
  testing.tRunner()
      /usr/lib/google-golang/src/testing/testing.go:1193 +0x202

Goroutine 243 (running) created at:
  cloud.google.com/go/bigtable/bttest.TestTableRowsConcurrent()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem_test.go:325 +0x664
  testing.tRunner()
      /usr/lib/google-golang/src/testing/testing.go:1193 +0x202
==================
==================
WARNING: DATA RACE
Read at 0x00c000517fd0 by goroutine 237:
  github.com/google/btree.(*BTree).ReplaceOrInsert()
      /usr/local/google/home/coryan/go/pkg/mod/github.com/google/btree@v1.0.1/btree.go:687 +0x74
  cloud.google.com/go/bigtable/bttest.(*table).mutableRow()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem.go:1227 +0x3c4
  cloud.google.com/go/bigtable/bttest.(*server).MutateRow()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem.go:795 +0x1bd
  cloud.google.com/go/bigtable/bttest.TestTableRowsConcurrent.func1()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem_test.go:307 +0x564
  cloud.google.com/go/bigtable/bttest.TestTableRowsConcurrent.func2()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem_test.go:316 +0x51

Previous write at 0x00c000517fd0 by goroutine 243:
  github.com/google/btree.NewWithFreeList()
      /usr/local/google/home/coryan/go/pkg/mod/github.com/google/btree@v1.0.1/btree.go:136 +0x6e4
  github.com/google/btree.New()
      /usr/local/google/home/coryan/go/pkg/mod/github.com/google/btree@v1.0.1/btree.go:128 +0x6b6
  cloud.google.com/go/bigtable/bttest.(*server).DropRowRange()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem.go:264 +0x793
  cloud.google.com/go/bigtable/bttest.TestTableRowsConcurrent.func3()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem_test.go:331 +0x14c

Goroutine 237 (running) created at:
  cloud.google.com/go/bigtable/bttest.TestTableRowsConcurrent()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem_test.go:315 +0x5f0
  testing.tRunner()
      /usr/lib/google-golang/src/testing/testing.go:1193 +0x202

Goroutine 243 (running) created at:
  cloud.google.com/go/bigtable/bttest.TestTableRowsConcurrent()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem_test.go:325 +0x664
  testing.tRunner()
      /usr/lib/google-golang/src/testing/testing.go:1193 +0x202
==================
==================
WARNING: DATA RACE
Read at 0x00c000517fd8 by goroutine 237:
  github.com/google/btree.(*BTree).ReplaceOrInsert()
      /usr/local/google/home/coryan/go/pkg/mod/github.com/google/btree@v1.0.1/btree.go:688 +0x7bd
  cloud.google.com/go/bigtable/bttest.(*table).mutableRow()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem.go:1227 +0x3c4
  cloud.google.com/go/bigtable/bttest.(*server).MutateRow()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem.go:795 +0x1bd
  cloud.google.com/go/bigtable/bttest.TestTableRowsConcurrent.func1()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem_test.go:307 +0x564
  cloud.google.com/go/bigtable/bttest.TestTableRowsConcurrent.func2()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem_test.go:316 +0x51

Previous write at 0x00c000517fd8 by goroutine 243:
  github.com/google/btree.NewWithFreeList()
      /usr/local/google/home/coryan/go/pkg/mod/github.com/google/btree@v1.0.1/btree.go:136 +0x6e4
  github.com/google/btree.New()
      /usr/local/google/home/coryan/go/pkg/mod/github.com/google/btree@v1.0.1/btree.go:128 +0x6b6
  cloud.google.com/go/bigtable/bttest.(*server).DropRowRange()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem.go:264 +0x793
  cloud.google.com/go/bigtable/bttest.TestTableRowsConcurrent.func3()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem_test.go:331 +0x14c

Goroutine 237 (running) created at:
  cloud.google.com/go/bigtable/bttest.TestTableRowsConcurrent()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem_test.go:315 +0x5f0
  testing.tRunner()
      /usr/lib/google-golang/src/testing/testing.go:1193 +0x202

Goroutine 243 (running) created at:
  cloud.google.com/go/bigtable/bttest.TestTableRowsConcurrent()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem_test.go:325 +0x664
  testing.tRunner()
      /usr/lib/google-golang/src/testing/testing.go:1193 +0x202
==================
==================
WARNING: DATA RACE
Read at 0x00c00050e3b0 by goroutine 237:
  github.com/google/btree.(*copyOnWriteContext).newNode()
      /usr/local/google/home/coryan/go/pkg/mod/github.com/google/btree@v1.0.1/btree.go:646 +0x7dc
  github.com/google/btree.(*BTree).ReplaceOrInsert()
      /usr/local/google/home/coryan/go/pkg/mod/github.com/google/btree@v1.0.1/btree.go:688 +0x7b1
  cloud.google.com/go/bigtable/bttest.(*table).mutableRow()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem.go:1227 +0x3c4
  cloud.google.com/go/bigtable/bttest.(*server).MutateRow()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem.go:795 +0x1bd
  cloud.google.com/go/bigtable/bttest.TestTableRowsConcurrent.func1()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem_test.go:307 +0x564
  cloud.google.com/go/bigtable/bttest.TestTableRowsConcurrent.func2()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem_test.go:316 +0x51

Previous write at 0x00c00050e3b0 by goroutine 243:
  github.com/google/btree.NewWithFreeList()
      /usr/local/google/home/coryan/go/pkg/mod/github.com/google/btree@v1.0.1/btree.go:138 +0x747
  github.com/google/btree.New()
      /usr/local/google/home/coryan/go/pkg/mod/github.com/google/btree@v1.0.1/btree.go:128 +0x6b6
  cloud.google.com/go/bigtable/bttest.(*server).DropRowRange()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem.go:264 +0x793
  cloud.google.com/go/bigtable/bttest.TestTableRowsConcurrent.func3()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem_test.go:331 +0x14c

Goroutine 237 (running) created at:
  cloud.google.com/go/bigtable/bttest.TestTableRowsConcurrent()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem_test.go:315 +0x5f0
  testing.tRunner()
      /usr/lib/google-golang/src/testing/testing.go:1193 +0x202

Goroutine 243 (running) created at:
  cloud.google.com/go/bigtable/bttest.TestTableRowsConcurrent()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem_test.go:325 +0x664
  testing.tRunner()
      /usr/lib/google-golang/src/testing/testing.go:1193 +0x202
==================
==================
WARNING: DATA RACE
Write at 0x00c000517fa0 by goroutine 237:
  sync/atomic.CompareAndSwapInt32()
      /usr/lib/google-golang/src/runtime/race_amd64.s:321 +0xb
  sync.(*Mutex).Lock()
      /usr/lib/google-golang/src/sync/mutex.go:74 +0x4d
  github.com/google/btree.(*FreeList).newNode()
      /usr/local/google/home/coryan/go/pkg/mod/github.com/google/btree@v1.0.1/btree.go:93 +0x3e
  github.com/google/btree.(*copyOnWriteContext).newNode()
      /usr/local/google/home/coryan/go/pkg/mod/github.com/google/btree@v1.0.1/btree.go:646 +0x7f0
  github.com/google/btree.(*BTree).ReplaceOrInsert()
      /usr/local/google/home/coryan/go/pkg/mod/github.com/google/btree@v1.0.1/btree.go:688 +0x7b1
  cloud.google.com/go/bigtable/bttest.(*table).mutableRow()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem.go:1227 +0x3c4
  cloud.google.com/go/bigtable/bttest.(*server).MutateRow()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem.go:795 +0x1bd
  cloud.google.com/go/bigtable/bttest.TestTableRowsConcurrent.func1()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem_test.go:307 +0x564
  cloud.google.com/go/bigtable/bttest.TestTableRowsConcurrent.func2()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem_test.go:316 +0x51

Previous write at 0x00c000517fa0 by goroutine 243:
  github.com/google/btree.NewFreeList()
      /usr/local/google/home/coryan/go/pkg/mod/github.com/google/btree@v1.0.1/btree.go:89 +0x644
  github.com/google/btree.New()
      /usr/local/google/home/coryan/go/pkg/mod/github.com/google/btree@v1.0.1/btree.go:128 +0x5dd
  cloud.google.com/go/bigtable/bttest.(*server).DropRowRange()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem.go:264 +0x793
  cloud.google.com/go/bigtable/bttest.TestTableRowsConcurrent.func3()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem_test.go:331 +0x14c

Goroutine 237 (running) created at:
  cloud.google.com/go/bigtable/bttest.TestTableRowsConcurrent()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem_test.go:315 +0x5f0
  testing.tRunner()
      /usr/lib/google-golang/src/testing/testing.go:1193 +0x202

Goroutine 243 (running) created at:
  cloud.google.com/go/bigtable/bttest.TestTableRowsConcurrent()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem_test.go:325 +0x664
  testing.tRunner()
      /usr/lib/google-golang/src/testing/testing.go:1193 +0x202
==================
==================
WARNING: DATA RACE
Read at 0x00c000517fa8 by goroutine 237:
  github.com/google/btree.(*FreeList).newNode()
      /usr/local/google/home/coryan/go/pkg/mod/github.com/google/btree@v1.0.1/btree.go:94 +0x55
  github.com/google/btree.(*copyOnWriteContext).newNode()
      /usr/local/google/home/coryan/go/pkg/mod/github.com/google/btree@v1.0.1/btree.go:646 +0x7f0
  github.com/google/btree.(*BTree).ReplaceOrInsert()
      /usr/local/google/home/coryan/go/pkg/mod/github.com/google/btree@v1.0.1/btree.go:688 +0x7b1
  cloud.google.com/go/bigtable/bttest.(*table).mutableRow()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem.go:1227 +0x3c4
  cloud.google.com/go/bigtable/bttest.(*server).MutateRow()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem.go:795 +0x1bd
  cloud.google.com/go/bigtable/bttest.TestTableRowsConcurrent.func1()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem_test.go:307 +0x564
  cloud.google.com/go/bigtable/bttest.TestTableRowsConcurrent.func2()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem_test.go:316 +0x51

Previous write at 0x00c000517fa8 by goroutine 243:
  github.com/google/btree.NewFreeList()
      /usr/local/google/home/coryan/go/pkg/mod/github.com/google/btree@v1.0.1/btree.go:89 +0x644
  github.com/google/btree.New()
      /usr/local/google/home/coryan/go/pkg/mod/github.com/google/btree@v1.0.1/btree.go:128 +0x5dd
  cloud.google.com/go/bigtable/bttest.(*server).DropRowRange()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem.go:264 +0x793
  cloud.google.com/go/bigtable/bttest.TestTableRowsConcurrent.func3()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem_test.go:331 +0x14c

Goroutine 237 (running) created at:
  cloud.google.com/go/bigtable/bttest.TestTableRowsConcurrent()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem_test.go:315 +0x5f0
  testing.tRunner()
      /usr/lib/google-golang/src/testing/testing.go:1193 +0x202

Goroutine 243 (running) created at:
  cloud.google.com/go/bigtable/bttest.TestTableRowsConcurrent()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem_test.go:325 +0x664
  testing.tRunner()
      /usr/lib/google-golang/src/testing/testing.go:1193 +0x202
==================
==================
WARNING: DATA RACE
Read at 0x00c000517fc8 by goroutine 237:
  github.com/google/btree.(*BTree).ReplaceOrInsert()
      /usr/local/google/home/coryan/go/pkg/mod/github.com/google/btree@v1.0.1/btree.go:690 +0x996
  cloud.google.com/go/bigtable/bttest.(*table).mutableRow()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem.go:1227 +0x3c4
  cloud.google.com/go/bigtable/bttest.(*server).MutateRow()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem.go:795 +0x1bd
  cloud.google.com/go/bigtable/bttest.TestTableRowsConcurrent.func1()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem_test.go:307 +0x564
  cloud.google.com/go/bigtable/bttest.TestTableRowsConcurrent.func2()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem_test.go:316 +0x51

Previous write at 0x00c000517fc8 by goroutine 243:
  github.com/google/btree.NewWithFreeList()
      /usr/local/google/home/coryan/go/pkg/mod/github.com/google/btree@v1.0.1/btree.go:136 +0x6e4
  github.com/google/btree.New()
      /usr/local/google/home/coryan/go/pkg/mod/github.com/google/btree@v1.0.1/btree.go:128 +0x6b6
  cloud.google.com/go/bigtable/bttest.(*server).DropRowRange()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem.go:264 +0x793
  cloud.google.com/go/bigtable/bttest.TestTableRowsConcurrent.func3()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem_test.go:331 +0x14c

Goroutine 237 (running) created at:
  cloud.google.com/go/bigtable/bttest.TestTableRowsConcurrent()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem_test.go:315 +0x5f0
  testing.tRunner()
      /usr/lib/google-golang/src/testing/testing.go:1193 +0x202

Goroutine 243 (running) created at:
  cloud.google.com/go/bigtable/bttest.TestTableRowsConcurrent()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem_test.go:325 +0x664
  testing.tRunner()
      /usr/lib/google-golang/src/testing/testing.go:1193 +0x202
==================
==================
WARNING: DATA RACE
Read at 0x00c0005ac470 by goroutine 237:
  github.com/google/btree.(*BTree).Get()
      /usr/local/google/home/coryan/go/pkg/mod/github.com/google/btree@v1.0.1/btree.go:819 +0x144
  cloud.google.com/go/bigtable/bttest.(*table).mutableRow()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem.go:1213 +0xfd
  cloud.google.com/go/bigtable/bttest.(*server).MutateRow()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem.go:795 +0x1bd
  cloud.google.com/go/bigtable/bttest.TestTableRowsConcurrent.func1()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem_test.go:307 +0x564
  cloud.google.com/go/bigtable/bttest.TestTableRowsConcurrent.func2()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem_test.go:316 +0x51

Previous write at 0x00c0005ac470 by goroutine 243:
  github.com/google/btree.NewWithFreeList()
      /usr/local/google/home/coryan/go/pkg/mod/github.com/google/btree@v1.0.1/btree.go:136 +0x6e4
  github.com/google/btree.New()
      /usr/local/google/home/coryan/go/pkg/mod/github.com/google/btree@v1.0.1/btree.go:128 +0x6b6
  cloud.google.com/go/bigtable/bttest.(*server).DropRowRange()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem.go:264 +0x793
  cloud.google.com/go/bigtable/bttest.TestTableRowsConcurrent.func3()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem_test.go:331 +0x14c

Goroutine 237 (running) created at:
  cloud.google.com/go/bigtable/bttest.TestTableRowsConcurrent()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem_test.go:315 +0x5f0
  testing.tRunner()
      /usr/lib/google-golang/src/testing/testing.go:1193 +0x202

Goroutine 243 (running) created at:
  cloud.google.com/go/bigtable/bttest.TestTableRowsConcurrent()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem_test.go:325 +0x664
  testing.tRunner()
      /usr/lib/google-golang/src/testing/testing.go:1193 +0x202
==================
==================
WARNING: DATA RACE
Read at 0x00c00026de20 by goroutine 237:
  github.com/google/btree.(*BTree).maxItems()
      /usr/local/google/home/coryan/go/pkg/mod/github.com/google/btree@v1.0.1/btree.go:636 +0x177
  github.com/google/btree.(*BTree).ReplaceOrInsert()
      /usr/local/google/home/coryan/go/pkg/mod/github.com/google/btree@v1.0.1/btree.go:694 +0x126
  cloud.google.com/go/bigtable/bttest.(*table).mutableRow()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem.go:1227 +0x3c4
  cloud.google.com/go/bigtable/bttest.(*server).MutateRow()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem.go:795 +0x1bd
  cloud.google.com/go/bigtable/bttest.TestTableRowsConcurrent.func1()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem_test.go:307 +0x564
  cloud.google.com/go/bigtable/bttest.TestTableRowsConcurrent.func2()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem_test.go:316 +0x51

Previous write at 0x00c00026de20 by goroutine 243:
  github.com/google/btree.NewWithFreeList()
      /usr/local/google/home/coryan/go/pkg/mod/github.com/google/btree@v1.0.1/btree.go:136 +0x6e4
  github.com/google/btree.New()
      /usr/local/google/home/coryan/go/pkg/mod/github.com/google/btree@v1.0.1/btree.go:128 +0x6b6
  cloud.google.com/go/bigtable/bttest.(*server).DropRowRange()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem.go:264 +0x793
  cloud.google.com/go/bigtable/bttest.TestTableRowsConcurrent.func3()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem_test.go:331 +0x14c

Goroutine 237 (running) created at:
  cloud.google.com/go/bigtable/bttest.TestTableRowsConcurrent()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem_test.go:315 +0x5f0
  testing.tRunner()
      /usr/lib/google-golang/src/testing/testing.go:1193 +0x202

Goroutine 243 (finished) created at:
  cloud.google.com/go/bigtable/bttest.TestTableRowsConcurrent()
      /usr/local/google/home/coryan/go-develop/bigtable/bttest/inmem_test.go:325 +0x664
  testing.tRunner()
      /usr/lib/google-golang/src/testing/testing.go:1193 +0x202
==================
--- FAIL: TestTableRowsConcurrent (0.04s)
    testing.go:1092: race detected during execution of test
2021/06/02 23:05:42 Bad pattern "[": error parsing regexp: missing closing ]: `[)$`
2021/06/02 23:05:42 Bad pattern "[": error parsing regexp: missing closing ]: `[)$`
2021/06/02 23:05:42 Bad pattern "[": error parsing regexp: missing closing ]: `[)$`
2021/06/02 23:05:42 Bad pattern "[": error parsing regexp: missing closing ]: `[)$`
2021/06/02 23:05:42 Bad pattern "[": error parsing regexp: missing closing ]: `[)$`
2021/06/02 23:05:42 Bad pattern "[": error parsing regexp: missing closing ]: `[)$`
2021/06/02 23:05:42 Bad pattern "[": error parsing regexp: missing closing ]: `[)$`
2021/06/02 23:05:42 Bad pattern "a\\xC.+": error parsing regexp: invalid escape sequence: `\xC.`
FAIL
FAIL	cloud.google.com/go/bigtable/bttest	0.269s
FAIL
```
