### PR TITLE
chore: bump owlobot sha

### DIFF
--- a/.github/.OwlBot.lock.yaml
+++ b/.github/.OwlBot.lock.yaml
@@ -13,4 +13,4 @@
 # limitations under the License.
 docker:
   image: gcr.io/cloud-devrel-public-resources/owlbot-go:latest
-  digest: sha256:6eb2183b6e08c8e73e66f5c3a409f1d2a97235bc56349355a7e9d5dd72e02b1e
+  digest: sha256:fdf903db0d4978c98a3777a21341737706d4e68b3d2a34a3be020e5193fde81f


### PR DESCRIPTION
Because the postprocessor refs our config manifest we need to update it when removing clients.

Related: #7539