### PR TITLE
fix(storage): fix read-write race in Writer.Write

### DIFF
--- a/storage/writer.go
+++ b/storage/writer.go
@@ -190,6 +190,9 @@ func (w *Writer) openWriter() (err error) {
 		progress:           w.progress,
 		setObj:             func(o *ObjectAttrs) { w.obj = o },
 	}
+	if err := w.ctx.Err(); err != nil {
+		return err // short-circuit
+	}
 	w.pw, err = w.o.c.tc.OpenWriter(params, opts...)
 	if err != nil {
 		return err

--- a/storage/writer.go
+++ b/storage/writer.go
@@ -176,7 +176,6 @@ func (w *Writer) openWriter() (err error) {
 
 	isIdempotent := w.o.conds != nil && (w.o.conds.GenerationMatch >= 0 || w.o.conds.DoesNotExist == true)
 	opts := makeStorageOpts(isIdempotent, w.o.retry, w.o.userProject)
-	go w.monitorCancel()
 	params := &openWriterParams{
 		ctx:                w.ctx,
 		chunkSize:          w.ChunkSize,
@@ -196,6 +195,7 @@ func (w *Writer) openWriter() (err error) {
 		return err
 	}
 	w.opened = true
+	go w.monitorCancel()
 
 	return nil
 }


### PR DESCRIPTION
https://github.com/googleapis/google-cloud-go/issues/6816

`w.monitorCancel()` -> `w.CloseWithError()` reads the values of `w.opened` and `w.pw` concurrently with the calling routine initializing them; if the incoming context is cancelled before or during initialization.

The fix is simply to deploy starting the monitor until all fields are initialized.  The older `open()` code from previous releases did this in the right order:

https://github.com/googleapis/google-cloud-go/blob/storage/v1.24.0/storage/writer.go#L130-L134