### PR TITLE
test(spanner): skip TestIntegration_StartBackupOperation test with PG dialect because of timeouts

### DIFF
--- a/spanner/integration_test.go
+++ b/spanner/integration_test.go
@@ -3483,6 +3483,7 @@ func readPGSingerTable(iter *RowIterator) ([][]interface{}, error) {
 
 func TestIntegration_StartBackupOperation(t *testing.T) {
 	skipEmulatorTest(t)
+	skipUnsupportedPGTest(t)
 	t.Parallel()
 
 	startTime := time.Now()


### PR DESCRIPTION
Fixes: https://github.com/googleapis/google-cloud-go/issues/5709