### PR TITLE
fix(pubsub): use MaxInt instead of MaxInt64 for BufferedByteLimit

### DIFF
--- a/pubsub/topic.go
+++ b/pubsub/topic.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"math"
 	"runtime"
 	"strings"
 	"sync"
@@ -51,6 +50,13 @@ const (
 	// MaxPublishRequestBytes is the maximum size of a single publish request
 	// in bytes, as defined by the PubSub service.
 	MaxPublishRequestBytes = 1e7
+)
+
+const (
+	// TODO: math.MaxInt was added in Go 1.17. We should use that once 1.17
+	// becomes the minimum supported version of Go.
+	intSize = 32 << (^uint(0) >> 63)
+	maxInt  = 1<<(intSize-1) - 1
 )
 
 // ErrOversizedMessage indicates that a message's size exceeds MaxPublishRequestBytes.
@@ -639,7 +645,7 @@ func (t *Topic) initBundler() {
 		// This is because there's no way to set "unlimited" for BufferedByteLimit,
 		// and simply setting it to MaxOutstandingBytes occasionally leads to issues where
 		// BufferedByteLimit is reached even though there are resources available.
-		t.PublishSettings.BufferedByteLimit = math.MaxInt
+		t.PublishSettings.BufferedByteLimit = maxInt
 	}
 	if t.PublishSettings.FlowControlSettings.MaxOutstandingMessages > 0 {
 		fcs.MaxOutstandingMessages = t.PublishSettings.FlowControlSettings.MaxOutstandingMessages

--- a/pubsub/topic.go
+++ b/pubsub/topic.go
@@ -639,7 +639,7 @@ func (t *Topic) initBundler() {
 		// This is because there's no way to set "unlimited" for BufferedByteLimit,
 		// and simply setting it to MaxOutstandingBytes occasionally leads to issues where
 		// BufferedByteLimit is reached even though there are resources available.
-		t.PublishSettings.BufferedByteLimit = math.MaxInt64
+		t.PublishSettings.BufferedByteLimit = math.MaxInt
 	}
 	if t.PublishSettings.FlowControlSettings.MaxOutstandingMessages > 0 {
 		fcs.MaxOutstandingMessages = t.PublishSettings.FlowControlSettings.MaxOutstandingMessages


### PR DESCRIPTION
Should fix compatibility with 32-bit architectures.

Closes #6112.