### PR TITLE
chore(storage): migrate Reader

### DIFF
--- a/storage/client.go
+++ b/storage/client.go
@@ -281,14 +281,14 @@ type openWriterParams struct {
 }
 
 type newRangeReaderParams struct {
-	bucket        string
-	conds         *Conditions
-	encryptionKey []byte
-	gen           int64
-	length        int64
-	object        string
-	offset        int64
-	readCompressed bool  // Use accept-encoding: gzip. Only works for HTTP currently.
+	bucket         string
+	conds          *Conditions
+	encryptionKey  []byte
+	gen            int64
+	length         int64
+	object         string
+	offset         int64
+	readCompressed bool // Use accept-encoding: gzip. Only works for HTTP currently.
 }
 
 type composeObjectRequest struct {

--- a/storage/client.go
+++ b/storage/client.go
@@ -288,6 +288,7 @@ type newRangeReaderParams struct {
 	length        int64
 	object        string
 	offset        int64
+	readCompressed bool  // Use accept-encoding: gzip. Only works for HTTP currently.
 }
 
 type composeObjectRequest struct {

--- a/storage/grpc_client.go
+++ b/storage/grpc_client.go
@@ -824,13 +824,11 @@ func (c *grpcStorageClient) NewRangeReader(ctx context.Context, params *newRange
 	ctx = trace.StartSpan(ctx, "cloud.google.com/go/storage.grpcStorageClient.NewRangeReader")
 	defer func() { trace.EndSpan(ctx, err) }()
 
-	if params.conds != nil {
-		if err := params.conds.validate("grpcStorageClient.NewRangeReader"); err != nil {
-			return nil, err
-		}
-	}
-
 	s := callSettings(c.settings, opts...)
+
+	if s.userProject != "" {
+		ctx = setUserProjectMetadata(ctx, s.userProject)
+	}
 
 	// A negative length means "read to the end of the object", but the
 	// read_limit field it corresponds to uses zero to mean the same thing. Thus

--- a/storage/http_client.go
+++ b/storage/http_client.go
@@ -774,14 +774,6 @@ func (c *httpStorageClient) NewRangeReader(ctx context.Context, params *newRange
 
 	s := callSettings(c.settings, opts...)
 
-	if params.offset < 0 && params.length >= 0 {
-		return nil, fmt.Errorf("storage: invalid offset %d < 0 requires negative length", params.offset)
-	}
-	if params.conds != nil {
-		if err := params.conds.validate("NewRangeReader"); err != nil {
-			return nil, err
-		}
-	}
 	u := &url.URL{
 		Scheme: c.scheme,
 		Host:   c.readHost,
@@ -799,10 +791,9 @@ func (c *httpStorageClient) NewRangeReader(ctx context.Context, params *newRange
 	if s.userProject != "" {
 		req.Header.Set("X-Goog-User-Project", s.userProject)
 	}
-	// TODO(noahdietz): add option for readCompressed.
-	// if o.readCompressed {
-	// 	req.Header.Set("Accept-Encoding", "gzip")
-	// }
+	if params.readCompressed {
+		req.Header.Set("Accept-Encoding", "gzip")
+	}
 	if err := setEncryptionHeaders(req.Header, params.encryptionKey, false); err != nil {
 		return nil, err
 	}

--- a/storage/reader.go
+++ b/storage/reader.go
@@ -105,13 +105,13 @@ func (o *ObjectHandle) NewRangeReader(ctx context.Context, offset, length int64)
 	opts := makeStorageOpts(true, o.retry, o.userProject)
 
 	params := &newRangeReaderParams{
-		bucket:        o.bucket,
-		object:        o.object,
-		gen:           o.gen,
-		offset:        offset,
-		length:        length,
-		encryptionKey: o.encryptionKey,
-		conds:         o.conds,
+		bucket:         o.bucket,
+		object:         o.object,
+		gen:            o.gen,
+		offset:         offset,
+		length:         length,
+		encryptionKey:  o.encryptionKey,
+		conds:          o.conds,
 		readCompressed: o.readCompressed,
 	}
 

--- a/storage/reader.go
+++ b/storage/reader.go
@@ -16,19 +16,15 @@ package storage
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"hash/crc32"
 	"io"
 	"io/ioutil"
 	"net/http"
-	"net/url"
-	"strconv"
 	"strings"
 	"time"
 
 	"cloud.google.com/go/internal/trace"
-	"google.golang.org/api/googleapi"
 )
 
 var crc32cTable = crc32.MakeTable(crc32.Castagnoli)
@@ -94,10 +90,6 @@ func (o *ObjectHandle) NewRangeReader(ctx context.Context, offset, length int64)
 	ctx = trace.StartSpan(ctx, "cloud.google.com/go/storage.Object.NewRangeReader")
 	defer func() { trace.EndSpan(ctx, err) }()
 
-	if o.c.useGRPC {
-		return o.newRangeReaderWithGRPC(ctx, offset, length)
-	}
-
 	if err := o.validate(); err != nil {
 		return nil, err
 	}
@@ -109,200 +101,23 @@ func (o *ObjectHandle) NewRangeReader(ctx context.Context, offset, length int64)
 			return nil, err
 		}
 	}
-	u := &url.URL{
-		Scheme: o.c.scheme,
-		Host:   o.c.readHost,
-		Path:   fmt.Sprintf("/%s/%s", o.bucket, o.object),
-	}
-	verb := "GET"
-	if length == 0 {
-		verb = "HEAD"
-	}
-	req, err := http.NewRequest(verb, u.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if o.userProject != "" {
-		req.Header.Set("X-Goog-User-Project", o.userProject)
-	}
-	if o.readCompressed {
-		req.Header.Set("Accept-Encoding", "gzip")
-	}
-	if err := setEncryptionHeaders(req.Header, o.encryptionKey, false); err != nil {
-		return nil, err
+
+	opts := makeStorageOpts(true, o.retry, o.userProject)
+
+	params := &newRangeReaderParams{
+		bucket:        o.bucket,
+		object:        o.object,
+		gen:           o.gen,
+		offset:        offset,
+		length:        length,
+		encryptionKey: o.encryptionKey,
+		conds:         o.conds,
+		readCompressed: o.readCompressed,
 	}
 
-	gen := o.gen
+	r, err = o.c.tc.NewRangeReader(ctx, params, opts...)
 
-	// Define a function that initiates a Read with offset and length, assuming we
-	// have already read seen bytes.
-	reopen := func(seen int64) (*http.Response, error) {
-		// If the context has already expired, return immediately without making a
-		// call.
-		if err := ctx.Err(); err != nil {
-			return nil, err
-		}
-		start := offset + seen
-		if length < 0 && start < 0 {
-			req.Header.Set("Range", fmt.Sprintf("bytes=%d", start))
-		} else if length < 0 && start > 0 {
-			req.Header.Set("Range", fmt.Sprintf("bytes=%d-", start))
-		} else if length > 0 {
-			// The end character isn't affected by how many bytes we've seen.
-			req.Header.Set("Range", fmt.Sprintf("bytes=%d-%d", start, offset+length-1))
-		}
-		// We wait to assign conditions here because the generation number can change in between reopen() runs.
-		if err := setConditionsHeaders(req.Header, o.conds); err != nil {
-			return nil, err
-		}
-		// If an object generation is specified, include generation as query string parameters.
-		if gen >= 0 {
-			req.URL.RawQuery = fmt.Sprintf("generation=%d", gen)
-		}
-
-		var res *http.Response
-		err = run(ctx, func() error {
-			res, err = o.c.hc.Do(req)
-			if err != nil {
-				return err
-			}
-			if res.StatusCode == http.StatusNotFound {
-				res.Body.Close()
-				return ErrObjectNotExist
-			}
-			if res.StatusCode < 200 || res.StatusCode > 299 {
-				body, _ := ioutil.ReadAll(res.Body)
-				res.Body.Close()
-				return &googleapi.Error{
-					Code:   res.StatusCode,
-					Header: res.Header,
-					Body:   string(body),
-				}
-			}
-
-			partialContentNotSatisfied :=
-				!decompressiveTranscoding(res) &&
-					start > 0 && length != 0 &&
-					res.StatusCode != http.StatusPartialContent
-
-			if partialContentNotSatisfied {
-				res.Body.Close()
-				return errors.New("storage: partial request not satisfied")
-			}
-
-			// With "Content-Encoding": "gzip" aka decompressive transcoding, GCS serves
-			// back the whole file regardless of the range count passed in as per:
-			//      https://cloud.google.com/storage/docs/transcoding#range,
-			// thus we have to manually move the body forward by seen bytes.
-			if decompressiveTranscoding(res) && seen > 0 {
-				_, _ = io.CopyN(ioutil.Discard, res.Body, seen)
-			}
-
-			// If a generation hasn't been specified, and this is the first response we get, let's record the
-			// generation. In future requests we'll use this generation as a precondition to avoid data races.
-			if gen < 0 && res.Header.Get("X-Goog-Generation") != "" {
-				gen64, err := strconv.ParseInt(res.Header.Get("X-Goog-Generation"), 10, 64)
-				if err != nil {
-					return err
-				}
-				gen = gen64
-			}
-			return nil
-		}, o.retry, true, setRetryHeaderHTTP(&readerRequestWrapper{req}))
-		if err != nil {
-			return nil, err
-		}
-		return res, nil
-	}
-
-	res, err := reopen(0)
-	if err != nil {
-		return nil, err
-	}
-	var (
-		size        int64 // total size of object, even if a range was requested.
-		checkCRC    bool
-		crc         uint32
-		startOffset int64 // non-zero if range request.
-	)
-	if res.StatusCode == http.StatusPartialContent {
-		cr := strings.TrimSpace(res.Header.Get("Content-Range"))
-		if !strings.HasPrefix(cr, "bytes ") || !strings.Contains(cr, "/") {
-			return nil, fmt.Errorf("storage: invalid Content-Range %q", cr)
-		}
-		// Content range is formatted <first byte>-<last byte>/<total size>. We take
-		// the total size.
-		size, err = strconv.ParseInt(cr[strings.LastIndex(cr, "/")+1:], 10, 64)
-		if err != nil {
-			return nil, fmt.Errorf("storage: invalid Content-Range %q", cr)
-		}
-
-		dashIndex := strings.Index(cr, "-")
-		if dashIndex >= 0 {
-			startOffset, err = strconv.ParseInt(cr[len("bytes="):dashIndex], 10, 64)
-			if err != nil {
-				return nil, fmt.Errorf("storage: invalid Content-Range %q: %v", cr, err)
-			}
-		}
-	} else {
-		size = res.ContentLength
-		// Check the CRC iff all of the following hold:
-		// - We asked for content (length != 0).
-		// - We got all the content (status != PartialContent).
-		// - The server sent a CRC header.
-		// - The Go http stack did not uncompress the file.
-		// - We were not served compressed data that was uncompressed on download.
-		// The problem with the last two cases is that the CRC will not match -- GCS
-		// computes it on the compressed contents, but we compute it on the
-		// uncompressed contents.
-		if length != 0 && !res.Uncompressed && !uncompressedByServer(res) {
-			crc, checkCRC = parseCRC32c(res)
-		}
-	}
-
-	remain := res.ContentLength
-	body := res.Body
-	if length == 0 {
-		remain = 0
-		body.Close()
-		body = emptyBody
-	}
-	var metaGen int64
-	if res.Header.Get("X-Goog-Metageneration") != "" {
-		metaGen, err = strconv.ParseInt(res.Header.Get("X-Goog-Metageneration"), 10, 64)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	var lm time.Time
-	if res.Header.Get("Last-Modified") != "" {
-		lm, err = http.ParseTime(res.Header.Get("Last-Modified"))
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	attrs := ReaderObjectAttrs{
-		Size:            size,
-		ContentType:     res.Header.Get("Content-Type"),
-		ContentEncoding: res.Header.Get("Content-Encoding"),
-		CacheControl:    res.Header.Get("Cache-Control"),
-		LastModified:    lm,
-		StartOffset:     startOffset,
-		Generation:      gen,
-		Metageneration:  metaGen,
-	}
-	return &Reader{
-		Attrs:    attrs,
-		body:     body,
-		size:     size,
-		remain:   remain,
-		wantCRC:  crc,
-		checkCRC: checkCRC,
-		reopen:   reopen,
-	}, nil
+	return r, err
 }
 
 // decompressiveTranscoding returns true if the request was served decompressed
@@ -375,37 +190,21 @@ var emptyBody = ioutil.NopCloser(strings.NewReader(""))
 // is skipped if transcoding occurs. See https://cloud.google.com/storage/docs/transcoding.
 type Reader struct {
 	Attrs              ReaderObjectAttrs
-	body               io.ReadCloser
 	seen, remain, size int64
 	checkCRC           bool   // should we check the CRC?
 	wantCRC            uint32 // the CRC32c value the server sent in the header
 	gotCRC             uint32 // running crc
-	reopen             func(seen int64) (*http.Response, error)
 
 	reader io.ReadCloser
 }
 
 // Close closes the Reader. It must be called when done reading.
 func (r *Reader) Close() error {
-	if r.body != nil {
-		return r.body.Close()
-	}
-
-	// TODO(noahdietz): Complete integration means returning this call's return
-	// value, which for gRPC will always be nil.
-	if r.reader != nil {
-		return r.reader.Close()
-	}
-	return nil
+	return r.reader.Close()
 }
 
 func (r *Reader) Read(p []byte) (int, error) {
-	read := r.readWithRetry
-	if r.reader != nil {
-		read = r.reader.Read
-	}
-
-	n, err := read(p)
+	n, err := r.reader.Read(p)
 	if r.remain != -1 {
 		r.remain -= int64(n)
 	}
@@ -422,56 +221,6 @@ func (r *Reader) Read(p []byte) (int, error) {
 		}
 	}
 	return n, err
-}
-
-// newRangeReaderWithGRPC creates a new Reader with the given range that uses
-// gRPC to read Object content.
-//
-// This is an experimental API and not intended for public use.
-func (o *ObjectHandle) newRangeReaderWithGRPC(ctx context.Context, offset, length int64) (r *Reader, err error) {
-	ctx = trace.StartSpan(ctx, "cloud.google.com/go/storage.Object.newRangeReaderWithGRPC")
-	defer func() { trace.EndSpan(ctx, err) }()
-
-	if err = o.validate(); err != nil {
-		return
-	}
-
-	params := &newRangeReaderParams{
-		bucket:        o.bucket,
-		object:        o.object,
-		gen:           o.gen,
-		offset:        offset,
-		length:        length,
-		encryptionKey: o.encryptionKey,
-		conds:         o.conds,
-	}
-
-	r, err = o.c.tc.NewRangeReader(ctx, params)
-
-	return r, err
-}
-
-func (r *Reader) readWithRetry(p []byte) (int, error) {
-	n := 0
-	for len(p[n:]) > 0 {
-		m, err := r.body.Read(p[n:])
-		n += m
-		r.seen += int64(m)
-		if err == nil || err == io.EOF {
-			return n, err
-		}
-		// Read failed (likely due to connection issues), but we will try to reopen
-		// the pipe and continue. Send a ranged read request that takes into account
-		// the number of bytes we've already seen.
-		res, err := r.reopen(r.seen)
-		if err != nil {
-			// reopen already retries
-			return n, err
-		}
-		r.body.Close()
-		r.body = res.Body
-	}
-	return n, nil
 }
 
 // Size returns the size of the object in bytes.


### PR DESCRIPTION
Migrate the Reader to use the new transport-agnostic interface.
A few minor fixes were required:
* Move validations above interface
* Add settings for call and fix up userProject for gRPC
* Add param for sending with accept-encoding: gzip (HTTP only)
* Fix up reader resumption test