### PR TITLE
passing `skipPrefixes` config as parameter

### DIFF
--- a/internal/gapicgen/cmd/genbot/bot.go
+++ b/internal/gapicgen/cmd/genbot/bot.go
@@ -32,6 +32,7 @@ type botConfig struct {
 	githubUsername    string
 	githubName        string
 	githubEmail       string
+	skipPrefixes      []string
 	forceAll          bool
 }
 

--- a/internal/gapicgen/cmd/genbot/local.go
+++ b/internal/gapicgen/cmd/genbot/local.go
@@ -36,6 +36,7 @@ type localConfig struct {
 	genprotoDir        string
 	protoDir           string
 	gapicToGenerate    string
+	skipPrefixes       []string
 	onlyGapics         bool
 	regenOnly          bool
 	forceAll           bool
@@ -73,6 +74,7 @@ func genLocal(ctx context.Context, c localConfig) error {
 		GapicDir:           deafultDir(tmpGocloudDir, c.gocloudDir),
 		ProtoDir:           deafultDir(tmpProtoDir, c.protoDir),
 		GapicToGenerate:    c.gapicToGenerate,
+		SkipPrefixes:       c.skipPrefixes,
 		OnlyGenerateGapic:  c.onlyGapics,
 		LocalMode:          true,
 		RegenOnly:          c.regenOnly,

--- a/internal/gapicgen/cmd/genbot/main.go
+++ b/internal/gapicgen/cmd/genbot/main.go
@@ -25,6 +25,7 @@ import (
 	"log"
 	"os"
 	"strconv"
+	"strings"
 
 	"cloud.google.com/go/internal/gapicgen"
 )
@@ -50,6 +51,7 @@ func main() {
 	gocloudDir := flag.String("gocloud-dir", os.Getenv("GOCLOUD_DIR"), "Directory where sources of googleapis/google-cloud-go resides. If unset the sources will be cloned to a temporary directory that is not cleaned up.")
 	genprotoDir := flag.String("genproto-dir", os.Getenv("GENPROTO_DIR"), "Directory where sources of googleapis/go-genproto resides. If unset the sources will be cloned to a temporary directory that is not cleaned up.")
 	protoDir := flag.String("proto-dir", os.Getenv("PROTO_DIR"), "Directory where sources of google/protobuf resides. If unset the sources will be cloned to a temporary directory that is not cleaned up.")
+	skipPrefixes := flag.String("skip-prefixes", os.Getenv("SKIP_PREFIXES"), `Specifies which gapic prefixes should not be generated separated by a comma. The value should be in the form of an import path (Ex: google.golang.org/genproto/googleapis/ads). '-' value will allow to generate all gapics. The default "google.golang.org/genproto/googleapis/ads" generates all gapics except ads.`)
 	gapicToGenerate := flag.String("gapic", os.Getenv("GAPIC_TO_GENERATE"), `Specifies which gapic to generate. The value should be in the form of an import path (Ex: cloud.google.com/go/pubsub/apiv1). The default "" generates all gapics.`)
 	onlyGapics := flag.Bool("only-gapics", strToBool(os.Getenv("ONLY_GAPICS")), "Enabling stops regenerating genproto.")
 	regenOnly := flag.Bool("regen-only", strToBool(os.Getenv("REGEN_ONLY")), "Enabling means no vetting, manifest updates, or compilation.")
@@ -64,6 +66,7 @@ func main() {
 			genprotoDir:        *genprotoDir,
 			protoDir:           *protoDir,
 			gapicToGenerate:    *gapicToGenerate,
+			skipPrefixes:       getSkipPrefixes(*skipPrefixes),
 			onlyGapics:         *onlyGapics,
 			regenOnly:          *regenOnly,
 			forceAll:           *forceAll,
@@ -77,6 +80,7 @@ func main() {
 		githubUsername:    *githubUsername,
 		githubName:        *githubName,
 		githubEmail:       *githubEmail,
+		skipPrefixes:      getSkipPrefixes(*skipPrefixes),
 		forceAll:          *forceAll,
 	}); err != nil {
 		log.Fatal(err)
@@ -87,4 +91,17 @@ func strToBool(s string) bool {
 	// Treat error as false
 	b, _ := strconv.ParseBool(s)
 	return b
+}
+
+func getSkipPrefixes(s string) []string {
+	if s == "" { // if empty, use default case
+		return []string{
+			"google.golang.org/genproto/googleapis/ads",
+		}
+
+	} else if s == "-" { // if value is "-" return empty filter
+		return nil
+	}
+
+	return strings.Split(s, ",")
 }

--- a/internal/gapicgen/generator/generator.go
+++ b/internal/gapicgen/generator/generator.go
@@ -36,6 +36,7 @@ type Config struct {
 	GapicDir           string
 	ProtoDir           string
 	GapicToGenerate    string
+	SkipPrefixes       []string
 	OnlyGenerateGapic  bool
 	LocalMode          bool
 	RegenOnly          bool

--- a/internal/gapicgen/generator/genproto.go
+++ b/internal/gapicgen/generator/genproto.go
@@ -59,6 +59,7 @@ type GenprotoGenerator struct {
 	googleapisDir      string
 	googleapisDiscoDir string
 	protoSrcDir        string
+	skipPrefixes       []string
 	forceAll           bool
 }
 
@@ -70,11 +71,8 @@ func NewGenprotoGenerator(c *Config) *GenprotoGenerator {
 		googleapisDiscoDir: c.GoogleapisDiscoDir,
 		protoSrcDir:        filepath.Join(c.ProtoDir, "/src"),
 		forceAll:           c.ForceAll,
+		skipPrefixes:       c.SkipPrefixes,
 	}
-}
-
-var skipPrefixes = []string{
-	"google.golang.org/genproto/googleapis/ads",
 }
 
 func hasPrefix(s string, prefixes []string) bool {
@@ -131,7 +129,7 @@ func (g *GenprotoGenerator) Regen(ctx context.Context) error {
 	log.Println("generating from protos")
 	grp, _ := errgroup.WithContext(ctx)
 	for pkg, fileNames := range pkgFiles {
-		if !strings.HasPrefix(pkg, "google.golang.org/genproto") || denylist[pkg] || hasPrefix(pkg, skipPrefixes) {
+		if !strings.HasPrefix(pkg, "google.golang.org/genproto") || denylist[pkg] || hasPrefix(pkg, g.skipPrefixes) {
 			continue
 		}
 		pk := pkg


### PR DESCRIPTION
Is your feature request related to a problem? Please describe.
My team ends up generating a Google Ads SDK using `genbot`. Right now `ads` are skipped using hardcoded config. I would like to have an option to use `genbot` directly without having a fork where this gapic is allowed. SDK itself works great and I didn't have any issues with it so far.

Describe the solution you'd like
I would like to have some way to enable generation for Ads without code changes.

Describe alternatives you've considered
Please consider this pull request as MVP, if you have better ways to achieve it, I would like to help with it.