### PR TITLE
chore: update supported versions of Go runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,12 @@ For an updated list of all of our released APIs please see our
 
 ## [Go Versions Supported](#supported-versions)
 
-We currently support Go versions 1.11 and newer.
+Our libraries are compatible with at least the three most recent, major Go
+releases. They are currently compatible with:
+
+- Go 1.17
+- Go 1.16
+- Go 1.15
 
 ## Authorization
 


### PR DESCRIPTION
In the coming days we will have some more docs and updates around
this change. In general though going forward we will support the
three latest versions of Go. The infrastructure changes around this
will land after more of our documentation does.