### PR TITLE
refactor: augment poolRouter interface (and simpleRouter)

### DIFF
--- a/bigquery/storage/managedwriter/connection.go
+++ b/bigquery/storage/managedwriter/connection.go
@@ -76,14 +76,14 @@ func (pool *connectionPool) addWriter(writer *ManagedStream) error {
 	if pool.router != nil {
 		return pool.router.writerAttach(writer)
 	}
-	return nil
+	return fmt.Errorf("no router for pool")
 }
 
 func (pool *connectionPool) removeWriter(writer *ManagedStream) error {
 	if pool.router != nil {
 		return pool.router.writerDetach(writer)
 	}
-	return nil
+	return fmt.Errorf("no router for pool")
 }
 
 // openWithRetry establishes a new bidi stream and channel pair.  It is used by connection objects

--- a/bigquery/storage/managedwriter/connection.go
+++ b/bigquery/storage/managedwriter/connection.go
@@ -416,6 +416,8 @@ func (rtr *simpleRouter) detachWriter(writer *ManagedStream) error {
 }
 
 func (rtr *simpleRouter) pickConnection(pw *pendingWrite) (*connection, error) {
+	rtr.mu.RLock()
+	defer rtr.mu.RUnlock()
 	if rtr.conn != nil {
 		return rtr.conn, nil
 	}

--- a/bigquery/storage/managedwriter/connection_test.go
+++ b/bigquery/storage/managedwriter/connection_test.go
@@ -67,6 +67,8 @@ func TestConnection_OpenWithRetry(t *testing.T) {
 			},
 		}
 		pool.router = newSimpleRouter(pool)
+		writer := &ManagedStream{id: "foo"}
+		pool.addWriter(writer)
 		conn, err := pool.router.pickConnection(nil)
 		if err != nil {
 			t.Errorf("case %s, failed to add connection: %v", tc.desc, err)
@@ -86,5 +88,40 @@ func TestConnection_OpenWithRetry(t *testing.T) {
 				t.Errorf("case %s: expected channel, got nil", tc.desc)
 			}
 		}
+	}
+}
+
+func TestSimpleRouter(t *testing.T) {
+
+	ctx := context.Background()
+
+	pool := &connectionPool{
+		ctx: ctx,
+		open: func(opts ...gax.CallOption) (storagepb.BigQueryWrite_AppendRowsClient, error) {
+			return &testAppendRowsClient{}, nil
+		},
+	}
+	// TODO: switch to attach semantics in future PR.
+	pool.router = newSimpleRouter(pool)
+	pw := newPendingWrite(ctx, [][]byte{[]byte("foo")})
+	// picking before attaching should yield error
+	if _, err := pool.router.pickConnection(pw); err == nil {
+		t.Errorf("pickConnection: expected error, got success")
+	}
+	writer := &ManagedStream{
+		id:   "writer",
+		pool: pool,
+	}
+	if err := pool.addWriter(writer); err != nil {
+		t.Errorf("addWriter: %v", err)
+	}
+	if _, err := pool.router.pickConnection(pw); err != nil {
+		t.Errorf("pickConnection error: %v", err)
+	}
+	if err := pool.disconnectWriter(writer); err != nil {
+		t.Errorf("disconnectWriter: %v", err)
+	}
+	if _, err := pool.router.pickConnection(pw); err == nil {
+		t.Errorf("pickConnection: expected error, got success")
 	}
 }

--- a/bigquery/storage/managedwriter/connection_test.go
+++ b/bigquery/storage/managedwriter/connection_test.go
@@ -118,7 +118,7 @@ func TestSimpleRouter(t *testing.T) {
 	if _, err := pool.router.pickConnection(pw); err != nil {
 		t.Errorf("pickConnection error: %v", err)
 	}
-	if err := pool.disconnectWriter(writer); err != nil {
+	if err := pool.removeWriter(writer); err != nil {
 		t.Errorf("disconnectWriter: %v", err)
 	}
 	if _, err := pool.router.pickConnection(pw); err == nil {


### PR DESCRIPTION
This PR extends the poolRouter interface to include more lifecycle signalling:
* when a router takes control of it's connectionPool
* when a connection pool is going away
* when a writer is attached to the pool
* when a writer is detached from the pool

The core problem this addresses is proper shutdown between the components.  We need to propagate this information to shutdown cleanly so that connections can go away in response to their writers.

This PR also augments our existing simpleRouter to adhere to the enlarged interface contract.  The pool attach/detach events are left unimplemented as we need to plumb this in when we wire up the abstractions end to end, which will happen when we rewire the internals to use the new abstractions.

A test has been added to assert simpleRouter state when writers are attached and removed.

Towards: https://github.com/googleapis/google-cloud-go/issues/7103