### PR TITLE
chore(changefinder): add -base flag

### DIFF
--- a/internal/actions/cmd/changefinder/README.md
+++ b/internal/actions/cmd/changefinder/README.md
@@ -14,6 +14,8 @@ The available flags are as follows:
  * `-format=[plain|github]`: The `stdout` output format. Default is `plain`.
  * `-gh-var=[variable name]`: The variabe name to set output for in `github`
  format mode. Defaults to `submodules`.
+ * `-base=[ref name]`: The base ref to compare `HEAD` to. Default is
+ `origin/main`.
 
 Example usages from this repo root:
 

--- a/internal/actions/cmd/changefinder/main.go
+++ b/internal/actions/cmd/changefinder/main.go
@@ -29,6 +29,7 @@ var (
 	dir       = flag.String("dir", "", "the root directory to evaluate")
 	format    = flag.String("format", "plain", "output format, one of [plain|github], defaults to 'plain'")
 	ghVarName = flag.String("gh-var", "submodules", "github format's variable name to set output for, defaults to 'submodules'.")
+	base      = flag.String("base", "origin/main", "the base ref to compare to, defaults to 'origin/main'")
 	quiet     = flag.Bool("q", false, "quiet mode, minimal logging")
 	// Only used in quiet mode, printed in the event of an error.
 	logBuffer []string
@@ -127,7 +128,7 @@ func mods(dir string) (submodules []string, err error) {
 }
 
 func gitFilesChanges(dir string) ([]string, error) {
-	c := exec.Command("git", "diff", "--name-only", "origin/main")
+	c := exec.Command("git", "diff", "--name-only", *base)
 	c.Dir = dir
 	b, err := c.Output()
 	if err != nil {


### PR DESCRIPTION
Adds a `-base` flag that is useful for comparing to various references/branches.