### PR TITLE
fix(spanner): result from unmarshal of string and spanner.NullString type from json should be consistent

### DIFF
--- a/spanner/value.go
+++ b/spanner/value.go
@@ -286,12 +286,17 @@ func (n *NullString) UnmarshalJSON(payload []byte) error {
 		n.Valid = false
 		return nil
 	}
-	payload, err := trimDoubleQuotes(payload)
-	if err != nil {
+	var s *string
+	if err := json.Unmarshal(payload, &s); err != nil {
 		return err
 	}
-	n.StringVal = string(payload)
-	n.Valid = true
+	if s != nil {
+		n.StringVal = *s
+		n.Valid = true
+	} else {
+		n.StringVal = ""
+		n.Valid = false
+	}
 	return nil
 }
 

--- a/spanner/value_test.go
+++ b/spanner/value_test.go
@@ -2647,6 +2647,7 @@ func TestJSONUnmarshal_NullTypes(t *testing.T) {
 				{input: []byte(`"this is a test string"`), got: NullString{}, isNull: false, expect: "this is a test string", expectError: false},
 				{input: []byte(`""`), got: NullString{}, isNull: false, expect: "", expectError: false},
 				{input: []byte("null"), got: NullString{}, isNull: true, expect: nullString, expectError: false},
+				{input: []byte(`"{\"sub_a\": \"value_1\"}"`), got: NullString{}, isNull: false, expect: `{"sub_a": "value_1"}`, expectError: false},
 				{input: nil, got: NullString{}, isNull: true, expect: nullString, expectError: true},
 				{input: []byte(""), got: NullString{}, isNull: true, expect: nullString, expectError: true},
 				{input: []byte(`"hello`), got: NullString{}, isNull: true, expect: nullString, expectError: true},


### PR DESCRIPTION
Fixes: https://github.com/googleapis/google-cloud-go/issues/5259