### PR TITLE
fix(spanner): fix TestRetryInfoTransactionOutcomeUnknownError flaky behaviour

### DIFF
--- a/spanner/retry_test.go
+++ b/spanner/retry_test.go
@@ -63,7 +63,8 @@ func TestRetryInfoTransactionOutcomeUnknownError(t *testing.T) {
 	if gotDelay, ok := ExtractRetryDelay(err); ok {
 		t.Errorf("Got unexpected delay\nGot: %v\nWant: %v", gotDelay, 0)
 	}
-	if !testEqual(err.(*Error).err, &TransactionOutcomeUnknownError{status.FromContextError(context.DeadlineExceeded).Err()}) {
+	want := &TransactionOutcomeUnknownError{status.FromContextError(context.DeadlineExceeded).Err()}
+	if !testEqual(err.(*Error).err.Error(), want.Error()) {
 		t.Errorf("Missing expected TransactionOutcomeUnknownError wrapped error")
 	}
 }


### PR DESCRIPTION
Fixes: https://github.com/googleapis/google-cloud-go/issues/7887

toSpannerErrorWithCommitInfo returns *gax-go.ApiError after the changes https://github.com/googleapis/gax-go/pull/260, this PR will fix the flaky issue because of this