### PR TITLE
test(pubsublite): fix flaky TestIntegration_PublishSubscribeSinglePartition

### DIFF
--- a/pubsublite/pscompat/integration_test.go
+++ b/pubsublite/pscompat/integration_test.go
@@ -554,10 +554,11 @@ func TestIntegration_PublishSubscribeSinglePartition(t *testing.T) {
 		if _, err := result.Get(ctx); !test.ErrorHasCode(err, wantCode) {
 			t.Errorf("Publish() got err: %v, want code: %v", err, wantCode)
 		}
+
+		publisher.Stop()
 		if err := xerrors.Unwrap(publisher.Error()); !test.ErrorHasCode(err, wantCode) {
 			t.Errorf("Error() got err: %v, want code: %v", err, wantCode)
 		}
-		publisher.Stop()
 	})
 
 	// Verifies that cancelling the context passed to NewSubscriberClient can shut


### PR DESCRIPTION
The error may not have propagated to the top-level publisher yet. Ran the test 100 times without error.

Fixes: https://github.com/googleapis/google-cloud-go/issues/4492