### PR TITLE
fix(spanner/spansql): fix unstable SelectFromTable SQL

### DIFF
--- a/spanner/spansql/sql.go
+++ b/spanner/spansql/sql.go
@@ -25,6 +25,7 @@ package spansql
 
 import (
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -373,6 +374,7 @@ func (sft SelectFromTable) SQL() string {
 			kvs[i] = fmt.Sprintf("%s=%s", k, v)
 			i++
 		}
+		sort.Strings(kvs)
 		str += strings.Join(kvs, ",")
 		str += "}"
 	}


### PR DESCRIPTION
https://github.com/googleapis/google-cloud-go/pull/4457 made unstable SQL string, and fail test sometimes like this.
```
--- FAIL: TestSQL (0.00s)
    sql_test.go:410: {{false [A] [{Table  map[FORCE_INDEX:Idx GROUPBY_SCAN_OPTIMIZATION:TRUE]}] {4 B b <nil>} [] [] []} [] <nil> <nil>}.SQL() wrong.
         got SELECT A FROM Table@{GROUPBY_SCAN_OPTIMIZATION=TRUE,FORCE_INDEX=Idx} WHERE B = @b
        want SELECT A FROM Table@{FORCE_INDEX=Idx,GROUPBY_SCAN_OPTIMIZATION=TRUE} WHERE B = @b
```
Because map range result is unstable.
This PR makes the SQL output stable by sorting the Hints keys.