### PR TITLE
chore(storage): migrate top-level methods

### DIFF
--- a/storage/bucket.go
+++ b/storage/bucket.go
@@ -2125,7 +2125,6 @@ type BucketIterator struct {
 	buckets   []*BucketAttrs
 	pageInfo  *iterator.PageInfo
 	nextFunc  func() error
-	retry     *retryConfig
 }
 
 // Next returns the next result. Its second return value is iterator.Done if

--- a/storage/bucket.go
+++ b/storage/bucket.go
@@ -2125,6 +2125,7 @@ type BucketIterator struct {
 	buckets   []*BucketAttrs
 	pageInfo  *iterator.PageInfo
 	nextFunc  func() error
+	retry     *retryConfig
 }
 
 // Next returns the next result. Its second return value is iterator.Done if

--- a/storage/bucket.go
+++ b/storage/bucket.go
@@ -2124,17 +2124,8 @@ func (it *ObjectIterator) fetch(pageSize int, pageToken string) (string, error) 
 //
 // Note: The returned iterator is not safe for concurrent operations without explicit synchronization.
 func (c *Client) Buckets(ctx context.Context, projectID string) *BucketIterator {
-	it := &BucketIterator{
-		ctx:       ctx,
-		client:    c,
-		projectID: projectID,
-	}
-	it.pageInfo, it.nextFunc = iterator.NewPageInfo(
-		it.fetch,
-		func() int { return len(it.buckets) },
-		func() interface{} { b := it.buckets; it.buckets = nil; return b })
-
-	return it
+	o := makeStorageOpts(true, c.retry, "")
+	return c.tc.ListBuckets(ctx, projectID, o...)
 }
 
 // A BucketIterator is an iterator over BucketAttrs.

--- a/storage/client.go
+++ b/storage/client.go
@@ -44,7 +44,7 @@ type storageClient interface {
 	// Top-level methods.
 
 	GetServiceAccount(ctx context.Context, project string, opts ...storageOption) (string, error)
-	CreateBucket(ctx context.Context, project string, attrs *BucketAttrs, opts ...storageOption) (*BucketAttrs, error)
+	CreateBucket(ctx context.Context, project, bucket string, attrs *BucketAttrs, opts ...storageOption) (*BucketAttrs, error)
 	ListBuckets(ctx context.Context, project string, opts ...storageOption) *BucketIterator
 	Close() error
 

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -39,7 +39,7 @@ func TestCreateBucketEmulated(t *testing.T) {
 				LogBucket: bucket,
 			},
 		}
-		got, err := client.CreateBucket(context.Background(), project, want)
+		got, err := client.CreateBucket(context.Background(), project, want.Name, want)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -62,7 +62,7 @@ func TestDeleteBucketEmulated(t *testing.T) {
 			Name: bucket,
 		}
 		// Create the bucket that will be deleted.
-		_, err := client.CreateBucket(context.Background(), project, b)
+		_, err := client.CreateBucket(context.Background(), project, b.Name, b)
 		if err != nil {
 			t.Fatalf("client.CreateBucket: %v", err)
 		}
@@ -80,7 +80,7 @@ func TestGetBucketEmulated(t *testing.T) {
 			Name: bucket,
 		}
 		// Create the bucket that will be retrieved.
-		_, err := client.CreateBucket(context.Background(), project, want)
+		_, err := client.CreateBucket(context.Background(), project, want.Name, want)
 		if err != nil {
 			t.Fatalf("client.CreateBucket: %v", err)
 		}
@@ -100,7 +100,7 @@ func TestUpdateBucketEmulated(t *testing.T) {
 			Name: bucket,
 		}
 		// Create the bucket that will be updated.
-		_, err := client.CreateBucket(context.Background(), project, bkt)
+		_, err := client.CreateBucket(context.Background(), project, bkt.Name, bkt)
 		if err != nil {
 			t.Fatalf("client.CreateBucket: %v", err)
 		}
@@ -191,7 +191,7 @@ func TestGetServiceAccountEmulated(t *testing.T) {
 
 func TestGetSetTestIamPolicyEmulated(t *testing.T) {
 	transportClientTest(t, func(t *testing.T, project, bucket string, client storageClient) {
-		battrs, err := client.CreateBucket(context.Background(), project, &BucketAttrs{
+		battrs, err := client.CreateBucket(context.Background(), project, bucket, &BucketAttrs{
 			Name: bucket,
 		})
 		if err != nil {
@@ -222,7 +222,7 @@ func TestGetSetTestIamPolicyEmulated(t *testing.T) {
 func TestDeleteObjectEmulated(t *testing.T) {
 	transportClientTest(t, func(t *testing.T, project, bucket string, client storageClient) {
 		// Populate test object that will be deleted.
-		_, err := client.CreateBucket(context.Background(), project, &BucketAttrs{
+		_, err := client.CreateBucket(context.Background(), project, bucket, &BucketAttrs{
 			Name: bucket,
 		})
 		if err != nil {
@@ -249,7 +249,7 @@ func TestDeleteObjectEmulated(t *testing.T) {
 func TestGetObjectEmulated(t *testing.T) {
 	transportClientTest(t, func(t *testing.T, project, bucket string, client storageClient) {
 		// Populate test object.
-		_, err := client.CreateBucket(context.Background(), project, &BucketAttrs{
+		_, err := client.CreateBucket(context.Background(), project, bucket, &BucketAttrs{
 			Name: bucket,
 		})
 		if err != nil {
@@ -279,7 +279,7 @@ func TestGetObjectEmulated(t *testing.T) {
 func TestRewriteObjectEmulated(t *testing.T) {
 	transportClientTest(t, func(t *testing.T, project, bucket string, client storageClient) {
 		// Populate test object.
-		_, err := client.CreateBucket(context.Background(), project, &BucketAttrs{
+		_, err := client.CreateBucket(context.Background(), project, bucket, &BucketAttrs{
 			Name: bucket,
 		})
 		if err != nil {
@@ -324,7 +324,7 @@ func TestRewriteObjectEmulated(t *testing.T) {
 func TestUpdateObjectEmulated(t *testing.T) {
 	transportClientTest(t, func(t *testing.T, project, bucket string, client storageClient) {
 		// Populate test object.
-		_, err := client.CreateBucket(context.Background(), project, &BucketAttrs{
+		_, err := client.CreateBucket(context.Background(), project, bucket, &BucketAttrs{
 			Name: bucket,
 		})
 		if err != nil {
@@ -391,7 +391,7 @@ func TestUpdateObjectEmulated(t *testing.T) {
 func TestListObjectsEmulated(t *testing.T) {
 	transportClientTest(t, func(t *testing.T, project, bucket string, client storageClient) {
 		// Populate test data.
-		_, err := client.CreateBucket(context.Background(), project, &BucketAttrs{
+		_, err := client.CreateBucket(context.Background(), project, bucket, &BucketAttrs{
 			Name: bucket,
 		})
 		if err != nil {
@@ -449,7 +449,7 @@ func TestListObjectsEmulated(t *testing.T) {
 func TestListObjectsWithPrefixEmulated(t *testing.T) {
 	transportClientTest(t, func(t *testing.T, project, bucket string, client storageClient) {
 		// Populate test data.
-		_, err := client.CreateBucket(context.Background(), project, &BucketAttrs{
+		_, err := client.CreateBucket(context.Background(), project, bucket, &BucketAttrs{
 			Name: bucket,
 		})
 		if err != nil {
@@ -515,7 +515,7 @@ func TestListBucketsEmulated(t *testing.T) {
 		}
 		// Create the buckets that will be listed.
 		for _, b := range want {
-			_, err := client.CreateBucket(context.Background(), project, b)
+			_, err := client.CreateBucket(context.Background(), project, b.Name, b)
 			if err != nil {
 				t.Fatalf("client.CreateBucket: %v", err)
 			}
@@ -556,7 +556,7 @@ func TestListBucketACLsEmulated(t *testing.T) {
 			PredefinedACL: "publicRead",
 		}
 		// Create the bucket that will be retrieved.
-		if _, err := client.CreateBucket(ctx, project, attrs); err != nil {
+		if _, err := client.CreateBucket(ctx, project, attrs.Name, attrs); err != nil {
 			t.Fatalf("client.CreateBucket: %v", err)
 		}
 
@@ -578,7 +578,7 @@ func TestUpdateBucketACLEmulated(t *testing.T) {
 			PredefinedACL: "authenticatedRead",
 		}
 		// Create the bucket that will be retrieved.
-		if _, err := client.CreateBucket(ctx, project, attrs); err != nil {
+		if _, err := client.CreateBucket(ctx, project, attrs.Name, attrs); err != nil {
 			t.Fatalf("client.CreateBucket: %v", err)
 		}
 		var listAcls []ACLRule
@@ -614,7 +614,7 @@ func TestDeleteBucketACLEmulated(t *testing.T) {
 			PredefinedACL: "publicRead",
 		}
 		// Create the bucket that will be retrieved.
-		if _, err := client.CreateBucket(ctx, project, attrs); err != nil {
+		if _, err := client.CreateBucket(ctx, project, attrs.Name, attrs); err != nil {
 			t.Fatalf("client.CreateBucket: %v", err)
 		}
 		// Assert bucket has two BucketACL entities, including project owner and predefinedACL.
@@ -648,7 +648,7 @@ func TestDefaultObjectACLCRUDEmulated(t *testing.T) {
 			PredefinedDefaultObjectACL: "publicRead",
 		}
 		// Create the bucket that will be retrieved.
-		if _, err := client.CreateBucket(ctx, project, attrs); err != nil {
+		if _, err := client.CreateBucket(ctx, project, attrs.Name, attrs); err != nil {
 			t.Fatalf("client.CreateBucket: %v", err)
 		}
 		// Assert bucket has 2 DefaultObjectACL entities, including project owner and PredefinedDefaultObjectACL.
@@ -692,7 +692,7 @@ func TestObjectACLCRUDEmulated(t *testing.T) {
 	transportClientTest(t, func(t *testing.T, project, bucket string, client storageClient) {
 		// Populate test object.
 		ctx := context.Background()
-		_, err := client.CreateBucket(ctx, project, &BucketAttrs{
+		_, err := client.CreateBucket(ctx, project, bucket, &BucketAttrs{
 			Name: bucket,
 		})
 		if err != nil {
@@ -746,7 +746,7 @@ func TestObjectACLCRUDEmulated(t *testing.T) {
 func TestOpenReaderEmulated(t *testing.T) {
 	transportClientTest(t, func(t *testing.T, project, bucket string, client storageClient) {
 		// Populate test data.
-		_, err := client.CreateBucket(context.Background(), project, &BucketAttrs{
+		_, err := client.CreateBucket(context.Background(), project, bucket, &BucketAttrs{
 			Name: bucket,
 		})
 		if err != nil {
@@ -791,7 +791,7 @@ func TestOpenReaderEmulated(t *testing.T) {
 func TestOpenWriterEmulated(t *testing.T) {
 	transportClientTest(t, func(t *testing.T, project, bucket string, client storageClient) {
 		// Populate test data.
-		_, err := client.CreateBucket(context.Background(), project, &BucketAttrs{
+		_, err := client.CreateBucket(context.Background(), project, bucket, &BucketAttrs{
 			Name: bucket,
 		})
 		if err != nil {
@@ -854,7 +854,7 @@ func TestListNotificationsEmulated(t *testing.T) {
 	transportClientTest(t, func(t *testing.T, project, bucket string, client storageClient) {
 		// Populate test object.
 		ctx := context.Background()
-		_, err := client.CreateBucket(ctx, project, &BucketAttrs{
+		_, err := client.CreateBucket(ctx, project, bucket, &BucketAttrs{
 			Name: bucket,
 		})
 		if err != nil {
@@ -882,7 +882,7 @@ func TestCreateNotificationEmulated(t *testing.T) {
 	transportClientTest(t, func(t *testing.T, project, bucket string, client storageClient) {
 		// Populate test object.
 		ctx := context.Background()
-		_, err := client.CreateBucket(ctx, project, &BucketAttrs{
+		_, err := client.CreateBucket(ctx, project, bucket, &BucketAttrs{
 			Name: bucket,
 		})
 		if err != nil {
@@ -908,7 +908,7 @@ func TestDeleteNotificationEmulated(t *testing.T) {
 	transportClientTest(t, func(t *testing.T, project, bucket string, client storageClient) {
 		// Populate test object.
 		ctx := context.Background()
-		_, err := client.CreateBucket(ctx, project, &BucketAttrs{
+		_, err := client.CreateBucket(ctx, project, bucket, &BucketAttrs{
 			Name: bucket,
 		})
 		if err != nil {
@@ -982,7 +982,7 @@ func TestLockBucketRetentionPolicyEmulated(t *testing.T) {
 			},
 		}
 		// Create the bucket that will be locked.
-		_, err := client.CreateBucket(context.Background(), project, b)
+		_, err := client.CreateBucket(context.Background(), project, b.Name, b)
 		if err != nil {
 			t.Fatalf("client.CreateBucket: %v", err)
 		}
@@ -1006,7 +1006,7 @@ func TestComposeEmulated(t *testing.T) {
 		ctx := context.Background()
 
 		// Populate test data.
-		_, err := client.CreateBucket(context.Background(), project, &BucketAttrs{
+		_, err := client.CreateBucket(context.Background(), project, bucket, &BucketAttrs{
 			Name: bucket,
 		})
 		if err != nil {

--- a/storage/grpc_client.go
+++ b/storage/grpc_client.go
@@ -133,10 +133,10 @@ func (c *grpcStorageClient) GetServiceAccount(ctx context.Context, project strin
 	return resp.EmailAddress, err
 }
 
-func (c *grpcStorageClient) CreateBucket(ctx context.Context, project string, attrs *BucketAttrs, opts ...storageOption) (*BucketAttrs, error) {
+func (c *grpcStorageClient) CreateBucket(ctx context.Context, project, bucket string, attrs *BucketAttrs, opts ...storageOption) (*BucketAttrs, error) {
 	s := callSettings(c.settings, opts...)
 	b := attrs.toProtoBucket()
-
+	b.Name = bucket
 	// If there is lifecycle information but no location, explicitly set
 	// the location. This is a GCS quirk/bug.
 	if b.GetLocation() == "" && b.GetLifecycle() != nil {

--- a/storage/grpc_client.go
+++ b/storage/grpc_client.go
@@ -168,6 +168,7 @@ func (c *grpcStorageClient) ListBuckets(ctx context.Context, project string, opt
 	it := &BucketIterator{
 		ctx:       ctx,
 		projectID: project,
+		retry:     s.retry,
 	}
 
 	var gitr *gapic.BucketIterator

--- a/storage/grpc_client.go
+++ b/storage/grpc_client.go
@@ -168,7 +168,6 @@ func (c *grpcStorageClient) ListBuckets(ctx context.Context, project string, opt
 	it := &BucketIterator{
 		ctx:       ctx,
 		projectID: project,
-		retry:     s.retry,
 	}
 
 	var gitr *gapic.BucketIterator

--- a/storage/http_client.go
+++ b/storage/http_client.go
@@ -159,7 +159,7 @@ func (c *httpStorageClient) GetServiceAccount(ctx context.Context, project strin
 	return res.EmailAddress, nil
 }
 
-func (c *httpStorageClient) CreateBucket(ctx context.Context, project string, attrs *BucketAttrs, opts ...storageOption) (*BucketAttrs, error) {
+func (c *httpStorageClient) CreateBucket(ctx context.Context, project, bucket string, attrs *BucketAttrs, opts ...storageOption) (*BucketAttrs, error) {
 	s := callSettings(c.settings, opts...)
 	var bkt *raw.Bucket
 	if attrs != nil {
@@ -167,7 +167,7 @@ func (c *httpStorageClient) CreateBucket(ctx context.Context, project string, at
 	} else {
 		bkt = &raw.Bucket{}
 	}
-
+	bkt.Name = bucket
 	// If there is lifecycle information but no location, explicitly set
 	// the location. This is a GCS quirk/bug.
 	if bkt.Location == "" && bkt.Lifecycle != nil {

--- a/storage/http_client.go
+++ b/storage/http_client.go
@@ -198,7 +198,6 @@ func (c *httpStorageClient) ListBuckets(ctx context.Context, project string, opt
 	it := &BucketIterator{
 		ctx:       ctx,
 		projectID: project,
-		retry:     s.retry,
 	}
 
 	fetch := func(pageSize int, pageToken string) (token string, err error) {

--- a/storage/http_client.go
+++ b/storage/http_client.go
@@ -198,6 +198,7 @@ func (c *httpStorageClient) ListBuckets(ctx context.Context, project string, opt
 	it := &BucketIterator{
 		ctx:       ctx,
 		projectID: project,
+		retry:     s.retry,
 	}
 
 	fetch := func(pageSize int, pageToken string) (token string, err error) {

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -2106,17 +2106,9 @@ func toProtoCommonObjectRequestParams(key []byte) *storagepb.CommonObjectRequest
 
 // ServiceAccount fetches the email address of the given project's Google Cloud Storage service account.
 func (c *Client) ServiceAccount(ctx context.Context, projectID string) (string, error) {
-	r := c.raw.Projects.ServiceAccount.Get(projectID)
-	var res *raw.ServiceAccount
-	var err error
-	err = run(ctx, func() error {
-		res, err = r.Context(ctx).Do()
-		return err
-	}, c.retry, true, setRetryHeaderHTTP(r))
-	if err != nil {
-		return "", err
-	}
-	return res.EmailAddress, nil
+	o := makeStorageOpts(true, c.retry, "")
+	return c.tc.GetServiceAccount(ctx, projectID, o...)
+
 }
 
 // bucketResourceName formats the given project ID and bucketResourceName ID

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -1356,7 +1356,7 @@ func TestRetryer(t *testing.T) {
 				},
 				{
 					name: "client.Buckets()",
-					r:    c.Buckets(ctx, "pID").client.retry,
+					r:    c.Buckets(ctx, "pID").retry,
 					want: c.retry,
 				},
 				{

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -1356,7 +1356,7 @@ func TestRetryer(t *testing.T) {
 				},
 				{
 					name: "client.Buckets()",
-					r:    c.Buckets(ctx, "pID").retry,
+					r:    c.Buckets(ctx, "pID").client.retry,
 					want: c.retry,
 				},
 				{

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -1355,11 +1355,6 @@ func TestRetryer(t *testing.T) {
 					want: c.retry,
 				},
 				{
-					name: "client.Buckets()",
-					r:    c.Buckets(ctx, "pID").client.retry,
-					want: c.retry,
-				},
-				{
 					name: "bucket.Objects()",
 					r:    b.Objects(ctx, nil).bucket.retry,
 					want: b.retry,


### PR DESCRIPTION
Migrate few top-level methods to transport-agnostic interface.
- GetServiceAccount
- ListBuckets
- CreateBucket*

*Interface refactoring
Shown in the [current implementation](https://github.com/googleapis/google-cloud-go/blob/main/storage/bucket.go#L91), bucketName is referenced from `BucketHandle`, so proposing to include `bucket string` as an arg for method `CreateBucket()`

Integration tests pass locally 