### PR TITLE
fix(pubsub): retry all goaway errors

### DIFF
--- a/pubsub/service.go
+++ b/pubsub/service.go
@@ -64,8 +64,7 @@ func (r *defaultRetryer) Retry(err error) (pause time.Duration, shouldRetry bool
 		return 0, false
 	case codes.Unknown:
 		// Retry GOAWAY, see https://github.com/googleapis/google-cloud-go/issues/4257.
-		isGoaway := strings.Contains(s.Message(), "error reading from server: EOF") &&
-			strings.Contains(s.Message(), "received prior goaway")
+		isGoaway := strings.Contains(s.Message(), "received prior goaway: code: NO_ERROR")
 		if isGoaway {
 			return r.bo.Pause(), true
 		}


### PR DESCRIPTION
The previous iteration of this PR, #4313, only retried GOAWAY in conjunction with an EOF string, which doesn't capture all GOAWAY errors. Now, all error messages with `GOAWAY` and error code `UNKNOWN` are retried.

Fixes #4257