### PR TITLE
feat(pubsub): add helper method for parsing ErrorInfos

### DIFF
--- a/pubsub/iterator.go
+++ b/pubsub/iterator.go
@@ -17,6 +17,7 @@ package pubsub
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"strings"
 	"sync"
@@ -27,6 +28,7 @@ import (
 	"cloud.google.com/go/pubsub/internal/distribution"
 	gax "github.com/googleapis/gax-go/v2"
 	pb "google.golang.org/genproto/googleapis/pubsub/v1"
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -138,8 +140,6 @@ func newMessageIterator(subc *vkit.SubscriberClient, subName string, po *pullOpt
 
 // Subscription.receive will call stop on its messageIterator when finished with it.
 // Stop will block until Done has been called on all Messages that have been
-// returned by Next, or until the context with which the messageIterator was created
-// is cancelled or exceeds its deadline.
 func (it *messageIterator) stop() {
 	it.cancel()
 	it.mu.Lock()
@@ -661,4 +661,71 @@ func maxDuration(x, y time.Duration) time.Duration {
 		return x
 	}
 	return y
+}
+
+func getStatus(err error) *status.Status {
+	st, ok := status.FromError(err)
+	if !ok {
+		return nil
+	}
+	return st
+}
+
+// getAckErrors retrieves the metadata of an rpc error if available.
+func getAckErrors(err error) map[string]string {
+	st := getStatus(err)
+	if st != nil {
+		for _, detail := range st.Details() {
+			info, _ := detail.(*errdetails.ErrorInfo)
+			return info.GetMetadata()
+		}
+	}
+	return nil
+}
+
+// processResults processes AckResults by referring to errorStatus and errorsMap.
+// The errors returned by the server in `errorStatus` or in `errorsMap`
+// are used to complete the AckResults in `ackResMap` (with a success
+// or error) or to return requests for further retries.
+// Logic is derived from python-pubsub: https://github.com/googleapis/python-pubsub/blob/main/google/cloud/pubsub_v1/subscriber/_protocol/streaming_pull_manager.py#L161-L220
+func processResults(errorStatus *status.Status, ackResMap map[string]*AckResult, errorsMap map[string]string) ([]*AckResult, []*AckResult) {
+	var completedResults, retryResults []*AckResult
+	for ackID, res := range ackResMap {
+		// Handle special errors returned for ack/modack RPCs via the ErrorInfo
+		// sidecar metadata when exactly-once delivery is enabled.
+		if exactlyOnceErrStr, ok := errorsMap[ackID]; ok {
+			if strings.HasPrefix(exactlyOnceErrStr, "TRANSIENT_") {
+				retryResults = append(retryResults, res)
+			} else {
+				exactlyOnceErr := fmt.Errorf(exactlyOnceErrStr)
+				if exactlyOnceErrStr == "PERMANENT_FAILURE_INVALID_ACK_ID" {
+					ipubsub.SetAckResult(res, AckResponseInvalidAckID, exactlyOnceErr)
+				} else {
+					ipubsub.SetAckResult(res, AckResponseOther, exactlyOnceErr)
+				}
+				completedResults = append(completedResults, res)
+			}
+		} else if errorStatus != nil && contains(errorStatus.Code(), exactlyOnceDeliveryTemporaryRetryErrors) {
+			retryResults = append(retryResults, ackResMap[ackID])
+		} else if errorStatus != nil {
+			// Other gRPC errors are not retried.
+			switch errorStatus.Code() {
+			case codes.PermissionDenied:
+				ipubsub.SetAckResult(res, AckResponsePermissionDenied, errorStatus.Err())
+			case codes.FailedPrecondition:
+				ipubsub.SetAckResult(res, AckResponseFailedPrecondition, errorStatus.Err())
+			default:
+				ipubsub.SetAckResult(res, AckResponseOther, errorStatus.Err())
+			}
+			completedResults = append(completedResults, res)
+		} else if res != nil {
+			// Since no error occurred, requests with AckResults are completed successfully.
+			ipubsub.SetAckResult(res, AckResponseSuccess, nil)
+			completedResults = append(completedResults, res)
+		} else {
+			// All other requests are considered completed.
+			completedResults = append(completedResults, res)
+		}
+	}
+	return completedResults, retryResults
 }

--- a/pubsub/iterator.go
+++ b/pubsub/iterator.go
@@ -699,21 +699,9 @@ func processResults(errorStatus *status.Status, ackResMap map[string]*AckResult,
 			} else {
 				exactlyOnceErr := fmt.Errorf(exactlyOnceErrStr)
 				if exactlyOnceErrStr == "PERMANENT_FAILURE_INVALID_ACK_ID" {
-<<<<<<< HEAD
-<<<<<<< HEAD
 					ipubsub.SetAckResult(res, AcknowledgeStatusInvalidAckID, exactlyOnceErr)
 				} else {
 					ipubsub.SetAckResult(res, AcknowledgeStatusOther, exactlyOnceErr)
-=======
-					ipubsub.SetAckResult(res, AckResponseInvalidAckID, exactlyOnceErr)
-				} else {
-					ipubsub.SetAckResult(res, AckResponseOther, exactlyOnceErr)
->>>>>>> 9f5510c83 (add process results)
-=======
-					ipubsub.SetAckResult(res, AcknowledgeStatusInvalidAckID, exactlyOnceErr)
-				} else {
-					ipubsub.SetAckResult(res, AcknowledgeStatusOther, exactlyOnceErr)
->>>>>>> f212ab9b55d5b7db5c93e0f750d57cea56da0aa8
 				}
 				completedResults = append(completedResults, res)
 			}
@@ -723,38 +711,16 @@ func processResults(errorStatus *status.Status, ackResMap map[string]*AckResult,
 			// Other gRPC errors are not retried.
 			switch errorStatus.Code() {
 			case codes.PermissionDenied:
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> f212ab9b55d5b7db5c93e0f750d57cea56da0aa8
 				ipubsub.SetAckResult(res, AcknowledgeStatusPermissionDenied, errorStatus.Err())
 			case codes.FailedPrecondition:
 				ipubsub.SetAckResult(res, AcknowledgeStatusFailedPrecondition, errorStatus.Err())
 			default:
 				ipubsub.SetAckResult(res, AcknowledgeStatusOther, errorStatus.Err())
-<<<<<<< HEAD
-=======
-				ipubsub.SetAckResult(res, AckResponsePermissionDenied, errorStatus.Err())
-			case codes.FailedPrecondition:
-				ipubsub.SetAckResult(res, AckResponseFailedPrecondition, errorStatus.Err())
-			default:
-				ipubsub.SetAckResult(res, AckResponseOther, errorStatus.Err())
->>>>>>> 9f5510c83 (add process results)
-=======
->>>>>>> f212ab9b55d5b7db5c93e0f750d57cea56da0aa8
 			}
 			completedResults = append(completedResults, res)
 		} else if res != nil {
 			// Since no error occurred, requests with AckResults are completed successfully.
-<<<<<<< HEAD
-<<<<<<< HEAD
 			ipubsub.SetAckResult(res, AcknowledgeStatusSuccess, nil)
-=======
-			ipubsub.SetAckResult(res, AckResponseSuccess, nil)
->>>>>>> 9f5510c83 (add process results)
-=======
-			ipubsub.SetAckResult(res, AcknowledgeStatusSuccess, nil)
->>>>>>> f212ab9b55d5b7db5c93e0f750d57cea56da0aa8
 			completedResults = append(completedResults, res)
 		} else {
 			// All other requests are considered completed.

--- a/pubsub/iterator.go
+++ b/pubsub/iterator.go
@@ -28,7 +28,6 @@ import (
 	"cloud.google.com/go/pubsub/internal/distribution"
 	gax "github.com/googleapis/gax-go/v2"
 	pb "google.golang.org/genproto/googleapis/pubsub/v1"
-	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -663,26 +662,6 @@ func maxDuration(x, y time.Duration) time.Duration {
 		return x
 	}
 	return y
-}
-
-func getStatus(err error) *status.Status {
-	st, ok := status.FromError(err)
-	if !ok {
-		return nil
-	}
-	return st
-}
-
-// getAckErrors retrieves the metadata of an rpc error if available.
-func getAckErrors(err error) map[string]string {
-	st := getStatus(err)
-	if st != nil {
-		for _, detail := range st.Details() {
-			info, _ := detail.(*errdetails.ErrorInfo)
-			return info.GetMetadata()
-		}
-	}
-	return nil
 }
 
 // processResults processes AckResults by referring to errorStatus and errorsMap.

--- a/pubsub/iterator.go
+++ b/pubsub/iterator.go
@@ -700,6 +700,7 @@ func processResults(errorStatus *status.Status, ackResMap map[string]*AckResult,
 				exactlyOnceErr := fmt.Errorf(exactlyOnceErrStr)
 				if exactlyOnceErrStr == "PERMANENT_FAILURE_INVALID_ACK_ID" {
 <<<<<<< HEAD
+<<<<<<< HEAD
 					ipubsub.SetAckResult(res, AcknowledgeStatusInvalidAckID, exactlyOnceErr)
 				} else {
 					ipubsub.SetAckResult(res, AcknowledgeStatusOther, exactlyOnceErr)
@@ -708,6 +709,11 @@ func processResults(errorStatus *status.Status, ackResMap map[string]*AckResult,
 				} else {
 					ipubsub.SetAckResult(res, AckResponseOther, exactlyOnceErr)
 >>>>>>> 9f5510c83 (add process results)
+=======
+					ipubsub.SetAckResult(res, AcknowledgeStatusInvalidAckID, exactlyOnceErr)
+				} else {
+					ipubsub.SetAckResult(res, AcknowledgeStatusOther, exactlyOnceErr)
+>>>>>>> f212ab9b55d5b7db5c93e0f750d57cea56da0aa8
 				}
 				completedResults = append(completedResults, res)
 			}
@@ -718,11 +724,15 @@ func processResults(errorStatus *status.Status, ackResMap map[string]*AckResult,
 			switch errorStatus.Code() {
 			case codes.PermissionDenied:
 <<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> f212ab9b55d5b7db5c93e0f750d57cea56da0aa8
 				ipubsub.SetAckResult(res, AcknowledgeStatusPermissionDenied, errorStatus.Err())
 			case codes.FailedPrecondition:
 				ipubsub.SetAckResult(res, AcknowledgeStatusFailedPrecondition, errorStatus.Err())
 			default:
 				ipubsub.SetAckResult(res, AcknowledgeStatusOther, errorStatus.Err())
+<<<<<<< HEAD
 =======
 				ipubsub.SetAckResult(res, AckResponsePermissionDenied, errorStatus.Err())
 			case codes.FailedPrecondition:
@@ -730,15 +740,21 @@ func processResults(errorStatus *status.Status, ackResMap map[string]*AckResult,
 			default:
 				ipubsub.SetAckResult(res, AckResponseOther, errorStatus.Err())
 >>>>>>> 9f5510c83 (add process results)
+=======
+>>>>>>> f212ab9b55d5b7db5c93e0f750d57cea56da0aa8
 			}
 			completedResults = append(completedResults, res)
 		} else if res != nil {
 			// Since no error occurred, requests with AckResults are completed successfully.
 <<<<<<< HEAD
+<<<<<<< HEAD
 			ipubsub.SetAckResult(res, AcknowledgeStatusSuccess, nil)
 =======
 			ipubsub.SetAckResult(res, AckResponseSuccess, nil)
 >>>>>>> 9f5510c83 (add process results)
+=======
+			ipubsub.SetAckResult(res, AcknowledgeStatusSuccess, nil)
+>>>>>>> f212ab9b55d5b7db5c93e0f750d57cea56da0aa8
 			completedResults = append(completedResults, res)
 		} else {
 			// All other requests are considered completed.

--- a/pubsub/iterator.go
+++ b/pubsub/iterator.go
@@ -699,9 +699,9 @@ func processResults(errorStatus *status.Status, ackResMap map[string]*AckResult,
 			} else {
 				exactlyOnceErr := fmt.Errorf(exactlyOnceErrStr)
 				if exactlyOnceErrStr == "PERMANENT_FAILURE_INVALID_ACK_ID" {
-					ipubsub.SetAckResult(res, AckResponseInvalidAckID, exactlyOnceErr)
+					ipubsub.SetAckResult(res, AcknowledgeStatusInvalidAckID, exactlyOnceErr)
 				} else {
-					ipubsub.SetAckResult(res, AckResponseOther, exactlyOnceErr)
+					ipubsub.SetAckResult(res, AcknowledgeStatusOther, exactlyOnceErr)
 				}
 				completedResults = append(completedResults, res)
 			}
@@ -711,16 +711,16 @@ func processResults(errorStatus *status.Status, ackResMap map[string]*AckResult,
 			// Other gRPC errors are not retried.
 			switch errorStatus.Code() {
 			case codes.PermissionDenied:
-				ipubsub.SetAckResult(res, AckResponsePermissionDenied, errorStatus.Err())
+				ipubsub.SetAckResult(res, AcknowledgeStatusPermissionDenied, errorStatus.Err())
 			case codes.FailedPrecondition:
-				ipubsub.SetAckResult(res, AckResponseFailedPrecondition, errorStatus.Err())
+				ipubsub.SetAckResult(res, AcknowledgeStatusFailedPrecondition, errorStatus.Err())
 			default:
-				ipubsub.SetAckResult(res, AckResponseOther, errorStatus.Err())
+				ipubsub.SetAckResult(res, AcknowledgeStatusOther, errorStatus.Err())
 			}
 			completedResults = append(completedResults, res)
 		} else if res != nil {
 			// Since no error occurred, requests with AckResults are completed successfully.
-			ipubsub.SetAckResult(res, AckResponseSuccess, nil)
+			ipubsub.SetAckResult(res, AcknowledgeStatusSuccess, nil)
 			completedResults = append(completedResults, res)
 		} else {
 			// All other requests are considered completed.

--- a/pubsub/iterator.go
+++ b/pubsub/iterator.go
@@ -17,7 +17,6 @@ package pubsub
 import (
 	"context"
 	"errors"
-	"fmt"
 	"io"
 	"strings"
 	"sync"
@@ -681,15 +680,14 @@ func processResults(errorStatus *status.Status, ackResMap map[string]*AckResult,
 		// Handle special errors returned for ack/modack RPCs via the ErrorInfo
 		// sidecar metadata when exactly-once delivery is enabled.
 		if errAckID, ok := errorsByAckID[ackID]; ok {
-			exactlyOnceErrStr := errAckID.Error()
-			if strings.HasPrefix(exactlyOnceErrStr, transientErrStringPrefix) {
+			errAckIDStr := errAckID.Error()
+			if strings.HasPrefix(errAckIDStr, transientErrStringPrefix) {
 				retryResults = append(retryResults, res)
 			} else {
-				exactlyOnceErr := fmt.Errorf(exactlyOnceErrStr)
-				if exactlyOnceErrStr == permanentInvalidAckErrString {
-					ipubsub.SetAckResult(res, AcknowledgeStatusInvalidAckID, exactlyOnceErr)
+				if errAckIDStr == permanentInvalidAckErrString {
+					ipubsub.SetAckResult(res, AcknowledgeStatusInvalidAckID, errAckID)
 				} else {
-					ipubsub.SetAckResult(res, AcknowledgeStatusOther, exactlyOnceErr)
+					ipubsub.SetAckResult(res, AcknowledgeStatusOther, errAckID)
 				}
 				completedResults = append(completedResults, res)
 			}

--- a/pubsub/iterator.go
+++ b/pubsub/iterator.go
@@ -699,9 +699,15 @@ func processResults(errorStatus *status.Status, ackResMap map[string]*AckResult,
 			} else {
 				exactlyOnceErr := fmt.Errorf(exactlyOnceErrStr)
 				if exactlyOnceErrStr == "PERMANENT_FAILURE_INVALID_ACK_ID" {
+<<<<<<< HEAD
 					ipubsub.SetAckResult(res, AcknowledgeStatusInvalidAckID, exactlyOnceErr)
 				} else {
 					ipubsub.SetAckResult(res, AcknowledgeStatusOther, exactlyOnceErr)
+=======
+					ipubsub.SetAckResult(res, AckResponseInvalidAckID, exactlyOnceErr)
+				} else {
+					ipubsub.SetAckResult(res, AckResponseOther, exactlyOnceErr)
+>>>>>>> 9f5510c83 (add process results)
 				}
 				completedResults = append(completedResults, res)
 			}
@@ -711,16 +717,28 @@ func processResults(errorStatus *status.Status, ackResMap map[string]*AckResult,
 			// Other gRPC errors are not retried.
 			switch errorStatus.Code() {
 			case codes.PermissionDenied:
+<<<<<<< HEAD
 				ipubsub.SetAckResult(res, AcknowledgeStatusPermissionDenied, errorStatus.Err())
 			case codes.FailedPrecondition:
 				ipubsub.SetAckResult(res, AcknowledgeStatusFailedPrecondition, errorStatus.Err())
 			default:
 				ipubsub.SetAckResult(res, AcknowledgeStatusOther, errorStatus.Err())
+=======
+				ipubsub.SetAckResult(res, AckResponsePermissionDenied, errorStatus.Err())
+			case codes.FailedPrecondition:
+				ipubsub.SetAckResult(res, AckResponseFailedPrecondition, errorStatus.Err())
+			default:
+				ipubsub.SetAckResult(res, AckResponseOther, errorStatus.Err())
+>>>>>>> 9f5510c83 (add process results)
 			}
 			completedResults = append(completedResults, res)
 		} else if res != nil {
 			// Since no error occurred, requests with AckResults are completed successfully.
+<<<<<<< HEAD
 			ipubsub.SetAckResult(res, AcknowledgeStatusSuccess, nil)
+=======
+			ipubsub.SetAckResult(res, AckResponseSuccess, nil)
+>>>>>>> 9f5510c83 (add process results)
 			completedResults = append(completedResults, res)
 		} else {
 			// All other requests are considered completed.

--- a/pubsub/iterator.go
+++ b/pubsub/iterator.go
@@ -140,6 +140,8 @@ func newMessageIterator(subc *vkit.SubscriberClient, subName string, po *pullOpt
 
 // Subscription.receive will call stop on its messageIterator when finished with it.
 // Stop will block until Done has been called on all Messages that have been
+// returned by Next, or until the context with which the messageIterator was created
+// is cancelled or exceeds its deadline.
 func (it *messageIterator) stop() {
 	it.cancel()
 	it.mu.Lock()

--- a/pubsub/iterator_test.go
+++ b/pubsub/iterator_test.go
@@ -621,6 +621,8 @@ func TestPingStreamAckDeadline(t *testing.T) {
 }
 
 func TestExactlyOnceProcessRequests(t *testing.T) {
+	ctx := context.Background()
+
 	t.Run("no results", func(t *testing.T) {
 		// If the ackResMap is nil, then the resulting slices should be empty.
 		// Nil maps here behave the same as if they were empty maps.
@@ -661,9 +663,12 @@ func TestExactlyOnceProcessRequests(t *testing.T) {
 		if len(retry) != 0 {
 			t.Errorf("expected retry slice to be empty, got: %v\n", completed)
 		}
-		s, err := r.Get()
+		s, err := r.Get(ctx)
 		if err != nil {
 			t.Errorf("got err from AckResult: %v", err)
+		}
+		if s != AcknowledgeStatusSuccess {
+			t.Errorf("expected AcknowledgeStatusSuccess, got %v", s)
 		}
 	})
 

--- a/pubsub/iterator_test.go
+++ b/pubsub/iterator_test.go
@@ -621,8 +621,11 @@ func TestPingStreamAckDeadline(t *testing.T) {
 }
 
 func TestExactlyOnceProcessRequests(t *testing.T) {
+<<<<<<< HEAD
 	ctx := context.Background()
 
+=======
+>>>>>>> 9f5510c83 (add process results)
 	t.Run("no results", func(t *testing.T) {
 		// If the ackResMap is nil, then the resulting slices should be empty.
 		// Nil maps here behave the same as if they were empty maps.

--- a/pubsub/message.go
+++ b/pubsub/message.go
@@ -171,10 +171,6 @@ func (ah *psAckHandler) OnNackWithResult() *AckResult {
 	return ah.ackResult
 }
 
-func (ah *psAckHandler) AckResult() *AckResult {
-	return ah.ackResult
-}
-
 func (ah *psAckHandler) done(ack bool) {
 	if ah.calledDone {
 		return

--- a/pubsub/service.go
+++ b/pubsub/service.go
@@ -106,3 +106,25 @@ func (r *publishRetryer) Retry(err error) (pause time.Duration, shouldRetry bool
 	}
 	return r.defaultRetryer.Retry(err)
 }
+
+var (
+	exactlyOnceDeliveryTemporaryRetryErrors = []codes.Code{
+		codes.DeadlineExceeded,
+		codes.ResourceExhausted,
+		codes.Aborted,
+		codes.Internal,
+		codes.Unavailable,
+	}
+)
+
+// check if a grpc code is in the target slice
+// consider replacing with generics's slice.Contains
+// once go 1.18 is the min version.
+func contains(v codes.Code, t []codes.Code) bool {
+	for _, c := range t {
+		if v == c {
+			return true
+		}
+	}
+	return false
+}

--- a/pubsub/service.go
+++ b/pubsub/service.go
@@ -108,22 +108,17 @@ func (r *publishRetryer) Retry(err error) (pause time.Duration, shouldRetry bool
 }
 
 var (
-	exactlyOnceDeliveryTemporaryRetryErrors = []codes.Code{
-		codes.DeadlineExceeded,
-		codes.ResourceExhausted,
-		codes.Aborted,
-		codes.Internal,
-		codes.Unavailable,
+	exactlyOnceDeliveryTemporaryRetryErrors = map[codes.Code]struct{}{
+		codes.DeadlineExceeded:  {},
+		codes.ResourceExhausted: {},
+		codes.Aborted:           {},
+		codes.Internal:          {},
+		codes.Unavailable:       {},
 	}
 )
 
-// contains checks if grpc code v is in t, a slice of retryable error codes.
-// Consider replacing with generics's slice.Contains once go 1.18 is the min version.
-func contains(v codes.Code, t []codes.Code) bool {
-	for _, c := range t {
-		if v == c {
-			return true
-		}
-	}
-	return false
+// contains checks if grpc code v is in t, a set of retryable error codes.
+func contains(v codes.Code, t map[codes.Code]struct{}) bool {
+	_, ok := t[v]
+	return ok
 }

--- a/pubsub/service.go
+++ b/pubsub/service.go
@@ -117,9 +117,8 @@ var (
 	}
 )
 
-// check if a grpc code is in the target slice
-// consider replacing with generics's slice.Contains
-// once go 1.18 is the min version.
+// contains checks if grpc code v is in t, a slice of retryable error codes.
+// Consider replacing with generics's slice.Contains once go 1.18 is the min version.
 func contains(v codes.Code, t []codes.Code) bool {
 	for _, c := range t {
 		if v == c {

--- a/pubsub/subscription.go
+++ b/pubsub/subscription.go
@@ -292,7 +292,7 @@ type SubscriptionConfig struct {
 	// and will be ignored if sent in a request.
 	TopicMessageRetentionDuration time.Duration
 
-	// EnableExcactlyOnceDelivery configures Pub/Sub to provide the following guarantees
+	// EnableExactlyOnceDelivery configures Pub/Sub to provide the following guarantees
 	// for the delivery of a message with a given MessageID on this subscription:
 	//
 	// The message sent to a subscriber is guaranteed not to be resent


### PR DESCRIPTION
This PR corresponds with the 6th point in the PR sequencing doc. Logic is derived from Python's `process_requests` function.