### PR TITLE
chore: try to get renovate working

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,7 +11,7 @@
     ],
     "commitMessagePrefix": "chore(all): ",
     "commitMessageAction": "update",
-    "groupName": "all",
+    "groupName": "everything",
     "ignoreDeps": [
         "google.golang.org/genproto",
         "github.com/google/martian/v3"


### PR DESCRIPTION
Switching the group name should make changes come from a new branch on the renovate fork I believe. This may fix the issue that we are no longer getting PRs from our current branch.