### PR TITLE
test(bigtable): allow read stats integration tests to use the emulator

### DIFF
--- a/bigtable/integration_test.go
+++ b/bigtable/integration_test.go
@@ -1109,10 +1109,6 @@ func TestIntegration_FullReadStats(t *testing.T) {
 	}
 	defer cleanup()
 
-	if !testEnv.Config().UseProd {
-		t.Skip("emulator doesn't support request stats")
-	}
-
 	// Insert some data.
 	initialData := map[string][]string{
 		"wmckinley":   {"tjefferson"},


### PR DESCRIPTION
This PR...

- Allows read stats integration tests to use the emulator.
- Relaxes the checks for CellsSeenCount and RowsSeenCount when using the emulator.

There are inconsistencies between production CBT and the emulator regarding how those stats are calculated.

- Sometimes prod scans fewer cells. Likely due to optimizations that allow prod to skip some cells.
- Sometimes prod scans more cells. Likely due to filter combinations consuming cells more than once.
- Both factors can apply to the same query, further complicating the outcome.

Similar effects apply for RowsSeenCount.

It would take notable effort to fully reproduce prod's calculations in the emulator. Relaxing the checks is more practical.