### PR TITLE
fix(pubsublite): lower grpc keepalive timeouts

### DIFF
--- a/pubsublite/internal/wire/rpc.go
+++ b/pubsublite/internal/wire/rpc.go
@@ -183,9 +183,11 @@ func isStreamResetSignal(err error) bool {
 func defaultClientOptions(region string) []option.ClientOption {
 	return []option.ClientOption{
 		internaloption.WithDefaultEndpoint(region + pubsubLiteDefaultEndpoint),
-		// Keep inactive connections alive.
+		// Detect if transport is still alive if there is inactivity.
 		option.WithGRPCDialOption(grpc.WithKeepaliveParams(keepalive.ClientParameters{
-			Time: 5 * time.Minute,
+			Time:                1 * time.Minute,
+			Timeout:             1 * time.Minute,
+			PermitWithoutStream: true,
 		})),
 	}
 }


### PR DESCRIPTION
Sets the same grpc keepalive params as the [Java client](https://github.com/googleapis/java-pubsublite/blob/70749d8f4c9cc23937fbb332a5fd168be4ac0d2f/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/ServiceClients.java#L52).