### PR TITLE
docs(bigquery): use equality operator in Errors example

### DIFF
--- a/bigquery/doc.go
+++ b/bigquery/doc.go
@@ -307,7 +307,7 @@ These errors can be introspected for more information by using `xerrors.As` with
 
 	var e *googleapi.Error
 	if ok := xerrors.As(err, &e); ok {
-		  if e.Code = 409 { ... }
+		  if e.Code == 409 { ... }
     }
 
 In some cases, your client may received unstructured googleapi.Error error responses.  In such cases, it is likely that


### PR DESCRIPTION
I believe the intention of this example is to show how to introspect errors for more information (such as the error code). This updates the example to use the equality operator instead of assignment operator.