### PR TITLE
chore(all): Use fieldmask types directly instead of field_mask genproto alias

### DIFF
--- a/bigtable/admin.go
+++ b/bigtable/admin.go
@@ -40,8 +40,8 @@ import (
 	gtransport "google.golang.org/api/transport/grpc"
 	btapb "google.golang.org/genproto/googleapis/bigtable/admin/v2"
 	"google.golang.org/genproto/googleapis/rpc/status"
-	"google.golang.org/genproto/protobuf/field_mask"
 	"google.golang.org/grpc/metadata"
+	field_mask "google.golang.org/protobuf/types/known/fieldmaskpb"
 )
 
 const adminAddr = "bigtableadmin.googleapis.com:443"

--- a/logging/logadmin/sinks.go
+++ b/logging/logadmin/sinks.go
@@ -22,7 +22,7 @@ import (
 	vkit "cloud.google.com/go/logging/apiv2"
 	logpb "cloud.google.com/go/logging/apiv2/loggingpb"
 	"google.golang.org/api/iterator"
-	maskpb "google.golang.org/genproto/protobuf/field_mask"
+	maskpb "google.golang.org/protobuf/types/known/fieldmaskpb"
 )
 
 // Sink describes a sink used to export log entries outside Cloud

--- a/pubsub/pstest/fake_test.go
+++ b/pubsub/pstest/fake_test.go
@@ -29,11 +29,11 @@ import (
 
 	"cloud.google.com/go/internal/testutil"
 	pb "cloud.google.com/go/pubsub/apiv1/pubsubpb"
-	"google.golang.org/genproto/protobuf/field_mask"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/durationpb"
+	field_mask "google.golang.org/protobuf/types/known/fieldmaskpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 

--- a/pubsub/snapshot.go
+++ b/pubsub/snapshot.go
@@ -21,7 +21,7 @@ import (
 	"time"
 
 	pb "cloud.google.com/go/pubsub/apiv1/pubsubpb"
-	fmpb "google.golang.org/genproto/protobuf/field_mask"
+	fmpb "google.golang.org/protobuf/types/known/fieldmaskpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 

--- a/pubsub/subscription.go
+++ b/pubsub/subscription.go
@@ -30,10 +30,10 @@ import (
 	"cloud.google.com/go/pubsub/internal/scheduler"
 	gax "github.com/googleapis/gax-go/v2"
 	"golang.org/x/sync/errgroup"
-	fmpb "google.golang.org/genproto/protobuf/field_mask"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	durpb "google.golang.org/protobuf/types/known/durationpb"
+	fmpb "google.golang.org/protobuf/types/known/fieldmaskpb"
 
 	vkit "cloud.google.com/go/pubsub/apiv1"
 )

--- a/pubsub/topic.go
+++ b/pubsub/topic.go
@@ -34,12 +34,12 @@ import (
 	"go.opencensus.io/stats"
 	"go.opencensus.io/tag"
 	"google.golang.org/api/support/bundler"
-	fmpb "google.golang.org/genproto/protobuf/field_mask"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/durationpb"
+	fmpb "google.golang.org/protobuf/types/known/fieldmaskpb"
 )
 
 const (

--- a/pubsublite/admin.go
+++ b/pubsublite/admin.go
@@ -22,7 +22,7 @@ import (
 
 	vkit "cloud.google.com/go/pubsublite/apiv1"
 	pb "cloud.google.com/go/pubsublite/apiv1/pubsublitepb"
-	fmpb "google.golang.org/genproto/protobuf/field_mask"
+	fmpb "google.golang.org/protobuf/types/known/fieldmaskpb"
 )
 
 var (

--- a/pubsublite/admin_test.go
+++ b/pubsublite/admin_test.go
@@ -29,7 +29,7 @@ import (
 	emptypb "github.com/golang/protobuf/ptypes/empty"
 	tspb "github.com/golang/protobuf/ptypes/timestamp"
 	statuspb "google.golang.org/genproto/googleapis/rpc/status"
-	fmpb "google.golang.org/genproto/protobuf/field_mask"
+	fmpb "google.golang.org/protobuf/types/known/fieldmaskpb"
 )
 
 func newTestAdminClient(t *testing.T) *AdminClient {

--- a/pubsublite/config.go
+++ b/pubsublite/config.go
@@ -21,7 +21,7 @@ import (
 	"github.com/golang/protobuf/ptypes"
 
 	pb "cloud.google.com/go/pubsublite/apiv1/pubsublitepb"
-	fmpb "google.golang.org/genproto/protobuf/field_mask"
+	fmpb "google.golang.org/protobuf/types/known/fieldmaskpb"
 )
 
 // InfiniteRetention is a sentinel used in topic configs to denote an infinite

--- a/pubsublite/config_test.go
+++ b/pubsublite/config_test.go
@@ -22,7 +22,7 @@ import (
 
 	pb "cloud.google.com/go/pubsublite/apiv1/pubsublitepb"
 	dpb "github.com/golang/protobuf/ptypes/duration"
-	fmpb "google.golang.org/genproto/protobuf/field_mask"
+	fmpb "google.golang.org/protobuf/types/known/fieldmaskpb"
 )
 
 func TestTopicConfigToProtoConversion(t *testing.T) {


### PR DESCRIPTION
related to https://github.com/kubernetes/kubernetes/issues/113366#issuecomment-1292400083

cc @codyoss 