### PR TITLE
feat(spanner): support for enum columns as keys, index and integration tests

### DIFF
--- a/spanner/integration_test.go
+++ b/spanner/integration_test.go
@@ -2326,7 +2326,7 @@ CREATE TABLE Singers (
  SingerInfo spanner.examples.music.SingerInfo,
  SingerGenre spanner.examples.music.Genre,
  SingerNationality STRING(1024) AS (SingerInfo.nationality) STORED,
-) PRIMARY KEY (SingerGenre);
+) PRIMARY KEY (SingerNationality, SingerGenre);
 
 CREATE INDEX SingerByNationalityAndGenre ON Singers(SingerNationality, SingerGenre) STORING (SingerId, FirstName, LastName);
 */
@@ -2448,17 +2448,17 @@ func TestIntegration_ProtoColumns_DML_ParameterizedQueries_Pk_Indexes(t *testing
 		}
 	}
 
-	// Read all rows based on Proto Enum Primary key column values
-	got, err := readAll(ro.Read(ctx, "Singers", KeySets(Key{pb.Genre_ROCK}, Key{pb.Genre_JAZZ}), []string{"SingerId", "FirstName", "LastName"}))
+	// Read all rows based on Proto Message field and Proto Enum Primary key column values
+	got, err := readAll(ro.Read(ctx, "Singers", KeySets(Key{"Country1", pb.Genre_ROCK}, Key{"Country3", pb.Genre_JAZZ}), []string{"SingerId", "FirstName", "LastName"}))
 	if err != nil {
 		t.Errorf("Reading rows from Primary key values returns error %v, want nil", err)
 	}
-	want := [][]interface{}{{int64(3), "Singer3", "Singer3"}, {int64(1), "Singer1", "Singer1"}}
+	want := [][]interface{}{{int64(1), "Singer1", "Singer1"}, {int64(3), "Singer3", "Singer3"}}
 	if !testEqual(got, want) {
 		t.Errorf("got unexpected result while reading rows from Primary key values: %v, want %v", got, want)
 	}
 
-	// Read rows using Index on Proto Enum column
+	// Read rows using Index on Proto Message field and Proto Enum column
 	got, err = readAll(ro.ReadUsingIndex(ctx, "Singers", "SingerByNationalityAndGenre", KeySets(Key{"Country1", pb.Genre_ROCK}, Key{"Country2", pb.Genre_FOLK}), []string{"SingerId", "FirstName", "LastName"}))
 	if err != nil {
 		t.Errorf("ReadUsingIndex on Proto Enum column returns error %v, want nil", err)

--- a/spanner/integration_test.go
+++ b/spanner/integration_test.go
@@ -2317,6 +2317,165 @@ func TestIntegration_BasicTypes_ProtoColumns_Errors(t *testing.T) {
 	}
 }
 
+/*
+The schema for Table Singers and Index SingerByNationalityAndGenre for Proto column integration tests is shown below:
+CREATE TABLE Singers (
+ SingerId   INT64 NOT NULL,
+ FirstName  STRING(1024),
+ LastName   STRING(1024),
+ SingerInfo spanner.examples.music.SingerInfo,
+ SingerGenre spanner.examples.music.Genre,
+ SingerNationality STRING(1024) AS (SingerInfo.nationality) STORED,
+) PRIMARY KEY (SingerGenre);
+
+CREATE INDEX SingerByNationalityAndGenre ON Singers(SingerNationality, SingerGenre) STORING (SingerId, FirstName, LastName);
+*/
+
+// Test DML, Parameterized query, Primary key and Indexing on Proto columns
+func TestIntegration_ProtoColumns_DML_ParameterizedQueries_Pk_Indexes(t *testing.T) {
+	skipEmulatorTest(t)
+	t.Parallel()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	stmts := []string{}
+	client, _, cleanup := prepareIntegrationTestForProtoColumns(ctx, t, DefaultSessionPoolConfig, stmts)
+	defer cleanup()
+
+	singerProtoEnum := pb.Genre_ROCK
+	singerProtoMessage := pb.SingerInfo{
+		SingerId:    proto.Int64(1),
+		BirthDate:   proto.String("January"),
+		Nationality: proto.String("Country1"),
+		Genre:       &singerProtoEnum,
+	}
+	singer2ProtoEnum := pb.Genre_FOLK
+	singer2ProtoMessage := pb.SingerInfo{
+		SingerId:    proto.Int64(2),
+		BirthDate:   proto.String("February"),
+		Nationality: proto.String("Country2"),
+		Genre:       &singer2ProtoEnum,
+	}
+	singer3ProtoEnum := pb.Genre_JAZZ
+	singer3ProtoMessage := pb.SingerInfo{
+		SingerId:    proto.Int64(3),
+		BirthDate:   proto.String("March"),
+		Nationality: proto.String("Country3"),
+		Genre:       &singer3ProtoEnum,
+	}
+
+	for i, test := range []struct {
+		sql    string
+		params map[string]interface{}
+	}{
+		{sql: "INSERT INTO Singers (SingerId, FirstName, LastName, SingerInfo, SingerGenre) VALUES (@singerId, @firstName, @lastName, @singerInfo, @singerGenre)",
+			params: map[string]interface{}{
+				"singerId":    1,
+				"firstName":   "Singer1",
+				"lastName":    "Singer1",
+				"singerInfo":  &singerProtoMessage,
+				"singerGenre": singerProtoEnum,
+			},
+		}, {sql: "INSERT INTO Singers (SingerId, FirstName, LastName, SingerInfo, SingerGenre) VALUES (@singerId, @firstName, @lastName, @singerInfo, @singerGenre)",
+			params: map[string]interface{}{
+				"singerId":    2,
+				"firstName":   "Singer2",
+				"lastName":    "Singer2",
+				"singerInfo":  &singer2ProtoMessage,
+				"singerGenre": singer2ProtoEnum,
+			},
+		}, {sql: "INSERT INTO Singers (SingerId, FirstName, LastName, SingerInfo, SingerGenre) VALUES (@singerId, @firstName, @lastName, @singerInfo, @singerGenre)",
+			params: map[string]interface{}{
+				"singerId":    3,
+				"firstName":   "Singer3",
+				"lastName":    "Singer3",
+				"singerInfo":  &singer3ProtoMessage,
+				"singerGenre": singer3ProtoEnum,
+			},
+		},
+	} {
+		_, err := client.ReadWriteTransaction(ctx, func(ctx context.Context, tx *ReadWriteTransaction) error {
+			count, err := tx.Update(ctx, Statement{
+				SQL:    test.sql,
+				Params: test.params,
+			})
+			if err != nil {
+				return err
+			}
+			if count != 1 {
+				t.Errorf("row count: got %d, want 1", count)
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("%d: failed to insert values using DML: %v", i, err)
+		}
+	}
+
+	for i, test := range []struct {
+		sql    string
+		params map[string]interface{}
+		want   [][]interface{}
+	}{
+		// Filter rows using Proto Enum Parameterized query
+		{sql: "SELECT SingerId, FirstName, LastName, SingerInfo, SingerGenre FROM Singers WHERE SingerGenre=@genre",
+			params: map[string]interface{}{
+				"genre": pb.Genre_FOLK,
+			},
+			want: [][]interface{}{{int64(2), "Singer2", "Singer2"}},
+		},
+		// Filter rows using Proto Message Field Parameterized query
+		{sql: "SELECT SingerId, FirstName, LastName, SingerInfo, SingerGenre FROM Singers WHERE SingerInfo.Nationality=@country",
+			params: map[string]interface{}{
+				"country": "Country3",
+			},
+			want: [][]interface{}{{int64(3), "Singer3", "Singer3"}},
+		},
+	} {
+		ro := client.ReadOnlyTransaction()
+		got, err := readAll(ro.Query(
+			ctx,
+			Statement{
+				SQL:    test.sql,
+				Params: test.params,
+			}))
+		if err != nil {
+			t.Errorf("%d: Parameterized query returns error %v, want nil", i, err)
+		}
+		if !testEqual(got, test.want) {
+			t.Errorf("%d: got unexpected result from Parameterized query: %v, want %v", i, got, test.want)
+		}
+	}
+
+	// Read all rows based on Proto Enum Primary key column values
+	ro := client.ReadOnlyTransaction()
+	got, err := readAll(ro.Read(ctx, "Singers", KeySets(Key{pb.Genre_ROCK}, Key{pb.Genre_JAZZ}), []string{"SingerId", "FirstName", "LastName"}))
+	if err != nil {
+		t.Errorf("Reading rows from Primary key values returns error %v, want nil", err)
+	}
+	want := [][]interface{}{{int64(3), "Singer3", "Singer3"}, {int64(1), "Singer1", "Singer1"}}
+	if !testEqual(got, want) {
+		t.Errorf("got unexpected result while reading rows from Primary key values: %v, want %v", got, want)
+	}
+
+	// Read rows using Index on Proto Enum column
+	got, err = readAll(ro.ReadUsingIndex(ctx, "Singers", "SingerByNationalityAndGenre", KeySets(Key{"Country1", pb.Genre_ROCK}, Key{"Country2", pb.Genre_FOLK}), []string{"SingerId", "FirstName", "LastName"}))
+	if err != nil {
+		t.Errorf("ReadUsingIndex on Proto Enum column returns error %v, want nil", err)
+	}
+	// The results from ReadUsingIndex is sorted by the index rather than
+	// primary key.
+	want = [][]interface{}{{int64(1), "Singer1", "Singer1"}, {int64(2), "Singer2", "Singer2"}}
+	if !testEqual(got, want) {
+		t.Errorf("got unexpected result from ReadUsingIndex on Proto Enum column: %v, want %v", got, want)
+	}
+
+	// Delete all the rows in the Singers table.
+	_, err = client.Apply(ctx, []*Mutation{Delete("Singers", AllKeys())})
+	if err != nil {
+		t.Fatalf("failed to delete all rows: %v", err)
+	}
+}
+
 // Test decoding Cloud Spanner STRUCT type.
 func TestIntegration_StructTypes(t *testing.T) {
 	t.Parallel()

--- a/spanner/integration_test.go
+++ b/spanner/integration_test.go
@@ -2411,6 +2411,9 @@ func TestIntegration_ProtoColumns_DML_ParameterizedQueries_Pk_Indexes(t *testing
 		}
 	}
 
+	ro := client.ReadOnlyTransaction()
+	defer ro.Close()
+
 	for i, test := range []struct {
 		sql    string
 		params map[string]interface{}
@@ -2431,7 +2434,6 @@ func TestIntegration_ProtoColumns_DML_ParameterizedQueries_Pk_Indexes(t *testing
 			want: [][]interface{}{{int64(3), "Singer3", "Singer3"}},
 		},
 	} {
-		ro := client.ReadOnlyTransaction()
 		got, err := readAll(ro.Query(
 			ctx,
 			Statement{
@@ -2447,7 +2449,6 @@ func TestIntegration_ProtoColumns_DML_ParameterizedQueries_Pk_Indexes(t *testing
 	}
 
 	// Read all rows based on Proto Enum Primary key column values
-	ro := client.ReadOnlyTransaction()
 	got, err := readAll(ro.Read(ctx, "Singers", KeySets(Key{pb.Genre_ROCK}, Key{pb.Genre_JAZZ}), []string{"SingerId", "FirstName", "LastName"}))
 	if err != nil {
 		t.Errorf("Reading rows from Primary key values returns error %v, want nil", err)

--- a/spanner/key.go
+++ b/spanner/key.go
@@ -26,6 +26,7 @@ import (
 	proto3 "github.com/golang/protobuf/ptypes/struct"
 	sppb "google.golang.org/genproto/googleapis/spanner/v1"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
 // A Key can be either a Cloud Spanner row's primary key or a secondary index
@@ -58,6 +59,7 @@ import (
 //   - string and NullString are mapped to Cloud Spanner's STRING type.
 //   - time.Time and NullTime are mapped to Cloud Spanner's TIMESTAMP type.
 //   - civil.Date and NullDate are mapped to Cloud Spanner's DATE type.
+//   - protoreflect.Enum and NullProtoEnum are mapped to Cloud Spanner's ENUM type.
 type Key []interface{}
 
 // errInvdKeyPartType returns error for unsupported key part type.
@@ -85,7 +87,7 @@ func keyPartValue(part interface{}) (pb *proto3.Value, err error) {
 		pb, _, err = encodeValue(int64(v))
 	case float32:
 		pb, _, err = encodeValue(float64(v))
-	case int64, float64, NullInt64, NullFloat64, bool, NullBool, []byte, string, NullString, time.Time, civil.Date, NullTime, NullDate, big.Rat, NullNumeric:
+	case int64, float64, NullInt64, NullFloat64, bool, NullBool, []byte, string, NullString, time.Time, civil.Date, NullTime, NullDate, big.Rat, NullNumeric, protoreflect.Enum, NullProtoEnum:
 		pb, _, err = encodeValue(v)
 	case Encoder:
 		part, err = v.EncodeSpanner()
@@ -140,7 +142,7 @@ func (key Key) String() string {
 
 func (key Key) elemString(b *bytes.Buffer, part interface{}) {
 	switch v := part.(type) {
-	case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, float32, float64, bool:
+	case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, float32, float64, bool, protoreflect.Enum:
 		// Use %v to print numeric types and bool.
 		fmt.Fprintf(b, "%v", v)
 	case string:
@@ -151,7 +153,7 @@ func (key Key) elemString(b *bytes.Buffer, part interface{}) {
 		} else {
 			fmt.Fprint(b, nullString)
 		}
-	case NullInt64, NullFloat64, NullBool, NullNumeric:
+	case NullInt64, NullFloat64, NullBool, NullNumeric, NullProtoEnum:
 		// The above types implement fmt.Stringer.
 		fmt.Fprintf(b, "%s", v)
 	case NullString, NullDate, NullTime:

--- a/spanner/key_test.go
+++ b/spanner/key_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/civil"
+	pb "cloud.google.com/go/spanner/testdata/protos"
 	proto3 "github.com/golang/protobuf/ptypes/struct"
 	sppb "google.golang.org/genproto/googleapis/spanner/v1"
 )
@@ -233,6 +234,16 @@ func TestKey(t *testing.T) {
 			k:         Key{customKeyToError{}},
 			wantProto: nil,
 			wantStr:   `(error)`,
+		},
+		{
+			k:         Key{pb.Genre_ROCK},
+			wantProto: listValueProto(stringProto("3")),
+			wantStr:   "(ROCK)",
+		},
+		{
+			k:         Key{NullProtoEnum{pb.Genre_FOLK, true}},
+			wantProto: listValueProto(stringProto("2")),
+			wantStr:   "(FOLK)",
 		},
 	} {
 		if got := test.k.String(); got != test.wantStr {


### PR DESCRIPTION
This PR has the following changes,
1. Adds support for Enum columns in primary key and indexes.
2. Integration tests for Parameter Binding.
3. Integration tests for Proto fields and Enum columns as Primary keys.
4. Integration tests for Proto fields and Enum columns as Indexes.