### PR TITLE
fix(profiler): relax service name regexp to allow service name to start with number

### DIFF
--- a/profiler/profiler.go
+++ b/profiler/profiler.go
@@ -80,7 +80,7 @@ var (
 	sleep            = gax.Sleep
 	dialGRPC         = gtransport.DialPool
 	onGCE            = gcemd.OnGCE
-	serviceRegexp    = regexp.MustCompile(`^[a-z]([-a-z0-9_.]{0,253}[a-z0-9])?$`)
+	serviceRegexp    = regexp.MustCompile(`^[a-z0-9]([-a-z0-9_.]{0,253}[a-z0-9])?$`)
 
 	// For testing only.
 	// When the profiling loop has exited without error and this channel is

--- a/profiler/profiler_test.go
+++ b/profiler/profiler_test.go
@@ -504,9 +504,19 @@ func TestInitializeConfig(t *testing.T) {
 		envProjectID    bool
 	}{
 		{
-			"accepts service name",
-			Config{Service: testService},
-			Config{Service: testService, ProjectID: testGCEProjectID, Zone: testZone, Instance: testInstance},
+			"accepts service name starting with letter",
+			Config{Service: "test-service-1"},
+			Config{Service: "test-service-1", ProjectID: testGCEProjectID, Zone: testZone, Instance: testInstance},
+			"",
+			false,
+			false,
+			true,
+			false,
+		},
+		{
+			"accepts service name starting number",
+			Config{Service: "12service"},
+			Config{Service: "12service", ProjectID: testGCEProjectID, Zone: testZone, Instance: testInstance},
 			"",
 			false,
 			false,
@@ -537,7 +547,7 @@ func TestInitializeConfig(t *testing.T) {
 			"requires valid service name",
 			Config{Service: "Service"},
 			Config{Service: "Service"},
-			"service name \"Service\" does not match regular expression ^[a-z]([-a-z0-9_.]{0,253}[a-z0-9])?$",
+			"service name \"Service\" does not match regular expression ^[a-z0-9]([-a-z0-9_.]{0,253}[a-z0-9])?$",
 			false,
 			false,
 			true,


### PR DESCRIPTION
With this change, profiling agents can be run with App Engine applications whose service names start with number.