### PR TITLE
test(bigtable): randomize instance name to avoid collision

### DIFF
--- a/bigtable/integration_test.go
+++ b/bigtable/integration_test.go
@@ -2458,8 +2458,6 @@ func TestIntegration_AdminBackup(t *testing.T) {
 	}
 
 	// Create backup
-	uniqueID := make([]byte, 8)
-	_, err = rand.Read(uniqueID)
 	if err != nil {
 		t.Fatalf("Failed to generate a unique ID: %v", err)
 	}

--- a/bigtable/integration_test.go
+++ b/bigtable/integration_test.go
@@ -2422,7 +2422,9 @@ func TestIntegration_AdminBackup(t *testing.T) {
 		t.Fatalf("NewInstanceAdminClient: %v", err)
 	}
 	defer iAdminClient.Close()
-	diffInstance := testEnv.Config().Instance + "-d"
+	uniqueID := make([]byte, 8)
+	_, err = rand.Read(uniqueID)
+	diffInstance := testEnv.Config().Instance + "-d" + string(uniqueID)
 	diffCluster := sourceCluster + "-d"
 	conf := &InstanceConf{
 		InstanceId:   diffInstance,


### PR DESCRIPTION
fixes #4891