### PR TITLE
test(bigquery/storage/managedwriter): address data race

### DIFF
--- a/bigquery/storage/managedwriter/integration_test.go
+++ b/bigquery/storage/managedwriter/integration_test.go
@@ -640,11 +640,11 @@ func testSchemaEvolution(ctx context.Context, t *testing.T, mwClient *Client, bq
 	for i := 0; i < 5; i++ {
 		wg.Add(1)
 		go func() {
-			result, err = ms.AppendRows(ctx, [][]byte{b}, UpdateSchemaDescriptor(descriptorProto))
+			res, err := ms.AppendRows(ctx, [][]byte{b}, UpdateSchemaDescriptor(descriptorProto))
 			if err != nil {
 				t.Errorf("failed evolved append: %v", err)
 			}
-			_, err = result.GetResult(ctx)
+			_, err = res.GetResult(ctx)
 			if err != nil {
 				t.Errorf("error on evolved append: %v", err)
 			}


### PR DESCRIPTION
Ironically, the test to do more concurrent things to trigger a specific
kind of race condition itself added a new kind of concurrency data race.

This switches from using shared variables for checking results to
goroutine-local versions.

Fixes: #6171