### PR TITLE
chore(storage): migrate Copier

### DIFF
--- a/storage/client.go
+++ b/storage/client.go
@@ -326,5 +326,6 @@ type rewriteObjectResponse struct {
 	resource *ObjectAttrs
 	done     bool
 	written  int64
+	size     int64
 	token    string
 }

--- a/storage/grpc_client.go
+++ b/storage/grpc_client.go
@@ -811,6 +811,7 @@ func (c *grpcStorageClient) RewriteObject(ctx context.Context, req *rewriteObjec
 	r := &rewriteObjectResponse{
 		done:     res.GetDone(),
 		written:  res.GetTotalBytesRewritten(),
+		size:     res.GetObjectSize(),
 		token:    res.GetRewriteToken(),
 		resource: newObjectFromProto(res.GetResource()),
 	}

--- a/storage/http_client.go
+++ b/storage/http_client.go
@@ -760,6 +760,7 @@ func (c *httpStorageClient) RewriteObject(ctx context.Context, req *rewriteObjec
 	r := &rewriteObjectResponse{
 		done:     res.Done,
 		written:  res.TotalBytesRewritten,
+		size:     res.ObjectSize,
 		token:    res.RewriteToken,
 		resource: newObject(res.Resource),
 	}

--- a/storage/integration_test.go
+++ b/storage/integration_test.go
@@ -2735,26 +2735,6 @@ func TestIntegration_PerObjectStorageClass(t *testing.T) {
 	}
 }
 
-func TestIntegration_BucketInCopyAttrs(t *testing.T) {
-	// Confirm that if bucket is included in the object attributes of a rewrite
-	// call, but object name and content-type aren't, then we get an error. See
-	// the comment in Copier.Run.
-	ctx := context.Background()
-	client := testConfig(ctx, t)
-	defer client.Close()
-	h := testHelper{t}
-
-	bkt := client.Bucket(bucketName)
-	obj := bkt.Object("bucketInCopyAttrs")
-	h.mustWrite(obj.NewWriter(ctx), []byte("foo"))
-	copier := obj.CopierFrom(obj)
-	rawObject := copier.ObjectAttrs.toRawObject(bucketName)
-	_, err := copier.callRewrite(ctx, rawObject)
-	if err == nil {
-		t.Errorf("got nil, want error")
-	}
-}
-
 func TestIntegration_NoUnicodeNormalization(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()


### PR DESCRIPTION
Migrate Copier to use the new transport-agnostic interface.
I found one additional piece of data that needs to be passed back
through the interface in the process (object size).
    
I removed one integration test. This test is old and currently
calls rewriteObject in a way that an external library user could
not accomplish. I don't think this test adds any value.
