### PR TITLE
fix(bigquery): update streaming insert error test

### DIFF
--- a/bigquery/integration_test.go
+++ b/bigquery/integration_test.go
@@ -1378,9 +1378,11 @@ func TestIntegration_InsertErrors(t *testing.T) {
 	if !ok {
 		t.Errorf("Wanted googleapi.Error, got: %v", err)
 	}
-	want := "Request payload size exceeds the limit"
-	if !strings.Contains(e.Message, want) {
-		t.Errorf("Error didn't contain expected message (%s): %s", want, e.Message)
+	if e.Code != http.StatusRequestEntityTooLarge {
+		want := "Request payload size exceeds the limit"
+		if !strings.Contains(e.Message, want) {
+			t.Errorf("Error didn't contain expected message (%s): %#v", want, e)
+		}
 	}
 	// Case 2: Very Large Request
 	// Request so large it gets rejected by intermediate infra (3x 10MB rows)


### PR DESCRIPTION
More backend changes appear to be inducing two forms of error message,
depending on which component intercepts the error first.  This test
captures both outcomes (we always get an error).

Fixes: https://github.com/googleapis/google-cloud-go/issues/4285