### PR TITLE
feat(spanner): add support for Array of Proto columns

### DIFF
--- a/spanner/integration_test.go
+++ b/spanner/integration_test.go
@@ -2036,6 +2036,13 @@ func TestIntegration_BasicTypes_ProtoColumns(t *testing.T) {
 		Nationality: proto.String("Country1"),
 		Genre:       &singerProtoEnum,
 	}
+	singer2ProtoEnum := pb.Genre_FOLK
+	singer2ProtoMessage := pb.SingerInfo{
+		SingerId:    proto.Int64(1),
+		BirthDate:   proto.String("January"),
+		Nationality: proto.String("Country1"),
+		Genre:       &singer2ProtoEnum,
+	}
 	bytesSingerProtoMessage, _ := proto.Marshal(&singerProtoMessage)
 
 	tests := []struct {
@@ -2091,6 +2098,50 @@ func TestIntegration_BasicTypes_ProtoColumns(t *testing.T) {
 		{col: "ProtoMessage", val: []byte(nil), want: NullProtoMessage{}},
 		{col: "ProtoMessage", val: NullProtoMessage{&singerProtoMessage, true}, want: bytesSingerProtoMessage},
 		{col: "ProtoMessage", val: NullProtoMessage{&singerProtoMessage, true}, want: NullProtoMessage{&singerProtoMessage, true}},
+		// Array of Proto Messages : Tests insert and read operations on ARRAY<PROTO> type column
+		{col: "ProtoMessageArray", val: []*pb.SingerInfo{&singerProtoMessage, &singer2ProtoMessage}},
+		{col: "ProtoMessageArray", val: []*pb.SingerInfo(nil)},
+		{col: "ProtoMessageArray", val: []*pb.SingerInfo{}},
+		// Array of Proto Enum : Tests insert and read operations on ARRAY<ENUM> type column
+		{col: "ProtoEnumArray", val: []pb.Genre{pb.Genre_ROCK, pb.Genre_FOLK}, want: []*pb.Genre{&singerProtoEnum, &singer2ProtoEnum}},
+		{col: "ProtoEnumArray", val: []pb.Genre{pb.Genre_ROCK, pb.Genre_FOLK}, want: []pb.Genre{singerProtoEnum, singer2ProtoEnum}},
+		{col: "ProtoEnumArray", val: []*pb.Genre{&singerProtoEnum, &singer2ProtoEnum}},
+		{col: "ProtoEnumArray", val: []*pb.Genre{&singerProtoEnum, &singer2ProtoEnum}, want: []pb.Genre{singerProtoEnum, singer2ProtoEnum}},
+		{col: "ProtoEnumArray", val: []pb.Genre{}, want: []*pb.Genre{}},
+		{col: "ProtoEnumArray", val: []pb.Genre(nil), want: []*pb.Genre(nil)},
+		{col: "ProtoEnumArray", val: []*pb.Genre{}, want: []pb.Genre{}},
+		{col: "ProtoEnumArray", val: []*pb.Genre(nil), want: []pb.Genre(nil)},
+		{col: "ProtoEnumArray", val: []pb.Genre{}},
+		{col: "ProtoEnumArray", val: []pb.Genre(nil)},
+		{col: "ProtoEnumArray", val: []*pb.Genre{}},
+		{col: "ProtoEnumArray", val: []*pb.Genre(nil)},
+		// Tests Compatibility between Array of Int64 and Array of ProtoEnum type
+		{col: "ProtoEnumArray", val: []int64{3, 2}, want: []pb.Genre{singerProtoEnum, singer2ProtoEnum}},
+		{col: "ProtoEnumArray", val: []int64{3, 2}, want: []*pb.Genre{&singerProtoEnum, &singer2ProtoEnum}},
+		{col: "ProtoEnumArray", val: []int64(nil), want: []pb.Genre(nil)},
+		{col: "ProtoEnumArray", val: []int64{}, want: []pb.Genre{}},
+		{col: "ProtoEnumArray", val: []pb.Genre{singerProtoEnum, singer2ProtoEnum}, want: []int64{3, 2}},
+		{col: "ProtoEnumArray", val: []pb.Genre{}, want: []int64{}},
+		{col: "ProtoEnumArray", val: []*pb.Genre{&singerProtoEnum, &singer2ProtoEnum}, want: []int64{3, 2}},
+		{col: "ProtoEnumArray", val: []*pb.Genre(nil), want: []int64(nil)},
+		{col: "ProtoEnumArray", val: []*pb.Genre{}, want: []int64{}},
+		{col: "ProtoEnumArray", val: []*pb.Genre{&singerProtoEnum, &singer2ProtoEnum, nil}, want: []NullInt64{{3, true}, {2, true}, {}}},
+		{col: "Int64Array", val: []int64{3, 2}, want: []pb.Genre{singerProtoEnum, singer2ProtoEnum}},
+		{col: "Int64Array", val: []int64{3, 2}, want: []*pb.Genre{&singerProtoEnum, &singer2ProtoEnum}},
+		{col: "Int64Array", val: []pb.Genre{singerProtoEnum, singer2ProtoEnum}, want: []int64{3, 2}},
+		{col: "Int64Array", val: []*pb.Genre{&singerProtoEnum, &singer2ProtoEnum}, want: []int64{3, 2}},
+		{col: "Int64Array", val: []pb.Genre(nil), want: []int64(nil)},
+		// Tests Compatibility between Array of Bytes and Array of ProtoMessages type
+		{col: "ProtoMessageArray", val: []*pb.SingerInfo{&singerProtoMessage}, want: [][]byte{bytesSingerProtoMessage}},
+		{col: "ProtoMessageArray", val: [][]byte{bytesSingerProtoMessage}},
+		{col: "ProtoMessageArray", val: [][]byte{bytesSingerProtoMessage}, want: []*pb.SingerInfo{&singerProtoMessage}},
+		{col: "ProtoMessageArray", val: [][]byte(nil), want: []*pb.SingerInfo(nil)},
+		{col: "ProtoMessageArray", val: []*pb.SingerInfo(nil), want: [][]byte(nil)},
+		{col: "BytesArray", val: []*pb.SingerInfo{&singerProtoMessage}},
+		{col: "BytesArray", val: []*pb.SingerInfo{&singerProtoMessage}, want: [][]byte{bytesSingerProtoMessage}},
+		{col: "BytesArray", val: [][]byte{bytesSingerProtoMessage}, want: []*pb.SingerInfo{&singerProtoMessage}},
+		{col: "BytesArray", val: [][]byte(nil), want: []*pb.SingerInfo(nil)},
+		{col: "BytesArray", val: []*pb.SingerInfo(nil), want: [][]byte(nil)},
 	}
 
 	// Write rows into table first using DML.
@@ -3882,7 +3933,7 @@ func prepareDBAndClientForProtoColumns(ctx context.Context, t *testing.T, spc Se
 	dbName := dbNameSpace.New()
 	// TODO: Remove this
 	testInstanceID = "go-int-test-proto-column"
-	dbName = "go_int_test_proto_column"
+	dbName = "go_int_test_proto_column_db"
 
 	dbPath := fmt.Sprintf("projects/%v/instances/%v/databases/%v", testProjectID, testInstanceID, dbName)
 	client, err := createClient(ctx, dbPath, spc)

--- a/spanner/value.go
+++ b/spanner/value.go
@@ -114,6 +114,9 @@ var (
 	commitTimestamp = time.Unix(0, 0).In(time.FixedZone("CommitTimestamp placeholder", 0xDB))
 
 	jsonNullBytes = []byte("null")
+
+	protoMsgReflectType  = reflect.TypeOf((*proto.Message)(nil)).Elem()
+	protoEnumReflectType = reflect.TypeOf((*protoreflect.Enum)(nil)).Elem()
 )
 
 // Encoder is the interface implemented by a custom type that can be encoded to
@@ -1257,7 +1260,7 @@ func decodeValue(v *proto3.Value, t *sppb.Type, ptr interface{}, opts ...decodeO
 		if p == nil {
 			return errNilDst(p)
 		}
-		if acode != sppb.TypeCode_BYTES {
+		if acode != sppb.TypeCode_BYTES && acode != sppb.TypeCode_PROTO {
 			return errTypeMismatch(code, acode, ptr)
 		}
 		if isNull {
@@ -1327,7 +1330,7 @@ func decodeValue(v *proto3.Value, t *sppb.Type, ptr interface{}, opts ...decodeO
 		if p == nil {
 			return errNilDst(p)
 		}
-		if acode != sppb.TypeCode_INT64 {
+		if acode != sppb.TypeCode_INT64 && acode != sppb.TypeCode_ENUM {
 			return errTypeMismatch(code, acode, ptr)
 		}
 		if isNull {
@@ -1361,7 +1364,7 @@ func decodeValue(v *proto3.Value, t *sppb.Type, ptr interface{}, opts ...decodeO
 		if p == nil {
 			return errNilDst(p)
 		}
-		if acode != sppb.TypeCode_INT64 {
+		if acode != sppb.TypeCode_INT64 && acode != sppb.TypeCode_ENUM {
 			return errTypeMismatch(code, acode, ptr)
 		}
 		if isNull {
@@ -2067,6 +2070,47 @@ func decodeValue(v *proto3.Value, t *sppb.Type, ptr interface{}, opts ...decodeO
 				return errDstNotForNull(ptr)
 			}
 			return decodableType.decodeValueToCustomType(v, t, acode, atypeAnnotation, ptr)
+		}
+
+		// Check if the proto encoding is for an array of proto message or array of proto enum.
+		// The below scenario cannot be handled in a switch case statement because the pointer in this case
+		// would be an array of proto message or array of proto enum which are user defined types.
+		// Adding a generic switch case for these user defined types is not possible, hence we use proto encoding.
+		if code == sppb.TypeCode_ARRAY && (acode == sppb.TypeCode_PROTO ||
+			acode == sppb.TypeCode_ENUM || acode == sppb.TypeCode_INT64 ||
+			acode == sppb.TypeCode_BYTES) {
+			rv := reflect.ValueOf(ptr)
+			typ := rv.Type()
+			if typ.Kind() != reflect.Ptr {
+				return errNotAPointer(ptr)
+			}
+			if isNull {
+				break
+			}
+			etyp := typ.Elem().Elem()
+			switch acode {
+			case sppb.TypeCode_PROTO, sppb.TypeCode_BYTES:
+				if etyp.Implements(protoMsgReflectType) && etyp.Kind() == reflect.Ptr {
+					x, err := getListValue(v)
+					if err != nil {
+						return err
+					}
+					return decodeProtoMessagePtrArray(x, t.ArrayElementType, rv)
+				}
+				return errTypeMismatch(code, acode, ptr)
+			case sppb.TypeCode_ENUM, sppb.TypeCode_INT64:
+				if etyp.Implements(protoEnumReflectType) {
+					x, err := getListValue(v)
+					if err != nil {
+						return err
+					}
+					if etyp.Kind() == reflect.Ptr {
+						return decodeProtoEnumPtrArray(x, t.ArrayElementType, rv)
+					} else {
+						return decodeProtoEnumArray(x, t.ArrayElementType, rv)
+					}
+				}
+			}
 		}
 
 		// Check if the proto encoding is for an array of structs.
@@ -3121,6 +3165,69 @@ func decodeByteArray(pb *proto3.ListValue) ([][]byte, error) {
 	return a, nil
 }
 
+// decodeProtoMessagePtrArray decodes proto3.ListValue pb into a *proto.Message slice.
+// The elements in the array implements proto.Message interface only if the element is a pointer (e.g. *ProtoMessage).
+// However, if the element is a value (e.g. ProtoMessage), then it does not implement proto.Message.
+// Therefore, decodeProtoMessagePtrArray allows decoding of proto message array if the array element is a pointer only.
+func decodeProtoMessagePtrArray(pb *proto3.ListValue, t *sppb.Type, rv reflect.Value) error {
+	if pb == nil {
+		return errNilListValue("PROTO")
+	}
+	etyp := rv.Type().Elem().Elem().Elem()
+	a := reflect.MakeSlice(rv.Type().Elem(), len(pb.Values), len(pb.Values))
+	for i, v := range pb.Values {
+		msg := reflect.New(etyp).Interface().(proto.Message)
+		if err := decodeValue(v, t, msg); err != nil {
+			return errDecodeArrayElement(i, v, "PROTO", err)
+		}
+		a.Index(i).Set(reflect.ValueOf(msg))
+	}
+	rv.Elem().Set(a)
+	return nil
+}
+
+// decodeProtoEnumPtrArray decodes proto3.ListValue pb into a *protoreflect.Enum slice.
+func decodeProtoEnumPtrArray(pb *proto3.ListValue, t *sppb.Type, rv reflect.Value) error {
+	if pb == nil {
+		return errNilListValue("ENUM")
+	}
+	etyp := rv.Type().Elem().Elem().Elem()
+	a := reflect.MakeSlice(rv.Type().Elem(), len(pb.Values), len(pb.Values))
+	for i, v := range pb.Values {
+		enum := reflect.New(etyp).Interface().(protoreflect.Enum)
+		if err := decodeValue(v, t, enum); err != nil {
+			return errDecodeArrayElement(i, v, "ENUM", err)
+		}
+		a.Index(i).Set(reflect.ValueOf(enum))
+	}
+	rv.Elem().Set(a)
+	return nil
+}
+
+// decodeProtoEnumArray decodes proto3.ListValue pb into a protoreflect.Enum slice.
+func decodeProtoEnumArray(pb *proto3.ListValue, t *sppb.Type, rv reflect.Value) error {
+	if pb == nil {
+		return errNilListValue("ENUM")
+	}
+	a := reflect.MakeSlice(rv.Type().Elem(), len(pb.Values), len(pb.Values))
+	// decodeValue method can decode only if ENUM is a pointer type.
+	// As the ENUM element in the Array is not a pointer type we cannot use decodeValue method
+	// and hence handle it separately.
+	for i, v := range pb.Values {
+		x, err := getStringValue(v)
+		if err != nil {
+			return err
+		}
+		y, err := strconv.ParseInt(x, 10, 64)
+		if err != nil {
+			return errBadEncoding(v, err)
+		}
+		a.Index(i).SetInt(y)
+	}
+	rv.Elem().Set(a)
+	return nil
+}
+
 // decodeNullTimeArray decodes proto3.ListValue pb into a NullTime slice.
 func decodeNullTimeArray(pb *proto3.ListValue) ([]NullTime, error) {
 	if pb == nil {
@@ -3853,7 +3960,7 @@ func encodeValue(v interface{}) (*proto3.Value, *sppb.Type, error) {
 			return encodeValue(converted)
 		}
 
-		if !isStructOrArrayOfStructValue(v) {
+		if !isStructOrArrayOfStructValue(v) && !isAnArrayOfProtoColumn(v) {
 			return nil, nil, errEncoderUnsupportedType(v)
 		}
 		typ := reflect.TypeOf(v)
@@ -3866,7 +3973,11 @@ func encodeValue(v interface{}) (*proto3.Value, *sppb.Type, error) {
 
 		// Value is a slice of Go struct values/ptrs.
 		if typ.Kind() == reflect.Slice {
-			return encodeStructArray(v)
+			if isAnArrayOfProtoColumn(v) {
+				return encodeProtoArray(v)
+			} else {
+				return encodeStructArray(v)
+			}
 		}
 	}
 	return pb, pt, nil
@@ -4119,6 +4230,42 @@ func encodeStructArray(v interface{}) (*proto3.Value, *sppb.Type, error) {
 	return listProto(values...), listType(elemTyp), nil
 }
 
+// Encodes a slice of proto messages or enum in v to the spanner Value and Type
+// protos.
+func encodeProtoArray(v interface{}) (*proto3.Value, *sppb.Type, error) {
+	pb := nullProto()
+	var pt *sppb.Type
+	var err error
+	sliceval := reflect.ValueOf(v)
+	etyp := reflect.TypeOf(v).Elem()
+
+	if etyp.Implements(protoMsgReflectType) {
+		if !sliceval.IsNil() {
+			pb, err = encodeProtoMessageArray(sliceval.Len(), func(i int) reflect.Value { return sliceval.Index(i) })
+			if err != nil {
+				return nil, nil, err
+			}
+		}
+		defaultInstance := reflect.Zero(etyp).Interface().(proto.Message)
+		protoMessagefqn := string(proto.MessageReflect(defaultInstance).Descriptor().FullName())
+		pt = listType(protoMessageType(protoMessagefqn))
+	} else if etyp.Implements(protoEnumReflectType) {
+		if !sliceval.IsNil() {
+			pb, err = encodeProtoEnumArray(sliceval.Len(), func(i int) reflect.Value { return sliceval.Index(i) })
+			if err != nil {
+				return nil, nil, err
+			}
+		}
+		if etyp.Kind() == reflect.Ptr {
+			etyp = etyp.Elem()
+		}
+		defaultInstance := reflect.Zero(etyp).Interface().(protoreflect.Enum)
+		protoEnumfqn := string(defaultInstance.Descriptor().FullName())
+		pt = listType(protoEnumType(protoEnumfqn))
+	}
+	return pb, pt, nil
+}
+
 func isStructOrArrayOfStructValue(v interface{}) bool {
 	typ := reflect.TypeOf(v)
 	if typ.Kind() == reflect.Slice {
@@ -4128,6 +4275,14 @@ func isStructOrArrayOfStructValue(v interface{}) bool {
 		typ = typ.Elem()
 	}
 	return typ.Kind() == reflect.Struct
+}
+
+func isAnArrayOfProtoColumn(v interface{}) bool {
+	typ := reflect.TypeOf(v)
+	if typ.Kind() == reflect.Slice {
+		typ = typ.Elem()
+	}
+	return typ.Implements(protoMsgReflectType) || typ.Implements(protoEnumReflectType)
 }
 
 func isSupportedMutationType(v interface{}) bool {
@@ -4145,6 +4300,10 @@ func isSupportedMutationType(v interface{}) bool {
 	default:
 		// Check if the custom type implements spanner.Encoder interface.
 		if _, ok := v.(Encoder); ok {
+			return true
+		}
+
+		if isAnArrayOfProtoColumn(v) {
 			return true
 		}
 
@@ -4177,6 +4336,32 @@ func encodeArray(len int, at func(int) interface{}) (*proto3.Value, error) {
 	var err error
 	for i := 0; i < len; i++ {
 		vs[i], _, err = encodeValue(at(i))
+		if err != nil {
+			return nil, err
+		}
+	}
+	return listProto(vs...), nil
+}
+
+func encodeProtoMessageArray(len int, at func(int) reflect.Value) (*proto3.Value, error) {
+	vs := make([]*proto3.Value, len)
+	var err error
+	for i := 0; i < len; i++ {
+		v := at(i).Interface().(proto.Message)
+		vs[i], _, err = encodeValue(v)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return listProto(vs...), nil
+}
+
+func encodeProtoEnumArray(len int, at func(int) reflect.Value) (*proto3.Value, error) {
+	vs := make([]*proto3.Value, len)
+	var err error
+	for i := 0; i < len; i++ {
+		v := at(i).Interface().(protoreflect.Enum)
+		vs[i], _, err = encodeValue(v)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This PR contains implementation changes to add support for handling array of Proto Messages and Proto Enum type columns.

To run integration tests, set the below environment variables:
```
GCLOUD_TESTS_GOLANG_PROJECT_ID=span-cloud-testing
GCLOUD_TESTS_GOLANG_SPANNER_HOST=staging-wrenchworks.sandbox.googleapis.com:443
```