### PR TITLE
fix(pubsub): fix iterator distribution bound calculations

### DIFF
--- a/pubsub/iterator.go
+++ b/pubsub/iterator.go
@@ -161,8 +161,8 @@ func (it *messageIterator) checkDrained() {
 // min/maxDurationPerLeaseExtension.
 func (it *messageIterator) addToDistribution(receiveTime time.Time) {
 	d := time.Since(receiveTime)
-	d = minDuration(d, minDurationPerLeaseExtension)
-	d = maxDuration(d, maxDurationPerLeaseExtension)
+	d = maxDuration(d, minDurationPerLeaseExtension)
+	d = minDuration(d, maxDurationPerLeaseExtension)
 	it.ackTimeDist.Record(int(d / time.Second))
 }
 

--- a/pubsub/iterator_test.go
+++ b/pubsub/iterator_test.go
@@ -510,6 +510,7 @@ func TestIterator_BoundedDuration(t *testing.T) {
 	}
 	iter := newMessageIterator(client.subc, fullyQualifiedTopicName, &pullOptions{})
 
+	// Start with a datapoint that's too small that should be bounded to 10s.
 	receiveTime := time.Now().Add(time.Duration(-1) * time.Second)
 	iter.addToDistribution(receiveTime)
 	deadline := iter.ackTimeDist.Percentile(.99)
@@ -517,6 +518,8 @@ func TestIterator_BoundedDuration(t *testing.T) {
 	if deadline != want {
 		t.Errorf("99th percentile ack distribution got: %v, want %v", deadline, want)
 	} 
+
+	// The next datapoint should not be bounded.
 	receiveTime = time.Now().Add(time.Duration(-300) * time.Second)
 	iter.addToDistribution(receiveTime)
 	deadline = iter.ackTimeDist.Percentile(.99)
@@ -525,6 +528,7 @@ func TestIterator_BoundedDuration(t *testing.T) {
 		t.Errorf("99th percentile ack distribution got: %v, want %v", deadline, want)
 	} 
 
+	// Lastly, add a datapoint that should be bounded to 600s
 	receiveTime = time.Now().Add(time.Duration(-1000) * time.Second)
 	iter.addToDistribution(receiveTime)
 	deadline = iter.ackTimeDist.Percentile(.99)

--- a/pubsub/iterator_test.go
+++ b/pubsub/iterator_test.go
@@ -496,3 +496,40 @@ func TestIterator_BoundedDuration(t *testing.T) {
 		})
 	}
 }
+
+ func TestAddToDistribution(t *testing.T) {
+	srv := pstest.NewServer()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	srv.Publish(fullyQualifiedTopicName, []byte("creating a topic"), nil)
+
+	_, client, err := initConn(ctx, srv.Addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	iter := newMessageIterator(client.subc, fullyQualifiedTopicName, &pullOptions{})
+
+	receiveTime := time.Now().Add(time.Duration(-1) * time.Second)
+	iter.addToDistribution(receiveTime)
+	deadline := iter.ackTimeDist.Percentile(.99)
+	want := 10
+	if deadline != want {
+		t.Errorf("99th percentile ack distribution got: %v, want %v", deadline, want)
+	} 
+	receiveTime = time.Now().Add(time.Duration(-300) * time.Second)
+	iter.addToDistribution(receiveTime)
+	deadline = iter.ackTimeDist.Percentile(.99)
+	want = 300 
+	if deadline != want {
+		t.Errorf("99th percentile ack distribution got: %v, want %v", deadline, want)
+	} 
+
+	receiveTime = time.Now().Add(time.Duration(-1000) * time.Second)
+	iter.addToDistribution(receiveTime)
+	deadline = iter.ackTimeDist.Percentile(.99)
+	want = 600
+	if deadline != want {
+		t.Errorf("99th percentile ack distribution got: %v, want %v", deadline, want)
+	} 
+ }

--- a/pubsub/iterator_test.go
+++ b/pubsub/iterator_test.go
@@ -497,7 +497,7 @@ func TestIterator_BoundedDuration(t *testing.T) {
 	}
 }
 
- func TestAddToDistribution(t *testing.T) {
+func TestAddToDistribution(t *testing.T) {
 	srv := pstest.NewServer()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -517,16 +517,16 @@ func TestIterator_BoundedDuration(t *testing.T) {
 	want := 10
 	if deadline != want {
 		t.Errorf("99th percentile ack distribution got: %v, want %v", deadline, want)
-	} 
+	}
 
 	// The next datapoint should not be bounded.
 	receiveTime = time.Now().Add(time.Duration(-300) * time.Second)
 	iter.addToDistribution(receiveTime)
 	deadline = iter.ackTimeDist.Percentile(.99)
-	want = 300 
+	want = 300
 	if deadline != want {
 		t.Errorf("99th percentile ack distribution got: %v, want %v", deadline, want)
-	} 
+	}
 
 	// Lastly, add a datapoint that should be bounded to 600s
 	receiveTime = time.Now().Add(time.Duration(-1000) * time.Second)
@@ -535,5 +535,5 @@ func TestIterator_BoundedDuration(t *testing.T) {
 	want = 600
 	if deadline != want {
 		t.Errorf("99th percentile ack distribution got: %v, want %v", deadline, want)
-	} 
- }
+	}
+}


### PR DESCRIPTION
The new method `addToDistribution` added to support `MinExtensionPeriod` incorrectly sets the bounds (needed to reverse min/max duration).

Fixes #6123 