### PR TITLE
chore(tests): fix google-cloud-sdk-app-engine-go installation in test script

### DIFF
--- a/internal/kokoro/environment.sh
+++ b/internal/kokoro/environment.sh
@@ -65,7 +65,7 @@ echo $ENVCTL_ID
 
 # If App Engine, install app-engine-go component
 if [[ $ENVIRONMENT == *"appengine"* ]]; then
-  gcloud components install app-engine-go -q
+  apt-get install google-cloud-sdk-app-engine-go -y | cat
 fi
 
 # If Kubernetes, install kubectl component


### PR DESCRIPTION
Related to https://github.com/googleapis/google-cloud-go/pull/4561. It looks like the GAE test is also failing for a similar reason.

This PR removes the `gcloud components install` line to install using `apt-get` instead. It also adds a ` | cat` so that the script will continue if installtion fails, in case the package ends up being unnecessary.

Note that this impacts the `environment.sh` test script only currently used by the logging library.