### PR TITLE
feat(spanner): Handle null expiration time in the St…

### DIFF
--- a/spanner/admin/database/apiv1/backup.go
+++ b/spanner/admin/database/apiv1/backup.go
@@ -47,15 +47,19 @@ func (c *DatabaseAdminClient) StartBackupOperation(ctx context.Context, backupID
 		return nil, fmt.Errorf("database name %q should conform to pattern %q",
 			databasePath, validDBPattern)
 	}
-	ts := &pbt.Timestamp{Seconds: expireTime.Unix(), Nanos: int32(expireTime.Nanosecond())}
+
+	backup := &databasepb.Backup {
+		Database: databasePath,
+	}
+	if !expireTime.IsZero() {
+		backup.ExpireTime = &pbt.Timestamp{Seconds: expireTime.Unix(), Nanos: int32(expireTime.Nanosecond())}
+	}
+
 	// Create request from parameters.
 	req := &databasepb.CreateBackupRequest{
 		Parent:   fmt.Sprintf("projects/%s/instances/%s", m[1], m[2]),
 		BackupId: backupID,
-		Backup: &databasepb.Backup{
-			Database:   databasePath,
-			ExpireTime: ts,
-		},
+		Backup: backup,
 	}
 	return c.CreateBackup(ctx, req, opts...)
 }


### PR DESCRIPTION
…artBackupOperation API

Context: Today, cloud customers have to mandatorily specify the expiration timestamp at the time of create/copy backup. With the default retention period feature, the expiration timestamp is made optional at the time of create/copy backup. If the customer doesn't specify the expiration timestamp, the default retention period of the backup is set to 1 year.

In this commit, making changes to handle null expiration time in the StartBackupOperation API. Do not set the expiration timestamp in the protobuf if the expire time passed in is zero.