### PR TITLE
fix(pubsublite): fixed version in stream headers

### DIFF
--- a/pubsublite/internal/wire/rpc.go
+++ b/pubsublite/internal/wire/rpc.go
@@ -246,6 +246,12 @@ func stringValue(str string) *structpb.Value {
 	}
 }
 
+func numberValue(val int64) *structpb.Value {
+	return &structpb.Value{
+		Kind: &structpb.Value_NumberValue{NumberValue: float64(val)},
+	}
+}
+
 // pubsubMetadata stores key/value pairs that should be added to gRPC metadata.
 type pubsubMetadata map[string]string
 
@@ -274,8 +280,8 @@ func (pm pubsubMetadata) doAddClientInfo(framework FrameworkType, version string
 		s.Fields[frameworkKey] = stringValue(string(framework))
 	}
 	if version, ok := parseVersion(version); ok {
-		s.Fields[majorVersionKey] = stringValue(version.Major)
-		s.Fields[minorVersionKey] = stringValue(version.Minor)
+		s.Fields[majorVersionKey] = numberValue(version.Major)
+		s.Fields[minorVersionKey] = numberValue(version.Minor)
 	}
 	if bytes, err := proto.Marshal(s); err == nil {
 		pm[clientInfoMetadataHeader] = base64.StdEncoding.EncodeToString(bytes)

--- a/pubsublite/internal/wire/rpc_test.go
+++ b/pubsublite/internal/wire/rpc_test.go
@@ -134,8 +134,8 @@ func TestPubsubMetadataAddClientInfo(t *testing.T) {
 				Fields: map[string]*structpb.Value{
 					"language":      stringValue("GOLANG"),
 					"framework":     stringValue("CLOUD_PUBSUB_SHIM"),
-					"major_version": stringValue("1"),
-					"minor_version": stringValue("2"),
+					"major_version": numberValue(1),
+					"minor_version": numberValue(2),
 				},
 			},
 		},

--- a/pubsublite/internal/wire/version.go
+++ b/pubsublite/internal/wire/version.go
@@ -19,8 +19,8 @@ import (
 )
 
 type version struct {
-	Major string
-	Minor string
+	Major int64
+	Minor int64
 }
 
 // parseVersion attempts to parse the pubsublite library version in the format:
@@ -28,13 +28,13 @@ type version struct {
 func parseVersion(value string) (v version, ok bool) {
 	components := strings.Split(value, ".")
 	if len(components) >= 2 {
-		if _, err := strconv.ParseInt(components[0], 10, 32); err != nil {
+		var err error
+		if v.Major, err = strconv.ParseInt(components[0], 10, 32); err != nil {
 			return
 		}
-		if _, err := strconv.ParseInt(components[1], 10, 32); err != nil {
+		if v.Minor, err = strconv.ParseInt(components[1], 10, 32); err != nil {
 			return
 		}
-		v = version{Major: components[0], Minor: components[1]}
 		ok = true
 	}
 	return

--- a/pubsublite/internal/wire/version_test.go
+++ b/pubsublite/internal/wire/version_test.go
@@ -30,13 +30,13 @@ func TestParseVersion(t *testing.T) {
 		{
 			desc:        "valid 3 components",
 			input:       "1.2.2",
-			wantVersion: version{Major: "1", Minor: "2"},
+			wantVersion: version{Major: 1, Minor: 2},
 			wantOk:      true,
 		},
 		{
 			desc:        "valid 2 components",
 			input:       "2.3",
-			wantVersion: version{Major: "2", Minor: "3"},
+			wantVersion: version{Major: 2, Minor: 3},
 			wantOk:      true,
 		},
 		{
@@ -44,9 +44,10 @@ func TestParseVersion(t *testing.T) {
 			wantOk: false,
 		},
 		{
-			desc:   "minor version invalid",
-			input:  "1.a.2",
-			wantOk: false,
+			desc:        "minor version invalid",
+			input:       "1.a.2",
+			wantVersion: version{Major: 1},
+			wantOk:      false,
 		},
 		{
 			desc:   "major version invalid",


### PR DESCRIPTION
The major and minor versions should be sent as struct number values, rather than string values.