### PR TITLE
fix(pubsublite): fixes for background partition count updates

### DIFF
--- a/pubsublite/internal/wire/partition_count.go
+++ b/pubsublite/internal/wire/partition_count.go
@@ -104,11 +104,10 @@ func (p *partitionCountWatcher) updatePartitionCount() {
 				// Ignore errors after the first update.
 				// TODO: Log the error.
 				return p.partitionCount, nil
-			} else {
-				err = fmt.Errorf("pubsublite: failed to update topic partition count: %v", err)
-				p.unsafeInitiateShutdown(err)
-				return 0, err
 			}
+			err = fmt.Errorf("pubsublite: failed to update topic partition count: %v", err)
+			p.unsafeInitiateShutdown(err)
+			return 0, err
 		}
 		if resp.GetPartitionCount() <= 0 {
 			err := fmt.Errorf("pubsublite: topic has invalid number of partitions %d", resp.GetPartitionCount())

--- a/pubsublite/internal/wire/publisher_test.go
+++ b/pubsublite/internal/wire/publisher_test.go
@@ -1004,14 +1004,16 @@ func TestRoutingPublisherPartitionCountUpdateFails(t *testing.T) {
 	t.Run("Failed update", func(t *testing.T) {
 		pub.pub.partitionWatcher.updatePartitionCount()
 
-		// Failed background update terminates the routingPublisher.
-		if gotErr := pub.WaitStopped(); !test.ErrorHasMsg(gotErr, serverErr.Error()) {
-			t.Errorf("Final error got: (%v), want: (%v)", gotErr, serverErr)
-		}
+		// Failed update ignored.
 		if got, want := pub.NumPartitionPublishers(), initialPartitionCount; got != want {
 			t.Errorf("Num partition publishers: got %d, want %d", got, want)
 		}
 	})
+
+	pub.Stop()
+	if gotErr := pub.WaitStopped(); gotErr != nil {
+		t.Errorf("Stop() got err: (%v)", gotErr)
+	}
 }
 
 func TestNewPublisherValidatesSettings(t *testing.T) {

--- a/pubsublite/internal/wire/rpc.go
+++ b/pubsublite/internal/wire/rpc.go
@@ -110,7 +110,7 @@ func isRetryableStreamError(err error, isEligible func(codes.Code) bool) bool {
 	return isEligible(s.Code())
 }
 
-// Wraps an ordered list of retryers.
+// Wraps an ordered list of retryers. Earlier retryers take precedence.
 type compositeRetryer struct {
 	retryers []gax.Retryer
 }

--- a/pubsublite/internal/wire/rpc.go
+++ b/pubsublite/internal/wire/rpc.go
@@ -110,24 +110,49 @@ func isRetryableStreamError(err error, isEligible func(codes.Code) bool) bool {
 	return isEligible(s.Code())
 }
 
-// retryableReadOnlyCallOption returns a call option that retries with backoff
-// for ResourceExhausted in addition to other default retryable codes for
-// Pub/Sub. Suitable for read-only operations which are subject to only QPS
+// Wraps an ordered list of retryers.
+type compositeRetryer struct {
+	retryers []gax.Retryer
+}
+
+func (cr *compositeRetryer) Retry(err error) (pause time.Duration, shouldRetry bool) {
+	for _, r := range cr.retryers {
+		pause, shouldRetry = r.Retry(err)
+		if shouldRetry {
+			return
+		}
+	}
+	return 0, false
+}
+
+// resourceExhaustedRetryer returns a call option that retries slowly with
+// backoff for ResourceExhausted in addition to other default retryable codes
+// for Pub/Sub. Suitable for read-only operations which are subject to only QPS
 // quota limits.
-func retryableReadOnlyCallOption() gax.CallOption {
+func resourceExhaustedRetryer() gax.CallOption {
 	return gax.WithRetry(func() gax.Retryer {
-		return gax.OnCodes([]codes.Code{
-			codes.Aborted,
-			codes.DeadlineExceeded,
-			codes.Internal,
-			codes.ResourceExhausted,
-			codes.Unavailable,
-			codes.Unknown,
-		}, gax.Backoff{
-			Initial:    100 * time.Millisecond,
-			Max:        60 * time.Second,
-			Multiplier: 1.3,
-		})
+		return &compositeRetryer{
+			retryers: []gax.Retryer{
+				gax.OnCodes([]codes.Code{
+					codes.ResourceExhausted,
+				}, gax.Backoff{
+					Initial:    time.Second,
+					Max:        60 * time.Second,
+					Multiplier: 3,
+				}),
+				gax.OnCodes([]codes.Code{
+					codes.Aborted,
+					codes.DeadlineExceeded,
+					codes.Internal,
+					codes.Unavailable,
+					codes.Unknown,
+				}, gax.Backoff{
+					Initial:    100 * time.Millisecond,
+					Max:        60 * time.Second,
+					Multiplier: 1.3,
+				}),
+			},
+		}
 	})
 }
 


### PR DESCRIPTION
* When refreshing topic partition counts in the background for Publishers, retry slowly upon resource exhausted errors. The last `gax.Retryer` found in call options is used, so we introduce a `compositeRetryer` for error codes with different backoff params.
* `partitionCountWatcher` ignores errors after the first update. This is consistent with implementations in the Lite Java and Python client libraries.