### PR TITLE
feat: migrate managedwriter to v1 write from v1beta2

### DIFF
--- a/bigquery/storage/managedwriter/adapt/protoconversion.go
+++ b/bigquery/storage/managedwriter/adapt/protoconversion.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"strings"
 
-	storagepb "google.golang.org/genproto/googleapis/cloud/bigquery/storage/v1beta2"
+	storagepb "google.golang.org/genproto/googleapis/cloud/bigquery/storage/v1"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protodesc"
 	"google.golang.org/protobuf/reflect/protoreflect"

--- a/bigquery/storage/managedwriter/adapt/protoconversion_test.go
+++ b/bigquery/storage/managedwriter/adapt/protoconversion_test.go
@@ -21,7 +21,7 @@ import (
 
 	"cloud.google.com/go/bigquery/storage/managedwriter/testdata"
 	"github.com/google/go-cmp/cmp"
-	storagepb "google.golang.org/genproto/googleapis/cloud/bigquery/storage/v1beta2"
+	storagepb "google.golang.org/genproto/googleapis/cloud/bigquery/storage/v1"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protodesc"

--- a/bigquery/storage/managedwriter/adapt/schemaconversion.go
+++ b/bigquery/storage/managedwriter/adapt/schemaconversion.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 
 	"cloud.google.com/go/bigquery"
-	storagepb "google.golang.org/genproto/googleapis/cloud/bigquery/storage/v1beta2"
+	storagepb "google.golang.org/genproto/googleapis/cloud/bigquery/storage/v1"
 )
 
 var fieldTypeMap = map[bigquery.FieldType]storagepb.TableFieldSchema_Type{

--- a/bigquery/storage/managedwriter/adapt/schemaconversion_test.go
+++ b/bigquery/storage/managedwriter/adapt/schemaconversion_test.go
@@ -20,7 +20,7 @@ import (
 	"cloud.google.com/go/bigquery"
 	"cloud.google.com/go/internal/testutil"
 	"github.com/google/go-cmp/cmp"
-	storagepb "google.golang.org/genproto/googleapis/cloud/bigquery/storage/v1beta2"
+	storagepb "google.golang.org/genproto/googleapis/cloud/bigquery/storage/v1"
 	"google.golang.org/protobuf/testing/protocmp"
 )
 

--- a/bigquery/storage/managedwriter/appendresult.go
+++ b/bigquery/storage/managedwriter/appendresult.go
@@ -17,7 +17,7 @@ package managedwriter
 import (
 	"context"
 
-	storagepb "google.golang.org/genproto/googleapis/cloud/bigquery/storage/v1beta2"
+	storagepb "google.golang.org/genproto/googleapis/cloud/bigquery/storage/v1"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )

--- a/bigquery/storage/managedwriter/client.go
+++ b/bigquery/storage/managedwriter/client.go
@@ -20,11 +20,11 @@ import (
 	"runtime"
 	"strings"
 
-	storage "cloud.google.com/go/bigquery/storage/apiv1beta2"
+	storage "cloud.google.com/go/bigquery/storage/apiv1"
 	"cloud.google.com/go/internal/detect"
 	"github.com/googleapis/gax-go/v2"
 	"google.golang.org/api/option"
-	storagepb "google.golang.org/genproto/googleapis/cloud/bigquery/storage/v1beta2"
+	storagepb "google.golang.org/genproto/googleapis/cloud/bigquery/storage/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 )

--- a/bigquery/storage/managedwriter/doc.go
+++ b/bigquery/storage/managedwriter/doc.go
@@ -19,7 +19,7 @@ More information about this new write client may also be found in the public doc
 It is EXPERIMENTAL and subject to change or removal without notice.  This library is in a pre-alpha
 state, and breaking changes are frequent.
 
-Currently, this client targets the BigQueryWriteClient present in the v1beta2 endpoint, and is intended as a more
+Currently, this client targets the BigQueryWriteClient present in the v1 endpoint, and is intended as a more
 feature-rich successor to the classic BigQuery streaming interface, which is presented as the Inserter abstraction
 in cloud.google.com/go/bigquery, and the tabledata.insertAll method if you're more familiar with the BigQuery v2 REST
 methods.

--- a/bigquery/storage/managedwriter/managed_stream.go
+++ b/bigquery/storage/managedwriter/managed_stream.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/googleapis/gax-go/v2"
 	"go.opencensus.io/tag"
-	storagepb "google.golang.org/genproto/googleapis/cloud/bigquery/storage/v1beta2"
+	storagepb "google.golang.org/genproto/googleapis/cloud/bigquery/storage/v1"
 	"google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/descriptorpb"

--- a/bigquery/storage/managedwriter/managed_stream_test.go
+++ b/bigquery/storage/managedwriter/managed_stream_test.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"testing"
 
-	storagepb "google.golang.org/genproto/googleapis/cloud/bigquery/storage/v1beta2"
+	storagepb "google.golang.org/genproto/googleapis/cloud/bigquery/storage/v1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"


### PR DESCRIPTION
This PR updates the managedwriter to use the v1 endpoint of
bigquerystorage for interactions with the BigQueryWriteClient.

Towards: https://github.com/googleapis/google-cloud-go/issues/4366