### PR TITLE
test(bigtable): increase test context timeout

### DIFF
--- a/bigtable/integration_test.go
+++ b/bigtable/integration_test.go
@@ -2395,7 +2395,7 @@ func TestIntegration_AdminBackup(t *testing.T) {
 		t.Skip("emulator doesn't support backups")
 	}
 
-	timeout := 5 * time.Minute
+	timeout := 10 * time.Minute
 	ctx, _ := context.WithTimeout(context.Background(), timeout)
 
 	adminClient, err := testEnv.NewAdminClient()


### PR DESCRIPTION
While this usually runs in 25-50s, it seems there is a long tail that may take longer.

Fix #4891 

```
integration_test.go:2560: RestoreTableFrom: context deadline exceeded
integration_test.go:2782: DeleteTable: retry failed with context deadline exceeded; last error: rpc error: code = DeadlineExceeded desc = context deadline exceeded
```