### PR TITLE
chore(errorreporting): Refactor error in error reporting

### DIFF
--- a/errorreporting/errors.go
+++ b/errorreporting/errors.go
@@ -118,7 +118,7 @@ func NewClient(ctx context.Context, projectID string, cfg Config, opts ...option
 		for _, req := range reqs {
 			_, err = client.apiClient.ReportErrorEvent(ctx, req)
 			if err != nil {
-				client.onError(err)
+				client.onError(fmt.Errorf("report error event: %w", err))
 			}
 		}
 	})


### PR DESCRIPTION
When we don't register error handling function, error will be logged with `log.Println`.
However, since we don't add any context, it's unclear where the error is logged and what is the error for.
This PR fixes it by updating error message.
```
"2022/11/23 15:46:14 rpc error: code = PermissionDenied desc = User not authorized."
```