### PR TITLE
test(bigtable): print hex using %x, sprintf to be valid utf-8

### DIFF
--- a/bigtable/integration_test.go
+++ b/bigtable/integration_test.go
@@ -2462,7 +2462,7 @@ func TestIntegration_AdminBackup(t *testing.T) {
 		t.Fatalf("Failed to generate a unique ID: %v", err)
 	}
 
-	backupName := "mybackup-" + string(uniqueID)
+	backupName := fmt.Sprintf("mybackup-%x", uniqueID)
 	defer adminClient.DeleteBackup(ctx, sourceCluster, backupName)
 
 	if err = adminClient.CreateBackup(ctx, tblConf.TableID, sourceCluster, backupName, time.Now().Add(8*time.Hour)); err != nil {


### PR DESCRIPTION
casting byte vals to string was causing some chars to be (randomly) invalid for identifiers