### PR TITLE
feat(spanner): remove dedefault dial option that disables service config

### DIFF
--- a/spanner/apiv1/spanner_client.go
+++ b/spanner/apiv1/spanner_client.go
@@ -63,7 +63,6 @@ func defaultGRPCClientOptions() []option.ClientOption {
 		internaloption.WithDefaultAudience("https://spanner.googleapis.com/"),
 		internaloption.WithDefaultScopes(DefaultAuthScopes()...),
 		internaloption.EnableJwtWithScope(),
-		option.WithGRPCDialOption(grpc.WithDisableServiceConfig()),
 		option.WithGRPCDialOption(grpc.WithDefaultCallOptions(
 			grpc.MaxCallRecvMsgSize(math.MaxInt32))),
 	}


### PR DESCRIPTION
DirectPath based on Traffic Director can not work with `grpc.WithDisableServiceConfig()`. 
Background: https://github.com/googleapis/google-api-go-client/pull/1260
Bug: b/202169093#comment8