### PR TITLE
feat(bigquery/storage/managedwriter): add a safe Retryer type to managedwriter (#5094)

### DIFF
--- a/bigquery/storage/managedwriter/retry.go
+++ b/bigquery/storage/managedwriter/retry.go
@@ -15,6 +15,8 @@
 package managedwriter
 
 import (
+	"context"
+	"errors"
 	"time"
 
 	"github.com/googleapis/gax-go/v2"
@@ -22,22 +24,130 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-type defaultRetryer struct {
-	bo gax.Backoff
+const (
+	// DefaultMaxRetries is used as the default for the maxRetries property of Retryer,
+	// used in case property is 0.
+	DefaultMaxRetries = -1
+
+	// DefaultInitialRetryDelay is used as the default for the InitialRetryDuration property
+	// of Retryer, used in case the property is 0 (e.g. when undefined).
+	//
+	// Default based on suggestions made in https://cloud.google.com/bigquery/sla.
+	DefaultInitialRetryDelay = time.Second * 1
+
+	// DefaultMaxRetryDeadlineOffset is the default max amount of the the retryer will
+	// allow the retry back off logic to retry, as to ensure a goroutine isn't blocked for too long on a faulty write.
+	//
+	// Default based on suggestions made in https://cloud.google.com/bigquery/sla.
+	DefaultMaxRetryDeadlineOffset = time.Second * 32
+
+	// DefaultRetryDelayMultiplier is the default retry delay multipler used by the defaultRetryer's
+	// back off algorithm in order to increase the delay in between each sequential write-retry of the
+	// same back off sequence. Used in case the property is < 2, as 2 is also the lowest possible multiplier accepted.
+	DefaultRetryDelayMultiplier = 2
+)
+
+// Retryer is the default gax.Retryer type as used by
+// the managed writer for its GRPC retryable operations.
+type Retryer struct {
+	backoff                gax.Backoff
+	retries                int
+	maxRetries             int
+	startTime              time.Time
+	maxRetryDeadlineOffset time.Duration
+	deadlineCtx            context.Context
+	cancelDeadlineCtx      func()
 }
 
-func (r *defaultRetryer) Retry(err error) (pause time.Duration, shouldRetry bool) {
-	// TODO: refine this logic in a subsequent PR, there's some service-specific
-	// retry predicates in addition to statuscode-based.
-	s, ok := status.FromError(err)
-	if !ok {
-		// non-status based errors as retryable
-		return r.bo.Pause(), true
+// compile-time interface compliance
+var _ gax.Retryer = (*Retryer)(nil)
+
+// not exposed as there is no point in defining this retryer,
+// if all you want is the default retryer
+func newDefaultRetryer(ctx context.Context) *Retryer {
+	return NewRetryer(
+		ctx,
+		DefaultMaxRetries,
+		DefaultInitialRetryDelay,
+		DefaultMaxRetryDeadlineOffset,
+		DefaultRetryDelayMultiplier,
+	)
+}
+
+// NewRetryer creates a new Retryer, the packaged `gax.Retryer` implementation
+// shipped with the bqwriter package. See the documentation of `Retryer` for more information
+// on how it is implemented why it should be used.
+func NewRetryer(ctx context.Context, maxRetries int, initialRetryDelay time.Duration, maxRetryDeadlineOffset time.Duration, retryDelayMultiplier float64) *Retryer {
+	if maxRetries <= 0 {
+		maxRetries = DefaultMaxRetries
 	}
-	switch s.Code() {
-	case codes.Unavailable:
-		return r.bo.Pause(), true
+	if initialRetryDelay == 0 {
+		initialRetryDelay = DefaultInitialRetryDelay
+	}
+	if maxRetryDeadlineOffset == 0 {
+		maxRetryDeadlineOffset = DefaultMaxRetryDeadlineOffset
+	}
+	if retryDelayMultiplier <= 1 {
+		retryDelayMultiplier = DefaultRetryDelayMultiplier
+	}
+	startTime := time.Now()
+	deadlineCtx, cancelDeadlineCtx := context.WithDeadline(ctx, startTime.Add(maxRetryDeadlineOffset))
+	return &Retryer{
+		backoff: gax.Backoff{
+			Initial:    initialRetryDelay,
+			Max:        maxRetryDeadlineOffset,
+			Multiplier: retryDelayMultiplier,
+		},
+		maxRetries:             maxRetries,
+		startTime:              startTime,
+		maxRetryDeadlineOffset: maxRetryDeadlineOffset,
+		deadlineCtx:            deadlineCtx,
+		cancelDeadlineCtx:      cancelDeadlineCtx,
+	}
+}
+
+func (r *Retryer) Retry(err error) (pause time.Duration, shouldRetry bool) {
+	defer func() {
+		if !shouldRetry {
+			r.cancelDeadlineCtx()
+		}
+	}()
+	if err == nil {
+		// no error returned, no need to retry
+		return 0, false
+	}
+	if errors.Is(r.deadlineCtx.Err(), context.Canceled) {
+		// if parent ctx is done or the deadline has been reached,
+		// no retry is possible any longer either
+		return 0, false
+	}
+	if r.maxRetries >= 0 && r.retries >= r.maxRetries {
+		// no longer need to retry,
+		// already exhausted our retry attempts
+		return 0, false
+	}
+	if !grcpRetryErrorFilter(err) {
+		// we do not wish to retry this kind of error either,
+		// as it is not detected as retryable by us
+		return 0, false
+	}
+	// correct the Max time, as to stay as close as possible to our max elapsed retry time
+	elapsedTime := time.Since(r.startTime)
+	r.backoff.Max = r.maxRetryDeadlineOffset - elapsedTime
+	// retry with the pause time indicated by the gax BackOff algorithm
+	r.retries += 1
+	return r.backoff.Pause(), true
+}
+
+func grcpRetryErrorFilter(err error) bool {
+	st, ok := status.FromError(err)
+	if !ok {
+		return false
+	}
+	switch st.Code() {
+	case codes.Unavailable, codes.FailedPrecondition, codes.ResourceExhausted, codes.DataLoss:
+		return true
 	default:
-		return r.bo.Pause(), false
+		return false
 	}
 }

--- a/bigquery/storage/managedwriter/retry_test.go
+++ b/bigquery/storage/managedwriter/retry_test.go
@@ -1,0 +1,191 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package managedwriter
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestDefaultRetryerNoRetryBecauseOfNilError(t *testing.T) {
+	retryer := NewRetryer(
+		context.Background(),
+		DefaultMaxRetries,
+		DefaultInitialRetryDelay,
+		DefaultMaxRetryDeadlineOffset,
+		DefaultRetryDelayMultiplier,
+	)
+	pause, shouldRetry := retryer.Retry(nil)
+	if shouldRetry {
+		t.Error("should not retry")
+	}
+	if pause != 0 {
+		t.Errorf("unexpected pause duration received: %v", pause)
+	}
+}
+
+func TestDefaultRetryerDefaults(t *testing.T) {
+	testCases := []struct {
+		MaxRetries             int
+		InitialRetryDelay      time.Duration
+		MaxRetryDeadlineOffset time.Duration
+		RetryDelayMultiplier   float64
+
+		ExpectedMaxRetries             int
+		ExpectedInitialRetryDelay      time.Duration
+		ExpectedMaxRetryDeadlineOffset time.Duration
+		ExpectedRetryDelayMultiplier   float64
+	}{
+		{
+			0, 0, 0, 0,
+			DefaultMaxRetries, DefaultInitialRetryDelay, DefaultMaxRetryDeadlineOffset, DefaultRetryDelayMultiplier,
+		},
+		{
+			-1, 0, 0, 0,
+			-1, DefaultInitialRetryDelay, DefaultMaxRetryDeadlineOffset, DefaultRetryDelayMultiplier,
+		},
+		{
+			0, 0, 0, 1,
+			DefaultMaxRetries, DefaultInitialRetryDelay, DefaultMaxRetryDeadlineOffset, DefaultRetryDelayMultiplier,
+		},
+		{
+			0, 0, 0, 3,
+			DefaultMaxRetries, DefaultInitialRetryDelay, DefaultMaxRetryDeadlineOffset, 3,
+		},
+		{
+			0, 0, 42, 0,
+			DefaultMaxRetries, DefaultInitialRetryDelay, 42, DefaultRetryDelayMultiplier,
+		},
+		{
+			0, 20, 0, 0,
+			DefaultMaxRetries, 20, DefaultMaxRetryDeadlineOffset, DefaultRetryDelayMultiplier,
+		},
+	}
+	err := status.New(codes.DataLoss, "static retry error").Err()
+	for testIndex, testCase := range testCases {
+		retryer := NewRetryer(
+			context.Background(),
+			testCase.MaxRetries,
+			testCase.InitialRetryDelay,
+			testCase.MaxRetryDeadlineOffset,
+			testCase.RetryDelayMultiplier,
+		)
+		if retryer.maxRetries != testCase.ExpectedMaxRetries {
+			t.Errorf("%d) unexpected MaxRetries: %v != %v\n ... %v", testIndex, retryer.maxRetries, testCase.ExpectedMaxRetries, testCase)
+		}
+		if retryer.backoff.Max != testCase.ExpectedMaxRetryDeadlineOffset {
+			t.Errorf("%d) unexpected MaxRetryDeadlineOffset: %v != %v\n ... %v", testIndex, retryer.backoff.Max, testCase.ExpectedMaxRetryDeadlineOffset, testCase)
+		}
+		if retryer.backoff.Initial != testCase.ExpectedInitialRetryDelay {
+			t.Errorf("%d) unexpected InitialRetryDelay: %v != %v\n ... %v", testIndex, retryer.backoff.Initial, testCase.ExpectedInitialRetryDelay, testCase)
+		}
+		if retryer.backoff.Multiplier != testCase.ExpectedRetryDelayMultiplier {
+			t.Errorf("%d) unexpected RetryDelayMultiplier: %v != %v\n ... %v", testIndex, retryer.backoff.Multiplier, testCase.ExpectedRetryDelayMultiplier, testCase)
+		}
+		pause, shouldRetry := retryer.Retry(err)
+		if !shouldRetry {
+			t.Errorf("%d) should retry", testIndex)
+		}
+		if pause == 0 {
+			t.Errorf("%d) unexpected pause duration received: %v", testIndex, pause)
+		}
+	}
+}
+
+func TestDefaultRetryerNoRetryBecauseOfCanceledContext(t *testing.T) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	cancelFunc()
+	retryer := NewRetryer(
+		ctx,
+		DefaultMaxRetries,
+		DefaultInitialRetryDelay,
+		DefaultMaxRetryDeadlineOffset,
+		DefaultRetryDelayMultiplier,
+	)
+	err := status.New(codes.DataLoss, "static retry error").Err()
+	pause, shouldRetry := retryer.Retry(err)
+	if shouldRetry {
+		t.Error("should not retry")
+	}
+	if pause != 0 {
+		t.Errorf("unexpected pause duration received: %v", pause)
+	}
+}
+
+func TestDefaultRetryerNoRetryBecauseOfMaxRetries(t *testing.T) {
+	retryer := NewRetryer(
+		context.Background(),
+		1, // retry max 1 time
+		DefaultInitialRetryDelay,
+		DefaultMaxRetryDeadlineOffset,
+		DefaultRetryDelayMultiplier,
+	)
+
+	err := status.New(codes.DataLoss, "static retry error").Err()
+
+	// first time will work
+	pause, shouldRetry := retryer.Retry(err)
+	if !shouldRetry {
+		t.Error("should retry")
+	}
+	if pause == 0 || pause > DefaultInitialRetryDelay {
+		t.Errorf("unexpeted pause duration: %v", pause)
+	}
+
+	// second time not, as we reached our limit of max retries
+	pause, shouldRetry = retryer.Retry(err)
+	if shouldRetry {
+		t.Error("should not retry")
+	}
+	if pause != 0 {
+		t.Errorf("unexpected pause duration received: %v", pause)
+	}
+}
+
+func TestGRPCRetryErrorFilterTrue(t *testing.T) {
+	testCases := []codes.Code{
+		codes.Unavailable,
+		codes.FailedPrecondition,
+		codes.ResourceExhausted,
+		codes.DataLoss,
+	}
+	for _, testCase := range testCases {
+		err := status.New(testCase, "test error").Err()
+		if !grcpRetryErrorFilter(err) {
+			t.Errorf("err should trigger filter: %v", err)
+		}
+	}
+}
+
+func TestGRPCRetryErrorFilterFalse(t *testing.T) {
+	// nil error is not an accepted error
+	if grcpRetryErrorFilter(nil) {
+		t.Error("nil error should not trigger filter")
+	}
+	// custom error is not an accepted error
+	if grcpRetryErrorFilter(errors.New("todo")) {
+		t.Error("custom error should not trigger filter")
+	}
+	// correct error, but wrong code
+	err := status.New(codes.Aborted, "test error").Err()
+	if grcpRetryErrorFilter(err) {
+		t.Error("status error with non-retryable code should not trigger filter")
+	}
+}


### PR DESCRIPTION
This is my first contribution to this wonderful codebase. As such,
upfront, my apologies if I forgot to tick some boxes or made some ignorant mistakes.

This PR replaces the defaultRetryer with a more complete implementation.
It also exposes the type so that anyone can tweak its parameters if desired,
by passing a custom created retryer as the ManagedStreamer's CallOptions. The latter
is now also used for the AppendRow action.
and also use the ManagedStreamer's call options
for the append rows call

resolves #5094