### PR TITLE
chore(storage): gRPC ComposeObject implementation

### DIFF
--- a/storage/client.go
+++ b/storage/client.go
@@ -278,11 +278,24 @@ type newRangeReaderParams struct {
 
 type composeObjectRequest struct {
 	dstBucket     string
-	dstObject     string
-	srcs          []string
-	gen           int64
-	conds         *Conditions
+	dstObject     composeDstObject
+	srcs          []composeSrcObject
 	predefinedACL string
+	encryptionKey []byte
+	sendCRC32C    bool
+}
+
+// composeObject manages per-object params for compose sources and destination.
+type composeSrcObject struct {
+	name  string
+	gen   int64
+	conds *Conditions
+}
+
+type composeDstObject struct {
+	name  string
+	conds *Conditions
+	attrs *ObjectAttrs // attrs to set on the destination object.
 }
 
 type rewriteObjectRequest struct {

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -948,6 +948,64 @@ func TestLockBucketRetentionPolicyEmulated(t *testing.T) {
 	})
 }
 
+func TestComposeEmulated(t *testing.T) {
+	transportClientTest(t, func(t *testing.T, project, bucket string, client storageClient) {
+		ctx := context.Background()
+
+		// Populate test data.
+		_, err := client.CreateBucket(context.Background(), project, &BucketAttrs{
+			Name: bucket,
+		})
+		if err != nil {
+			t.Fatalf("client.CreateBucket: %v", err)
+		}
+		prefix := time.Now().Nanosecond()
+		srcNames := []string{
+			fmt.Sprintf("%d-object1", prefix),
+			fmt.Sprintf("%d-object2", prefix),
+		}
+
+		for _, n := range srcNames {
+			w := veneerClient.Bucket(bucket).Object(n).NewWriter(ctx)
+			if _, err := w.Write(randomBytesToWrite); err != nil {
+				t.Fatalf("failed to populate test data: %v", err)
+			}
+			if err := w.Close(); err != nil {
+				t.Fatalf("closing object: %v", err)
+			}
+		}
+
+		dstName := fmt.Sprintf("%d-object3", prefix)
+		req := composeObjectRequest{
+			dstBucket: bucket,
+			dstObject: composeDstObject{
+				name:  dstName,
+				attrs: &ObjectAttrs{StorageClass: "COLDLINE"},
+			},
+			srcs: []composeSrcObject{
+				{name: srcNames[0]},
+				{name: srcNames[1]},
+			},
+		}
+		attrs, err := client.ComposeObject(ctx, &req)
+		if err != nil {
+			t.Fatalf("client.ComposeObject(): %v", err)
+		}
+		if got := attrs.Name; got != dstName {
+			t.Errorf("attrs.Name: got %v, want %v", got, dstName)
+		}
+		// Check that the destination object size is equal to the sum of its
+		// sources.
+		if got, want := attrs.Size, 2*len(randomBytesToWrite); got != int64(want) {
+			t.Errorf("attrs.Size: got %v, want %v", got, want)
+		}
+		// Check that destination attrs set via object attrs are preserved.
+		if got, want := attrs.StorageClass, "COLDLINE"; got != want {
+			t.Errorf("attrs.StorageClass: got %v, want %v", got, want)
+		}
+	})
+}
+
 // transportClienttest executes the given function with a sub-test, a project name
 // based on the transport, a unique bucket name also based on the transport, and
 // the transport-specific client to run the test with. It also checks the environment

--- a/storage/copy.go
+++ b/storage/copy.go
@@ -192,13 +192,6 @@ func (c *Composer) Run(ctx context.Context) (attrs *ObjectAttrs, err error) {
 		return nil, errors.New("storage: at least one source object must be specified")
 	}
 
-	req := &raw.ComposeRequest{}
-	// Compose requires a non-empty Destination, so we always set it,
-	// even if the caller-provided ObjectAttrs is the zero value.
-	req.Destination = c.ObjectAttrs.toRawObject(c.dst.bucket)
-	if c.SendCRC32C {
-		req.Destination.Crc32c = encodeUint32(c.ObjectAttrs.CRC32C)
-	}
 	for _, src := range c.srcs {
 		if err := src.validate(); err != nil {
 			return nil, err
@@ -209,6 +202,17 @@ func (c *Composer) Run(ctx context.Context) (attrs *ObjectAttrs, err error) {
 		if src.encryptionKey != nil {
 			return nil, fmt.Errorf("storage: compose source %s.%s must not have encryption key", src.bucket, src.object)
 		}
+	}
+
+	// TODO: transport agnostic interface starts here.
+	req := &raw.ComposeRequest{}
+	// Compose requires a non-empty Destination, so we always set it,
+	// even if the caller-provided ObjectAttrs is the zero value.
+	req.Destination = c.ObjectAttrs.toRawObject(c.dst.bucket)
+	if c.SendCRC32C {
+		req.Destination.Crc32c = encodeUint32(c.ObjectAttrs.CRC32C)
+	}
+	for _, src := range c.srcs {
 		srcObj := &raw.ComposeRequestSourceObjects{
 			Name: src.object,
 		}

--- a/storage/http_client.go
+++ b/storage/http_client.go
@@ -641,7 +641,47 @@ func (c *httpStorageClient) UpdateObjectACL(ctx context.Context, bucket, object 
 // Media operations.
 
 func (c *httpStorageClient) ComposeObject(ctx context.Context, req *composeObjectRequest, opts ...storageOption) (*ObjectAttrs, error) {
-	return nil, errMethodNotSupported
+	s := callSettings(c.settings, opts...)
+	rawReq := &raw.ComposeRequest{}
+	// Compose requires a non-empty Destination, so we always set it,
+	// even if the caller-provided ObjectAttrs is the zero value.
+	rawReq.Destination = req.dstObject.attrs.toRawObject(req.dstBucket)
+	if req.sendCRC32C {
+		rawReq.Destination.Crc32c = encodeUint32(req.dstObject.attrs.CRC32C)
+	}
+	for _, src := range req.srcs {
+		srcObj := &raw.ComposeRequestSourceObjects{
+			Name: src.name,
+		}
+		if err := applyConds("ComposeFrom source", src.gen, src.conds, composeSourceObj{srcObj}); err != nil {
+			return nil, err
+		}
+		rawReq.SourceObjects = append(rawReq.SourceObjects, srcObj)
+	}
+
+	call := c.raw.Objects.Compose(req.dstBucket, req.dstObject.name, rawReq).Context(ctx)
+	if err := applyConds("ComposeFrom destination", -1, req.dstObject.conds, call); err != nil {
+		return nil, err
+	}
+	if s.userProject != "" {
+		call.UserProject(s.userProject)
+	}
+	if req.predefinedACL != "" {
+		call.DestinationPredefinedAcl(req.predefinedACL)
+	}
+	if err := setEncryptionHeaders(call.Header(), req.encryptionKey, false); err != nil {
+		return nil, err
+	}
+	var obj *raw.Object
+	setClientHeader(call.Header())
+
+	var err error
+	retryCall := func() error { obj, err = call.Do(); return err }
+
+	if err := run(ctx, retryCall, s.retry, s.idempotent, setRetryHeaderHTTP(call)); err != nil {
+		return nil, err
+	}
+	return newObject(obj), nil
 }
 func (c *httpStorageClient) RewriteObject(ctx context.Context, req *rewriteObjectRequest, opts ...storageOption) (*rewriteObjectResponse, error) {
 	return nil, errMethodNotSupported


### PR DESCRIPTION
Adds implementation in gRPC and HTTP for client.ComposeObject
as well as an emulator test.
    
Required a bit of refactoring around method signature and params
but hopefully this makes it clearer what is going on.