### PR TITLE
chore: fix new module bug

### DIFF
--- a/internal/postprocessor/main.go
+++ b/internal/postprocessor/main.go
@@ -178,10 +178,7 @@ func (p *postProcessor) InitializeNewModules(manifest map[string]ManifestEntry) 
 	log.Println("checking for new modules and clients")
 	for _, moduleName := range p.config.Modules {
 		modulePath := filepath.Join(p.googleCloudDir, moduleName)
-		importPath, err := gocmd.ListModName(modulePath)
-		if err != nil {
-			return err
-		}
+		importPath := filepath.Join("cloud.google.com/go", moduleName)
 
 		pathToModVersionFile := filepath.Join(modulePath, "internal/version.go")
 		// Check if <module>/internal/version.go file exists
@@ -207,7 +204,7 @@ func (p *postProcessor) InitializeNewModules(manifest map[string]ManifestEntry) 
 			}
 		}
 		// Check if version.go files exist for each client
-		err = filepath.WalkDir(modulePath, func(path string, d fs.DirEntry, err error) error {
+		err := filepath.WalkDir(modulePath, func(path string, d fs.DirEntry, err error) error {
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Partial revert of #7904. If the module does not exist yet the old code yeilded the root module and messed up automation. All v2 mods have been migrated to in-place so this should be a safe assumption.