### PR TITLE
refactor(bigquery): amend name for MaxTimeTravel on datasets

### DIFF
--- a/bigquery/dataset.go
+++ b/bigquery/dataset.go
@@ -58,9 +58,9 @@ type DatasetMetadata struct {
 	// More information: https://cloud.google.com/bigquery/docs/reference/standard-sql/collation-concepts
 	DefaultCollation string
 
-	// MaxTimeTravelHours represents the number of hours for the max time travel for all tables
+	// MaxTimeTravel represents the number of hours for the max time travel for all tables
 	// in the dataset.  Durations are rounded towards zero for the nearest hourly value.
-	MaxTimeTravelHours time.Duration
+	MaxTimeTravel time.Duration
 
 	// Storage billing model to be used for all tables in the dataset.
 	// Can be set to PHYSICAL. Default is LOGICAL.
@@ -135,9 +135,9 @@ type DatasetMetadataToUpdate struct {
 	// created in the dataset.
 	DefaultCollation optional.String
 
-	// MaxTimeTravelHours represents the number of hours for the max time travel for all tables
+	// MaxTimeTravel represents the number of hours for the max time travel for all tables
 	// in the dataset.  Durations are rounded towards zero for the nearest hourly value.
-	MaxTimeTravelHours optional.Duration
+	MaxTimeTravel optional.Duration
 
 	// Storage billing model to be used for all tables in the dataset.
 	// Can be set to PHYSICAL. Default is LOGICAL.
@@ -216,7 +216,7 @@ func (dm *DatasetMetadata) toBQ() (*bq.Dataset, error) {
 	ds.DefaultTableExpirationMs = int64(dm.DefaultTableExpiration / time.Millisecond)
 	ds.DefaultPartitionExpirationMs = int64(dm.DefaultPartitionExpiration / time.Millisecond)
 	ds.DefaultCollation = dm.DefaultCollation
-	ds.MaxTimeTravelHours = int64(dm.MaxTimeTravelHours / time.Hour)
+	ds.MaxTimeTravelHours = int64(dm.MaxTimeTravel / time.Hour)
 	ds.StorageBillingModel = string(dm.StorageBillingModel)
 	ds.Labels = dm.Labels
 	var err error
@@ -304,7 +304,7 @@ func bqToDatasetMetadata(d *bq.Dataset, c *Client) (*DatasetMetadata, error) {
 		DefaultTableExpiration:     time.Duration(d.DefaultTableExpirationMs) * time.Millisecond,
 		DefaultPartitionExpiration: time.Duration(d.DefaultPartitionExpirationMs) * time.Millisecond,
 		DefaultCollation:           d.DefaultCollation,
-		MaxTimeTravelHours:         time.Duration(d.MaxTimeTravelHours) * time.Hour,
+		MaxTimeTravel:              time.Duration(d.MaxTimeTravelHours) * time.Hour,
 		StorageBillingModel:        d.StorageBillingModel,
 		DefaultEncryptionConfig:    bqToEncryptionConfig(d.DefaultEncryptionConfiguration),
 		Description:                d.Description,
@@ -395,8 +395,8 @@ func (dm *DatasetMetadataToUpdate) toBQ() (*bq.Dataset, error) {
 		ds.DefaultCollation = optional.ToString(dm.DefaultCollation)
 		forceSend("DefaultCollation")
 	}
-	if dm.MaxTimeTravelHours != nil {
-		dur := optional.ToDuration(dm.MaxTimeTravelHours)
+	if dm.MaxTimeTravel != nil {
+		dur := optional.ToDuration(dm.MaxTimeTravel)
 		if dur == 0 {
 			// Send a null to delete the field.
 			ds.NullFields = append(ds.NullFields, "MaxTimeTravelHours")

--- a/bigquery/dataset_integration_test.go
+++ b/bigquery/dataset_integration_test.go
@@ -173,7 +173,7 @@ func TestIntegration_DatasetUpdateDefaultExpirationAndMaxTimeTravel(t *testing.T
 	// Set the default expiration time.
 	md, err := dataset.Update(ctx, DatasetMetadataToUpdate{
 		DefaultTableExpiration: wantExpiration,
-		MaxTimeTravelHours:     wantTimeTravel,
+		MaxTimeTravel:          wantTimeTravel,
 	}, "")
 	if err != nil {
 		t.Fatal(err)
@@ -181,8 +181,8 @@ func TestIntegration_DatasetUpdateDefaultExpirationAndMaxTimeTravel(t *testing.T
 	if got := md.DefaultTableExpiration; got != wantExpiration {
 		t.Fatalf("DefaultTableExpiration want %s got %s", wantExpiration, md.DefaultTableExpiration)
 	}
-	if got := md.MaxTimeTravelHours; got != wantTimeTravel {
-		t.Fatalf("MaxTimeTravelHours want %s got %s", wantTimeTravel, md.MaxTimeTravelHours)
+	if got := md.MaxTimeTravel; got != wantTimeTravel {
+		t.Fatalf("MaxTimeTravelHours want %s got %s", wantTimeTravel, md.MaxTimeTravel)
 	}
 	// Omitting DefaultTableExpiration doesn't change it.
 	md, err = dataset.Update(ctx, DatasetMetadataToUpdate{Name: "xyz"}, "")

--- a/bigquery/dataset_test.go
+++ b/bigquery/dataset_test.go
@@ -322,7 +322,7 @@ func TestDatasetToBQ(t *testing.T) {
 			Name:                       "name",
 			Description:                "desc",
 			DefaultTableExpiration:     time.Hour,
-			MaxTimeTravelHours:         time.Duration(181 * time.Minute),
+			MaxTimeTravel:              time.Duration(181 * time.Minute),
 			DefaultPartitionExpiration: 24 * time.Hour,
 			DefaultEncryptionConfig: &EncryptionConfig{
 				KMSKeyName: "some_key",
@@ -431,7 +431,7 @@ func TestBQToDatasetMetadata(t *testing.T) {
 		Name:                       "name",
 		Description:                "desc",
 		DefaultTableExpiration:     time.Hour,
-		MaxTimeTravelHours:         time.Duration(3 * time.Hour),
+		MaxTimeTravel:              time.Duration(3 * time.Hour),
 		DefaultPartitionExpiration: 24 * time.Hour,
 		DefaultEncryptionConfig: &EncryptionConfig{
 			KMSKeyName: "some_key",
@@ -471,7 +471,7 @@ func TestDatasetMetadataToUpdateToBQ(t *testing.T) {
 		Name:                       "name",
 		DefaultTableExpiration:     time.Hour,
 		DefaultPartitionExpiration: 24 * time.Hour,
-		MaxTimeTravelHours:         time.Duration(181 * time.Minute),
+		MaxTimeTravel:              time.Duration(181 * time.Minute),
 		StorageBillingModel:        PhysicalStorageBillingModel,
 		DefaultEncryptionConfig: &EncryptionConfig{
 			KMSKeyName: "some_key",


### PR DESCRIPTION
PR https://github.com/googleapis/google-cloud-go/pull/7706 submitted before the edit to shorten the name landed.  This PR updates it.