### PR TITLE
refactor(pubsublite): remove usages of xerrors

### DIFF
--- a/pubsublite/go.mod
+++ b/pubsublite/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/googleapis/gax-go/v2 v2.3.0
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
-	golang.org/x/xerrors v0.0.0-20220411194840-2f41105eb62f
+	golang.org/x/xerrors v0.0.0-20220411194840-2f41105eb62f // indirect
 	google.golang.org/api v0.74.0
 	google.golang.org/genproto v0.0.0-20220413183235-5e96e2839df9
 	google.golang.org/grpc v1.45.0

--- a/pubsublite/internal/test/util.go
+++ b/pubsublite/internal/test/util.go
@@ -14,12 +14,12 @@
 package test
 
 import (
+	"errors"
 	"log"
 	"strings"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"golang.org/x/xerrors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
@@ -28,7 +28,7 @@ import (
 
 // ErrorEqual compares two errors for equivalence.
 func ErrorEqual(got, want error) bool {
-	if xerrors.Is(got, want) {
+	if errors.Is(got, want) {
 		return true
 	}
 	return cmp.Equal(got, want, cmpopts.EquateErrors())

--- a/pubsublite/internal/wire/errors.go
+++ b/pubsublite/internal/wire/errors.go
@@ -16,8 +16,6 @@ package wire
 import (
 	"errors"
 	"fmt"
-
-	"golang.org/x/xerrors"
 )
 
 // Errors exported from this package.
@@ -51,7 +49,7 @@ var (
 
 func wrapError(context, resource string, err error) error {
 	if err != nil {
-		return xerrors.Errorf("%s(%s): %w", context, resource, err)
+		return fmt.Errorf("%s(%s): %w", context, resource, err)
 	}
 	return err
 }

--- a/pubsublite/internal/wire/partition_count.go
+++ b/pubsublite/internal/wire/partition_count.go
@@ -18,8 +18,6 @@ import (
 	"fmt"
 	"time"
 
-	"golang.org/x/xerrors"
-
 	vkit "cloud.google.com/go/pubsublite/apiv1"
 	gax "github.com/googleapis/gax-go/v2"
 	pb "google.golang.org/genproto/googleapis/cloud/pubsublite/v1"
@@ -121,7 +119,7 @@ func (p *partitionCountWatcher) updatePartitionCount() {
 				// TODO: Log the error.
 				return p.partitionCount, nil
 			}
-			err = xerrors.Errorf("pubsublite: failed to update topic partition count: %w", rt.ResolveError(err))
+			err = fmt.Errorf("pubsublite: failed to update topic partition count: %w", rt.ResolveError(err))
 			p.unsafeInitiateShutdown(err)
 			return 0, err
 		}

--- a/pubsublite/internal/wire/publish_batcher.go
+++ b/pubsublite/internal/wire/publish_batcher.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 	"fmt"
 
-	"golang.org/x/xerrors"
 	"google.golang.org/api/support/bundler"
 	"google.golang.org/protobuf/proto"
 
@@ -115,7 +114,7 @@ func (b *publishMessageBatcher) AddMessage(msg *pb.PubSubMessage, onResult Publi
 	msgSize := proto.Size(msg)
 	switch {
 	case msgSize > MaxPublishRequestBytes:
-		return xerrors.Errorf("pubsublite: serialized message size is %d bytes: %w", msgSize, ErrOversizedMessage)
+		return fmt.Errorf("pubsublite: serialized message size is %d bytes: %w", msgSize, ErrOversizedMessage)
 	case msgSize > b.availableBufferBytes:
 		return ErrOverflow
 	}

--- a/pubsublite/internal/wire/publish_batcher_test.go
+++ b/pubsublite/internal/wire/publish_batcher_test.go
@@ -15,13 +15,13 @@ package wire
 
 import (
 	"bytes"
+	"errors"
 	"testing"
 	"time"
 
 	"cloud.google.com/go/internal/testutil"
 	"cloud.google.com/go/pubsublite/internal/test"
 	"github.com/google/go-cmp/cmp"
-	"golang.org/x/xerrors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
@@ -188,7 +188,7 @@ func TestPublishBatcherAddMessage(t *testing.T) {
 
 	t.Run("oversized message", func(t *testing.T) {
 		msg := &pb.PubSubMessage{Data: bytes.Repeat([]byte{'0'}, MaxPublishRequestBytes)}
-		if gotErr := batcher.AddMessage(msg, nil); !xerrors.Is(gotErr, ErrOversizedMessage) {
+		if gotErr := batcher.AddMessage(msg, nil); !errors.Is(gotErr, ErrOversizedMessage) {
 			t.Errorf("AddMessage(%v) got err: %v, want err: %q", msg, gotErr, ErrOversizedMessage)
 		}
 	})

--- a/pubsublite/internal/wire/streams.go
+++ b/pubsublite/internal/wire/streams.go
@@ -15,12 +15,12 @@ package wire
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"reflect"
 	"sync"
 	"time"
 
-	"golang.org/x/xerrors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -362,7 +362,7 @@ func (rs *retryableStream) initNewStream() (newStream grpc.ClientStream, err err
 			break
 		}
 		if r.ExceededDeadline() {
-			err = xerrors.Errorf("%v: %w", err, ErrBackendUnavailable)
+			err = fmt.Errorf("%v: %w", err, ErrBackendUnavailable)
 			break
 		}
 		if err = gax.Sleep(rs.ctx, backoff); err != nil {

--- a/pubsublite/pscompat/example_test.go
+++ b/pubsublite/pscompat/example_test.go
@@ -15,6 +15,7 @@ package pscompat_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -22,7 +23,6 @@ import (
 	"cloud.google.com/go/pubsub"
 	"cloud.google.com/go/pubsublite/pscompat"
 	"golang.org/x/sync/errgroup"
-	"golang.org/x/xerrors"
 )
 
 func ExamplePublisherClient_Publish() {
@@ -145,7 +145,7 @@ func ExamplePublisherClient_Publish_errorHandling() {
 				// created to republish failed messages.
 				fmt.Printf("Publish error: %v\n", err)
 				// Oversized messages cannot be published.
-				if !xerrors.Is(err, pscompat.ErrOversizedMessage) {
+				if !errors.Is(err, pscompat.ErrOversizedMessage) {
 					mu.Lock()
 					toRepublish = append(toRepublish, msg)
 					mu.Unlock()
@@ -159,9 +159,9 @@ func ExamplePublisherClient_Publish_errorHandling() {
 	if err := g.Wait(); err != nil {
 		fmt.Printf("Publisher client terminated due to error: %v\n", publisher.Error())
 		switch {
-		case xerrors.Is(publisher.Error(), pscompat.ErrBackendUnavailable):
+		case errors.Is(publisher.Error(), pscompat.ErrBackendUnavailable):
 			// TODO: Create a new publisher client to republish failed messages.
-		case xerrors.Is(publisher.Error(), pscompat.ErrOverflow):
+		case errors.Is(publisher.Error(), pscompat.ErrOverflow):
 			// TODO: Create a new publisher client to republish failed messages.
 			// Throttle publishing. Note that backend unavailability can also cause
 			// buffer overflow before the ErrBackendUnavailable error.
@@ -217,7 +217,7 @@ func ExampleSubscriberClient_Receive_errorHandling() {
 		})
 		if err != nil {
 			fmt.Printf("Subscriber client stopped receiving due to error: %v\n", err)
-			if xerrors.Is(err, pscompat.ErrBackendUnavailable) {
+			if errors.Is(err, pscompat.ErrBackendUnavailable) {
 				// TODO: Alert if necessary. Receive can be retried.
 			} else {
 				// TODO: Handle fatal error.


### PR DESCRIPTION
Remove usages of `xerrors` in `pubsublite` now that the minimum supported Go version has increased.