### PR TITLE
chore: update how we handle mod replacements

### DIFF
--- a/internal/gapicgen/generator/gapics.go
+++ b/internal/gapicgen/generator/gapics.go
@@ -245,6 +245,7 @@ func (g *GapicGenerator) addModReplaceGenproto(dir string) error {
 set -ex
 
 go mod edit -replace "google.golang.org/genproto=$GENPROTO_DIR"
+go mod tidy
 `)
 	c.Dir = dir
 	c.Env = []string{
@@ -262,7 +263,8 @@ func (g *GapicGenerator) dropModReplaceGenproto(dir string) error {
 	c := execv.Command("bash", "-c", `
 set -ex
 
-go mod edit -dropreplace "google.golang.org/genproto"
+git restore go.mod
+git restore go.sum 
 `)
 	c.Dir = dir
 	c.Env = []string{


### PR DESCRIPTION
- Add a tidy after replace. The genproto dependency is getting more complex as it now associates with many aliases. A tidy is now requried.
- Since we are tidying we can no longer just simply drop the replace as there would have been dependency updates because of the tidy. Instead we can achive the same effect by using git restore.