### PR TITLE
fix(internal/gapicgen): add a temporary import

### DIFF
--- a/compute/apiv1/doc.go
+++ b/compute/apiv1/doc.go
@@ -81,6 +81,7 @@ import (
 	"strings"
 	"unicode"
 
+	_ "golang.org/x/xerrors"
 	"google.golang.org/api/option"
 	"google.golang.org/grpc/metadata"
 )

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/googleapis/gax-go/v2 v2.1.0
 	go.opencensus.io v0.23.0
 	golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 	google.golang.org/api v0.56.0
 	google.golang.org/genproto v0.0.0-20210909211513-a8c4777a87af
 	google.golang.org/grpc v1.40.0


### PR DESCRIPTION
The new compute beta makes use of xerrors which is causing regen
to fail since we don't depend on this yet. This change will be
blown away by regen, which is intended.