### PR TITLE
testing(bigquery): consistently instantiate clients

### DIFF
--- a/bigquery/integration_test.go
+++ b/bigquery/integration_test.go
@@ -218,7 +218,7 @@ func initIntegrationTest() func() {
 		if err != nil {
 			log.Fatalf("NewClient: %v", err)
 		}
-		err = storageOptimizedClient.EnableStorageReadClient(ctx)
+		err = storageOptimizedClient.EnableStorageReadClient(ctx, bqOpts...)
 		if err != nil {
 			log.Fatalf("ConfigureStorageReadClient: %v", err)
 		}

--- a/bigquery/storage_integration_test.go
+++ b/bigquery/storage_integration_test.go
@@ -43,10 +43,10 @@ func TestIntegration_StorageReadBasicTypes(t *testing.T) {
 		}
 		err = checkIteratorRead(it, c.wantRow)
 		if err != nil {
-			t.Fatalf("error on query `%s`[%v]: %v", c.query, c.parameters, err)
+			t.Fatalf("%s: error on query `%s`[%v]: %v", it.SourceJob().ID(), c.query, c.parameters, err)
 		}
 		if !it.IsAccelerated() {
-			t.Fatal("expected storage api to be used")
+			t.Fatalf("%s: expected storage api to be used", it.SourceJob().ID())
 		}
 	}
 }


### PR DESCRIPTION
This one was subtle.  It turns out my local environment had an inconsistency between the credential specified for testing and my ADC credentials.  Because the identifies differed, the storage iterator couldn't instantiate read sessions.  The underlying error:

```
rpc error: code = PermissionDenied desc = Access Denied: Dataset
projectid:_<some hash corresponding to anon dataset>: User does
not have permission to access results of another user's job.
error details: name = DebugInfo detail = [ACCESS_DENIED]
errorProto=code: "ACCESS_DENIED"
```

This is because anonymous result are entirely private to the identity issuing the query.

This also has a small change to the error responses to implicate the job ID when failures occur.