### PR TITLE
chore(bigquery): cleanup some lint errors

### DIFF
--- a/bigquery/internal/version.go
+++ b/bigquery/internal/version.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// This internal package is used to manage versioning of the released library.
 package internal
 
 // Version is the current tagged release of the library.

--- a/bigquery/internal/version.go
+++ b/bigquery/internal/version.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// This internal package is used to manage versioning of the released library.
+// Package internal is used to manage versioning of the released library.
 package internal
 
 // Version is the current tagged release of the library.

--- a/bigquery/storage/managedwriter/integration_test.go
+++ b/bigquery/storage/managedwriter/integration_test.go
@@ -611,10 +611,6 @@ func testSchemaEvolution(ctx context.Context, t *testing.T, mwClient *Client, bq
 			break
 		}
 		curOffset = curOffset + 1
-		if err != nil {
-			t.Errorf("got error on offset %d: %v", curOffset, err)
-			break
-		}
 		s, err := resp.UpdatedSchema(ctx)
 		if err != nil {
 			t.Errorf("getting schema error: %v", err)

--- a/bigquery/storage/managedwriter/managed_stream_test.go
+++ b/bigquery/storage/managedwriter/managed_stream_test.go
@@ -231,7 +231,8 @@ func TestManagedStream_FlowControllerFailure(t *testing.T) {
 	// Create a context that will expire during the append.
 	// This is expected to surface a flowcontroller error, as there's no
 	// capacity.
-	expireCtx, _ := context.WithTimeout(ctx, 100*time.Millisecond)
+	expireCtx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
+	defer cancel()
 	_, err := ms.AppendRows(expireCtx, fakeData)
 	if err == nil {
 		t.Errorf("expected AppendRows to error, but it succeeded")
@@ -317,7 +318,8 @@ func TestManagedStream_LeakingGoroutines(t *testing.T) {
 	// Send a bunch of appends that expire quicker than response, and monitor that
 	// goroutine growth stays within bounded threshold.
 	for i := 0; i < 500; i++ {
-		expireCtx, _ := context.WithTimeout(ctx, 25*time.Millisecond)
+		expireCtx, cancel := context.WithTimeout(ctx, 25*time.Millisecond)
+		defer cancel()
 		ms.AppendRows(expireCtx, fakeData)
 		if i%50 == 0 {
 			if current := runtime.NumGoroutine(); current > threshold {


### PR DESCRIPTION
This PR addresses linter/tricorder errors surfaced when importing this
library internally.  See cl/454723109 for examples.