### PR TITLE
refactor: switch from syntax to presence checks

### DIFF
--- a/bigquery/storage/managedwriter/adapt/protoconversion.go
+++ b/bigquery/storage/managedwriter/adapt/protoconversion.go
@@ -384,34 +384,30 @@ func normalizeDescriptorInternal(in protoreflect.MessageDescriptor, visitedTypes
 	for i := 0; i < in.Fields().Len(); i++ {
 		inField := in.Fields().Get(i)
 		resultFDP := protodesc.ToFieldDescriptorProto(inField)
-		// For proto3 messages without presence, use proto2 default values to match proto3
-		// behavior in default values.
-		if inField.Syntax() == protoreflect.Proto3 && inField.Cardinality() != protoreflect.Repeated {
-			// Only set default value if there's no field presence.
-			if resultFDP.Proto3Optional == nil || !resultFDP.GetProto3Optional() {
-				switch resultFDP.GetType() {
-				case descriptorpb.FieldDescriptorProto_TYPE_BOOL:
-					resultFDP.DefaultValue = proto.String("false")
-				case descriptorpb.FieldDescriptorProto_TYPE_BYTES, descriptorpb.FieldDescriptorProto_TYPE_STRING:
-					resultFDP.DefaultValue = proto.String("")
-				case descriptorpb.FieldDescriptorProto_TYPE_ENUM:
-					// Resolve the proto3 default value.  The default value should be the value name.
-					defValue := inField.Enum().Values().ByNumber(inField.Default().Enum())
-					resultFDP.DefaultValue = proto.String(string(defValue.Name()))
-				case descriptorpb.FieldDescriptorProto_TYPE_DOUBLE,
-					descriptorpb.FieldDescriptorProto_TYPE_FLOAT,
-					descriptorpb.FieldDescriptorProto_TYPE_INT64,
-					descriptorpb.FieldDescriptorProto_TYPE_UINT64,
-					descriptorpb.FieldDescriptorProto_TYPE_INT32,
-					descriptorpb.FieldDescriptorProto_TYPE_FIXED64,
-					descriptorpb.FieldDescriptorProto_TYPE_FIXED32,
-					descriptorpb.FieldDescriptorProto_TYPE_UINT32,
-					descriptorpb.FieldDescriptorProto_TYPE_SFIXED32,
-					descriptorpb.FieldDescriptorProto_TYPE_SFIXED64,
-					descriptorpb.FieldDescriptorProto_TYPE_SINT32,
-					descriptorpb.FieldDescriptorProto_TYPE_SINT64:
-					resultFDP.DefaultValue = proto.String("0")
-				}
+		// For messages without explicit presence, use default values to match implicit presence behavior.
+		if !inField.HasPresence() && inField.Cardinality() != protoreflect.Repeated {
+			switch resultFDP.GetType() {
+			case descriptorpb.FieldDescriptorProto_TYPE_BOOL:
+				resultFDP.DefaultValue = proto.String("false")
+			case descriptorpb.FieldDescriptorProto_TYPE_BYTES, descriptorpb.FieldDescriptorProto_TYPE_STRING:
+				resultFDP.DefaultValue = proto.String("")
+			case descriptorpb.FieldDescriptorProto_TYPE_ENUM:
+				// Resolve the proto3 default value.  The default value should be the value name.
+				defValue := inField.Enum().Values().ByNumber(inField.Default().Enum())
+				resultFDP.DefaultValue = proto.String(string(defValue.Name()))
+			case descriptorpb.FieldDescriptorProto_TYPE_DOUBLE,
+				descriptorpb.FieldDescriptorProto_TYPE_FLOAT,
+				descriptorpb.FieldDescriptorProto_TYPE_INT64,
+				descriptorpb.FieldDescriptorProto_TYPE_UINT64,
+				descriptorpb.FieldDescriptorProto_TYPE_INT32,
+				descriptorpb.FieldDescriptorProto_TYPE_FIXED64,
+				descriptorpb.FieldDescriptorProto_TYPE_FIXED32,
+				descriptorpb.FieldDescriptorProto_TYPE_UINT32,
+				descriptorpb.FieldDescriptorProto_TYPE_SFIXED32,
+				descriptorpb.FieldDescriptorProto_TYPE_SFIXED64,
+				descriptorpb.FieldDescriptorProto_TYPE_SINT32,
+				descriptorpb.FieldDescriptorProto_TYPE_SINT64:
+				resultFDP.DefaultValue = proto.String("0")
 			}
 		}
 		// Clear proto3 optional annotation, as the backend converter can


### PR DESCRIPTION
Added in response to internal cl/514925348, which is trying to deprecate syntax version checking in favor of capability checks.