### PR TITLE
chore(httpreplay): specify localhost for proxy listener

### DIFF
--- a/httpreplay/internal/proxy/record.go
+++ b/httpreplay/internal/proxy/record.go
@@ -131,7 +131,7 @@ func newProxy(filename string) (*Proxy, error) {
 }
 
 func (p *Proxy) start(port int) error {
-	l, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+	l, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
closes: #7087

@codyoss Is `httpreplay` ever used remotely? Will this change cause issues for anyone?

(Note that the package docs for `httpreplay` state: "This package is EXPERIMENTAL and is subject to change or removal without notice.")