### PR TITLE
chore: adjust assuredworkload yaml file name

### DIFF
--- a/internal/gapicgen/generator/config.go
+++ b/internal/gapicgen/generator/config.go
@@ -910,7 +910,7 @@ var MicrogenGapicConfigs = []*MicrogenConfig{
 		Pkg:                   "assuredworkloads",
 		ImportPath:            "cloud.google.com/go/assuredworkloads/apiv1beta1",
 		GRPCServiceConfigPath: "assuredworkloads_grpc_service_config.json",
-		ApiServiceConfigPath:  "assuredworkloads_v1beta1.yaml",
+		ApiServiceConfigPath:  "assuredworkloads.yaml",
 		ReleaseLevel:          "beta",
 	},
 	{


### PR DESCRIPTION
Similar reasons to https://github.com/googleapis/go-genproto/pull/824