### PR TITLE
refactor(logging): move testing util functions into own file

### DIFF
--- a/logging/logging_unexported_test.go
+++ b/logging/logging_unexported_test.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	"cloud.google.com/go/internal/testutil"
-	logpb "cloud.google.com/go/logging/apiv2/loggingpb"
 	"github.com/golang/protobuf/proto"
 	durpb "github.com/golang/protobuf/ptypes/duration"
 	structpb "github.com/golang/protobuf/ptypes/struct"
@@ -349,15 +348,4 @@ func TestMonitoredResource(t *testing.T) {
 			t.Errorf("%q: got %+v, want %+v", test.parent, got, test.want)
 		}
 	}
-}
-
-// Used by the tests in logging_test.
-func SetNow(f func() time.Time) func() time.Time {
-	now, f = f, now
-	return f
-}
-
-func SetToLogEntryInternal(f func(Entry, *Logger, string, int) (*logpb.LogEntry, error)) func(Entry, *Logger, string, int) (*logpb.LogEntry, error) {
-	toLogEntryInternal, f = f, toLogEntryInternal
-	return f
 }

--- a/logging/testutils.go
+++ b/logging/testutils.go
@@ -1,0 +1,34 @@
+// Copyright 2016 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Functions for testing that require access to unexported names of the logging package.
+
+package logging
+
+import (
+	"time"
+
+	logpb "cloud.google.com/go/logging/apiv2/loggingpb"
+)
+
+// Used by the tests in logging_test.
+func SetNow(f func() time.Time) func() time.Time {
+	now, f = f, now
+	return f
+}
+
+func SetToLogEntryInternal(f func(Entry, *Logger, string, int) (*logpb.LogEntry, error)) func(Entry, *Logger, string, int) (*logpb.LogEntry, error) {
+	toLogEntryInternal, f = f, toLogEntryInternal
+	return f
+}


### PR DESCRIPTION
Move functions used for tests into their own file.

This removes the build dependency on logging_unexported_test.go from package logging_test.