### PR TITLE
docs(debugger): incorrect snippets metadata (#7824)

### DIFF
--- a/internal/generated/snippets/debugger/apiv2/snippet_metadata.google.devtools.clouddebugger.v2.json
+++ b/internal/generated/snippets/debugger/apiv2/snippet_metadata.google.devtools.clouddebugger.v2.json
@@ -19,7 +19,7 @@
       "language": "GO",
       "clientMethod": {
         "shortName": "ListActiveBreakpoints",
-        "fullName": "google.devtools.clouddebugger.v2.Controller2Client.ListActiveBreakpoints",
+        "fullName": "google.devtools.debugger.v2.Controller2Client.ListActiveBreakpoints",
         "parameters": [
           {
             "type": "context.Context",


### PR DESCRIPTION
Fixes #7824

debugger: incorrect snippets metadata #7824

Changed the name of client files are incorrect as a result of snippetgen moving to gapic-generator-go, a snippets metadata file snippet_metadata.google.devtools.clouddebugger.v2.json.