### PR TITLE
fix(logging): Prefer X-Cloud-Trace-Context over Traceparent

### DIFF
--- a/logging/logging.go
+++ b/logging/logging.go
@@ -729,18 +729,7 @@ func populateTraceInfo(e *Entry, req *http.Request) bool {
 			return false
 		}
 	}
-	header := req.Header.Get("Traceparent")
-	if header != "" {
-		// do not use traceSampled flag defined by traceparent because
-		// flag's definition differs from expected by Cloud Tracing
-		traceID, spanID, _ := deconstructTraceParent(header)
-		if traceID != "" {
-			e.Trace = traceID
-			e.SpanID = spanID
-			return true
-		}
-	}
-	header = req.Header.Get("X-Cloud-Trace-Context")
+	header := req.Header.Get("X-Cloud-Trace-Context")
 	if header != "" {
 		traceID, spanID, traceSampled := deconstructXCloudTraceContext(header)
 		if traceID != "" {
@@ -748,6 +737,17 @@ func populateTraceInfo(e *Entry, req *http.Request) bool {
 			e.SpanID = spanID
 			// enforce sampling if required
 			e.TraceSampled = e.TraceSampled || traceSampled
+			return true
+		}
+	}
+	header = req.Header.Get("Traceparent")
+	if header != "" {
+		// do not use traceSampled flag defined by traceparent because
+		// flag's definition differs from expected by Cloud Tracing
+		traceID, spanID, _ := deconstructTraceParent(header)
+		if traceID != "" {
+			e.Trace = traceID
+			e.SpanID = spanID
 			return true
 		}
 	}

--- a/logging/logging_test.go
+++ b/logging/logging_test.go
@@ -455,8 +455,9 @@ func TestToLogEntry(t *testing.T) {
 				},
 			},
 			want: logpb.LogEntry{
-				Trace:  "projects/P/traces/105445aa7843bc8bf206b1200010aaaa",
-				SpanId: "0000000000000aaa",
+				Trace:        "projects/P/traces/105445aa7843bc8bf206b120000000",
+				SpanId:       "0000000000000bbb",
+				TraceSampled: true,
 			},
 		},
 		{


### PR DESCRIPTION
When both X-Cloud-Trace-Context and Traceparent headers are present in the request, extract trace context from the former.

Addresses a bug identified in issue #7207.