### PR TITLE
test(spanner): update test to pass spanner host

### DIFF
--- a/spanner/integration_test.go
+++ b/spanner/integration_test.go
@@ -1648,7 +1648,9 @@ func TestIntegration_CreateDBRetry(t *testing.T) {
 		return err
 	}
 
-	dbAdmin, err := database.NewDatabaseAdminClient(ctx, option.WithGRPCDialOption(grpc.WithUnaryInterceptor(interceptor)))
+	// Pass spanner host as options for running builds against different environments
+	opts := []option.ClientOption{option.WithEndpoint(spannerHost), option.WithGRPCDialOption(grpc.WithUnaryInterceptor(interceptor))}
+	dbAdmin, err := database.NewDatabaseAdminClient(ctx, opts...)
 	if err != nil {
 		log.Fatalf("cannot create dbAdmin client: %v", err)
 	}


### PR DESCRIPTION
This PR updates existing test that does not pass spanner host option when creating new admin client. This is needed to run spanner tests across different environments.