### PR TITLE
feat(bigquery): add minimal INTERVAL support

### DIFF
--- a/bigquery/schema.go
+++ b/bigquery/schema.go
@@ -226,6 +226,10 @@ const (
 	// BigNumericFieldType is a numeric field type that supports values of larger precision
 	// and scale than the NumericFieldType.
 	BigNumericFieldType FieldType = "BIGNUMERIC"
+	// IntervalFieldType is a representation of a duration or amount of time.
+	//
+	// This type is in preview.  It is EXPERIMENTAL and subject to change or removal without notice.
+	IntervalFieldType FieldType = "INTERVAL"
 )
 
 var (
@@ -244,6 +248,7 @@ var (
 		NumericFieldType:    true,
 		GeographyFieldType:  true,
 		BigNumericFieldType: true,
+		IntervalFieldType:   true,
 	}
 	// The API will accept alias names for the types based on the Standard SQL type names.
 	fieldAliases = map[FieldType]FieldType{

--- a/bigquery/schema_test.go
+++ b/bigquery/schema_test.go
@@ -1082,7 +1082,8 @@ func TestSchemaFromJSON(t *testing.T) {
 	{"name":"aliased_boolean","type":"BOOL","mode":"NULLABLE","description":"Aliased nullable boolean"},
 	{"name":"aliased_float","type":"FLOAT64","mode":"REQUIRED","description":"Aliased required float"},
 	{"name":"aliased_record","type":"STRUCT","mode":"NULLABLE","description":"Aliased nullable record"},
-	{"name":"aliased_bignumeric","type":"BIGDECIMAL","mode":"NULLABLE","description":"Aliased nullable bignumeric"}
+	{"name":"aliased_bignumeric","type":"BIGDECIMAL","mode":"NULLABLE","description":"Aliased nullable bignumeric"},
+	{"name":"flat_interval","type":"INTERVAL","mode":"NULLABLE","description":"Flat nullable interval"}
 ]`),
 			expectedSchema: Schema{
 				fieldSchema("Flat nullable string", "flat_string", "STRING", false, false, nil),
@@ -1102,6 +1103,7 @@ func TestSchemaFromJSON(t *testing.T) {
 				fieldSchema("Aliased required float", "aliased_float", "FLOAT", false, true, nil),
 				fieldSchema("Aliased nullable record", "aliased_record", "RECORD", false, false, nil),
 				fieldSchema("Aliased nullable bignumeric", "aliased_bignumeric", "BIGNUMERIC", false, false, nil),
+				fieldSchema("Flat nullable interval", "flat_interval", "INTERVAL", false, false, nil),
 			},
 		},
 		{


### PR DESCRIPTION
This PR simply adds the interval type to the allowed schema values.  It
does not include any type conversion support between go<-->bigquery
types, nor does it include features like query parameters.


Towards: https://github.com/googleapis/google-cloud-go/issues/4663