### PR TITLE
fix(pubsub/pstest): fix failing bq config test

### DIFF
--- a/pubsub/pstest/fake_test.go
+++ b/pubsub/pstest/fake_test.go
@@ -1575,7 +1575,7 @@ func TestSubscriptionPushPull(t *testing.T) {
 	}
 
 	// Switch back to a pull subscription.
-	updateSub.BigqueryConfig = &pb.BigQueryConfig{}
+	updateSub.BigqueryConfig = nil
 	got = mustUpdateSubscription(ctx, t, sclient, &pb.UpdateSubscriptionRequest{
 		Subscription: updateSub,
 		UpdateMask:   &field_mask.FieldMask{Paths: []string{"bigquery_config"}},


### PR DESCRIPTION
The correct behavior in the fake while updating subscriptions is to clear BQ config on a nil value, rather than empty value. This updates a test that was still running on the previous assumption.

Fixes #8044