### PR TITLE
chore(tests): install kubectl using apt-get in test script

### DIFF
--- a/internal/kokoro/environment.sh
+++ b/internal/kokoro/environment.sh
@@ -71,6 +71,7 @@ fi
 # If Kubernetes, install kubectl component
 if [[ $ENVIRONMENT == *"kubernetes"* ]]; then
   gcloud components install kubectl -q
+  sudo apt-get install kubectl -y
 fi
 
 # Run the environment test for the specified GCP service

--- a/internal/kokoro/environment.sh
+++ b/internal/kokoro/environment.sh
@@ -70,7 +70,6 @@ fi
 
 # If Kubernetes, install kubectl component
 if [[ $ENVIRONMENT == *"kubernetes"* ]]; then
-  gcloud components install kubectl -q
   sudo apt-get install kubectl -y
 fi
 


### PR DESCRIPTION
Our [environment tests scripts](go/cdpe-ops-testgrid) are currently failing with the error message:

```
You cannot perform this action because the Cloud SDK component manager 
is disabled for this installation. You can run the following command 
to achieve the same result for this installation: 
```

This PR attempts to fix this by switching to the apt-get installation method