### PR TITLE
feat(pubsub): retry temporary failures for ack/modacks

### DIFF
--- a/pubsub/integration_test.go
+++ b/pubsub/integration_test.go
@@ -127,15 +127,6 @@ func TestIntegration_All(t *testing.T) {
 	client := integrationTestClient(ctx, t)
 	defer client.Close()
 
-	for _, sync := range []bool{false, true} {
-		for _, maxMsgs := range []int{0, 3, -1} { // MaxOutstandingMessages = default, 3, unlimited
-			testPublishAndReceive(t, client, maxMsgs, sync, 10, 0)
-		}
-
-		// Tests for large messages (larger than the 4MB gRPC limit).
-		testPublishAndReceive(t, client, 0, sync, 1, 5*1024*1024)
-	}
-
 	topic, err := client.CreateTopic(ctx, topicIDs.New())
 	if err != nil {
 		t.Errorf("CreateTopic error: %v", err)
@@ -228,6 +219,20 @@ func TestIntegration_All(t *testing.T) {
 	}
 }
 
+func TestPublishReceive(t *testing.T) {
+	ctx := context.Background()
+	client := integrationTestClient(ctx, t)
+
+	for _, sync := range []bool{false, true} {
+		for _, maxMsgs := range []int{0, 3, -1} { // MaxOutstandingMessages = default, 3, unlimited
+			testPublishAndReceive(t, client, maxMsgs, sync, false, 10, 0)
+		}
+
+		// Tests for large messages (larger than the 4MB gRPC limit).
+		testPublishAndReceive(t, client, 0, sync, false, 1, 5*1024*1024)
+	}
+}
+
 // withGoogleClientInfo sets the name and version of the application in
 // the `x-goog-api-client` header passed on each request and returns the
 // updated context.
@@ -246,94 +251,100 @@ func withGoogleClientInfo(ctx context.Context) context.Context {
 	return metadata.NewOutgoingContext(ctx, metadata.Join(allMDs...))
 }
 
-func testPublishAndReceive(t *testing.T, client *Client, maxMsgs int, synchronous bool, numMsgs, extraBytes int) {
-	ctx := context.Background()
-	topic, err := client.CreateTopic(ctx, topicIDs.New())
-	if err != nil {
-		t.Errorf("CreateTopic error: %v", err)
-	}
-	defer topic.Stop()
-	exists, err := topic.Exists(ctx)
-	if err != nil {
-		t.Fatalf("TopicExists error: %v", err)
-	}
-	if !exists {
-		t.Errorf("topic %v should exist, but it doesn't", topic)
-	}
-
-	var sub *Subscription
-	if sub, err = client.CreateSubscription(ctx, subIDs.New(), SubscriptionConfig{Topic: topic}); err != nil {
-		t.Errorf("CreateSub error: %v", err)
-	}
-	exists, err = sub.Exists(ctx)
-	if err != nil {
-		t.Fatalf("SubExists error: %v", err)
-	}
-	if !exists {
-		t.Errorf("subscription %s should exist, but it doesn't", sub.ID())
-	}
-	var msgs []*Message
-	for i := 0; i < numMsgs; i++ {
-		text := fmt.Sprintf("a message with an index %d - %s", i, strings.Repeat(".", extraBytes))
-		attrs := make(map[string]string)
-		attrs["foo"] = "bar"
-		msgs = append(msgs, &Message{
-			Data:       []byte(text),
-			Attributes: attrs,
-		})
-	}
-
-	// Publish some messages.
-	type pubResult struct {
-		m *Message
-		r *PublishResult
-	}
-	var rs []pubResult
-	for _, m := range msgs {
-		r := topic.Publish(ctx, m)
-		rs = append(rs, pubResult{m, r})
-	}
-	want := make(map[string]messageData)
-	for _, res := range rs {
-		id, err := res.r.Get(ctx)
+func testPublishAndReceive(t *testing.T, client *Client, maxMsgs int, synchronous, exactlyOnceDelivery bool, numMsgs, extraBytes int) {
+	t.Run(fmt.Sprintf("maxMsgs:%d,synchronous:%t,exactlyOnceDelivery:%t,numMsgs:%d", maxMsgs, synchronous, exactlyOnceDelivery, numMsgs), func(t *testing.T) {
+		t.Parallel()
+		ctx := context.Background()
+		topic, err := client.CreateTopic(ctx, topicIDs.New())
 		if err != nil {
-			t.Fatal(err)
+			t.Errorf("CreateTopic error: %v", err)
 		}
-		md := extractMessageData(res.m)
-		md.ID = id
-		want[md.ID] = md
-	}
+		defer topic.Stop()
+		exists, err := topic.Exists(ctx)
+		if err != nil {
+			t.Fatalf("TopicExists error: %v", err)
+		}
+		if !exists {
+			t.Errorf("topic %v should exist, but it doesn't", topic)
+		}
 
-	sub.ReceiveSettings.MaxOutstandingMessages = maxMsgs
-	sub.ReceiveSettings.Synchronous = synchronous
+		sub, err := client.CreateSubscription(ctx, subIDs.New(), SubscriptionConfig{
+			Topic:                     topic,
+			EnableExactlyOnceDelivery: exactlyOnceDelivery,
+		})
+		if err != nil {
+			t.Errorf("CreateSub error: %v", err)
+		}
+		exists, err = sub.Exists(ctx)
+		if err != nil {
+			t.Fatalf("SubExists error: %v", err)
+		}
+		if !exists {
+			t.Errorf("subscription %s should exist, but it doesn't", sub.ID())
+		}
+		var msgs []*Message
+		for i := 0; i < numMsgs; i++ {
+			text := fmt.Sprintf("a message with an index %d - %s", i, strings.Repeat(".", extraBytes))
+			attrs := make(map[string]string)
+			attrs["foo"] = "bar"
+			msgs = append(msgs, &Message{
+				Data:       []byte(text),
+				Attributes: attrs,
+			})
+		}
 
-	// Use a timeout to ensure that Pull does not block indefinitely if there are
-	// unexpectedly few messages available.
-	now := time.Now()
-	timeout := 3 * time.Minute
-	timeoutCtx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-	gotMsgs, err := pullN(timeoutCtx, sub, len(want), func(ctx context.Context, m *Message) {
-		m.Ack()
-	})
-	if err != nil {
-		if c := status.Convert(err); c.Code() == codes.Canceled {
-			if time.Since(now) >= timeout {
-				t.Fatal("pullN took too long")
+		// Publish some messages.
+		type pubResult struct {
+			m *Message
+			r *PublishResult
+		}
+		var rs []pubResult
+		for _, m := range msgs {
+			r := topic.Publish(ctx, m)
+			rs = append(rs, pubResult{m, r})
+		}
+		want := make(map[string]messageData)
+		for _, res := range rs {
+			id, err := res.r.Get(ctx)
+			if err != nil {
+				t.Fatal(err)
 			}
-		} else {
-			t.Fatalf("Pull: %v", err)
+			md := extractMessageData(res.m)
+			md.ID = id
+			want[md.ID] = md
 		}
-	}
-	got := make(map[string]messageData)
-	for _, m := range gotMsgs {
-		md := extractMessageData(m)
-		got[md.ID] = md
-	}
-	if !testutil.Equal(got, want) {
-		t.Fatalf("MaxOutstandingMessages=%d, Synchronous=%t, messages got: %+v, messages want: %+v",
-			maxMsgs, synchronous, got, want)
-	}
+
+		sub.ReceiveSettings.MaxOutstandingMessages = maxMsgs
+		sub.ReceiveSettings.Synchronous = synchronous
+
+		// Use a timeout to ensure that Pull does not block indefinitely if there are
+		// unexpectedly few messages available.
+		now := time.Now()
+		timeout := 3 * time.Minute
+		timeoutCtx, cancel := context.WithTimeout(ctx, timeout)
+		defer cancel()
+		gotMsgs, err := pullN(timeoutCtx, sub, len(want), func(ctx context.Context, m *Message) {
+			m.Ack()
+		})
+		if err != nil {
+			if c := status.Convert(err); c.Code() == codes.Canceled {
+				if time.Since(now) >= timeout {
+					t.Fatal("pullN took too long")
+				}
+			} else {
+				t.Fatalf("Pull: %v", err)
+			}
+		}
+		got := make(map[string]messageData)
+		for _, m := range gotMsgs {
+			md := extractMessageData(m)
+			got[md.ID] = md
+		}
+		if !testutil.Equal(got, want) {
+			t.Fatalf("MaxOutstandingMessages=%d, Synchronous=%t, messages got: %+v, messages want: %+v",
+				maxMsgs, synchronous, got, want)
+		}
+	})
 }
 
 // IAM tests.
@@ -1979,4 +1990,16 @@ func TestIntegration_TopicRetention(t *testing.T) {
 	if got := cfg.RetentionDuration; got != nil {
 		t.Fatalf("expected cleared retention duration, got: %v", got)
 	}
+}
+
+func TestExactlyOnceDelivery_PublishReceive(t *testing.T) {
+	ctx := context.Background()
+	client := integrationTestClient(ctx, t)
+
+	for _, maxMsgs := range []int{0, 3, -1} { // MaxOutstandingMessages = default, 3, unlimited
+		testPublishAndReceive(t, client, maxMsgs, false, true, 10, 0)
+	}
+
+	// Tests for large messages (larger than the 4MB gRPC limit).
+	testPublishAndReceive(t, client, 0, false, true, 1, 5*1024*1024)
 }

--- a/pubsub/pstest/fake.go
+++ b/pubsub/pstest/fake.go
@@ -933,6 +933,7 @@ func (s *GServer) StreamingPull(sps pb.Subscriber_StreamingPullServer) error {
 	}
 	// Create a new stream to handle the pull.
 	st := sub.newStream(sps, s.streamTimeout)
+	st.ackTimeout = time.Duration(req.StreamAckDeadlineSeconds) * time.Second
 	err = st.pull(&s.wg)
 	sub.deleteStream(st)
 	return err

--- a/pubsub/service.go
+++ b/pubsub/service.go
@@ -122,3 +122,11 @@ func contains(v codes.Code, t map[codes.Code]struct{}) bool {
 	_, ok := t[v]
 	return ok
 }
+
+func newExactlyOnceBackoff() gax.Backoff {
+	return gax.Backoff{
+		Initial:    1 * time.Second,
+		Max:        64 * time.Second,
+		Multiplier: 2,
+	}
+}

--- a/pubsub/streaming_pull_test.go
+++ b/pubsub/streaming_pull_test.go
@@ -467,7 +467,6 @@ func pullN(ctx context.Context, sub *Subscription, n int, f func(context.Context
 		mu.Unlock()
 		f(ctx, m)
 		if nSeen >= n {
-			// time.Sleep(1 * time.Second)
 			cancel()
 		}
 	})

--- a/pubsub/streaming_pull_test.go
+++ b/pubsub/streaming_pull_test.go
@@ -467,6 +467,7 @@ func pullN(ctx context.Context, sub *Subscription, n int, f func(context.Context
 		mu.Unlock()
 		f(ctx, m)
 		if nSeen >= n {
+			// time.Sleep(1 * time.Second)
 			cancel()
 		}
 	})

--- a/pubsub/subscription.go
+++ b/pubsub/subscription.go
@@ -714,9 +714,10 @@ type ReceiveSettings struct {
 	// Deprecated.
 	// Previously, users might use Synchronous mode since StreamingPull had a limitation
 	// where MaxOutstandingMessages was not always respected with large batches of
-	// small messsages. With server side flow control, this is no longer an issue
+	// small messages. With server side flow control, this is no longer an issue
 	// and we recommend switching to the default StreamingPull mode by setting
 	// Synchronous to false.
+	// Synchronous mode does not work with exactly once delivery.
 	Synchronous bool
 }
 


### PR DESCRIPTION
This PR adds the logic for retrying temporary ack/modack (including nack) failures for exactly once delivery.

Some other changes captured in this PR
1. Updating `subscription_test.go` and `integration_test.go` to support exactly once delivery for publish/subscribing.
   (Git diff is not great here, but a lot of changes just  involves moving a lot of the publish/receive test code into a sub-test function so they can be invoked in parallel. Not much logic change.)
3. Reverted all `ackResultWithID` to just be `AckResult`. Passing around the map of ackID->AckResult works best and we just needed to be consistent.