### PR TITLE
chore(storage): reuse grpc buffer for leftovers

### DIFF
--- a/storage/reader.go
+++ b/storage/reader.go
@@ -632,10 +632,7 @@ func (r *Reader) readWithGRPC(p []byte) (int, error) {
 	if leftover > 0 {
 		// Wasn't able to copy all of the data in the message, store for
 		// future Read calls.
-		// TODO: Instead of acquiring a new block of memory, should we reuse
-		// the existing leftovers slice, expanding it if necessary?
-		r.leftovers = make([]byte, leftover)
-		copy(r.leftovers, content[n:])
+		r.leftovers = content[n:]
 	}
 	r.seen += int64(n)
 


### PR DESCRIPTION
Simplifies management of leftover bytes from a read message by just reusing the sub-slice of unread content as the `leftovers` instead of maintaining a copy of it. gRPC will allocate the memory to deserialize a message no matter what, so we should just keep referencing that block until we've read it all. Doing some simple profiling shows that this reduces memory allocations even in simple cases because the Reader now longer allocates a new block for leftovers.