### PR TITLE
chore(storage): handle zero-byte reads in gRPC

### DIFF
--- a/storage/grpc_client.go
+++ b/storage/grpc_client.go
@@ -907,15 +907,8 @@ func (c *grpcStorageClient) NewRangeReader(ctx context.Context, params *newRange
 
 		req.ReadOffset = params.offset + seen
 
-		// A negative length means "read to the end of the object", but the
-		// read_limit field it corresponds to uses zero to mean the same thing. Thus
-		// we coerce the length to 0 to read to the end of the object.
-		if params.length < 0 {
-			params.length = 0
-		}
-
-		// Only set a ReadLimit if length is greater than zero, because zero
-		// means read it all.
+		// Only set a ReadLimit if length is greater than zero, because <= 0 means
+		// to read it all.
 		if params.length > 0 {
 			req.ReadLimit = params.length - seen
 		}
@@ -985,6 +978,7 @@ func (c *grpcStorageClient) NewRangeReader(ctx context.Context, params *newRange
 			// client buffer for reading later.
 			leftovers: msg.GetChecksummedData().GetContent(),
 			settings:  s,
+			zeroRange: params.length == 0,
 		},
 	}
 
@@ -996,8 +990,15 @@ func (c *grpcStorageClient) NewRangeReader(ctx context.Context, params *newRange
 		r.remain = size
 	}
 
+	// For a zero-length request, explicitly close the stream and set remaining
+	// bytes to zero.
+	if params.length == 0 {
+		r.remain = 0
+		r.reader.Close()
+	}
+
 	// Only support checksums when reading an entire object, not a range.
-	if checksums := msg.GetObjectChecksums(); checksums != nil && checksums.Crc32C != nil && params.offset == 0 && params.length == 0 {
+	if checksums := msg.GetObjectChecksums(); checksums != nil && checksums.Crc32C != nil && params.offset == 0 && params.length < 0 {
 		r.wantCRC = checksums.GetCrc32C()
 		r.checkCRC = true
 	}
@@ -1357,6 +1358,7 @@ type readStreamResponse struct {
 
 type gRPCReader struct {
 	seen, size int64
+	zeroRange  bool
 	stream     storagepb.Storage_ReadObjectClient
 	reopen     func(seen int64) (*readStreamResponse, context.CancelFunc, error)
 	leftovers  []byte
@@ -1366,17 +1368,17 @@ type gRPCReader struct {
 
 // Read reads bytes into the user's buffer from an open gRPC stream.
 func (r *gRPCReader) Read(p []byte) (int, error) {
-	// No stream to read from, either never initiliazed or Close was called.
+	// The entire object has been read by this reader, return EOF.
+	if r.size == r.seen || r.zeroRange {
+		return 0, io.EOF
+	}
+
+	// No stream to read from, either never initialized or Close was called.
 	// Note: There is a potential concurrency issue if multiple routines are
 	// using the same reader. One encounters an error and the stream is closed
 	// and then reopened while the other routine attempts to read from it.
 	if r.stream == nil {
 		return 0, fmt.Errorf("reader has been closed")
-	}
-
-	// The entire object has been read by this reader, return EOF.
-	if r.size != 0 && r.size == r.seen {
-		return 0, io.EOF
 	}
 
 	var n int

--- a/storage/http_client.go
+++ b/storage/http_client.go
@@ -1373,6 +1373,8 @@ func parseReadResponse(res *http.Response, params *newRangeReaderParams, reopen 
 
 	remain := res.ContentLength
 	body := res.Body
+	// If the user requested zero bytes, explicitly close and remove the request
+	// body.
 	if params.length == 0 {
 		remain = 0
 		body.Close()

--- a/storage/integration_test.go
+++ b/storage/integration_test.go
@@ -3931,7 +3931,7 @@ func TestIntegration_ServiceAccount(t *testing.T) {
 }
 
 func TestIntegration_Reader(t *testing.T) {
-	multiTransportTest(skipGRPC("cannot ask for 0 bytes with GRPC"), t, func(t *testing.T, ctx context.Context, bucket string, _ string, client *Client) {
+	multiTransportTest(context.Background(), t, func(t *testing.T, ctx context.Context, bucket string, _ string, client *Client) {
 		b := client.Bucket(bucket)
 		const defaultType = "text/plain"
 


### PR DESCRIPTION
Reads with a range of zero bytes should match the behavior in JSON/XML by requesting the whole object, but immediately closing the stream before fetching all the data.

I cleaned up some confusing discrepancies around the semantics of Reader.length as well.

Reader integration tests pass locally and can now be enabled for gRPC.

Fixes #7756