### PR TITLE
vision: incorrect version in v2 snippets metadata

### DIFF
--- a/internal/generated/snippets/vision/v2/apiv1p1beta1/snippet_metadata.google.cloud.vision.v1p1beta1.json
+++ b/internal/generated/snippets/vision/v2/apiv1p1beta1/snippet_metadata.google.cloud.vision.v1p1beta1.json
@@ -1,7 +1,7 @@
 {
   "clientLibrary": {
     "name": "cloud.google.com/go/vision/v2/apiv1p1beta1",
-    "version": "1.2.0",
+    "version": "2.7.0",
     "language": "GO",
     "apis": [
       {


### PR DESCRIPTION
Fixes #7826 

As mentioned in https://github.com/googleapis/google-cloud-go/issues/7826#issue-1682142702 for issue #7826 the version of metadata file of vision API needs to be changed to version `2.7.0`.