### PR TITLE
fix(storage): retry LockRetentionPolicy

### DIFF
--- a/storage/bucket.go
+++ b/storage/bucket.go
@@ -949,8 +949,10 @@ func (b *BucketHandle) LockRetentionPolicy(ctx context.Context) error {
 		metageneration = b.conds.MetagenerationMatch
 	}
 	req := b.c.raw.Buckets.LockRetentionPolicy(b.name, metageneration)
-	_, err := req.Context(ctx).Do()
-	return err
+	return runWithRetry(ctx, func() error {
+		_, err := req.Context(ctx).Do()
+		return err
+	})
 }
 
 // applyBucketConds modifies the provided call using the conditions in conds.


### PR DESCRIPTION
This call is fully idempotent and retryable according to
go/gcs-api-retry-guidance.

Fixes #4437