### PR TITLE
testing(bigquery/storage/managedwriter):  instrumentation retries

### DIFF
--- a/bigquery/storage/managedwriter/integration_test.go
+++ b/bigquery/storage/managedwriter/integration_test.go
@@ -705,7 +705,21 @@ func testInstrumentation(ctx context.Context, t *testing.T, mwClient *Client, bq
 	time.Sleep(time.Second)
 
 	for _, tv := range testedViews {
-		metricData, err := view.RetrieveData(tv.Name)
+		// Attempt to further improve race failures by retrying metrics retrieval.
+		metricData, err := func() ([]*view.Row, error) {
+			attempt := 0
+			for {
+				data, err := view.RetrieveData(tv.Name)
+				attempt = attempt + 1
+				if attempt > 5 {
+					return data, err
+				}
+				if err == nil && len(data) == 1 {
+					return data, err
+				}
+				time.Sleep(time.Duration(attempt) * 500 * time.Millisecond)
+			}
+		}()
 		if err != nil {
 			t.Errorf("view %q RetrieveData: %v", tv.Name, err)
 		}


### PR DESCRIPTION
We've caught more than one instance of a race failure.  Add retries
for the opencensus metrics test to reduce the likelihood of this
failures.

Fixes: #6535