### PR TITLE
feat(bigquery/storage/managedwriter): introduce location routing header

### DIFF
--- a/bigquery/storage/managedwriter/connection.go
+++ b/bigquery/storage/managedwriter/connection.go
@@ -43,7 +43,8 @@ var (
 // The pool retains references to connections, and maintains the mapping between writers
 // and connections.
 type connectionPool struct {
-	id string
+	id       string
+	location string // BQ region associated with this pool.
 
 	// the pool retains the long-lived context responsible for opening/maintaining bidi connections.
 	ctx    context.Context


### PR DESCRIPTION
This allows for the backend to more efficient route traffic.  Normally we'd extract this from the request, but location is not part of the write identifier.