### PR TITLE
fix(pubsub): prevent infinite retry with publishing invalid utf-8 chars

### DIFF
--- a/pubsub/topic.go
+++ b/pubsub/topic.go
@@ -678,7 +678,8 @@ func (t *Topic) publishMessageBundle(ctx context.Context, bms []*bundledMessage)
 		res, err = t.c.pubc.Publish(ctx, &pb.PublishRequest{
 			Topic:    t.name,
 			Messages: pbMsgs,
-		}, gax.WithGRPCOptions(grpc.MaxCallSendMsgSize(maxSendRecvBytes)))
+		}, gax.WithGRPCOptions(grpc.MaxCallSendMsgSize(maxSendRecvBytes)),
+			gax.WithRetry(func() gax.Retryer { return &publishRetryer{} }))
 	}
 	end := time.Now()
 	if err != nil {


### PR DESCRIPTION
`INTERNAL` is a retryable code for `Publish` but we should not indefinitely retry this error code when message attributes contains invalid utf-8 characters, which the `grpc-go` library returns as an `INTERNAL` error.

Fixes #5268