### PR TITLE
chore: exit fast if there is no emulator test

### DIFF
--- a/internal/kokoro/check_incompat_changes.sh
+++ b/internal/kokoro/check_incompat_changes.sh
@@ -17,7 +17,7 @@
 set -x
 
 # Only run apidiff checks on latest (we only need it once).
-if [[ `go version` != *"go1.19"* ]]; then
+if [[ $(go version) != *"go1.19"* ]]; then
     exit 0
 fi
 

--- a/internal/kokoro/continuous.sh
+++ b/internal/kokoro/continuous.sh
@@ -33,7 +33,7 @@ export GCLOUD_TESTS_GOLANG_PROJECT_ID=dulcet-port-762
 export GCLOUD_TESTS_GOLANG_KEY=$GOOGLE_APPLICATION_CREDENTIALS
 export GCLOUD_TESTS_GOLANG_FIRESTORE_PROJECT_ID=gcloud-golang-firestore-tests
 export GCLOUD_TESTS_GOLANG_FIRESTORE_KEY=$KOKORO_KEYSTORE_DIR/72523_go_firestore_integration_service_account
-export GCLOUD_TESTS_API_KEY=`cat $KOKORO_KEYSTORE_DIR/72523_go_gcloud_tests_api_key`
+export GCLOUD_TESTS_API_KEY=$(cat $KOKORO_KEYSTORE_DIR/72523_go_gcloud_tests_api_key)
 export GCLOUD_TESTS_GOLANG_KEYRING=projects/dulcet-port-762/locations/us/keyRings/go-integration-test
 export GCLOUD_TESTS_GOLANG_PROFILER_ZONE="us-west1-b"
 
@@ -89,8 +89,8 @@ runDirectoryTests() {
     tee sponge_log.log
   # Takes the kokoro output log (raw stdout) and creates a machine-parseable
   # xUnit XML file.
-  cat sponge_log.log \
-    | go-junit-report -set-exit-code > sponge_log.xml
+  cat sponge_log.log |
+    go-junit-report -set-exit-code >sponge_log.xml
   # Add the exit codes together so we exit non-zero if any module fails.
   exit_code=$(($exit_code + $?))
 }
@@ -104,8 +104,8 @@ runEmulatorTests() {
   fi
   # Takes the kokoro output log (raw stdout) and creates a machine-parseable
   # xUnit XML file.
-  cat sponge_log.log \
-    | go-junit-report -set-exit-code > sponge_log.xml
+  cat sponge_log.log |
+    go-junit-report -set-exit-code >sponge_log.xml
   # Add the exit codes together so we exit non-zero if any module fails.
   exit_code=$(($exit_code + $?))
 }
@@ -114,11 +114,11 @@ runEmulatorTests() {
 testAllModules() {
   echo "Testing all modules"
   for i in $(find . -name go.mod); do
-    pushd "$(dirname "$i")" > /dev/null;
-      runDirectoryTests
-      # Run integration tests against an emulator.
-      runEmulatorTests
-    popd > /dev/null;
+    pushd "$(dirname "$i")" >/dev/null
+    runDirectoryTests
+    # Run integration tests against an emulator.
+    runEmulatorTests
+    popd >/dev/null
   done
 }
 
@@ -128,9 +128,9 @@ testChangedModules() {
     goDirectories="$(find "$d" -name "*.go" -printf "%h\n" | sort -u)"
     if [[ -n "$goDirectories" ]]; then
       for gd in $goDirectories; do
-        pushd "$gd" > /dev/null;
-          runDirectoryTests .
-        popd > /dev/null;
+        pushd "$gd" >/dev/null
+        runDirectoryTests .
+        popd >/dev/null
       done
     fi
   done
@@ -156,15 +156,15 @@ if [[ $KOKORO_JOB_NAME == *"continuous"* ]]; then
 elif [[ $KOKORO_JOB_NAME == *"nightly"* ]]; then
   # Expected job name format: ".../nightly/[OPTIONAL_MODULE_NAME]/[OPTIONAL_JOB_NAMES...]"
   ARR=(${KOKORO_JOB_NAME//// }) # Splits job name by "/" where ARR[0] is expected to be "nightly".
-  SUBMODULE_NAME=${ARR[5]} # Gets the token after "nightly/".
+  SUBMODULE_NAME=${ARR[5]}      # Gets the token after "nightly/".
   if [[ -n $SUBMODULE_NAME ]] && [[ -d "./$SUBMODULE_NAME" ]]; then
     # Only run tests in the submodule designated in the Kokoro job name.
     # Expected format example: ...google-cloud-go/nightly/logging.
     runDirectoryTests . # Always run base tests
     echo "Running tests in one submodule: $SUBMODULE_NAME"
-    pushd $SUBMODULE_NAME > /dev/null;
-      runDirectoryTests
-    popd > /dev/null
+    pushd $SUBMODULE_NAME >/dev/null
+    runDirectoryTests
+    popd >/dev/null
   else
     # Run all tests if it is a regular nightly job.
     testAllModules

--- a/internal/kokoro/continuous.sh
+++ b/internal/kokoro/continuous.sh
@@ -99,6 +99,8 @@ runDirectoryTests() {
 runEmulatorTests() {
   if [ -f "emulator_test.sh" ]; then
     ./emulator_test.sh
+  else
+    return
   fi
   # Takes the kokoro output log (raw stdout) and creates a machine-parseable
   # xUnit XML file.

--- a/internal/kokoro/environment.sh
+++ b/internal/kokoro/environment.sh
@@ -25,8 +25,8 @@ if [[ -z "${ENVIRONMENT:-}" ]]; then
   exit 1
 fi
 
-if [[ -z "${PROJECT_ROOT:-}"  ]]; then
-    PROJECT_ROOT="github/google-cloud-go"
+if [[ -z "${PROJECT_ROOT:-}" ]]; then
+  PROJECT_ROOT="github/google-cloud-go"
 fi
 
 # add kokoro labels for testgrid filtering
@@ -44,7 +44,7 @@ echo "using python version: $ENV_TEST_PY_VERSION"
 # run tests from git tag golang-envtest-pin when available
 TAG_ID="golang-envtest-pin"
 git fetch --tags
-if [ $(git tag -l "$TAG_ID")  ]; then
+if [ $(git tag -l "$TAG_ID") ]; then
   git -c advice.detachedHead=false checkout $TAG_ID
 else
   echo "WARNING: tag $TAG_ID not found in repo"
@@ -70,7 +70,7 @@ gcloud config set compute/zone us-central1-b
 gcloud auth configure-docker -q
 
 # create a unique id for this run
-UUID=$(python3  -c 'import uuid; print(uuid.uuid1())' | head -c 7)
+UUID=$(python3 -c 'import uuid; print(uuid.uuid1())' | head -c 7)
 export ENVCTL_ID=ci-$UUID
 echo $ENVCTL_ID
 

--- a/internal/kokoro/trampoline.sh
+++ b/internal/kokoro/trampoline.sh
@@ -19,7 +19,7 @@ set -eo pipefail
 function cleanup() {
     chmod +x ${KOKORO_GFILE_DIR}/trampoline_cleanup.sh
     ${KOKORO_GFILE_DIR}/trampoline_cleanup.sh
-    echo "cleanup";
+    echo "cleanup"
 }
 trap cleanup EXIT
 python3 "${KOKORO_GFILE_DIR}/trampoline_v1.py"


### PR DESCRIPTION
This should fix some build errors in nightly.

Also, ran a formatter on kokoro *.sh files as they had bash warnings.