### PR TITLE
chore(.github): revert to v2 of release-please

### DIFF
--- a/.github/workflows/release-submodule.yaml
+++ b/.github/workflows/release-submodule.yaml
@@ -35,7 +35,7 @@ jobs:
       matrix:
         package: ${{fromJson(needs.changeFinder.outputs.submodules)}}
     steps:
-      - uses: GoogleCloudPlatform/release-please-action@v3
+      - uses: GoogleCloudPlatform/release-please-action@v2
         id: release-please
         with:
            path: ${{ matrix.package }}
@@ -69,7 +69,7 @@ jobs:
       matrix:
         package: ${{fromJson(needs.changeFinder.outputs.submodules)}}
     steps:
-      - uses: GoogleCloudPlatform/release-please-action@v3
+      - uses: GoogleCloudPlatform/release-please-action@v2
         id: tag-release
         with:
           path: ${{ matrix.package }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - id: release-pr # Open the release PR from a fork.
-        uses: GoogleCloudPlatform/release-please-action@v3
+        uses: GoogleCloudPlatform/release-please-action@v2
         with:
           # token: ${{ secrets.FORKING_TOKEN }}
           token: ${{ secrets.FORKING_TOKEN }}
@@ -38,7 +38,7 @@ jobs:
     if: github.repository == 'googleapis/google-cloud-go'
     runs-on: ubuntu-latest
     steps:
-      - uses: GoogleCloudPlatform/release-please-action@v3
+      - uses: GoogleCloudPlatform/release-please-action@v2
         id: tag-release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
With the big refactor the logic to selectively filter commits on
scope was removed. Until that logic is reinstated we will move
back to v2.