### PR TITLE
test(storage): revert scenario 8 conf test change

### DIFF
--- a/storage/internal/test/conformance/retry_tests.json
+++ b/storage/internal/test/conformance/retry_tests.json
@@ -268,7 +268,7 @@
       "description": "downloads_handle_complex_retries",
       "cases": [
         {
-          "instructions": ["return-broken-stream", "return-broken-stream"]
+          "instructions": ["return-broken-stream"]
         },
         {
           "instructions": ["return-broken-stream-after-256K"]


### PR DESCRIPTION
In #7704 we revised one of the S8 cases to match the upstream in googleapis/conformance-tests. Unfortunately it seems like that breaks the test; a download can seemingly recover from 1 broken stream but not 2 in a row. We should investigate and fix this but for now reverting the change so that the test stops failing.

Updates #7774