### PR TITLE
test(bigquery/storage/managedwriter): improve instrumentation testing

### DIFF
--- a/bigquery/storage/managedwriter/integration_test.go
+++ b/bigquery/storage/managedwriter/integration_test.go
@@ -710,7 +710,7 @@ func testInstrumentation(ctx context.Context, t *testing.T, mwClient *Client, bq
 			t.Errorf("view %q RetrieveData: %v", tv.Name, err)
 		}
 		if len(metricData) != 1 {
-			t.Errorf("%q: only expected 1 row, got %d", tv.Name, len(metricData))
+			t.Errorf("%q: expected 1 row of metrics, got %d", tv.Name, len(metricData))
 			continue
 		}
 		if len(metricData[0].Tags) != 1 {

--- a/bigquery/storage/managedwriter/integration_test.go
+++ b/bigquery/storage/managedwriter/integration_test.go
@@ -709,8 +709,8 @@ func testInstrumentation(ctx context.Context, t *testing.T, mwClient *Client, bq
 		if err != nil {
 			t.Errorf("view %q RetrieveData: %v", tv.Name, err)
 		}
-		if len(metricData) != 1 {
-			t.Errorf("%q: expected 1 row of metrics, got %d", tv.Name, len(metricData))
+		if mlen := len(metricData); mlen != 1 {
+			t.Errorf("%q: expected 1 row of metrics, got %d", tv.Name, mlen)
 			continue
 		}
 		if len(metricData[0].Tags) != 1 {

--- a/bigquery/storage/managedwriter/integration_test.go
+++ b/bigquery/storage/managedwriter/integration_test.go
@@ -709,8 +709,9 @@ func testInstrumentation(ctx context.Context, t *testing.T, mwClient *Client, bq
 		if err != nil {
 			t.Errorf("view %q RetrieveData: %v", tv.Name, err)
 		}
-		if len(metricData) > 1 {
+		if len(metricData) != 1 {
 			t.Errorf("%q: only expected 1 row, got %d", tv.Name, len(metricData))
+			continue
 		}
 		if len(metricData[0].Tags) != 1 {
 			t.Errorf("%q: only expected 1 tag, got %d", tv.Name, len(metricData[0].Tags))


### PR DESCRIPTION
The integration testing for instrumentation can suffer from races, and
the failure mode here induces panic which incorrectly implicates other
tests run as part of the test group.

This small change avoid the indexing problem so that future failures
only implicate the instrumentation test.

Fixes: #6535
Fixes: #6534
Fixes: #6533
Fixes: #6532
Fixes: #6531
Fixes: #6530
Fixes: #6529
Fixes: #6528
Fixes: #6527