### PR TITLE
chore(internal): update microgen to v0.21.5

### DIFF
--- a/internal/gapicgen/cmd/genbot/Dockerfile
+++ b/internal/gapicgen/cmd/genbot/Dockerfile
@@ -28,7 +28,7 @@ RUN GO111MODULE=on go get \
     golang.org/x/lint/golint@latest \
     golang.org/x/tools/cmd/goimports@latest \
     honnef.co/go/tools/cmd/staticcheck@latest \
-    github.com/googleapis/gapic-generator-go/cmd/protoc-gen-go_gapic@v0.21.3
+    github.com/googleapis/gapic-generator-go/cmd/protoc-gen-go_gapic@v0.21.5
 ENV PATH="${PATH}:/root/go/bin"
 
 # Source: http://debuggable.com/posts/disable-strict-host-checking-for-git-clone:49896ff3-0ac0-4263-9703-1eae4834cda3


### PR DESCRIPTION
* Fixes REST gapic go 1.11 compat
* Stabilizes GAPIC metadata JSON output

Manual regen of compute passed CI: https://github.com/googleapis/google-cloud-go/pull/4364