### PR TITLE
fix(pubsub): increase modack deadline RPC timeout

### DIFF
--- a/pubsub/iterator.go
+++ b/pubsub/iterator.go
@@ -467,7 +467,7 @@ func (it *messageIterator) sendModAck(m map[string]bool, deadline time.Duration)
 		// transient (since the deadline is relative to the current time) and it
 		// isn't crucial for correctness (since expired messages will just be
 		// resent).
-		cctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		cctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 		defer cancel()
 		bo := gax.Backoff{
 			Initial:    100 * time.Millisecond,


### PR DESCRIPTION
Increase modack deadline timeout to align with ack timeout of 60s. The default of 2 seconds can be too low for environments with higher network latency and can cause messages to be redelivered frequently.

Internal only, see guidance for internal deadlines of ModAckDeadline: screen/B68KaMcqgPbmg4u