### PR TITLE
fix(spanner/spansql) Add tests for INSERT parsing, fix INTO bug

### DIFF
--- a/spanner/spansql/parser_test.go
+++ b/spanner/spansql/parser_test.go
@@ -312,6 +312,13 @@ func TestParseDMLStmt(t *testing.T) {
 				Input:   Values{{IntegerLiteral(1), StringLiteral("Marc"), StringLiteral("Richards")}},
 			},
 		},
+		{"INSERT INTO Singers (SingerId, FirstName, LastName) VALUES (1, 'Marc', 'Richards')",
+			&Insert{
+				Table:   "Singers",
+				Columns: []ID{ID("SingerId"), ID("FirstName"), ID("LastName")},
+				Input:   Values{{IntegerLiteral(1), StringLiteral("Marc"), StringLiteral("Richards")}},
+			},
+		},
 		{"INSERT Singers (SingerId, FirstName, LastName) SELECT * FROM UNNEST ([1, 2, 3]) AS data",
 			&Insert{
 				Table:   "Singers",

--- a/spanner/spansql/sql.go
+++ b/spanner/spansql/sql.go
@@ -157,6 +157,7 @@ func (rrdp ReplaceRowDeletionPolicy) SQL() string {
 func (drdp DropRowDeletionPolicy) SQL() string {
 	return "DROP ROW DELETION POLICY"
 }
+
 func (sct SetColumnType) SQL() string {
 	str := sct.Type.SQL()
 	if sct.NotNull {
@@ -261,7 +262,7 @@ func (u *Update) SQL() string {
 }
 
 func (i *Insert) SQL() string {
-	str := "INSERT " + i.Table.SQL() + " INTO ("
+	str := "INSERT INTO " + i.Table.SQL() + " ("
 	for i, column := range i.Columns {
 		if i > 0 {
 			str += ", "

--- a/spanner/spansql/sql_test.go
+++ b/spanner/spansql/sql_test.go
@@ -412,6 +412,15 @@ func TestSQL(t *testing.T) {
 			reparseDDL,
 		},
 		{
+			&Insert{
+				Table:   "Singers",
+				Columns: []ID{ID("SingerId"), ID("FirstName"), ID("LastName")},
+				Input:   Values{{IntegerLiteral(1), StringLiteral("Marc"), StringLiteral("Richards")}},
+			},
+			`INSERT INTO Singers (SingerId, FirstName, LastName) VALUES (1, "Marc", "Richards")`,
+			reparseDML,
+		},
+		{
 			&Delete{
 				Table: "Ta",
 				Where: ComparisonOp{


### PR DESCRIPTION
#6148 introduced a bug in the way `INSERT` statements are produced.

Currently, INSERT statements produced by the parser are invalid, for example:

```
INSERT Singers INTO ...
```
Where the [correct form](https://cloud.google.com/spanner/docs/reference/standard-sql/dml-syntax#insert-statement) should be:
```sql
INSERT INTO Singers ...
-- or
INSERT Singers ...
```
The first form (INSERT INTO) has been chosen as it aligns with the [documented examples](https://cloud.google.com/spanner/docs/reference/standard-sql/dml-syntax#insert_examples).

This PR addresses the issue and adds necessary tests.