### PR TITLE
chore(internal): gen googleapis-discovery compute genproto

### DIFF
--- a/internal/gapicgen/cmd/genbot/generate.go
+++ b/internal/gapicgen/cmd/genbot/generate.go
@@ -42,6 +42,7 @@ func generate(ctx context.Context, githubClient *git.GithubClient, forceAll bool
 	log.Printf("working out %s\n", tmpDir)
 
 	googleapisDir := filepath.Join(tmpDir, "googleapis")
+	googleapisDiscoDir := filepath.Join(tmpDir, "googleapis-discovery")
 	gocloudDir := filepath.Join(tmpDir, "gocloud")
 	genprotoDir := filepath.Join(tmpDir, "genproto")
 	protoDir := filepath.Join(tmpDir, "proto")
@@ -51,6 +52,9 @@ func generate(ctx context.Context, githubClient *git.GithubClient, forceAll bool
 	grp, _ := errgroup.WithContext(ctx)
 	grp.Go(func() error {
 		return git.DeepClone("https://github.com/googleapis/googleapis", googleapisDir)
+	})
+	grp.Go(func() error {
+		return git.DeepClone("https://github.com/googleapis/googleapis-discovery", googleapisDiscoDir)
 	})
 	grp.Go(func() error {
 		return git.DeepClone("https://github.com/googleapis/go-genproto", genprotoDir)
@@ -67,11 +71,12 @@ func generate(ctx context.Context, githubClient *git.GithubClient, forceAll bool
 
 	// Regen.
 	conf := &generator.Config{
-		GoogleapisDir: googleapisDir,
-		GenprotoDir:   genprotoDir,
-		GapicDir:      gocloudDir,
-		ProtoDir:      protoDir,
-		ForceAll:      forceAll,
+		GoogleapisDir:      googleapisDir,
+		GoogleapisDiscoDir: googleapisDiscoDir,
+		GenprotoDir:        genprotoDir,
+		GapicDir:           gocloudDir,
+		ProtoDir:           protoDir,
+		ForceAll:           forceAll,
 	}
 	changes, err := generator.Generate(ctx, conf)
 	if err != nil {

--- a/internal/gapicgen/cmd/genbot/local.go
+++ b/internal/gapicgen/cmd/genbot/local.go
@@ -29,13 +29,14 @@ import (
 )
 
 type localConfig struct {
-	googleapisDir   string
-	gocloudDir      string
-	genprotoDir     string
-	protoDir        string
-	gapicToGenerate string
-	onlyGapics      bool
-	regenOnly       bool
+	googleapisDir      string
+	googleapisDiscoDir string
+	gocloudDir         string
+	genprotoDir        string
+	protoDir           string
+	gapicToGenerate    string
+	onlyGapics         bool
+	regenOnly          bool
 }
 
 func genLocal(ctx context.Context, c localConfig) error {
@@ -46,6 +47,7 @@ func genLocal(ctx context.Context, c localConfig) error {
 	}
 	log.Printf("temp dir created at %s\n", tmpDir)
 	tmpGoogleapisDir := filepath.Join(tmpDir, "googleapis")
+	tmpGoogleapisDiscoDir := filepath.Join(tmpDir, "googleapis-discovery")
 	tmpGenprotoDir := filepath.Join(tmpDir, "genproto")
 	tmpGocloudDir := filepath.Join(tmpDir, "gocloud")
 	tmpProtoDir := filepath.Join(tmpDir, "proto")
@@ -53,6 +55,7 @@ func genLocal(ctx context.Context, c localConfig) error {
 	// Clone repositories if needed.
 	grp, _ := errgroup.WithContext(ctx)
 	gitShallowClone(grp, "https://github.com/googleapis/googleapis.git", c.googleapisDir, tmpGoogleapisDir)
+	gitShallowClone(grp, "https://github.com/googleapis/googleapis-discovery.git", c.googleapisDiscoDir, tmpGoogleapisDiscoDir)
 	gitShallowClone(grp, "https://github.com/googleapis/go-genproto", c.genprotoDir, tmpGenprotoDir)
 	gitShallowClone(grp, "https://github.com/googleapis/google-cloud-go", c.gocloudDir, tmpGocloudDir)
 	gitShallowClone(grp, "https://github.com/protocolbuffers/protobuf", c.protoDir, tmpProtoDir)
@@ -62,14 +65,15 @@ func genLocal(ctx context.Context, c localConfig) error {
 
 	// Regen.
 	conf := &generator.Config{
-		GoogleapisDir:     deafultDir(tmpGoogleapisDir, c.googleapisDir),
-		GenprotoDir:       deafultDir(tmpGenprotoDir, c.genprotoDir),
-		GapicDir:          deafultDir(tmpGocloudDir, c.gocloudDir),
-		ProtoDir:          deafultDir(tmpProtoDir, c.protoDir),
-		GapicToGenerate:   c.gapicToGenerate,
-		OnlyGenerateGapic: c.onlyGapics,
-		LocalMode:         true,
-		RegenOnly:         c.regenOnly,
+		GoogleapisDir:      deafultDir(tmpGoogleapisDir, c.googleapisDir),
+		GoogleapisDiscoDir: deafultDir(tmpGoogleapisDiscoDir, c.googleapisDiscoDir),
+		GenprotoDir:        deafultDir(tmpGenprotoDir, c.genprotoDir),
+		GapicDir:           deafultDir(tmpGocloudDir, c.gocloudDir),
+		ProtoDir:           deafultDir(tmpProtoDir, c.protoDir),
+		GapicToGenerate:    c.gapicToGenerate,
+		OnlyGenerateGapic:  c.onlyGapics,
+		LocalMode:          true,
+		RegenOnly:          c.regenOnly,
 	}
 	if _, err := generator.Generate(ctx, conf); err != nil {
 		log.Printf("Generator ran (and failed) in %s\n", tmpDir)

--- a/internal/gapicgen/cmd/genbot/main.go
+++ b/internal/gapicgen/cmd/genbot/main.go
@@ -45,6 +45,7 @@ func main() {
 
 	// flags for local mode
 	googleapisDir := flag.String("googleapis-dir", os.Getenv("GOOGLEAPIS_DIR"), "Directory where sources of googleapis/googleapis resides. If unset the sources will be cloned to a temporary directory that is not cleaned up.")
+	googleapisDiscoDir := flag.String("googleapis-disco-dir", os.Getenv("GOOGLEAPIS_DISCO_DIR"), "Directory where sources of googleapis/googleapis-discovery resides. If unset the sources will be cloned to a temporary directory that is not cleaned up.")
 	gocloudDir := flag.String("gocloud-dir", os.Getenv("GOCLOUD_DIR"), "Directory where sources of googleapis/google-cloud-go resides. If unset the sources will be cloned to a temporary directory that is not cleaned up.")
 	genprotoDir := flag.String("genproto-dir", os.Getenv("GENPROTO_DIR"), "Directory where sources of googleapis/go-genproto resides. If unset the sources will be cloned to a temporary directory that is not cleaned up.")
 	protoDir := flag.String("proto-dir", os.Getenv("PROTO_DIR"), "Directory where sources of google/protobuf resides. If unset the sources will be cloned to a temporary directory that is not cleaned up.")
@@ -56,13 +57,14 @@ func main() {
 
 	if *localMode {
 		if err := genLocal(ctx, localConfig{
-			googleapisDir:   *googleapisDir,
-			gocloudDir:      *gocloudDir,
-			genprotoDir:     *genprotoDir,
-			protoDir:        *protoDir,
-			gapicToGenerate: *gapicToGenerate,
-			onlyGapics:      *onlyGapics,
-			regenOnly:       *regenOnly,
+			googleapisDir:      *googleapisDir,
+			googleapisDiscoDir: *googleapisDiscoDir,
+			gocloudDir:         *gocloudDir,
+			genprotoDir:        *genprotoDir,
+			protoDir:           *protoDir,
+			gapicToGenerate:    *gapicToGenerate,
+			onlyGapics:         *onlyGapics,
+			regenOnly:          *regenOnly,
 		}); err != nil {
 			log.Fatal(err)
 		}

--- a/internal/gapicgen/generator/generator.go
+++ b/internal/gapicgen/generator/generator.go
@@ -29,15 +29,16 @@ import (
 
 // Config contains inputs needed to generate sources.
 type Config struct {
-	GoogleapisDir     string
-	GenprotoDir       string
-	GapicDir          string
-	ProtoDir          string
-	GapicToGenerate   string
-	OnlyGenerateGapic bool
-	LocalMode         bool
-	RegenOnly         bool
-	ForceAll          bool
+	GoogleapisDir      string
+	GoogleapisDiscoDir string
+	GenprotoDir        string
+	GapicDir           string
+	ProtoDir           string
+	GapicToGenerate    string
+	OnlyGenerateGapic  bool
+	LocalMode          bool
+	RegenOnly          bool
+	ForceAll           bool
 }
 
 // Generate generates genproto and gapics.


### PR DESCRIPTION
Hardcodes go-genproto generation for google/cloud/compute/v1 from googleapis-discovery. We will need to figure out how we support other protos in that repo in the future.

Note: This **deos not** add gapic gen for compute yet.

Note: `compute.pb.go` is approximately 158k LoC 😮 .

cc: @vchudnov-g @software-dov 