### PR TITLE
chore(internal/gapicgen): rescope genbot context to include repo

### DIFF
--- a/internal/gapicgen/cmd/genbot/Dockerfile
+++ b/internal/gapicgen/cmd/genbot/Dockerfile
@@ -35,12 +35,8 @@ RUN mkdir /root/.ssh && echo -e "Host github.com\n\tStrictHostKeyChecking no\n" 
 
 RUN echo -e '#!/bin/bash\n\
     set -ex\n\
-    if [[ ${GENBOT_LOCAL_MODE} = "true" ]]; then\n\
     cd internal/gapicgen\n\
     go run cloud.google.com/go/internal/gapicgen/cmd/genbot\n\
-    exit 0\n\
-    fi\n\
-    go mod download \n\
     go run cloud.google.com/go/internal/gapicgen/cmd/genbot \
     ' >> /run.sh
 RUN chmod a+x /run.sh


### PR DESCRIPTION
This allows the replace statements in the go.mod to work properly