### PR TITLE
feat(spanner/spansql): support grant/revoke view, change stream, table function

### DIFF
--- a/spanner/spansql/parser.go
+++ b/spanner/spansql/parser.go
@@ -1351,6 +1351,12 @@ func (p *parser) parseGrantRole() (*GrantRole, *parseError) {
 			return nil, err
 		}
 		g.GrantRoleNames = roleList
+	} else if p.eat("EXECUTE", "ON", "TABLE", "FUNCTION") {
+		tvfList, err := p.parseGrantOrRevokeRoleList("TO")
+		if err != nil {
+			return nil, err
+		}
+		g.TvfNames = tvfList
 	} else {
 		var privs []Privilege
 		privs, err := p.parsePrivileges()
@@ -1392,6 +1398,12 @@ func (p *parser) parseRevokeRole() (*RevokeRole, *parseError) {
 			return nil, err
 		}
 		r.RevokeRoleNames = roleList
+	} else if p.eat("EXECUTE", "ON", "TABLE", "FUNCTION") {
+		tvfList, err := p.parseGrantOrRevokeRoleList("FROM")
+		if err != nil {
+			return nil, err
+		}
+		r.TvfNames = tvfList
 	} else {
 		var privs []Privilege
 		privs, err := p.parsePrivileges()

--- a/spanner/spansql/parser.go
+++ b/spanner/spansql/parser.go
@@ -1357,6 +1357,18 @@ func (p *parser) parseGrantRole() (*GrantRole, *parseError) {
 			return nil, err
 		}
 		g.TvfNames = tvfList
+	} else if p.eat("SELECT", "ON", "VIEW") {
+		viewList, err := p.parseGrantOrRevokeRoleList("TO")
+		if err != nil {
+			return nil, err
+		}
+		g.ViewNames = viewList
+	} else if p.eat("SELECT", "ON", "CHANGE", "STREAM") {
+		csList, err := p.parseGrantOrRevokeRoleList("TO")
+		if err != nil {
+			return nil, err
+		}
+		g.ChangeStreamNames = csList
 	} else {
 		var privs []Privilege
 		privs, err := p.parsePrivileges()
@@ -1404,6 +1416,18 @@ func (p *parser) parseRevokeRole() (*RevokeRole, *parseError) {
 			return nil, err
 		}
 		r.TvfNames = tvfList
+	} else if p.eat("SELECT", "ON", "VIEW") {
+		viewList, err := p.parseGrantOrRevokeRoleList("FROM")
+		if err != nil {
+			return nil, err
+		}
+		r.ViewNames = viewList
+	} else if p.eat("SELECT", "ON", "CHANGE", "STREAM") {
+		csList, err := p.parseGrantOrRevokeRoleList("FROM")
+		if err != nil {
+			return nil, err
+		}
+		r.ChangeStreamNames = csList
 	} else {
 		var privs []Privilege
 		privs, err := p.parsePrivileges()

--- a/spanner/spansql/parser_test.go
+++ b/spanner/spansql/parser_test.go
@@ -676,6 +676,8 @@ func TestParseDDL(t *testing.T) {
 		GRANT SELECT(name, level, location), UPDATE(location) ON TABLE employees, contractors TO ROLE hr_manager;
 		GRANT ROLE pii_access, pii_update TO ROLE hr_manager, hr_director;
 		GRANT EXECUTE ON TABLE FUNCTION tvf_name_one, tvf_name_two TO ROLE hr_manager, hr_director;
+		GRANT SELECT ON VIEW view_name_one, view_name_two TO ROLE hr_manager, hr_director;
+		GRANT SELECT ON CHANGE STREAM cs_name_one, cs_name_two TO ROLE hr_manager, hr_director;
 
 		REVOKE SELECT ON TABLE employees FROM ROLE hr_rep;
 		REVOKE SELECT(name, address, phone) ON TABLE contractors FROM ROLE hr_rep;
@@ -683,6 +685,8 @@ func TestParseDDL(t *testing.T) {
 		REVOKE SELECT(name, level, location), UPDATE(location) ON TABLE employees, contractors FROM ROLE hr_manager;
 		REVOKE ROLE pii_access, pii_update FROM ROLE hr_manager, hr_director;
 		REVOKE EXECUTE ON TABLE FUNCTION tvf_name_one, tvf_name_two FROM ROLE hr_manager, hr_director;
+		REVOKE SELECT ON VIEW view_name_one, view_name_two FROM ROLE hr_manager, hr_director;
+		REVOKE SELECT ON CHANGE STREAM cs_name_one, cs_name_two FROM ROLE hr_manager, hr_director;
 
 		ALTER INDEX MyFirstIndex ADD STORED COLUMN UpdatedAt;
 		ALTER INDEX MyFirstIndex DROP STORED COLUMN UpdatedAt;
@@ -1028,6 +1032,18 @@ func TestParseDDL(t *testing.T) {
 
 				Position: line(92),
 			},
+			&GrantRole{
+				ToRoleNames: []ID{"hr_manager", "hr_director"},
+				ViewNames:   []ID{"view_name_one", "view_name_two"},
+
+				Position: line(93),
+			},
+			&GrantRole{
+				ToRoleNames:       []ID{"hr_manager", "hr_director"},
+				ChangeStreamNames: []ID{"cs_name_one", "cs_name_two"},
+
+				Position: line(94),
+			},
 			&RevokeRole{
 				FromRoleNames: []ID{"hr_rep"},
 				Privileges: []Privilege{
@@ -1035,7 +1051,7 @@ func TestParseDDL(t *testing.T) {
 				},
 				TableNames: []ID{"employees"},
 
-				Position: line(94),
+				Position: line(96),
 			},
 			&RevokeRole{
 				FromRoleNames: []ID{"hr_rep"},
@@ -1044,7 +1060,7 @@ func TestParseDDL(t *testing.T) {
 				},
 				TableNames: []ID{"contractors"},
 
-				Position: line(95),
+				Position: line(97),
 			},
 			&RevokeRole{
 				FromRoleNames: []ID{"hr_manager"},
@@ -1055,7 +1071,7 @@ func TestParseDDL(t *testing.T) {
 				},
 				TableNames: []ID{"employees"},
 
-				Position: line(96),
+				Position: line(98),
 			},
 			&RevokeRole{
 				FromRoleNames: []ID{"hr_manager"},
@@ -1065,29 +1081,41 @@ func TestParseDDL(t *testing.T) {
 				},
 				TableNames: []ID{"employees", "contractors"},
 
-				Position: line(97),
+				Position: line(99),
 			},
 			&RevokeRole{
 				FromRoleNames:   []ID{"hr_manager", "hr_director"},
 				RevokeRoleNames: []ID{"pii_access", "pii_update"},
 
-				Position: line(98),
+				Position: line(100),
 			},
 			&RevokeRole{
 				FromRoleNames: []ID{"hr_manager", "hr_director"},
 				TvfNames:      []ID{"tvf_name_one", "tvf_name_two"},
 
-				Position: line(99),
+				Position: line(101),
+			},
+			&RevokeRole{
+				FromRoleNames: []ID{"hr_manager", "hr_director"},
+				ViewNames:     []ID{"view_name_one", "view_name_two"},
+
+				Position: line(102),
+			},
+			&RevokeRole{
+				FromRoleNames:     []ID{"hr_manager", "hr_director"},
+				ChangeStreamNames: []ID{"cs_name_one", "cs_name_two"},
+
+				Position: line(103),
 			},
 			&AlterIndex{
 				Name:       "MyFirstIndex",
 				Alteration: AddStoredColumn{Name: "UpdatedAt"},
-				Position:   line(101),
+				Position:   line(105),
 			},
 			&AlterIndex{
 				Name:       "MyFirstIndex",
 				Alteration: DropStoredColumn{Name: "UpdatedAt"},
-				Position:   line(102),
+				Position:   line(106),
 			},
 		}, Comments: []*Comment{
 			{
@@ -1124,7 +1152,7 @@ func TestParseDDL(t *testing.T) {
 			{Marker: "--", Isolated: true, Start: line(75), End: line(75), Text: []string{"Table has a column with a default value."}},
 
 			// Comment after everything else.
-			{Marker: "--", Isolated: true, Start: line(104), End: line(104), Text: []string{"Trailing comment at end of file."}},
+			{Marker: "--", Isolated: true, Start: line(108), End: line(108), Text: []string{"Trailing comment at end of file."}},
 		}}},
 		// No trailing comma:
 		{`ALTER TABLE T ADD COLUMN C2 INT64`, &DDL{Filename: "filename", List: []DDLStmt{

--- a/spanner/spansql/parser_test.go
+++ b/spanner/spansql/parser_test.go
@@ -675,12 +675,14 @@ func TestParseDDL(t *testing.T) {
 		GRANT SELECT, UPDATE(location), DELETE ON TABLE employees TO ROLE hr_manager;
 		GRANT SELECT(name, level, location), UPDATE(location) ON TABLE employees, contractors TO ROLE hr_manager;
 		GRANT ROLE pii_access, pii_update TO ROLE hr_manager, hr_director;
+		GRANT EXECUTE ON TABLE FUNCTION tvf_name_one, tvf_name_two TO ROLE hr_manager, hr_director;
 
 		REVOKE SELECT ON TABLE employees FROM ROLE hr_rep;
 		REVOKE SELECT(name, address, phone) ON TABLE contractors FROM ROLE hr_rep;
 		REVOKE SELECT, UPDATE(location), DELETE ON TABLE employees FROM ROLE hr_manager;
 		REVOKE SELECT(name, level, location), UPDATE(location) ON TABLE employees, contractors FROM ROLE hr_manager;
 		REVOKE ROLE pii_access, pii_update FROM ROLE hr_manager, hr_director;
+		REVOKE EXECUTE ON TABLE FUNCTION tvf_name_one, tvf_name_two FROM ROLE hr_manager, hr_director;
 
 		ALTER INDEX MyFirstIndex ADD STORED COLUMN UpdatedAt;
 		ALTER INDEX MyFirstIndex DROP STORED COLUMN UpdatedAt;
@@ -1020,6 +1022,12 @@ func TestParseDDL(t *testing.T) {
 
 				Position: line(91),
 			},
+			&GrantRole{
+				ToRoleNames: []ID{"hr_manager", "hr_director"},
+				TvfNames:    []ID{"tvf_name_one", "tvf_name_two"},
+
+				Position: line(92),
+			},
 			&RevokeRole{
 				FromRoleNames: []ID{"hr_rep"},
 				Privileges: []Privilege{
@@ -1027,7 +1035,7 @@ func TestParseDDL(t *testing.T) {
 				},
 				TableNames: []ID{"employees"},
 
-				Position: line(93),
+				Position: line(94),
 			},
 			&RevokeRole{
 				FromRoleNames: []ID{"hr_rep"},
@@ -1036,7 +1044,7 @@ func TestParseDDL(t *testing.T) {
 				},
 				TableNames: []ID{"contractors"},
 
-				Position: line(94),
+				Position: line(95),
 			},
 			&RevokeRole{
 				FromRoleNames: []ID{"hr_manager"},
@@ -1047,7 +1055,7 @@ func TestParseDDL(t *testing.T) {
 				},
 				TableNames: []ID{"employees"},
 
-				Position: line(95),
+				Position: line(96),
 			},
 			&RevokeRole{
 				FromRoleNames: []ID{"hr_manager"},
@@ -1057,23 +1065,29 @@ func TestParseDDL(t *testing.T) {
 				},
 				TableNames: []ID{"employees", "contractors"},
 
-				Position: line(96),
+				Position: line(97),
 			},
 			&RevokeRole{
 				FromRoleNames:   []ID{"hr_manager", "hr_director"},
 				RevokeRoleNames: []ID{"pii_access", "pii_update"},
 
-				Position: line(97),
+				Position: line(98),
+			},
+			&RevokeRole{
+				FromRoleNames: []ID{"hr_manager", "hr_director"},
+				TvfNames:      []ID{"tvf_name_one", "tvf_name_two"},
+
+				Position: line(99),
 			},
 			&AlterIndex{
 				Name:       "MyFirstIndex",
 				Alteration: AddStoredColumn{Name: "UpdatedAt"},
-				Position:   line(99),
+				Position:   line(101),
 			},
 			&AlterIndex{
 				Name:       "MyFirstIndex",
 				Alteration: DropStoredColumn{Name: "UpdatedAt"},
-				Position:   line(100),
+				Position:   line(102),
 			},
 		}, Comments: []*Comment{
 			{
@@ -1110,7 +1124,7 @@ func TestParseDDL(t *testing.T) {
 			{Marker: "--", Isolated: true, Start: line(75), End: line(75), Text: []string{"Table has a column with a default value."}},
 
 			// Comment after everything else.
-			{Marker: "--", Isolated: true, Start: line(102), End: line(102), Text: []string{"Trailing comment at end of file."}},
+			{Marker: "--", Isolated: true, Start: line(104), End: line(104), Text: []string{"Trailing comment at end of file."}},
 		}}},
 		// No trailing comma:
 		{`ALTER TABLE T ADD COLUMN C2 INT64`, &DDL{Filename: "filename", List: []DDLStmt{

--- a/spanner/spansql/sql.go
+++ b/spanner/spansql/sql.go
@@ -166,6 +166,8 @@ func (gr GrantRole) SQL() string {
 			}
 		}
 		sql += " ON TABLE " + idList(gr.TableNames, ", ")
+	} else if len(gr.TvfNames) > 0 {
+		sql += "EXECUTE ON TABLE FUNCTION " + idList(gr.TvfNames, ", ")
 	} else {
 		sql += "ROLE " + idList(gr.GrantRoleNames, ", ")
 	}
@@ -186,6 +188,8 @@ func (rr RevokeRole) SQL() string {
 			}
 		}
 		sql += " ON TABLE " + idList(rr.TableNames, ", ")
+	} else if len(rr.TvfNames) > 0 {
+		sql += "EXECUTE ON TABLE FUNCTION " + idList(rr.TvfNames, ", ")
 	} else {
 		sql += "ROLE " + idList(rr.RevokeRoleNames, ", ")
 	}

--- a/spanner/spansql/sql.go
+++ b/spanner/spansql/sql.go
@@ -168,6 +168,10 @@ func (gr GrantRole) SQL() string {
 		sql += " ON TABLE " + idList(gr.TableNames, ", ")
 	} else if len(gr.TvfNames) > 0 {
 		sql += "EXECUTE ON TABLE FUNCTION " + idList(gr.TvfNames, ", ")
+	} else if len(gr.ViewNames) > 0 {
+		sql += "SELECT ON VIEW " + idList(gr.ViewNames, ", ")
+	} else if len(gr.ChangeStreamNames) > 0 {
+		sql += "SELECT ON CHANGE STREAM " + idList(gr.ChangeStreamNames, ", ")
 	} else {
 		sql += "ROLE " + idList(gr.GrantRoleNames, ", ")
 	}
@@ -190,6 +194,10 @@ func (rr RevokeRole) SQL() string {
 		sql += " ON TABLE " + idList(rr.TableNames, ", ")
 	} else if len(rr.TvfNames) > 0 {
 		sql += "EXECUTE ON TABLE FUNCTION " + idList(rr.TvfNames, ", ")
+	} else if len(rr.ViewNames) > 0 {
+		sql += "SELECT ON VIEW " + idList(rr.ViewNames, ", ")
+	} else if len(rr.ChangeStreamNames) > 0 {
+		sql += "SELECT ON CHANGE STREAM " + idList(rr.ChangeStreamNames, ", ")
 	} else {
 		sql += "ROLE " + idList(rr.RevokeRoleNames, ", ")
 	}

--- a/spanner/spansql/sql_test.go
+++ b/spanner/spansql/sql_test.go
@@ -249,6 +249,16 @@ func TestSQL(t *testing.T) {
 			reparseDDL,
 		},
 		{
+			&GrantRole{
+				ToRoleNames: []ID{"hr_manager"},
+				TvfNames:    []ID{"tvf_name_one", "tvf_name_two"},
+
+				Position: line(1),
+			},
+			"GRANT EXECUTE ON TABLE FUNCTION tvf_name_one, tvf_name_two TO ROLE hr_manager",
+			reparseDDL,
+		},
+		{
 			&RevokeRole{
 				FromRoleNames: []ID{"hr_manager"},
 				Privileges: []Privilege{
@@ -260,6 +270,16 @@ func TestSQL(t *testing.T) {
 				Position: line(1),
 			},
 			"REVOKE SELECT(name, level, location), UPDATE(location) ON TABLE employees, contractors FROM ROLE hr_manager",
+			reparseDDL,
+		},
+		{
+			&RevokeRole{
+				FromRoleNames: []ID{"hr_manager"},
+				TvfNames:      []ID{"tvf_name_one", "tvf_name_two"},
+
+				Position: line(1),
+			},
+			"REVOKE EXECUTE ON TABLE FUNCTION tvf_name_one, tvf_name_two FROM ROLE hr_manager",
 			reparseDDL,
 		},
 		{

--- a/spanner/spansql/sql_test.go
+++ b/spanner/spansql/sql_test.go
@@ -259,6 +259,26 @@ func TestSQL(t *testing.T) {
 			reparseDDL,
 		},
 		{
+			&GrantRole{
+				ToRoleNames: []ID{"hr_manager"},
+				ViewNames:   []ID{"view_name_one", "view_name_two"},
+
+				Position: line(1),
+			},
+			"GRANT SELECT ON VIEW view_name_one, view_name_two TO ROLE hr_manager",
+			reparseDDL,
+		},
+		{
+			&GrantRole{
+				ToRoleNames:       []ID{"hr_manager"},
+				ChangeStreamNames: []ID{"cs_name_one", "cs_name_two"},
+
+				Position: line(1),
+			},
+			"GRANT SELECT ON CHANGE STREAM cs_name_one, cs_name_two TO ROLE hr_manager",
+			reparseDDL,
+		},
+		{
 			&RevokeRole{
 				FromRoleNames: []ID{"hr_manager"},
 				Privileges: []Privilege{
@@ -280,6 +300,26 @@ func TestSQL(t *testing.T) {
 				Position: line(1),
 			},
 			"REVOKE EXECUTE ON TABLE FUNCTION tvf_name_one, tvf_name_two FROM ROLE hr_manager",
+			reparseDDL,
+		},
+		{
+			&RevokeRole{
+				FromRoleNames: []ID{"hr_manager"},
+				ViewNames:     []ID{"view_name_one", "view_name_two"},
+
+				Position: line(1),
+			},
+			"REVOKE SELECT ON VIEW view_name_one, view_name_two FROM ROLE hr_manager",
+			reparseDDL,
+		},
+		{
+			&RevokeRole{
+				FromRoleNames:     []ID{"hr_manager"},
+				ChangeStreamNames: []ID{"cs_name_one", "cs_name_two"},
+
+				Position: line(1),
+			},
+			"REVOKE SELECT ON CHANGE STREAM cs_name_one, cs_name_two FROM ROLE hr_manager",
 			reparseDDL,
 		},
 		{

--- a/spanner/spansql/types.go
+++ b/spanner/spansql/types.go
@@ -201,11 +201,13 @@ func (dr *DropRole) clearOffset()   { dr.Position.Offset = 0 }
 // GrantRole represents a GRANT statement.
 // https://cloud.google.com/spanner/docs/reference/standard-sql/data-definition-language#grant_statement
 type GrantRole struct {
-	ToRoleNames    []ID
-	GrantRoleNames []ID
-	Privileges     []Privilege
-	TableNames     []ID
-	TvfNames       []ID
+	ToRoleNames       []ID
+	GrantRoleNames    []ID
+	Privileges        []Privilege
+	TableNames        []ID
+	TvfNames          []ID
+	ViewNames         []ID
+	ChangeStreamNames []ID
 
 	Position Position // position of the "GRANT" token
 }
@@ -218,12 +220,14 @@ func (gr *GrantRole) clearOffset()   { gr.Position.Offset = 0 }
 // RevokeRole represents a REVOKE statement.
 // https://cloud.google.com/spanner/docs/reference/standard-sql/data-definition-language#revoke_statement
 type RevokeRole struct {
-	FromRoleNames   []ID
-	RevokeRoleNames []ID
-	Privileges      []Privilege
-	TableNames      []ID
-	TvfNames        []ID
-	Position        Position // position of the "REVOKE" token
+	FromRoleNames     []ID
+	RevokeRoleNames   []ID
+	Privileges        []Privilege
+	TableNames        []ID
+	TvfNames          []ID
+	ViewNames         []ID
+	ChangeStreamNames []ID
+	Position          Position // position of the "REVOKE" token
 }
 
 func (rr *RevokeRole) String() string { return fmt.Sprintf("%#v", rr) }

--- a/spanner/spansql/types.go
+++ b/spanner/spansql/types.go
@@ -205,6 +205,7 @@ type GrantRole struct {
 	GrantRoleNames []ID
 	Privileges     []Privilege
 	TableNames     []ID
+	TvfNames       []ID
 
 	Position Position // position of the "GRANT" token
 }
@@ -221,8 +222,8 @@ type RevokeRole struct {
 	RevokeRoleNames []ID
 	Privileges      []Privilege
 	TableNames      []ID
-
-	Position Position // position of the "REVOKE" token
+	TvfNames        []ID
+	Position        Position // position of the "REVOKE" token
 }
 
 func (rr *RevokeRole) String() string { return fmt.Sprintf("%#v", rr) }


### PR DESCRIPTION
This PR adds support for [GRANT/REVOKE](https://cloud.google.com/spanner/docs/reference/standard-sql/data-definition-language#grant_and_revoke_statements) to some additional resources as below.

```
GRANT SELECT ON VIEW view_list TO ROLE role_list

GRANT SELECT ON CHANGE STREAM change_stream_list TO ROLE role_list

GRANT EXECUTE ON TABLE FUNCTION tvf_list TO ROLE role_list

REVOKE SELECT ON VIEW view_list FROM ROLE role_list

REVOKE SELECT ON CHANGE STREAM change_stream_list FROM ROLE role_list

REVOKE EXECUTE ON TABLE FUNCTION tvf_list FROM ROLE role_list
```