### PR TITLE
chore(bigquery): switch existing formatters to enable error wrapping

### DIFF
--- a/bigquery/bigquery.go
+++ b/bigquery/bigquery.go
@@ -80,7 +80,7 @@ func NewClient(ctx context.Context, projectID string, opts ...option.ClientOptio
 	o = append(o, opts...)
 	bqs, err := bq.NewService(ctx, o...)
 	if err != nil {
-		return nil, fmt.Errorf("bigquery: constructing client: %v", err)
+		return nil, fmt.Errorf("bigquery: constructing client: %w", err)
 	}
 
 	// Handle project autodetection.

--- a/bigquery/intervalvalue.go
+++ b/bigquery/intervalvalue.go
@@ -202,7 +202,7 @@ func getNumVal(part intervalPart, s string) (string, int32, error) {
 	}
 	parsed, err := strconv.ParseInt(captured, 10, 32)
 	if err != nil {
-		return "", 0, fmt.Errorf("error parsing value %s for %s: %v", captured, part.String(), err)
+		return "", 0, fmt.Errorf("error parsing value %s for %s: %w", captured, part.String(), err)
 	}
 	return s, int32(parsed), nil
 }

--- a/bigquery/job.go
+++ b/bigquery/job.go
@@ -918,7 +918,7 @@ func (j *Job) setStatus(qs *bq.JobStatus) error {
 	}
 	state, ok := stateMap[qs.State]
 	if !ok {
-		return fmt.Errorf("unexpected job state: %v", qs.State)
+		return fmt.Errorf("unexpected job state: %s", qs.State)
 	}
 	j.lastStatus = &JobStatus{
 		State: state,

--- a/bigquery/routine.go
+++ b/bigquery/routine.go
@@ -209,7 +209,7 @@ func (rm *RoutineMetadata) toBQ() (*bq.Routine, error) {
 	if rm.ReturnTableType != nil {
 		tt, err := rm.ReturnTableType.toBQ()
 		if err != nil {
-			return nil, fmt.Errorf("couldn't convert return table type: %v", err)
+			return nil, fmt.Errorf("couldn't convert return table type: %w", err)
 		}
 		r.ReturnTableType = tt
 	}

--- a/bigquery/schema.go
+++ b/bigquery/schema.go
@@ -565,7 +565,7 @@ func validateKnownType(in FieldType) (FieldType, error) {
 		if resolved, ok := fieldAliases[in]; ok {
 			return resolved, nil
 		}
-		return "", fmt.Errorf("unknown field type (%v)", in)
+		return "", fmt.Errorf("unknown field type (%s)", in)
 	}
 	return in, nil
 }

--- a/bigquery/standardsql.go
+++ b/bigquery/standardsql.go
@@ -169,7 +169,7 @@ func standardSQLStructFieldsToBQ(fields []*StandardSQLField) ([]*bq.StandardSqlF
 	for _, v := range fields {
 		bqf, err := v.toBQ()
 		if err != nil {
-			return nil, fmt.Errorf("error converting struct fields: %v", err)
+			return nil, fmt.Errorf("error converting struct fields: %w", err)
 		}
 		bqFields = append(bqFields, bqf)
 	}

--- a/bigquery/storage/managedwriter/adapt/error.go
+++ b/bigquery/storage/managedwriter/adapt/error.go
@@ -28,6 +28,10 @@ func (ce *conversionError) Error() string {
 	return fmt.Sprintf("conversion error in location %q: %v", ce.Location, ce.Details)
 }
 
+func (ce *conversionError) Unwrap() error {
+	return ce.Details
+}
+
 func newConversionError(loc string, err error) *conversionError {
 	return &conversionError{
 		Location: loc,

--- a/bigquery/storage/managedwriter/adapt/protoconversion.go
+++ b/bigquery/storage/managedwriter/adapt/protoconversion.go
@@ -109,7 +109,7 @@ func (dm dependencyCache) add(schema *storagepb.TableSchema, descriptor protoref
 	}
 	b, err := proto.Marshal(schema)
 	if err != nil {
-		return fmt.Errorf("failed to serialize tableschema: %v", err)
+		return fmt.Errorf("failed to serialize tableschema: %w", err)
 	}
 	encoded := base64.StdEncoding.EncodeToString(b)
 	(dm)[encoded] = descriptor
@@ -166,7 +166,7 @@ func storageSchemaToDescriptorInternal(inSchema *storagepb.TableSchema, scope st
 				// construct field descriptor for the message
 				fdp, err := tableFieldSchemaToFieldDescriptorProto(f, fNumber, string(foundDesc.FullName()), useProto3)
 				if err != nil {
-					return nil, newConversionError(scope, fmt.Errorf("couldn't convert field to FieldDescriptorProto: %v", err))
+					return nil, newConversionError(scope, fmt.Errorf("couldn't convert field to FieldDescriptorProto: %w", err))
 				}
 				fields = append(fields, fdp)
 			} else {
@@ -176,18 +176,18 @@ func storageSchemaToDescriptorInternal(inSchema *storagepb.TableSchema, scope st
 				}
 				desc, err := storageSchemaToDescriptorInternal(ts, currentScope, cache, useProto3)
 				if err != nil {
-					return nil, newConversionError(currentScope, fmt.Errorf("couldn't convert message: %v", err))
+					return nil, newConversionError(currentScope, fmt.Errorf("couldn't convert message: %w", err))
 				}
 				// Now that we have the submessage definition, we append it both to the local dependencies, as well
 				// as inserting it into the cache for possible reuse elsewhere.
 				deps = append(deps, desc.ParentFile())
 				err = cache.add(ts, desc)
 				if err != nil {
-					return nil, newConversionError(currentScope, fmt.Errorf("failed to add descriptor to dependency cache: %v", err))
+					return nil, newConversionError(currentScope, fmt.Errorf("failed to add descriptor to dependency cache: %w", err))
 				}
 				fdp, err := tableFieldSchemaToFieldDescriptorProto(f, fNumber, currentScope, useProto3)
 				if err != nil {
-					return nil, newConversionError(currentScope, fmt.Errorf("couldn't compute field schema : %v", err))
+					return nil, newConversionError(currentScope, fmt.Errorf("couldn't compute field schema : %w", err))
 				}
 				fields = append(fields, fdp)
 			}

--- a/bigquery/storage/managedwriter/client.go
+++ b/bigquery/storage/managedwriter/client.go
@@ -135,7 +135,7 @@ func (c *Client) buildManagedStream(ctx context.Context, streamFunc streamClient
 					}}
 				resp, err := ms.c.rawClient.CreateWriteStream(ctx, req)
 				if err != nil {
-					return nil, fmt.Errorf("couldn't create write stream: %v", err)
+					return nil, fmt.Errorf("couldn't create write stream: %w", err)
 				}
 				streamName = resp.GetName()
 			}


### PR DESCRIPTION
Did a quick audit to check for error formatters where we could potentially
wrap errors and were not currently.

This PR also added an explicit unwrapper to the custom error type exposed in bigquery/storage/managedwriter/adapt

Explicitly did not audit/update test code.