### PR TITLE
chore: carve out compute/metadata module

### DIFF
--- a/.release-please-manifest-submodules.json
+++ b/.release-please-manifest-submodules.json
@@ -23,7 +23,7 @@
   "cloudbuild": "1.3.0",
   "clouddms": "1.3.0",
   "cloudtasks": "1.7.0",
-  "compute": "1.11.0",
+  "compute": "1.12.0",
   "contactcenterinsights": "1.3.0",
   "container": "1.6.0",
   "containeranalysis": "0.6.0",

--- a/compute/CHANGES.md
+++ b/compute/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes
 
+## [1.12.0](https://github.com/googleapis/google-cloud-go/compare/compute/v1.11.0...compute/v1.12.0) (2022-10-26)
+
+Compute metadata has been moved to its own module.
+
 ## [1.11.0](https://github.com/googleapis/google-cloud-go/compare/compute/v1.10.0...compute/v1.11.0) (2022-10-25)
 
 

--- a/compute/go.mod
+++ b/compute/go.mod
@@ -12,6 +12,7 @@ require (
 )
 
 require (
+	cloud.google.com/go/compute/metadata v0.1.0 // indirect
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/go-cmp v0.5.9 // indirect

--- a/compute/metadata/CHANGES.md
+++ b/compute/metadata/CHANGES.md
@@ -1,0 +1,5 @@
+# Changes
+
+## [0.1.0] (2022-10-26)
+
+Initial release of metadata being it's own module.

--- a/compute/metadata/README.md
+++ b/compute/metadata/README.md
@@ -1,0 +1,27 @@
+# Compute API
+
+[![Go Reference](https://pkg.go.dev/badge/cloud.google.com/go/compute.svg)](https://pkg.go.dev/cloud.google.com/go/compute/metadata)
+
+This is a utility library for communicating with Google Cloud metadata service
+on Google Cloud.
+
+## Install
+
+```bash
+go get cloud.google.com/go/compute/metadata
+```
+
+## Go Version Support
+
+See the [Go Versions Supported](https://github.com/googleapis/google-cloud-go#go-versions-supported)
+section in the root directory's README.
+
+## Contributing
+
+Contributions are welcome. Please, see the [CONTRIBUTING](https://github.com/GoogleCloudPlatform/google-cloud-go/blob/main/CONTRIBUTING.md)
+document for details.
+
+Please note that this project is released with a Contributor Code of Conduct.
+By participating in this project you agree to abide by its terms. See
+[Contributor Code of Conduct](https://github.com/GoogleCloudPlatform/google-cloud-go/blob/main/CONTRIBUTING.md#contributor-code-of-conduct)
+for more information.

--- a/compute/metadata/go.mod
+++ b/compute/metadata/go.mod
@@ -1,0 +1,5 @@
+module cloud.google.com/go/compute/metadata
+
+go 1.19
+
+require cloud.google.com/go/compute v1.12.0

--- a/compute/metadata/internal/version.go
+++ b/compute/metadata/internal/version.go
@@ -1,0 +1,18 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+// Version is the current tagged release of the library.
+const Version = "0.1.0"

--- a/compute/metadata/tidyhack.go
+++ b/compute/metadata/tidyhack.go
@@ -1,0 +1,23 @@
+// Copyright {{.Year}} Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file, and the {{.RootMod}} import, won't actually become part of
+// the resultant binary.
+//go:build modhack
+// +build modhack
+
+package metadata
+
+// Necessary for safely adding multi-module repo. See: https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository
+import _ "cloud.google.com/go/compute/internal"


### PR DESCRIPTION
This commit will be manually tagged
- compute/v1.12.0
- compute/metadata/v0.1.0

Updates: #6311