### PR TITLE
chore(logging): add detectResource benchmark

### DIFF
--- a/logging/resource_test.go
+++ b/logging/resource_test.go
@@ -243,6 +243,12 @@ func TestResourceDetection(t *testing.T) {
 		},
 	}
 
+	// cleanup
+	oldAttrs := detectedResource.attrs
+	defer func() {
+		detectedResource.attrs = oldAttrs
+		detectedResource.once = new(sync.Once)
+	}()
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			setupDetectedResource(tc.envVars, tc.metaVars, tc.fsPaths)
@@ -252,4 +258,16 @@ func TestResourceDetection(t *testing.T) {
 			}
 		})
 	}
+}
+
+var benchmarkResultHolder *mrpb.MonitoredResource
+
+func BenchmarkDetectResource(b *testing.B) {
+	var result *mrpb.MonitoredResource
+
+	for n := 0; n < b.N; n++ {
+		result = detectResource()
+	}
+
+	benchmarkResultHolder = result
 }


### PR DESCRIPTION
Adding a benchmark test to measure execution time for detectResource() to address #5855.
Current implementation uses cloud.google.com/go/compute/metadata package to read Google Cloud metadata server attributes. The package implements retrying mechanism to cover on occasional problems of miscommunication with the metadata server. When a new Logger instance is being created, it calls detectResource() to read the monitored resource object. The resource detection algorithm is invoked once per process (regardless of how many Logger instances is created). The algorithm checks whether the environment runs the metadata server as a first step and to avoid further validations. Due to the retrying mechanism, this call may take between 6 to 7 seconds which composes the overall delay of creating a first instance of the Logger.
The benchmark demonstrates that only first Logger takes long time:

```bash
go test -run=XXX -bench=BenchmarkDetectResource -benchtime 8s
goos: linux
goarch: amd64
pkg: cloud.google.com/go/logging
cpu: 11th Gen Intel(R) Core(TM) i7-1185G7 @ 3.00GHz
BenchmarkDetectResource-8       1000000000               2.291 ns/op
PASS
ok      cloud.google.com/go/logging     9.955s
```

When the  cloud.google.com/go/compute/metadata package will be modified to allow customizable retrying mechanism, this logic will be altered to minimize the number of retries for the initial call.