### PR TITLE
feat(bigquery/storage/managedwriter): append improvements

### DIFF
--- a/bigquery/storage/managedwriter/integration_test.go
+++ b/bigquery/storage/managedwriter/integration_test.go
@@ -211,7 +211,14 @@ func testDefaultStream(ctx context.Context, t *testing.T, mwClient *Client, bqCl
 	}
 	// wait for the result to indicate ready, then validate again.  Our total rows have increased, but
 	// cardinality should not.
-	result.Ready()
+	// wait for the result to indicate ready, then validate.
+	o, err := result.GetResult(ctx)
+	if err != nil {
+		t.Errorf("result error for last send: %v", err)
+	}
+	if o != NoStreamOffset {
+		t.Errorf("offset mismatch, got %d want %d", o, NoStreamOffset)
+	}
 	validateTableConstraints(ctx, t, bqClient, testTable, "after second send round",
 		withExactRowCount(int64(2*len(testSimpleData))),
 		withDistinctValues("name", int64(len(testSimpleData))),
@@ -267,7 +274,13 @@ func testDefaultStreamDynamicJSON(ctx context.Context, t *testing.T, mwClient *C
 	}
 
 	// wait for the result to indicate ready, then validate.
-	result.Ready()
+	o, err := result.GetResult(ctx)
+	if err != nil {
+		t.Errorf("result error for last send: %v", err)
+	}
+	if o != NoStreamOffset {
+		t.Errorf("offset mismatch, got %d want %d", o, NoStreamOffset)
+	}
 	validateTableConstraints(ctx, t, bqClient, testTable, "after send",
 		withExactRowCount(int64(len(sampleJSONData))),
 		withDistinctValues("name", int64(len(sampleJSONData))),

--- a/bigquery/storage/managedwriter/managed_stream_test.go
+++ b/bigquery/storage/managedwriter/managed_stream_test.go
@@ -87,38 +87,63 @@ func TestManagedStream_OpenWithRetry(t *testing.T) {
 	}
 }
 
+type testAppendRowsClient struct {
+	storagepb.BigQueryWrite_AppendRowsClient
+	openCount int
+	requests  []*storagepb.AppendRowsRequest
+	sendF     func(*storagepb.AppendRowsRequest) error
+	recvF     func() (*storagepb.AppendRowsResponse, error)
+}
+
+func (tarc *testAppendRowsClient) Send(req *storagepb.AppendRowsRequest) error {
+	return tarc.sendF(req)
+}
+
+func (tarc *testAppendRowsClient) Recv() (*storagepb.AppendRowsResponse, error) {
+	return tarc.recvF()
+}
+
+// openTestArc handles wiring in a test AppendRowsClient into a managedstream by providing the open function.
+func openTestArc(testARC *testAppendRowsClient, sendF func(req *storagepb.AppendRowsRequest) error, recvF func() (*storagepb.AppendRowsResponse, error)) func(s string, opts ...gax.CallOption) (storagepb.BigQueryWrite_AppendRowsClient, error) {
+	sF := func(req *storagepb.AppendRowsRequest) error {
+		testARC.requests = append(testARC.requests, req)
+		return nil
+	}
+	if sendF != nil {
+		sF = sendF
+	}
+	rF := func() (*storagepb.AppendRowsResponse, error) {
+		return &storagepb.AppendRowsResponse{
+			Response: &storagepb.AppendRowsResponse_AppendResult_{},
+		}, nil
+	}
+	if recvF != nil {
+		rF = recvF
+	}
+	testARC.sendF = sF
+	testARC.recvF = rF
+	return func(s string, opts ...gax.CallOption) (storagepb.BigQueryWrite_AppendRowsClient, error) {
+		testARC.openCount = testARC.openCount + 1
+		return testARC, nil
+	}
+}
+
 func TestManagedStream_FirstAppendBehavior(t *testing.T) {
 
 	ctx := context.Background()
 
-	var testARC *testAppendRowsClient
-	testARC = &testAppendRowsClient{
-		recvF: func() (*storagepb.AppendRowsResponse, error) {
-			return &storagepb.AppendRowsResponse{
-				Response: &storagepb.AppendRowsResponse_AppendResult_{},
-			}, nil
-		},
-		sendF: func(req *storagepb.AppendRowsRequest) error {
-			testARC.requests = append(testARC.requests, req)
-			return nil
-		},
-	}
-	schema := &descriptorpb.DescriptorProto{
-		Name: proto.String("testDescriptor"),
-	}
-
+	testARC := &testAppendRowsClient{}
 	ms := &ManagedStream{
-		ctx: ctx,
-		open: func(s string, opts ...gax.CallOption) (storagepb.BigQueryWrite_AppendRowsClient, error) {
-			testARC.openCount = testARC.openCount + 1
-			return testARC, nil
-		},
+		ctx:            ctx,
+		open:           openTestArc(testARC, nil, nil),
 		streamSettings: defaultStreamSettings(),
 		fc:             newFlowController(0, 0),
 	}
 	ms.streamSettings.streamID = "FOO"
 	ms.streamSettings.TraceID = "TRACE"
-	ms.schemaDescriptor = schema
+	ms.schemaDescriptor = &descriptorpb.DescriptorProto{
+		Name: proto.String("testDescriptor"),
+	}
 
 	fakeData := [][]byte{
 		[]byte("foo"),
@@ -179,22 +204,6 @@ func TestManagedStream_FirstAppendBehavior(t *testing.T) {
 	}
 }
 
-type testAppendRowsClient struct {
-	storagepb.BigQueryWrite_AppendRowsClient
-	openCount int
-	requests  []*storagepb.AppendRowsRequest
-	sendF     func(*storagepb.AppendRowsRequest) error
-	recvF     func() (*storagepb.AppendRowsResponse, error)
-}
-
-func (tarc *testAppendRowsClient) Send(req *storagepb.AppendRowsRequest) error {
-	return tarc.sendF(req)
-}
-
-func (tarc *testAppendRowsClient) Recv() (*storagepb.AppendRowsResponse, error) {
-	return tarc.recvF()
-}
-
 func TestManagedStream_FlowControllerFailure(t *testing.T) {
 
 	ctx := context.Background()
@@ -203,12 +212,14 @@ func TestManagedStream_FlowControllerFailure(t *testing.T) {
 	fc := newFlowController(1, 0)
 	fc.acquire(ctx, 0)
 
-	// Construct a skeleton ManagedStream.  This doesn't include an ARC or open func
-	// because this test should never invoke it.
 	ms := &ManagedStream{
 		ctx:            ctx,
 		streamSettings: defaultStreamSettings(),
 		fc:             fc,
+		open:           openTestArc(&testAppendRowsClient{}, nil, nil),
+	}
+	ms.schemaDescriptor = &descriptorpb.DescriptorProto{
+		Name: proto.String("testDescriptor"),
 	}
 
 	fakeData := [][]byte{
@@ -224,5 +235,38 @@ func TestManagedStream_FlowControllerFailure(t *testing.T) {
 	if err == nil {
 		t.Errorf("expected AppendRows to error, but it succeeded")
 	}
+}
 
+func TestManagedStream_AppendWithDeadline(t *testing.T) {
+	ctx := context.Background()
+
+	ms := &ManagedStream{
+		ctx:            ctx,
+		streamSettings: defaultStreamSettings(),
+		fc:             newFlowController(0, 0),
+		open: openTestArc(&testAppendRowsClient{},
+			func(req *storagepb.AppendRowsRequest) error {
+				// Append is intentionally slow.
+				time.Sleep(time.Second)
+				return nil
+			}, nil),
+	}
+	ms.schemaDescriptor = &descriptorpb.DescriptorProto{
+		Name: proto.String("testDescriptor"),
+	}
+
+	fakeData := [][]byte{
+		[]byte("foo"),
+	}
+
+	// Create a context that will expire during the append, to verify the passed in
+	// context expires.
+	expireCtx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
+	defer cancel()
+
+	_, err := ms.AppendRows(expireCtx, fakeData)
+	if err == nil {
+		t.Errorf("expected AppendRows to error, but it succeeded")
+	}
+	time.Sleep(time.Second)
 }


### PR DESCRIPTION
Fixes: https://github.com/googleapis/google-cloud-go/issues/5459

This PR addresses two issues.  The receiver channel for processing
asyncronous updates is switched to a buffer channel, based on the
allowed append depth.

The second change is that this allows for better context
expiry/cancellation when invoking AppendRows on a managed stream.

This also improves testing with some test refactors, as well as
shaking out some timing issues due the larger queue depth.