### PR TITLE
test: test fix presubmit for earliest

### DIFF
--- a/internal/kokoro/presubmit.sh
+++ b/internal/kokoro/presubmit.sh
@@ -48,8 +48,7 @@ exit_code=0
 # to be pushed to GCS as artifact.
 runPresubmitTests() {
   if [[ $PWD != *"/internal/"* ]] ||
-    [[ $PWD != *"/third_party/"* ]] &&
-    [[ $KOKORO_JOB_NAME == *"earliest"* ]]; then
+    [[ $PWD != *"/third_party/"* ]]; then
     # internal tools only expected to work with latest go version
     return
   fi


### PR DESCRIPTION
This script was missing a set of parentheses which caused us to not run test/build on earliest, currectly 1.17. Removed some conditionals as now the third_party dir is 1.17+.