### PR TITLE
fix(internal/gapicgen): disable rest for non-rest APIs

### DIFF
--- a/internal/gapicgen/cmd/genbot/Dockerfile
+++ b/internal/gapicgen/cmd/genbot/Dockerfile
@@ -30,7 +30,7 @@ RUN go install github.com/golang/protobuf/protoc-gen-go@v1.5.2 && \
     go install golang.org/x/lint/golint@latest && \
     go install golang.org/x/tools/cmd/goimports@latest && \
     go install honnef.co/go/tools/cmd/staticcheck@latest && \
-    go install github.com/googleapis/gapic-generator-go/cmd/protoc-gen-go_gapic@v0.33.1
+    go install github.com/googleapis/gapic-generator-go/cmd/protoc-gen-go_gapic@v0.33.5
 ENV PATH="${PATH}:/root/go/bin"
 
 # Source: http://debuggable.com/posts/disable-strict-host-checking-for-git-clone:49896ff3-0ac0-4263-9703-1eae4834cda3

--- a/internal/gapicgen/generator/config.go
+++ b/internal/gapicgen/generator/config.go
@@ -427,6 +427,7 @@ var MicrogenGapicConfigs = []*MicrogenConfig{
 		GRPCServiceConfigPath: "agentendpoint_grpc_service_config.json",
 		ApiServiceConfigPath:  "osconfig_v1beta.yaml",
 		ReleaseLevel:          "beta",
+		Transports:            []string{"grpc"},
 	},
 	{
 		InputDirectoryPath:    "google/cloud/datacatalog/v1",
@@ -1115,6 +1116,7 @@ var MicrogenGapicConfigs = []*MicrogenConfig{
 		GRPCServiceConfigPath: "mediatranslation_grpc_service_config.json",
 		ApiServiceConfigPath:  "mediatranslation_v1beta1.yaml",
 		ReleaseLevel:          "beta",
+		Transports:            []string{"grpc"},
 	},
 	{
 		InputDirectoryPath:   "google/api/servicecontrol/v1",


### PR DESCRIPTION
fix(osconfig/agentendpoint/v1beta1): disable REST transport generation
fix(mediatranslation/v1beta1): disable REST transport generation
chore(internal/gapicgen): update microgenerator to v0.33.5

As a result of updating the generator, when `rest` is a selected transport for a package, proto services lacking a REST-enabled method will not get a REST client type generated. This will break `videointelligence/v1p3beta1` as a result. The aforementioned fixes are also breaking changes for those packages, but being in beta it is allowable.