### PR TITLE
chore: fix gapicgen flag

### DIFF
--- a/internal/gapicgen/generator/gapics.go
+++ b/internal/gapicgen/generator/gapics.go
@@ -298,7 +298,7 @@ func (g *GapicGenerator) microgen(conf *MicrogenConfig) error {
 		"-I", g.protoDir,
 		"--go_gapic_out", g.googleCloudDir,
 		// TODO(chrisdsmith): Enable snippets by deleting the next line after removing internal/gapicgen/gensnippets.
-		"--go_gapic_opt", "omit-snippets",
+		"--go_gapic_opt", "omit-snippets=true",
 		"--go_gapic_opt", fmt.Sprintf("go-gapic-package=%s;%s", conf.ImportPath, conf.Pkg),
 		"--go_gapic_opt", fmt.Sprintf("api-service-config=%s", filepath.Join(conf.InputDirectoryPath, conf.ApiServiceConfigPath))}
 


### PR DESCRIPTION
Build was failing with:

`--go_gapic_out: invalid plugin option format, must be key=value: omit-snippets`