### PR TITLE
test(spanner): fix flaky TestIntegration_StartBackupOperation test

### DIFF
--- a/spanner/integration_test.go
+++ b/spanner/integration_test.go
@@ -3171,6 +3171,7 @@ func TestIntegration_StartBackupOperation(t *testing.T) {
 	skipEmulatorTest(t)
 	t.Parallel()
 
+	startTime := time.Now()
 	// Backups can be slow, so use 1 hour timeout.
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Hour)
 	defer cancel()
@@ -3190,6 +3191,7 @@ func TestIntegration_StartBackupOperation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	t.Logf("create backup operation took: %v\n", time.Since(startTime))
 	respMetadata, err := respLRO.Metadata()
 	if err != nil {
 		t.Fatalf("backup response metadata, got error %v, want nil", err)


### PR DESCRIPTION
* Increased timeout for TestIntegration_StartBackupOperation to 1 hour from 30 minutes.
Fixes #4774