### PR TITLE
test(storage): fix panicking test

### DIFF
--- a/storage/integration_test.go
+++ b/storage/integration_test.go
@@ -1420,11 +1420,11 @@ func TestIntegration_ObjectChecksums(t *testing.T) {
 			wc := b.Object(c.name + uidSpaceObjects.New()).NewWriter(ctx)
 			for _, data := range c.contents {
 				if _, err := wc.Write(data); err != nil {
-					t.Errorf("Write(%q) failed with %q", data, err)
+					t.Fatalf("Write(%q) failed with %q", data, err)
 				}
 			}
 			if err := wc.Close(); err != nil {
-				t.Errorf("%q: close failed with %q", c.name, err)
+				t.Fatalf("%q: close failed with %q", c.name, err)
 			}
 			obj := wc.Attrs()
 			if got, want := obj.Size, c.size; got != want {


### PR DESCRIPTION
Use t.Fatalf instead of Errorf to prevent panic on a transient failure.

Closes #8045
Closes #8046
Closes #8047
Closes #8048
Closes #8049
Closes #8050