### PR TITLE
chore(storage): add withUserProject internal setting option

### DIFF
--- a/storage/client.go
+++ b/storage/client.go
@@ -120,6 +120,9 @@ type settings struct {
 	// transport initialization. See https://pkg.go.dev/google.golang.org/api/option
 	// for a list of supported options.
 	clientOption []option.ClientOption
+
+	// userProject is the user project that should be billed for the request.
+	userProject string
 }
 
 func initSettings(opts ...storageOption) *settings {
@@ -196,6 +199,16 @@ type clientOption struct {
 }
 
 func (o *clientOption) Apply(s *settings) { s.clientOption = o.opts }
+
+func withUserProject(project string) storageOption {
+	return &userProjectOption{project}
+}
+
+type userProjectOption struct {
+	project string
+}
+
+func (o *userProjectOption) Apply(s *settings) { s.userProject = o.project }
 
 type composeObjectRequest struct {
 	dstBucket     string


### PR DESCRIPTION
Adds a `userProject string` field to the transport-agnostic client settings and a `withUserProject` `storageOption` to modify it at either the client init or per-call level.