### PR TITLE
fix(storage): fix nil check in gRPC Reader

### DIFF
--- a/storage/reader.go
+++ b/storage/reader.go
@@ -541,8 +541,8 @@ func (o *ObjectHandle) newRangeReaderWithGRPC(ctx context.Context, offset, lengt
 	}
 
 	// Only support checksums when reading an entire object, not a range.
-	if msg.GetObjectChecksums().Crc32C != nil && offset == 0 && length == 0 {
-		r.wantCRC = msg.GetObjectChecksums().GetCrc32C()
+	if checksums := msg.GetObjectChecksums(); checksums != nil && checksums.Crc32C != nil && offset == 0 && length == 0 {
+		r.wantCRC = checksums.GetCrc32C()
 		r.checkCRC = true
 	}
 


### PR DESCRIPTION
GetObjectChecksums() can return nil if no checksums are present,
so we need to check for nil.

This might just be an emulator artifact but it's probably not a bad idea
to have this check regardless.