### PR TITLE
test(pubsub): increase TestIntegration_All timeout for Pull flakiness

### DIFF
--- a/pubsub/integration_test.go
+++ b/pubsub/integration_test.go
@@ -310,14 +310,15 @@ func testPublishAndReceive(t *testing.T, client *Client, maxMsgs int, synchronou
 	// Use a timeout to ensure that Pull does not block indefinitely if there are
 	// unexpectedly few messages available.
 	now := time.Now()
-	timeoutCtx, cancel := context.WithTimeout(ctx, time.Minute)
+	timeout := 3 * time.Minute
+	timeoutCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	gotMsgs, err := pullN(timeoutCtx, sub, len(want), func(ctx context.Context, m *Message) {
 		m.Ack()
 	})
 	if err != nil {
 		if c := status.Convert(err); c.Code() == codes.Canceled {
-			if time.Since(now) >= time.Minute {
+			if time.Since(now) >= timeout {
 				t.Fatal("pullN took too long")
 			}
 		} else {


### PR DESCRIPTION
The max timeout for `TestIntegration_All` is 1 minute, which is occasionally too short for pulling all required messages for a test to pass. Increasing this timeout to 3 minutes will make synchronous pull tests a lot less likely to flake.

Fixes #5257 