### PR TITLE
chore(internal/gapicgen): fix logging yaml name

### DIFF
--- a/internal/gapicgen/generator/config.go
+++ b/internal/gapicgen/generator/config.go
@@ -685,7 +685,7 @@ var microgenGapicConfigs = []*microgenConfig{
 		pkg:                   "logging",
 		importPath:            "cloud.google.com/go/logging/apiv2",
 		gRPCServiceConfigPath: "logging_grpc_service_config.json",
-		apiServiceConfigPath:  "logging.yaml",
+		apiServiceConfigPath:  "logging_v2.yaml",
 		releaseLevel:          "ga",
 	},
 	{


### PR DESCRIPTION
The serivce config yaml for logging was renamed to conform, so we must rename it in the generation config.