### PR TITLE
 fix(internal/postprocessor): do not change PR title if OwlBot api-name placeholder not present

### DIFF
--- a/internal/postprocessor/main.go
+++ b/internal/postprocessor/main.go
@@ -405,6 +405,10 @@ func extractHashFromLine(line string) string {
 func updateCommitTitle(title, titlePkg string) string {
 	var newTitle string
 
+	if !strings.Contains(title, apiNameOwlBotScope) {
+		return title
+	}
+
 	firstTitlePart := firstPartTitlePattern.ReplaceAllString(title, "$titleFirstPart")
 	secondTitlePart := secondPartTitlePattern.ReplaceAllString(title, "$titleSecondPart")
 

--- a/internal/postprocessor/main_test.go
+++ b/internal/postprocessor/main_test.go
@@ -63,86 +63,111 @@ func TestProcessCommit(t *testing.T) {
 			title: "feat: [REPLACEME] Adds named reservation to InstancePolicy",
 			body: `- [ ] Regenerate this pull request now.
 
----
-docs:Remove "not yet implemented" for Accelerator & Refine Volume API docs
+					---
+					docs:Remove "not yet implemented" for Accelerator & Refine Volume API docs
 
----
-docs: update the job id format requirement
+					---
+					docs: update the job id format requirement
 
-PiperOrigin-RevId: 489502315
+					PiperOrigin-RevId: 489502315
 
-Source-Link: https://togithub.com/googleapis/googleapis/commit/db1cc1139fe0def1e87ead1fffbc5bedbeccb887
+					Source-Link: https://togithub.com/googleapis/googleapis/commit/db1cc1139fe0def1e87ead1fffbc5bedbeccb887
 
-Source-Link: https://togithub.com/googleapis/googleapis-gen/commit/fcc564ef064c7dff31d7970e12318ad084703ac6
-Copy-Tag: eyJwIjoiamF2YS1iYXRjaC8uT3dsQm90LnlhbWwiLCJoIjoiZmNjNTY0ZWYwNjRjN2RmZjMxZDc5NzBlMTIzMThhZDA4NDcwM2FjNiJ9
+					Source-Link: https://togithub.com/googleapis/googleapis-gen/commit/fcc564ef064c7dff31d7970e12318ad084703ac6
+					Copy-Tag: eyJwIjoiamF2YS1iYXRjaC8uT3dsQm90LnlhbWwiLCJoIjoiZmNjNTY0ZWYwNjRjN2RmZjMxZDc5NzBlMTIzMThhZDA4NDcwM2FjNiJ9
 
-BEGIN_NESTED_COMMIT
-feat: [REPLACEME] Adds named reservation to InstancePolicy
----
-docs:Remove "not yet implemented" for Accelerator & Refine Volume API docs
+					BEGIN_NESTED_COMMIT
+					feat: [REPLACEME] Adds named reservation to InstancePolicy
+					---
+					docs:Remove "not yet implemented" for Accelerator & Refine Volume API docs
 
----
-docs: update the job id format requirement
+					---
+					docs: update the job id format requirement
 
-PiperOrigin-RevId: 489501779
+					PiperOrigin-RevId: 489501779
 
-Source-Link: https://togithub.com/googleapis/googleapis/commit/488a4bdeebf9c7f505f48bed23f0b95fcbbec0bb
+					Source-Link: https://togithub.com/googleapis/googleapis/commit/488a4bdeebf9c7f505f48bed23f0b95fcbbec0bb
 
-Source-Link: https://togithub.com/googleapis/googleapis-gen/commit/5b3d3a550015e9367ad13ee5f9febe0c3f84cf33
-Copy-Tag: eyJwIjoiamF2YS1iYXRjaC8uT3dsQm90LnlhbWwiLCJoIjoiNWIzZDNhNTUwMDE1ZTkzNjdhZDEzZWU1ZjlmZWJlMGMzZjg0Y2YzMyJ9
-END_NESTED_COMMIT`,
+					Source-Link: https://togithub.com/googleapis/googleapis-gen/commit/5b3d3a550015e9367ad13ee5f9febe0c3f84cf33
+					Copy-Tag: eyJwIjoiamF2YS1iYXRjaC8uT3dsQm90LnlhbWwiLCJoIjoiNWIzZDNhNTUwMDE1ZTkzNjdhZDEzZWU1ZjlmZWJlMGMzZjg0Y2YzMyJ9
+					END_NESTED_COMMIT`,
 			want: "feat(batch): Adds named reservation to InstancePolicy",
 			want1: `- [ ] Regenerate this pull request now.
 
----
-docs:Remove "not yet implemented" for Accelerator & Refine Volume API docs
+					---
+					docs:Remove "not yet implemented" for Accelerator & Refine Volume API docs
 
----
-docs: update the job id format requirement
+					---
+					docs: update the job id format requirement
 
-PiperOrigin-RevId: 489502315
+					PiperOrigin-RevId: 489502315
 
-Source-Link: https://togithub.com/googleapis/googleapis/commit/db1cc1139fe0def1e87ead1fffbc5bedbeccb887
+					Source-Link: https://togithub.com/googleapis/googleapis/commit/db1cc1139fe0def1e87ead1fffbc5bedbeccb887
 
-Source-Link: https://togithub.com/googleapis/googleapis-gen/commit/fcc564ef064c7dff31d7970e12318ad084703ac6
-Copy-Tag: eyJwIjoiamF2YS1iYXRjaC8uT3dsQm90LnlhbWwiLCJoIjoiZmNjNTY0ZWYwNjRjN2RmZjMxZDc5NzBlMTIzMThhZDA4NDcwM2FjNiJ9
+					Source-Link: https://togithub.com/googleapis/googleapis-gen/commit/fcc564ef064c7dff31d7970e12318ad084703ac6
+					Copy-Tag: eyJwIjoiamF2YS1iYXRjaC8uT3dsQm90LnlhbWwiLCJoIjoiZmNjNTY0ZWYwNjRjN2RmZjMxZDc5NzBlMTIzMThhZDA4NDcwM2FjNiJ9
 
-BEGIN_NESTED_COMMIT
-feat: Adds named reservation to InstancePolicy
----
-docs:Remove "not yet implemented" for Accelerator & Refine Volume API docs
+					BEGIN_NESTED_COMMIT
+					feat: Adds named reservation to InstancePolicy
+					---
+					docs:Remove "not yet implemented" for Accelerator & Refine Volume API docs
 
----
-docs: update the job id format requirement
+					---
+					docs: update the job id format requirement
 
-PiperOrigin-RevId: 489501779
+					PiperOrigin-RevId: 489501779
 
-Source-Link: https://togithub.com/googleapis/googleapis/commit/488a4bdeebf9c7f505f48bed23f0b95fcbbec0bb
+					Source-Link: https://togithub.com/googleapis/googleapis/commit/488a4bdeebf9c7f505f48bed23f0b95fcbbec0bb
 
-Source-Link: https://togithub.com/googleapis/googleapis-gen/commit/5b3d3a550015e9367ad13ee5f9febe0c3f84cf33
-Copy-Tag: eyJwIjoiamF2YS1iYXRjaC8uT3dsQm90LnlhbWwiLCJoIjoiNWIzZDNhNTUwMDE1ZTkzNjdhZDEzZWU1ZjlmZWJlMGMzZjg0Y2YzMyJ9
-END_NESTED_COMMIT`,
+					Source-Link: https://togithub.com/googleapis/googleapis-gen/commit/5b3d3a550015e9367ad13ee5f9febe0c3f84cf33
+					Copy-Tag: eyJwIjoiamF2YS1iYXRjaC8uT3dsQm90LnlhbWwiLCJoIjoiNWIzZDNhNTUwMDE1ZTkzNjdhZDEzZWU1ZjlmZWJlMGMzZjg0Y2YzMyJ9
+					END_NESTED_COMMIT`,
 		},
 		{
 			name:  "test nested client scope",
 			title: "feat: [REPLACEME] added JSON_PACKAGE field to ExportAgentRequest",
 			body: `- [ ] Regenerate this pull request now.
 
-			PiperOrigin-RevId: 504031208
+					PiperOrigin-RevId: 504031208
 
-			Source-Link: https://github.com/googleapis/googleapis/commit/c6af392b613b435757358fac555628d84e443abd
-			
-			Source-Link: googleapis/googleapis-gen@7849764
-			Copy-Tag: eyJwIjoiLmdpdGh1Yi8uT3dsQm90LnlhbWwiLCJoIjoiNzg0OTc2NDc3NzYyZDk4YTljMzA4MzRkYzQ1ODVkODE1YWYyZmJmYiJ9`,
+					Source-Link: https://github.com/googleapis/googleapis/commit/c6af392b613b435757358fac555628d84e443abd
+
+					Source-Link: googleapis/googleapis-gen@7849764
+					Copy-Tag: eyJwIjoiLmdpdGh1Yi8uT3dsQm90LnlhbWwiLCJoIjoiNzg0OTc2NDc3NzYyZDk4YTljMzA4MzRkYzQ1ODVkODE1YWYyZmJmYiJ9`,
 			want: "feat(dialogflow/cx): added JSON_PACKAGE field to ExportAgentRequest",
 			want1: `- [ ] Regenerate this pull request now.
 
-			PiperOrigin-RevId: 504031208
+					PiperOrigin-RevId: 504031208
 
-			Source-Link: https://github.com/googleapis/googleapis/commit/c6af392b613b435757358fac555628d84e443abd
-			
-			Source-Link: googleapis/googleapis-gen@7849764
-			Copy-Tag: eyJwIjoiLmdpdGh1Yi8uT3dsQm90LnlhbWwiLCJoIjoiNzg0OTc2NDc3NzYyZDk4YTljMzA4MzRkYzQ1ODVkODE1YWYyZmJmYiJ9`,
+					Source-Link: https://github.com/googleapis/googleapis/commit/c6af392b613b435757358fac555628d84e443abd
+
+					Source-Link: googleapis/googleapis-gen@7849764
+					Copy-Tag: eyJwIjoiLmdpdGh1Yi8uT3dsQm90LnlhbWwiLCJoIjoiNzg0OTc2NDc3NzYyZDk4YTljMzA4MzRkYzQ1ODVkODE1YWYyZmJmYiJ9`,
+		},
+		{
+			name:  "title does not contain apiNameOwlBotScope",
+			title: "feat(batch): support custom scopes for service account in v1",
+			body: `- [ ] Regenerate this pull request now.
+					feat: Add boot disk field in InstanceStatus
+
+					feat: Add boot disk and image source fields to v1 InstancePolicy
+					PiperOrigin-RevId: 507014772
+
+					Source-Link: https://github.com/googleapis/googleapis/commit/9d6497f0f81f000562fc4fc5df8c4fcc8e09e864
+
+					Source-Link: googleapis/googleapis-gen@13ef8a3
+					Copy-Tag: eyJwIjoiLmdpdGh1Yi8uT3dsQm90LnlhbWwiLCJoIjoiMTNlZjhhM2I3ZWZlYjQ1ODY2ZWJjZWEzODBkZmQ2YTQzZWU1ZDQ4NiJ9`,
+			want: "feat(batch): support custom scopes for service account in v1",
+			want1: `- [ ] Regenerate this pull request now.
+					feat: Add boot disk field in InstanceStatus
+
+					feat: Add boot disk and image source fields to v1 InstancePolicy
+					PiperOrigin-RevId: 507014772
+
+					Source-Link: https://github.com/googleapis/googleapis/commit/9d6497f0f81f000562fc4fc5df8c4fcc8e09e864
+
+					Source-Link: googleapis/googleapis-gen@13ef8a3
+					Copy-Tag: eyJwIjoiLmdpdGh1Yi8uT3dsQm90LnlhbWwiLCJoIjoiMTNlZjhhM2I3ZWZlYjQ1ODY2ZWJjZWEzODBkZmQ2YTQzZWU1ZDQ4NiJ9`,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
This change adds a check to see if the OwlBot-inserted api-name is present in the PR title. If not, it leaves the title as-is.