### PR TITLE
build: separate main component

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,8 +1,10 @@
 {
   "release-type": "go-yoshi",
-  "separate-pull-requests": false,
+  "separate-pull-requests": true,
   "include-component-in-tag": false,
   "packages": {
-    ".": {}
+    ".": {
+      "component": "main"
+    }
   }
 }


### PR DESCRIPTION
This should open the root component as a separate PR that looks like: https://github.com/googleapis/google-cloud-go/pull/5349 (no expanding sections)
