### PR TITLE
fix(firestore): preconditions should have microsecond precision for timestamps

### DIFF
--- a/firestore/options.go
+++ b/firestore/options.go
@@ -54,9 +54,13 @@ func (e exists) String() string {
 }
 
 // LastUpdateTime returns a Precondition that checks that a resource must exist and
-// must have last been updated at the given time. If the check fails, the write
-// does not occur.
-func LastUpdateTime(t time.Time) Precondition { return lastUpdateTime(t) }
+// must have last been updated at the given time, rounded to microsecond precision.
+// If the check fails, the write does not occur.
+func LastUpdateTime(t time.Time) Precondition {
+	// UpdateTime preconditions have microsecond precision.
+	t = t.Round(time.Microsecond)
+	return lastUpdateTime(t)
+}
 
 type lastUpdateTime time.Time
 


### PR DESCRIPTION
Fix #4229 by ensuring times are round to microsecond precision. Related, this documentation may be incorrect. https://firebase.google.com/docs/firestore/reference/rest/v1/Precondition