### PR TITLE
chore(internal/gapicgen): update microgen v0.32.0

### DIFF
--- a/internal/gapicgen/cmd/genbot/Dockerfile
+++ b/internal/gapicgen/cmd/genbot/Dockerfile
@@ -27,7 +27,7 @@ RUN go install github.com/golang/protobuf/protoc-gen-go@v1.5.2 && \
     go install golang.org/x/lint/golint@latest && \
     go install golang.org/x/tools/cmd/goimports@latest && \
     go install honnef.co/go/tools/cmd/staticcheck@latest && \
-    go install github.com/googleapis/gapic-generator-go/cmd/protoc-gen-go_gapic@v0.31.2
+    go install github.com/googleapis/gapic-generator-go/cmd/protoc-gen-go_gapic@v0.32.0
 ENV PATH="${PATH}:/root/go/bin"
 
 # Source: http://debuggable.com/posts/disable-strict-host-checking-for-git-clone:49896ff3-0ac0-4263-9703-1eae4834cda3

--- a/internal/gapicgen/generator/config.go
+++ b/internal/gapicgen/generator/config.go
@@ -56,6 +56,12 @@ type MicrogenConfig struct {
 	// ImportPath plus the specified suffix separated by a "/", and using the
 	// same Pkg value.
 	StubsDir string
+
+	// NumericEnumsEnabled indicates, for REST GAPICs, if requests should be
+	// generated to send the $alt=json;enum-encoding=int system parameter with
+	// every API call. This should only be enabled for services that are
+	// up-to-date enough to support such a system parameter.
+	NumericEnumsEnabled bool
 }
 
 var MicrogenGapicConfigs = []*MicrogenConfig{

--- a/internal/gapicgen/generator/gapics.go
+++ b/internal/gapicgen/generator/gapics.go
@@ -304,6 +304,9 @@ func (g *GapicGenerator) microgen(conf *MicrogenConfig) error {
 	if len(conf.Transports) > 0 {
 		args = append(args, "--go_gapic_opt", fmt.Sprintf("transport=%s", strings.Join(conf.Transports, "+")))
 	}
+	if conf.NumericEnumsEnabled {
+		args = append(args, "--go_gapic_opt", "rest-numeric-enums")
+	}
 	// This is a bummer way of toggling diregapic generation, but it compute is the only one for the near term.
 	if conf.Pkg == "compute" {
 		args = append(args, "--go_gapic_opt", "diregapic")


### PR DESCRIPTION
Update Go GAPIC generator to v0.32.0 ([notes](https://github.com/googleapis/gapic-generator-go/releases/tag/v0.32.0)).

Also adds support for new generator option to the `MicrogenConfig` to toggle generation of the numeric enum encoding parameter.

cc @vchudnov-g @vam-google 