### PR TITLE
chore: CNDB CODEOWNERS and blunderbuss

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,9 +2,9 @@
 *                       @googleapis/yoshi-go-admins
 
 /bigtable/              @bhshkh @googleapis/api-bigtable @googleapis/yoshi-go-admins
-/bigtable/cmd/cbt       @igorbernstein2 @telpirion @googleapis/api-bigtable @googleapis/yoshi-go-admins
-/bigtable/cmd/emulator  @igorbernstein2 @telpirion @googleapis/api-bigtable @googleapis/yoshi-go-admins
-/bigtable/bttest        @igorbernstein2 @telpirion @googleapis/api-bigtable @googleapis/yoshi-go-admins
+/bigtable/cmd/cbt       @igorbernstein2 @bhshkh @googleapis/api-bigtable @googleapis/yoshi-go-admins
+/bigtable/cmd/emulator  @igorbernstein2 @bhshkh @googleapis/api-bigtable @googleapis/yoshi-go-admins
+/bigtable/bttest        @igorbernstein2 @bhshkh @googleapis/api-bigtable @googleapis/yoshi-go-admins
 /bigquery/              @googleapis/api-bigquery @googleapis/yoshi-go-admins
 /datastore/             @bhshkh @googleapis/cloud-native-db-dpes @googleapis/yoshi-go-admins
 /firestore/             @bhshkh @googleapis/cloud-native-db-dpes @googleapis/yoshi-go-admins

--- a/.github/blunderbuss.yml
+++ b/.github/blunderbuss.yml
@@ -4,7 +4,7 @@ assign_issues_by:
   - 'api: datastore'
   - 'api: firestore'
   to:
-  - telpirion
+  - bhshkh
 - labels:
   - 'api: storage'
   to:


### PR DESCRIPTION
Moves blunderbuss assignment for Firestore, Datastore, and Bigtable to @bhshkh