### PR TITLE
feat(storage): allow retry ErrorFunc configs

### DIFF
--- a/storage/invoke.go
+++ b/storage/invoke.go
@@ -45,9 +45,13 @@ func run(ctx context.Context, call func() error, retry *retryConfig, isIdempoten
 		bo.Initial = retry.backoff.Initial
 		bo.Max = retry.backoff.Max
 	}
+	var errorFunc func(err error) bool = shouldRetry
+	if retry.shouldRetry != nil {
+		errorFunc = retry.shouldRetry
+	}
 	return internal.Retry(ctx, bo, func() (stop bool, err error) {
 		err = call()
-		return !shouldRetry(err), err
+		return !errorFunc(err), err
 	})
 }
 

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -811,7 +811,7 @@ func TestRetryer(t *testing.T) {
 						Multiplier: 3,
 					}),
 					WithPolicy(RetryAlways),
-					WithErrorFunc(func(err error) bool {return false}))
+					WithErrorFunc(func(err error) bool { return false }))
 			},
 			want: &retryConfig{
 				backoff: &gax.Backoff{
@@ -820,7 +820,7 @@ func TestRetryer(t *testing.T) {
 					Multiplier: 3,
 				},
 				policy:      RetryAlways,
-				shouldRetry: func(err error) bool {return false},
+				shouldRetry: func(err error) bool { return false },
 			},
 		},
 		{
@@ -849,10 +849,10 @@ func TestRetryer(t *testing.T) {
 			name: "set ErrorFunc only",
 			call: func(o *ObjectHandle) *ObjectHandle {
 				return o.Retryer(
-					WithErrorFunc(func(err error) bool {return false}))
+					WithErrorFunc(func(err error) bool { return false }))
 			},
 			want: &retryConfig{
-				shouldRetry: func(err error) bool {return false},
+				shouldRetry: func(err error) bool { return false },
 			},
 		},
 	}

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -810,7 +810,8 @@ func TestRetryer(t *testing.T) {
 						Max:        30 * time.Second,
 						Multiplier: 3,
 					}),
-					WithPolicy(RetryAlways))
+					WithPolicy(RetryAlways),
+					WithErrorFunc(func(err error) bool {return false}))
 			},
 			want: &retryConfig{
 				backoff: &gax.Backoff{
@@ -818,7 +819,8 @@ func TestRetryer(t *testing.T) {
 					Max:        30 * time.Second,
 					Multiplier: 3,
 				},
-				policy: RetryAlways,
+				policy:      RetryAlways,
+				shouldRetry: func(err error) bool {return false},
 			},
 		},
 		{
@@ -843,11 +845,30 @@ func TestRetryer(t *testing.T) {
 				policy: RetryNever,
 			},
 		},
+		{
+			name: "set ErrorFunc only",
+			call: func(o *ObjectHandle) *ObjectHandle {
+				return o.Retryer(
+					WithErrorFunc(func(err error) bool {return false}))
+			},
+			want: &retryConfig{
+				shouldRetry: func(err error) bool {return false},
+			},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(s *testing.T) {
 			o := tc.call(&ObjectHandle{})
-			if diff := cmp.Diff(o.retry, tc.want, cmp.AllowUnexported(retryConfig{}, gax.Backoff{})); diff != "" {
+			if diff := cmp.Diff(
+				o.retry,
+				tc.want,
+				cmp.AllowUnexported(retryConfig{}, gax.Backoff{}),
+				// ErrorFunc cannot be compared directly, but we check if both are
+				// either nil or non-nil.
+				cmp.Comparer(func(a, b func(err error) bool) bool {
+					return (a == nil && b == nil) || (a != nil && b != nil)
+				}),
+			); diff != "" {
 				s.Fatalf("retry not configured correctly: %v", diff)
 			}
 		})


### PR DESCRIPTION
Allows users to supply a custom ErrorFunc which will be used
to determine whether the error is retryable.