### PR TITLE
Encode `civil.Time` with microsecond precision.

### DIFF
--- a/civil/civil.go
+++ b/civil/civil.go
@@ -164,13 +164,15 @@ func ParseTime(s string) (Time, error) {
 
 // String returns the date in the format described in ParseTime. If Nanoseconds
 // is zero, no fractional part will be generated. Otherwise, the result will
-// end with a fractional part consisting of a decimal point and nine digits.
+// end with a fractional part consisting of a decimal point and six digits.
+// The fractional part is limited to six digits because that is the precision
+// limit for BigQuery DATETIME columns.
 func (t Time) String() string {
 	s := fmt.Sprintf("%02d:%02d:%02d", t.Hour, t.Minute, t.Second)
 	if t.Nanosecond == 0 {
 		return s
 	}
-	return s + fmt.Sprintf(".%09d", t.Nanosecond)
+	return s + fmt.Sprintf(".%06d", t.Nanosecond/1000)
 }
 
 // IsValid reports whether the time is valid.

--- a/civil/civil_test.go
+++ b/civil/civil_test.go
@@ -218,25 +218,28 @@ func TestTimeToString(t *testing.T) {
 		roundTrip bool // ParseTime(str).String() == str?
 	}{
 		{"13:26:33", Time{13, 26, 33, 0}, true},
-		{"01:02:03.000023456", Time{1, 2, 3, 23456}, true},
-		{"00:00:00.000000001", Time{0, 0, 0, 1}, true},
+		{"01:02:03.000023", Time{1, 2, 3, 23000}, true},
+		{"00:00:00.000001", Time{0, 0, 0, 1000}, true},
 		{"13:26:03.1", Time{13, 26, 3, 100000000}, false},
 		{"13:26:33.0000003", Time{13, 26, 33, 300}, false},
 	} {
-		gotTime, err := ParseTime(test.str)
-		if err != nil {
-			t.Errorf("ParseTime(%q): got error: %v", test.str, err)
-			continue
-		}
-		if gotTime != test.time {
-			t.Errorf("ParseTime(%q) = %+v, want %+v", test.str, gotTime, test.time)
-		}
-		if test.roundTrip {
-			gotStr := test.time.String()
-			if gotStr != test.str {
-				t.Errorf("%#v.String() = %q, want %q", test.time, gotStr, test.str)
+		t.Run(test.str, func(t *testing.T) {
+
+			gotTime, err := ParseTime(test.str)
+			if err != nil {
+				t.Errorf("ParseTime(%q): got error: %v", test.str, err)
+				return
 			}
-		}
+			if gotTime != test.time {
+				t.Errorf("ParseTime(%q) = %+v, want %+v", test.str, gotTime, test.time)
+			}
+			if test.roundTrip {
+				gotStr := test.time.String()
+				if gotStr != test.str {
+					t.Errorf("%#v.String() = %q, want %q", test.time, gotStr, test.str)
+				}
+			}
+		})
 	}
 }
 
@@ -337,23 +340,26 @@ func TestDateTimeToString(t *testing.T) {
 		roundTrip bool // ParseDateTime(str).String() == str?
 	}{
 		{"2016-03-22T13:26:33", DateTime{Date{2016, 03, 22}, Time{13, 26, 33, 0}}, true},
-		{"2016-03-22T13:26:33.000000600", DateTime{Date{2016, 03, 22}, Time{13, 26, 33, 600}}, true},
+		{"2016-03-22T13:26:33.000000600", DateTime{Date{2016, 03, 22}, Time{13, 26, 33, 600}}, false},
+		{"2016-03-22T13:26:33.000006", DateTime{Date{2016, 03, 22}, Time{13, 26, 33, 6000}}, true},
 		{"2016-03-22t13:26:33", DateTime{Date{2016, 03, 22}, Time{13, 26, 33, 0}}, false},
 	} {
-		gotDateTime, err := ParseDateTime(test.str)
-		if err != nil {
-			t.Errorf("ParseDateTime(%q): got error: %v", test.str, err)
-			continue
-		}
-		if gotDateTime != test.dateTime {
-			t.Errorf("ParseDateTime(%q) = %+v, want %+v", test.str, gotDateTime, test.dateTime)
-		}
-		if test.roundTrip {
-			gotStr := test.dateTime.String()
-			if gotStr != test.str {
-				t.Errorf("%#v.String() = %q, want %q", test.dateTime, gotStr, test.str)
+		t.Run(test.str, func(t *testing.T) {
+			gotDateTime, err := ParseDateTime(test.str)
+			if err != nil {
+				t.Errorf("ParseDateTime(%q): got error: %v", test.str, err)
+				return
 			}
-		}
+			if gotDateTime != test.dateTime {
+				t.Errorf("ParseDateTime(%q) = %+v, want %+v", test.str, gotDateTime, test.dateTime)
+			}
+			if test.roundTrip {
+				gotStr := test.dateTime.String()
+				if gotStr != test.str {
+					t.Errorf("%#v.String() = %q, want %q", test.dateTime, gotStr, test.str)
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
This truncates the precision of `civil.[Date]Time` from nanoseconds to microseconds because that is the precision limit of BigQuery, which these types are intended to work with.

In particular the BigQuery data transfer service rejects records that use these types for JSON encoding today due to the extra precision.

Fixes: https://github.com/googleapis/google-cloud-go/issues/6409