### PR TITLE
feat(logging): support structured logging functionality

### DIFF
--- a/logging/README.md
+++ b/logging/README.md
@@ -28,8 +28,16 @@ logger := client.Logger("my-log")
 logger.Log(logging.Entry{Payload: "something happened!"})
 ```
 
-Close your client before your program exits, to flush any buffered log entries.
+If you need to write a critical log entry use synchronous ingestion method.
 [snip]:# (logging-3)
+
+```go
+logger := client.Logger("my-log")
+logger.LogSync(context.Background(), logging.Entry{Payload: "something happened!"})
+```
+
+Close your client before your program exits, to flush any buffered log entries.
+[snip]:# (logging-4)
 
 ```go
 err = client.Close()
@@ -37,3 +45,21 @@ if err != nil {
    // TODO: Handle error.
 }
 ```
+
+### Logger configuration options
+
+Creating a Logger using `logging.Logger` accept configuration [LoggerOption](loggeroption.go#L25) arguments. The following options are supported:
+
+| Configuration option | Arguments | Description |
+| -------------------- | --------- | ----------- |
+| CommonLabels | `map[string]string` | The set of labels that will be ingested for all log entries ingested by Logger. |
+| ConcurrentWriteLimit | `int` | Number of parallel goroutine the Logger will use to ingest logs asynchronously. High number of routines may exhaust API quota. The default is 1. |
+| DelayThreshold | `time.Duration` | Maximum time a log entry is buffered on client before being ingested. The default is 1 second. |
+| EntryCountThreshold | `int` | Maximum number of log entries to be buffered on client before being ingested. The default is 1000. |
+| EntryByteThreshold | `int` | Maximum size in bytes of log entries to be buffered on client before being ingested. The default is 8MiB. |
+| EntryByteLimit | `int` | Maximum size in bytes of the single write call to ingest log entries. If EntryByteLimit is smaller than EntryByteThreshold, the latter has no effect. The default is zero, meaning there is no limit. |
+| BufferedByteLimit | `int` | Maximum number of bytes that the Logger will keep in memory before returning ErrOverflow. This option limits the total memory consumption of the Logger (but note that each Logger has its own, separate limit). It is possible to reach BufferedByteLimit even if it is larger than EntryByteThreshold or EntryByteLimit, because calls triggered by the latter two options may be enqueued (and hence occupying memory) while new log entries are being added. |
+| ContextFunc | `func() (ctx context.Context, afterCall func())` | Callback function to be called to obtain `context.Context` during async log ingestion. |
+| SourceLocationPopulation | One of `logging.DoNotPopulateSourceLocation`, `logging.PopulateSourceLocationForDebugEntries` or `logging.AlwaysPopulateSourceLocation` | Controls auto-population of the logging.Entry.SoourceLocation field when ingesting log entries. Allows to disable population of source location info, allowing it only for log entries at Debug severity or enable it for all log entries. Enabling it for all entries may result in degradation in performance. Use `logging_test.BenchmarkSourceLocationPopulation` to test performance with and without the option. The default is set to `logging.DoNotPopulateSourceLocation`. |
+| PartialSuccess | | Make each write call to Logging service with [partialSuccess flag](https://cloud.google.com/logging/docs/reference/v2/rest/v2/entries/write#body.request_body.FIELDS.partial_success) set. The default is to make calls without setting the flag. |
+| RedirectAsJSON | `io.Writer` | Converts log entries to Jsonified one line string according to the [structured logging format](https://cloud.google.com/logging/docs/structured-logging#special-payload-fields) and writes it to provided `io.Writer`. Users should use this option with `os.Stdout` and `os.Stderr` to leverage the out-of-process ingestion of logs using logging agents that are deployed in Cloud Logging environments. |

--- a/logging/doc.go
+++ b/logging/doc.go
@@ -68,6 +68,18 @@ not recommended for normal use.
 	}
 
 
+Redirecting log ingestion
+
+Google Cloud environments support ingesting logs from standard output including stdout and stderr when logs are formatted
+as a one line Json following the supported structured log format.
+Use RedirectAsJSON() LoggerOption`s to create a Logger that writes formatted logs to provider io.Writer. Use it with os.Stdout
+and os.Stderr to redirect logs to Stdout and Stderr respectively.
+See https://cloud.google.com/logging/docs/structured-logging#special-payload-fields for the format description.
+
+	// Create a logger to print structured logs formatted as a single line Json to stdout
+	loggger := client.Logger("test-log", RedirectAsJSON(os.Stdout))
+
+
 Payloads
 
 An entry payload can be a string, as in the examples above. It can also be any value

--- a/logging/doc.go
+++ b/logging/doc.go
@@ -70,11 +70,14 @@ not recommended for normal use.
 
 Redirecting log ingestion
 
-Google Cloud environments support ingesting logs from standard output including stdout and stderr when logs are formatted
-as a one line Json following the supported structured log format.
-Use RedirectAsJSON() LoggerOption`s to create a Logger that writes formatted logs to provider io.Writer. Use it with os.Stdout
-and os.Stderr to redirect logs to Stdout and Stderr respectively.
+For cases when runtime environment supports out-of-process log ingestion,
+like logging agent, you can opt-in to write log entries to io.Writer instead of
+ingesting them to Cloud Logging service. Usually, you will use os.Stdout or os.Stderr as
+writers because Google Cloud logging agents are configured to capture logs from standard output.
+The entries will be Jsonified and wrote as one line strings following the structured logging format.
 See https://cloud.google.com/logging/docs/structured-logging#special-payload-fields for the format description.
+To instruct Logger to redirect log entries add RedirectAsJSON() LoggerOption`s.
+
 
 	// Create a logger to print structured logs formatted as a single line Json to stdout
 	loggger := client.Logger("test-log", RedirectAsJSON(os.Stdout))
@@ -96,6 +99,16 @@ If you have a []byte of JSON, wrap it in json.RawMessage:
 	j := []byte(`{"Name": "Bob", "Count": 3}`)
 	lg.Log(logging.Entry{Payload: json.RawMessage(j)})
 
+If you have proto.Message and want to send it as a protobuf payload, marshal it to anypb.Any:
+
+	// import
+    func logMessage (m proto.Message) {
+		var payload anypb.Any
+		err := anypb.MarshalFrom(&payload, m)
+		if err != nil {
+			lg.Log(logging.Entry{Payload: payload})
+		}
+	}
 
 The Standard Logger
 

--- a/logging/instrumentation.go
+++ b/logging/instrumentation.go
@@ -1,0 +1,83 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logging
+
+import (
+	"strings"
+
+	"cloud.google.com/go/logging/internal"
+	logpb "google.golang.org/genproto/googleapis/logging/v2"
+)
+
+const diagnosticLogID = "diagnostic-log"
+
+// instrumentationPayload defines telemetry log entry payload for capturing instrumentation info
+type instrumentationPayload struct {
+	InstrumentationSource []map[string]string `json:"instrumentation_source"`
+	Runtime               string              `json:"runtime,omitempty"`
+}
+
+var (
+	instrumentationInfo = &instrumentationPayload{
+		InstrumentationSource: []map[string]string{
+			{
+				"name":    "go",
+				"version": internal.Version,
+			},
+		},
+		Runtime: internal.VersionGo(),
+	}
+)
+
+// instrumentLogs appends log entry with library instrumentation info to the
+// list of log entries on the first function's call.
+func (l *Logger) instrumentLogs(entries []*logpb.LogEntry) ([]*logpb.LogEntry, bool) {
+	var instrumentationAdded bool
+
+	internal.InstrumentOnce.Do(func() {
+		ie, err := l.instrumentationEntry()
+		if err != nil {
+			// do not retry instrumenting logs if failed creating instrumentation entry
+			return
+		}
+		// populate LogName only when  directly ingesting entries
+		if l.redirectOutputWriter == nil {
+			ie.LogName = internal.LogPath(l.client.parent, diagnosticLogID)
+		}
+		entries = append(entries, ie)
+		instrumentationAdded = true
+	})
+	return entries, instrumentationAdded
+}
+
+func (l *Logger) instrumentationEntry() (*logpb.LogEntry, error) {
+	ent := Entry{
+		Payload: map[string]*instrumentationPayload{
+			"logging.googleapis.com/diagnostic": instrumentationInfo,
+		},
+	}
+	// pass nil for Logger and 0 for skip levels to ignore auto-population
+	return toLogEntryInternal(ent, nil, l.client.parent, 0)
+}
+
+// hasInstrumentation returns true if any of the log entries has diagnostic LogId
+func hasInstrumentation(entries []*logpb.LogEntry) bool {
+	for _, ent := range entries {
+		if strings.HasSuffix(ent.LogName, diagnosticLogID) {
+			return true
+		}
+	}
+	return false
+}

--- a/logging/internal/common.go
+++ b/logging/internal/common.go
@@ -16,13 +16,19 @@ package internal
 
 import (
 	"fmt"
+	"runtime"
 	"strings"
+	"sync"
+	"unicode"
 )
 
 const (
 	// ProdAddr is the production address.
 	ProdAddr = "logging.googleapis.com:443"
 )
+
+// InstrumentOnce guards instrumenting logs one time
+var InstrumentOnce = new(sync.Once)
 
 // LogPath creates a formatted path from a parent and a logID.
 func LogPath(parent, logID string) string {
@@ -38,4 +44,41 @@ func LogIDFromPath(parent, path string) string {
 	}
 	logID := path[start:]
 	return strings.Replace(logID, "%2F", "/", -1)
+}
+
+// VersionGo returns the Go runtime version. The returned string
+// has no whitespace, suitable for reporting in header.
+func VersionGo() string {
+	const develPrefix = "devel +"
+
+	s := runtime.Version()
+	if strings.HasPrefix(s, develPrefix) {
+		s = s[len(develPrefix):]
+		if p := strings.IndexFunc(s, unicode.IsSpace); p >= 0 {
+			s = s[:p]
+		}
+		return s
+	}
+
+	notSemverRune := func(r rune) bool {
+		return !strings.ContainsRune("0123456789.", r)
+	}
+
+	if strings.HasPrefix(s, "go1") {
+		s = s[2:]
+		var prerelease string
+		if p := strings.IndexFunc(s, notSemverRune); p >= 0 {
+			s, prerelease = s[:p], s[p:]
+		}
+		if strings.HasSuffix(s, ".") {
+			s += "0"
+		} else if strings.Count(s, ".") < 2 {
+			s += ".0"
+		}
+		if prerelease != "" {
+			s += "-" + prerelease
+		}
+		return s
+	}
+	return "UNKNOWN"
 }

--- a/logging/internal/environment.go
+++ b/logging/internal/environment.go
@@ -1,0 +1,75 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"io/ioutil"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"cloud.google.com/go/compute/metadata"
+)
+
+// ResourceAtttributesGetter abstracts environment lookup methods to query for environment variables, metadata attributes and file content.
+type ResourceAtttributesGetter interface {
+	EnvVar(name string) string
+	Metadata(path string) string
+	ReadAll(path string) string
+}
+
+var getter ResourceAtttributesGetter = &defaultResourceGetter{
+	metaClient: metadata.NewClient(&http.Client{
+		Transport: &http.Transport{
+			Dial: (&net.Dialer{
+				Timeout:   1 * time.Second,
+				KeepAlive: 10 * time.Second,
+			}).Dial,
+		},
+	})}
+
+// ResourceAttributes provides read-only access to the ResourceAtttributesGetter interface implementation.
+func ResourceAttributes() ResourceAtttributesGetter {
+	return getter
+}
+
+type defaultResourceGetter struct {
+	metaClient *metadata.Client
+}
+
+// EnvVar uses os.LookupEnv() to lookup for environment variable by name.
+func (g *defaultResourceGetter) EnvVar(name string) string {
+	return os.Getenv(name)
+}
+
+// Metadata uses metadata package Client.Get() to lookup for metadata attributes by path.
+func (g *defaultResourceGetter) Metadata(path string) string {
+	val, err := g.metaClient.Get(path)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(val)
+}
+
+// ReadAll reads all content of the file as a string.
+func (g *defaultResourceGetter) ReadAll(path string) string {
+	bytes, err := ioutil.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	return string(bytes)
+}

--- a/logging/internal/environment.go
+++ b/logging/internal/environment.go
@@ -25,14 +25,14 @@ import (
 	"cloud.google.com/go/compute/metadata"
 )
 
-// ResourceAtttributesGetter abstracts environment lookup methods to query for environment variables, metadata attributes and file content.
-type ResourceAtttributesGetter interface {
+// ResourceAttributesGetter abstracts environment lookup methods to query for environment variables, metadata attributes and file content.
+type ResourceAttributesGetter interface {
 	EnvVar(name string) string
 	Metadata(path string) string
 	ReadAll(path string) string
 }
 
-var getter ResourceAtttributesGetter = &defaultResourceGetter{
+var getter ResourceAttributesGetter = &defaultResourceGetter{
 	metaClient: metadata.NewClient(&http.Client{
 		Transport: &http.Transport{
 			Dial: (&net.Dialer{
@@ -43,7 +43,7 @@ var getter ResourceAtttributesGetter = &defaultResourceGetter{
 	})}
 
 // ResourceAttributes provides read-only access to the ResourceAtttributesGetter interface implementation.
-func ResourceAttributes() ResourceAtttributesGetter {
+func ResourceAttributes() ResourceAttributesGetter {
 	return getter
 }
 

--- a/logging/loggeroption.go
+++ b/logging/loggeroption.go
@@ -1,0 +1,189 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logging
+
+import (
+	"context"
+	"io"
+	"os"
+	"time"
+)
+
+// LoggerOption is a configuration option for a Logger.
+type LoggerOption interface {
+	set(*Logger)
+}
+
+// CommonLabels are labels that apply to all log entries written from a Logger,
+// so that you don't have to repeat them in each log entry's Labels field. If
+// any of the log entries contains a (key, value) with the same key that is in
+// CommonLabels, then the entry's (key, value) overrides the one in
+// CommonLabels.
+func CommonLabels(m map[string]string) LoggerOption { return commonLabels(m) }
+
+type commonLabels map[string]string
+
+func (c commonLabels) set(l *Logger) { l.commonLabels = c }
+
+// ConcurrentWriteLimit determines how many goroutines will send log entries to the
+// underlying service. The default is 1. Set ConcurrentWriteLimit to a higher value to
+// increase throughput.
+func ConcurrentWriteLimit(n int) LoggerOption { return concurrentWriteLimit(n) }
+
+type concurrentWriteLimit int
+
+func (c concurrentWriteLimit) set(l *Logger) { l.bundler.HandlerLimit = int(c) }
+
+// DelayThreshold is the maximum amount of time that an entry should remain
+// buffered in memory before a call to the logging service is triggered. Larger
+// values of DelayThreshold will generally result in fewer calls to the logging
+// service, while increasing the risk that log entries will be lost if the
+// process crashes.
+// The default is DefaultDelayThreshold.
+func DelayThreshold(d time.Duration) LoggerOption { return delayThreshold(d) }
+
+type delayThreshold time.Duration
+
+func (d delayThreshold) set(l *Logger) { l.bundler.DelayThreshold = time.Duration(d) }
+
+// EntryCountThreshold is the maximum number of entries that will be buffered
+// in memory before a call to the logging service is triggered. Larger values
+// will generally result in fewer calls to the logging service, while
+// increasing both memory consumption and the risk that log entries will be
+// lost if the process crashes.
+// The default is DefaultEntryCountThreshold.
+func EntryCountThreshold(n int) LoggerOption { return entryCountThreshold(n) }
+
+type entryCountThreshold int
+
+func (e entryCountThreshold) set(l *Logger) { l.bundler.BundleCountThreshold = int(e) }
+
+// EntryByteThreshold is the maximum number of bytes of entries that will be
+// buffered in memory before a call to the logging service is triggered. See
+// EntryCountThreshold for a discussion of the tradeoffs involved in setting
+// this option.
+// The default is DefaultEntryByteThreshold.
+func EntryByteThreshold(n int) LoggerOption { return entryByteThreshold(n) }
+
+type entryByteThreshold int
+
+func (e entryByteThreshold) set(l *Logger) { l.bundler.BundleByteThreshold = int(e) }
+
+// EntryByteLimit is the maximum number of bytes of entries that will be sent
+// in a single call to the logging service. ErrOversizedEntry is returned if an
+// entry exceeds EntryByteLimit. This option limits the size of a single RPC
+// payload, to account for network or service issues with large RPCs. If
+// EntryByteLimit is smaller than EntryByteThreshold, the latter has no effect.
+// The default is zero, meaning there is no limit.
+func EntryByteLimit(n int) LoggerOption { return entryByteLimit(n) }
+
+type entryByteLimit int
+
+func (e entryByteLimit) set(l *Logger) { l.bundler.BundleByteLimit = int(e) }
+
+// BufferedByteLimit is the maximum number of bytes that the Logger will keep
+// in memory before returning ErrOverflow. This option limits the total memory
+// consumption of the Logger (but note that each Logger has its own, separate
+// limit). It is possible to reach BufferedByteLimit even if it is larger than
+// EntryByteThreshold or EntryByteLimit, because calls triggered by the latter
+// two options may be enqueued (and hence occupying memory) while new log
+// entries are being added.
+// The default is DefaultBufferedByteLimit.
+func BufferedByteLimit(n int) LoggerOption { return bufferedByteLimit(n) }
+
+type bufferedByteLimit int
+
+func (b bufferedByteLimit) set(l *Logger) { l.bundler.BufferedByteLimit = int(b) }
+
+// ContextFunc is a function that will be called to obtain a context.Context for the
+// WriteLogEntries RPC executed in the background for calls to Logger.Log. The
+// default is a function that always returns context.Background. The second return
+// value of the function is a function to call after the RPC completes.
+//
+// The function is not used for calls to Logger.LogSync, since the caller can pass
+// in the context directly.
+//
+// This option is EXPERIMENTAL. It may be changed or removed.
+func ContextFunc(f func() (ctx context.Context, afterCall func())) LoggerOption {
+	return contextFunc(f)
+}
+
+type contextFunc func() (ctx context.Context, afterCall func())
+
+func (c contextFunc) set(l *Logger) { l.ctxFunc = c }
+
+// SourceLocationPopulation is the flag controlling population of the source location info
+// in the ingested entries. This options allows to configure automatic population of the
+// SourceLocation field for all ingested entries, entries with DEBUG severity or disable it.
+// Note that enabling this option can decrease execution time of Logger.Log and Logger.LogSync
+// by the factor of 2 or larger.
+// The default disables source location population.
+//
+// This option is not used when an entry is created using ToLogEntry.
+func SourceLocationPopulation(f int) LoggerOption {
+	return sourceLocationOption(f)
+}
+
+const (
+	// DoNotPopulateSourceLocation is default for clients when WithSourceLocation is not provided
+	DoNotPopulateSourceLocation = 0
+	// PopulateSourceLocationForDebugEntries is set when WithSourceLocation(PopulateDebugEntries) is provided
+	PopulateSourceLocationForDebugEntries = 1
+	// AlwaysPopulateSourceLocation is set when WithSourceLocation(PopulateAllEntries) is provided
+	AlwaysPopulateSourceLocation = 2
+)
+
+type sourceLocationOption int
+
+func (o sourceLocationOption) set(l *Logger) {
+	if o == DoNotPopulateSourceLocation || o == PopulateSourceLocationForDebugEntries || o == AlwaysPopulateSourceLocation {
+		l.populateSourceLocation = int(o)
+	}
+}
+
+// PartialSuccess sets the partialSuccess flag to true when ingesting a bundle of log entries.
+// See https://cloud.google.com/logging/docs/reference/v2/rest/v2/entries/write#body.request_body.FIELDS.partial_success
+// If not provided the partialSuccess flag is set to false.
+func PartialSuccess() LoggerOption {
+	return &partialSuccessOption{}
+}
+
+type partialSuccessOption struct{}
+
+func (o *partialSuccessOption) set(l *Logger) {
+	l.partialSuccess = true
+}
+
+// RedirectAsJSON instructs Logger to redirect output of calls to Log and LogSync to provided io.Writer instead of ingesting
+// to Cloud Logging. Logger formats log entries following logging agent's Json format.
+// See https://cloud.google.com/logging/docs/structured-logging#special-payload-fields for more info about the format.
+// Use this option to delegate log ingestion to an out-of-process logging agent.
+// If no writer is provided, the redirect is set to stdout.
+func RedirectAsJSON(w io.Writer) LoggerOption {
+	if w == nil {
+		w = os.Stdout
+	}
+	return &redirectOutputOption{
+		writer: w,
+	}
+}
+
+type redirectOutputOption struct {
+	writer io.Writer
+}
+
+func (o *redirectOutputOption) set(l *Logger) {
+	l.redirectOutputWriter = o.writer
+}

--- a/logging/logging_test.go
+++ b/logging/logging_test.go
@@ -1364,10 +1364,3 @@ func ExampleRedirectAsJson_withStdout() {
 	logger.LogSync(context.TODO(), logging.Entry{Timestamp: time.Unix(1000, 0), Severity: logging.Debug, Payload: "redirected log"})
 	// Output: {"message":"redirected log","severity":"DEBUG","timestamp":"seconds:1000"}
 }
-
-func ExampleRedirectAsJson_withStderr() {
-	// use previously created client
-	logger := client.Logger("redirect-to-stdout", logging.RedirectAsJSON(os.Stderr))
-	logger.LogSync(context.TODO(), logging.Entry{Timestamp: time.Unix(1000, 0), Severity: logging.Debug, Payload: "redirected log"})
-	// Output: {"message":"redirected log","severity":"DEBUG","timestamp":"seconds:1000"}
-}

--- a/logging/logging_test.go
+++ b/logging/logging_test.go
@@ -52,6 +52,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/anypb"
 )
 
 const testLogIDPrefix = "GO-LOGGING-CLIENT/TEST-LOG"
@@ -1190,4 +1191,183 @@ func TestPartialSuccessOption(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRedirectOutputIngestion(t *testing.T) {
+	var hookCalled bool
+
+	// setup fake server
+	fakeBackend := &writeLogEntriesTestHandler{}
+	l, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	gsrv := grpc.NewServer()
+	logpb.RegisterLoggingServiceV2Server(gsrv, fakeBackend)
+	fakeServerAddr := l.Addr().String()
+	go func() {
+		if err := gsrv.Serve(l); err != nil {
+			panic(err)
+		}
+	}()
+	fakeBackend.hook = func(e *logpb.WriteLogEntriesRequest) {
+		hookCalled = true
+	}
+	ctx := context.Background()
+	client, _ := logging.NewClient(ctx, "projects/test", option.WithEndpoint(fakeServerAddr),
+		option.WithoutAuthentication(),
+		option.WithGRPCDialOption(grpc.WithInsecure()))
+	defer client.Close()
+
+	entry := logging.Entry{Payload: "testing payload string"}
+	tests := []struct {
+		name   string
+		logger *logging.Logger
+		want   bool
+	}{
+		{
+			name:   "redirect output does not ingest",
+			logger: client.Logger("stdout-redirection-log", logging.RedirectAsJSON(os.Stdout)),
+			want:   false,
+		},
+		{
+			name:   "log without Redirect flags ingest",
+			logger: client.Logger("default-ingestion-log"),
+			want:   true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			hookCalled = false
+			tc.logger.LogSync(context.TODO(), entry)
+			if hookCalled != tc.want {
+				t.Errorf("Log ingestion works unexpected: got %v want %v\n", hookCalled, tc.want)
+			}
+		})
+	}
+}
+
+func TestRedirectOutputFormats(t *testing.T) {
+	testURL, _ := url.Parse("https://example.com/test")
+	tests := []struct {
+		name      string
+		in        *logging.Entry
+		want      string
+		wantError error
+	}{
+		{
+			name: "full data redirect with text payload",
+			in: &logging.Entry{
+				Labels:       map[string]string{"key1": "value1", "key2": "value2"},
+				Timestamp:    testNow().UTC(),
+				Severity:     logging.Debug,
+				InsertID:     "0000AAA01",
+				Trace:        "projects/P/ABCD12345678AB12345678",
+				SpanID:       "000000000001",
+				TraceSampled: true,
+				SourceLocation: &logpb.LogEntrySourceLocation{
+					File:     "acme.go",
+					Function: "main",
+					Line:     100,
+				},
+				Operation: &logpb.LogEntryOperation{
+					Id:       "0123456789",
+					Producer: "test",
+				},
+				HTTPRequest: &logging.HTTPRequest{
+					Request: &http.Request{
+						URL:    testURL,
+						Method: "POST",
+					},
+				},
+				Payload: "this is text payload",
+			},
+			want: `{"message":"this is text payload","severity":"DEBUG","httpRequest":{"request_method":"POST","request_url":"https://example.com/test"},` +
+				`"timestamp":"seconds:1000","logging.googleapis.com/labels":{"key1":"value1","key2":"value2"},"logging.googleapis.com/insertId":"0000AAA01",` +
+				`"logging.googleapis.com/operation":{"id":"0123456789","producer":"test"},"logging.googleapis.com/sourceLocation":{"file":"acme.go","line":100,"function":"main"},` +
+				`"logging.googleapis.com/spanId":"000000000001","logging.googleapis.com/trace":"projects/P/ABCD12345678AB12345678","logging.googleapis.com/trace_sampled":true}`,
+		},
+		{
+			name: "full data redirect with json payload",
+			in: &logging.Entry{
+				Labels:       map[string]string{"key1": "value1", "key2": "value2"},
+				Timestamp:    testNow().UTC(),
+				Severity:     logging.Debug,
+				InsertID:     "0000AAA01",
+				Trace:        "projects/P/ABCD12345678AB12345678",
+				SpanID:       "000000000001",
+				TraceSampled: true,
+				SourceLocation: &logpb.LogEntrySourceLocation{
+					File:     "acme.go",
+					Function: "main",
+					Line:     100,
+				},
+				Operation: &logpb.LogEntryOperation{
+					Id:       "0123456789",
+					Producer: "test",
+				},
+				HTTPRequest: &logging.HTTPRequest{
+					Request: &http.Request{
+						URL:    testURL,
+						Method: "POST",
+					},
+				},
+				Payload: map[string]interface{}{
+					"Message": "message part of the payload",
+					"Latency": 321,
+				},
+			},
+			want: `{"message":{"Latency":321,"Message":"message part of the payload"},"severity":"DEBUG","httpRequest":{"request_method":"POST","request_url":"https://example.com/test"},` +
+				`"timestamp":"seconds:1000","logging.googleapis.com/labels":{"key1":"value1","key2":"value2"},"logging.googleapis.com/insertId":"0000AAA01",` +
+				`"logging.googleapis.com/operation":{"id":"0123456789","producer":"test"},"logging.googleapis.com/sourceLocation":{"file":"acme.go","line":100,"function":"main"},` +
+				`"logging.googleapis.com/spanId":"000000000001","logging.googleapis.com/trace":"projects/P/ABCD12345678AB12345678","logging.googleapis.com/trace_sampled":true}`,
+		},
+		{
+			name: "error on redirect with proto payload",
+			in: &logging.Entry{
+				Timestamp: testNow().UTC(),
+				Severity:  logging.Debug,
+				Payload:   &anypb.Any{},
+			},
+			wantError: logging.ErrRedirectProtoPayloadNotSupported,
+		},
+	}
+	buffer := &strings.Builder{}
+	logger := client.Logger("test-redirect-output", logging.RedirectAsJSON(buffer))
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			buffer.Reset()
+			err := logger.LogSync(context.TODO(), *tc.in)
+			if err != nil {
+				if tc.wantError == nil {
+					t.Fatalf("Unexpected error: %+v: %v", tc.in, err)
+				}
+				if tc.wantError != err {
+					t.Errorf("Expected error: %+v, got: %v want: %v\n", tc.in, err, tc.wantError)
+				}
+			} else {
+				if tc.wantError != nil {
+					t.Errorf("Expected error: %+v, want: %v\n", tc.in, tc.wantError)
+				}
+				got := strings.TrimSpace(buffer.String())
+				if got != tc.want {
+					t.Errorf("TestRedirectOutputFormats: %+v: got %v, want %v", tc.in, got, tc.want)
+				}
+			}
+		})
+	}
+}
+
+func ExampleRedirectAsJson_withStdout() {
+	// use previously created client
+	logger := client.Logger("redirect-to-stdout", logging.RedirectAsJSON(os.Stdout))
+	logger.LogSync(context.TODO(), logging.Entry{Timestamp: time.Unix(1000, 0), Severity: logging.Debug, Payload: "redirected log"})
+	// Output: {"message":"redirected log","severity":"DEBUG","timestamp":"seconds:1000"}
+}
+
+func ExampleRedirectAsJson_withStderr() {
+	// use previously created client
+	logger := client.Logger("redirect-to-stdout", logging.RedirectAsJSON(os.Stderr))
+	logger.LogSync(context.TODO(), logging.Entry{Timestamp: time.Unix(1000, 0), Severity: logging.Debug, Payload: "redirected log"})
+	// Output: {"message":"redirected log","severity":"DEBUG","timestamp":"seconds:1000"}
 }

--- a/logging/logging_unexported_test.go
+++ b/logging/logging_unexported_test.go
@@ -208,7 +208,7 @@ func TestToLogEntryPayload(t *testing.T) {
 			},
 		},
 	} {
-		e, err := toLogEntryInternal(Entry{Payload: test.in}, nil, "")
+		e, err := toLogEntryInternal(Entry{Payload: test.in}, nil, "", 0)
 		if err != nil {
 			t.Fatalf("%+v: %v", test.in, err)
 		}

--- a/logging/resource.go
+++ b/logging/resource.go
@@ -15,12 +15,11 @@
 package logging
 
 import (
-	"io/ioutil"
-	"os"
+	"runtime"
 	"strings"
 	"sync"
 
-	"cloud.google.com/go/compute/metadata"
+	"cloud.google.com/go/logging/internal"
 	mrpb "google.golang.org/genproto/googleapis/api/monitoredres"
 )
 
@@ -34,165 +33,180 @@ type commonResource struct{ *mrpb.MonitoredResource }
 
 func (r commonResource) set(l *Logger) { l.commonResource = r.MonitoredResource }
 
-var detectedResource struct {
-	pb   *mrpb.MonitoredResource
-	once sync.Once
+type resource struct {
+	pb    *mrpb.MonitoredResource
+	attrs internal.ResourceAtttributesGetter
+	once  *sync.Once
+}
+
+var detectedResource = &resource{
+	attrs: internal.ResourceAttributes(),
+	once:  new(sync.Once),
+}
+
+func (r *resource) metadataProjectID() string {
+	return r.attrs.Metadata("project/project-id")
+}
+
+func (r *resource) metadataZone() string {
+	zone := r.attrs.Metadata("instance/zone")
+	if zone != "" {
+		return zone[strings.LastIndex(zone, "/")+1:]
+	}
+	return ""
+}
+
+func (r *resource) metadataRegion() string {
+	region := r.attrs.Metadata("instance/region")
+	if region != "" {
+		return region[strings.LastIndex(region, "/")+1:]
+	}
+	return ""
+}
+
+// isMetadataActive queries valid response on "/computeMetadata/v1/" URL
+func (r *resource) isMetadataActive() bool {
+	data := r.attrs.Metadata("")
+	return data != ""
 }
 
 // isAppEngine returns true for both standard and flex
-func isAppEngine() bool {
-	_, service := os.LookupEnv("GAE_SERVICE")
-	_, version := os.LookupEnv("GAE_VERSION")
-	_, instance := os.LookupEnv("GAE_INSTANCE")
-
-	return service && version && instance
+func (r *resource) isAppEngine() bool {
+	service := r.attrs.EnvVar("GAE_SERVICE")
+	version := r.attrs.EnvVar("GAE_VERSION")
+	instance := r.attrs.EnvVar("GAE_INSTANCE")
+	return service != "" && version != "" && instance != ""
 }
 
 func detectAppEngineResource() *mrpb.MonitoredResource {
-	projectID, err := metadata.ProjectID()
-	if err != nil {
-		return nil
+	projectID := detectedResource.metadataProjectID()
+	if projectID == "" {
+		projectID = detectedResource.attrs.EnvVar("GOOGLE_CLOUD_PROJECT")
 	}
 	if projectID == "" {
-		projectID = os.Getenv("GOOGLE_CLOUD_PROJECT")
-	}
-	zone, err := metadata.Zone()
-	if err != nil {
 		return nil
 	}
+	zone := detectedResource.metadataZone()
+	service := detectedResource.attrs.EnvVar("GAE_SERVICE")
+	version := detectedResource.attrs.EnvVar("GAE_VERSION")
 
 	return &mrpb.MonitoredResource{
 		Type: "gae_app",
 		Labels: map[string]string{
-			"project_id":  projectID,
-			"module_id":   os.Getenv("GAE_SERVICE"),
-			"version_id":  os.Getenv("GAE_VERSION"),
-			"instance_id": os.Getenv("GAE_INSTANCE"),
-			"runtime":     os.Getenv("GAE_RUNTIME"),
-			"zone":        zone,
+			"project_id": projectID,
+			"module_id":  service,
+			"version_id": version,
+			"zone":       zone,
 		},
 	}
 }
 
-func isCloudFunction() bool {
-	// Reserved envvars in older function runtimes, e.g. Node.js 8, Python 3.7 and Go 1.11.
-	_, name := os.LookupEnv("FUNCTION_NAME")
-	_, region := os.LookupEnv("FUNCTION_REGION")
-	_, entry := os.LookupEnv("ENTRY_POINT")
-
-	// Reserved envvars in newer function runtimes.
-	_, target := os.LookupEnv("FUNCTION_TARGET")
-	_, signature := os.LookupEnv("FUNCTION_SIGNATURE_TYPE")
-	_, service := os.LookupEnv("K_SERVICE")
-	return (name && region && entry) || (target && signature && service)
+func (r *resource) isCloudFunction() bool {
+	target := r.attrs.EnvVar("FUNCTION_TARGET")
+	signature := r.attrs.EnvVar("FUNCTION_SIGNATURE_TYPE")
+	// note that this envvar is also present in Cloud Run environments
+	service := r.attrs.EnvVar("K_SERVICE")
+	return target != "" && signature != "" && service != ""
 }
 
 func detectCloudFunction() *mrpb.MonitoredResource {
-	projectID, err := metadata.ProjectID()
-	if err != nil {
+	projectID := detectedResource.metadataProjectID()
+	if projectID == "" {
 		return nil
 	}
-	zone, err := metadata.Zone()
-	if err != nil {
-		return nil
-	}
-	// Newer functions runtimes store name in K_SERVICE.
-	functionName, exists := os.LookupEnv("K_SERVICE")
-	if !exists {
-		functionName, _ = os.LookupEnv("FUNCTION_NAME")
-	}
+	region := detectedResource.metadataRegion()
+	functionName := detectedResource.attrs.EnvVar("K_SERVICE")
 	return &mrpb.MonitoredResource{
 		Type: "cloud_function",
 		Labels: map[string]string{
 			"project_id":    projectID,
-			"region":        regionFromZone(zone),
+			"region":        region,
 			"function_name": functionName,
 		},
 	}
 }
 
-func isCloudRun() bool {
-	_, config := os.LookupEnv("K_CONFIGURATION")
-	_, service := os.LookupEnv("K_SERVICE")
-	_, revision := os.LookupEnv("K_REVISION")
-	return config && service && revision
+func (r *resource) isCloudRun() bool {
+	config := r.attrs.EnvVar("K_CONFIGURATION")
+	// note that this envvar is also present in Cloud Function environments
+	service := r.attrs.EnvVar("K_SERVICE")
+	revision := r.attrs.EnvVar("K_REVISION")
+	return config != "" && service != "" && revision != ""
 }
 
 func detectCloudRunResource() *mrpb.MonitoredResource {
-	projectID, err := metadata.ProjectID()
-	if err != nil {
+	projectID := detectedResource.metadataProjectID()
+	if projectID == "" {
 		return nil
 	}
-	zone, err := metadata.Zone()
-	if err != nil {
-		return nil
-	}
+	region := detectedResource.metadataRegion()
+	config := detectedResource.attrs.EnvVar("K_CONFIGURATION")
+	service := detectedResource.attrs.EnvVar("K_SERVICE")
+	revision := detectedResource.attrs.EnvVar("K_REVISION")
 	return &mrpb.MonitoredResource{
 		Type: "cloud_run_revision",
 		Labels: map[string]string{
 			"project_id":         projectID,
-			"location":           regionFromZone(zone),
-			"service_name":       os.Getenv("K_SERVICE"),
-			"revision_name":      os.Getenv("K_REVISION"),
-			"configuration_name": os.Getenv("K_CONFIGURATION"),
+			"location":           region,
+			"service_name":       service,
+			"revision_name":      revision,
+			"configuration_name": config,
 		},
 	}
 }
 
-func isKubernetesEngine() bool {
-	clusterName, err := metadata.InstanceAttributeValue("cluster-name")
-	// Note: InstanceAttributeValue can return "", nil
-	if err != nil || clusterName == "" {
+func (r *resource) isKubernetesEngine() bool {
+	clusterName := r.attrs.Metadata("instance/attributes/cluster-name")
+	if clusterName == "" {
 		return false
 	}
 	return true
 }
 
 func detectKubernetesResource() *mrpb.MonitoredResource {
-	projectID, err := metadata.ProjectID()
-	if err != nil {
+	projectID := detectedResource.metadataProjectID()
+	if projectID == "" {
 		return nil
 	}
-	zone, err := metadata.Zone()
-	if err != nil {
-		return nil
+	zone := detectedResource.metadataZone()
+	clusterName := detectedResource.attrs.Metadata("instance/attributes/cluster-name")
+	namespaceName := detectedResource.attrs.ReadAll("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+	if namespaceName == "" {
+		// if automountServiceAccountToken is disabled allow to customize
+		// the namespace via environment
+		namespaceName = detectedResource.attrs.EnvVar("NAMESPACE_NAME")
 	}
-	clusterName, err := metadata.InstanceAttributeValue("cluster-name")
-	if err != nil {
-		return nil
-	}
-	namespaceBytes, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
-	namespaceName := ""
-	if err == nil {
-		namespaceName = string(namespaceBytes)
-	}
+	// note: if deployment customizes hostname, HOSTNAME envvar will have invalid content
+	podName := detectedResource.attrs.EnvVar("HOSTNAME")
+	// there is no way to derive container name from within container; use custom envvar if available
+	containerName := detectedResource.attrs.EnvVar("CONTAINER_NAME")
 	return &mrpb.MonitoredResource{
 		Type: "k8s_container",
 		Labels: map[string]string{
 			"cluster_name":   clusterName,
 			"location":       zone,
 			"project_id":     projectID,
-			"pod_name":       os.Getenv("HOSTNAME"),
+			"pod_name":       podName,
 			"namespace_name": namespaceName,
-			// To get the `container_name` label, users need to explicitly provide it.
-			"container_name": os.Getenv("CONTAINER_NAME"),
+			"container_name": containerName,
 		},
 	}
 }
 
-func detectGCEResource() *mrpb.MonitoredResource {
-	projectID, err := metadata.ProjectID()
-	if err != nil {
+func (r *resource) isComputeEngine() bool {
+	preempted := r.attrs.Metadata("instance/preempted")
+	platform := r.attrs.Metadata("instance/cpu-platform")
+	appBucket := r.attrs.Metadata("instance/attributes/gae_app_bucket")
+	return preempted != "" && platform != "" && appBucket == ""
+}
+
+func detectComputeEngineResource() *mrpb.MonitoredResource {
+	projectID := detectedResource.metadataProjectID()
+	if projectID == "" {
 		return nil
 	}
-	id, err := metadata.InstanceID()
-	if err != nil {
-		return nil
-	}
-	zone, err := metadata.Zone()
-	if err != nil {
-		return nil
-	}
+	id := detectedResource.attrs.Metadata("instance/id")
+	zone := detectedResource.metadataZone()
 	return &mrpb.MonitoredResource{
 		Type: "gce_instance",
 		Labels: map[string]string{
@@ -205,22 +219,36 @@ func detectGCEResource() *mrpb.MonitoredResource {
 
 func detectResource() *mrpb.MonitoredResource {
 	detectedResource.once.Do(func() {
-		switch {
-		// AppEngine, Functions, CloudRun, Kubernetes are detected first,
-		// as metadata.OnGCE() erroneously returns true on these runtimes.
-		case isAppEngine():
-			detectedResource.pb = detectAppEngineResource()
-		case isCloudFunction():
-			detectedResource.pb = detectCloudFunction()
-		case isCloudRun():
-			detectedResource.pb = detectCloudRunResource()
-		case isKubernetesEngine():
-			detectedResource.pb = detectKubernetesResource()
-		case metadata.OnGCE():
-			detectedResource.pb = detectGCEResource()
+		if detectedResource.isMetadataActive() {
+			name := systemProductName()
+			switch {
+			case name == "Google App Engine", detectedResource.isAppEngine():
+				detectedResource.pb = detectAppEngineResource()
+			case name == "Google Cloud Functions", detectedResource.isCloudFunction():
+				detectedResource.pb = detectCloudFunction()
+			case name == "Google Cloud Run", detectedResource.isCloudRun():
+				detectedResource.pb = detectCloudRunResource()
+			// cannot use name validation for GKE and GCE because
+			// both of them set product name to "Google Compute Engine"
+			case detectedResource.isKubernetesEngine():
+				detectedResource.pb = detectKubernetesResource()
+			case detectedResource.isComputeEngine():
+				detectedResource.pb = detectComputeEngineResource()
+			}
 		}
 	})
 	return detectedResource.pb
+}
+
+// systemProductName reads resource type on the Linux-based environments such as
+// Cloud Functions, Cloud Run, GKE, GCE, GAE, etc.
+func systemProductName() string {
+	if runtime.GOOS != "linux" {
+		// We don't have any non-Linux clues available, at least yet.
+		return ""
+	}
+	slurp := detectedResource.attrs.ReadAll("/sys/class/dmi/id/product_name")
+	return strings.TrimSpace(slurp)
 }
 
 var resourceInfo = map[string]struct{ rtype, label string }{
@@ -243,14 +271,6 @@ func monitoredResource(parent string) *mrpb.MonitoredResource {
 		Type:   info.rtype,
 		Labels: map[string]string{info.label: parts[1]},
 	}
-}
-
-func regionFromZone(zone string) string {
-	cutoff := strings.LastIndex(zone, "-")
-	if cutoff > 0 {
-		return zone[:cutoff]
-	}
-	return zone
 }
 
 func globalResource(projectID string) *mrpb.MonitoredResource {

--- a/logging/resource.go
+++ b/logging/resource.go
@@ -35,7 +35,7 @@ func (r commonResource) set(l *Logger) { l.commonResource = r.MonitoredResource 
 
 type resource struct {
 	pb    *mrpb.MonitoredResource
-	attrs internal.ResourceAtttributesGetter
+	attrs internal.ResourceAttributesGetter
 	once  *sync.Once
 }
 

--- a/logging/resource_test.go
+++ b/logging/resource_test.go
@@ -1,0 +1,255 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logging
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	mrpb "google.golang.org/genproto/googleapis/api/monitoredres"
+)
+
+const (
+	there               = "anyvalue"
+	projectID           = "test-project"
+	zoneID              = "test-region-zone"
+	regionID            = "test-region"
+	serviceName         = "test-service"
+	version             = "1.0"
+	instanceName        = "test-12345"
+	qualifiedZoneName   = "projects/" + projectID + "/zones/" + zoneID
+	qualifiedRegionName = "projects/" + projectID + "/regions/" + regionID
+	funcSignature       = "test-cf-signature"
+	funcTarget          = "test-cf-target"
+	crConfig            = "test-cr-config"
+	clusterName         = "test-k8s-cluster"
+	podName             = "test-k8s-pod-name"
+	containerName       = "test-k8s-container-name"
+	namespaceName       = "test-k8s-namespace-name"
+	instanceID          = "test-instance-12345"
+)
+
+// fakeResourceGetter mocks internal.ResourceAtttributesGetter interface to retrieve env vars and metadata
+type fakeResourceGetter struct {
+	envVars  map[string]string
+	metaVars map[string]string
+	fsPaths  map[string]string
+}
+
+func (g *fakeResourceGetter) EnvVar(name string) string {
+	if g.envVars != nil {
+		if v, ok := g.envVars[name]; ok {
+			return v
+		}
+	}
+	return ""
+}
+
+func (g *fakeResourceGetter) Metadata(path string) string {
+	if g.metaVars != nil {
+		if v, ok := g.metaVars[path]; ok {
+			return v
+		}
+	}
+	return ""
+}
+
+func (g *fakeResourceGetter) ReadAll(path string) string {
+	if g.fsPaths != nil {
+		if v, ok := g.fsPaths[path]; ok {
+			return v
+		}
+	}
+	return ""
+}
+
+// setupDetectResource resets sync.Once on detectResource and enforces mocked resource attribute getter
+func setupDetectedResource(envVars, metaVars, fsPaths map[string]string) {
+	detectedResource.once = new(sync.Once)
+	detectedResource.attrs = &fakeResourceGetter{
+		envVars:  envVars,
+		metaVars: metaVars,
+		fsPaths:  fsPaths,
+	}
+	detectedResource.pb = nil
+}
+
+func TestResourceDetection(t *testing.T) {
+	tests := []struct {
+		name     string
+		envVars  map[string]string
+		metaVars map[string]string
+		fsPaths  map[string]string
+		want     *mrpb.MonitoredResource
+	}{
+		{
+			name:     "detect GAE resource",
+			envVars:  map[string]string{"GAE_SERVICE": serviceName, "GAE_VERSION": version, "GAE_INSTANCE": instanceName},
+			metaVars: map[string]string{"": there, "project/project-id": projectID, "instance/zone": qualifiedZoneName, "instance/attributes/gae_app_bucket": there},
+			want: &mrpb.MonitoredResource{
+				Type: "gae_app",
+				Labels: map[string]string{
+					"project_id": projectID,
+					"module_id":  serviceName,
+					"version_id": version,
+					"zone":       zoneID,
+				},
+			},
+		},
+		{
+			name:     "detect Cloud Function resource",
+			envVars:  map[string]string{"FUNCTION_TARGET": funcTarget, "FUNCTION_SIGNATURE_TYPE": funcSignature, "K_SERVICE": serviceName},
+			metaVars: map[string]string{"": there, "project/project-id": projectID, "instance/region": qualifiedRegionName},
+			want: &mrpb.MonitoredResource{
+				Type: "cloud_function",
+				Labels: map[string]string{
+					"project_id":    projectID,
+					"region":        regionID,
+					"function_name": serviceName,
+				},
+			},
+		},
+		{
+			name:     "detect Cloud Run resource",
+			envVars:  map[string]string{"K_CONFIGURATION": crConfig, "K_SERVICE": serviceName, "K_REVISION": version},
+			metaVars: map[string]string{"": there, "project/project-id": projectID, "instance/region": qualifiedRegionName},
+			want: &mrpb.MonitoredResource{
+				Type: "cloud_run_revision",
+				Labels: map[string]string{
+					"project_id":         projectID,
+					"location":           regionID,
+					"service_name":       serviceName,
+					"revision_name":      version,
+					"configuration_name": crConfig,
+				},
+			},
+		},
+		{
+			name:     "detect GKE resource",
+			envVars:  map[string]string{"HOSTNAME": podName},
+			metaVars: map[string]string{"": there, "project/project-id": projectID, "instance/zone": qualifiedZoneName, "instance/attributes/cluster-name": clusterName},
+			fsPaths:  map[string]string{"/var/run/secrets/kubernetes.io/serviceaccount/namespace": namespaceName},
+			want: &mrpb.MonitoredResource{
+				Type: "k8s_container",
+				Labels: map[string]string{
+					"cluster_name":   clusterName,
+					"location":       zoneID,
+					"project_id":     projectID,
+					"pod_name":       podName,
+					"namespace_name": namespaceName,
+					"container_name": "",
+				},
+			},
+		},
+		{
+			name:     "detect GKE resource with custom container and namespace config",
+			envVars:  map[string]string{"HOSTNAME": podName, "CONTAINER_NAME": containerName, "NAMESPACE_NAME": namespaceName},
+			metaVars: map[string]string{"": there, "project/project-id": projectID, "instance/zone": qualifiedZoneName, "instance/attributes/cluster-name": clusterName},
+			want: &mrpb.MonitoredResource{
+				Type: "k8s_container",
+				Labels: map[string]string{
+					"cluster_name":   clusterName,
+					"location":       zoneID,
+					"project_id":     projectID,
+					"pod_name":       podName,
+					"namespace_name": namespaceName,
+					"container_name": containerName,
+				},
+			},
+		},
+		{
+			name:     "detect Compute Engine resource",
+			envVars:  map[string]string{},
+			metaVars: map[string]string{"": there, "project/project-id": projectID, "instance/id": instanceID, "instance/zone": qualifiedZoneName, "instance/preempted": there, "instance/cpu-platform": there},
+			want: &mrpb.MonitoredResource{
+				Type: "gce_instance",
+				Labels: map[string]string{
+					"project_id":  projectID,
+					"instance_id": instanceID,
+					"zone":        zoneID,
+				},
+			},
+		},
+		{
+			name:     "detect GAE resource by product name",
+			envVars:  map[string]string{},
+			metaVars: map[string]string{"": there, "project/project-id": projectID, "instance/zone": qualifiedZoneName, "instance/attributes/gae_app_bucket": there},
+			fsPaths:  map[string]string{"/sys/class/dmi/id/product_name": "Google App Engine"},
+			want: &mrpb.MonitoredResource{
+				Type: "gae_app",
+				Labels: map[string]string{
+					"project_id": projectID,
+					"module_id":  "",
+					"version_id": "",
+					"zone":       zoneID,
+				},
+			},
+		},
+		{
+			name:     "detect Cloud Function resource by product name",
+			envVars:  map[string]string{},
+			metaVars: map[string]string{"": there, "project/project-id": projectID, "instance/region": qualifiedRegionName},
+			fsPaths:  map[string]string{"/sys/class/dmi/id/product_name": "Google Cloud Functions"},
+			want: &mrpb.MonitoredResource{
+				Type: "cloud_function",
+				Labels: map[string]string{
+					"project_id":    projectID,
+					"region":        regionID,
+					"function_name": "",
+				},
+			},
+		},
+		{
+			name:     "detect Cloud Run resource by product name",
+			envVars:  map[string]string{},
+			metaVars: map[string]string{"": there, "project/project-id": projectID, "instance/region": qualifiedRegionName},
+			fsPaths:  map[string]string{"/sys/class/dmi/id/product_name": "Google Cloud Run"},
+			want: &mrpb.MonitoredResource{
+				Type: "cloud_run_revision",
+				Labels: map[string]string{
+					"project_id":         projectID,
+					"location":           regionID,
+					"service_name":       "",
+					"revision_name":      "",
+					"configuration_name": "",
+				},
+			},
+		},
+		{
+			name:     "unknown resource detection",
+			envVars:  map[string]string{},
+			metaVars: map[string]string{"": there, "project/project-id": projectID},
+			want:     nil,
+		},
+		{
+			name:     "resource without metadata detection",
+			envVars:  map[string]string{},
+			metaVars: map[string]string{},
+			want:     nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			setupDetectedResource(tc.envVars, tc.metaVars, tc.fsPaths)
+			got := detectResource()
+			if diff := cmp.Diff(got, tc.want, cmpopts.IgnoreUnexported(mrpb.MonitoredResource{})); diff != "" {
+				t.Errorf("got(-),want(+):\n%s", diff)
+			}
+		})
+	}
+}

--- a/logging/resource_test.go
+++ b/logging/resource_test.go
@@ -243,6 +243,12 @@ func TestResourceDetection(t *testing.T) {
 		},
 	}
 
+	// cleanup
+	oldAttrs := detectedResource.attrs
+	defer func() {
+		detectedResource.attrs = oldAttrs
+		detectedResource.once = new(sync.Once)
+	}()
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			setupDetectedResource(tc.envVars, tc.metaVars, tc.fsPaths)
@@ -252,4 +258,16 @@ func TestResourceDetection(t *testing.T) {
 			}
 		})
 	}
+}
+
+var benchmarkResultHolder *mrpb.MonitoredResource
+
+func BenchmarkDetectResource(b *testing.B) {
+	var result *mrpb.MonitoredResource
+
+	for n := 0; n < b.N; n++ {
+		result = detectResource()
+	}
+
+	benchmarkResultHolder = result
 }


### PR DESCRIPTION
Align resource detection with heuristics in logging libraries for other languages (PR #6022)
Adds automatic population of the source location for ingested log entries with severity = Debug (PR #6043)
Adds benchmark for detectResource() to validate the long delays of the logger creation in non-GCP environments (PR #6084)
Adds PartialSuccess logger option to set the partialSuccess flag in all write log entries calls to true (PR #6092)
Adds support for W3C trace context header: `traceparent` in addition to X-Cloud-Trace-Context (PR #6101)
Adds RedirectToStderr and RedirectToStdout logger options to enable printing Jsonified log entries to STDOUT or STDERR instead of ingesting them directly to Cloud Logging (PR #6130)
Adds sending instrumentation info about the package on each use (one time per process) (PR #6210)

Fixes #5829
Fixes #5831
Fixes #5830
Fixes #3824
Fixes #5855
Fixes #6087
Fixes #6086
Fixes #6131
Fixes #6132