### PR TITLE
chore(ci): ignore go.mod and go.sum changes in service dirs

### DIFF
--- a/.github/workflows/apidiff.yml
+++ b/.github/workflows/apidiff.yml
@@ -18,7 +18,7 @@ jobs:
       id: changed_dirs
       # Ignore changes to the internal and root directories.
       run: |
-        dirs=$(git diff-tree --no-commit-id --name-only --diff-filter=DMR -r ${{ steps.main.outputs.hash }}..HEAD | xargs -r -L1 dirname | uniq | grep -v -e 'internal' -e '\.' | cat)
+        dirs=$(git diff-tree --no-commit-id --name-only --diff-filter=DMR -r ${{ steps.main.outputs.hash }}..HEAD | grep -v -e 'go\.[mod|sum]' | xargs -r -L1 dirname | uniq | grep -v -e 'internal' -e '\.' | cat)
         if [ -z "$dirs" ]
         then
           echo "skip=1" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Discovered in #6918 that changes in "service root" directories, like updating `go.mod` and `go.sum`, where there are no Go files might cause false positives in apidiff. Those changes shouldn't produce an apidiff run.