### PR TITLE
chore(internal/postprocessor): auto-update release-please files

### DIFF
--- a/internal/postprocessor/main.go
+++ b/internal/postprocessor/main.go
@@ -159,6 +159,9 @@ func (p *postProcessor) run(ctx context.Context) error {
 	if err := p.TidyAffectedMods(); err != nil {
 		return err
 	}
+	if err := p.UpdateReleaseFiles(); err != nil {
+		return err
+	}
 	if err := gocmd.Vet(p.googleCloudDir); err != nil {
 		return err
 	}

--- a/internal/postprocessor/main_test.go
+++ b/internal/postprocessor/main_test.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"bytes"
 	"flag"
 	"log"
 	"os"
@@ -156,4 +157,36 @@ func TestUpdateSnippetsMetadata(t *testing.T) {
 		t.Fatalf("UpdateSnippetsMetadata() did not update metadata as expected, check %s", f)
 	}
 
+}
+
+func TestUpdateConfigFile(t *testing.T) {
+	var b bytes.Buffer
+	if err := updateConfigFile(&b, []string{"accessapproval", "newmod"}); err != nil {
+		t.Fatal(err)
+	}
+	want, err := os.ReadFile("testdata/release-please-config-yoshi-submodules.want")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff(want, b.Bytes()); diff != "" {
+		t.Errorf("updateConfigFile() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestUpdateManifestFile(t *testing.T) {
+	existing, err := os.ReadFile("testdata/.release-please-manifest-submodules.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var b bytes.Buffer
+	if err := updateManifestFile(&b, existing, []string{"accessapproval", "newmod"}); err != nil {
+		t.Fatal(err)
+	}
+	want, err := os.ReadFile("testdata/.release-please-manifest-submodules.want")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff(want, b.Bytes()); diff != "" {
+		t.Errorf("updateConfigFile() mismatch (-want +got):\n%s", diff)
+	}
 }

--- a/internal/postprocessor/releaseplease.go
+++ b/internal/postprocessor/releaseplease.go
@@ -1,0 +1,148 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"io/fs"
+	"log"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+var individuallyReleasedModules map[string]bool = map[string]bool{
+	".":              true,
+	"bigquery":       true,
+	"bigtable":       true,
+	"datastore":      true,
+	"errorreporting": true,
+	"firestore":      true,
+	"logging":        true,
+	"profiler":       true,
+	"pubsub":         true,
+	"pubsublite":     true,
+	"spanner":        true,
+	"storage":        true,
+}
+
+var defaultReleasePleaseConfig = &releasePleaseConfig{
+	ReleaseType:           "go-yoshi",
+	IncludeComponentInTag: true,
+	TagSeparator:          "/",
+	Packages:              map[string]*releasePleasePackage{},
+	Plugins:               []string{"sentence-case"},
+}
+
+type releasePleaseConfig struct {
+	ReleaseType           string                           `json:"release-type"`
+	IncludeComponentInTag bool                             `json:"include-component-in-tag"`
+	TagSeparator          string                           `json:"tag-separator"`
+	Packages              map[string]*releasePleasePackage `json:"packages"`
+	Plugins               []string                         `json:"plugins"`
+}
+
+type releasePleasePackage struct {
+	Component string `json:"component"`
+}
+
+// updateReleaseFiles reconciles release-please configure based of the state of
+// the repo. It will auto-detect and add configure for new modules.
+func (p *postProcessor) UpdateReleaseFiles() error {
+	mods, err := detectModules(p.googleCloudDir)
+	if err != nil {
+		return err
+	}
+	sort.Strings(mods)
+
+	f, err := os.OpenFile(filepath.Join(p.googleCloudDir, "release-please-config-yoshi-submodules.json"), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	if err := updateConfigFile(f, mods); err != nil {
+		return err
+	}
+
+	fp := filepath.Join(p.googleCloudDir, ".release-please-manifest-submodules.json")
+	b, err := os.ReadFile(fp)
+	if err != nil {
+		return err
+	}
+	f2, err := os.OpenFile(fp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	if err != nil {
+		return err
+	}
+	defer f2.Close()
+	if err := updateManifestFile(f2, b, mods); err != nil {
+		return err
+	}
+	return nil
+}
+
+// updateConfigFile updates the release-please submodule config file.
+func updateConfigFile(w io.Writer, mods []string) error {
+	conf := *defaultReleasePleaseConfig
+	for _, mod := range mods {
+		conf.Packages[mod] = &releasePleasePackage{
+			Component: mod,
+		}
+	}
+	e := json.NewEncoder(w)
+	e.SetIndent("", "    ")
+	if err := e.Encode(&conf); err != nil {
+		return err
+	}
+	return nil
+}
+
+// updateManifestFile updates the release-please submodule manifest file.
+func updateManifestFile(w io.Writer, existingContents []byte, mods []string) error {
+	manifest := map[string]string{}
+	if err := json.Unmarshal(existingContents, &manifest); err != nil {
+		return err
+	}
+	for _, mod := range mods {
+		if _, ok := manifest[mod]; !ok {
+			log.Printf("adding release please manifest entry for: %s", mod)
+			manifest[mod] = "0.0.0"
+		}
+	}
+	e := json.NewEncoder(w)
+	e.SetIndent("", "    ")
+	if err := e.Encode(&manifest); err != nil {
+		return err
+	}
+	return nil
+}
+
+// detectModules returns a list of relative paths to module roots that are
+// managed by release-please.
+func detectModules(dir string) ([]string, error) {
+	var mods []string
+	fileSystem := os.DirFS(dir)
+	err := fs.WalkDir(fileSystem, ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			log.Fatal(err)
+		}
+		if !d.IsDir() && d.Name() == "go.mod" && !strings.Contains(path, "internal") && !individuallyReleasedModules[filepath.Dir(path)] {
+			mods = append(mods, filepath.Dir(path))
+		}
+		return nil
+	})
+	return mods, err
+}

--- a/internal/postprocessor/testdata/.release-please-manifest-submodules.json
+++ b/internal/postprocessor/testdata/.release-please-manifest-submodules.json
@@ -1,0 +1,3 @@
+{
+    "accessapproval": "1.6.1"
+}

--- a/internal/postprocessor/testdata/.release-please-manifest-submodules.want
+++ b/internal/postprocessor/testdata/.release-please-manifest-submodules.want
@@ -1,0 +1,4 @@
+{
+    "accessapproval": "1.6.1",
+    "newmod": "0.0.0"
+}

--- a/internal/postprocessor/testdata/release-please-config-yoshi-submodules.want
+++ b/internal/postprocessor/testdata/release-please-config-yoshi-submodules.want
@@ -1,0 +1,16 @@
+{
+    "release-type": "go-yoshi",
+    "include-component-in-tag": true,
+    "tag-separator": "/",
+    "packages": {
+        "accessapproval": {
+            "component": "accessapproval"
+        },
+        "newmod": {
+            "component": "newmod"
+        }
+    },
+    "plugins": [
+        "sentence-case"
+    ]
+}


### PR DESCRIPTION
This is more of a reconsiling job. The post-processor will now add entries to the release-please files for relevant modules that are detected.

Fixes: #7837