### PR TITLE
chore: add releaseType to config

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -1,64 +1,77 @@
 handleGHRelease: true
 manifest: true
+releaseType: go-yoshi
 
 branches:
   - branch: main
     handleGHRelease: true
     manifest: true
+    releaseType: go-yoshi
     manifestFile: .release-please-manifest-submodules.json
     manifestConfig: release-please-config-yoshi-submodules.json
   - branch: main
     handleGHRelease: true
     manifest: true
+    releaseType: go-yoshi
     manifestFile: bigquery/.release-please-manifest.json
     manifestConfig: bigquery/release-please-config.json
   - branch: main
     handleGHRelease: true
     manifest: true
+    releaseType: go-yoshi
     manifestFile: bigtable/.release-please-manifest.json
     manifestConfig: bigtable/release-please-config.json
   - branch: main
     handleGHRelease: true
     manifest: true
+    releaseType: go-yoshi
     manifestFile: datastore/.release-please-manifest.json
     manifestConfig: datastore/release-please-config.json
   - branch: main
     handleGHRelease: true
     manifest: true
+    releaseType: go-yoshi
     manifestFile: errorreporting/.release-please-manifest.json
     manifestConfig: errorreporting/release-please-config.json
   - branch: main
     handleGHRelease: true
     manifest: true
+    releaseType: go-yoshi
     manifestFile: firestore/.release-please-manifest.json
     manifestConfig: firestore/release-please-config.json
   - branch: main
     handleGHRelease: true
     manifest: true
+    releaseType: go-yoshi
     manifestFile: logging/.release-please-manifest.json
     manifestConfig: logging/release-please-config.json
   - branch: main
     handleGHRelease: true
     manifest: true
+    releaseType: go-yoshi
     manifestFile: profiler/.release-please-manifest.json
     manifestConfig: profiler/release-please-config.json
   - branch: main
     handleGHRelease: true
     manifest: true
+    releaseType: go-yoshi
     manifestFile: pubsub/.release-please-manifest.json
     manifestConfig: pubsub/release-please-config.json
   - branch: main
     handleGHRelease: true
     manifest: true
+    releaseType: go-yoshi
     manifestFile: pubsublite/.release-please-manifest.json
     manifestConfig: pubsublite/release-please-config.json
   - branch: main
     handleGHRelease: true
     manifest: true
+    releaseType: go-yoshi
     manifestFile: spanner/.release-please-manifest.json
     manifestConfig: spanner/release-please-config.json
   - branch: main
     handleGHRelease: true
     manifest: true
+    releaseType: go-yoshi
     manifestFile: storage/.release-please-manifest.json
     manifestConfig: storage/release-please-config.json


### PR DESCRIPTION
This setting is not read from the manifest config today so it is best for us to set it here for now as well. This guidance was given in https://github.com/googleapis/repo-automation-bots/issues/4032

Fixes: #5964