### PR TITLE
fix(firestore): prefer exact matches when reflecting fields

### DIFF
--- a/firestore/document_test.go
+++ b/firestore/document_test.go
@@ -160,6 +160,38 @@ func TestDataAt(t *testing.T) {
 	}
 }
 
+func TestDataTo(t *testing.T) {
+	doc := &DocumentSnapshot{
+		proto: &pb.Document{
+			Fields: map[string]*pb.Value{
+				"tags": arrayval(strval("value1"), strval("value2")),
+				"Tags": arrayval(strval("value3"), strval("value4")),
+				"TaGs": {ValueType: &pb.Value_NullValue{}},
+			},
+		},
+	}
+
+	type test struct {
+		Nothing string
+		Tags    []string
+	}
+
+	// DataTo displayed indeterminate results run to run.
+	// https://github.com/googleapis/google-cloud-go/issues/4722
+	want := &test{Tags: []string{"value3", "value4"}}
+
+	for i := 0; i < 20; i++ {
+		got := &test{}
+		if err := doc.DataTo(got); err != nil {
+			t.Fatal(err)
+		}
+
+		if !testEqual(got, want) {
+			t.Fatalf("got %#v\nwant %#v", got, want)
+		}
+	}
+}
+
 func TestDataAtPath(t *testing.T) {
 	for _, test := range []struct {
 		fieldPath FieldPath

--- a/firestore/from_value.go
+++ b/firestore/from_value.go
@@ -20,6 +20,7 @@ import (
 	"reflect"
 	"strings"
 
+	"cloud.google.com/go/internal/fields"
 	"github.com/golang/protobuf/ptypes"
 	pb "google.golang.org/genproto/googleapis/firestore/v1"
 )
@@ -306,15 +307,19 @@ func createMapFromValueMap(pm map[string]*pb.Value, c *Client) (map[string]inter
 // populateStruct sets the fields of vs, which must be a struct, from
 // the matching elements of pm.
 func populateStruct(vs reflect.Value, pm map[string]*pb.Value, c *Client) error {
-	fields, err := fieldCache.Fields(vs.Type())
+	fs, err := fieldCache.Fields(vs.Type())
 	if err != nil {
 		return err
 	}
 
+	type match struct {
+		vproto *pb.Value
+		f      *fields.Field
+	}
 	// Find best field matches
-	matched := make(map[string]*pb.Value)
+	matched := make(map[string]match)
 	for k, vproto := range pm {
-		f := fields.Match(k)
+		f := fs.Match(k)
 		if f == nil {
 			continue
 		}
@@ -322,19 +327,18 @@ func populateStruct(vs reflect.Value, pm map[string]*pb.Value, c *Client) error 
 			// If multiple case insensitive fields match, the exact match
 			// should win.
 			if f.Name == k {
-				matched[k] = vproto
+				matched[k] = match{vproto: vproto, f: f}
 			}
 		} else {
-			matched[f.Name] = vproto
+			matched[f.Name] = match{vproto: vproto, f: f}
 		}
 	}
 
 	// Reflect values
-	for k, vproto := range matched {
-		f := fields.Match(k)
-		if f == nil {
-			continue
-		}
+	for _, v := range matched {
+		f := v.f
+		vproto := v.vproto
+
 		if err := setReflectFromProtoValue(vs.FieldByIndex(f.Index), vproto, c); err != nil {
 			return fmt.Errorf("%s.%s: %v", vs.Type(), f.Name, err)
 		}

--- a/firestore/from_value.go
+++ b/firestore/from_value.go
@@ -310,7 +310,27 @@ func populateStruct(vs reflect.Value, pm map[string]*pb.Value, c *Client) error 
 	if err != nil {
 		return err
 	}
+
+	// Find best field matches
+	matched := make(map[string]*pb.Value)
 	for k, vproto := range pm {
+		f := fields.Match(k)
+		if f == nil {
+			continue
+		}
+		if _, ok := matched[f.Name]; ok {
+			// If multiple case insensitive fields match, the exact match
+			// should win.
+			if f.Name == k {
+				matched[k] = vproto
+			}
+		} else {
+			matched[f.Name] = vproto
+		}
+	}
+
+	// Reflect values
+	for k, vproto := range matched {
 		f := fields.Match(k)
 		if f == nil {
 			continue


### PR DESCRIPTION
Fixes #4722 by preferring the best matches in pb value to struct code.