### PR TITLE
chore(internal/gapicgen): reduce openssh build reqs

### DIFF
--- a/internal/gapicgen/cmd/genbot/Dockerfile
+++ b/internal/gapicgen/cmd/genbot/Dockerfile
@@ -8,7 +8,7 @@ ENV GO111MODULE on
 RUN apk update && \
     apk add ca-certificates wget git unzip
 # Install bash and ssh tools (needed to run regen.sh etc).
-RUN apk add bash openssh openssh-client build-base
+RUN apk add bash openssh-client build-base
 RUN which bash
 
 # Install libc compatibility (required by protoc and go)


### PR DESCRIPTION
This will cause the container to build but not sure it will have enough of openssh installed for build to git push -- but I think it will.

Updates: #7394