### PR TITLE
feat(spanner/spansql): fix (date|timestamp) comparison parse.

### DIFF
--- a/spanner/spansql/parser.go
+++ b/spanner/spansql/parser.go
@@ -2714,11 +2714,15 @@ func (p *parser) parseLit() (Expr, *parseError) {
 		p.back()
 		return p.parseArrayLit()
 	case tok.caseEqual("DATE"):
-		p.back()
-		return p.parseDateLit()
+		if !p.sniff("=") {
+			p.back()
+			return p.parseDateLit()
+		}
 	case tok.caseEqual("TIMESTAMP"):
-		p.back()
-		return p.parseTimestampLit()
+		if !p.sniff("=") {
+			p.back()
+			return p.parseTimestampLit()
+		}
 	}
 
 	// TODO: struct literals

--- a/spanner/spansql/parser_test.go
+++ b/spanner/spansql/parser_test.go
@@ -250,6 +250,13 @@ func TestParseQuery(t *testing.T) {
 }
 
 func TestParseExpr(t *testing.T) {
+	timef := func(format, s string) time.Time {
+		ti, err := time.ParseInLocation(format, string(s), defaultLocation)
+		if err != nil {
+			t.Errorf("parsing %s [%s] time.ParseInLocation failed.", s, format)
+		}
+		return ti
+	}
 	tests := []struct {
 		in   string
 		want Expr
@@ -336,7 +343,11 @@ func TestParseExpr(t *testing.T) {
 
 		// Date and timestamp literals:
 		{`DATE '2014-09-27'`, DateLiteral(civil.Date{Year: 2014, Month: time.September, Day: 27})},
+		{`TIMESTAMP '2014-09-27 12:30:00'`, TimestampLiteral(timef("2006-01-02 15:04:05", "2014-09-27 12:30:00"))},
 
+		// date and timestamp
+		{`DATE = '2014-09-27'`, ComparisonOp{LHS: ID("DATE"), Op: Eq, RHS: StringLiteral("2014-09-27")}},
+		{`TIMESTAMP = '2014-09-27 12:30:00'`, ComparisonOp{LHS: ID("TIMESTAMP"), Op: Eq, RHS: StringLiteral("2014-09-27 12:30:00")}},
 		// Array literals:
 		// https://cloud.google.com/spanner/docs/lexical#array_literals
 		{`[1, 2, 3]`, Array{IntegerLiteral(1), IntegerLiteral(2), IntegerLiteral(3)}},

--- a/spanner/spansql/sql.go
+++ b/spanner/spansql/sql.go
@@ -25,6 +25,7 @@ package spansql
 
 import (
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -373,6 +374,7 @@ func (sft SelectFromTable) SQL() string {
 			kvs[i] = fmt.Sprintf("%s=%s", k, v)
 			i++
 		}
+		sort.Strings(kvs)
 		str += strings.Join(kvs, ",")
 		str += "}"
 	}


### PR DESCRIPTION
This PR fixes two nit things.

- fix (date|timestamp) comparison parse.
- fix unstable SelectFromTable SQL

Second was made unstable tests and SQL output by #4457 (sorry.)
