### PR TITLE
chore: release certificatemanager 1.1.0

### DIFF
--- a/.release-please-manifest-submodules.json
+++ b/.release-please-manifest-submodules.json
@@ -18,7 +18,7 @@
   "beyondcorp": "0.1.1",
   "billing": "1.5.0",
   "binaryauthorization": "1.2.0",
-  "certificatemanager": "1.0.0",
+  "certificatemanager": "1.1.0",
   "channel": "1.7.0",
   "cloudbuild": "1.2.0",
   "clouddms": "1.2.0",

--- a/certificatemanager/CHANGES.md
+++ b/certificatemanager/CHANGES.md
@@ -1,5 +1,12 @@
 # Changes
 
+## [1.1.0](https://github.com/googleapis/google-cloud-go/compare/certificatemanager/v1.0.0...certificatemanager/v1.1.0) (2022-10-10)
+
+
+### Features
+
+* **certificatemanager:** added support for Private Trust to Certificate Manager API ([92b2f99](https://github.com/googleapis/google-cloud-go/commit/92b2f991244687c662e9e07801e1fae9bcea9a8b))
+
 ## [1.0.0](https://github.com/googleapis/google-cloud-go/compare/certificatemanager/v0.2.1...certificatemanager/v1.0.0) (2022-09-19)
 
 

--- a/certificatemanager/internal/version.go
+++ b/certificatemanager/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "1.0.0"
+const Version = "1.1.0"


### PR DESCRIPTION

<details><summary>certificatemanager: 1.1.0</summary>

## [1.1.0](https://github.com/googleapis/google-cloud-go/compare/certificatemanager/v1.0.0...certificatemanager/v1.1.0) (2022-10-10)


### Features

* **certificatemanager:** added support for Private Trust to Certificate Manager API ([92b2f99](https://github.com/googleapis/google-cloud-go/commit/92b2f991244687c662e9e07801e1fae9bcea9a8b))
</details>


