### PR TITLE
fix(pubsublite): ensure api clients are closed when startup fails

### DIFF
--- a/pubsublite/internal/wire/rpc.go
+++ b/pubsublite/internal/wire/rpc.go
@@ -165,21 +165,6 @@ func defaultClientOptions(region string) []option.ClientOption {
 	}
 }
 
-type apiClient interface {
-	Close() error
-}
-
-type apiClients []apiClient
-
-func (ac apiClients) Close() (retErr error) {
-	for _, c := range ac {
-		if err := c.Close(); retErr == nil {
-			retErr = err
-		}
-	}
-	return
-}
-
 // NewAdminClient creates a new gapic AdminClient for a region.
 func NewAdminClient(ctx context.Context, region string, opts ...option.ClientOption) (*vkit.AdminClient, error) {
 	options := append(defaultClientOptions(region), opts...)

--- a/pubsublite/internal/wire/service.go
+++ b/pubsublite/internal/wire/service.go
@@ -343,6 +343,21 @@ func removeFromSlice(services []service, removeIdx int) []service {
 	return services[:lastIdx]
 }
 
+type apiClient interface {
+	Close() error
+}
+
+type apiClients []apiClient
+
+func (ac apiClients) Close() (retErr error) {
+	for _, c := range ac {
+		if err := c.Close(); retErr == nil {
+			retErr = err
+		}
+	}
+	return
+}
+
 // A compositeService that handles closing API clients on shutdown.
 type apiClientService struct {
 	clients apiClients

--- a/pubsublite/internal/wire/service.go
+++ b/pubsublite/internal/wire/service.go
@@ -342,3 +342,24 @@ func removeFromSlice(services []service, removeIdx int) []service {
 	services[lastIdx] = nil
 	return services[:lastIdx]
 }
+
+// A compositeService that handles closing API clients on shutdown.
+type apiClientService struct {
+	clients apiClients
+
+	compositeService
+}
+
+func (acs *apiClientService) WaitStarted() error {
+	err := acs.compositeService.WaitStarted()
+	if err != nil {
+		acs.WaitStopped()
+	}
+	return err
+}
+
+func (acs *apiClientService) WaitStopped() error {
+	err := acs.compositeService.WaitStopped()
+	acs.clients.Close()
+	return err
+}


### PR DESCRIPTION
* Ensure that `NewSubscriber` and `NewPublisher` constructors close all created API clients if they partially fail.
* Added an `apiClientService` base class to handle closing clients when startup fails, as well as after shutdown.