### PR TITLE
feat(datastore): save enums as string repr

### DIFF
--- a/datastore/save.go
+++ b/datastore/save.go
@@ -76,6 +76,8 @@ func reflectFieldSave(props *[]Property, p Property, name string, opts saveOpts,
 		p.Value = x.In(time.UTC)
 		*props = append(*props, p)
 		return nil
+	case fmt.Stringer:
+		p.Value = x.String()
 	default:
 		switch v.Kind() {
 		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:


### PR DESCRIPTION
Add the hability to save string representation of enums when Stringer interface is implemented.

There is just one issue for now: actually if a struct (not an enum) implements the Stringer interface, the save method will also save its string representation instead of a Datastore Entity (as expected).

The solution would be to add a `stringer` or `string` tag to allow or not using the Stringer method ? Like:
```go
type MyStruct struct {
  MyNestedStruct                   MyNestedStruct
  AFieldInStringerRepresentation   AFieldInStringerRepresentation   `datastore:",stringer"`
}
```
I would like to have opinions of contributors about this if possible :) 

Should fixes #4196