### PR TITLE
fix(internal/gapicgen): add slashes to be more strict with matching

### DIFF
--- a/internal/gapicgen/generator/genproto.go
+++ b/internal/gapicgen/generator/genproto.go
@@ -77,8 +77,8 @@ func NewGenprotoGenerator(c *Config) *GenprotoGenerator {
 }
 
 var skipPrefixes = []string{
-	"google.golang.org/genproto/googleapis/ads",
-	"google.golang.org/genproto/googleapis/storage",
+	"google.golang.org/genproto/googleapis/ads/",
+	"google.golang.org/genproto/googleapis/storage/",
 }
 
 func hasPrefix(s string, prefixes []string) bool {


### PR DESCRIPTION
We had a false negative show up today where change for: "google.golang.org/genproto/googleapis/storagetransfer" were not generated when they should have been.