### PR TITLE
fix(spanner): fallback to check grpc error message when ResourceType nil

### DIFF
--- a/spanner/session.go
+++ b/spanner/session.go
@@ -1722,7 +1722,7 @@ func isSessionNotFoundError(err error) bool {
 			return rt == sessionResourceType
 		}
 	}
-	return false
+	return strings.Contains(err.Error(), "Session not found")
 }
 
 // isClientClosing returns true if the given error is a


### PR DESCRIPTION
This will make the SessionNotFound check similar to [C++](https://github.com/googleapis/google-cloud-cpp/blob/21bad1fc7c22d472f8ba8d9194dfe54342c29e2b/google/cloud/spanner/internal/status_utils.cc#L28-L50) and [NodeJS](https://github.com/googleapis/nodejs-spanner/blob/main/src/session-pool.ts#L226) client libraries.