### PR TITLE
feat(internal/godocfx): detect preview versions

### DIFF
--- a/internal/godocfx/pkgload/load.go
+++ b/internal/godocfx/pkgload/load.go
@@ -158,7 +158,7 @@ func Load(glob, workingDir string, filter []string) ([]Info, error) {
 			Doc:           docPkg,
 			Fset:          fset,
 			ImportRenames: imports,
-			Status:        pkgStatus(pkgPath, docPkg.Doc),
+			Status:        pkgStatus(pkgPath, docPkg.Doc, idToPkg[pkgPath].Module.Version),
 		})
 	}
 
@@ -170,8 +170,11 @@ func Load(glob, workingDir string, filter []string) ([]Info, error) {
 //
 // pkgStatus does not use repo-metadata-full.json because it's
 // not available for all modules nor all versions.
-func pkgStatus(importPath, doc string) string {
+func pkgStatus(importPath, doc, version string) string {
 	switch {
+	case strings.Contains(version, "-"):
+		return "preview"
+
 	case strings.Contains(doc, "\nDeprecated:"):
 		return "deprecated"
 	case strings.Contains(doc, "This package is in alpha"):

--- a/internal/godocfx/pkgload/load_test.go
+++ b/internal/godocfx/pkgload/load_test.go
@@ -20,6 +20,7 @@ func TestPkgStatus(t *testing.T) {
 	tests := []struct {
 		importPath string
 		doc        string
+		version    string
 		want       string
 	}{
 		{
@@ -56,10 +57,18 @@ func TestPkgStatus(t *testing.T) {
 			doc:        "Package foo is great\nDeprecated: not anymore",
 			want:       "deprecated", // Deprecated comes before alpha and beta.
 		},
+		{
+			version: "v0.1.0",
+			want:    "",
+		},
+		{
+			version: "v2.1.0-alpha",
+			want:    "preview", // Preview comes before alpha and beta.
+		},
 	}
 	for _, test := range tests {
-		if got := pkgStatus(test.importPath, test.doc); got != test.want {
-			t.Errorf("pkgStatus(%q, %q) got %q, want %q", test.importPath, test.doc, got, test.want)
+		if got := pkgStatus(test.importPath, test.doc, test.version); got != test.want {
+			t.Errorf("pkgStatus(%q, %q, %q) got %q, want %q", test.importPath, test.doc, test.version, got, test.want)
 		}
 	}
 }


### PR DESCRIPTION
See b/197007831.

I added unit tests. But, I also confirmed this works on `google.golang.org/appengine/v2` (`status: preview` shows up in the output YAML).