### PR TITLE
feat(spanner/spansql): add support for CAST functions

### DIFF
--- a/spanner/spansql/parser_test.go
+++ b/spanner/spansql/parser_test.go
@@ -322,6 +322,8 @@ func TestParseExpr(t *testing.T) {
 		{`X BETWEEN Y AND Z`, ComparisonOp{LHS: ID("X"), Op: Between, RHS: ID("Y"), RHS2: ID("Z")}},
 		{`@needle IN UNNEST(@haystack)`, InOp{LHS: Param("needle"), RHS: []Expr{Param("haystack")}, Unnest: true}},
 		{`@needle NOT IN UNNEST(@haystack)`, InOp{LHS: Param("needle"), Neg: true, RHS: []Expr{Param("haystack")}, Unnest: true}},
+		{`CAST(x=1 AS STRING)`, CastFunc{Op: Cast, Expr: ComparisonOp{LHS: ID("x"), Op: Eq, RHS: IntegerLiteral(1)}, Type: Type{Base: String}}},
+		{`SAFE_CAST("apple" AS INT64)`, CastFunc{Op: SafeCast, Expr: StringLiteral("apple"), Type: Type{Base: Int64}}},
 
 		// Functions
 		{`STARTS_WITH(Bar, 'B')`, Func{Name: "STARTS_WITH", Args: []Expr{ID("Bar"), StringLiteral("B")}}},

--- a/spanner/spansql/sql.go
+++ b/spanner/spansql/sql.go
@@ -574,6 +574,23 @@ func (io IsOp) addSQL(sb *strings.Builder) {
 	io.RHS.addSQL(sb)
 }
 
+func (c CastFunc) SQL() string { return buildSQL(c) }
+func (c CastFunc) addSQL(sb *strings.Builder) {
+	switch c.Op {
+	default:
+		panic("unknown CastOp")
+	case Cast:
+		sb.WriteString("CAST")
+	case SafeCast:
+		sb.WriteString("SAFE_CAST")
+	}
+	sb.WriteString("(")
+	c.Expr.addSQL(sb)
+	sb.WriteString(" AS ")
+	sb.WriteString(c.Type.SQL())
+	sb.WriteString(")")
+}
+
 func (f Func) SQL() string { return buildSQL(f) }
 func (f Func) addSQL(sb *strings.Builder) {
 	sb.WriteString(f.Name)

--- a/spanner/spansql/sql_test.go
+++ b/spanner/spansql/sql_test.go
@@ -482,6 +482,21 @@ func TestSQL(t *testing.T) {
 			reparseQuery,
 		},
 		{
+			Query{
+				Select: Select{
+					List: []Expr{
+						CastFunc{
+							Op:   SafeCast,
+							Expr: StringLiteral("apple"),
+							Type: Type{Base: Int64},
+						},
+					},
+				},
+			},
+			`SELECT SAFE_CAST("apple" AS INT64)`,
+			reparseQuery,
+		},
+		{
 			DateLiteral(civil.Date{Year: 2014, Month: time.September, Day: 27}),
 			`DATE '2014-09-27'`,
 			reparseExpr,

--- a/spanner/spansql/types.go
+++ b/spanner/spansql/types.go
@@ -627,6 +627,24 @@ type PathExp []ID
 
 func (PathExp) isExpr() {}
 
+// Cast Functions
+
+type CastOperator int
+
+const (
+	Cast CastOperator = iota
+	SafeCast
+)
+
+type CastFunc struct {
+	Op   CastOperator
+	Expr Expr
+	Type Type
+}
+
+func (CastFunc) isBoolExpr() {} // possibly bool
+func (CastFunc) isExpr()     {}
+
 // Func represents a function call.
 type Func struct {
 	Name string // not ID


### PR DESCRIPTION
The changes make the spansql library possible to parse type conversion functions (`CAST` and `SAFE_CAST`).

https://cloud.google.com/spanner/docs/conversion_functions

- added `CastFunc` struct  for handling these functions.
- added a bool argument `noParam` to `parseType` function, because parameterized typename (e.g. `STRING(MAX)`) is not supported in cast function.