### PR TITLE
Fix git issue in buildscript

### DIFF
--- a/profiler/kokoro/integration_test.sh
+++ b/profiler/kokoro/integration_test.sh
@@ -30,6 +30,8 @@ set -x
 
 cd $(dirname $0)/..
 
+git config --global --add safe.directory /tmpfs/src/github/google-cloud-go
+
 export GOOGLE_APPLICATION_CREDENTIALS="${KOKORO_KEYSTORE_DIR}/72935_cloud-profiler-e2e-service-account-key"
 export GCLOUD_TESTS_GOLANG_PROJECT_ID="cloud-profiler-e2e"
 


### PR DESCRIPTION
Contains the safe directory git issue fix to resolve - 

```
go test -run TestAgentIntegration -run_only_profiler_backoff_test -timeout 1h
--- FAIL: TestAgentIntegration (0.01s)
    integration_test.go:239: failed to gather the Git revision of the current source: exit status 128
FAIL
exit status 1
```

For some reason the continuous builds did not show the explicit safe directory issue. The actual issue was revealed when a manual build was triggered. 