### PR TITLE
chore(cmd/go-cloud-debug-agent): Fix staticcheck errors

### DIFF
--- a/cmd/go-cloud-debug-agent/internal/breakpoints/breakpoints_test.go
+++ b/cmd/go-cloud-debug-agent/internal/breakpoints/breakpoints_test.go
@@ -31,7 +31,6 @@ var (
 	testLine2   uint64 = 99
 	testLogPC   uint64 = 0x9abc
 	testLogLine uint64 = 43
-	testBadPC   uint64 = 0xdef0
 	testBadLine uint64 = 44
 	testBP             = &cd.Breakpoint{
 		Action:       "CAPTURE",

--- a/cmd/go-cloud-debug-agent/internal/controller/client.go
+++ b/cmd/go-cloud-debug-agent/internal/controller/client.go
@@ -96,7 +96,7 @@ var newService = func(ctx context.Context, tokenSource oauth2.TokenSource) (serv
 	if err != nil {
 		return nil, err
 	}
-	s, err := cd.New(httpClient)
+	s, err := cd.NewService(ctx, option.WithHTTPClient(httpClient))
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/go-cloud-debug-agent/internal/controller/client_test.go
+++ b/cmd/go-cloud-debug-agent/internal/controller/client_test.go
@@ -174,7 +174,7 @@ func TestDebugletControllerClientLibrary(t *testing.T) {
 	if err := validateLabels(c, opts); err != nil {
 		t.Fatalf("Invalid labels:\n%v", err)
 	}
-	if list, err = c.List(ctx); err != nil {
+	if _, err = c.List(ctx); err != nil {
 		t.Fatal("List:", err)
 	}
 	if m.registerCallsSeen != 1 {
@@ -189,21 +189,21 @@ func TestDebugletControllerClientLibrary(t *testing.T) {
 	if err = c.Update(ctx, list.Breakpoints[0].Id, &cd.Breakpoint{Id: testBreakpointID, IsFinalState: true}); err != nil {
 		t.Fatal("Update:", err)
 	}
-	if list, err = c.List(ctx); err != nil {
+	if _, err = c.List(ctx); err != nil {
 		t.Fatal("List:", err)
 	}
 	if m.registerCallsSeen != 1 {
 		t.Errorf("saw %d Register calls, want 1", m.registerCallsSeen)
 	}
 	// The next List call produces an error that should cause a Register call.
-	if list, err = c.List(ctx); err == nil {
+	if _, err = c.List(ctx); err == nil {
 		t.Fatal("List should have returned an error")
 	}
 	if m.registerCallsSeen != 2 {
 		t.Errorf("saw %d Register calls, want 2", m.registerCallsSeen)
 	}
 	// The next List call produces an error that should not cause a Register call.
-	if list, err = c.List(ctx); err == nil {
+	if _, err = c.List(ctx); err == nil {
 		t.Fatal("List should have returned an error")
 	}
 	if m.registerCallsSeen != 2 {

--- a/cmd/go-cloud-debug-agent/internal/debug/dwarf/const.go
+++ b/cmd/go-cloud-debug-agent/internal/debug/dwarf/const.go
@@ -447,22 +447,22 @@ const (
 	opNe         = 0x2E
 	opLit0       = 0x30
 	/* OpLitN = OpLit0 + N for N = 0..31 */
-	opReg0 = 0x50
+	/* opReg0 = 0x50 */
 	/* OpRegN = OpReg0 + N for N = 0..31 */
-	opBreg0 = 0x70 /* 1 op, signed LEB128 constant */
+	/* opBreg0 = 0x70 */ /* 1 op, signed LEB128 constant */
 	/* OpBregN = OpBreg0 + N for N = 0..31 */
-	opRegx       = 0x90 /* 1 op, ULEB128 register */
-	opFbreg      = 0x91 /* 1 op, SLEB128 offset */
-	opBregx      = 0x92 /* 2 op, ULEB128 reg; SLEB128 off */
-	opPiece      = 0x93 /* 1 op, ULEB128 size of piece */
-	opDerefSize  = 0x94 /* 1-byte size of data retrieved */
-	opXderefSize = 0x95 /* 1-byte size of data retrieved */
-	opNop        = 0x96
+	/* opRegx       = 0x90 */ /* 1 op, ULEB128 register */
+	/* opFbreg      = 0x91 */ /* 1 op, SLEB128 offset */
+	/* opBregx      = 0x92 */ /* 2 op, ULEB128 reg; SLEB128 off */
+	/* opPiece      = 0x93 */ /* 1 op, ULEB128 size of piece */
+	/* opDerefSize  = 0x94 */ /* 1-byte size of data retrieved */
+	/* opXderefSize = 0x95 */ /* 1-byte size of data retrieved */
+	/* opNop        = 0x96 */
 	/* next four new in Dwarf v3 */
-	opPushObjAddr = 0x97
-	opCall2       = 0x98 /* 2-byte offset of DIE */
-	opCall4       = 0x99 /* 4-byte offset of DIE */
-	opCallRef     = 0x9A /* 4- or 8- byte offset of DIE */
+	/* opPushObjAddr = 0x97 */
+	/* opCall2       = 0x98 */ /* 2-byte offset of DIE */
+	/* opCall4       = 0x99 */ /* 4-byte offset of DIE */
+	/* opCallRef     = 0x9A */ /* 4- or 8- byte offset of DIE */
 	/* 0xE0-0xFF reserved for user-specific */
 )
 

--- a/cmd/go-cloud-debug-agent/internal/debug/dwarf/frame.go
+++ b/cmd/go-cloud-debug-agent/internal/debug/dwarf/frame.go
@@ -39,7 +39,7 @@ func (d *Data) PCToSPOffset(pc uint64) (offset int64, err error) {
 		return 0, fmt.Errorf("PCToSPOffset: no info section")
 	}
 	buf := makeBuf(d, &d.unit[0], "frame", 0, d.frame)
-	for len(buf.data) > 0 {
+	if len(buf.data) > 0 {
 		offset, err := m.evalCompilationUnit(&buf, pc)
 		if err != nil {
 			return 0, err
@@ -144,10 +144,10 @@ func (m *frameMachine) parseCIE(allBuf *buf) error {
 	if m.version >= 4 {
 		m.addressSize = b.uint8()
 		m.segmentSize = b.uint8()
-	} else {
-		// Unused. Gc generates version 3, so these values will not be
-		// set, but they are also not used so it's OK.
-	}
+	} // else {
+	// Unused. Gc generates version 3, so these values will not be
+	// set, but they are also not used so it's OK.
+	// }
 	m.codeAlignmentFactor = b.uint()
 	m.dataAlignmentFactor = b.int()
 	m.returnAddressRegister = int(b.uint())
@@ -232,7 +232,7 @@ func (m *frameMachine) run(b *buf, pc uint64) (int64, error) {
 			continue
 		case frameRestore: // (6.4.2.3)
 			// register in low bits
-			return 0, fmt.Errorf("unimplemented frameRestore(R%d)\n", op&0x3F)
+			return 0, fmt.Errorf("unimplemented frameRestore(R%d)", op&0x3F)
 		}
 
 		// The remaining ops do not have embedded operands.

--- a/cmd/go-cloud-debug-agent/internal/debug/dwarf/typeunit.go
+++ b/cmd/go-cloud-debug-agent/internal/debug/dwarf/typeunit.go
@@ -138,7 +138,7 @@ type typeUnitReader struct {
 func (tur *typeUnitReader) Seek(off Offset) {
 	tur.err = nil
 	doff := off - tur.tu.off
-	if doff < 0 || doff >= Offset(len(tur.tu.data)) {
+	if doff > off || doff >= Offset(len(tur.tu.data)) {
 		tur.err = fmt.Errorf("%s: offset %d out of range; max %d", tur.tu.name, doff, len(tur.tu.data))
 		return
 	}

--- a/cmd/go-cloud-debug-agent/internal/debug/elf/file.go
+++ b/cmd/go-cloud-debug-agent/internal/debug/elf/file.go
@@ -1004,7 +1004,6 @@ func (f *File) applyRelocationsRISCV64(dst []byte, rels []byte) error {
 		sym := &symbols[symNo-1]
 		switch SymType(sym.Info & 0xf) {
 		case STT_SECTION, STT_NOTYPE:
-			break
 		default:
 			continue
 		}
@@ -1053,7 +1052,6 @@ func (f *File) applyRelocationss390x(dst []byte, rels []byte) error {
 		sym := &symbols[symNo-1]
 		switch SymType(sym.Info & 0xf) {
 		case STT_SECTION, STT_NOTYPE:
-			break
 		default:
 			continue
 		}


### PR DESCRIPTION
refs: #1765

The following errors are fixed in this PR:

```
➜  go-cloud-debug-agent git:(staticcheck) ✗ staticcheck -go 1.15 ./...
internal/breakpoints/breakpoints_test.go:34:2: var testBadPC is unused (U1000)
internal/controller/client.go:99:12: cd.New is deprecated: please use NewService instead. To provide a custom HTTP client, use option.WithHTTPClient. If you are using google.golang.org/api/googleapis/transport.APIKey, use option.WithAPIKey with NewService instead.  (SA1019)
internal/controller/client_test.go:177:5: this value of list is never used (SA4006)
internal/controller/client_test.go:192:5: this value of list is never used (SA4006)
internal/controller/client_test.go:199:5: this value of list is never used (SA4006)
internal/controller/client_test.go:206:5: this value of list is never used (SA4006)
internal/debug/dwarf/const.go:450:2: const opReg0 is unused (U1000)
internal/debug/dwarf/const.go:452:2: const opBreg0 is unused (U1000)
internal/debug/dwarf/const.go:454:2: const opRegx is unused (U1000)
internal/debug/dwarf/const.go:455:2: const opFbreg is unused (U1000)
internal/debug/dwarf/const.go:456:2: const opBregx is unused (U1000)
internal/debug/dwarf/const.go:457:2: const opPiece is unused (U1000)
internal/debug/dwarf/const.go:458:2: const opDerefSize is unused (U1000)
internal/debug/dwarf/const.go:459:2: const opXderefSize is unused (U1000)
internal/debug/dwarf/const.go:460:2: const opNop is unused (U1000)
internal/debug/dwarf/const.go:462:2: const opPushObjAddr is unused (U1000)
internal/debug/dwarf/const.go:463:2: const opCall2 is unused (U1000)
internal/debug/dwarf/const.go:464:2: const opCall4 is unused (U1000)
internal/debug/dwarf/const.go:465:2: const opCallRef is unused (U1000)
internal/debug/dwarf/frame.go:47:3: the surrounding loop is unconditionally terminated (SA4004)
internal/debug/dwarf/frame.go:147:9: empty branch (SA9003)
internal/debug/dwarf/frame.go:235:14: error strings should not end with punctuation or newlines (ST1005)
internal/debug/dwarf/typeunit.go:141:5: no value of type uint32 is less than 0 (SA4003)
internal/debug/elf/file.go:1007:4: ineffective break statement. Did you mean to break out of the outer loop? (SA4011)
internal/debug/elf/file.go:1056:4: ineffective break statement. Did you mean to break out of the outer loop? (SA4011)
```