### PR TITLE
chore(internal/postprocessor): don't include manifest entry for root mod

### DIFF
--- a/.github/.OwlBot.lock.yaml
+++ b/.github/.OwlBot.lock.yaml
@@ -13,4 +13,4 @@
 # limitations under the License.
 docker:
   image: gcr.io/cloud-devrel-public-resources/owlbot-go:latest
-  digest: sha256:aa9c69ec550a3e1a436daf5bfccee59657b366cd81d28ab940bcc1b787892d32
+  digest: sha256:85737ea58a1bb7adf8734bf4d40f534492e8f08f34da7af9ef0d38e51a4e831b

--- a/internal/postprocessor/manifest.go
+++ b/internal/postprocessor/manifest.go
@@ -81,11 +81,9 @@ func (p *postProcessor) Manifest() (map[string]ManifestEntry, error) {
 		if err != nil {
 			return nil, fmt.Errorf("unable to build docs URL: %v", err)
 		}
-		// TODO(codyoss): We can read a files doc.go to see if it has a warning
-		// if needs. For beta/alpha use a guess
 		releaseLevel, err := releaseLevel(p.googleCloudDir, conf.ImportPath)
 		if err != nil {
-			return nil, fmt.Errorf("unable to calculate release level for: %v", inputDir)
+			return nil, fmt.Errorf("unable to calculate release level for %v: %v", inputDir, err)
 		}
 
 		entry := ManifestEntry{
@@ -99,6 +97,8 @@ func (p *postProcessor) Manifest() (map[string]ManifestEntry, error) {
 		}
 		entries[conf.ImportPath] = entry
 	}
+	// Remove base module entry
+	delete(entries, "")
 	enc := json.NewEncoder(f)
 	enc.SetIndent("", "  ")
 	return entries, enc.Encode(entries)


### PR DESCRIPTION
Noticed in a recent PR, that this value was erroneous:
https://github.com/googleapis/google-cloud-go/pull/7743/files#diff-cf8298f2c65cb44cbdb5d6fb762bd404f31199f843acac98121ebeaf674d986fR4 