### PR TITLE
chore(internal/gapicgen): update microgenerator to v0.28.0

### DIFF
--- a/internal/gapicgen/cmd/genbot/Dockerfile
+++ b/internal/gapicgen/cmd/genbot/Dockerfile
@@ -27,7 +27,7 @@ RUN go install github.com/golang/protobuf/protoc-gen-go@v1.5.2 && \
     go install golang.org/x/lint/golint@latest && \
     go install golang.org/x/tools/cmd/goimports@latest && \
     go install honnef.co/go/tools/cmd/staticcheck@latest && \
-    go install github.com/googleapis/gapic-generator-go/cmd/protoc-gen-go_gapic@v0.26.0
+    go install github.com/googleapis/gapic-generator-go/cmd/protoc-gen-go_gapic@v0.28.0
 ENV PATH="${PATH}:/root/go/bin"
 
 # Source: http://debuggable.com/posts/disable-strict-host-checking-for-git-clone:49896ff3-0ac0-4263-9703-1eae4834cda3


### PR DESCRIPTION
v0.28.0:
- regapic automatic header injection
- regapic gax.WithPath override support
- regapic handle url.Parse errors

v0.27.0:
- dependency updates
- bazel workspace refactor
- regapic server streaming support