### PR TITLE
fix(bigtable): return empty Row when reading missing row

### DIFF
--- a/bigtable/bigtable.go
+++ b/bigtable/bigtable.go
@@ -253,7 +253,7 @@ func (t *Table) ReadRows(ctx context.Context, arg RowSet, f func(Row) bool, opts
 // ReadRow is a convenience implementation of a single-row reader.
 // A missing row will return a zero-length map and a nil error.
 func (t *Table) ReadRow(ctx context.Context, row string, opts ...ReadOption) (Row, error) {
-	var r Row
+	r := make(Row)
 	err := t.ReadRows(ctx, SingleRow(row), func(rr Row) bool {
 		r = rr
 		return true


### PR DESCRIPTION
Fixes #5828, `ReadRow` will return zero-length map and nil error according to the docs. 