### PR TITLE
test(bigquery/storage/managedwriter): relax error checking

### DIFF
--- a/bigquery/storage/managedwriter/integration_test.go
+++ b/bigquery/storage/managedwriter/integration_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -520,17 +519,9 @@ func testLargeInsert(ctx context.Context, t *testing.T, mwClient *Client, bqClie
 		if !ok {
 			t.Errorf("GetResult error was not an instance of ApiError")
 		}
-		if status := apiErr.GRPCStatus(); status.Code() != codes.InvalidArgument {
+		status := apiErr.GRPCStatus()
+		if status.Code() != codes.InvalidArgument {
 			t.Errorf("expected InvalidArgument status, got %v", status)
-		}
-
-		details := apiErr.Details()
-		if details.DebugInfo == nil {
-			t.Errorf("expected DebugInfo to be populated, was nil. apiError is %v, Unwrapped error is %T", apiErr, apiErr.Unwrap())
-		}
-		wantSubstring := "Message size exceed the limitation of byte based flow control."
-		if detail := details.DebugInfo.GetDetail(); !strings.Contains(detail, wantSubstring) {
-			t.Errorf("detail missing desired substring: %s", detail)
 		}
 	}
 	// send a subsequent append as verification we can proceed.


### PR DESCRIPTION
When a user issues a large request, the response from the
backend is a bare "InvalidArgument".  This PR removes additional
validation on information that is only attached when interrogating
the backend from a known client; it's stripped in the normal case.

Internal issue 239740070 was created to address the unactionable
nature of the response.

Fixes: https://github.com/googleapis/google-cloud-go/issues/6361