### PR TITLE
feat(spanner): add ToStructLenient method to decode to struct fields with no error return in case of un-matched row's column with struct's exported fields

### DIFF
--- a/spanner/client_test.go
+++ b/spanner/client_test.go
@@ -2198,6 +2198,7 @@ func TestClient_DecodeCustomFieldType(t *testing.T) {
 	defer iter.Stop()
 
 	var results []typesTable
+	var lenientResults []typesTable
 	for {
 		row, err := iter.Next()
 		if err == iterator.Done {
@@ -2212,9 +2213,15 @@ func TestClient_DecodeCustomFieldType(t *testing.T) {
 			t.Fatalf("failed to convert a row to a struct: %v", err)
 		}
 		results = append(results, d)
+
+		var d2 typesTable
+		if err := row.ToStructLenient(&d2); err != nil {
+			t.Fatalf("failed to convert a row to a struct: %v", err)
+		}
+		lenientResults = append(lenientResults, d2)
 	}
 
-	if len(results) > 1 {
+	if len(results) > 1 || len(lenientResults) > 1 {
 		t.Fatalf("mismatch length of array: got %v, want 1", results)
 	}
 
@@ -2228,7 +2235,11 @@ func TestClient_DecodeCustomFieldType(t *testing.T) {
 	}
 	got := results[0]
 	if !testEqual(got, want) {
-		t.Fatalf("mismatch result: got %v, want %v", got, want)
+		t.Fatalf("mismatch result from ToStruct: got %v, want %v", got, want)
+	}
+	got = lenientResults[0]
+	if !testEqual(got, want) {
+		t.Fatalf("mismatch result from ToStructLenient: got %v, want %v", got, want)
 	}
 }
 

--- a/spanner/examples_test.go
+++ b/spanner/examples_test.go
@@ -404,6 +404,30 @@ func ExampleRow_ToStruct() {
 	fmt.Println(acct)
 }
 
+func ExampleRow_ToStructLenient() {
+	ctx := context.Background()
+	client, err := spanner.NewClient(ctx, myDB)
+	if err != nil {
+		// TODO: Handle error.
+	}
+	row, err := client.Single().ReadRow(ctx, "Accounts", spanner.Key{"alice"}, []string{"accountID", "name", "balance"})
+	if err != nil {
+		// TODO: Handle error.
+	}
+
+	type Account struct {
+		Name     string
+		Balance  int64
+		NickName string
+	}
+
+	var acct Account
+	if err := row.ToStructLenient(&acct); err != nil {
+		// TODO: Handle error.
+	}
+	fmt.Println(acct)
+}
+
 func ExampleReadOnlyTransaction_Read() {
 	ctx := context.Background()
 	client, err := spanner.NewClient(ctx, myDB)

--- a/spanner/value.go
+++ b/spanner/value.go
@@ -2871,6 +2871,11 @@ func errNilSpannerStructType() error {
 	return spannerErrorf(codes.FailedPrecondition, "unexpected nil StructType in decoding Cloud Spanner STRUCT")
 }
 
+// errDupGoField returns error for duplicated Go STRUCT field names
+func errDupGoField(s interface{}, name string) error {
+	return spannerErrorf(codes.InvalidArgument, "Go struct %+v(type %T) has duplicate fields for GO STRUCT field %s", s, s, name)
+}
+
 // errUnnamedField returns error for decoding a Cloud Spanner STRUCT with
 // unnamed field into a Go struct.
 func errUnnamedField(ty *sppb.StructType, i int) error {
@@ -2905,7 +2910,7 @@ func errDecodeStructField(ty *sppb.StructType, f string, err error) error {
 // decodeStruct decodes proto3.ListValue pb into struct referenced by pointer
 // ptr, according to
 // the structural information given in sppb.StructType ty.
-func decodeStruct(ty *sppb.StructType, pb *proto3.ListValue, ptr interface{}) error {
+func decodeStruct(ty *sppb.StructType, pb *proto3.ListValue, ptr interface{}, lenient bool) error {
 	if reflect.ValueOf(ptr).IsNil() {
 		return errNilDst(ptr)
 	}
@@ -2921,6 +2926,15 @@ func decodeStruct(ty *sppb.StructType, pb *proto3.ListValue, ptr interface{}) er
 	if err != nil {
 		return ToSpannerError(err)
 	}
+	// return error if lenient is true and destination has duplicate exported columns
+	if lenient {
+		fieldNames := getAllFieldNames(v)
+		for _, f := range fieldNames {
+			if fields.Match(f) == nil {
+				return errDupGoField(ptr, f)
+			}
+		}
+	}
 	seen := map[string]bool{}
 	for i, f := range ty.Fields {
 		if f.Name == "" {
@@ -2928,6 +2942,9 @@ func decodeStruct(ty *sppb.StructType, pb *proto3.ListValue, ptr interface{}) er
 		}
 		sf := fields.Match(f.Name)
 		if sf == nil {
+			if lenient {
+				continue
+			}
 			return errNoOrDupGoField(ptr, f.Name)
 		}
 		if seen[f.Name] {
@@ -2986,13 +3003,44 @@ func decodeStructArray(ty *sppb.StructType, pb *proto3.ListValue, ptr interface{
 			return errDecodeArrayElement(i, pv, "STRUCT", err)
 		}
 		// Decode proto3.ListValue l into struct referenced by s.Interface().
-		if err = decodeStruct(ty, l, s.Interface()); err != nil {
+		if err = decodeStruct(ty, l, s.Interface(), false); err != nil {
 			return errDecodeArrayElement(i, pv, "STRUCT", err)
 		}
 		// Append the decoded struct back into the slice.
 		v.Set(reflect.Append(v, s))
 	}
 	return nil
+}
+
+func getAllFieldNames(v reflect.Value) []string {
+	var names []string
+	typeOfT := v.Type()
+	for i := 0; i < v.NumField(); i++ {
+		f := v.Field(i)
+		fieldType := typeOfT.Field(i)
+		exported := (fieldType.PkgPath == "")
+		// If a named field is unexported, ignore it. An anonymous
+		// unexported field is processed, because it may contain
+		// exported fields, which are visible.
+		if !exported && !fieldType.Anonymous {
+			continue
+		}
+		if f.Kind() == reflect.Struct {
+			if fieldType.Anonymous {
+				names = append(names, getAllFieldNames(reflect.ValueOf(f.Interface()))...)
+			}
+			continue
+		}
+		name, keep, _, _ := spannerTagParser(fieldType.Tag)
+		if !keep {
+			continue
+		}
+		if name == "" {
+			name = fieldType.Name
+		}
+		names = append(names, name)
+	}
+	return names
 }
 
 // errEncoderUnsupportedType returns error for not being able to encode a value

--- a/spanner/value_test.go
+++ b/spanner/value_test.go
@@ -2049,38 +2049,74 @@ func TestDecodeStruct(t *testing.T) {
 	)
 
 	for _, test := range []struct {
-		desc string
-		ptr  interface{}
-		want interface{}
-		fail bool
+		desc    string
+		lenient bool
+		ptr     interface{}
+		want    interface{}
+		fail    bool
 	}{
 		{
-			desc: "decode to S1",
-			ptr:  &s1,
-			want: &S1{ID: "id", Time: t1},
+			desc:    "decode to S1 with lenient enabled",
+			ptr:     &s1,
+			want:    &S1{ID: "id", Time: t1},
+			lenient: true,
 		},
 		{
-			desc: "decode to S2",
-			ptr:  &s2,
-			fail: true,
+			desc:    "decode to S1 with lenient disabled",
+			ptr:     &s1,
+			want:    &S1{ID: "id", Time: t1},
+			lenient: false,
 		},
 		{
-			desc: "decode to S3",
-			ptr:  &s3,
-			want: &S3{ID: CustomString("id"), Time: CustomTime(t1)},
+			desc:    "decode to S2 with lenient enabled",
+			ptr:     &s2,
+			fail:    true,
+			lenient: true,
 		},
 		{
-			desc: "decode to S4",
-			ptr:  &s4,
-			fail: true,
+			desc:    "decode to S2 with lenient disabled",
+			ptr:     &s2,
+			fail:    true,
+			lenient: false,
 		},
 		{
-			desc: "decode to S5",
-			ptr:  &s5,
-			fail: true,
+			desc:    "decode to S3 with lenient enabled",
+			ptr:     &s3,
+			want:    &S3{ID: CustomString("id"), Time: CustomTime(t1)},
+			lenient: true,
+		},
+		{
+			desc:    "decode to S3 with lenient disabled",
+			ptr:     &s3,
+			want:    &S3{ID: CustomString("id"), Time: CustomTime(t1)},
+			lenient: false,
+		},
+		{
+			desc:    "decode to S4 with lenient enabled",
+			ptr:     &s4,
+			fail:    true,
+			lenient: true,
+		},
+		{
+			desc:    "decode to S4 with lenient disabled",
+			ptr:     &s4,
+			fail:    true,
+			lenient: false,
+		},
+		{
+			desc:    "decode to S5 with lenient enabled",
+			ptr:     &s5,
+			want:    &S5{NullString: NullString{}, Time: CustomTime(t1)},
+			lenient: true,
+		},
+		{
+			desc:    "decode to S5 with lenient disabled",
+			ptr:     &s5,
+			fail:    true,
+			lenient: false,
 		},
 	} {
-		err := decodeStruct(stype, lv, test.ptr)
+		err := decodeStruct(stype, lv, test.ptr, test.lenient)
 		if (err != nil) != test.fail {
 			t.Errorf("%s: got error %v, wanted fail: %v", test.desc, err, test.fail)
 		}
@@ -2195,7 +2231,7 @@ func TestDecodeStructWithPointers(t *testing.T) {
 			want: &S1{Str: nil, Int: nil, Bool: nil, Float: nil, Time: nil, Date: nil, StrArray: nil, IntArray: nil, BoolArray: nil, FloatArray: nil, TimeArray: nil, DateArray: nil},
 		},
 	} {
-		err := decodeStruct(stype, lv[i], test.ptr)
+		err := decodeStruct(stype, lv[i], test.ptr, false)
 		if (err != nil) != test.fail {
 			t.Errorf("%s: got error %v, wanted fail: %v", test.desc, err, test.fail)
 		}


### PR DESCRIPTION
The PR adds method `ToStructLenient` which decodes the row's column into the struct's exported fields, the difference with the existing `ToStruct` methods are:
* Decoding from row's column to struct with no matching exported fields is allowed.

ToStructLenient should pass all existing and future test cases for ToStruct method so tests are updated to make sure same test cases run for both methods.

ToStructLenient is created to handle below example:

DDL:
```
CREATE TABLE Singers (
    SingerId	INT64 NOT NULL,
    FirstName	STRING(1024)
) PRIMARY KEY (SingerId)
```
and client code looks like
```
struct Singer {
  SingerId     int64
  FirstName string
}

func GetSinger(ID int64) (*Singer, error) {
  ...
  spannerCli.Single().Query(ctx, spanner.Statement {
      SQL: 'SELECT * FROM singers WHERE SingerId=@id',
      Params: map[string]string{"id": ID},
  ).Do(func(r *spanner.Row) error {
       singer := new(Singer)
       r.ToStruct(singer)
  )
}
```

Now, let's say we update the singers table to have new column `LastName`, ToStruct will start returning errNoOrDupGoField after schema update to fix this ToStructLenient can be used instead of ToStruct.
  
Fixes: https://github.com/googleapis/google-cloud-go/issues/5131

