### PR TITLE
fix(storage): empty readHost when STORAGE_EMULATOR_HOST is set to host:port

### DIFF
--- a/storage/storage.go
+++ b/storage/storage.go
@@ -143,7 +143,7 @@ func NewClient(ctx context.Context, opts ...option.ClientOption) (*Client, error
 		return nil, fmt.Errorf("storage client: %v", err)
 	}
 	// Update readHost with the chosen endpoint.
-	u, err := url.Parse(ep)
+	u, err := url.Parse(rawService.BasePath)
 	if err != nil {
 		return nil, fmt.Errorf("supplied endpoint %q is not valid: %v", ep, err)
 	}


### PR DESCRIPTION
This change will fix the problem with the empty `readHost` in the storage.

fixes #4444