### PR TITLE
chore(storage): migrate Notification methods

### DIFF
--- a/storage/integration_test.go
+++ b/storage/integration_test.go
@@ -3144,6 +3144,9 @@ func TestIntegration_Notifications(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	if n.ID == "" {
+		t.Fatal("expected created Notification to have non-empty ID")
+	}
 	nArg.ID = n.ID
 	if !testutil.Equal(n, nArg) {
 		t.Errorf("got %+v, want %+v", n, nArg)

--- a/storage/notifications.go
+++ b/storage/notifications.go
@@ -157,21 +157,10 @@ func (b *BucketHandle) AddNotification(ctx context.Context, n *Notification) (re
 	if n.TopicID == "" {
 		return nil, errors.New("storage: AddNotification: missing TopicID")
 	}
-	call := b.c.raw.Notifications.Insert(b.name, toRawNotification(n))
-	setClientHeader(call.Header())
-	if b.userProject != "" {
-		call.UserProject(b.userProject)
-	}
 
-	var rn *raw.Notification
-	err = run(ctx, func() error {
-		rn, err = call.Context(ctx).Do()
-		return err
-	}, b.retry, false, setRetryHeaderHTTP(call))
-	if err != nil {
-		return nil, err
-	}
-	return toNotification(rn), nil
+	opts := makeStorageOpts(false, b.retry, b.userProject)
+	ret, err = b.c.tc.CreateNotification(ctx, b.name, n, opts...)
+	return n, err
 }
 
 // Notifications returns all the Notifications configured for this bucket, as a map
@@ -180,20 +169,9 @@ func (b *BucketHandle) Notifications(ctx context.Context) (n map[string]*Notific
 	ctx = trace.StartSpan(ctx, "cloud.google.com/go/storage.Bucket.Notifications")
 	defer func() { trace.EndSpan(ctx, err) }()
 
-	call := b.c.raw.Notifications.List(b.name)
-	setClientHeader(call.Header())
-	if b.userProject != "" {
-		call.UserProject(b.userProject)
-	}
-	var res *raw.Notifications
-	err = run(ctx, func() error {
-		res, err = call.Context(ctx).Do()
-		return err
-	}, b.retry, true, setRetryHeaderHTTP(call))
-	if err != nil {
-		return nil, err
-	}
-	return notificationsToMap(res.Items), nil
+	opts := makeStorageOpts(true, b.retry, b.userProject)
+	n, err = b.c.tc.ListNotifications(ctx, b.name, opts...)
+	return n, err
 }
 
 func notificationsToMap(rns []*raw.Notification) map[string]*Notification {
@@ -217,12 +195,6 @@ func (b *BucketHandle) DeleteNotification(ctx context.Context, id string) (err e
 	ctx = trace.StartSpan(ctx, "cloud.google.com/go/storage.Bucket.DeleteNotification")
 	defer func() { trace.EndSpan(ctx, err) }()
 
-	call := b.c.raw.Notifications.Delete(b.name, id)
-	setClientHeader(call.Header())
-	if b.userProject != "" {
-		call.UserProject(b.userProject)
-	}
-	return run(ctx, func() error {
-		return call.Context(ctx).Do()
-	}, b.retry, true, setRetryHeaderHTTP(call))
+	opts := makeStorageOpts(true, b.retry, b.userProject)
+	return b.c.tc.DeleteNotification(ctx, b.name, id, opts...)
 }

--- a/storage/notifications.go
+++ b/storage/notifications.go
@@ -160,7 +160,7 @@ func (b *BucketHandle) AddNotification(ctx context.Context, n *Notification) (re
 
 	opts := makeStorageOpts(false, b.retry, b.userProject)
 	ret, err = b.c.tc.CreateNotification(ctx, b.name, n, opts...)
-	return n, err
+	return ret, err
 }
 
 // Notifications returns all the Notifications configured for this bucket, as a map


### PR DESCRIPTION
Migrates the Notification APIs to the transport agnostic surface. Integration tests passed and added a check to ensure that AddNotification returns a Notification with a non-empty ID.