### PR TITLE
chore(bigtable): more text proxy tune-up

### DIFF
--- a/bigtable/internal/testproxy/proxy.go
+++ b/bigtable/internal/testproxy/proxy.go
@@ -355,7 +355,7 @@ func statusFromError(err error) *statpb.Status {
 func parseTableID(tableName string) (tableID string, _ error) {
 	paths := strings.Split(tableName, "/")
 
-	if len(paths) == 0 {
+	if len(paths) < 6 {
 		return "", errors.New("table resource name does not have the correct format")
 	}
 

--- a/bigtable/internal/testproxy/proxy_test.go
+++ b/bigtable/internal/testproxy/proxy_test.go
@@ -36,7 +36,7 @@ import (
 
 const (
 	buffer           = 1024 * 1024
-	tableName        = "table"
+	tableName        = "projects/my-project/instances/my-instance/tables/table"
 	columnFamily     = "cf"
 	testProxyClient  = "testProxyClient"
 	testProxyAddress = "localhost:9990"

--- a/bigtable/internal/testproxy/proxy_test.go
+++ b/bigtable/internal/testproxy/proxy_test.go
@@ -37,6 +37,7 @@ import (
 const (
 	buffer           = 1024 * 1024
 	tableName        = "projects/my-project/instances/my-instance/tables/table"
+	tableID          = "table"
 	columnFamily     = "cf"
 	testProxyClient  = "testProxyClient"
 	testProxyAddress = "localhost:9990"
@@ -70,7 +71,7 @@ func populateTable(bts *bttest.Server) error {
 	}
 	defer adminClient.Close()
 
-	if err := adminClient.CreateTable(ctx, tableName); err != nil {
+	if err := adminClient.CreateTable(ctx, tableID); err != nil {
 		return fmt.Errorf("testproxy setup: can't create table: %v", err)
 	}
 
@@ -78,7 +79,7 @@ func populateTable(bts *bttest.Server) error {
 	count := 3
 	for i := 0; i < count; i++ {
 		cfName := fmt.Sprintf("%s%d", columnFamily, i)
-		if err := adminClient.CreateColumnFamily(ctx, tableName, cfName); err != nil {
+		if err := adminClient.CreateColumnFamily(ctx, tableID, cfName); err != nil {
 			return fmt.Errorf("testproxy setup: can't create column family: %s", cfName)
 		}
 	}
@@ -90,7 +91,7 @@ func populateTable(bts *bttest.Server) error {
 	}
 	defer dataClient.Close()
 
-	t := dataClient.Open(tableName)
+	t := dataClient.Open(tableID)
 
 	for fc := 0; fc < count; fc++ {
 		for cc := count; cc > 0; cc-- {


### PR DESCRIPTION
This PR:

* Changes how table IDs are passed to `Client.Open()`
* Changes the error returned to the caller for a closed client.