### PR TITLE
chore(storage): migrate bucket methods

### DIFF
--- a/storage/bucket.go
+++ b/storage/bucket.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/http"
 	"reflect"
 	"time"
 
@@ -168,43 +167,9 @@ func (b *BucketHandle) Update(ctx context.Context, uattrs BucketAttrsToUpdate) (
 	ctx = trace.StartSpan(ctx, "cloud.google.com/go/storage.Bucket.Create")
 	defer func() { trace.EndSpan(ctx, err) }()
 
-	req, err := b.newPatchCall(&uattrs)
-	if err != nil {
-		return nil, err
-	}
-	if uattrs.PredefinedACL != "" {
-		req.PredefinedAcl(uattrs.PredefinedACL)
-	}
-	if uattrs.PredefinedDefaultObjectACL != "" {
-		req.PredefinedDefaultObjectAcl(uattrs.PredefinedDefaultObjectACL)
-	}
-
 	isIdempotent := b.conds != nil && b.conds.MetagenerationMatch != 0
-
-	var rawBucket *raw.Bucket
-	call := func() error {
-		rb, err := req.Context(ctx).Do()
-		rawBucket = rb
-		return err
-	}
-
-	if err := run(ctx, call, b.retry, isIdempotent, setRetryHeaderHTTP(req)); err != nil {
-		return nil, err
-	}
-	return newBucket(rawBucket)
-}
-
-func (b *BucketHandle) newPatchCall(uattrs *BucketAttrsToUpdate) (*raw.BucketsPatchCall, error) {
-	rb := uattrs.toRawBucket()
-	req := b.c.raw.Buckets.Patch(b.name, rb).Projection("full")
-	setClientHeader(req.Header())
-	if err := applyBucketConds("BucketHandle.Update", b.conds, req); err != nil {
-		return nil, err
-	}
-	if b.userProject != "" {
-		req.UserProject(b.userProject)
-	}
-	return req, nil
+	o := makeStorageOpts(isIdempotent, b.retry, b.userProject)
+	return b.c.tc.UpdateBucket(ctx, b.name, &uattrs, b.conds, o...)
 }
 
 // SignedURL returns a URL for the specified object. Signed URLs allow anyone
@@ -1321,15 +1286,8 @@ func (b *BucketHandle) UserProject(projectID string) *BucketHandle {
 // most customers. It might be changed in backwards-incompatible ways and is not
 // subject to any SLA or deprecation policy.
 func (b *BucketHandle) LockRetentionPolicy(ctx context.Context) error {
-	var metageneration int64
-	if b.conds != nil {
-		metageneration = b.conds.MetagenerationMatch
-	}
-	req := b.c.raw.Buckets.LockRetentionPolicy(b.name, metageneration)
-	return run(ctx, func() error {
-		_, err := req.Context(ctx).Do()
-		return err
-	}, b.retry, true, setRetryHeaderHTTP(req))
+	o := makeStorageOpts(true, b.retry, b.userProject)
+	return b.c.tc.LockBucketRetentionPolicy(ctx, b.name, b.conds, o...)
 }
 
 // applyBucketConds modifies the provided call using the conditions in conds.
@@ -1945,18 +1903,8 @@ func customPlacementFromProto(c *storagepb.Bucket_CustomPlacementConfig) *Custom
 //
 // Note: The returned iterator is not safe for concurrent operations without explicit synchronization.
 func (b *BucketHandle) Objects(ctx context.Context, q *Query) *ObjectIterator {
-	it := &ObjectIterator{
-		ctx:    ctx,
-		bucket: b,
-	}
-	it.pageInfo, it.nextFunc = iterator.NewPageInfo(
-		it.fetch,
-		func() int { return len(it.items) },
-		func() interface{} { b := it.items; it.items = nil; return b })
-	if q != nil {
-		it.query = *q
-	}
-	return it
+	o := makeStorageOpts(true, b.retry, b.userProject)
+	return b.c.tc.ListObjects(ctx, b.name, q, o...)
 }
 
 // Retryer returns a bucket handle that is configured with custom retry
@@ -1991,7 +1939,6 @@ func (b *BucketHandle) Retryer(opts ...RetryOption) *BucketHandle {
 // Note: This iterator is not safe for concurrent operations without explicit synchronization.
 type ObjectIterator struct {
 	ctx      context.Context
-	bucket   *BucketHandle
 	query    Query
 	pageInfo *iterator.PageInfo
 	nextFunc func() error
@@ -2026,52 +1973,6 @@ func (it *ObjectIterator) Next() (*ObjectAttrs, error) {
 	item := it.items[0]
 	it.items = it.items[1:]
 	return item, nil
-}
-
-func (it *ObjectIterator) fetch(pageSize int, pageToken string) (string, error) {
-	req := it.bucket.c.raw.Objects.List(it.bucket.name)
-	setClientHeader(req.Header())
-	projection := it.query.Projection
-	if projection == ProjectionDefault {
-		projection = ProjectionFull
-	}
-	req.Projection(projection.String())
-	req.Delimiter(it.query.Delimiter)
-	req.Prefix(it.query.Prefix)
-	req.StartOffset(it.query.StartOffset)
-	req.EndOffset(it.query.EndOffset)
-	req.Versions(it.query.Versions)
-	req.IncludeTrailingDelimiter(it.query.IncludeTrailingDelimiter)
-	if len(it.query.fieldSelection) > 0 {
-		req.Fields("nextPageToken", googleapi.Field(it.query.fieldSelection))
-	}
-	req.PageToken(pageToken)
-	if it.bucket.userProject != "" {
-		req.UserProject(it.bucket.userProject)
-	}
-	if pageSize > 0 {
-		req.MaxResults(int64(pageSize))
-	}
-	var resp *raw.Objects
-	var err error
-	err = run(it.ctx, func() error {
-		resp, err = req.Context(it.ctx).Do()
-		return err
-	}, it.bucket.retry, true, setRetryHeaderHTTP(req))
-	if err != nil {
-		var e *googleapi.Error
-		if ok := errors.As(err, &e); ok && e.Code == http.StatusNotFound {
-			err = ErrBucketNotExist
-		}
-		return "", err
-	}
-	for _, item := range resp.Items {
-		it.items = append(it.items, newObject(item))
-	}
-	for _, prefix := range resp.Prefixes {
-		it.items = append(it.items, &ObjectAttrs{Prefix: prefix})
-	}
-	return resp.NextPageToken, nil
 }
 
 // Buckets returns an iterator over the buckets in the project. You may

--- a/storage/bucket_test.go
+++ b/storage/bucket_test.go
@@ -610,16 +610,6 @@ func TestCallBuilders(t *testing.T) {
 		metagenFunc func(interface{})
 	}{
 		{
-			func(b *BucketHandle) (interface{}, error) { return b.newGetCall() },
-			rc.Buckets.Get("name").Projection("full"),
-			func(req interface{}) { req.(*raw.BucketsGetCall).IfMetagenerationMatch(metagen).UserProject("p") },
-		},
-		{
-			func(b *BucketHandle) (interface{}, error) { return b.newDeleteCall() },
-			rc.Buckets.Delete("name"),
-			func(req interface{}) { req.(*raw.BucketsDeleteCall).IfMetagenerationMatch(metagen).UserProject("p") },
-		},
-		{
 			func(b *BucketHandle) (interface{}, error) {
 				return b.newPatchCall(&BucketAttrsToUpdate{
 					VersioningEnabled: false,
@@ -659,12 +649,6 @@ func TestCallBuilders(t *testing.T) {
 
 	// Error.
 	bm = b.If(BucketConditions{MetagenerationMatch: 1, MetagenerationNotMatch: 2})
-	if _, err := bm.newGetCall(); err == nil {
-		t.Errorf("got nil, want error")
-	}
-	if _, err := bm.newDeleteCall(); err == nil {
-		t.Errorf("got nil, want error")
-	}
 	if _, err := bm.newPatchCall(&BucketAttrsToUpdate{}); err == nil {
 		t.Errorf("got nil, want error")
 	}

--- a/storage/bucket_test.go
+++ b/storage/bucket_test.go
@@ -15,9 +15,6 @@
 package storage
 
 import (
-	"context"
-	"net/http"
-	"reflect"
 	"testing"
 	"time"
 
@@ -576,82 +573,6 @@ func TestAgeConditionBackwardCompat(t *testing.T) {
 		t.Fatalf("got %v, want %v", getAgeCondition(tp), want)
 	}
 
-}
-
-func TestCallBuilders(t *testing.T) {
-	rc, err := raw.NewService(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-	c := &Client{raw: rc}
-	const metagen = 17
-
-	b := c.Bucket("name")
-	bm := b.If(BucketConditions{MetagenerationMatch: metagen}).UserProject("p")
-
-	equal := func(x, y interface{}) bool {
-		return testutil.Equal(x, y,
-			cmp.AllowUnexported(
-				raw.BucketsGetCall{},
-				raw.BucketsDeleteCall{},
-				raw.BucketsPatchCall{},
-			),
-			cmp.FilterPath(func(p cmp.Path) bool {
-				return p[len(p)-1].Type() == reflect.TypeOf(&raw.Service{})
-			}, cmp.Ignore()),
-		)
-	}
-
-	for i, test := range []struct {
-		callFunc func(*BucketHandle) (interface{}, error)
-		want     interface {
-			Header() http.Header
-		}
-		metagenFunc func(interface{})
-	}{
-		{
-			func(b *BucketHandle) (interface{}, error) {
-				return b.newPatchCall(&BucketAttrsToUpdate{
-					VersioningEnabled: false,
-					RequesterPays:     false,
-				})
-			},
-			rc.Buckets.Patch("name", &raw.Bucket{
-				Versioning: &raw.BucketVersioning{
-					Enabled:         false,
-					ForceSendFields: []string{"Enabled"},
-				},
-				Billing: &raw.BucketBilling{
-					RequesterPays:   false,
-					ForceSendFields: []string{"RequesterPays"},
-				},
-			}).Projection("full"),
-			func(req interface{}) { req.(*raw.BucketsPatchCall).IfMetagenerationMatch(metagen).UserProject("p") },
-		},
-	} {
-		got, err := test.callFunc(b)
-		if err != nil {
-			t.Fatal(err)
-		}
-		setClientHeader(test.want.Header())
-		if !equal(got, test.want) {
-			t.Errorf("#%d: got %#v, want %#v", i, got, test.want)
-		}
-		got, err = test.callFunc(bm)
-		if err != nil {
-			t.Fatal(err)
-		}
-		test.metagenFunc(test.want)
-		if !equal(got, test.want) {
-			t.Errorf("#%d:\ngot  %#v\nwant %#v", i, got, test.want)
-		}
-	}
-
-	// Error.
-	bm = b.If(BucketConditions{MetagenerationMatch: 1, MetagenerationNotMatch: 2})
-	if _, err := bm.newPatchCall(&BucketAttrsToUpdate{}); err == nil {
-		t.Errorf("got nil, want error")
-	}
 }
 
 func TestNewBucket(t *testing.T) {

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -1354,11 +1354,6 @@ func TestRetryer(t *testing.T) {
 					r:    c.HMACKeyHandle("pID", "accessID").retry,
 					want: c.retry,
 				},
-				{
-					name: "client.Buckets()",
-					r:    c.Buckets(ctx, "pID").client.retry,
-					want: c.retry,
-				},
 			}
 			for _, ac := range configHandleCases {
 				s.Run(ac.name, func(ss *testing.T) {

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -1359,11 +1359,6 @@ func TestRetryer(t *testing.T) {
 					r:    c.Buckets(ctx, "pID").client.retry,
 					want: c.retry,
 				},
-				{
-					name: "bucket.Objects()",
-					r:    b.Objects(ctx, nil).bucket.retry,
-					want: b.retry,
-				},
 			}
 			for _, ac := range configHandleCases {
 				s.Run(ac.name, func(ss *testing.T) {


### PR DESCRIPTION
Migrate Bucket operations to transport-agnostic interface. Integration tests pass locally
- DeleteBucket
- GetBucket
- UpdateBucket
- LockBucketRetentionPolicy
- ListObjects


Part of the migration
- removed Bucket helpers `new{Get/Delete/Patch}Call`
- similar to ListBuckets, removed internal fetch method that is no longer used by the iterator