### PR TITLE
refactor(bigquery/storage/managedwriter): change AppendRows behavior

### DIFF
--- a/bigquery/storage/managedwriter/appendresult.go
+++ b/bigquery/storage/managedwriter/appendresult.go
@@ -26,10 +26,10 @@ import (
 // stream offset (e.g. a default stream which allows simultaneous append streams).
 const NoStreamOffset int64 = -1
 
-// AppendResult tracks the status of a single row of data.
+// AppendResult tracks the status of a batch of data rows.
 type AppendResult struct {
 	// rowData contains the serialized row data.
-	rowData []byte
+	rowData [][]byte
 
 	ready chan struct{}
 
@@ -40,7 +40,7 @@ type AppendResult struct {
 	offset int64
 }
 
-func newAppendResult(data []byte) *AppendResult {
+func newAppendResult(data [][]byte) *AppendResult {
 	return &AppendResult{
 		ready:   make(chan struct{}),
 		rowData: data,
@@ -66,7 +66,7 @@ func (ar *AppendResult) GetResult(ctx context.Context) (int64, error) {
 // append request.
 type pendingWrite struct {
 	request *storagepb.AppendRowsRequest
-	results []*AppendResult
+	result  *AppendResult
 
 	// this is used by the flow controller.
 	reqSize int
@@ -78,11 +78,6 @@ type pendingWrite struct {
 // the server (e.g. for default/COMMITTED streams).  For BUFFERED/PENDING
 // streams, this should be managed by the user.
 func newPendingWrite(appends [][]byte, offset int64) *pendingWrite {
-
-	results := make([]*AppendResult, len(appends))
-	for k, r := range appends {
-		results[k] = newAppendResult(r)
-	}
 	pw := &pendingWrite{
 		request: &storagepb.AppendRowsRequest{
 			Rows: &storagepb.AppendRowsRequest_ProtoRows{
@@ -93,7 +88,7 @@ func newPendingWrite(appends [][]byte, offset int64) *pendingWrite {
 				},
 			},
 		},
-		results: results,
+		result: newAppendResult(appends),
 	}
 	if offset > 0 {
 		pw.request.Offset = &wrapperspb.Int64Value{Value: offset}
@@ -105,24 +100,12 @@ func newPendingWrite(appends [][]byte, offset int64) *pendingWrite {
 	return pw
 }
 
-// markDone propagates finalization of an append request to associated
-// AppendResult references.
+// markDone propagates finalization of an append request to the associated
+// AppendResult.
 func (pw *pendingWrite) markDone(startOffset int64, err error, fc *flowController) {
-	curOffset := startOffset
-	for _, ar := range pw.results {
-		if err != nil {
-			ar.err = err
-			close(ar.ready)
-			continue
-		}
-
-		ar.offset = curOffset
-		// only advance curOffset if we were given a valid starting offset.
-		if startOffset >= 0 {
-			curOffset = curOffset + 1
-		}
-		close(ar.ready)
-	}
+	pw.result.err = err
+	pw.result.offset = startOffset
+	close(pw.result.ready)
 	// Clear the reference to the request.
 	pw.request = nil
 	// if there's a flow controller, signal release.  The only time this should be nil is when

--- a/bigquery/storage/managedwriter/managed_stream.go
+++ b/bigquery/storage/managedwriter/managed_stream.go
@@ -323,10 +323,12 @@ func (ms *ManagedStream) Close() error {
 	return err
 }
 
-// AppendRows sends the append requests to the service, and returns one AppendResult per row.
+// AppendRows sends the append requests to the service, and returns a single AppendResult for tracking
+// the set of data.
+//
 // The format of the row data is binary serialized protocol buffer bytes, and and the message
 // must adhere to the format of the schema Descriptor passed in when creating the managed stream.
-func (ms *ManagedStream) AppendRows(ctx context.Context, data [][]byte, offset int64) ([]*AppendResult, error) {
+func (ms *ManagedStream) AppendRows(ctx context.Context, data [][]byte, offset int64) (*AppendResult, error) {
 	pw := newPendingWrite(data, offset)
 	// check flow control
 	if err := ms.fc.acquire(ctx, pw.reqSize); err != nil {
@@ -339,7 +341,7 @@ func (ms *ManagedStream) AppendRows(ctx context.Context, data [][]byte, offset i
 		pw.markDone(NoStreamOffset, err, ms.fc)
 		return nil, err
 	}
-	return pw.results, nil
+	return pw.result, nil
 }
 
 // recvProcessor is used to propagate append responses back up with the originating write requests in a goroutine.


### PR DESCRIPTION
Previously, AppendRows() on a managed stream would return one
AppendResult per data row.  This change instead switches the
behavior to return a single AppendResult for tracking the behavior
of the set of rows.

The original per-row contract was done in expectation that we'd
consider making batching decisions at a very granular level. However,
at this point it seems reasonable to consider only batching multiple
appends, not dividing individual batches more granularly.

From stress testing, we know we're able to push 50k RPS on a single stream
currently, issuing batches at roughly 1.5 batches per sec.  This change means
that rather than creating 50k AppendResults per sec (and associated channels etc)
that we're instead creating only a single appendresult every 1.5 secs.  Early numbers
indicates that this change improves stresstest throughput by 5-15% depending on the metric
you're using (rows/batches/bytes), in addition to compute/memory overhead savings.

BREAKING CHANGE: managedwriter AppendRows now returns a single AppendResponse for the whole append rather than one per row.