### PR TITLE
feat(pubsublite): expose functions to encode/decode message event times

### DIFF
--- a/pubsublite/pscompat/integration_test.go
+++ b/pubsublite/pscompat/integration_test.go
@@ -37,6 +37,7 @@ import (
 
 	vkit "cloud.google.com/go/pubsublite/apiv1"
 	pb "cloud.google.com/go/pubsublite/apiv1/pubsublitepb"
+	tspb "github.com/golang/protobuf/ptypes/timestamp"
 )
 
 const (
@@ -367,12 +368,20 @@ func TestIntegration_PublishSubscribeSinglePartition(t *testing.T) {
 
 	// Sets all fields for a message and ensures it is correctly received.
 	t.Run("AllFieldsRoundTrip", func(t *testing.T) {
+		eventTime, err := EncodeEventTimeAttribute(&tspb.Timestamp{
+			Seconds: 1672531200,
+			Nanos:   500000000,
+		})
+		if err != nil {
+			t.Errorf("EncodeEventTimeAttribute() got err: %v", err)
+		}
 		msg := &pubsub.Message{
 			Data:        []byte("round_trip"),
 			OrderingKey: "ordering_key",
 			Attributes: map[string]string{
-				"attr1": "value1",
-				"attr2": "value2",
+				"attr1":               "value1",
+				"attr2":               "value2",
+				EventTimeAttributeKey: eventTime,
 			},
 		}
 		publishMessages(t, DefaultPublishSettings, topicPath, msg)

--- a/pubsublite/pscompat/message.go
+++ b/pubsublite/pscompat/message.go
@@ -28,16 +28,17 @@ import (
 	tspb "github.com/golang/protobuf/ptypes/timestamp"
 )
 
-// Message transforms and event timestamp encoding mirrors the Java client
-// library implementation:
-// https://github.com/googleapis/java-pubsublite/blob/master/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/cloudpubsub/MessageTransforms.java
-const eventTimestampAttributeKey = "x-goog-pubsublite-event-time-timestamp-proto"
+// EventTimeAttributeKey is the key of the attribute whose value is an encoded
+// Timestamp proto. The value will be used to set the event time property of a
+// Pub/Sub Lite message.
+const EventTimeAttributeKey = "x-goog-pubsublite-event-time-timestamp-proto"
 
 var errInvalidMessage = errors.New("pubsublite: invalid received message")
 
-// Encodes a timestamp in a way that it will be interpreted as an event time if
-// published on a message with an attribute named eventTimestampAttributeKey.
-func encodeEventTimestamp(eventTime *tspb.Timestamp) (string, error) {
+// EncodeEventTimeAttribute encodes a timestamp in a way that it will be
+// interpreted as an event time if published on a message with an attribute
+// named EventTimeAttributeKey.
+func EncodeEventTimeAttribute(eventTime *tspb.Timestamp) (string, error) {
 	bytes, err := proto.Marshal(eventTime)
 	if err != nil {
 		return "", err
@@ -45,8 +46,9 @@ func encodeEventTimestamp(eventTime *tspb.Timestamp) (string, error) {
 	return base64.StdEncoding.EncodeToString(bytes), nil
 }
 
-// Decodes a timestamp encoded with encodeEventTimestamp.
-func decodeEventTimestamp(value string) (*tspb.Timestamp, error) {
+// DecodeEventTimeAttribute decodes a timestamp that was encoded with
+// EncodeEventTimeAttribute.
+func DecodeEventTimeAttribute(value string) (*tspb.Timestamp, error) {
 	bytes, err := base64.StdEncoding.DecodeString(value)
 	if err != nil {
 		return nil, err
@@ -76,8 +78,8 @@ func transformPublishedMessage(from *pubsub.Message, to *pb.PubSubMessage, extra
 	if len(from.Attributes) > 0 {
 		to.Attributes = make(map[string]*pb.AttributeValues)
 		for key, value := range from.Attributes {
-			if key == eventTimestampAttributeKey {
-				eventpb, err := decodeEventTimestamp(value)
+			if key == EventTimeAttributeKey {
+				eventpb, err := DecodeEventTimeAttribute(value)
 				if err != nil {
 					return err
 				}
@@ -113,15 +115,15 @@ func transformReceivedMessage(from *pb.SequencedMessage, to *pubsub.Message) err
 	to.Attributes = make(map[string]string)
 
 	if msg.EventTime != nil {
-		val, err := encodeEventTimestamp(msg.EventTime)
+		val, err := EncodeEventTimeAttribute(msg.EventTime)
 		if err != nil {
 			return fmt.Errorf("%s: %s", errInvalidMessage.Error(), err)
 		}
-		to.Attributes[eventTimestampAttributeKey] = val
+		to.Attributes[EventTimeAttributeKey] = val
 	}
 	for key, values := range msg.Attributes {
-		if key == eventTimestampAttributeKey {
-			return fmt.Errorf("%s: attribute with reserved key %q exists in API message", errInvalidMessage.Error(), eventTimestampAttributeKey)
+		if key == EventTimeAttributeKey {
+			return fmt.Errorf("%s: attribute with reserved key %q exists in API message", errInvalidMessage.Error(), EventTimeAttributeKey)
 		}
 		if len(values.Values) > 1 {
 			return fmt.Errorf("%s: cannot transform API message with multiple values for attribute with key %q", errInvalidMessage.Error(), key)

--- a/pubsublite/pscompat/message_test.go
+++ b/pubsublite/pscompat/message_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func encodeTimestamp(seconds int64, nanos int32) string {
-	val, err := encodeEventTimestamp(&tspb.Timestamp{
+	val, err := EncodeEventTimeAttribute(&tspb.Timestamp{
 		Seconds: seconds,
 		Nanos:   nanos,
 	})


### PR DESCRIPTION
`pubsublite` messages have an event time property, but this field is not present in `pubsub` messages. Event times are stored as encoded message attribute values.