### PR TITLE
feat(logging): accept values of type error in Entry.Payload

### DIFF
--- a/logging/logging.go
+++ b/logging/logging.go
@@ -442,7 +442,7 @@ type Entry struct {
 	// The zero value is Default.
 	Severity Severity
 
-	// Payload must be either a string, or something that marshals via the
+	// Payload must be either a string, an error, or something that marshals via the
 	// encoding/json package to a JSON object (and not any other type of JSON value).
 	Payload interface{}
 
@@ -934,6 +934,8 @@ func toLogEntryInternalImpl(e Entry, l *Logger, parent string, skipLevels int) (
 	switch p := e.Payload.(type) {
 	case string:
 		ent.Payload = &logpb.LogEntry_TextPayload{TextPayload: p}
+	case error:
+		ent.Payload = &logpb.LogEntry_TextPayload{TextPayload: p.Error()}
 	case *anypb.Any:
 		ent.Payload = &logpb.LogEntry_ProtoPayload{ProtoPayload: p}
 	default:

--- a/logging/logging_unexported_test.go
+++ b/logging/logging_unexported_test.go
@@ -18,6 +18,7 @@ package logging
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/url"
 	"testing"
@@ -189,6 +190,10 @@ func TestToLogEntryPayload(t *testing.T) {
 		{
 			in:       "string",
 			wantText: "string",
+		},
+		{
+			in:       errors.New("oops"),
+			wantText: "oops",
 		},
 		{
 			in: map[string]interface{}{"a": 1, "b": true},


### PR DESCRIPTION
It's natural to pass in values of type error when logging at the error level. We were accidentally doing this and were left with a confusing, empty payload in the logging UI.

You can see [here](https://go.dev/play/p/xTNZmTvBfwC) how an `error` JSON marshals into `{}`.