### PR TITLE
feat(bigquery/storage/managedwriter): more instrumentation support

### DIFF
--- a/bigquery/storage/managedwriter/client.go
+++ b/bigquery/storage/managedwriter/client.go
@@ -126,7 +126,7 @@ func (c *Client) buildManagedStream(ctx context.Context, streamFunc streamClient
 	}
 	if ms.streamSettings != nil {
 		if ms.ctx != nil {
-			ms.ctx = keyContextWithStreamID(ms.ctx, ms.streamSettings.streamID)
+			ms.ctx = keyContextWithTags(ms.ctx, ms.streamSettings.streamID, ms.streamSettings.dataOrigin)
 		}
 		ms.fc = newFlowController(ms.streamSettings.MaxInflightRequests, ms.streamSettings.MaxInflightBytes)
 	} else {

--- a/bigquery/storage/managedwriter/managed_stream.go
+++ b/bigquery/storage/managedwriter/managed_stream.go
@@ -112,6 +112,10 @@ type streamSettings struct {
 	// TraceID can be set when appending data on a stream. It's
 	// purpose is to aid in debug and diagnostic scenarios.
 	TraceID string
+
+	// dataOrigin can be set for classifying metrics generated
+	// by a stream.
+	dataOrigin string
 }
 
 func defaultStreamSettings() *streamSettings {

--- a/bigquery/storage/managedwriter/writer_option.go
+++ b/bigquery/storage/managedwriter/writer_option.go
@@ -77,3 +77,11 @@ func WithSchemaDescriptor(dp *descriptorpb.DescriptorProto) WriterOption {
 		ms.schemaDescriptor = dp
 	}
 }
+
+// WithDataOrigin is used to attach an origin context to the instrumentation metrics
+// emitted by the library.
+func WithDataOrigin(dataOrigin string) WriterOption {
+	return func(ms *ManagedStream) {
+		ms.streamSettings.dataOrigin = dataOrigin
+	}
+}

--- a/bigquery/storage/managedwriter/writer_option_test.go
+++ b/bigquery/storage/managedwriter/writer_option_test.go
@@ -84,6 +84,18 @@ func TestWriterOptions(t *testing.T) {
 			}(),
 		},
 		{
+			desc:    "WithDataOrigin",
+			options: []WriterOption{WithDataOrigin("origin")},
+			want: func() *ManagedStream {
+				ms := &ManagedStream{
+					streamSettings:   defaultStreamSettings(),
+					destinationTable: "foo",
+				}
+				ms.streamSettings.dataOrigin = "origin"
+				return ms
+			}(),
+		},
+		{
 			desc: "multiple",
 			options: []WriterOption{
 				WithType(PendingStream),

--- a/bigquery/storage/managedwriter/writer_option_test.go
+++ b/bigquery/storage/managedwriter/writer_option_test.go
@@ -88,8 +88,7 @@ func TestWriterOptions(t *testing.T) {
 			options: []WriterOption{WithDataOrigin("origin")},
 			want: func() *ManagedStream {
 				ms := &ManagedStream{
-					streamSettings:   defaultStreamSettings(),
-					destinationTable: "foo",
+					streamSettings: defaultStreamSettings(),
 				}
 				ms.streamSettings.dataOrigin = "origin"
 				return ms


### PR DESCRIPTION
This PR adds a bytes metric to the list of defined instrumentation
metrics, and adds an additional key to track data origin.  Ability
for users to set the data origin comes a new WithDataOrigin option
that can be passed to the managed stream constructor.

This also does some minor refactoring of how opencensus view creation
is handled.

Towards: https://github.com/googleapis/google-cloud-go/issues/4366