### PR TITLE
feat(bigquery): don't generate random insertId

### DIFF
--- a/bigquery/inserter.go
+++ b/bigquery/inserter.go
@@ -26,7 +26,7 @@ import (
 
 // NoDedupeID indicates a streaming insert row wants to opt out of best-effort
 // deduplication.
-// It is EXPERIMENTAL and subject to change or removal without notice.
+// Deprecated: use an empty string instead.
 const NoDedupeID = "NoDedupeID"
 
 // An Inserter does streaming inserts into a BigQuery table.
@@ -205,11 +205,8 @@ func (u *Inserter) newInsertRequest(savers []ValueSaver) (*bq.TableDataInsertAll
 		if err != nil {
 			return nil, err
 		}
-		if insertID == NoDedupeID {
-			// User wants to opt-out of sending deduplication ID.
+		if insertID == NoDedupeID { // For backwards compatibility.
 			insertID = ""
-		} else if insertID == "" {
-			insertID = randomIDFn()
 		}
 		m := make(map[string]bq.JsonValue)
 		for k, v := range row {

--- a/bigquery/inserter_test.go
+++ b/bigquery/inserter_test.go
@@ -17,7 +17,6 @@ package bigquery
 import (
 	"errors"
 	"fmt"
-	"strconv"
 	"testing"
 
 	"cloud.google.com/go/internal/pretty"
@@ -37,11 +36,6 @@ func (ts testSaver) Save() (map[string]Value, string, error) {
 }
 
 func TestNewInsertRequest(t *testing.T) {
-	prev := randomIDFn
-	n := 0
-	randomIDFn = func() string { n++; return strconv.Itoa(n) }
-	defer func() { randomIDFn = prev }()
-
 	tests := []struct {
 		ul     *Uploader
 		savers []ValueSaver
@@ -61,8 +55,8 @@ func TestNewInsertRequest(t *testing.T) {
 			},
 			req: &bq.TableDataInsertAllRequest{
 				Rows: []*bq.TableDataInsertAllRequestRows{
-					{InsertId: "1", Json: map[string]bq.JsonValue{"one": 1}},
-					{InsertId: "2", Json: map[string]bq.JsonValue{"two": 2}},
+					{InsertId: "", Json: map[string]bq.JsonValue{"one": 1}},
+					{InsertId: "", Json: map[string]bq.JsonValue{"two": 2}},
 					{InsertId: "", Json: map[string]bq.JsonValue{"three": 3}},
 				},
 			},
@@ -80,7 +74,7 @@ func TestNewInsertRequest(t *testing.T) {
 			req: &bq.TableDataInsertAllRequest{
 				Rows: []*bq.TableDataInsertAllRequestRows{
 					{InsertId: "a", Json: map[string]bq.JsonValue{"one": 1}},
-					{InsertId: "3", Json: map[string]bq.JsonValue{"two": 2}},
+					{InsertId: "", Json: map[string]bq.JsonValue{"two": 2}},
 				},
 				TemplateSuffix:      "suffix",
 				SkipInvalidRows:     true,


### PR DESCRIPTION
Random insertIds are basically the same as not setting the insertId, except that not setting it allows for a lot more inserts per second.

The code for the random insertIds was still something from before empty insertIds was supported.