### PR TITLE
test(spanner): Fine Grained Access Control for PG dialect

### DIFF
--- a/spanner/integration_test.go
+++ b/spanner/integration_test.go
@@ -2489,9 +2489,8 @@ func TestIntegration_TransactionRunner(t *testing.T) {
 
 func TestIntegration_QueryWithRoles(t *testing.T) {
 	t.Parallel()
-	// Database roles are not currently available in emulator and PG dialect
+	// Database roles are not currently available in emulator
 	skipEmulatorTest(t)
-	skipUnsupportedPGTest(t)
 
 	// Set up testing environment.
 	var (
@@ -2504,13 +2503,13 @@ func TestIntegration_QueryWithRoles(t *testing.T) {
 	)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
+
+	createSingersTableDDL := singerDBStatements[0]
+	if testDialect == adminpb.DatabaseDialect_POSTGRESQL {
+		createSingersTableDDL = singerDBPGStatements[0]
+	}
 	stmts := []string{
-		`CREATE TABLE Singers (
-				SingerId	INT64 NOT NULL,
-				FirstName	STRING(1024),
-				LastName	STRING(1024),
-				SingerInfo	BYTES(MAX)
-			) PRIMARY KEY (SingerId)`,
+		createSingersTableDDL,
 		`CREATE ROLE singers_reader`,
 		`CREATE ROLE singers_unauthorized`,
 		`CREATE ROLE singers_reader_revoked`,
@@ -2603,9 +2602,8 @@ func TestIntegration_QueryWithRoles(t *testing.T) {
 
 func TestIntegration_ReadWithRoles(t *testing.T) {
 	t.Parallel()
-	// Database roles are not currently available in emulator and PG dialect
+	// Database roles are not currently available in emulator
 	skipEmulatorTest(t)
-	skipUnsupportedPGTest(t)
 
 	// Set up testing environment.
 	var (
@@ -2618,13 +2616,13 @@ func TestIntegration_ReadWithRoles(t *testing.T) {
 	)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
+
+	createSingersTableDDL := singerDBStatements[0]
+	if testDialect == adminpb.DatabaseDialect_POSTGRESQL {
+		createSingersTableDDL = singerDBPGStatements[0]
+	}
 	stmts := []string{
-		`CREATE TABLE Singers (
-				SingerId	INT64 NOT NULL,
-				FirstName	STRING(1024),
-				LastName	STRING(1024),
-				SingerInfo	BYTES(MAX)
-			) PRIMARY KEY (SingerId)`,
+		createSingersTableDDL,
 		`CREATE ROLE singers_reader`,
 		`CREATE ROLE singers_unauthorized`,
 		`CREATE ROLE singers_reader_revoked`,
@@ -2716,9 +2714,8 @@ func TestIntegration_ReadWithRoles(t *testing.T) {
 
 func TestIntegration_DMLWithRoles(t *testing.T) {
 	t.Parallel()
-	// Database roles are not currently available in emulator and PG dialect
+	// Database roles are not currently available in emulator
 	skipEmulatorTest(t)
-	skipUnsupportedPGTest(t)
 
 	// Set up testing environment.
 	var (
@@ -2727,13 +2724,13 @@ func TestIntegration_DMLWithRoles(t *testing.T) {
 	)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
+
+	createSingersTableDDL := singerDBStatements[0]
+	if testDialect == adminpb.DatabaseDialect_POSTGRESQL {
+		createSingersTableDDL = singerDBPGStatements[0]
+	}
 	stmts := []string{
-		`CREATE TABLE Singers (
-				SingerId	INT64 NOT NULL,
-				FirstName	STRING(1024),
-				LastName	STRING(1024),
-				SingerInfo	BYTES(MAX)
-			) PRIMARY KEY (SingerId)`,
+		createSingersTableDDL,
 		`CREATE ROLE singers_updater`,
 		`CREATE ROLE singers_unauthorized`,
 		`CREATE ROLE singers_creator`,
@@ -2857,9 +2854,8 @@ func TestIntegration_DMLWithRoles(t *testing.T) {
 
 func TestIntegration_MutationWithRoles(t *testing.T) {
 	t.Parallel()
-	// Database roles are not currently available in emulator and PG dialect
+	// Database roles are not currently available in emulator
 	skipEmulatorTest(t)
-	skipUnsupportedPGTest(t)
 
 	// Set up testing environment.
 	var (
@@ -2868,13 +2864,13 @@ func TestIntegration_MutationWithRoles(t *testing.T) {
 	)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
+
+	createSingersTableDDL := singerDBStatements[0]
+	if testDialect == adminpb.DatabaseDialect_POSTGRESQL {
+		createSingersTableDDL = singerDBPGStatements[0]
+	}
 	stmts := []string{
-		`CREATE TABLE Singers (
-				SingerId	INT64 NOT NULL,
-				FirstName	STRING(1024),
-				LastName	STRING(1024),
-				SingerInfo	BYTES(MAX)
-			) PRIMARY KEY (SingerId)`,
+		createSingersTableDDL,
 		`CREATE ROLE singers_updater`,
 		`CREATE ROLE singers_unauthorized`,
 		`CREATE ROLE singers_creator`,
@@ -2988,9 +2984,8 @@ func TestIntegration_MutationWithRoles(t *testing.T) {
 
 func TestIntegration_ListDatabaseRoles(t *testing.T) {
 	t.Parallel()
-	// Database roles are not currently available in emulator and PG dialect
+	// Database roles are not currently available in emulator
 	skipEmulatorTest(t)
-	skipUnsupportedPGTest(t)
 
 	// Set up testing environment.
 	var (


### PR DESCRIPTION
This PR adds support for database roles for PG dialect and un-skips the integration tests which were earlier skipped for PG dialect. With this, Database roles support is now available in both GoogleSql and PostgreSql dialects.

Note: Database Roles support is still not available in Emulator.