### PR TITLE
test(bigtable): fix #4173, increase ctx timeout

### DIFF
--- a/bigtable/integration_test.go
+++ b/bigtable/integration_test.go
@@ -1564,7 +1564,7 @@ func TestIntegration_AdminEncryptionInfo(t *testing.T) {
 		t.Fatalf("NewProdEnv: %v", err)
 	}
 
-	timeout := 5 * time.Minute
+	timeout := 10 * time.Minute
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 


### PR DESCRIPTION
ctx timeout is the same as the time we wait for a status to propagate. It needs to be larger to not prematurely terminate.