### PR TITLE
chore(internal/gapicgen): add alias mode to gapicgen

### DIFF
--- a/internal/gapicgen/cmd/genbot/Dockerfile
+++ b/internal/gapicgen/cmd/genbot/Dockerfile
@@ -36,9 +36,7 @@ RUN mkdir /root/.ssh && echo -e "Host github.com\n\tStrictHostKeyChecking no\n" 
 RUN echo -e '#!/bin/bash\n\
     set -ex\n\
     cd internal/gapicgen\n\
-    go run cloud.google.com/go/internal/gapicgen/cmd/genbot\n\
-    go run cloud.google.com/go/internal/gapicgen/cmd/genbot \
-    ' >> /run.sh
+    go run cloud.google.com/go/internal/gapicgen/cmd/genbot' >> /run.sh
 RUN chmod a+x /run.sh
 
 WORKDIR /google-cloud-go

--- a/internal/gapicgen/cmd/genbot/alias.go
+++ b/internal/gapicgen/cmd/genbot/alias.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"path/filepath"
+	"strings"
+
+	"cloud.google.com/go/internal/aliasfix"
+	"cloud.google.com/go/internal/aliasgen"
+	"cloud.google.com/go/internal/gapicgen/execv/gocmd"
+	"cloud.google.com/go/internal/gapicgen/git"
+)
+
+type aliasConfig struct {
+	gocloudDir  string
+	genprotoDir string
+}
+
+func generateAliases(ctx context.Context, c aliasConfig) error {
+	log.Println("creating temp dir")
+	tmpDir, err := ioutil.TempDir("", "update-genproto")
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Printf("temp dir created at %s\n", tmpDir)
+	// Clone repositories if needed.
+	git.DeepClone("https://github.com/googleapis/go-genproto", filepath.Join(tmpDir, "genproto"))
+	git.DeepClone("https://github.com/googleapis/google-cloud-go", filepath.Join(tmpDir, "gocloud"))
+
+	genprotoDir := deafultDir(filepath.Join(tmpDir, "genproto"), c.genprotoDir)
+	gocloudDir := deafultDir(filepath.Join(tmpDir, "gocloud"), c.gocloudDir)
+	for k, v := range aliasfix.GenprotoPkgMigration {
+		if v.Status != aliasfix.StatusMigrated {
+			continue
+		}
+		log.Printf("Generating aliases for: %s", k)
+		gapicSrcDir := filepath.Join(gocloudDir, strings.TrimPrefix(v.ImportPath, "cloud.google.com/go/"))
+		genprotoStubsDir := filepath.Join(genprotoDir, strings.TrimPrefix(k, "google.golang.org/genproto/"))
+
+		// Find out what is the latest version of cloud client library
+		module, version, err := gocmd.ListModVersion(gapicSrcDir)
+		if err != nil {
+			return err
+		}
+
+		// checkout said version
+		if err := checkoutRef(gocloudDir, module, version); err != nil {
+			return err
+		}
+		// Try to upgrade dependency to said version
+		if err := gocmd.Get(genprotoDir, module, version); err != nil {
+			return err
+		}
+
+		if err := aliasgen.Run(gapicSrcDir, genprotoStubsDir); err != nil {
+			return err
+		}
+
+		// checkout HEAD of cloud client library
+		if err := checkoutRef(gocloudDir, "", ""); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// checkoutRef checks out the ref that is constructed by using the module
+// name and version. If the version provided is empty the main branch will be
+// checked out.
+func checkoutRef(dir string, modName string, version string) error {
+	var ref string
+	if version == "" {
+		ref = "main"
+	} else {
+		// Transform cloud.google.com/storage/v2 into storage for example
+		vPrefix := strings.Split(strings.TrimPrefix(modName, "cloud.google.com/go/"), "/")[0]
+		ref = fmt.Sprintf("%s/%s", vPrefix, version)
+
+	}
+	return git.CheckoutRef(dir, ref)
+}

--- a/internal/gapicgen/cmd/genbot/main.go
+++ b/internal/gapicgen/cmd/genbot/main.go
@@ -44,6 +44,8 @@ func main() {
 	localMode := flag.Bool("local", strToBool(os.Getenv("GENBOT_LOCAL_MODE")), "Enables generating sources locally. This mode will not open any pull requests.")
 	forceAll := flag.Bool("forceAll", strToBool(os.Getenv("GENBOT_FORCE_ALL")), "Enables regenerating everything regardless of changes in googleapis.")
 
+	aliasMode := flag.Bool("alias-mode", strToBool(os.Getenv("GENBOT_ALIAS_MODE")), "Enables updating aliases.")
+
 	// flags for local mode
 	googleapisDir := flag.String("googleapis-dir", os.Getenv("GOOGLEAPIS_DIR"), "Directory where sources of googleapis/googleapis resides. If unset the sources will be cloned to a temporary directory that is not cleaned up.")
 	gocloudDir := flag.String("gocloud-dir", os.Getenv("GOCLOUD_DIR"), "Directory where sources of googleapis/google-cloud-go resides. If unset the sources will be cloned to a temporary directory that is not cleaned up.")
@@ -73,6 +75,13 @@ func main() {
 			log.Fatal(err)
 		}
 		return
+	} else if *aliasMode {
+		if err := generateAliases(ctx, aliasConfig{
+			gocloudDir:  *gocloudDir,
+			genprotoDir: *genprotoDir,
+		}); err != nil {
+			log.Fatal(err)
+		}
 	}
 	if err := genBot(ctx, botConfig{
 		githubAccessToken: *githubAccessToken,

--- a/internal/gapicgen/execv/gocmd/gocmd.go
+++ b/internal/gapicgen/execv/gocmd/gocmd.go
@@ -75,6 +75,22 @@ func ModTidyAll(dir string) error {
 	return nil
 }
 
+// ListModVersion returns the module name and latest version given a module
+// directory.
+func ListModVersion(dir string) (string, string, error) {
+	modC := execv.Command("go", "list", "-m", "-versions")
+	modC.Dir = dir
+	output, err := modC.Output()
+	if err != nil {
+		return "", "", err
+	}
+	ss := strings.Split(string(output), " ")
+	if len(ss) < 2 {
+		return "", "", fmt.Errorf("expected at slice with at least len 2")
+	}
+	return strings.TrimSpace(ss[0]), strings.TrimSpace(ss[len(ss)-1]), nil
+}
+
 // ListModName finds a modules name for a given directory.
 func ListModName(dir string) (string, error) {
 	modC := execv.Command("go", "list", "-m")
@@ -140,4 +156,11 @@ func CurrentMod(dir string) (string, error) {
 		return "", err
 	}
 	return strings.TrimSpace(string(out)), nil
+}
+
+// Get upgrades the specified module dependency to the version provided.
+func Get(dir, module, version string) error {
+	c := execv.Command("go", "get", fmt.Sprintf("%s@%s", module, version))
+	c.Dir = dir
+	return c.Run()
 }

--- a/internal/gapicgen/git/git.go
+++ b/internal/gapicgen/git/git.go
@@ -244,6 +244,13 @@ func FileDiff(dir, filename string) (string, error) {
 	return strings.TrimSpace(string(out)), nil
 }
 
+// CheckoutRef checks out the ref in the provided git project directory.
+func CheckoutRef(dir, ref string) error {
+	cmd := execv.Command("git", "checkout", ref)
+	cmd.Dir = dir
+	return cmd.Run()
+}
+
 // filesChanged returns a list of files changed in a commit for the provdied
 // hash in the given gitDir.
 func filesChanged(gitDir, hash string) ([]string, error) {


### PR DESCRIPTION
This mode will be run as a cron to keep alias files found in go-genproto up-to-date with the most current release of the google-cloud-go service libray. We need to make sure to refresh aliases only on released versions of google-cloud-go clients. Genproto will naturally lag behind google-cloud-go a little be, but this is fine and the lag may act as an insentive to migrate to the new stubs dir.