### PR TITLE
fix(storage): fix request token passing for Copier.Run

### DIFF
--- a/storage/copy.go
+++ b/storage/copy.go
@@ -126,6 +126,7 @@ func (c *Copier) Run(ctx context.Context) (attrs *ObjectAttrs, err error) {
 		if err != nil {
 			return nil, err
 		}
+		c.RewriteToken = res.token
 		req.token = res.token
 		if c.ProgressFunc != nil {
 			c.ProgressFunc(uint64(res.written), uint64(res.size))

--- a/storage/copy.go
+++ b/storage/copy.go
@@ -126,7 +126,7 @@ func (c *Copier) Run(ctx context.Context) (attrs *ObjectAttrs, err error) {
 		if err != nil {
 			return nil, err
 		}
-		c.RewriteToken = res.token
+		req.token = res.token
 		if c.ProgressFunc != nil {
 			c.ProgressFunc(uint64(res.written), uint64(res.size))
 		}


### PR DESCRIPTION
This fixes infinite retry issues.

Will follow up with tests to catch this behaviour.

Fixes #6857