### PR TITLE
test(bigquery/storage/managedwriter): add a basic append benchmark

### DIFF
--- a/bigquery/storage/managedwriter/benchmark_test.go
+++ b/bigquery/storage/managedwriter/benchmark_test.go
@@ -1,0 +1,87 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package managedwriter
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/bigquery"
+	"cloud.google.com/go/bigquery/storage/managedwriter/adapt"
+	"cloud.google.com/go/bigquery/storage/managedwriter/testdata"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/descriptorpb"
+)
+
+var (
+	benchmarkTimeout = 2 * time.Minute
+	benchLocation    = "us-east1"
+)
+
+func benchmarkAppend(location string, schema bigquery.Schema, dp *descriptorpb.DescriptorProto, serializedRows [][]byte, b *testing.B) {
+	mwClient, bqClient := getTestClients(context.Background(), b)
+	defer mwClient.Close()
+	defer bqClient.Close()
+
+	dataset, cleanup, err := setupTestDataset(context.Background(), b, bqClient, location)
+	if err != nil {
+		b.Fatalf("failed to init test dataset: %v", err)
+	}
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), benchmarkTimeout)
+	defer cancel()
+
+	testTable := dataset.Table(tableIDs.New())
+	if err := testTable.Create(ctx, &bigquery.TableMetadata{Schema: schema}); err != nil {
+		b.Fatalf("failed to create test table %q: %v", testTable.FullyQualifiedName(), err)
+	}
+
+	// setup default stream.
+	ms, err := mwClient.NewManagedStream(ctx,
+		WithDestinationTable(TableParentFromParts(testTable.ProjectID, testTable.DatasetID, testTable.TableID)),
+		WithType(DefaultStream),
+		WithSchemaDescriptor(dp),
+	)
+	if err != nil {
+		b.Fatalf("NewManagedStream: %v", err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := ms.AppendRows(ctx, serializedRows)
+		if err != nil {
+			b.Errorf("append failed: %v", err)
+		}
+	}
+}
+
+func BenchmarkAppend_SingleSimpleData(b *testing.B) {
+
+	// prepare test append payload
+	by, err := proto.Marshal(testSimpleData[0])
+	if err != nil {
+		b.Fatalf("failed to marshall proto data: %v", err)
+	}
+	rowData := [][]byte{by}
+
+	// prepare schema
+	desc, err := adapt.NormalizeDescriptor(testSimpleData[0].ProtoReflect().Descriptor())
+	if err != nil {
+		b.Fatalf("NormalizeDescriptor: %v", err)
+	}
+	benchmarkAppend(benchLocation, testdata.SimpleMessageSchema, desc, rowData, b)
+}

--- a/bigquery/storage/managedwriter/integration_test.go
+++ b/bigquery/storage/managedwriter/integration_test.go
@@ -56,7 +56,7 @@ var testSimpleData = []*testdata.SimpleMessageProto2{
 	{Name: proto.String("five"), Value: proto.Int64(2)},
 }
 
-func getTestClients(ctx context.Context, t *testing.T, opts ...option.ClientOption) (*Client, *bigquery.Client) {
+func getTestClients(ctx context.Context, t testing.TB, opts ...option.ClientOption) (*Client, *bigquery.Client) {
 	if testing.Short() {
 		t.Skip("Integration tests skipped in short mode")
 	}
@@ -82,7 +82,7 @@ func getTestClients(ctx context.Context, t *testing.T, opts ...option.ClientOpti
 }
 
 // setupTestDataset generates a unique dataset for testing, and a cleanup that can be deferred.
-func setupTestDataset(ctx context.Context, t *testing.T, bqc *bigquery.Client, location string) (ds *bigquery.Dataset, cleanup func(), err error) {
+func setupTestDataset(ctx context.Context, t testing.TB, bqc *bigquery.Client, location string) (ds *bigquery.Dataset, cleanup func(), err error) {
 	dataset := bqc.Dataset(datasetIDs.New())
 	if err := dataset.Create(ctx, &bigquery.DatasetMetadata{Location: location}); err != nil {
 		return nil, nil, err


### PR DESCRIPTION
This PR adds a basic append benchmark so we can start looking for more performance-oriented issues.  It also provides an easy way to augment with other data/schema shapes.

Unsuprisingly, the benchmark is super volatile given it benchmarks live behavior with an integration test.


Invocation details:
```
$ go test -bench=. -run=^$ -benchmem -cpuprofile profile.out
goos: linux
goarch: amd64
pkg: cloud.google.com/go/bigquery/storage/managedwriter
cpu: Intel(R) Xeon(R) CPU @ 2.20GHz
BenchmarkAppend/Single_SimpleMessage-8              3572            299977 ns/op            1718 B/op         32 allocs/op
BenchmarkAppend/2MB_SimpleMessage-8                    6         177468544 ns/op         9080173 B/op      50481 allocs/op
PASS
ok      cloud.google.com/go/bigquery/storage/managedwriter      20.860s


$ go tool pprof profile.out
File: managedwriter.test
Type: cpu
Time: Sep 14, 2022 at 10:34pm (UTC)
Duration: 20.83s, Total samples = 1.91s ( 9.17%)
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) top 20
Showing nodes accounting for 1070ms, 56.02% of 1910ms total
Showing top 20 nodes out of 456
      flat  flat%   sum%        cum   cum%
     170ms  8.90%  8.90%      320ms 16.75%  runtime.scanobject
     100ms  5.24% 14.14%      100ms  5.24%  runtime.memclrNoHeapPointers
     100ms  5.24% 19.37%      100ms  5.24%  runtime/internal/syscall.Syscall6
      70ms  3.66% 23.04%       90ms  4.71%  runtime.findObject
      70ms  3.66% 26.70%       70ms  3.66%  runtime.futex
      70ms  3.66% 30.37%       70ms  3.66%  runtime.memmove
      60ms  3.14% 33.51%       60ms  3.14%  google.golang.org/protobuf/encoding/protowire.SizeVarint
      60ms  3.14% 36.65%       60ms  3.14%  runtime.heapBitsSetType
      50ms  2.62% 39.27%       50ms  2.62%  math/big.addMulVVW
      50ms  2.62% 41.88%      290ms 15.18%  runtime.mallocgc
      40ms  2.09% 43.98%      310ms 16.23%  google.golang.org/protobuf/internal/impl.mergeBytesSlice
      30ms  1.57% 45.55%       30ms  1.57%  runtime.getpid
      30ms  1.57% 47.12%       70ms  3.66%  runtime.greyobject
      30ms  1.57% 48.69%       30ms  1.57%  runtime.markBits.isMarked (inline)
      30ms  1.57% 50.26%       50ms  2.62%  runtime.runqgrab
      30ms  1.57% 51.83%       30ms  1.57%  runtime.tgkill
      20ms  1.05% 52.88%       80ms  4.19%  crypto/tls.(*Conn).writeRecordLocked
      20ms  1.05% 53.93%       20ms  1.05%  google.golang.org/protobuf/encoding/protowire.AppendVarint
      20ms  1.05% 54.97%       30ms  1.57%  google.golang.org/protobuf/internal/impl.(*MessageInfo).initOneofFieldCoders.func2
      20ms  1.05% 56.02%       50ms  2.62%  google.golang.org/protobuf/internal/impl.appendBytesSlice

```

