### PR TITLE
fix(storage): upgrade genproto

### DIFF
--- a/storage/go.mod
+++ b/storage/go.mod
@@ -10,7 +10,7 @@ require (
 	golang.org/x/oauth2 v0.0.0-20211005180243-6b3c2da341f1
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 	google.golang.org/api v0.58.0
-	google.golang.org/genproto v0.0.0-20211015135405-485ec31e706e
+	google.golang.org/genproto v0.0.0-20211016002631-37fc39342514
 	google.golang.org/grpc v1.40.0
 	google.golang.org/protobuf v1.27.1
 )

--- a/storage/go.sum
+++ b/storage/go.sum
@@ -499,6 +499,8 @@ google.golang.org/genproto v0.0.0-20210917145530-b395a37504d4/go.mod h1:eFjDcFEc
 google.golang.org/genproto v0.0.0-20210924002016-3dee208752a0/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
 google.golang.org/genproto v0.0.0-20211015135405-485ec31e706e h1:8QimPqBPS4AUoLliaTHdC00MiGVe4csovJUlesHP9Mw=
 google.golang.org/genproto v0.0.0-20211015135405-485ec31e706e/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
+google.golang.org/genproto v0.0.0-20211016002631-37fc39342514 h1:Rp1vYDPD4TdkMH5S/bZbopsGCsWhPcrLBUwOVhAQCxM=
+google.golang.org/genproto v0.0.0-20211016002631-37fc39342514/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
 google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=


### PR DESCRIPTION
This PR is mostly being made so we have a version of storage that
has a hard dependency on a newer version of genproto. This will
help alleviate the internal gRPC breaking chnage that happned in
the client last week.

Updates: #4991 