### PR TITLE
feat(spanner): add support for handling null value in Proto columns

### DIFF
--- a/spanner/integration_test.go
+++ b/spanner/integration_test.go
@@ -2048,14 +2048,12 @@ func TestIntegration_BasicTypes_ProtoColumns(t *testing.T) {
 		{col: "ProtoMessage", val: &singerProtoMessage, want: NullProto{&singerProtoMessage, true}},
 		{col: "ProtoMessage", val: NullProto{&singerProtoMessage, true}, want: singerProtoMessage},
 		{col: "ProtoMessage", val: NullProto{&singerProtoMessage, true}, want: NullProto{&singerProtoMessage, true}},
-		{col: "ProtoMessage", val: NullProto{&singerProtoMessage, false}, want: NullProto{}},
 		{col: "ProtoMessage", val: nil, want: NullProto{}},
 		// Proto Enum
 		{col: "ProtoEnum", val: pb.Genre_ROCK, want: singerProtoEnum},
 		{col: "ProtoEnum", val: pb.Genre_ROCK, want: NullEnum{&singerProtoEnum, true}},
 		{col: "ProtoEnum", val: NullEnum{pb.Genre_ROCK, true}, want: singerProtoEnum},
 		{col: "ProtoEnum", val: NullEnum{pb.Genre_ROCK, true}, want: NullEnum{&singerProtoEnum, true}},
-		{col: "ProtoEnum", val: NullEnum{pb.Genre_ROCK, false}, want: NullEnum{}},
 		{col: "ProtoEnum", val: nil, want: NullEnum{}},
 		// Test Compatibility between Int64 and ProtoEnum
 		{col: "Int64a", val: pb.Genre_ROCK, want: int64(3)},
@@ -2080,23 +2078,19 @@ func TestIntegration_BasicTypes_ProtoColumns(t *testing.T) {
 		{col: "Int64a", val: NullEnum{pb.Genre_ROCK, true}, want: NullEnum{&singerProtoEnum, true}},
 		{col: "Int64a", val: NullInt64{3, true}, want: NullEnum{&singerProtoEnum, true}},
 		{col: "Int64a", val: NullInt64{3, false}, want: NullEnum{}},
-		{col: "Int64a", val: NullEnum{}, want: NullInt64{}},
 		{col: "ProtoEnum", val: NullInt64{3, true}, want: singerProtoEnum},
 		{col: "ProtoEnum", val: NullInt64{3, true}, want: NullEnum{&singerProtoEnum, true}},
 		{col: "ProtoEnum", val: NullInt64{3, true}, want: NullInt64{3, true}},
 		{col: "ProtoEnum", val: NullEnum{pb.Genre_ROCK, true}, want: NullInt64{3, true}},
-		{col: "ProtoEnum", val: NullEnum{pb.Genre_ROCK, false}, want: NullInt64{}},
 		// Test Compatibility between Bytes and NullProto
 		{col: "Bytes", val: NullProto{&singerProtoMessage, true}, want: bytesSingerProtoMessage},
 		{col: "Bytes", val: NullProto{&singerProtoMessage, true}, want: NullProto{&singerProtoMessage, true}},
 		{col: "Bytes", val: bytesSingerProtoMessage, want: NullProto{&singerProtoMessage, true}},
 		{col: "Bytes", val: bytesSingerProtoMessage},
-		{col: "Bytes", val: NullProto{}, want: []byte(nil)},
 		{col: "ProtoMessage", val: bytesSingerProtoMessage, want: NullProto{&singerProtoMessage, true}},
 		{col: "ProtoMessage", val: []byte(nil), want: NullProto{}},
 		{col: "ProtoMessage", val: NullProto{&singerProtoMessage, true}, want: bytesSingerProtoMessage},
 		{col: "ProtoMessage", val: NullProto{&singerProtoMessage, true}, want: NullProto{&singerProtoMessage, true}},
-		{col: "ProtoMessage", val: NullProto{&singerProtoMessage, false}, want: []byte(nil)},
 	}
 
 	// Write rows into table first using DML.

--- a/spanner/integration_test.go
+++ b/spanner/integration_test.go
@@ -2045,16 +2045,16 @@ func TestIntegration_BasicTypes_ProtoColumns(t *testing.T) {
 	}{
 		// Proto Message
 		{col: "ProtoMessage", val: &singerProtoMessage, want: singerProtoMessage},
-		{col: "ProtoMessage", val: &singerProtoMessage, want: NullProto{&singerProtoMessage, true}},
-		{col: "ProtoMessage", val: NullProto{&singerProtoMessage, true}, want: singerProtoMessage},
-		{col: "ProtoMessage", val: NullProto{&singerProtoMessage, true}, want: NullProto{&singerProtoMessage, true}},
-		{col: "ProtoMessage", val: nil, want: NullProto{}},
+		{col: "ProtoMessage", val: &singerProtoMessage, want: NullProtoMessage{&singerProtoMessage, true}},
+		{col: "ProtoMessage", val: NullProtoMessage{&singerProtoMessage, true}, want: singerProtoMessage},
+		{col: "ProtoMessage", val: NullProtoMessage{&singerProtoMessage, true}, want: NullProtoMessage{&singerProtoMessage, true}},
+		{col: "ProtoMessage", val: nil, want: NullProtoMessage{}},
 		// Proto Enum
 		{col: "ProtoEnum", val: pb.Genre_ROCK, want: singerProtoEnum},
-		{col: "ProtoEnum", val: pb.Genre_ROCK, want: NullEnum{&singerProtoEnum, true}},
-		{col: "ProtoEnum", val: NullEnum{pb.Genre_ROCK, true}, want: singerProtoEnum},
-		{col: "ProtoEnum", val: NullEnum{pb.Genre_ROCK, true}, want: NullEnum{&singerProtoEnum, true}},
-		{col: "ProtoEnum", val: nil, want: NullEnum{}},
+		{col: "ProtoEnum", val: pb.Genre_ROCK, want: NullProtoEnum{&singerProtoEnum, true}},
+		{col: "ProtoEnum", val: NullProtoEnum{pb.Genre_ROCK, true}, want: singerProtoEnum},
+		{col: "ProtoEnum", val: NullProtoEnum{pb.Genre_ROCK, true}, want: NullProtoEnum{&singerProtoEnum, true}},
+		{col: "ProtoEnum", val: nil, want: NullProtoEnum{}},
 		// Test Compatibility between Int64 and ProtoEnum
 		{col: "Int64a", val: pb.Genre_ROCK, want: int64(3)},
 		{col: "Int64a", val: pb.Genre_ROCK, want: singerProtoEnum},
@@ -2073,24 +2073,24 @@ func TestIntegration_BasicTypes_ProtoColumns(t *testing.T) {
 		{col: "ProtoMessage", val: bytesSingerProtoMessage, want: bytesSingerProtoMessage},
 		{col: "ProtoMessage", val: &singerProtoMessage, want: bytesSingerProtoMessage},
 		{col: "ProtoMessage", val: &singerProtoMessage, want: singerProtoMessage},
-		// Test Compatibility between NullInt64 and NullEnum
-		{col: "Int64a", val: NullEnum{pb.Genre_ROCK, true}, want: NullInt64{3, true}},
-		{col: "Int64a", val: NullEnum{pb.Genre_ROCK, true}, want: NullEnum{&singerProtoEnum, true}},
-		{col: "Int64a", val: NullInt64{3, true}, want: NullEnum{&singerProtoEnum, true}},
-		{col: "Int64a", val: NullInt64{3, false}, want: NullEnum{}},
+		// Test Compatibility between NullInt64 and NullProtoEnum
+		{col: "Int64a", val: NullProtoEnum{pb.Genre_ROCK, true}, want: NullInt64{3, true}},
+		{col: "Int64a", val: NullProtoEnum{pb.Genre_ROCK, true}, want: NullProtoEnum{&singerProtoEnum, true}},
+		{col: "Int64a", val: NullInt64{3, true}, want: NullProtoEnum{&singerProtoEnum, true}},
+		{col: "Int64a", val: NullInt64{3, false}, want: NullProtoEnum{}},
 		{col: "ProtoEnum", val: NullInt64{3, true}, want: singerProtoEnum},
-		{col: "ProtoEnum", val: NullInt64{3, true}, want: NullEnum{&singerProtoEnum, true}},
+		{col: "ProtoEnum", val: NullInt64{3, true}, want: NullProtoEnum{&singerProtoEnum, true}},
 		{col: "ProtoEnum", val: NullInt64{3, true}, want: NullInt64{3, true}},
-		{col: "ProtoEnum", val: NullEnum{pb.Genre_ROCK, true}, want: NullInt64{3, true}},
-		// Test Compatibility between Bytes and NullProto
-		{col: "Bytes", val: NullProto{&singerProtoMessage, true}, want: bytesSingerProtoMessage},
-		{col: "Bytes", val: NullProto{&singerProtoMessage, true}, want: NullProto{&singerProtoMessage, true}},
-		{col: "Bytes", val: bytesSingerProtoMessage, want: NullProto{&singerProtoMessage, true}},
+		{col: "ProtoEnum", val: NullProtoEnum{pb.Genre_ROCK, true}, want: NullInt64{3, true}},
+		// Test Compatibility between Bytes and NullProtoMessage
+		{col: "Bytes", val: NullProtoMessage{&singerProtoMessage, true}, want: bytesSingerProtoMessage},
+		{col: "Bytes", val: NullProtoMessage{&singerProtoMessage, true}, want: NullProtoMessage{&singerProtoMessage, true}},
+		{col: "Bytes", val: bytesSingerProtoMessage, want: NullProtoMessage{&singerProtoMessage, true}},
 		{col: "Bytes", val: bytesSingerProtoMessage},
-		{col: "ProtoMessage", val: bytesSingerProtoMessage, want: NullProto{&singerProtoMessage, true}},
-		{col: "ProtoMessage", val: []byte(nil), want: NullProto{}},
-		{col: "ProtoMessage", val: NullProto{&singerProtoMessage, true}, want: bytesSingerProtoMessage},
-		{col: "ProtoMessage", val: NullProto{&singerProtoMessage, true}, want: NullProto{&singerProtoMessage, true}},
+		{col: "ProtoMessage", val: bytesSingerProtoMessage, want: NullProtoMessage{&singerProtoMessage, true}},
+		{col: "ProtoMessage", val: []byte(nil), want: NullProtoMessage{}},
+		{col: "ProtoMessage", val: NullProtoMessage{&singerProtoMessage, true}, want: bytesSingerProtoMessage},
+		{col: "ProtoMessage", val: NullProtoMessage{&singerProtoMessage, true}, want: NullProtoMessage{&singerProtoMessage, true}},
 	}
 
 	// Write rows into table first using DML.
@@ -2134,11 +2134,11 @@ func TestIntegration_BasicTypes_ProtoColumns(t *testing.T) {
 		v := gotp.Interface()
 
 		switch nullValue := v.(type) {
-		case *NullProto:
-			nullValue.ProtoVal = &pb.SingerInfo{}
-		case *NullEnum:
+		case *NullProtoMessage:
+			nullValue.ProtoMessageVal = &pb.SingerInfo{}
+		case *NullProtoEnum:
 			var singerProtoEnumDefault pb.Genre
-			nullValue.EnumVal = &singerProtoEnumDefault
+			nullValue.ProtoEnumVal = &singerProtoEnumDefault
 		default:
 		}
 

--- a/spanner/value.go
+++ b/spanner/value.go
@@ -878,6 +878,7 @@ func (n *PGNumeric) UnmarshalJSON(payload []byte) error {
 }
 
 // NullProtoMessage represents a Cloud Spanner PROTO that may be NULL.
+// To write a NULL value using NullProtoMessage set ProtoMessageVal to typed nil and set Valid to true.
 type NullProtoMessage struct {
 	ProtoMessageVal proto.Message // ProtoMessageVal contains the value when Valid is true, and nil when NULL.
 	Valid           bool          // Valid is true if ProtoMessageVal is not NULL.
@@ -916,13 +917,14 @@ func (n *NullProtoMessage) UnmarshalJSON(payload []byte) error {
 	}
 	err := json.Unmarshal(payload, n.ProtoMessageVal)
 	if err != nil {
-		return fmt.Errorf("payload cannot be converted to a proto message: got %v, err: %s", string(payload), err)
+		return fmt.Errorf("payload cannot be converted to a proto message: err: %s", err)
 	}
 	n.Valid = true
 	return nil
 }
 
 // NullProtoEnum represents a Cloud Spanner ENUM that may be NULL.
+// To write a NULL value using NullProtoEnum set ProtoEnumVal to typed nil and set Valid to true.
 type NullProtoEnum struct {
 	ProtoEnumVal protoreflect.Enum // ProtoEnumVal contains the value when Valid is true, and nil when NULL.
 	Valid        bool              // Valid is true if ProtoEnumVal is not NULL.

--- a/spanner/value.go
+++ b/spanner/value.go
@@ -910,6 +910,7 @@ func (n *NullProto) UnmarshalJSON(payload []byte) error {
 		return fmt.Errorf("payload should not be nil")
 	}
 	if bytes.Equal(payload, jsonNullBytes) {
+		n.ProtoVal = nil
 		n.Valid = false
 		return nil
 	}
@@ -954,6 +955,7 @@ func (n *NullEnum) UnmarshalJSON(payload []byte) error {
 		return fmt.Errorf("payload should not be nil")
 	}
 	if bytes.Equal(payload, jsonNullBytes) {
+		n.EnumVal = nil
 		n.Valid = false
 		return nil
 	}

--- a/spanner/value.go
+++ b/spanner/value.go
@@ -2694,6 +2694,7 @@ func getIntegerFromStringValue(v *proto3.Value) (int64, error) {
 	return y, nil
 }
 
+// getBytesFromStringValue returns the bytes value of the string value encoded in proto3.Value v
 func getBytesFromStringValue(v *proto3.Value) ([]byte, error) {
 	x, err := getStringValue(v)
 	if err != nil {

--- a/spanner/value_test.go
+++ b/spanner/value_test.go
@@ -478,10 +478,10 @@ func TestEncodeValue(t *testing.T) {
 		{singer1ProtoEnum, protoEnumProto(singer1ProtoEnum), tProtoEnum, "Proto Enum"},
 		{(*pb.SingerInfo)(nil), nullProto(), tProtoMessage, "Proto Message with nil"},
 		{(*pb.Genre)(nil), nullProto(), tProtoEnum, "Proto Enum with nil"},
-		{NullProto{singer1ProtoMsg, true}, protoMessageProto(singer1ProtoMsg), tProtoMessage, "NullProto with value"},
-		{NullEnum{singer1ProtoEnum, true}, protoEnumProto(singer1ProtoEnum), tProtoEnum, "NullEnum with value"},
-		{NullProto{(*pb.SingerInfo)(nil), true}, nullProto(), tProtoMessage, "NullProto with value nil"},
-		{NullEnum{(*pb.Genre)(nil), true}, nullProto(), tProtoEnum, "NullEnum with value nil"},
+		{NullProtoMessage{singer1ProtoMsg, true}, protoMessageProto(singer1ProtoMsg), tProtoMessage, "NullProto with value"},
+		{NullProtoEnum{singer1ProtoEnum, true}, protoEnumProto(singer1ProtoEnum), tProtoEnum, "NullEnum with value"},
+		{NullProtoMessage{(*pb.SingerInfo)(nil), true}, nullProto(), tProtoMessage, "NullProto with value nil"},
+		{NullProtoEnum{(*pb.Genre)(nil), true}, nullProto(), tProtoEnum, "NullEnum with value nil"},
 	} {
 		got, gotType, err := encodeValue(test.in)
 		if err != nil {
@@ -525,8 +525,8 @@ func TestEncodeInvalidValues(t *testing.T) {
 		{desc: "custom numeric type with invalid scale component", in: CustomNumeric(*invalidNumPtr1), errMsg: "max scale for a numeric is 9. The requested numeric has more"},
 		{desc: "custom numeric type with invalid whole component", in: CustomNumeric(*invalidNumPtr2), errMsg: "max precision for the whole component of a numeric is 29. The requested numeric has a whole component with precision 30"},
 		// PROTO MESSAGE AND PROTO ENUM
-		{desc: "Invalid Null Proto", in: NullProto{}, errMsg: "spanner: code = \"InvalidArgument\", desc = \"cannot have valid field as false in spanner.NullProto\""},
-		{desc: "Invalid Null Enum", in: NullEnum{}, errMsg: "spanner: code = \"InvalidArgument\", desc = \"cannot have valid field as false in spanner.NullEnum\""},
+		{desc: "Invalid Null Proto", in: NullProtoMessage{}, errMsg: "spanner: code = \"InvalidArgument\", desc = \"cannot have valid field as false in spanner.NullProto\""},
+		{desc: "Invalid Null Enum", in: NullProtoEnum{}, errMsg: "spanner: code = \"InvalidArgument\", desc = \"cannot have valid field as false in spanner.NullEnum\""},
 	} {
 		_, _, err := encodeValue(test.in)
 		if err == nil {
@@ -1826,10 +1826,10 @@ func TestDecodeValue(t *testing.T) {
 		// PROTO MESSAGE AND PROTO ENUM
 		{desc: "decode PROTO to proto.Message", proto: protoMessageProto(&singerProtoMsg), protoType: protoMessageType(protoMessagefqn), want: singerProtoMsg},
 		{desc: "decode ENUM to protoreflect.Enum", proto: protoEnumProto(pb.Genre_ROCK), protoType: protoEnumType(protoEnumfqn), want: singerEnumValue},
-		{desc: "decode PROTO to NullProto", proto: protoMessageProto(&singerProtoMsg), protoType: protoMessageType(protoMessagefqn), want: NullProto{&singerProtoMsg, true}},
-		{desc: "decode NULL to NullProto", proto: nullProto(), protoType: protoMessageType(protoMessagefqn), want: NullProto{}},
-		{desc: "decode ENUM to NullEnum", proto: protoEnumProto(pb.Genre_ROCK), protoType: protoEnumType(protoEnumfqn), want: NullEnum{&singerEnumValue, true}},
-		{desc: "decode NULL to NullEnum", proto: nullProto(), protoType: protoEnumType(protoEnumfqn), want: NullEnum{}},
+		{desc: "decode PROTO to NullProto", proto: protoMessageProto(&singerProtoMsg), protoType: protoMessageType(protoMessagefqn), want: NullProtoMessage{&singerProtoMsg, true}},
+		{desc: "decode NULL to NullProto", proto: nullProto(), protoType: protoMessageType(protoMessagefqn), want: NullProtoMessage{}},
+		{desc: "decode ENUM to NullEnum", proto: protoEnumProto(pb.Genre_ROCK), protoType: protoEnumType(protoEnumfqn), want: NullProtoEnum{&singerEnumValue, true}},
+		{desc: "decode NULL to NullEnum", proto: nullProto(), protoType: protoEnumType(protoEnumfqn), want: NullProtoEnum{}},
 	} {
 		gotp := reflect.New(reflect.TypeOf(test.want))
 		v := gotp.Interface()
@@ -1849,11 +1849,11 @@ func TestDecodeValue(t *testing.T) {
 			nullValue.Time = time.Unix(100, 100)
 		case *NullDate:
 			nullValue.Date = civil.DateOf(time.Unix(100, 200))
-		case *NullProto:
-			nullValue.ProtoVal = &pb.SingerInfo{}
-		case *NullEnum:
+		case *NullProtoMessage:
+			nullValue.ProtoMessageVal = &pb.SingerInfo{}
+		case *NullProtoEnum:
 			var singerProtoEnumDefault pb.Genre
-			nullValue.EnumVal = &singerProtoEnumDefault
+			nullValue.ProtoEnumVal = &singerProtoEnumDefault
 		default:
 		}
 		err := decodeValue(test.proto, test.protoType, v)

--- a/spanner/value_test.go
+++ b/spanner/value_test.go
@@ -476,10 +476,12 @@ func TestEncodeValue(t *testing.T) {
 		// PROTO MESSAGE AND PROTO ENUM
 		{singer1ProtoMsg, protoMessageProto(singer1ProtoMsg), tProtoMessage, "Proto Message"},
 		{singer1ProtoEnum, protoEnumProto(singer1ProtoEnum), tProtoEnum, "Proto Enum"},
+		{(*pb.SingerInfo)(nil), nullProto(), tProtoMessage, "Proto Message with nil"},
+		{(*pb.Genre)(nil), nullProto(), tProtoEnum, "Proto Enum with nil"},
 		{NullProto{singer1ProtoMsg, true}, protoMessageProto(singer1ProtoMsg), tProtoMessage, "NullProto with value"},
-		{NullProto{}, nullProto(), protoMessageType(""), "NullProto with null"},
 		{NullEnum{singer1ProtoEnum, true}, protoEnumProto(singer1ProtoEnum), tProtoEnum, "NullEnum with value"},
-		{NullEnum{}, nullProto(), protoEnumType(""), "NullEnum with null"},
+		{NullProto{(*pb.SingerInfo)(nil), true}, nullProto(), tProtoMessage, "NullProto with value nil"},
+		{NullEnum{(*pb.Genre)(nil), true}, nullProto(), tProtoEnum, "NullEnum with value nil"},
 	} {
 		got, gotType, err := encodeValue(test.in)
 		if err != nil {
@@ -523,10 +525,8 @@ func TestEncodeInvalidValues(t *testing.T) {
 		{desc: "custom numeric type with invalid scale component", in: CustomNumeric(*invalidNumPtr1), errMsg: "max scale for a numeric is 9. The requested numeric has more"},
 		{desc: "custom numeric type with invalid whole component", in: CustomNumeric(*invalidNumPtr2), errMsg: "max precision for the whole component of a numeric is 29. The requested numeric has a whole component with precision 30"},
 		// PROTO MESSAGE AND PROTO ENUM
-		{desc: "Nil Proto Message", in: (*pb.SingerInfo)(nil), errMsg: "spanner: code = \"InvalidArgument\", desc = \"cannot use nil type *protos.SingerInfo\""},
-		{desc: "Nil Proto Enum", in: (*pb.Genre)(nil), errMsg: "spanner: code = \"InvalidArgument\", desc = \"cannot use nil type *protos.Genre\""},
-		{desc: "Nil Proto Message", in: NullProto{(*pb.SingerInfo)(nil), true}, errMsg: "spanner: code = \"InvalidArgument\", desc = \"cannot use nil type *protos.SingerInfo\""},
-		{desc: "Nil Proto Enum", in: NullEnum{(*pb.Genre)(nil), true}, errMsg: "spanner: code = \"InvalidArgument\", desc = \"cannot use nil type *protos.Genre\""},
+		{desc: "Invalid Null Proto", in: NullProto{}, errMsg: "spanner: code = \"InvalidArgument\", desc = \"cannot have valid field as false in spanner.NullProto\""},
+		{desc: "Invalid Null Enum", in: NullEnum{}, errMsg: "spanner: code = \"InvalidArgument\", desc = \"cannot have valid field as false in spanner.NullEnum\""},
 	} {
 		_, _, err := encodeValue(test.in)
 		if err == nil {

--- a/spanner/value_test.go
+++ b/spanner/value_test.go
@@ -525,8 +525,8 @@ func TestEncodeInvalidValues(t *testing.T) {
 		{desc: "custom numeric type with invalid scale component", in: CustomNumeric(*invalidNumPtr1), errMsg: "max scale for a numeric is 9. The requested numeric has more"},
 		{desc: "custom numeric type with invalid whole component", in: CustomNumeric(*invalidNumPtr2), errMsg: "max precision for the whole component of a numeric is 29. The requested numeric has a whole component with precision 30"},
 		// PROTO MESSAGE AND PROTO ENUM
-		{desc: "Invalid Null Proto", in: NullProtoMessage{}, errMsg: "spanner: code = \"InvalidArgument\", desc = \"cannot have valid field as false in spanner.NullProto\""},
-		{desc: "Invalid Null Enum", in: NullProtoEnum{}, errMsg: "spanner: code = \"InvalidArgument\", desc = \"cannot have valid field as false in spanner.NullEnum\""},
+		{desc: "Invalid Null Proto", in: NullProtoMessage{}, errMsg: "spanner: code = \"InvalidArgument\", desc = \"field \\\"Valid\\\" of spanner.NullProtoMessage cannot be set to false when writing data to Cloud Spanner. Use typed nil in spanner.NullProtoMessage to write null values to Cloud Spanner\""},
+		{desc: "Invalid Null Enum", in: NullProtoEnum{}, errMsg: "spanner: code = \"InvalidArgument\", desc = \"field \\\"Valid\\\" of spanner.NullProtoEnum cannot be set to false when writing data to Cloud Spanner. Use typed nil in spanner.NullProtoEnum to write null values to Cloud Spanner\""},
 	} {
 		_, _, err := encodeValue(test.in)
 		if err == nil {


### PR DESCRIPTION
This PR contains implementation changes to add support for handling null values in Proto Messages and Proto Enum type columns. Also the PR has changes to get `protoTypeFqn` for nil types.