### PR TITLE
docs: fix incorrect connection pool documentation

### DIFF
--- a/pubsub/doc.go
+++ b/pubsub/doc.go
@@ -95,7 +95,7 @@ pull method.
 Streams Management
 
 Streams used for streaming pull are managed by the gRPC connection pool setting.
-By default, the number of connections in the pool is max(4,GOMAXPROCS/NumCPU).
+By default, the number of connections in the pool is min(4,GOMAXPROCS).
 
 If you have 4 or more CPU cores, the default setting allows 400 streams which is still a good default for most cases.
 If you want to have more open streams (such as for low CPU core machines), you should pass in the grpc option as described below:


### PR DESCRIPTION
As part of discussion in #6129, the section on streams management needs to be updated.