### PR TITLE
feat(bigtable): adds autoscaling target storage per node

### DIFF
--- a/bigtable/admin.go
+++ b/bigtable/admin.go
@@ -1062,6 +1062,12 @@ type AutoscalingConfig struct {
 	// CPUTargetPercent sets the CPU utilization target for your cluster's
 	// workload.
 	CPUTargetPercent int
+	// StorageUtilizationPerNode sets the storage usage target, in GB, for
+	// each node in a cluster. This number is limited between 2560 (2.5TiB) and
+	// 5120 (5TiB) for a SSD cluster and between 8192 (8TiB) and 16384 (16 TiB)
+	// for an HDD cluster. If set to zero, the default values are used:
+	// 2560 for SSD and 8192 for HDD.
+	StorageUtilizationPerNode int
 }
 
 func (a *AutoscalingConfig) proto() *btapb.Cluster_ClusterAutoscalingConfig {
@@ -1074,7 +1080,8 @@ func (a *AutoscalingConfig) proto() *btapb.Cluster_ClusterAutoscalingConfig {
 			MaxServeNodes: int32(a.MaxNodes),
 		},
 		AutoscalingTargets: &btapb.AutoscalingTargets{
-			CpuUtilizationPercent: int32(a.CPUTargetPercent),
+			CpuUtilizationPercent:        int32(a.CPUTargetPercent),
+			StorageUtilizationGibPerNode: int32(a.StorageUtilizationPerNode),
 		},
 	}
 }
@@ -1340,9 +1347,10 @@ func fromClusterConfigProto(c *btapb.Cluster_ClusterConfig) *AutoscalingConfig {
 		return nil
 	}
 	return &AutoscalingConfig{
-		MinNodes:         int(got.AutoscalingLimits.MinServeNodes),
-		MaxNodes:         int(got.AutoscalingLimits.MaxServeNodes),
-		CPUTargetPercent: int(got.AutoscalingTargets.CpuUtilizationPercent),
+		MinNodes:                  int(got.AutoscalingLimits.MinServeNodes),
+		MaxNodes:                  int(got.AutoscalingLimits.MaxServeNodes),
+		CPUTargetPercent:          int(got.AutoscalingTargets.CpuUtilizationPercent),
+		StorageUtilizationPerNode: int(got.AutoscalingTargets.StorageUtilizationGibPerNode),
 	}
 }
 

--- a/bigtable/admin_test.go
+++ b/bigtable/admin_test.go
@@ -129,13 +129,14 @@ func TestInstanceAdmin_GetCluster(t *testing.T) {
 								MaxServeNodes: 2,
 							},
 							AutoscalingTargets: &btapb.AutoscalingTargets{
-								CpuUtilizationPercent: 10,
+								CpuUtilizationPercent:        10,
+								StorageUtilizationGibPerNode: 3000,
 							},
 						},
 					},
 				},
 			},
-			wantConfig: &AutoscalingConfig{MinNodes: 1, MaxNodes: 2, CPUTargetPercent: 10},
+			wantConfig: &AutoscalingConfig{MinNodes: 1, MaxNodes: 2, CPUTargetPercent: 10, StorageUtilizationPerNode: 3000},
 		},
 	}
 
@@ -186,13 +187,14 @@ func TestInstanceAdmin_Clusters(t *testing.T) {
 								MaxServeNodes: 2,
 							},
 							AutoscalingTargets: &btapb.AutoscalingTargets{
-								CpuUtilizationPercent: 10,
+								CpuUtilizationPercent:        10,
+								StorageUtilizationGibPerNode: 3000,
 							},
 						},
 					},
 				},
 			},
-			wantConfig: &AutoscalingConfig{MinNodes: 1, MaxNodes: 2, CPUTargetPercent: 10},
+			wantConfig: &AutoscalingConfig{MinNodes: 1, MaxNodes: 2, CPUTargetPercent: 10, StorageUtilizationPerNode: 3000},
 		},
 	}
 
@@ -221,9 +223,10 @@ func TestInstanceAdmin_SetAutoscaling(t *testing.T) {
 	c := setupClient(t, mock)
 
 	err := c.SetAutoscaling(context.Background(), "myinst", "mycluster", AutoscalingConfig{
-		MinNodes:         1,
-		MaxNodes:         2,
-		CPUTargetPercent: 10,
+		MinNodes:                  1,
+		MaxNodes:                  2,
+		CPUTargetPercent:          10,
+		StorageUtilizationPerNode: 3000,
 	})
 	if err != nil {
 		t.Fatalf("SetAutoscaling failed: %v", err)
@@ -255,6 +258,11 @@ func TestInstanceAdmin_SetAutoscaling(t *testing.T) {
 	wantCPU := int32(10)
 	if gotCPU := gotConfig.AutoscalingTargets.CpuUtilizationPercent; wantCPU != gotCPU {
 		t.Fatalf("want autoscaling cpu = %v, got = %v", wantCPU, gotCPU)
+	}
+
+	wantStorage := int32(3000)
+	if gotStorage := gotConfig.AutoscalingTargets.StorageUtilizationGibPerNode; wantStorage != gotStorage {
+		t.Fatalf("want autoscaling storage = %v, got = %v", wantStorage, gotStorage)
 	}
 }
 
@@ -288,7 +296,7 @@ func TestInstanceAdmin_CreateInstance_WithAutoscaling(t *testing.T) {
 		ClusterId:         "mycluster",
 		Zone:              "us-central1-a",
 		StorageType:       SSD,
-		AutoscalingConfig: &AutoscalingConfig{MinNodes: 1, MaxNodes: 2, CPUTargetPercent: 10},
+		AutoscalingConfig: &AutoscalingConfig{MinNodes: 1, MaxNodes: 2, CPUTargetPercent: 10, StorageUtilizationPerNode: 3000},
 	})
 	if err != nil {
 		t.Fatalf("CreateInstance failed: %v", err)
@@ -346,7 +354,7 @@ func TestInstanceAdmin_CreateInstanceWithClusters_WithAutoscaling(t *testing.T) 
 				ClusterID:         "mycluster",
 				Zone:              "us-central1-a",
 				StorageType:       SSD,
-				AutoscalingConfig: &AutoscalingConfig{MinNodes: 1, MaxNodes: 2, CPUTargetPercent: 10},
+				AutoscalingConfig: &AutoscalingConfig{MinNodes: 1, MaxNodes: 2, CPUTargetPercent: 10, StorageUtilizationPerNode: 3000},
 			},
 		},
 	})
@@ -382,7 +390,7 @@ func TestInstanceAdmin_CreateCluster_WithAutoscaling(t *testing.T) {
 		ClusterID:         "mycluster",
 		Zone:              "us-central1-a",
 		StorageType:       SSD,
-		AutoscalingConfig: &AutoscalingConfig{MinNodes: 1, MaxNodes: 2, CPUTargetPercent: 10},
+		AutoscalingConfig: &AutoscalingConfig{MinNodes: 1, MaxNodes: 2, CPUTargetPercent: 10, StorageUtilizationPerNode: 3000},
 	})
 	if err != nil {
 		t.Fatalf("CreateCluster failed: %v", err)
@@ -404,6 +412,11 @@ func TestInstanceAdmin_CreateCluster_WithAutoscaling(t *testing.T) {
 	wantCPU := int32(10)
 	if gotCPU := gotConfig.AutoscalingTargets.CpuUtilizationPercent; wantCPU != gotCPU {
 		t.Fatalf("want autoscaling cpu = %v, got = %v", wantCPU, gotCPU)
+	}
+
+	wantStorage := int32(3000)
+	if gotStorage := gotConfig.AutoscalingTargets.StorageUtilizationGibPerNode; wantStorage != gotStorage {
+		t.Fatalf("want autoscaling storage = %v, got = %v", wantStorage, gotStorage)
 	}
 
 	err = c.CreateCluster(context.Background(), &ClusterConfig{
@@ -459,7 +472,7 @@ func TestInstanceAdmin_UpdateInstanceWithClusters_WithAutoscaling(t *testing.T) 
 			{
 				ClusterID:         "mycluster",
 				Zone:              "us-central1-a",
-				AutoscalingConfig: &AutoscalingConfig{MinNodes: 1, MaxNodes: 2, CPUTargetPercent: 10},
+				AutoscalingConfig: &AutoscalingConfig{MinNodes: 1, MaxNodes: 2, CPUTargetPercent: 10, StorageUtilizationPerNode: 3000},
 			},
 		},
 	})
@@ -483,6 +496,11 @@ func TestInstanceAdmin_UpdateInstanceWithClusters_WithAutoscaling(t *testing.T) 
 	wantCPU := int32(10)
 	if gotCPU := gotConfig.AutoscalingTargets.CpuUtilizationPercent; wantCPU != gotCPU {
 		t.Fatalf("want autoscaling cpu = %v, got = %v", wantCPU, gotCPU)
+	}
+
+	wantStorage := int32(3000)
+	if gotStorage := gotConfig.AutoscalingTargets.StorageUtilizationGibPerNode; wantStorage != gotStorage {
+		t.Fatalf("want autoscaling storage = %v, got = %v", wantStorage, gotStorage)
 	}
 
 	err = c.UpdateInstanceWithClusters(context.Background(), &InstanceWithClustersConfig{
@@ -522,7 +540,8 @@ func TestInstanceAdmin_UpdateInstanceAndSyncClusters_WithAutoscaling(t *testing.
 							MaxServeNodes: 2,
 						},
 						AutoscalingTargets: &btapb.AutoscalingTargets{
-							CpuUtilizationPercent: 10,
+							CpuUtilizationPercent:        10,
+							StorageUtilizationGibPerNode: 3000,
 						},
 					},
 				},
@@ -538,7 +557,7 @@ func TestInstanceAdmin_UpdateInstanceAndSyncClusters_WithAutoscaling(t *testing.
 			{
 				ClusterID:         "mycluster",
 				Zone:              "us-central1-a",
-				AutoscalingConfig: &AutoscalingConfig{MinNodes: 1, MaxNodes: 2, CPUTargetPercent: 10},
+				AutoscalingConfig: &AutoscalingConfig{MinNodes: 1, MaxNodes: 2, CPUTargetPercent: 10, StorageUtilizationPerNode: 3000},
 			},
 		},
 	})
@@ -562,6 +581,11 @@ func TestInstanceAdmin_UpdateInstanceAndSyncClusters_WithAutoscaling(t *testing.
 	wantCPU := int32(10)
 	if gotCPU := gotConfig.AutoscalingTargets.CpuUtilizationPercent; wantCPU != gotCPU {
 		t.Fatalf("want autoscaling cpu = %v, got = %v", wantCPU, gotCPU)
+	}
+
+	wantStorage := int32(3000)
+	if gotStorage := gotConfig.AutoscalingTargets.StorageUtilizationGibPerNode; wantStorage != gotStorage {
+		t.Fatalf("want autoscaling storage = %v, got = %v", wantStorage, gotStorage)
 	}
 
 	_, err = UpdateInstanceAndSyncClusters(context.Background(), c, &InstanceWithClustersConfig{

--- a/bigtable/go.mod
+++ b/bigtable/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/google/go-cmp v0.5.8
 	github.com/googleapis/gax-go/v2 v2.4.0
 	google.golang.org/api v0.85.0
-	google.golang.org/genproto v0.0.0-20220617124728-180714bec0ad
+	google.golang.org/genproto v0.0.0-20220708155623-50e5f4832e73
 	google.golang.org/grpc v1.47.0
 	google.golang.org/protobuf v1.28.0
 	rsc.io/binaryregexp v0.2.0

--- a/bigtable/go.sum
+++ b/bigtable/go.sum
@@ -622,6 +622,8 @@ google.golang.org/genproto v0.0.0-20220608133413-ed9918b62aac/go.mod h1:KEWEmljW
 google.golang.org/genproto v0.0.0-20220616135557-88e70c0c3a90/go.mod h1:KEWEmljWE5zPzLBa/oHl6DaEt9LmfH6WtH1OHIvleBA=
 google.golang.org/genproto v0.0.0-20220617124728-180714bec0ad h1:kqrS+lhvaMHCxul6sKQvKJ8nAAhlVItmZV822hYFH/U=
 google.golang.org/genproto v0.0.0-20220617124728-180714bec0ad/go.mod h1:KEWEmljWE5zPzLBa/oHl6DaEt9LmfH6WtH1OHIvleBA=
+google.golang.org/genproto v0.0.0-20220708155623-50e5f4832e73 h1:sdZWfcGN37Dv0QWIhuasQGMzAQJOL2oqnvot4/kPgfQ=
+google.golang.org/genproto v0.0.0-20220708155623-50e5f4832e73/go.mod h1:KEWEmljWE5zPzLBa/oHl6DaEt9LmfH6WtH1OHIvleBA=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
 google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=


### PR DESCRIPTION
Exposes the [`StorageUtilizationGibPerNode`](https://pkg.go.dev/google.golang.org/genproto/googleapis/bigtable/admin/v2#AutoscalingTargets) field for Bigtable autoscaler.