### PR TITLE
fix!(pubsub/pstest): make fake handling of bq subs to be like live service

### DIFF
--- a/pubsub/pstest/fake.go
+++ b/pubsub/pstest/fake.go
@@ -499,9 +499,10 @@ func (s *GServer) CreateSubscription(_ context.Context, ps *pb.Subscription) (*p
 	if ps.PushConfig == nil {
 		ps.PushConfig = &pb.PushConfig{}
 	}
-	if ps.BigqueryConfig == nil {
-		ps.BigqueryConfig = &pb.BigQueryConfig{}
-	} else if ps.BigqueryConfig.Table != "" {
+	// Consider any table set to mean the config is active.
+	// We don't convert nil config to empty like with PushConfig above
+	// as this mimics the live service behavior.
+	if ps.GetBigqueryConfig() != nil && ps.GetBigqueryConfig().GetTable() != "" {
 		ps.BigqueryConfig.State = pb.BigQueryConfig_ACTIVE
 	}
 	ps.TopicMessageRetentionDuration = top.proto.MessageRetentionDuration
@@ -605,7 +606,7 @@ func (s *GServer) UpdateSubscription(_ context.Context, req *pb.UpdateSubscripti
 			sub.proto.PushConfig = req.Subscription.PushConfig
 
 		case "bigquery_config":
-			// If bq config is nil here, it will have been cleared.
+			// If bq config is nil here, it will be cleared.
 			// Otherwise, we'll consider the subscription active if any table is set.
 			sub.proto.BigqueryConfig = req.GetSubscription().GetBigqueryConfig()
 			if sub.proto.GetBigqueryConfig() != nil {

--- a/pubsub/pstest/fake_test.go
+++ b/pubsub/pstest/fake_test.go
@@ -1583,8 +1583,8 @@ func TestSubscriptionPushPull(t *testing.T) {
 	if diff := testutil.Diff(got.PushConfig, new(pb.PushConfig)); diff != "" {
 		t.Errorf("sub.PushConfig should be zero value\n%s", diff)
 	}
-	if diff := testutil.Diff(got.BigqueryConfig, new(pb.BigQueryConfig)); diff != "" {
-		t.Errorf("sub.BigqueryConfig should be zero value\n%s", diff)
+	if got.BigqueryConfig != nil {
+		t.Errorf("sub.BigqueryConfig should be nil, got %s", got.BigqueryConfig)
 	}
 }
 


### PR DESCRIPTION
When creating BQ subscriptions and when `BigQueryConfig == nil`, we were incorrectly converting this to the zero valued `BigQueryConfig{}`. This was done to mimic the behavior of `PushConfig` but upon further investigation, the live service does not behave like this (`PushConfig` is always empty valued, `BigQueryConfig` can be `nil`).

The fake is considered experimental and is safe to break.

Fixes #8044