### PR TITLE
chore(storage): refactor emulator tests, resolve some TODOs

### DIFF
--- a/storage/bucket.go
+++ b/storage/bucket.go
@@ -920,11 +920,9 @@ func (b *BucketAttrs) toProtoBucket() *storagepb.Bucket {
 				Enabled: true,
 			}
 		}
-		// TODO(noahdietz): This will be switched to a string.
-		//
-		// if b.PublicAccessPrevention != PublicAccessPreventionUnknown {
-		// 	bktIAM.PublicAccessPrevention = b.PublicAccessPrevention.String()
-		// }
+		if b.PublicAccessPrevention != PublicAccessPreventionUnknown {
+			bktIAM.PublicAccessPrevention = b.PublicAccessPrevention.String()
+		}
 	}
 
 	return &storagepb.Bucket{

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -29,8 +29,6 @@ import (
 var emulatorClients map[string]storageClient
 
 func TestCreateBucketEmulated(t *testing.T) {
-	checkEmulatorEnvironment(t)
-
 	transportClientTest(t, func(t *testing.T, project, bucket string, client storageClient) {
 		want := &BucketAttrs{
 			Name: bucket,
@@ -50,8 +48,6 @@ func TestCreateBucketEmulated(t *testing.T) {
 }
 
 func TestDeleteBucketEmulated(t *testing.T) {
-	checkEmulatorEnvironment(t)
-
 	transportClientTest(t, func(t *testing.T, project, bucket string, client storageClient) {
 		b := &BucketAttrs{
 			Name: bucket,
@@ -70,8 +66,6 @@ func TestDeleteBucketEmulated(t *testing.T) {
 }
 
 func TestGetBucketEmulated(t *testing.T) {
-	checkEmulatorEnvironment(t)
-
 	transportClientTest(t, func(t *testing.T, project, bucket string, client storageClient) {
 		want := &BucketAttrs{
 			Name: bucket,
@@ -92,8 +86,6 @@ func TestGetBucketEmulated(t *testing.T) {
 }
 
 func TestGetSetTestIamPolicyEmulated(t *testing.T) {
-	checkEmulatorEnvironment(t)
-
 	transportClientTest(t, func(t *testing.T, project, bucket string, client storageClient) {
 		battrs, err := client.CreateBucket(context.Background(), project, &BucketAttrs{
 			Name: bucket,
@@ -158,8 +150,11 @@ func initEmulatorClients() func() error {
 
 // transportClienttest executes the given function with a sub-test, a project name
 // based on the transport, a unique bucket name also based on the transport, and
-// the transport-specific client to run the test with.
+// the transport-specific client to run the test with. It also checks the environment
+// to ensure it is suitable for emulator-based tests, or skips.
 func transportClientTest(t *testing.T, test func(*testing.T, string, string, storageClient)) {
+	checkEmulatorEnvironment(t)
+
 	for transport, client := range emulatorClients {
 		t.Run(transport, func(t *testing.T) {
 			project := fmt.Sprintf("%s-project", transport)

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -39,10 +39,10 @@ func TestCreateBucketEmulated(t *testing.T) {
 		}
 		want.Location = "US"
 		if diff := cmp.Diff(got.Name, want.Name); diff != "" {
-			t.Fatalf("got(-),want(+):\n%s", diff)
+			t.Errorf("got(-),want(+):\n%s", diff)
 		}
 		if diff := cmp.Diff(got.Location, want.Location); diff != "" {
-			t.Fatalf("got(-),want(+):\n%s", diff)
+			t.Errorf("got(-),want(+):\n%s", diff)
 		}
 	})
 }
@@ -55,12 +55,12 @@ func TestDeleteBucketEmulated(t *testing.T) {
 		// Create the bucket that will be deleted.
 		_, err := client.CreateBucket(context.Background(), project, b)
 		if err != nil {
-			t.Fatalf("error on CreateBucket %v", err)
+			t.Fatalf("client.CreateBucket: %v", err)
 		}
 		// Delete the bucket that was just created.
 		err = client.DeleteBucket(context.Background(), b.Name, nil)
 		if err != nil {
-			t.Fatalf("error on DeleteBucket %v", err)
+			t.Fatalf("client.DeleteBucket: %v", err)
 		}
 	})
 }
@@ -73,14 +73,14 @@ func TestGetBucketEmulated(t *testing.T) {
 		// Create the bucket that will be retrieved.
 		_, err := client.CreateBucket(context.Background(), project, want)
 		if err != nil {
-			t.Fatalf("error on CreateBucket %v", err)
+			t.Fatalf("client.CreateBucket: %v", err)
 		}
 		got, err := client.GetBucket(context.Background(), want.Name, &BucketConditions{MetagenerationMatch: 1})
 		if err != nil {
 			t.Fatal(err)
 		}
 		if diff := cmp.Diff(got.Name, want.Name); diff != "" {
-			t.Fatalf("got(-),want(+):\n%s", diff)
+			t.Errorf("got(-),want(+):\n%s", diff)
 		}
 	})
 }
@@ -91,26 +91,26 @@ func TestGetSetTestIamPolicyEmulated(t *testing.T) {
 			Name: bucket,
 		})
 		if err != nil {
-			t.Fatalf("error on CreateBucket %v", err)
+			t.Fatalf("client.CreateBucket: %v", err)
 		}
 		got, err := client.GetIamPolicy(context.Background(), battrs.Name, 0)
 		if err != nil {
-			t.Fatalf("error on GetIamPolicy %v", err)
+			t.Fatalf("client.GetIamPolicy: %v", err)
 		}
 		err = client.SetIamPolicy(context.Background(), battrs.Name, &iampb.Policy{
 			Etag:     got.GetEtag(),
 			Bindings: []*iampb.Binding{{Role: "roles/viewer", Members: []string{"allUsers"}}},
 		})
 		if err != nil {
-			t.Fatalf("error on SetIamPolicy %v", err)
+			t.Fatalf("client.SetIamPolicy: %v", err)
 		}
 		want := []string{"storage.foo", "storage.bar"}
 		perms, err := client.TestIamPermissions(context.Background(), battrs.Name, want)
 		if err != nil {
-			t.Fatalf("error on TestIamPermissions %v", err)
+			t.Fatalf("client.TestIamPermissions: %v", err)
 		}
 		if diff := cmp.Diff(perms, want); diff != "" {
-			t.Fatalf("got(-),want(+):\n%s", diff)
+			t.Errorf("got(-),want(+):\n%s", diff)
 		}
 	})
 }

--- a/storage/grpc_client.go
+++ b/storage/grpc_client.go
@@ -123,13 +123,11 @@ func (c *grpcStorageClient) CreateBucket(ctx context.Context, project string, at
 	}
 
 	req := &storagepb.CreateBucketRequest{
-		Parent:   toProjectResource(project),
-		Bucket:   b,
-		BucketId: b.GetName(),
-		// TODO(noahdietz): This will be switched to a string.
-		//
-		// PredefinedAcl: attrs.PredefinedACL,
-		// PredefinedDefaultObjectAcl: attrs.PredefinedDefaultObjectACL,
+		Parent:                     toProjectResource(project),
+		Bucket:                     b,
+		BucketId:                   b.GetName(),
+		PredefinedAcl:              attrs.PredefinedACL,
+		PredefinedDefaultObjectAcl: attrs.PredefinedDefaultObjectACL,
 	}
 
 	var battrs *BucketAttrs


### PR DESCRIPTION
Resolve TODOs around use of predefined ACL strings in proto-based code.

Refactor emulator tests to run as sub-tests, and push boilerplate code into helper function.