### PR TITLE
test(spanner): skip flaky test for oc_stats  with PG dialect.

### DIFF
--- a/spanner/integration_test.go
+++ b/spanner/integration_test.go
@@ -4028,6 +4028,12 @@ func onlyRunForPGTest(t *testing.T) {
 	}
 }
 
+func skipForPGTest(t *testing.T) {
+	if testDialect == adminpb.DatabaseDialect_POSTGRESQL {
+		t.Skip("Skipping tests non needed for Postgres dialect.")
+	}
+}
+
 func verifyDirectPathRemoteAddress(t *testing.T) {
 	t.Helper()
 	if !dpConfig.attemptDirectPath {

--- a/spanner/oc_test.go
+++ b/spanner/oc_test.go
@@ -51,6 +51,7 @@ func TestOCStats(t *testing.T) {
 }
 
 func TestOCStats_SessionPool(t *testing.T) {
+	skipForPGTest(t)
 	DisableGfeLatencyAndHeaderMissingCountViews()
 	for _, test := range []struct {
 		name    string


### PR DESCRIPTION
Fix: https://github.com/googleapis/google-cloud-go/issues/5871

For PG dialect support there was no change made in open-census stats flow, hence no need to run separate test with PG dialect, since the test run in parallel so it's causing flaky issues when checking common tags. This PR will skip the not needed tests.