### PR TITLE
chore: don't test tools with earliest

### DIFF
--- a/internal/kokoro/continuous.sh
+++ b/internal/kokoro/continuous.sh
@@ -79,8 +79,14 @@ try3 go mod download
 # runDirectoryTests runs all tests in the current directory.
 # If a PATH argument is specified, it runs `go test [PATH]`.
 runDirectoryTests() {
-  go test -race -v -timeout 45m "${1:-./...}" 2>&1 \
-    | tee sponge_log.log
+  if [[ $PWD != *"/internal/"* ]] ||
+    [[ $PWD != *"/third_party/"* ]] &&
+    [[ $KOKORO_JOB_NAME == *"earliest"* ]]; then
+    # internal tools only expected to work with latest go version
+    return
+  fi
+  go test -race -v -timeout 45m "${1:-./...}" 2>&1 |
+    tee sponge_log.log
   # Takes the kokoro output log (raw stdout) and creates a machine-parseable
   # xUnit XML file.
   cat sponge_log.log \

--- a/internal/kokoro/presubmit.sh
+++ b/internal/kokoro/presubmit.sh
@@ -74,7 +74,9 @@ runPresubmitTests() {
     go-junit-report -set-exit-code >sponge_log.xml
   # Add the exit codes together so we exit non-zero if any module fails.
   exit_code=$(($exit_code + $?))
-  go build ./...
+  if [[ $PWD != *"/internal/"* ]]; then
+    go build ./...
+  fi
   exit_code=$(($exit_code + $?))
 }
 


### PR DESCRIPTION
Our tools are only expected to run with the latest go version we
support. So for those directories skip running tests on old Go
versions.