### PR TITLE
feat(pubsub): deprecate synchronous mode

### DIFF
--- a/pubsub/subscription.go
+++ b/pubsub/subscription.go
@@ -553,12 +553,18 @@ type ReceiveSettings struct {
 	// processed concurrently, set MaxOutstandingMessages.
 	NumGoroutines int
 
-	// If Synchronous is true, then no more than MaxOutstandingMessages will be in
-	// memory at one time. (In contrast, when Synchronous is false, more than
-	// MaxOutstandingMessages may have been received from the service and in memory
-	// before being processed.) MaxOutstandingBytes still refers to the total bytes
-	// processed, rather than in memory. NumGoroutines is ignored.
+	// Synchronous switches the underlying receiving mechanism to unary Pull.
+	// When Synchronous is false, the more performance StreamingPull is used.
+	// When in Synchronous mode, NumGoroutines is set to 1 and only one outstanding
+	// RPC will be made to poll messages.
 	// The default is false.
+	//
+	// Deprecated.
+	// Previously, users might use Synchronous mode since StreamingPull had a limitation
+	// where MaxOutstandingMessages was not always respected with large batches of
+	// small messsages. With server side flow control, this is no longer an issue
+	// and we recommend switching to the default StreamingPull mode by setting
+	// Synchronous to false.
 	Synchronous bool
 }
 


### PR DESCRIPTION
The Go Pub/Sub library is the only official Pub/Sub library that offers `Synchronous` mode, which switches the underlying poll mechanism to the unary Pull instead of the streaming StreamingPull API. This was significant in the past since StreamingPull had the limitation of "overpulling" from the server, since flow control was not respected on the server. Now that server side flow control has been out for a while, we are recommending to users to always use the more performant StreamingPull (or the default Synchronous = false) and will be removing `Synchronous` in a later version of the library.

Also fixes #5012 by updating the synchronous mode documentation.