### PR TITLE
test: start building all code

### DIFF
--- a/internal/kokoro/presubmit.sh
+++ b/internal/kokoro/presubmit.sh
@@ -67,6 +67,11 @@ runPresubmitTests() {
     | go-junit-report -set-exit-code > sponge_log.xml
   # Add the exit codes together so we exit non-zero if any module fails.
   exit_code=$(($exit_code + $?))
+  # There are some types of build failures that go-junit-report does not
+  # properly handle. We can be safe here and run go build as well to catch such
+  # failures.
+  go build ./...
+  exit_code=$(($exit_code + $?))
 }
 
 SIGNIFICANT_CHANGES=$(git --no-pager diff --name-only origin/main...$KOKORO_GIT_COMMIT_google_cloud_go \

--- a/internal/kokoro/presubmit.sh
+++ b/internal/kokoro/presubmit.sh
@@ -70,8 +70,7 @@ runPresubmitTests() {
   # There are some types of build failures that go-junit-report does not
   # properly handle. We can be safe here and run go build as well to catch such
   # failures.
-  if [[ $PWD != *"/internal/generated/snippets"* ]]; then
-    # We don't want to build snippets as it takes a lot of processing and memory
+  if [[ $PWD != *"/internal/"* ]]; then
     go build ./...
   fi
   exit_code=$(($exit_code + $?))


### PR DESCRIPTION
Code is built when testing it, but some type of build failures are
not properly translated by the junit converter we use. Adding this
extra build will catch this previously missed failures and should
affect test time minimally as builds will have been cached.

Fixes: #6439