### PR TITLE
docs(bigquery/storage/managedwriter):  improve tuning guidance

### DIFF
--- a/bigquery/storage/managedwriter/doc.go
+++ b/bigquery/storage/managedwriter/doc.go
@@ -246,5 +246,8 @@ multiplexing or not) may also wish to consider further tuning of this behavior. 
 sets a reasonable default, but this can be tuned further by leveraging the WithGRPCConnectionPool ClientOption,
 documented here:
 https://pkg.go.dev/google.golang.org/api/option#WithGRPCConnectionPool
+
+A reasonable upper bound for the connection pool size is the number of concurrent writers for explicit stream
+plus the configured size of the multiplex pool.
 */
 package managedwriter

--- a/bigquery/storage/managedwriter/doc.go
+++ b/bigquery/storage/managedwriter/doc.go
@@ -240,8 +240,11 @@ To enable multiplexing for writes to default streams, simply instantiate the cli
 		// TODO: Handle error.
 	}
 
-Special Consideration:  Users who would like to utilize many connections associated with a single Client
-may benefit from setting the WithGRPCConnectionPool ClientOption, documented here:
+Special Consideration:  The gRPC architecture is capable of its own sharing of underlying HTTP/2 connections.
+For users who are sending significant traffic on multiple writers (independent of whether they're leveraging
+multiplexing or not) may also wish to consider further tuning of this behavior.  The managedwriter library
+sets a reasonable default, but this can be tuned further by leveraging the WithGRPCConnectionPool ClientOption,
+documented here:
 https://pkg.go.dev/google.golang.org/api/option#WithGRPCConnectionPool
 */
 package managedwriter


### PR DESCRIPTION
Based on feedback from @derekperkins, revisit how we talk about connection pooling options.

Towards: https://github.com/googleapis/google-cloud-go/issues/7103