### PR TITLE
test(spanner): add logs to debug the configName used for TestIntegration_StartBackupOperation test

### DIFF
--- a/spanner/integration_test.go
+++ b/spanner/integration_test.go
@@ -282,7 +282,7 @@ func initIntegrationTests() (cleanup func()) {
 		}
 		configName = config.Name
 	}
-	log.Printf("running test using config: %s\n", configName)
+	log.Printf("Running test by using the instance config: %s\n", configName)
 
 	// First clean up any old test instances before we start the actual testing
 	// as these might cause this test run to fail.

--- a/spanner/integration_test.go
+++ b/spanner/integration_test.go
@@ -282,6 +282,7 @@ func initIntegrationTests() (cleanup func()) {
 		}
 		configName = config.Name
 	}
+	log.Printf("running test using config: %s\n", configName)
 
 	// First clean up any old test instances before we start the actual testing
 	// as these might cause this test run to fail.


### PR DESCRIPTION
Added logs to debug configName used for integration tests

Fixes: https://github.com/googleapis/google-cloud-go/issues/5037