### PR TITLE
fix(pubsub): enable updating enable_exactly_once_delivery in fake pubsub

### DIFF
--- a/pubsub/pstest/fake.go
+++ b/pubsub/pstest/fake.go
@@ -617,6 +617,9 @@ func (s *GServer) UpdateSubscription(_ context.Context, req *pb.UpdateSubscripti
 		case "filter":
 			sub.proto.Filter = req.Subscription.Filter
 
+		case "enable_exactly_once_delivery":
+			sub.proto.EnableExactlyOnceDelivery = req.Subscription.EnableExactlyOnceDelivery
+
 		default:
 			return nil, status.Errorf(codes.InvalidArgument, "unknown field name %q", path)
 		}


### PR DESCRIPTION
**Client**

PubSub

**Go Environment**

go version go1.17.1 linux/amd64

**Description**

The testing fake pubsub implementation does not yet support the new enable_exactly_once_delivery field in the UpdateSubscription method.

**Expected behavior**

When a Subscription is updated to set EnableExactlyOnceDelivery with UpdateSubscription, the RPC should not return an error and the subscription should be modified.

**Actual behavior**

The RPC returns InvalidArgument with: unknown field name "enable_exactly_once_delivery"