### PR TITLE
chore(storage): gRPC inject bucket ID in header for write

### DIFF
--- a/storage/grpc_client.go
+++ b/storage/grpc_client.go
@@ -19,6 +19,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 
 	"cloud.google.com/go/internal/trace"
@@ -1513,7 +1514,7 @@ func (w *gRPCWriter) uploadBuffer(recvd int, start int64, doneReading bool) (*st
 		// The first message on the WriteObject stream must either be the
 		// Object or the Resumable Upload ID.
 		if first {
-			ctx := gapic.InsertMetadata(w.ctx, metadata.Pairs("x-goog-request-params", "bucket="+w.bucket))
+			ctx := gapic.InsertMetadata(w.ctx, metadata.Pairs("x-goog-request-params", "bucket="+url.QueryEscape(w.bucket)))
 			w.stream, err = w.c.raw.WriteObject(ctx)
 			if err != nil {
 				return nil, 0, false, err

--- a/storage/grpc_client.go
+++ b/storage/grpc_client.go
@@ -1513,7 +1513,8 @@ func (w *gRPCWriter) uploadBuffer(recvd int, start int64, doneReading bool) (*st
 		// The first message on the WriteObject stream must either be the
 		// Object or the Resumable Upload ID.
 		if first {
-			w.stream, err = w.c.raw.WriteObject(w.ctx)
+			ctx := gapic.InsertMetadata(w.ctx, metadata.Pairs("x-goog-request-params", "bucket="+w.bucket))
+			w.stream, err = w.c.raw.WriteObject(ctx)
 			if err != nil {
 				return nil, 0, false, err
 			}

--- a/storage/internal/apiv2/metadata.go
+++ b/storage/internal/apiv2/metadata.go
@@ -1,0 +1,26 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"context"
+
+	"google.golang.org/grpc/metadata"
+)
+
+// InsertMetadata inserts the given gRPC metadata into the outgoing context.
+func InsertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
+	return insertMetadata(ctx, mds...)
+}


### PR DESCRIPTION
For gRPC, include the `bucket` ID (not resource name) in the `x-goog-request-params` header with the key `bucket` on the initial WriteObject RPC. All other RPCs, which are Unary on the client-side, are handled by the GAPIC layer for this. 

Instead of writing yet-another-header-injection helper, I exported the one form the GAPIC layer to reuse in the Veneer.

Fixes http://b/238793493 for Go.