### PR TITLE
fix(pubsublite): ensure timeout settings are respected

### DIFF
--- a/pubsublite/internal/wire/partition_count_test.go
+++ b/pubsublite/internal/wire/partition_count_test.go
@@ -16,6 +16,7 @@ package wire
 import (
 	"context"
 	"testing"
+	"time"
 
 	"cloud.google.com/go/internal/testutil"
 	"cloud.google.com/go/pubsublite/internal/test"
@@ -54,7 +55,7 @@ func newTestPartitionCountWatcher(t *testing.T, topicPath string, settings Publi
 	tw := &testPartitionCountWatcher{
 		t: t,
 	}
-	tw.watcher = newPartitionCountWatcher(ctx, adminClient, testPublishSettings(), topicPath, tw.onCountChanged)
+	tw.watcher = newPartitionCountWatcher(ctx, adminClient, settings, topicPath, tw.onCountChanged)
 	tw.initAndStart(t, tw.watcher, "PartitionCountWatcher", adminClient)
 	return tw
 }
@@ -93,6 +94,59 @@ func TestPartitionCountWatcherZeroPartitionCountFails(t *testing.T) {
 		t.Errorf("Start() got err: (%v), want msg: (%q)", gotErr, wantMsg)
 	}
 	watcher.VerifyCounts(nil)
+}
+
+func TestPartitionCountWatcherInitialRequestTimesOut(t *testing.T) {
+	const topic = "projects/123456/locations/us-central1-b/topics/my-topic"
+
+	verifiers := test.NewVerifiers(t)
+	barrier := verifiers.GlobalVerifier.PushWithBarrier(topicPartitionsReq(topic), topicPartitionsResp(1), nil)
+
+	mockServer.OnTestStart(verifiers)
+	defer mockServer.OnTestEnd()
+
+	settings := testPublishSettings()
+	settings.Timeout = 20 * time.Millisecond // Set low timeout for initial request
+	watcher := newTestPartitionCountWatcher(t, topic, settings)
+
+	if gotErr, wantErr := watcher.StartError(), ErrBackendUnavailable; !test.ErrorEqual(gotErr, wantErr) {
+		t.Errorf("Start() got err: (%v), want err: (%v)", gotErr, wantErr)
+	}
+	barrier.Release()
+	watcher.VerifyCounts(nil)
+}
+
+func TestPartitionCountWatcherUpdateLongerTimeouts(t *testing.T) {
+	const topic = "projects/123456/locations/us-central1-b/topics/my-topic"
+	wantPartitionCount1 := 1
+	wantPartitionCount2 := 2
+
+	verifiers := test.NewVerifiers(t)
+	verifiers.GlobalVerifier.Push(topicPartitionsReq(topic), topicPartitionsResp(wantPartitionCount1), nil)
+	// Barrier used to delay response.
+	barrier := verifiers.GlobalVerifier.PushWithBarrier(topicPartitionsReq(topic), topicPartitionsResp(wantPartitionCount2), nil)
+
+	mockServer.OnTestStart(verifiers)
+	defer mockServer.OnTestEnd()
+
+	watcher := newTestPartitionCountWatcher(t, topic, testPublishSettings())
+	if gotErr := watcher.StartError(); gotErr != nil {
+		t.Errorf("Start() got err: (%v)", gotErr)
+	}
+	watcher.VerifyCounts([]int{wantPartitionCount1})
+
+	// Override the initial timeout after the first request to verify that it
+	// isn't used. If set at creation, the first request will fail.
+	const timeout = time.Millisecond
+	watcher.watcher.initialTimeout = timeout
+	go func() {
+		barrier.ReleaseAfter(func() {
+			time.Sleep(5 * timeout)
+		})
+	}()
+	watcher.UpdatePartitionCount()
+	watcher.VerifyCounts([]int{wantPartitionCount1, wantPartitionCount2})
+	watcher.StopVerifyNoError()
 }
 
 func TestPartitionCountWatcherPartitionCountUnchanged(t *testing.T) {

--- a/pubsublite/internal/wire/publisher_test.go
+++ b/pubsublite/internal/wire/publisher_test.go
@@ -34,8 +34,9 @@ func testPublishSettings() PublishSettings {
 	// Send messages with minimal delay to speed up tests.
 	settings.DelayThreshold = time.Millisecond
 	settings.Timeout = 5 * time.Second
-	// Disable topic partition count background polling.
-	settings.ConfigPollPeriod = 0
+	// Set long poll period to prevent background update, but still have non-zero
+	// request timeout.
+	settings.ConfigPollPeriod = 1 * time.Minute
 	return settings
 }
 

--- a/pubsublite/internal/wire/request_timer.go
+++ b/pubsublite/internal/wire/request_timer.go
@@ -1,0 +1,78 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+
+package wire
+
+import (
+	"sync"
+	"time"
+)
+
+type requestTimerStatus int
+
+const (
+	requestTimerNew requestTimerStatus = iota
+	requestTimerStopped
+	requestTimerTriggered
+)
+
+// requestTimer bounds the duration of a request and executes `onTimeout` if
+// the timer is triggered.
+type requestTimer struct {
+	onTimeout  func()
+	timeoutErr error
+	timer      *time.Timer
+	mu         sync.Mutex
+	status     requestTimerStatus
+}
+
+func newRequestTimer(duration time.Duration, onTimeout func(), timeoutErr error) *requestTimer {
+	rt := &requestTimer{
+		onTimeout:  onTimeout,
+		timeoutErr: timeoutErr,
+		status:     requestTimerNew,
+	}
+	rt.timer = time.AfterFunc(duration, rt.onTriggered)
+	return rt
+}
+
+func (rt *requestTimer) onTriggered() {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	if rt.status == requestTimerNew {
+		rt.status = requestTimerTriggered
+		rt.onTimeout()
+	}
+}
+
+// Stop should be called upon a successful request to prevent the timer from
+// expiring.
+func (rt *requestTimer) Stop() {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	if rt.status == requestTimerNew {
+		rt.status = requestTimerStopped
+		rt.timer.Stop()
+	}
+}
+
+// ResolveError returns `timeoutErr` if the timer triggered, or otherwise
+// `originalErr`.
+func (rt *requestTimer) ResolveError(originalErr error) error {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	if rt.status == requestTimerTriggered {
+		return rt.timeoutErr
+	}
+	return originalErr
+}

--- a/pubsublite/internal/wire/request_timer_test.go
+++ b/pubsublite/internal/wire/request_timer_test.go
@@ -1,0 +1,61 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+
+package wire
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/pubsublite/internal/test"
+)
+
+func TestRequestTimerStop(t *testing.T) {
+	const timeout = 5 * time.Millisecond
+	onTimeout := func() {
+		t.Error("onTimeout should not be called")
+	}
+
+	rt := newRequestTimer(timeout, onTimeout, errors.New("unused"))
+	rt.Stop()
+	time.Sleep(2 * timeout)
+
+	if err := rt.ResolveError(nil); err != nil {
+		t.Errorf("ResolveError() got gotErr: %v", err)
+	}
+	wantErr := errors.New("original error")
+	if gotErr := rt.ResolveError(wantErr); !test.ErrorEqual(gotErr, wantErr) {
+		t.Errorf("ResolveError() got err: %v, want err: %v", gotErr, wantErr)
+	}
+}
+
+func TestRequestTimerExpires(t *testing.T) {
+	const timeout = 5 * time.Millisecond
+	timeoutErr := errors.New("on timeout")
+
+	expired := test.NewCondition("request timer expired")
+	onTimeout := func() {
+		expired.SetDone()
+	}
+
+	rt := newRequestTimer(timeout, onTimeout, timeoutErr)
+	expired.WaitUntilDone(t, serviceTestWaitTimeout)
+
+	if gotErr := rt.ResolveError(nil); !test.ErrorEqual(gotErr, timeoutErr) {
+		t.Errorf("ResolveError() got err: %v, want err: %v", gotErr, timeoutErr)
+	}
+	if gotErr := rt.ResolveError(errors.New("ignored")); !test.ErrorEqual(gotErr, timeoutErr) {
+		t.Errorf("ResolveError() got err: %v, want err: %v", gotErr, timeoutErr)
+	}
+}

--- a/pubsublite/internal/wire/streams.go
+++ b/pubsublite/internal/wire/streams.go
@@ -22,6 +22,8 @@ import (
 
 	"golang.org/x/xerrors"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	gax "github.com/googleapis/gax-go/v2"
 )
@@ -39,6 +41,11 @@ const (
 	streamConnected
 	streamTerminated
 )
+
+// Abort a stream initialization attempt after this duration to mitigate delays.
+const defaultInitTimeout = 2 * time.Minute
+
+var errStreamInitTimeout = status.Error(codes.DeadlineExceeded, "pubsublite: stream initialization timed out")
 
 type initialResponseRequired bool
 type notifyReset bool
@@ -95,10 +102,11 @@ type streamHandler interface {
 // are private implementation.
 type retryableStream struct {
 	// Immutable after creation.
-	ctx          context.Context
-	handler      streamHandler
-	responseType reflect.Type
-	timeout      time.Duration
+	ctx            context.Context
+	handler        streamHandler
+	responseType   reflect.Type
+	connectTimeout time.Duration
+	initTimeout    time.Duration
 
 	// Guards access to fields below.
 	mu sync.Mutex
@@ -115,11 +123,16 @@ type retryableStream struct {
 // maximum duration for reconnection. `responseType` is the type of the response
 // proto received on the stream.
 func newRetryableStream(ctx context.Context, handler streamHandler, timeout time.Duration, responseType reflect.Type) *retryableStream {
+	initTimeout := defaultInitTimeout
+	if timeout < defaultInitTimeout {
+		initTimeout = timeout
+	}
 	return &retryableStream{
-		ctx:          ctx,
-		handler:      handler,
-		responseType: responseType,
-		timeout:      timeout,
+		ctx:            ctx,
+		handler:        handler,
+		responseType:   responseType,
+		connectTimeout: timeout,
+		initTimeout:    initTimeout,
 	}
 }
 
@@ -268,8 +281,12 @@ func (rs *retryableStream) connectStream(notifyReset notifyReset) {
 	rs.listen(newStream)
 }
 
+func (rs *retryableStream) newInitTimer(cancelFunc func()) *requestTimer {
+	return newRequestTimer(rs.initTimeout, cancelFunc, errStreamInitTimeout)
+}
+
 func (rs *retryableStream) initNewStream() (newStream grpc.ClientStream, cancelFunc context.CancelFunc, err error) {
-	r := newStreamRetryer(rs.timeout)
+	r := newStreamRetryer(rs.connectTimeout)
 	for {
 		backoff, shouldRetry := func() (time.Duration, bool) {
 			var cctx context.Context
@@ -277,18 +294,21 @@ func (rs *retryableStream) initNewStream() (newStream grpc.ClientStream, cancelF
 			// Store the cancel func to quickly cancel reconnecting if the stream is
 			// terminated.
 			rs.setCancel(cancelFunc)
+			// Bound the duration of the stream initialization attempt.
+			it := rs.newInitTimer(cancelFunc)
+			defer it.Stop()
 
 			newStream, err = rs.handler.newStream(cctx)
-			if err != nil {
+			if err = it.ResolveError(err); err != nil {
 				return r.RetryRecv(err)
 			}
 			initReq, needsResponse := rs.handler.initialRequest()
-			if err = newStream.SendMsg(initReq); err != nil {
+			if err = it.ResolveError(newStream.SendMsg(initReq)); err != nil {
 				return r.RetrySend(err)
 			}
 			if needsResponse {
 				response := reflect.New(rs.responseType).Interface()
-				if err = newStream.RecvMsg(response); err != nil {
+				if err = it.ResolveError(newStream.RecvMsg(response)); err != nil {
 					if isStreamResetSignal(err) {
 						rs.handler.onStreamStatusChange(streamResetState)
 					}
@@ -299,6 +319,12 @@ func (rs *retryableStream) initNewStream() (newStream grpc.ClientStream, cancelF
 					cancelFunc()
 					return 0, false
 				}
+			}
+
+			// If the init timer fired due to a race, the stream would be unusable.
+			it.Stop()
+			if err = it.ResolveError(nil); err != nil {
+				return r.RetryRecv(err)
 			}
 
 			// We have a valid connection and should break from the outer loop.


### PR DESCRIPTION
Fixes to ensure `PublisherSettings.Timeout` and `ReceiveSettings.Timeout` are respected.

* Adds `requestTimer` for imposing timeouts on requests.
* Sets a limit of 2 min (or less if a lower timeout is provided by the user in settings) for stream initializations to mitigate stuckness. If this duration expires, stream initialization is retried with backoff.
* Sets a timeout for the first update of `partitionCountWatcher` from user-provided settings. This can stall publisher start up.

Minor refactor:

* Changes `retryableStream.setCancel()` to `retryableStream.newStreamContext()`.