### PR TITLE
chore(gapicgen)!: update microgen to v0.23.1

### DIFF
--- a/compute/apiv1/global_operations_client.go
+++ b/compute/apiv1/global_operations_client.go
@@ -58,7 +58,7 @@ type internalGlobalOperationsClient interface {
 	Delete(context.Context, *computepb.DeleteGlobalOperationRequest, ...gax.CallOption) (*computepb.DeleteGlobalOperationResponse, error)
 	Get(context.Context, *computepb.GetGlobalOperationRequest, ...gax.CallOption) (*computepb.Operation, error)
 	List(context.Context, *computepb.ListGlobalOperationsRequest, ...gax.CallOption) *OperationIterator
-	Wait(context.Context, *computepb.WaitGlobalOperationRequest, ...gax.CallOption) (*Operation, error)
+	Wait(context.Context, *computepb.WaitGlobalOperationRequest, ...gax.CallOption) (*computepb.Operation, error)
 }
 
 // GlobalOperationsClient is a client for interacting with Google Compute Engine API.
@@ -122,7 +122,7 @@ func (c *GlobalOperationsClient) List(ctx context.Context, req *computepb.ListGl
 //   In uncommon cases, when the server is overloaded, the request might return before the default deadline is reached, or might return after zero seconds.
 //
 //   If the default deadline is reached, there is no guarantee that the operation is actually done when the method returns. Be prepared to retry if the operation is not DONE.
-func (c *GlobalOperationsClient) Wait(ctx context.Context, req *computepb.WaitGlobalOperationRequest, opts ...gax.CallOption) (*Operation, error) {
+func (c *GlobalOperationsClient) Wait(ctx context.Context, req *computepb.WaitGlobalOperationRequest, opts ...gax.CallOption) (*computepb.Operation, error) {
 	return c.internalClient.Wait(ctx, req, opts...)
 }
 
@@ -449,7 +449,7 @@ func (c *globalOperationsRESTClient) List(ctx context.Context, req *computepb.Li
 //   In uncommon cases, when the server is overloaded, the request might return before the default deadline is reached, or might return after zero seconds.
 //
 //   If the default deadline is reached, there is no guarantee that the operation is actually done when the method returns. Be prepared to retry if the operation is not DONE.
-func (c *globalOperationsRESTClient) Wait(ctx context.Context, req *computepb.WaitGlobalOperationRequest, opts ...gax.CallOption) (*Operation, error) {
+func (c *globalOperationsRESTClient) Wait(ctx context.Context, req *computepb.WaitGlobalOperationRequest, opts ...gax.CallOption) (*computepb.Operation, error) {
 	baseUrl, _ := url.Parse(c.endpoint)
 	baseUrl.Path += fmt.Sprintf("/compute/v1/projects/%v/global/operations/%v/wait", req.GetProject(), req.GetOperation())
 
@@ -482,11 +482,7 @@ func (c *globalOperationsRESTClient) Wait(ctx context.Context, req *computepb.Wa
 	unm := protojson.UnmarshalOptions{AllowPartial: true, DiscardUnknown: true}
 	rsp := &computepb.Operation{}
 
-	if err := unm.Unmarshal(buf, rsp); err != nil {
-		return nil, err
-	}
-	op := &Operation{proto: rsp}
-	return op, err
+	return rsp, unm.Unmarshal(buf, rsp)
 }
 
 // OperationIterator manages a stream of *computepb.Operation.

--- a/compute/apiv1/region_operations_client.go
+++ b/compute/apiv1/region_operations_client.go
@@ -55,7 +55,7 @@ type internalRegionOperationsClient interface {
 	Delete(context.Context, *computepb.DeleteRegionOperationRequest, ...gax.CallOption) (*computepb.DeleteRegionOperationResponse, error)
 	Get(context.Context, *computepb.GetRegionOperationRequest, ...gax.CallOption) (*computepb.Operation, error)
 	List(context.Context, *computepb.ListRegionOperationsRequest, ...gax.CallOption) *OperationIterator
-	Wait(context.Context, *computepb.WaitRegionOperationRequest, ...gax.CallOption) (*Operation, error)
+	Wait(context.Context, *computepb.WaitRegionOperationRequest, ...gax.CallOption) (*computepb.Operation, error)
 }
 
 // RegionOperationsClient is a client for interacting with Google Compute Engine API.
@@ -114,7 +114,7 @@ func (c *RegionOperationsClient) List(ctx context.Context, req *computepb.ListRe
 //   In uncommon cases, when the server is overloaded, the request might return before the default deadline is reached, or might return after zero seconds.
 //
 //   If the default deadline is reached, there is no guarantee that the operation is actually done when the method returns. Be prepared to retry if the operation is not DONE.
-func (c *RegionOperationsClient) Wait(ctx context.Context, req *computepb.WaitRegionOperationRequest, opts ...gax.CallOption) (*Operation, error) {
+func (c *RegionOperationsClient) Wait(ctx context.Context, req *computepb.WaitRegionOperationRequest, opts ...gax.CallOption) (*computepb.Operation, error) {
 	return c.internalClient.Wait(ctx, req, opts...)
 }
 
@@ -347,7 +347,7 @@ func (c *regionOperationsRESTClient) List(ctx context.Context, req *computepb.Li
 //   In uncommon cases, when the server is overloaded, the request might return before the default deadline is reached, or might return after zero seconds.
 //
 //   If the default deadline is reached, there is no guarantee that the operation is actually done when the method returns. Be prepared to retry if the operation is not DONE.
-func (c *regionOperationsRESTClient) Wait(ctx context.Context, req *computepb.WaitRegionOperationRequest, opts ...gax.CallOption) (*Operation, error) {
+func (c *regionOperationsRESTClient) Wait(ctx context.Context, req *computepb.WaitRegionOperationRequest, opts ...gax.CallOption) (*computepb.Operation, error) {
 	baseUrl, _ := url.Parse(c.endpoint)
 	baseUrl.Path += fmt.Sprintf("/compute/v1/projects/%v/regions/%v/operations/%v/wait", req.GetProject(), req.GetRegion(), req.GetOperation())
 
@@ -380,9 +380,5 @@ func (c *regionOperationsRESTClient) Wait(ctx context.Context, req *computepb.Wa
 	unm := protojson.UnmarshalOptions{AllowPartial: true, DiscardUnknown: true}
 	rsp := &computepb.Operation{}
 
-	if err := unm.Unmarshal(buf, rsp); err != nil {
-		return nil, err
-	}
-	op := &Operation{proto: rsp}
-	return op, err
+	return rsp, unm.Unmarshal(buf, rsp)
 }

--- a/compute/apiv1/zone_operations_client.go
+++ b/compute/apiv1/zone_operations_client.go
@@ -55,7 +55,7 @@ type internalZoneOperationsClient interface {
 	Delete(context.Context, *computepb.DeleteZoneOperationRequest, ...gax.CallOption) (*computepb.DeleteZoneOperationResponse, error)
 	Get(context.Context, *computepb.GetZoneOperationRequest, ...gax.CallOption) (*computepb.Operation, error)
 	List(context.Context, *computepb.ListZoneOperationsRequest, ...gax.CallOption) *OperationIterator
-	Wait(context.Context, *computepb.WaitZoneOperationRequest, ...gax.CallOption) (*Operation, error)
+	Wait(context.Context, *computepb.WaitZoneOperationRequest, ...gax.CallOption) (*computepb.Operation, error)
 }
 
 // ZoneOperationsClient is a client for interacting with Google Compute Engine API.
@@ -114,7 +114,7 @@ func (c *ZoneOperationsClient) List(ctx context.Context, req *computepb.ListZone
 //   In uncommon cases, when the server is overloaded, the request might return before the default deadline is reached, or might return after zero seconds.
 //
 //   If the default deadline is reached, there is no guarantee that the operation is actually done when the method returns. Be prepared to retry if the operation is not DONE.
-func (c *ZoneOperationsClient) Wait(ctx context.Context, req *computepb.WaitZoneOperationRequest, opts ...gax.CallOption) (*Operation, error) {
+func (c *ZoneOperationsClient) Wait(ctx context.Context, req *computepb.WaitZoneOperationRequest, opts ...gax.CallOption) (*computepb.Operation, error) {
 	return c.internalClient.Wait(ctx, req, opts...)
 }
 
@@ -347,7 +347,7 @@ func (c *zoneOperationsRESTClient) List(ctx context.Context, req *computepb.List
 //   In uncommon cases, when the server is overloaded, the request might return before the default deadline is reached, or might return after zero seconds.
 //
 //   If the default deadline is reached, there is no guarantee that the operation is actually done when the method returns. Be prepared to retry if the operation is not DONE.
-func (c *zoneOperationsRESTClient) Wait(ctx context.Context, req *computepb.WaitZoneOperationRequest, opts ...gax.CallOption) (*Operation, error) {
+func (c *zoneOperationsRESTClient) Wait(ctx context.Context, req *computepb.WaitZoneOperationRequest, opts ...gax.CallOption) (*computepb.Operation, error) {
 	baseUrl, _ := url.Parse(c.endpoint)
 	baseUrl.Path += fmt.Sprintf("/compute/v1/projects/%v/zones/%v/operations/%v/wait", req.GetProject(), req.GetZone(), req.GetOperation())
 
@@ -380,9 +380,5 @@ func (c *zoneOperationsRESTClient) Wait(ctx context.Context, req *computepb.Wait
 	unm := protojson.UnmarshalOptions{AllowPartial: true, DiscardUnknown: true}
 	rsp := &computepb.Operation{}
 
-	if err := unm.Unmarshal(buf, rsp); err != nil {
-		return nil, err
-	}
-	op := &Operation{proto: rsp}
-	return op, err
+	return rsp, unm.Unmarshal(buf, rsp)
 }

--- a/internal/gapicgen/cmd/genbot/Dockerfile
+++ b/internal/gapicgen/cmd/genbot/Dockerfile
@@ -27,7 +27,7 @@ RUN go install github.com/golang/protobuf/protoc-gen-go@v1.5.2 && \
     go install golang.org/x/lint/golint@latest && \
     go install golang.org/x/tools/cmd/goimports@latest && \
     go install honnef.co/go/tools/cmd/staticcheck@latest && \
-    go install github.com/googleapis/gapic-generator-go/cmd/protoc-gen-go_gapic@v0.23.0
+    go install github.com/googleapis/gapic-generator-go/cmd/protoc-gen-go_gapic@v0.23.1
 ENV PATH="${PATH}:/root/go/bin"
 
 # Source: http://debuggable.com/posts/disable-strict-host-checking-for-git-clone:49896ff3-0ac0-4263-9703-1eae4834cda3


### PR DESCRIPTION
Updates microgen to v0.23.1. This incorporates a breaking change for compute that is intended. The heuristics for custom operation wrapping changed to exclude more RPCs (`Wait` RPCs). 

BREAKING_CHANGE_ALLOWED: intended breaking change to alpha client.