### PR TITLE
fix(bigquery/storage/managedwriter): fix option propagation

### DIFF
--- a/bigquery/storage/managedwriter/client_test.go
+++ b/bigquery/storage/managedwriter/client_test.go
@@ -58,7 +58,7 @@ func TestCreatePool_Location(t *testing.T) {
 	c := &Client{
 		cfg: &writerClientConfig{},
 	}
-	pool, err := c.createPool(context.Background(), "foo", nil, nil)
+	pool, err := c.createPool(context.Background(), "foo", nil)
 	if err != nil {
 		t.Fatalf("createPool: %v", err)
 	}
@@ -86,18 +86,14 @@ func TestCreatePool_Location(t *testing.T) {
 // of global configuration and per-writer configuration.
 func TestCreatePool(t *testing.T) {
 	testCases := []struct {
-		desc            string
-		cfg             *writerClientConfig
-		settings        *streamSettings
-		wantMaxBytes    int
-		wantMaxRequests int
-		wantCallOptions int
-		wantErr         bool
+		desc                string
+		cfg                 *writerClientConfig
+		settings            *streamSettings
+		wantMaxBytes        int
+		wantMaxRequests     int
+		wantCallOptions     int
+		wantPoolCallOptions int
 	}{
-		{
-			desc:    "no config",
-			wantErr: true,
-		},
 		{
 			desc: "cfg, no settings",
 			cfg: &writerClientConfig{
@@ -130,9 +126,9 @@ func TestCreatePool(t *testing.T) {
 				MaxInflightRequests: 99,
 				MaxInflightBytes:    1024,
 			},
-			wantMaxBytes:    1024,
-			wantMaxRequests: 99,
-			wantCallOptions: 1,
+			wantMaxBytes:        1024,
+			wantMaxRequests:     99,
+			wantPoolCallOptions: 1,
 		},
 		{
 			desc: "merge defaults and settings",
@@ -145,9 +141,10 @@ func TestCreatePool(t *testing.T) {
 				MaxInflightBytes:  1024,
 				appendCallOptions: []gax.CallOption{gax.WithPath("foo")},
 			},
-			wantMaxBytes:    1024,
-			wantMaxRequests: 123,
-			wantCallOptions: 2,
+			wantMaxBytes:        1024,
+			wantMaxRequests:     123,
+			wantCallOptions:     1,
+			wantPoolCallOptions: 1,
 		},
 	}
 
@@ -155,26 +152,36 @@ func TestCreatePool(t *testing.T) {
 		c := &Client{
 			cfg: tc.cfg,
 		}
-		got, err := c.createPool(context.Background(), "", tc.settings, nil)
+		pool, err := c.createPool(context.Background(), "", nil)
 		if err != nil {
-			if !tc.wantErr {
-				t.Errorf("case %q: createPool errored unexpectedly: %v", tc.desc, err)
-			}
+			t.Errorf("case %q: createPool errored unexpectedly: %v", tc.desc, err)
 			continue
 		}
-		if err == nil && tc.wantErr {
-			t.Errorf("case %q: expected createPool to error but it did not", tc.desc)
-			continue
+		writer := &ManagedStream{
+			id:             "foo",
+			streamSettings: tc.settings,
 		}
+		if err = pool.addWriter(writer); err != nil {
+			t.Errorf("case %q: addWriter: %v", tc.desc, err)
+		}
+		pw := newPendingWrite(context.Background(), writer, nil, nil, "", "")
+		gotConn, err := pool.selectConn(pw)
+		if err != nil {
+			t.Errorf("case %q: selectConn: %v", tc.desc, err)
+		}
+
 		// too many go-cmp overrides needed to quickly diff here, look at the interesting fields explicitly.
-		if gotVal := got.baseFlowController.maxInsertBytes; gotVal != tc.wantMaxBytes {
+		if gotVal := gotConn.fc.maxInsertBytes; gotVal != tc.wantMaxBytes {
 			t.Errorf("case %q: flowController maxInsertBytes mismatch, got %d want %d", tc.desc, gotVal, tc.wantMaxBytes)
 		}
-		if gotVal := got.baseFlowController.maxInsertCount; gotVal != tc.wantMaxRequests {
+		if gotVal := gotConn.fc.maxInsertCount; gotVal != tc.wantMaxRequests {
 			t.Errorf("case %q: flowController maxInsertCount mismatch, got %d want %d", tc.desc, gotVal, tc.wantMaxRequests)
 		}
-		if gotVal := len(got.callOptions); gotVal != tc.wantCallOptions {
+		if gotVal := len(gotConn.callOptions); gotVal != tc.wantCallOptions {
 			t.Errorf("case %q: calloption count mismatch, got %d want %d", tc.desc, gotVal, tc.wantCallOptions)
+		}
+		if gotVal := len(pool.callOptions); gotVal != tc.wantPoolCallOptions {
+			t.Errorf("case %q: POOL calloption count mismatch, got %d want %d", tc.desc, gotVal, tc.wantPoolCallOptions)
 		}
 	}
 }

--- a/bigquery/storage/managedwriter/connection.go
+++ b/bigquery/storage/managedwriter/connection.go
@@ -43,7 +43,8 @@ var (
 // The pool retains references to connections, and maintains the mapping between writers
 // and connections.
 type connectionPool struct {
-	id string
+	id       string
+	location string // BQ region associated with this pool.
 
 	// the pool retains the long-lived context responsible for opening/maintaining bidi connections.
 	ctx    context.Context

--- a/bigquery/storage/managedwriter/connection_test.go
+++ b/bigquery/storage/managedwriter/connection_test.go
@@ -172,7 +172,7 @@ func TestConnectionPool_OpenCallOptionPropagation(t *testing.T) {
 			gax.WithGRPCOptions(grpc.MaxCallRecvMsgSize(99)),
 		},
 	}
-	conn := newConnection(pool, "")
+	conn := newConnection(pool, "", nil)
 	pool.openWithRetry(conn)
 }
 

--- a/bigquery/storage/managedwriter/routers.go
+++ b/bigquery/storage/managedwriter/routers.go
@@ -81,7 +81,7 @@ func (rtr *simpleRouter) writerAttach(writer *ManagedStream) error {
 	defer rtr.mu.Unlock()
 	rtr.writers[writer.id] = struct{}{}
 	if rtr.conn == nil {
-		rtr.conn = newConnection(rtr.pool, rtr.mode)
+		rtr.conn = newConnection(rtr.pool, rtr.mode, nil)
 	}
 	return nil
 }
@@ -206,7 +206,7 @@ func (sr *sharedRouter) writerAttach(writer *ManagedStream) error {
 	if pair := sr.exclusiveConns[writer.id]; pair != nil {
 		return fmt.Errorf("writer %q already attached", writer.id)
 	}
-	sr.exclusiveConns[writer.id] = newConnection(sr.pool, simplexConnectionMode)
+	sr.exclusiveConns[writer.id] = newConnection(sr.pool, simplexConnectionMode, writer.streamSettings)
 	return nil
 }
 
@@ -242,9 +242,9 @@ func (sr *sharedRouter) orderAndGrowMultiConns() {
 			return sr.multiConns[i].curLoad() < sr.multiConns[j].curLoad()
 		})
 	if len(sr.multiConns) == 0 {
-		sr.multiConns = []*connection{newConnection(sr.pool, multiplexConnectionMode)}
+		sr.multiConns = []*connection{newConnection(sr.pool, multiplexConnectionMode, nil)}
 	} else if sr.multiConns[0].isLoaded() && len(sr.multiConns) < sr.maxConns {
-		sr.multiConns = append([]*connection{newConnection(sr.pool, multiplexConnectionMode)}, sr.multiConns...)
+		sr.multiConns = append([]*connection{newConnection(sr.pool, multiplexConnectionMode, nil)}, sr.multiConns...)
 	}
 }
 


### PR DESCRIPTION
With recent refactors, call options were not being propagated properly for non-multiplex writers.
We initially created a pool-per-writer and thus resolved these differences via the settings on the pool,
but have improved this situation to have a pool-per-region.  The custom settings were being silently
dropped on the floor.  The impacted settings were the connection-related options, namely flow control limits and custom call options.

With this change we allow for default settings on the pool, and custom settings on a connection.  In usage, this
is only leveraged for non-multiplexed connections as we have 1:1 relationships between connections and writers.

Towards: https://github.com/googleapis/google-cloud-go/issues/7103