### PR TITLE
testing: update build_samples.sh to reflect new documentai sample module

### DIFF
--- a/internal/kokoro/build_samples.sh
+++ b/internal/kokoro/build_samples.sh
@@ -59,6 +59,7 @@ for i in $(find . -name go.mod); do
   go mod edit -replace cloud.google.com/go/bigtable=$gcwd/bigtable
   go mod edit -replace cloud.google.com/go/bigquery=$gcwd/bigquery
   go mod edit -replace cloud.google.com/go/datastore=$gcwd/datastore
+  go mod edit -replace cloud.google.com/go/documentai=$gcwd/documentai
   go mod edit -replace cloud.google.com/go/firestore=$gcwd/firestore
   go mod edit -replace cloud.google.com/go/logging=$gcwd/logging
   go mod edit -replace cloud.google.com/go/pubsub=$gcwd/pubsub


### PR DESCRIPTION
https://github.com/GoogleCloudPlatform/golang-samples/pull/2857 promoted the documentai directory in golang-samples to be it's own module.  This PR updates the builder in google-cloud-go to align with that change.