### PR TITLE
chore(genbot): upgrade base image and protoc

### DIFF
--- a/internal/gapicgen/cmd/genbot/Dockerfile
+++ b/internal/gapicgen/cmd/genbot/Dockerfile
@@ -1,4 +1,7 @@
-FROM docker:stable-dind
+FROM docker:20.10
+
+# Log the version of Alpine in use.
+RUN cat /etc/alpine-release
 
 ENV GO111MODULE on
 
@@ -15,8 +18,8 @@ RUN apk add libc6-compat
 RUN apk add protoc protobuf-dev
 RUN protoc --version
 
-# Install Go.
-RUN wget -O /tmp/go.tgz https://dl.google.com/go/go1.19.linux-amd64.tar.gz && \
+# Install Go...quietly.
+RUN wget -O /tmp/go.tgz https://dl.google.com/go/go1.19.linux-amd64.tar.gz -q && \
     tar -C /usr/local -xzf /tmp/go.tgz && \
     rm /tmp/go.tgz
 ENV PATH /usr/local/go/bin:$PATH


### PR DESCRIPTION
Upgrade version of base image to sufficiently new version. This gets us on a newer version of Alpine Linux (`3.16.2`) which gets us on a newer version of `protoc` (`3.18.1`). This is not the newest version of `protoc`, but it includes the necessary `go_package` annotation updates to the common protos that protobuf maintains to upgrade our dependency to the "new" protobuf-go repo distributions.

`docker:20.10`
Alpine Linux: `3.16.2`
Protobuf: `3.18.1-rc3`

Fixes #7031 