### PR TITLE
chore: enable regapic on remaining beta

### DIFF
--- a/internal/gapicgen/generator/config.go
+++ b/internal/gapicgen/generator/config.go
@@ -278,6 +278,7 @@ var MicrogenGapicConfigs = []*MicrogenConfig{
 		ImportPath:            "cloud.google.com/go/bigquery/reservation/apiv1beta1",
 		GRPCServiceConfigPath: "bigqueryreservation_grpc_service_config.json",
 		ApiServiceConfigPath:  "bigqueryreservation_v1beta1.yaml",
+		Transports:            []string{"grpc", "rest"},
 		ReleaseLevel:          "beta",
 	},
 	{
@@ -464,6 +465,7 @@ var MicrogenGapicConfigs = []*MicrogenConfig{
 		ImportPath:            "cloud.google.com/go/datacatalog/apiv1beta1",
 		GRPCServiceConfigPath: "datacatalog_grpc_service_config.json",
 		ApiServiceConfigPath:  "datacatalog_v1beta1.yaml",
+		Transports:            []string{"grpc", "rest"},
 		ReleaseLevel:          "beta",
 	},
 	{
@@ -612,6 +614,7 @@ var MicrogenGapicConfigs = []*MicrogenConfig{
 		ImportPath:            "cloud.google.com/go/securitycenter/settings/apiv1beta1",
 		GRPCServiceConfigPath: "securitycenter_settings_grpc_service_config.json",
 		ApiServiceConfigPath:  "securitycenter_settings.yaml",
+		Transports:            []string{"grpc", "rest"},
 		ReleaseLevel:          "beta",
 	},
 	{
@@ -628,6 +631,7 @@ var MicrogenGapicConfigs = []*MicrogenConfig{
 		ImportPath:            "cloud.google.com/go/securitycenter/apiv1beta1",
 		GRPCServiceConfigPath: "securitycenter_grpc_service_config.json",
 		ApiServiceConfigPath:  "securitycenter_v1beta1.yaml",
+		Transports:            []string{"grpc", "rest"},
 		ReleaseLevel:          "beta",
 	},
 	{
@@ -636,6 +640,7 @@ var MicrogenGapicConfigs = []*MicrogenConfig{
 		ImportPath:            "cloud.google.com/go/securitycenter/apiv1p1beta1",
 		GRPCServiceConfigPath: "securitycenter_grpc_service_config.json",
 		ApiServiceConfigPath:  "securitycenter_v1p1beta1.yaml",
+		Transports:            []string{"grpc", "rest"},
 		ReleaseLevel:          "beta",
 	},
 	{
@@ -873,6 +878,7 @@ var MicrogenGapicConfigs = []*MicrogenConfig{
 		ImportPath:            "cloud.google.com/go/gaming/apiv1beta",
 		GRPCServiceConfigPath: "gaming_grpc_service_config.json",
 		ApiServiceConfigPath:  "gameservices_v1beta.yaml",
+		Transports:            []string{"grpc", "rest"},
 		ReleaseLevel:          "beta",
 	},
 	{
@@ -913,6 +919,7 @@ var MicrogenGapicConfigs = []*MicrogenConfig{
 		ImportPath:            "cloud.google.com/go/networkconnectivity/apiv1alpha1",
 		GRPCServiceConfigPath: "networkconnectivity_grpc_service_config.json",
 		ApiServiceConfigPath:  "networkconnectivity_v1alpha1.yaml",
+		Transports:            []string{"grpc", "rest"},
 		ReleaseLevel:          "alpha",
 	},
 	{
@@ -921,6 +928,7 @@ var MicrogenGapicConfigs = []*MicrogenConfig{
 		ImportPath:            "cloud.google.com/go/notebooks/apiv1beta1",
 		GRPCServiceConfigPath: "notebooks_grpc_service_config.json",
 		ApiServiceConfigPath:  "notebooks_v1beta1.yaml",
+		Transports:            []string{"grpc", "rest"},
 		ReleaseLevel:          "beta",
 	},
 	{
@@ -937,6 +945,7 @@ var MicrogenGapicConfigs = []*MicrogenConfig{
 		ImportPath:            "cloud.google.com/go/billing/budgets/apiv1beta1",
 		GRPCServiceConfigPath: "billingbudgets_grpc_service_config.json",
 		ApiServiceConfigPath:  "billingbudgets.yaml",
+		Transports:            []string{"grpc", "rest"},
 		ReleaseLevel:          "beta",
 	},
 	{
@@ -979,6 +988,7 @@ var MicrogenGapicConfigs = []*MicrogenConfig{
 		ImportPath:            "cloud.google.com/go/security/privateca/apiv1beta1",
 		GRPCServiceConfigPath: "privateca_grpc_service_config.json",
 		ApiServiceConfigPath:  "privateca_v1beta1.yaml",
+		Transports:            []string{"grpc", "rest"},
 		ReleaseLevel:          "beta",
 	},
 	{
@@ -1028,6 +1038,7 @@ var MicrogenGapicConfigs = []*MicrogenConfig{
 		ImportPath:            "cloud.google.com/go/artifactregistry/apiv1beta2",
 		GRPCServiceConfigPath: "artifactregistry_grpc_service_config.json",
 		ApiServiceConfigPath:  "artifactregistry_v1beta2.yaml",
+		Transports:            []string{"grpc", "rest"},
 		ReleaseLevel:          "ga",
 	},
 	{
@@ -1084,6 +1095,7 @@ var MicrogenGapicConfigs = []*MicrogenConfig{
 		ImportPath:            "cloud.google.com/go/datalabeling/apiv1beta1",
 		GRPCServiceConfigPath: "datalabeling_grpc_service_config.json",
 		ApiServiceConfigPath:  "datalabeling_v1beta1.yaml",
+		Transports:            []string{"grpc", "rest"},
 		ReleaseLevel:          "beta",
 	},
 	{
@@ -1109,6 +1121,7 @@ var MicrogenGapicConfigs = []*MicrogenConfig{
 		ImportPath:            "cloud.google.com/go/documentai/apiv1beta3",
 		GRPCServiceConfigPath: "documentai_v1beta3_grpc_service_config.json",
 		ApiServiceConfigPath:  "documentai_v1beta3.yaml",
+		Transports:            []string{"grpc", "rest"},
 		ReleaseLevel:          "beta",
 	},
 	{
@@ -1134,6 +1147,7 @@ var MicrogenGapicConfigs = []*MicrogenConfig{
 		ImportPath:            "cloud.google.com/go/mediatranslation/apiv1beta1",
 		GRPCServiceConfigPath: "mediatranslation_grpc_service_config.json",
 		ApiServiceConfigPath:  "mediatranslation_v1beta1.yaml",
+		Transports:            []string{"grpc", "rest"},
 		ReleaseLevel:          "beta",
 	},
 	{
@@ -1157,6 +1171,7 @@ var MicrogenGapicConfigs = []*MicrogenConfig{
 		ImportPath:            "cloud.google.com/go/recommendationengine/apiv1beta1",
 		GRPCServiceConfigPath: "recommendationengine_grpc_service_config.json",
 		ApiServiceConfigPath:  "recommendationengine_v1beta1.yaml",
+		Transports:            []string{"grpc", "rest"},
 		ReleaseLevel:          "beta",
 	},
 	{
@@ -1190,6 +1205,7 @@ var MicrogenGapicConfigs = []*MicrogenConfig{
 		ImportPath:            "cloud.google.com/go/metastore/apiv1alpha",
 		GRPCServiceConfigPath: "metastore_grpc_service_config.json",
 		ApiServiceConfigPath:  "metastore_v1alpha.yaml",
+		Transports:            []string{"grpc", "rest"},
 		ReleaseLevel:          "alpha",
 	},
 	{
@@ -1297,6 +1313,7 @@ var MicrogenGapicConfigs = []*MicrogenConfig{
 		ImportPath:            "cloud.google.com/go/aiplatform/apiv1beta1",
 		GRPCServiceConfigPath: "aiplatform_grpc_service_config.json",
 		ApiServiceConfigPath:  "aiplatform_v1beta1.yaml",
+		Transports:            []string{"grpc", "rest"},
 		ReleaseLevel:          "beta",
 	},
 	{
@@ -1305,6 +1322,7 @@ var MicrogenGapicConfigs = []*MicrogenConfig{
 		ImportPath:            "cloud.google.com/go/gkeconnect/gateway/apiv1beta1",
 		GRPCServiceConfigPath: "connectgw_grpc_service_config.json",
 		ApiServiceConfigPath:  "connectgateway_v1beta1.yaml",
+		Transports:            []string{"grpc", "rest"},
 		ReleaseLevel:          "beta",
 	},
 	{
@@ -1371,6 +1389,7 @@ var MicrogenGapicConfigs = []*MicrogenConfig{
 		ImportPath:            "cloud.google.com/go/networksecurity/apiv1beta1",
 		GRPCServiceConfigPath: "networksecurity_v1beta1_grpc_service_config.json",
 		ApiServiceConfigPath:  "networksecurity_v1beta1.yaml",
+		Transports:            []string{"grpc", "rest"},
 		ReleaseLevel:          "beta",
 	},
 	{
@@ -1560,6 +1579,7 @@ var MicrogenGapicConfigs = []*MicrogenConfig{
 		ImportPath:            "cloud.google.com/go/retail/apiv2alpha",
 		GRPCServiceConfigPath: "retail_grpc_service_config.json",
 		ApiServiceConfigPath:  "retail_v2alpha.yaml",
+		Transports:            []string{"grpc", "rest"},
 		ReleaseLevel:          "alpha",
 	},
 	{
@@ -1568,6 +1588,7 @@ var MicrogenGapicConfigs = []*MicrogenConfig{
 		ImportPath:            "cloud.google.com/go/retail/apiv2beta",
 		GRPCServiceConfigPath: "retail_grpc_service_config.json",
 		ApiServiceConfigPath:  "retail_v2beta.yaml",
+		Transports:            []string{"grpc", "rest"},
 		ReleaseLevel:          "beta",
 	},
 	{
@@ -1594,6 +1615,7 @@ var MicrogenGapicConfigs = []*MicrogenConfig{
 		ImportPath:            "cloud.google.com/go/videointelligence/apiv1p3beta1",
 		GRPCServiceConfigPath: "videointelligence_grpc_service_config.json",
 		ApiServiceConfigPath:  "videointelligence_v1p3beta1.yaml",
+		Transports:            []string{"grpc", "rest"},
 		ReleaseLevel:          "beta",
 	},
 	{
@@ -1701,6 +1723,7 @@ var MicrogenGapicConfigs = []*MicrogenConfig{
 		ImportPath:            "cloud.google.com/go/dialogflow/apiv2beta1",
 		GRPCServiceConfigPath: "dialogflow_grpc_service_config.json",
 		ApiServiceConfigPath:  "dialogflow_v2beta1.yaml",
+		Transports:            []string{"grpc", "rest"},
 		// GA after 2022/10/01
 		ReleaseLevel: "beta",
 	},
@@ -1719,6 +1742,7 @@ var MicrogenGapicConfigs = []*MicrogenConfig{
 		ImportPath:            "cloud.google.com/go/security/publicca/apiv1beta1",
 		GRPCServiceConfigPath: "publicca_v1beta1_grpc_service_config.json",
 		ApiServiceConfigPath:  "publicca_v1beta1.yaml",
+		Transports:            []string{"grpc", "rest"},
 		// GA after 2022/10/10
 		ReleaseLevel: "beta",
 	},


### PR DESCRIPTION
Enables REST client (REGAPIC) as a transport for remaining pre-GA clients (alpha and beta API packages).