### PR TITLE
chore(internal/gapicgen): fix dockerfile build

### DIFF
--- a/internal/gapicgen/cmd/genbot/Dockerfile
+++ b/internal/gapicgen/cmd/genbot/Dockerfile
@@ -1,3 +1,6 @@
+FROM golang:1.20-alpine as godist
+RUN go version
+
 FROM docker:20.10
 
 # Log the version of Alpine in use.
@@ -18,10 +21,8 @@ RUN apk add libc6-compat
 RUN apk add protoc protobuf-dev
 RUN protoc --version
 
-# Install Go...quietly.
-RUN wget -O /tmp/go.tgz https://dl.google.com/go/go1.20.linux-amd64.tar.gz -q && \
-    tar -C /usr/local -xzf /tmp/go.tgz && \
-    rm /tmp/go.tgz
+# Copy pre-built alpine Go
+COPY --from=godist /usr/local/go /usr/local/go
 ENV PATH /usr/local/go/bin:$PATH
 RUN go version
 


### PR DESCRIPTION
With the release of 1.20 golang no longer ships a bunch of stuff pre-compiled, see: https://tip.golang.org/doc/go1.20

This seems to mean non-glibc distros like alpine are harder to use Go with. From what I am seeing you basically need to build from source. That is a decent number of steps to get all the deps right so lets copy the go binary from the offical image for now. Was getting the error: Error loading shared library libresolv.so.2