### PR TITLE
docs: add Google Cloud Samples browser link to readme template

### DIFF
--- a/internal/gapicgen/generator/_README.md.txt
+++ b/internal/gapicgen/generator/_README.md.txt
@@ -21,7 +21,7 @@ However, a `v1+` module may have breaking changes in two scenarios:
 
 ## Google Cloud Samples
 
-To browse ready to use code samples check [Google Cloud Samples](https://cloud.google.com/docs/samples).
+To browse ready to use code samples check [Google Cloud Samples](https://cloud.google.com/docs/samples?l=go).
 
 ## Go Version Support
 


### PR DESCRIPTION
Adding a generic Google Code Sample link to readme template.

This is for the benefit of the users, in navigating available Google Cloud code samples.