### PR TITLE
refactor: expand pool and connection implementations

### DIFF
--- a/bigquery/storage/managedwriter/appendresult.go
+++ b/bigquery/storage/managedwriter/appendresult.go
@@ -164,6 +164,10 @@ func (ar *AppendResult) TotalAttempts(ctx context.Context) (int, error) {
 // pendingWrite tracks state for a set of rows that are part of a single
 // append request.
 type pendingWrite struct {
+	// writer retains a reference to the origin of a pending write.  Primary
+	// used is to inform routing decisions.
+	writer *ManagedStream
+
 	request *storagepb.AppendRowsRequest
 	// for schema evolution cases, accept a new schema
 	newSchema *descriptorpb.DescriptorProto

--- a/bigquery/storage/managedwriter/client.go
+++ b/bigquery/storage/managedwriter/client.go
@@ -39,8 +39,6 @@ import (
 // does not have the project ID encoded.
 const DetectProjectID = "*detect-project-id*"
 
-const managedstreamIDPrefix = "managedstream"
-
 // Client is a managed BigQuery Storage write client scoped to a single project.
 type Client struct {
 	rawClient *storage.BigQueryWriteClient
@@ -109,7 +107,7 @@ func (c *Client) buildManagedStream(ctx context.Context, streamFunc streamClient
 	ctx, cancel := context.WithCancel(ctx)
 
 	ms := &ManagedStream{
-		id:             newUUID(managedstreamIDPrefix),
+		id:             newUUID(writerIDPrefix),
 		streamSettings: defaultStreamSettings(),
 		c:              c,
 		ctx:            ctx,

--- a/bigquery/storage/managedwriter/connection_test.go
+++ b/bigquery/storage/managedwriter/connection_test.go
@@ -66,7 +66,8 @@ func TestConnection_OpenWithRetry(t *testing.T) {
 				return nil, err
 			},
 		}
-		conn, err := pool.addConnection()
+		pool.router = newSimpleRouter(pool)
+		conn, err := pool.router.pickConnection(nil)
 		if err != nil {
 			t.Errorf("case %s, failed to add connection: %v", tc.desc, err)
 		}

--- a/bigquery/storage/managedwriter/managed_stream.go
+++ b/bigquery/storage/managedwriter/managed_stream.go
@@ -75,6 +75,9 @@ type ManagedStream struct {
 	// Unique id for the managedstream instance.
 	id string
 
+	// pool retains a reference to the writer's pool.  A writer is only associated to a single pool.
+	pool *connectionPool
+
 	streamSettings   *streamSettings
 	schemaDescriptor *descriptorpb.DescriptorProto
 	destinationTable string

--- a/bigquery/storage/managedwriter/retry.go
+++ b/bigquery/storage/managedwriter/retry.go
@@ -98,6 +98,22 @@ func newStatelessRetryer() *statelessRetryer {
 	}
 }
 
+// resolveRetry handles fetching an appropriate retry policy.  If one isn't found,
+// it defaults to a policy that allows a single attempt (no retries).
+func resolveRetry(pw *pendingWrite, pool *connectionPool) *statelessRetryer {
+	if pw != nil {
+		if pw.writer != nil {
+			return pw.writer.statelessRetryer()
+		}
+	}
+	if pool != nil {
+		return pw.writer.pool.defaultRetryer()
+	}
+	return &statelessRetryer{
+		maxAttempts: 1,
+	}
+}
+
 func (sr *statelessRetryer) pause(aggressiveBackoff bool) time.Duration {
 	jitter := sr.jitter.Nanoseconds()
 	if jitter > 0 {


### PR DESCRIPTION
This PR includes much of the rewiring of the existing ManagedStream abstraction, but doesn't cut over to the new implemention yet.

We add a reference to the origin writer as part of the `pendingWrite` which retains information about a single write request and response.  This allows us to resolve retry settings for a given write by checking if the writer has a custom retry policy.  In other cases, we use the default settings of the connection pool.

We introduce internal UUID identifiers to the core abstractions (pool, connection, writer) so that we can add observability later to see which components are responsible for processing requests.

We remove the notion of adding connections to the connectionpool contract.  Instead, we introduce a new interface in the pool called a `poolRouter`.  By interface contract, it's responsible for picking the correct connection for a given write.  However, this allows us to abstract away different implementations for pool behavior and make it the responsibility of an individual router.

Further, this PR adds the most simplistic router we'll use for the initial migration to multiplexing (`simpleRouter`): it supports a single connection, and routes all traffic to it.

This PR also moves over more internal functionality from the ManagedStream, namely `appendWithRetry()` and `lockingAppend()`.  The implementations still remain on the ManagedStream implementation at this time, we'll remove most of the functionality when we cut over to using pools/connections.

Towards: https://github.com/googleapis/google-cloud-go/issues/7103
