### PR TITLE
fix: update comment about flushrows API

### DIFF
--- a/bigquery/storage/managedwriter/managed_stream.go
+++ b/bigquery/storage/managedwriter/managed_stream.go
@@ -48,9 +48,6 @@ var (
 
 	// BufferedStream is a form of checkpointed stream, that allows
 	// you to advance the offset of visible rows via Flush operations.
-	//
-	// NOTE: Buffered Streams are currently in limited preview, and as such
-	// methods like FlushRows() may yield errors for non-enrolled projects.
 	BufferedStream StreamType = "BUFFERED"
 
 	// PendingStream is a stream in which no data is made visible to


### PR DESCRIPTION
The API is GAed and ready for use.