### PR TITLE
chore: freeze gRPC version

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,7 +12,8 @@
     "commitMessageAction": "update",
     "groupName": "all",
     "ignoreDeps": [
-        "google.golang.org/genproto"
+        "google.golang.org/genproto",
+        "google.golang.org/grpc"
     ],
     "force": {
         "constraints": {


### PR DESCRIPTION
In the latest version of gRPC the library is no longer compatible
with 1.11. v1.41.0 of gRPC is currently compatible with 1.14+.
Until our versions align we should freeze updating this dependency.