### PR TITLE
fix: update test to be compatible with new containers

### DIFF
--- a/profiler/integration_test.go
+++ b/profiler/integration_test.go
@@ -214,7 +214,7 @@ func pstTimeStr() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to initialize PST location: %v", err)
 	}
-	return strings.Replace(time.Now().In(pst).Format("2006-01-02-15-04-05.000000-0700"), ".", "-", -1), nil
+	return strings.ToLower(strings.Replace(time.Now().In(pst).Format("2006-01-02-15-04-05.000000-MST"), ".", "-", -1)), nil
 }
 
 func TestAgentIntegration(t *testing.T) {

--- a/profiler/kokoro/integration_test.sh
+++ b/profiler/kokoro/integration_test.sh
@@ -35,20 +35,9 @@ export GCLOUD_TESTS_GOLANG_PROJECT_ID="cloud-profiler-e2e"
 
 # Ensure a newer version of Go is used so it is compatible with newer libraries.
 # Here we install v1.18.4 which is the current version as of July 2022.
-mkdir -p /tmp/bin
-GIMME=/tmp/bin/gimme
-retry curl -sL -o "$GIMME" https://raw.githubusercontent.com/travis-ci/gimme/master/gimme
-chmod +x "$GIMME"
-
-export GIMME_GO_VERSION=1.18.4
-export GIMME_ENV_PREFIX=/tmp/gimme_envs
-install_go() {
-  "$GIMME"
-  # If gimme fails, this file will not exists, source will fail, and install_go
-  # will be retried.
-  source "${GIMME_ENV_PREFIX}/go${GIMME_GO_VERSION}.env"
-}
-retry install_go
+retry curl -LO https://go.dev/dl/go1.18.4.linux-amd64.tar.gz
+sudo rm -rf /usr/local/go && tar -C /usr/local -xzf go1.18.4.linux-amd64.tar.gz
+export PATH=$PATH:/usr/local/go/bin
 
 # Run test.
 go version


### PR DESCRIPTION
Update the Go cloud profiler agent to be able to run in the new Kokoro VMs. 