### PR TITLE
fix(internal/godocfx): replace * with HTML code

### DIFF
--- a/internal/godocfx/parse.go
+++ b/internal/godocfx/parse.go
@@ -625,7 +625,11 @@ func toHTML(s string) string {
 		panic(err)
 	}
 
-	return mdBuf.String()
+	// Replace * with &#42; to avoid confusing the DocFX Markdown processor,
+	// which sometimes interprets * as <em>.
+	result := string(bytes.ReplaceAll(mdBuf.Bytes(), []byte("*"), []byte("&#42;")))
+
+	return result
 }
 
 func hasPrefix(s string, prefixes []string) bool {

--- a/internal/godocfx/testdata/golden/index.yml
+++ b/internal/godocfx/testdata/golden/index.yml
@@ -91,7 +91,7 @@ items:
     client are often of the type <a href=\"https://godoc.org/google.golang.org/api/googleapi#Error\"><code>googleapi.Error</code></a>.\nThese
     errors can be introspected for more information by type asserting to the richer
     <code>googleapi.Error</code> type. For example:</p>\n<pre class=\"prettyprint\"><code>if
-    e, ok := err.(*googleapi.Error); ok {\n\t  if e.Code == 409 { ... }\n}\n</code></pre>"
+    e, ok := err.(&#42;googleapi.Error); ok {\n\t  if e.Code == 409 { ... }\n}\n</code></pre>"
   type: package
   langs:
   - go


### PR DESCRIPTION
Sometimes, the DocFX Markdown interpreter interprets `*` as `<em>`.