### PR TITLE
chore(gapicgen): unfreeze grafeas and containeranalysis stub gen

### DIFF
--- a/internal/gapicgen/generator/genproto.go
+++ b/internal/gapicgen/generator/genproto.go
@@ -39,11 +39,6 @@ var denylist = map[string]bool{
 	// TODO(codyoss): re-enable after issue is resolve -- https://github.com/googleapis/go-genproto/issues/357
 	"google.golang.org/genproto/googleapis/cloud/recommendationengine/v1beta1": true,
 
-	// These two container APIs are currently frozen. They should not be updated
-	// due to manual layer built on top of them.
-	"google.golang.org/genproto/googleapis/grafeas/v1":                    true,
-	"google.golang.org/genproto/googleapis/devtools/containeranalysis/v1": true,
-
 	// Temporarily stop generation of removed protos. Will be manually cleaned
 	// up with: https://github.com/googleapis/google-cloud-go/issues/4098
 	"google.golang.org/genproto/googleapis/cloud/bigquery/storage/v1alpha2": true,


### PR DESCRIPTION
After running regen locally with `--forceAll`, regen succeeded and `go build ./...` of `go-genproto` succeeded. I think it is safe to enable protobuf/gRPC stub generation for grafeas and containeranalysis.

Note: This **does not** enable gapic generation for these APIs per #2711