### PR TITLE
chore(internal/postprocessor): fix pathing issues

### DIFF
--- a/.github/.OwlBot.lock.yaml
+++ b/.github/.OwlBot.lock.yaml
@@ -13,4 +13,4 @@
 # limitations under the License.
 docker:
   image: gcr.io/cloud-devrel-public-resources/owlbot-go:latest
-  digest: sha256:cb64c4f5b1e459cdddf05a38868d833509f2491e00e7a0fabbd388c249a6d3fa
+  digest: sha256:53acb45aca25b7525829c23923f30b5465ddd23a5c4e6a060961987fa3debab7

--- a/internal/postprocessor/config.go
+++ b/internal/postprocessor/config.go
@@ -45,6 +45,8 @@ type libraryInfo struct {
 	// ServiceConfig is the relative directory to the service config from the
 	// services directory in googleapis.
 	ServiceConfig string
+	// RelPath is the relative path to the client from the repo root.
+	RelPath string
 }
 
 func (p *postProcessor) loadConfig() error {
@@ -98,6 +100,7 @@ func (p *postProcessor) loadConfig() error {
 			return fmt.Errorf("unable to find value for %q, it may be missing a service config entry", v.Source[1:i])
 		}
 		li.ImportPath = v.Source[i+1:]
+		li.RelPath = v.Dest
 	}
 	p.config = c
 	return nil

--- a/internal/postprocessor/manifest.go
+++ b/internal/postprocessor/manifest.go
@@ -77,11 +77,11 @@ func (p *postProcessor) Manifest() (map[string]ManifestEntry, error) {
 		if err := yaml.NewDecoder(yamlFile).Decode(&yamlConfig); err != nil {
 			return nil, fmt.Errorf("decode: %v", err)
 		}
-		docURL, err := docURL(p.googleCloudDir, conf.ImportPath)
+		docURL, err := docURL(p.googleCloudDir, conf.ImportPath, conf.RelPath)
 		if err != nil {
 			return nil, fmt.Errorf("unable to build docs URL: %v", err)
 		}
-		releaseLevel, err := releaseLevel(p.googleCloudDir, conf.ImportPath)
+		releaseLevel, err := releaseLevel(p.googleCloudDir, conf.ImportPath, conf.RelPath)
 		if err != nil {
 			return nil, fmt.Errorf("unable to calculate release level for %v: %v", inputDir, err)
 		}
@@ -104,9 +104,9 @@ func (p *postProcessor) Manifest() (map[string]ManifestEntry, error) {
 	return entries, enc.Encode(entries)
 }
 
-func docURL(cloudDir, importPath string) (string, error) {
-	suffix := strings.TrimPrefix(importPath, "cloud.google.com/go/")
-	mod, err := gocmd.CurrentMod(filepath.Join(cloudDir, suffix))
+func docURL(cloudDir, importPath, relPath string) (string, error) {
+	dir := filepath.Join(cloudDir, relPath)
+	mod, err := gocmd.CurrentMod(dir)
 	if err != nil {
 		return "", err
 	}
@@ -114,7 +114,7 @@ func docURL(cloudDir, importPath string) (string, error) {
 	return "https://cloud.google.com/go/docs/reference/" + mod + "/latest/" + pkgPath, nil
 }
 
-func releaseLevel(cloudDir, importPath string) (string, error) {
+func releaseLevel(cloudDir, importPath, relPath string) (string, error) {
 	i := strings.LastIndex(importPath, "/")
 	lastElm := importPath[i+1:]
 	if strings.Contains(lastElm, "alpha") {
@@ -124,8 +124,7 @@ func releaseLevel(cloudDir, importPath string) (string, error) {
 	}
 
 	// Determine by scanning doc.go for our beta disclaimer
-	gapicRelPath := strings.TrimPrefix(importPath, "cloud.google.com/go/")
-	docFile := filepath.Join(cloudDir, gapicRelPath, "doc.go")
+	docFile := filepath.Join(cloudDir, relPath, "doc.go")
 	f, err := os.Open(docFile)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Now that paths don't always align with import paths we need to be more careful with path manipulations in the post processor.