### PR TITLE
chore: stop eventarc pub because package name error

### DIFF
--- a/.github/.OwlBot.yaml
+++ b/.github/.OwlBot.yaml
@@ -67,7 +67,7 @@ deep-remove-regex:
   - /domains/apiv1beta1
   - /edgecontainer/apiv1
   - /essentialcontacts/apiv1
-  - /eventarc/publishing/apiv1
+#  - /eventarc/publishing/apiv1
   - /eventarc/apiv1
   - /filestore/apiv1
   - /functions/apiv1
@@ -313,8 +313,8 @@ deep-copy-regex:
     dest: /edgecontainer/apiv1
   - source: /google/cloud/essentialcontacts/v1/cloud.google.com/go/essentialcontacts/apiv1
     dest: /essentialcontacts/apiv1
-  - source: /google/cloud/eventarc/publishing/v1/cloud.google.com/go/eventarc/publishing/apiv1
-    dest: /eventarc/publishing/apiv1
+#  - source: /google/cloud/eventarc/publishing/v1/cloud.google.com/go/eventarc/publishing/apiv1
+#   dest: /eventarc/publishing/apiv1
   - source: /google/cloud/eventarc/v1/cloud.google.com/go/eventarc/apiv1
     dest: /eventarc/apiv1
   - source: /google/cloud/filestore/v1/cloud.google.com/go/filestore/apiv1


### PR DESCRIPTION
https://github.com/googleapis/google-cloud-go/issues/7366
