### PR TITLE
test(spanner): fix errors not reporting when emulator test passes

### DIFF
--- a/spanner/emulator_test.sh
+++ b/spanner/emulator_test.sh
@@ -43,4 +43,4 @@ function cleanup() {
 }
 trap cleanup EXIT
 
-go test -v -timeout 10m ./... -run '^TestIntegration_' 2>&1 | tee sponge_log.log
+go test -v -timeout 10m ./... -run '^TestIntegration_' 2>&1 | tee -a sponge_log.log


### PR DESCRIPTION
Emulator tests were overwritting the results of the main test
run which can cause errors that occured in main test run not
to be reported when the emulator tests pass. Now emulator tests
append to the test log.

Updates: #4450