### PR TITLE
fix(bigtable): emulator crashes in SampleRowKeys

### DIFF
--- a/bigtable/bttest/inmem.go
+++ b/bigtable/bttest/inmem.go
@@ -1124,6 +1124,8 @@ func (s *server) SampleRowKeys(req *btpb.SampleRowKeysRequest, stream btpb.Bigta
 	i := 0
 	tbl.rows.Ascend(func(it btree.Item) bool {
 		row := it.(*row)
+		row.mu.Lock()
+		defer row.mu.Unlock()
 		if i == tbl.rows.Len()-1 || rand.Int31n(100) == 0 {
 			resp := &btpb.SampleRowKeysResponse{
 				RowKey:      []byte(row.key),


### PR DESCRIPTION
This is a second race condition in SampleRowKeys. As SampleRowKeys
iterates over the rows it needs to grab a lock before using the row, as
the contents of the row may be changed by another thread.

Fixes #2600 (again).
