### PR TITLE
fix(bigtable/bttest): correct CellsSeenCount and CellsReturnedCount calculations

### DIFF
--- a/bigtable/bttest/inmem.go
+++ b/bigtable/bttest/inmem.go
@@ -559,9 +559,6 @@ func streamRow(stream btpb.Bigtable_ReadRowsServer, r *row, f *btpb.RowFilter, s
 	}
 
 	s.RowsReturnedCount++
-	for _, f := range r.families {
-		s.CellsReturnedCount += int64(len(f.cells))
-	}
 
 	rrr := &btpb.ReadRowsResponse{}
 	families := r.sortedFamilies()
@@ -571,6 +568,7 @@ func streamRow(stream btpb.Bigtable_ReadRowsServer, r *row, f *btpb.RowFilter, s
 			if len(cells) == 0 {
 				continue
 			}
+			s.CellsReturnedCount += int64(len(cells))
 			for _, cell := range cells {
 				rrr.Chunks = append(rrr.Chunks, &btpb.ReadRowsResponse_CellChunk{
 					RowKey:          []byte(r.key),

--- a/bigtable/bttest/inmem.go
+++ b/bigtable/bttest/inmem.go
@@ -546,8 +546,11 @@ func streamRow(stream btpb.Bigtable_ReadRowsServer, r *row, f *btpb.RowFilter, s
 	r = nr
 
 	s.RowsSeenCount++
-	for _, f := range r.families {
-		s.CellsSeenCount += int64(len(f.cells))
+	// Count cells in the row before filtering for CellsSeenCount.
+	for _, fam := range r.families {
+		for _, colName := range fam.colNames {
+			s.CellsSeenCount += int64(len(fam.cells[colName]))
+		}
 	}
 
 	match, err := filterRow(f, r)


### PR DESCRIPTION
Correct how CellsSeenCount and CellsReturnedCount are calculated in the CBT emulator. The current implementation retrieves the length of the wrong map. It gives incorrect results (compared to production) for certain integration tests when emulator use is allowed.

The emulator and production still disagree on CellsSeenCount for some tests. This could be due to optimizations in production that would be out of scope for the emulator. I'll make the tests a bit more lenient in a follow-up PR.