### PR TITLE
test: update continuous.sh for storage-refactor

### DIFF
--- a/internal/kokoro/continuous.sh
+++ b/internal/kokoro/continuous.sh
@@ -56,7 +56,7 @@ set -eo pipefail
 set -x
 
 # cd to project dir on Kokoro instance
-cd github/google-cloud-go
+cd github/google-cloud-go-storage-refactor
 
 go version
 

--- a/internal/kokoro/continuous.sh
+++ b/internal/kokoro/continuous.sh
@@ -56,6 +56,7 @@ set -eo pipefail
 set -x
 
 # cd to project dir on Kokoro instance
+# TODO(#6444): change this back to github/google-cloud-go before merging to main
 cd github/google-cloud-go-storage-refactor
 
 go version


### PR DESCRIPTION
We only need this for continuous builds so I only updated this shell script.

Reviewed repository for kokoro job name: 

```
git grep "github/google-cloud-go"
internal/kokoro/build_samples.sh:gcwd=$PWD/github/google-cloud-go
internal/kokoro/continuous.sh:cd github/google-cloud-go
internal/kokoro/environment.sh:    PROJECT_ROOT="github/google-cloud-go"
internal/kokoro/environment.sh:cd "${KOKORO_ARTIFACTS_DIR}/github/google-cloud-go/internal/"
internal/kokoro/presubmit.sh:cd github/google-cloud-go
internal/kokoro/publish_docs.sh:cd github/google-cloud-go/internal/godocfx
```

Manually triggered test
```
https://fusion2.corp.google.com/invocations/5224e509-df4f-413e-9f43-9d0b35ead566/targets
```