### PR TITLE
chore(tests): fix kubectl installation in environment test script

### DIFF
--- a/internal/kokoro/environment.sh
+++ b/internal/kokoro/environment.sh
@@ -74,7 +74,7 @@ if [[ $ENVIRONMENT == *"kubernetes"* ]]; then
   chmod +x kubectl
   mkdir -p ~/.local/bin
   mv ./kubectl ~/.local/bin
-  export PATH=$PATH:/.local/bin/
+  export PATH=$PATH:~/.local/bin/
 fi
 
 # Run the environment test for the specified GCP service

--- a/internal/kokoro/environment.sh
+++ b/internal/kokoro/environment.sh
@@ -70,7 +70,7 @@ fi
 
 # If Kubernetes, install kubectl component
 if [[ $ENVIRONMENT == *"kubernetes"* ]]; then
-  curl -LO "https://dl.k8s.io/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl.sha256"
+  curl -LO "https://dl.k8s.io/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
   chmod +x kubectl
   mkdir -p ~/.local/bin
   mv ./kubectl ~/.local/bin


### PR DESCRIPTION
Related to https://github.com/googleapis/google-cloud-go/pull/4561

I had attempted to add manual kubectl installation to the environment test script, but there were a couple issues, and the test was still failing. I fixed the issues, and confirmed it works this time by finding and and running the changes inside the `gcr.io/cloud-devrel-kokoro-resources/go111` test container

Note that this impacts the environment.sh test script only currently used by the logging library.

@codyoss, you mentioned we should consider making these changes in the base image. Do you know where I could submit that change?