### PR TITLE
chore(gapicgen): update microgen and promote compute to beta

### DIFF
--- a/internal/gapicgen/cmd/genbot/Dockerfile
+++ b/internal/gapicgen/cmd/genbot/Dockerfile
@@ -27,7 +27,7 @@ RUN go install github.com/golang/protobuf/protoc-gen-go@v1.5.2 && \
     go install golang.org/x/lint/golint@latest && \
     go install golang.org/x/tools/cmd/goimports@latest && \
     go install honnef.co/go/tools/cmd/staticcheck@latest && \
-    go install github.com/googleapis/gapic-generator-go/cmd/protoc-gen-go_gapic@v0.23.1
+    go install github.com/googleapis/gapic-generator-go/cmd/protoc-gen-go_gapic@v0.23.2
 ENV PATH="${PATH}:/root/go/bin"
 
 # Source: http://debuggable.com/posts/disable-strict-host-checking-for-git-clone:49896ff3-0ac0-4263-9703-1eae4834cda3

--- a/internal/gapicgen/generator/config.go
+++ b/internal/gapicgen/generator/config.go
@@ -64,8 +64,8 @@ var microgenGapicConfigs = []*microgenConfig{
 		importPath:           "cloud.google.com/go/compute/apiv1",
 		apiServiceConfigPath: "compute_v1.yaml",
 		transports:           []string{"rest"},
-		// TODO(dovs): Change to "ga" when ready.
-		releaseLevel:        "alpha",
+		// TODO: Change to "ga" when ready.
+		releaseLevel:        "beta",
 		googleapisDiscovery: true,
 	},
 	{


### PR DESCRIPTION
Updates the microgenerator to v0.23.2 containing a small change to diregapic error wrapping.

Promotes `compute` to `beta` as all breaking changes should be complete.