### PR TITLE
chore(internal/aliasgen): only remove files when cleaning dir

### DIFF
--- a/internal/aliasgen/aliasgen.go
+++ b/internal/aliasgen/aliasgen.go
@@ -60,6 +60,9 @@ func cleanDir(dir string) error {
 		return err
 	}
 	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
 		if err := os.RemoveAll(filepath.Join(dir, entry.Name())); err != nil {
 			return err
 		}


### PR DESCRIPTION
Some clients, like aiplatform, have a nested folder structure under the client directory. In these cases we only are generating aliases for a specific dir, so we should only remove the files associated to said dir, and not the recursive dir structure as a whole.