### PR TITLE
testing: add an explicit module download step to build_samples.sh

### DIFF
--- a/internal/kokoro/build_samples.sh
+++ b/internal/kokoro/build_samples.sh
@@ -64,6 +64,8 @@ for i in $(find . -name go.mod); do
   go mod edit -replace cloud.google.com/go/pubsub=$gcwd/pubsub
   go mod edit -replace cloud.google.com/go/spanner=$gcwd/spanner
   go mod edit -replace cloud.google.com/go/storage=$gcwd/storage
+  echo "Downloading modules"
+  go mod download
   echo "Building module $i"
   go build ./...
   popd


### PR DESCRIPTION
Currently, the work to go mod replace doesn't account for dependency
changes in head.  This adds an explicit step to download modules to
reflect differences in the latest released google-cloud-go vs head.