### PR TITLE
feat(spanner): add tests for database roles in PG dialect

### DIFF
--- a/spanner/integration_test.go
+++ b/spanner/integration_test.go
@@ -2489,9 +2489,8 @@ func TestIntegration_TransactionRunner(t *testing.T) {
 
 func TestIntegration_QueryWithRoles(t *testing.T) {
 	t.Parallel()
-	// Database roles are not currently available in emulator and PG dialect
+	// Database roles are not currently available in emulator
 	skipEmulatorTest(t)
-	skipUnsupportedPGTest(t)
 
 	// Set up testing environment.
 	var (
@@ -2505,21 +2504,37 @@ func TestIntegration_QueryWithRoles(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 	stmts := []string{
-		`CREATE TABLE Singers (
-				SingerId	INT64 NOT NULL,
-				FirstName	STRING(1024),
-				LastName	STRING(1024),
-				SingerInfo	BYTES(MAX)
-			) PRIMARY KEY (SingerId)`,
 		`CREATE ROLE singers_reader`,
 		`CREATE ROLE singers_unauthorized`,
 		`CREATE ROLE singers_reader_revoked`,
 		`CREATE ROLE dropped`,
-		`GRANT SELECT(SingerId, FirstName, LastName) ON TABLE Singers TO ROLE singers_reader`,
-		`GRANT SELECT(SingerId, FirstName) ON TABLE Singers TO ROLE singers_unauthorized`,
-		`GRANT SELECT(SingerId, FirstName, LastName) ON TABLE Singers TO ROLE singers_reader_revoked`,
-		`REVOKE SELECT(LastName) ON TABLE Singers FROM ROLE singers_reader_revoked`,
 		`DROP ROLE dropped`,
+	}
+	if testDialect == adminpb.DatabaseDialect_POSTGRESQL {
+		stmts = append(stmts,
+			`CREATE TABLE Singers (
+					SingerId	BIGINT NOT NULL,
+					FirstName	VARCHAR(1024),
+					LastName	VARCHAR(1024),
+					SingerInfo	BYTEA,
+					PRIMARY KEY (SingerId)
+				)`,
+			`GRANT SELECT(SingerId, FirstName, LastName) ON Singers TO singers_reader`,
+			`GRANT SELECT(SingerId, FirstName) ON TABLE Singers TO singers_unauthorized`,
+			`GRANT SELECT(SingerId, FirstName, LastName) ON TABLE Singers TO singers_reader_revoked`,
+			`REVOKE SELECT(LastName) ON TABLE Singers FROM singers_reader_revoked`)
+	} else {
+		stmts = append(stmts,
+			`CREATE TABLE Singers (
+					SingerId	INT64 NOT NULL,
+					FirstName	STRING(1024),
+					LastName	STRING(1024),
+					SingerInfo	BYTES(MAX)
+				) PRIMARY KEY (SingerId)`,
+			`GRANT SELECT(SingerId, FirstName, LastName) ON TABLE Singers TO ROLE singers_reader`,
+			`GRANT SELECT(SingerId, FirstName) ON TABLE Singers TO ROLE singers_unauthorized`,
+			`GRANT SELECT(SingerId, FirstName, LastName) ON TABLE Singers TO ROLE singers_reader_revoked`,
+			`REVOKE SELECT(LastName) ON TABLE Singers FROM ROLE singers_reader_revoked`)
 	}
 	client, dbPath, cleanup := prepareIntegrationTest(ctx, t, DefaultSessionPoolConfig, stmts)
 	defer cleanup()
@@ -2603,9 +2618,8 @@ func TestIntegration_QueryWithRoles(t *testing.T) {
 
 func TestIntegration_ReadWithRoles(t *testing.T) {
 	t.Parallel()
-	// Database roles are not currently available in emulator and PG dialect
+	// Database roles are not currently available in emulator
 	skipEmulatorTest(t)
-	skipUnsupportedPGTest(t)
 
 	// Set up testing environment.
 	var (
@@ -2619,21 +2633,37 @@ func TestIntegration_ReadWithRoles(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 	stmts := []string{
-		`CREATE TABLE Singers (
-				SingerId	INT64 NOT NULL,
-				FirstName	STRING(1024),
-				LastName	STRING(1024),
-				SingerInfo	BYTES(MAX)
-			) PRIMARY KEY (SingerId)`,
 		`CREATE ROLE singers_reader`,
 		`CREATE ROLE singers_unauthorized`,
 		`CREATE ROLE singers_reader_revoked`,
 		`CREATE ROLE dropped`,
-		`GRANT SELECT(SingerId, FirstName, LastName) ON TABLE Singers TO ROLE singers_reader`,
-		`GRANT SELECT(SingerId, FirstName) ON TABLE Singers TO ROLE singers_unauthorized`,
-		`GRANT SELECT(SingerId, FirstName, LastName) ON TABLE Singers TO ROLE singers_reader_revoked`,
-		`REVOKE SELECT(LastName) ON TABLE Singers FROM ROLE singers_reader_revoked`,
 		`DROP ROLE dropped`,
+	}
+	if testDialect == adminpb.DatabaseDialect_POSTGRESQL {
+		stmts = append(stmts,
+			`CREATE TABLE Singers (
+					SingerId	BIGINT NOT NULL,
+					FirstName	VARCHAR(1024),
+					LastName	VARCHAR(1024),
+					SingerInfo	BYTEA,
+					PRIMARY KEY (SingerId)
+				)`,
+			`GRANT SELECT(SingerId, FirstName, LastName) ON Singers TO singers_reader`,
+			`GRANT SELECT(SingerId, FirstName) ON TABLE Singers TO singers_unauthorized`,
+			`GRANT SELECT(SingerId, FirstName, LastName) ON TABLE Singers TO singers_reader_revoked`,
+			`REVOKE SELECT(LastName) ON TABLE Singers FROM singers_reader_revoked`)
+	} else {
+		stmts = append(stmts,
+			`CREATE TABLE Singers (
+					SingerId	INT64 NOT NULL,
+					FirstName	STRING(1024),
+					LastName	STRING(1024),
+					SingerInfo	BYTES(MAX)
+				) PRIMARY KEY (SingerId)`,
+			`GRANT SELECT(SingerId, FirstName, LastName) ON TABLE Singers TO ROLE singers_reader`,
+			`GRANT SELECT(SingerId, FirstName) ON TABLE Singers TO ROLE singers_unauthorized`,
+			`GRANT SELECT(SingerId, FirstName, LastName) ON TABLE Singers TO ROLE singers_reader_revoked`,
+			`REVOKE SELECT(LastName) ON TABLE Singers FROM ROLE singers_reader_revoked`)
 	}
 	client, dbPath, cleanup := prepareIntegrationTest(ctx, t, DefaultSessionPoolConfig, stmts)
 	defer cleanup()
@@ -2716,9 +2746,8 @@ func TestIntegration_ReadWithRoles(t *testing.T) {
 
 func TestIntegration_DMLWithRoles(t *testing.T) {
 	t.Parallel()
-	// Database roles are not currently available in emulator and PG dialect
+	// Database roles are not currently available in emulator
 	skipEmulatorTest(t)
-	skipUnsupportedPGTest(t)
 
 	// Set up testing environment.
 	var (
@@ -2728,20 +2757,36 @@ func TestIntegration_DMLWithRoles(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 	stmts := []string{
-		`CREATE TABLE Singers (
-				SingerId	INT64 NOT NULL,
-				FirstName	STRING(1024),
-				LastName	STRING(1024),
-				SingerInfo	BYTES(MAX)
-			) PRIMARY KEY (SingerId)`,
 		`CREATE ROLE singers_updater`,
 		`CREATE ROLE singers_unauthorized`,
 		`CREATE ROLE singers_creator`,
 		`CREATE ROLE singers_deleter`,
-		`GRANT SELECT(SingerId), UPDATE(FirstName, LastName) ON TABLE Singers TO ROLE singers_updater`,
-		`GRANT SELECT(SingerId), UPDATE(FirstName) ON TABLE Singers TO ROLE singers_unauthorized`,
-		`GRANT INSERT(SingerId, FirstName, LastName) ON TABLE Singers TO ROLE singers_creator`,
-		`GRANT SELECT(SingerId), DELETE ON TABLE Singers TO ROLE singers_deleter`,
+	}
+	if testDialect == adminpb.DatabaseDialect_POSTGRESQL {
+		stmts = append(stmts,
+			`CREATE TABLE Singers (
+					SingerId	BIGINT NOT NULL,
+					FirstName	VARCHAR(1024),
+					LastName	VARCHAR(1024),
+					SingerInfo	BYTEA,
+					PRIMARY KEY (SingerId)
+				)`,
+			`GRANT SELECT(SingerId), UPDATE(FirstName, LastName) ON Singers TO singers_updater`,
+			`GRANT SELECT(SingerId), UPDATE(FirstName) ON TABLE Singers TO singers_unauthorized`,
+			`GRANT INSERT(SingerId, FirstName, LastName) ON TABLE Singers TO singers_creator`,
+			`GRANT SELECT(SingerId), DELETE ON TABLE Singers TO singers_deleter`)
+	} else {
+		stmts = append(stmts,
+			`CREATE TABLE Singers (
+					SingerId	INT64 NOT NULL,
+					FirstName	STRING(1024),
+					LastName	STRING(1024),
+					SingerInfo	BYTES(MAX)
+				) PRIMARY KEY (SingerId)`,
+			`GRANT SELECT(SingerId), UPDATE(FirstName, LastName) ON TABLE Singers TO ROLE singers_updater`,
+			`GRANT SELECT(SingerId), UPDATE(FirstName) ON TABLE Singers TO ROLE singers_unauthorized`,
+			`GRANT INSERT(SingerId, FirstName, LastName) ON TABLE Singers TO ROLE singers_creator`,
+			`GRANT SELECT(SingerId), DELETE ON TABLE Singers TO ROLE singers_deleter`)
 	}
 	client, dbPath, cleanup := prepareIntegrationTest(ctx, t, DefaultSessionPoolConfig, stmts)
 	defer cleanup()
@@ -2753,7 +2798,7 @@ func TestIntegration_DMLWithRoles(t *testing.T) {
 	if _, err := client.Apply(ctx, ms, ApplyAtLeastOnce()); err != nil {
 		t.Fatalf("Could not insert rows to table. Got error %v", err)
 	}
-	updateStmt := Statement{SQL: `UPDATE Singers SET FirstName = "Mark", LastName = "Richards" WHERE SingerId = 1`}
+	updateStmt := Statement{SQL: `UPDATE Singers SET FirstName = 'Mark', LastName = 'Richards' WHERE SingerId = 1`}
 
 	// A request with sufficient privileges should update the row
 	for _, dbRole := range []string{
@@ -2806,7 +2851,7 @@ func TestIntegration_DMLWithRoles(t *testing.T) {
 
 	// A request with sufficient privileges should insert the row
 	getInsertStmt := func(vals []interface{}) Statement {
-		sql := fmt.Sprintf(`INSERT INTO Singers (SingerId, FirstName, LastName) VALUES (%d, "%s", "%s")`, vals...)
+		sql := fmt.Sprintf(`INSERT INTO Singers (SingerId, FirstName, LastName) VALUES (%d, '%s', '%s')`, vals...)
 		return Statement{SQL: sql}
 	}
 	for _, test := range []struct {
@@ -2857,9 +2902,8 @@ func TestIntegration_DMLWithRoles(t *testing.T) {
 
 func TestIntegration_MutationWithRoles(t *testing.T) {
 	t.Parallel()
-	// Database roles are not currently available in emulator and PG dialect
+	// Database roles are not currently available in emulator
 	skipEmulatorTest(t)
-	skipUnsupportedPGTest(t)
 
 	// Set up testing environment.
 	var (
@@ -2869,20 +2913,36 @@ func TestIntegration_MutationWithRoles(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 	stmts := []string{
-		`CREATE TABLE Singers (
-				SingerId	INT64 NOT NULL,
-				FirstName	STRING(1024),
-				LastName	STRING(1024),
-				SingerInfo	BYTES(MAX)
-			) PRIMARY KEY (SingerId)`,
 		`CREATE ROLE singers_updater`,
 		`CREATE ROLE singers_unauthorized`,
 		`CREATE ROLE singers_creator`,
 		`CREATE ROLE singers_deleter`,
-		`GRANT SELECT(SingerId), UPDATE(SingerId, FirstName, LastName) ON TABLE Singers TO ROLE singers_updater`,
-		`GRANT SELECT(SingerId), UPDATE(SingerId, FirstName) ON TABLE Singers TO ROLE singers_unauthorized`,
-		`GRANT INSERT(SingerId, FirstName, LastName) ON TABLE Singers TO ROLE singers_creator`,
-		`GRANT SELECT(SingerId), DELETE ON TABLE Singers TO ROLE singers_deleter`,
+	}
+	if testDialect == adminpb.DatabaseDialect_POSTGRESQL {
+		stmts = append(stmts,
+			`CREATE TABLE Singers (
+					SingerId	BIGINT NOT NULL,
+					FirstName	VARCHAR(1024),
+					LastName	VARCHAR(1024),
+					SingerInfo	BYTEA,
+					PRIMARY KEY (SingerId)
+				)`,
+			`GRANT SELECT(SingerId), UPDATE(SingerId, FirstName, LastName) ON Singers TO singers_updater`,
+			`GRANT SELECT(SingerId), UPDATE(SingerId, FirstName) ON TABLE Singers TO singers_unauthorized`,
+			`GRANT INSERT(SingerId, FirstName, LastName) ON TABLE Singers TO singers_creator`,
+			`GRANT SELECT(SingerId), DELETE ON TABLE Singers TO singers_deleter`)
+	} else {
+		stmts = append(stmts,
+			`CREATE TABLE Singers (
+					SingerId	INT64 NOT NULL,
+					FirstName	STRING(1024),
+					LastName	STRING(1024),
+					SingerInfo	BYTES(MAX)
+				) PRIMARY KEY (SingerId)`,
+			`GRANT SELECT(SingerId), UPDATE(SingerId, FirstName, LastName) ON TABLE Singers TO ROLE singers_updater`,
+			`GRANT SELECT(SingerId), UPDATE(SingerId, FirstName) ON TABLE Singers TO ROLE singers_unauthorized`,
+			`GRANT INSERT(SingerId, FirstName, LastName) ON TABLE Singers TO ROLE singers_creator`,
+			`GRANT SELECT(SingerId), DELETE ON TABLE Singers TO ROLE singers_deleter`)
 	}
 	client, dbPath, cleanup := prepareIntegrationTest(ctx, t, DefaultSessionPoolConfig, stmts)
 	defer cleanup()
@@ -2988,9 +3048,8 @@ func TestIntegration_MutationWithRoles(t *testing.T) {
 
 func TestIntegration_ListDatabaseRoles(t *testing.T) {
 	t.Parallel()
-	// Database roles are not currently available in emulator and PG dialect
+	// Database roles are not currently available in emulator
 	skipEmulatorTest(t)
-	skipUnsupportedPGTest(t)
 
 	// Set up testing environment.
 	var (


### PR DESCRIPTION
Enables integration tests for database roles against Postgres dialect databases.