### PR TITLE
feat(pubsub/pstest): add ability to create a pstest server listening on a specified port

### DIFF
--- a/pubsub/pstest/examples_test.go
+++ b/pubsub/pstest/examples_test.go
@@ -42,3 +42,23 @@ func ExampleNewServer() {
 	defer client.Close()
 	_ = client // TODO: Use the client.
 }
+
+func ExampleNewServerWithPort() {
+	ctx := context.Background()
+	// Start a fake server running locally at 9001.
+	srv := pstest.NewServerWithPort(9001)
+	defer srv.Close()
+	// Connect to the server without using TLS.
+	conn, err := grpc.Dial(srv.Addr, grpc.WithInsecure())
+	if err != nil {
+		// TODO: Handle error.
+	}
+	defer conn.Close()
+	// Use the connection when creating a pubsub client.
+	client, err := pubsub.NewClient(ctx, "project", option.WithGRPCConn(conn))
+	if err != nil {
+		// TODO: Handle error.
+	}
+	defer client.Close()
+	_ = client // TODO: Use the client.
+}

--- a/pubsub/pstest/fake.go
+++ b/pubsub/pstest/fake.go
@@ -114,9 +114,14 @@ type GServer struct {
 
 // NewServer creates a new fake server running in the current process.
 func NewServer(opts ...ServerReactorOption) *Server {
-	srv, err := testutil.NewServer()
+	return NewServerWithPort(0, opts...)
+}
+
+// NewServerWithPort creates a new fake server running in the current process at the specified port.
+func NewServerWithPort(port int, opts ...ServerReactorOption) *Server {
+	srv, err := testutil.NewServerWithPort(port)
 	if err != nil {
-		panic(fmt.Sprintf("pstest.NewServer: %v", err))
+		panic(fmt.Sprintf("pstest.NewServerWithPort: %v", err))
 	}
 	reactorOptions := ReactorOptions{}
 	for _, opt := range opts {


### PR DESCRIPTION
In some of our tests we handle port allocations manually and would prefer to pass in an allocated port for our pstest Server dependency rather than having the `pstest.NewServer` call allocate an available port.