### PR TITLE
chore: remove installing python deps

### DIFF
--- a/internal/kokoro/environment.sh
+++ b/internal/kokoro/environment.sh
@@ -64,12 +64,6 @@ gcloud config set compute/zone us-central1-b
 # Authenticate docker
 gcloud auth configure-docker -q
 
-# Nox tests require Python 3.7, instead of 3.8
-pyenv global 3.7.10
-python3 -m pip uninstall --yes --quiet nox-automation
-python3 -m pip install --upgrade --quiet nox
-python3 -m nox --version
-
 # create a unique id for this run
 UUID=$(python  -c 'import uuid; print(uuid.uuid1())' | head -c 7)
 export ENVCTL_ID=ci-$UUID

--- a/internal/kokoro/publish_docs.sh
+++ b/internal/kokoro/publish_docs.sh
@@ -19,10 +19,6 @@ set -eo pipefail
 # Display commands being run.
 set -x
 
-python3 -m pip install --upgrade pip
-# Workaround for six 1.15 incompatibility issue.
-python3 -m pip install --use-feature=2020-resolver "gcp-docuploader<2019.0.0"
-
 cd github/google-cloud-go/internal/godocfx
 go install
 cd -


### PR DESCRIPTION
These will be backed directly into the image.

Related: https://github.com/googleapis/testing-infra-docker/pull/222