### PR TITLE
fix(internal/gapicgen): move breaking change indicator if present

### DIFF
--- a/internal/gapicgen/git/git.go
+++ b/internal/gapicgen/git/git.go
@@ -59,7 +59,15 @@ func FormatChanges(changes []*ChangeInfo, onlyGapicChanges bool) string {
 				if i := strings.Index(titleParts[0], "("); i > 0 {
 					titleParts[0] = titleParts[0][:i]
 				}
-				titleParts[0] = fmt.Sprintf("%s(%s)", titleParts[0], c.Package)
+
+				var breakChangeIndicator string
+				if strings.HasSuffix(titleParts[0], "!") {
+					// If the change is marked as breaking we need to move the
+					// bang to after the added scope.
+					titleParts[0] = titleParts[0][:len(titleParts[0])-1]
+					breakChangeIndicator = "!"
+				}
+				titleParts[0] = fmt.Sprintf("%s(%s)%s", titleParts[0], c.Package, breakChangeIndicator)
 			}
 			title = strings.Join(titleParts, ":")
 		}

--- a/internal/gapicgen/git/git_test.go
+++ b/internal/gapicgen/git/git_test.go
@@ -74,6 +74,11 @@ func TestFormatChanges(t *testing.T) {
 			want:    "\nChanges:\n\nfix(baz): foo\n  bar\n\n",
 		},
 		{
+			name:    "with package, breaking change",
+			changes: []*ChangeInfo{{Title: "feat!: foo", Body: "bar", Package: "baz"}},
+			want:    "\nChanges:\n\nfeat(baz)!: foo\n  bar\n\n",
+		},
+		{
 			name:    "multiple changes",
 			changes: []*ChangeInfo{{Title: "fix: foo", Body: "bar", Package: "foo"}, {Title: "fix: baz", Body: "bar"}},
 			want:    "\nChanges:\n\nfix(foo): foo\n  bar\n\nfix: baz\n  bar\n\n",


### PR DESCRIPTION
This was discovered processing 8e91ed1f2f2cb7fa77240dabcafcd2dedf97bda3.
If a scope is present to be compliant with conventional commits the bang
must be after the scope.