### PR TITLE
chore(ci): ignore snippet go.mod in vet check

### DIFF
--- a/.github/workflows/vet.sh
+++ b/.github/workflows/vet.sh
@@ -27,8 +27,11 @@ for i in $(find . -name go.mod); do
   go mod tidy
   popd
 done
-git diff '*go.mod' | tee /dev/stderr | (! read)
-git diff '*go.sum' | tee /dev/stderr | (! read)
+
+# Documentation for the :^ pathspec can be found at:
+# https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-aiddefpathspecapathspec
+git diff '*go.mod' :^internal/generated/snippets | tee /dev/stderr | (! read)
+git diff '*go.sum' :^internal/generated/snippets | tee /dev/stderr | (! read)
 
 gofmt -s -d -l . 2>&1 | tee /dev/stderr | (! read)
 goimports -l . 2>&1 | tee /dev/stderr | (! read)


### PR DESCRIPTION
Prevents the `vet` check from failing because of missing necessary changes in the `internal/generated/snippets` go.mod and go.sum files. This is because that module is not updated by renovate atm.