### PR TITLE
test(bigtable): abbreviate instance and cluster names to < 32 chars

### DIFF
--- a/bigtable/integration_test.go
+++ b/bigtable/integration_test.go
@@ -2427,7 +2427,7 @@ func TestIntegration_AdminBackup(t *testing.T) {
 		t.Fatalf("NewInstanceAdminClient: %v", err)
 	}
 	defer iAdminClient.Close()
-	uniqueID := make([]byte, 8)
+	uniqueID := make([]byte, 4)
 	_, err = rand.Read(uniqueID)
 	diffInstance := fmt.Sprintf("%s-d-%x", testEnv.Config().Instance, uniqueID)
 	diffCluster := sourceCluster + "-d"

--- a/internal/kokoro/continuous.sh
+++ b/internal/kokoro/continuous.sh
@@ -38,11 +38,11 @@ export GCLOUD_TESTS_GOLANG_KEYRING=projects/dulcet-port-762/locations/us/keyRing
 export GCLOUD_TESTS_GOLANG_PROFILER_ZONE="us-west1-b"
 
 # Bigtable integration tests expect an existing instance and cluster
-#  ❯ cbt createinstance gcloud-bt-it-tests-instance gcloud-bt-it-tests-instance \
-#    gcloud-bt-it-tests-cluster us-west1-b 1 SSD
+#  ❯ cbt createinstance gc-bt-it-instance gc-bt-it-instance \
+#    gc-bt-it-cluster us-west1-b 1 SSD
 export GCLOUD_TESTS_BIGTABLE_KEYRING=projects/dulcet-port-762/locations/us-central1/keyRings/go-integration-test
-export GCLOUD_TESTS_BIGTABLE_CLUSTER="gcloud-bt-it-tests-cluster"
-export GCLOUD_TESTS_BIGTABLE_INSTANCE="gcloud-bt-it-tests-instance"
+export GCLOUD_TESTS_BIGTABLE_CLUSTER="gc-bt-it-cluster"
+export GCLOUD_TESTS_BIGTABLE_INSTANCE="gc-bt-it-instance"
 
 # Fail on any error
 set -eo pipefail


### PR DESCRIPTION
test(bigtable): abbreviate instance and cluster names to much less than 32 chars to avoid overrun

Fixes #4891 