### PR TITLE
feat(firestore): add WithCommitResponseTo TransactionOption

### DIFF
--- a/.github/workflows/vet.sh
+++ b/.github/workflows/vet.sh
@@ -61,6 +61,7 @@ golint ./... 2>&1 | (
     grep -v "firestore.arrayUnion" |
     grep -v "firestore.arrayRemove" |
     grep -v "maxAttempts" |
+    grep -v "firestore.commitResponse" |
     grep -v "UptimeCheckIpIterator" |
     grep -vE "apiv[0-9]+" |
     grep -v "ALL_CAPS" |

--- a/firestore/examples_test.go
+++ b/firestore/examples_test.go
@@ -564,6 +564,9 @@ func ExampleClient_RunTransaction() {
 	}
 	defer client.Close()
 
+	// write the CommitResponse here, via firestore.WithCommitResponse (below)
+	var cr firestore.CommitResponse
+
 	nm := client.Doc("States/NewMexico")
 	err = client.RunTransaction(ctx, func(ctx context.Context, tx *firestore.Transaction) error {
 		doc, err := tx.Get(nm) // tx.Get, NOT nm.Get!
@@ -575,10 +578,11 @@ func ExampleClient_RunTransaction() {
 			return err
 		}
 		return tx.Update(nm, []firestore.Update{{Path: "pop", Value: pop.(float64) + 0.2}})
-	})
+	}, firestore.WithCommitResponseTo(&cr))
 	if err != nil {
 		// TODO: Handle error.
 	}
+	// CommitResponse can be accessed here
 }
 
 func ExampleArrayUnion_create() {

--- a/firestore/transaction_test.go
+++ b/firestore/transaction_test.go
@@ -84,6 +84,7 @@ func TestRunTransaction(t *testing.T) {
 		},
 		&pb.CommitResponse{CommitTime: aTimestamp3},
 	)
+	var commitResponse CommitResponse
 	err = c.RunTransaction(ctx, func(_ context.Context, tx *Transaction) error {
 		docref := c.Collection("C").Doc("a")
 		doc, err := tx.Get(docref)
@@ -95,9 +96,15 @@ func TestRunTransaction(t *testing.T) {
 			return err
 		}
 		return tx.Update(docref, []Update{{Path: "count", Value: count.(int64) + 1}})
-	})
+	}, WithCommitResponseTo(&commitResponse))
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	// validate commit time
+	commitTime := commitResponse.CommitTime()
+	if commitTime != aTimestamp3.AsTime() {
+		t.Fatalf("commit time %v should equal %v", commitTime, aTimestamp3)
 	}
 
 	// Query


### PR DESCRIPTION
Adds a new ```TransactionOption``` -- ```GetCommitTime``` -- that allows the caller to specify the address of a ```time.Time``` where the commit time of the transaction should be written, upon successful commit.