### PR TITLE
chore: update supported versions of Go runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,10 @@ For an updated list of all of our released APIs please see our
 Our libraries are compatible with at least the three most recent, major Go
 releases. They are currently compatible with:
 
+- Go 1.20
 - Go 1.19
 - Go 1.18
 - Go 1.17
-- Go 1.16
-- Go 1.15
 
 ## Authorization
 


### PR DESCRIPTION
This change accompanies an update to the [Supported Go Versions](https://cloud.google.com/go/getting-started/supported-go-versions) policy for Cloud Client Libraries. The difference from the previous policy is specifying "App Engine Standard" instead of "App Engine". This excludes App Engine Flex from the policy. (Note that users can bring their own runtime to App Engine Flex in order to support older versions.)