### PR TITLE
chore(internal/gapicgen): update generator to v0.31.0

### DIFF
--- a/internal/gapicgen/cmd/genbot/Dockerfile
+++ b/internal/gapicgen/cmd/genbot/Dockerfile
@@ -27,7 +27,7 @@ RUN go install github.com/golang/protobuf/protoc-gen-go@v1.5.2 && \
     go install golang.org/x/lint/golint@latest && \
     go install golang.org/x/tools/cmd/goimports@latest && \
     go install honnef.co/go/tools/cmd/staticcheck@latest && \
-    go install github.com/googleapis/gapic-generator-go/cmd/protoc-gen-go_gapic@v0.28.0
+    go install github.com/googleapis/gapic-generator-go/cmd/protoc-gen-go_gapic@v0.31.0
 ENV PATH="${PATH}:/root/go/bin"
 
 # Source: http://debuggable.com/posts/disable-strict-host-checking-for-git-clone:49896ff3-0ac0-4263-9703-1eae4834cda3


### PR DESCRIPTION
Update GAPIC generator to v0.31.0. Changes _since the last update_ include:
* generator support for protobuf-go `go_package` cli option `-Mproto=importpath`
* REGAPIC retry support
* REGAPIC encode enums as numbers
* REGAPIC fix path param parsing to remove duped query param
* REGAPIC LRO support