### PR TITLE
fix(datastore): validPropertyName function to allow property name start with numeric value.

### DIFF
--- a/datastore/load.go
+++ b/datastore/load.go
@@ -302,6 +302,11 @@ func setVal(v reflect.Value, p Property) (s string) {
 			return fmt.Sprintf("%v is unsettable", v.Type())
 		}
 
+		if pValue == nil {
+			v.Set(reflect.Zero(v.Type()))
+			break
+		}
+
 		rpValue := reflect.ValueOf(pValue)
 		if !rpValue.Type().AssignableTo(v.Type()) {
 			return fmt.Sprintf("%q is not assignable to %q", rpValue.Type(), v.Type())

--- a/datastore/prop.go
+++ b/datastore/prop.go
@@ -121,7 +121,7 @@ func validPropertyName(name string) bool {
 		for _, c := range s {
 			if first {
 				first = false
-				if c != '_' && !unicode.IsLetter(c) {
+				if c != '_' && !unicode.IsLetter(c) && !unicode.IsDigit(c) {
 					return false
 				}
 			} else {


### PR DESCRIPTION
Hi, 

google datastore is allowed the property name start with numeric, the validPropertyName function is currently not allowing that, could you please review my changes and merge it if appropriate? Fyi, Python implementation of gcp datastore client is working fine.