### PR TITLE
feat(pubsub): complete AckResult for exactly once

### DIFF
--- a/pubsub/go.mod
+++ b/pubsub/go.mod
@@ -3,7 +3,7 @@ module cloud.google.com/go/pubsub
 go 1.15
 
 require (
-	cloud.google.com/go v0.102.1-0.20220615234935-19a5d218ec4d
+	cloud.google.com/go v0.102.1-0.20220708235547-f3d2cc2c987e
 	cloud.google.com/go/iam v0.3.0
 	cloud.google.com/go/kms v1.4.0
 	github.com/golang/protobuf v1.5.2

--- a/pubsub/go.sum
+++ b/pubsub/go.sum
@@ -30,6 +30,8 @@ cloud.google.com/go v0.100.1/go.mod h1:fs4QogzfH5n2pBXBP9vRiU+eCny7lD2vmFZy79Iuw
 cloud.google.com/go v0.100.2/go.mod h1:4Xra9TjzAeYHrl5+oeLlzbM2k3mjVhZh4UqTZ//w99A=
 cloud.google.com/go v0.102.1-0.20220615234935-19a5d218ec4d h1:29ZuPdUkhuJw9mwHi6zVYkJRHq956wJ5G9OQUbWl5Ew=
 cloud.google.com/go v0.102.1-0.20220615234935-19a5d218ec4d/go.mod h1:mqs3bFXrt/gPc6aOZpchX8DEdQhuJluA/7LZNutd2Nc=
+cloud.google.com/go v0.102.1-0.20220708235547-f3d2cc2c987e h1:GZ9rHNbN2TY+p6/dTeU0EADYrOc3BCqy/KwGPZHLsdA=
+cloud.google.com/go v0.102.1-0.20220708235547-f3d2cc2c987e/go.mod h1:mqs3bFXrt/gPc6aOZpchX8DEdQhuJluA/7LZNutd2Nc=
 cloud.google.com/go/bigquery v1.0.1/go.mod h1:i/xbL2UlR5RvWAURpBYZTtm/cXjCha9lbfbpx4poX+o=
 cloud.google.com/go/bigquery v1.3.0/go.mod h1:PjpwJnslEMmckchkHFfq+HTD2DmtT67aNFKH1/VBDHE=
 cloud.google.com/go/bigquery v1.4.0/go.mod h1:S8dzgnTigyfTmLBfrtrhyYhwRxG72rYxvftPBK2Dvzc=

--- a/pubsub/iterator_test.go
+++ b/pubsub/iterator_test.go
@@ -642,7 +642,7 @@ func TestExactlyOnceProcessRequests(t *testing.T) {
 
 	t.Run("NoErrorsNilAckResult", func(t *testing.T) {
 		// No errors so request should be completed even without an AckResult.
-		ackReqMap := map[string]*AckResult{
+		ackReqMap := map[string]*ackResultWithID{
 			"ackID": nil,
 		}
 		completed, retry := processResults(nil, ackReqMap, nil)
@@ -652,8 +652,8 @@ func TestExactlyOnceProcessRequests(t *testing.T) {
 	t.Run("NoErrors", func(t *testing.T) {
 		// No errors so AckResult should be completed with success.
 		r := ipubsub.NewAckResult()
-		ackReqMap := map[string]*AckResult{
-			"ackID1": r,
+		ackReqMap := map[string]*ackResultWithID{
+			"ackID1": newAckResultWithID(r, "ackID1"),
 		}
 		completed, retry := processResults(nil, ackReqMap, nil)
 		compareCompletedRetryLengths(t, completed, retry, 1, 0)
@@ -670,8 +670,8 @@ func TestExactlyOnceProcessRequests(t *testing.T) {
 
 	t.Run("PermanentErrorInvalidAckID", func(t *testing.T) {
 		r := ipubsub.NewAckResult()
-		ackReqMap := map[string]*AckResult{
-			"ackID1": r,
+		ackReqMap := map[string]*ackResultWithID{
+			"ackID1": newAckResultWithID(r, "ackID1"),
 		}
 		errorsMap := map[string]string{
 			"ackID1": permanentInvalidAckErrString,
@@ -689,8 +689,8 @@ func TestExactlyOnceProcessRequests(t *testing.T) {
 
 	t.Run("TransientErrorRetry", func(t *testing.T) {
 		r := ipubsub.NewAckResult()
-		ackReqMap := map[string]*AckResult{
-			"ackID1": r,
+		ackReqMap := map[string]*ackResultWithID{
+			"ackID1": newAckResultWithID(r, "ackID1"),
 		}
 		errorsMap := map[string]string{
 			"ackID1": transientInvalidAckErrString,
@@ -701,8 +701,8 @@ func TestExactlyOnceProcessRequests(t *testing.T) {
 
 	t.Run("UnknownError", func(t *testing.T) {
 		r := ipubsub.NewAckResult()
-		ackReqMap := map[string]*AckResult{
-			"ackID1": r,
+		ackReqMap := map[string]*ackResultWithID{
+			"ackID1": newAckResultWithID(r, "ackID1"),
 		}
 		errorsMap := map[string]string{
 			"ackID1": "unknown_error",
@@ -721,8 +721,8 @@ func TestExactlyOnceProcessRequests(t *testing.T) {
 
 	t.Run("PermissionDenied", func(t *testing.T) {
 		r := ipubsub.NewAckResult()
-		ackReqMap := map[string]*AckResult{
-			"ackID1": r,
+		ackReqMap := map[string]*ackResultWithID{
+			"ackID1": newAckResultWithID(r, "ackID1"),
 		}
 		st := status.New(codes.PermissionDenied, "permission denied")
 		completed, retry := processResults(st, ackReqMap, nil)
@@ -738,8 +738,8 @@ func TestExactlyOnceProcessRequests(t *testing.T) {
 
 	t.Run("FailedPrecondition", func(t *testing.T) {
 		r := ipubsub.NewAckResult()
-		ackReqMap := map[string]*AckResult{
-			"ackID1": r,
+		ackReqMap := map[string]*ackResultWithID{
+			"ackID1": newAckResultWithID(r, "ackID1"),
 		}
 		st := status.New(codes.FailedPrecondition, "failed_precondition")
 		completed, retry := processResults(st, ackReqMap, nil)
@@ -755,8 +755,8 @@ func TestExactlyOnceProcessRequests(t *testing.T) {
 
 	t.Run("OtherErrorStatus", func(t *testing.T) {
 		r := ipubsub.NewAckResult()
-		ackReqMap := map[string]*AckResult{
-			"ackID1": r,
+		ackReqMap := map[string]*ackResultWithID{
+			"ackID1": newAckResultWithID(r, "ackID1"),
 		}
 		st := status.New(codes.OutOfRange, "out of range")
 		completed, retry := processResults(st, ackReqMap, nil)
@@ -774,10 +774,10 @@ func TestExactlyOnceProcessRequests(t *testing.T) {
 		r1 := ipubsub.NewAckResult()
 		r2 := ipubsub.NewAckResult()
 		r3 := ipubsub.NewAckResult()
-		ackReqMap := map[string]*AckResult{
-			"ackID1": r1,
-			"ackID2": r2,
-			"ackID3": r3,
+		ackReqMap := map[string]*ackResultWithID{
+			"ackID1": newAckResultWithID(r1, "ackID1"),
+			"ackID2": newAckResultWithID(r2, "ackID2"),
+			"ackID3": newAckResultWithID(r3, "ackID3"),
 		}
 		errorsMap := map[string]string{
 			"ackID1": permanentInvalidAckErrString,
@@ -815,8 +815,8 @@ func TestExactlyOnceProcessRequests(t *testing.T) {
 	t.Run("RetriableErrorStatusReturnsRequestForRetrying", func(t *testing.T) {
 		for c := range exactlyOnceDeliveryTemporaryRetryErrors {
 			r := ipubsub.NewAckResult()
-			ackReqMap := map[string]*AckResult{
-				"ackID1": r,
+			ackReqMap := map[string]*ackResultWithID{
+				"ackID1": newAckResultWithID(r, "ackID1"),
 			}
 			st := status.New(c, "")
 			completed, retry := processResults(st, ackReqMap, nil)

--- a/pubsub/iterator_test.go
+++ b/pubsub/iterator_test.go
@@ -51,16 +51,17 @@ func TestSplitRequestIDs(t *testing.T) {
 		ids        []string
 		splitIndex int
 	}{
-		{[]string{}, 0},
-		{ids, 2},
-		{ids[:2], 2},
+		{[]string{}, 0}, // empty slice, no split
+		{ids, 2},        // slice of size 5, split at index 2
+		{ids[:2], 2},    // slice of size 3, split at index 2
+		{ids[:1], 1},    // slice of size 1, split at index 1
 	} {
-		got1, got2 := splitRequestIDs(test.ids, 15)
+		got1, got2 := splitRequestIDs(test.ids, 2)
 		want1, want2 := test.ids[:test.splitIndex], test.ids[test.splitIndex:]
-		if !testutil.Equal(got1, want1) {
+		if !testutil.Equal(len(got1), len(want1)) {
 			t.Errorf("%v, 1: got %v, want %v", test, got1, want1)
 		}
-		if !testutil.Equal(got2, want2) {
+		if !testutil.Equal(len(got2), len(want2)) {
 			t.Errorf("%v, 2: got %v, want %v", test, got2, want2)
 		}
 	}
@@ -632,9 +633,6 @@ func compareCompletedRetryLengths(t *testing.T, completed, retry []*AckResult, w
 func TestExactlyOnceProcessRequests(t *testing.T) {
 	ctx := context.Background()
 
-	transientInvalidAckError := errors.New(transientInvalidAckErrString)
-	permanentInvalidAckError := errors.New(permanentInvalidAckErrString)
-
 	t.Run("NoResults", func(t *testing.T) {
 		// If the ackResMap is nil, then the resulting slices should be empty.
 		// nil maps here behave the same as if they were empty maps.
@@ -675,8 +673,8 @@ func TestExactlyOnceProcessRequests(t *testing.T) {
 		ackReqMap := map[string]*AckResult{
 			"ackID1": r,
 		}
-		errorsMap := map[string]error{
-			"ackID1": permanentInvalidAckError,
+		errorsMap := map[string]string{
+			"ackID1": permanentInvalidAckErrString,
 		}
 		completed, retry := processResults(nil, ackReqMap, errorsMap)
 		compareCompletedRetryLengths(t, completed, retry, 1, 0)
@@ -694,8 +692,8 @@ func TestExactlyOnceProcessRequests(t *testing.T) {
 		ackReqMap := map[string]*AckResult{
 			"ackID1": r,
 		}
-		errorsMap := map[string]error{
-			"ackID1": transientInvalidAckError,
+		errorsMap := map[string]string{
+			"ackID1": transientInvalidAckErrString,
 		}
 		completed, retry := processResults(nil, ackReqMap, errorsMap)
 		compareCompletedRetryLengths(t, completed, retry, 0, 1)
@@ -706,8 +704,8 @@ func TestExactlyOnceProcessRequests(t *testing.T) {
 		ackReqMap := map[string]*AckResult{
 			"ackID1": r,
 		}
-		errorsMap := map[string]error{
-			"ackID1": errors.New("unknown_error"),
+		errorsMap := map[string]string{
+			"ackID1": "unknown_error",
 		}
 		completed, retry := processResults(nil, ackReqMap, errorsMap)
 		compareCompletedRetryLengths(t, completed, retry, 1, 0)
@@ -781,9 +779,9 @@ func TestExactlyOnceProcessRequests(t *testing.T) {
 			"ackID2": r2,
 			"ackID3": r3,
 		}
-		errorsMap := map[string]error{
-			"ackID1": permanentInvalidAckError,
-			"ackID2": transientInvalidAckError,
+		errorsMap := map[string]string{
+			"ackID1": permanentInvalidAckErrString,
+			"ackID2": transientInvalidAckErrString,
 		}
 		completed, retry := processResults(nil, ackReqMap, errorsMap)
 		compareCompletedRetryLengths(t, completed, retry, 2, 1)

--- a/pubsub/iterator_test.go
+++ b/pubsub/iterator_test.go
@@ -621,7 +621,7 @@ func TestPingStreamAckDeadline(t *testing.T) {
 	iter.eoMu.RUnlock()
 }
 
-func compareCompletedRetryLengths(t *testing.T, completed, retry []*AckResult, wantCompleted, wantRetry int) {
+func compareCompletedRetryLengths(t *testing.T, completed, retry []*ackResultWithID, wantCompleted, wantRetry int) {
 	if l := len(completed); l != wantCompleted {
 		t.Errorf("completed slice length got %d, want %d", l, wantCompleted)
 	}

--- a/pubsub/message.go
+++ b/pubsub/message.go
@@ -184,6 +184,6 @@ func (ah *psAckHandler) done(ack bool) {
 // newSuccessAckResult returns an AckResult that resolves to success immediately.
 func newSuccessAckResult() *AckResult {
 	ar := ipubsub.NewAckResult()
-	ipubsub.SetAckResult(ar, ipubsub.AckResponseSuccess, nil)
+	ipubsub.SetAckResult(ar, AcknowledgeStatusSuccess, nil)
 	return ar
 }

--- a/pubsub/streaming_pull_test.go
+++ b/pubsub/streaming_pull_test.go
@@ -99,7 +99,13 @@ func testStreamingPullIteration(t *testing.T, client *Client, server *mockServer
 		}
 		opts := []cmp.Option{
 			cmp.AllowUnexported(Message{}, psAckHandler{}),
-			cmpopts.IgnoreTypes(time.Time{}, func(string, bool, *AckResult, time.Time) {}),
+			cmpopts.IgnoreTypes(
+				time.Time{},
+				func(string, bool,
+					*AckResult, time.Time) {
+				},
+				AckResult{},
+			),
 		}
 		if !testutil.Equal(got, want, opts...) {
 			t.Errorf("%d: got\n%#v\nwant\n%#v", i, got, want)


### PR DESCRIPTION
Pipe the output of Ack/Modack operations to AckResult that are returned when users call Ack/NackWithResult. This involves removing a callback and makes `sendAck` and `sendModAck` have repeated code. However, removing the callback also makes it more readable. In addition, we don't infinitely retry these methods until they fail anymore, since that will be handled by a later PR.

To support this, this PR also includes
1. Switching `processResults` back to using a map[string]string for ackID->error strings (since that's what apiError metadata field returns)
2. Changing the output of `processResults` and `pending` maps to use a new struct that contains both ackIDs and AckResult (for retrying later on)
3. Capping the max number of ackIDs per ack/modack to 2500 (which is in line with Python) instead of calculating it on the fly
