### PR TITLE
meta: make .repo-metadata-full.json pass linting

### DIFF
--- a/internal/.repo-metadata-full.json
+++ b/internal/.repo-metadata-full.json
@@ -2,2134 +2,2371 @@
   "cloud.google.com/go/accessapproval/apiv1": {
     "distribution_name": "cloud.google.com/go/accessapproval/apiv1",
     "description": "Access Approval API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/accessapproval/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/accessapproval/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "accessapproval"
   },
   "cloud.google.com/go/accesscontextmanager/apiv1": {
     "distribution_name": "cloud.google.com/go/accesscontextmanager/apiv1",
     "description": "Access Context Manager API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/accesscontextmanager/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/accesscontextmanager/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "accesscontextmanager"
   },
   "cloud.google.com/go/advisorynotifications/apiv1": {
     "distribution_name": "cloud.google.com/go/advisorynotifications/apiv1",
     "description": "Advisory Notifications API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/advisorynotifications/latest/apiv1",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/advisorynotifications/latest/apiv1",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "advisorynotifications"
   },
   "cloud.google.com/go/aiplatform/apiv1": {
     "distribution_name": "cloud.google.com/go/aiplatform/apiv1",
     "description": "Vertex AI API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/aiplatform/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/aiplatform/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "aiplatform"
   },
   "cloud.google.com/go/aiplatform/apiv1beta1": {
     "distribution_name": "cloud.google.com/go/aiplatform/apiv1beta1",
     "description": "Vertex AI API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/aiplatform/latest/apiv1beta1",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/aiplatform/latest/apiv1beta1",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "aiplatform"
   },
   "cloud.google.com/go/alloydb/apiv1": {
     "distribution_name": "cloud.google.com/go/alloydb/apiv1",
     "description": "AlloyDB API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/alloydb/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/alloydb/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "alloydb"
   },
   "cloud.google.com/go/alloydb/apiv1alpha": {
     "distribution_name": "cloud.google.com/go/alloydb/apiv1alpha",
     "description": "AlloyDB API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/alloydb/latest/apiv1alpha",
-    "release_level": "alpha",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/alloydb/latest/apiv1alpha",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "alloydb"
   },
   "cloud.google.com/go/alloydb/apiv1beta": {
     "distribution_name": "cloud.google.com/go/alloydb/apiv1beta",
     "description": "AlloyDB API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/alloydb/latest/apiv1beta",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/alloydb/latest/apiv1beta",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "alloydb"
   },
   "cloud.google.com/go/analytics/admin/apiv1alpha": {
     "distribution_name": "cloud.google.com/go/analytics/admin/apiv1alpha",
-    "description": "Google Analytics Admin API",
-    "language": "Go",
+    "description": "google Analytics Admin API",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/analytics/latest/admin/apiv1alpha",
-    "release_level": "alpha",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/analytics/latest/admin/apiv1alpha",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "analytics"
   },
-  "cloud.google.com/go/apigateway/apiv1": {
-    "distribution_name": "cloud.google.com/go/apigateway/apiv1",
+  "cloud.google.com/go/apistableteway/apiv1": {
+    "distribution_name": "cloud.google.com/go/apistableteway/apiv1",
     "description": "API Gateway API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/apigateway/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/apistableteway/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "apistableteway"
   },
   "cloud.google.com/go/apigeeconnect/apiv1": {
     "distribution_name": "cloud.google.com/go/apigeeconnect/apiv1",
     "description": "Apigee Connect API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/apigeeconnect/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/apigeeconnect/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "apigeeconnect"
   },
   "cloud.google.com/go/apigeeregistry/apiv1": {
     "distribution_name": "cloud.google.com/go/apigeeregistry/apiv1",
     "description": "Apigee Registry API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/apigeeregistry/latest/apiv1",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/apigeeregistry/latest/apiv1",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "apigeeregistry"
   },
   "cloud.google.com/go/apikeys/apiv2": {
     "distribution_name": "cloud.google.com/go/apikeys/apiv2",
     "description": "API Keys API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/apikeys/latest/apiv2",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/apikeys/latest/apiv2",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "apikeys"
   },
   "cloud.google.com/go/appengine/apiv1": {
     "distribution_name": "cloud.google.com/go/appengine/apiv1",
     "description": "App Engine Admin API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/appengine/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/appengine/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "appengine"
   },
   "cloud.google.com/go/area120/tables/apiv1alpha1": {
     "distribution_name": "cloud.google.com/go/area120/tables/apiv1alpha1",
     "description": "Area120 Tables API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/area120/latest/tables/apiv1alpha1",
-    "release_level": "alpha",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/area120/latest/tables/apiv1alpha1",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "area120"
   },
   "cloud.google.com/go/artifactregistry/apiv1": {
     "distribution_name": "cloud.google.com/go/artifactregistry/apiv1",
     "description": "Artifact Registry API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/artifactregistry/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/artifactregistry/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "artifactregistry"
   },
   "cloud.google.com/go/artifactregistry/apiv1beta2": {
     "distribution_name": "cloud.google.com/go/artifactregistry/apiv1beta2",
     "description": "Artifact Registry API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/artifactregistry/latest/apiv1beta2",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/artifactregistry/latest/apiv1beta2",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "artifactregistry"
   },
   "cloud.google.com/go/asset/apiv1": {
     "distribution_name": "cloud.google.com/go/asset/apiv1",
     "description": "Cloud Asset API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/asset/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/asset/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "asset"
   },
   "cloud.google.com/go/asset/apiv1p2beta1": {
     "distribution_name": "cloud.google.com/go/asset/apiv1p2beta1",
     "description": "Cloud Asset API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/asset/latest/apiv1p2beta1",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/asset/latest/apiv1p2beta1",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "asset"
   },
   "cloud.google.com/go/asset/apiv1p5beta1": {
     "distribution_name": "cloud.google.com/go/asset/apiv1p5beta1",
     "description": "Cloud Asset API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/asset/latest/apiv1p5beta1",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/asset/latest/apiv1p5beta1",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "asset"
   },
   "cloud.google.com/go/assuredworkloads/apiv1": {
     "distribution_name": "cloud.google.com/go/assuredworkloads/apiv1",
     "description": "Assured Workloads API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/assuredworkloads/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/assuredworkloads/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "assuredworkloads"
   },
   "cloud.google.com/go/assuredworkloads/apiv1beta1": {
     "distribution_name": "cloud.google.com/go/assuredworkloads/apiv1beta1",
     "description": "Assured Workloads API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/assuredworkloads/latest/apiv1beta1",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/assuredworkloads/latest/apiv1beta1",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "assuredworkloads"
   },
   "cloud.google.com/go/automl/apiv1": {
     "distribution_name": "cloud.google.com/go/automl/apiv1",
     "description": "Cloud AutoML API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/automl/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/automl/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "automl"
   },
   "cloud.google.com/go/automl/apiv1beta1": {
     "distribution_name": "cloud.google.com/go/automl/apiv1beta1",
     "description": "Cloud AutoML API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/automl/latest/apiv1beta1",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/automl/latest/apiv1beta1",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "automl"
   },
   "cloud.google.com/go/baremetalsolution/apiv2": {
     "distribution_name": "cloud.google.com/go/baremetalsolution/apiv2",
     "description": "Bare Metal Solution API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/baremetalsolution/latest/apiv2",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/baremetalsolution/latest/apiv2",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "baremetalsolution"
   },
   "cloud.google.com/go/batch/apiv1": {
     "distribution_name": "cloud.google.com/go/batch/apiv1",
     "description": "Batch API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/batch/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/batch/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "batch"
   },
   "cloud.google.com/go/beyondcorp/appconnections/apiv1": {
     "distribution_name": "cloud.google.com/go/beyondcorp/appconnections/apiv1",
     "description": "BeyondCorp API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/beyondcorp/latest/appconnections/apiv1",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/beyondcorp/latest/appconnections/apiv1",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "beyondcorp"
   },
   "cloud.google.com/go/beyondcorp/appconnectors/apiv1": {
     "distribution_name": "cloud.google.com/go/beyondcorp/appconnectors/apiv1",
     "description": "BeyondCorp API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/beyondcorp/latest/appconnectors/apiv1",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/beyondcorp/latest/appconnectors/apiv1",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "beyondcorp"
   },
-  "cloud.google.com/go/beyondcorp/appgateways/apiv1": {
-    "distribution_name": "cloud.google.com/go/beyondcorp/appgateways/apiv1",
+  "cloud.google.com/go/beyondcorp/appstableteways/apiv1": {
+    "distribution_name": "cloud.google.com/go/beyondcorp/appstableteways/apiv1",
     "description": "BeyondCorp API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/beyondcorp/latest/appgateways/apiv1",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/beyondcorp/latest/appstableteways/apiv1",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "beyondcorp"
   },
   "cloud.google.com/go/beyondcorp/clientconnectorservices/apiv1": {
     "distribution_name": "cloud.google.com/go/beyondcorp/clientconnectorservices/apiv1",
     "description": "BeyondCorp API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/beyondcorp/latest/clientconnectorservices/apiv1",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/beyondcorp/latest/clientconnectorservices/apiv1",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "beyondcorp"
   },
-  "cloud.google.com/go/beyondcorp/clientgateways/apiv1": {
-    "distribution_name": "cloud.google.com/go/beyondcorp/clientgateways/apiv1",
+  "cloud.google.com/go/beyondcorp/clientstableteways/apiv1": {
+    "distribution_name": "cloud.google.com/go/beyondcorp/clientstableteways/apiv1",
     "description": "BeyondCorp API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/beyondcorp/latest/clientgateways/apiv1",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/beyondcorp/latest/clientstableteways/apiv1",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "beyondcorp"
   },
   "cloud.google.com/go/bigquery": {
     "distribution_name": "cloud.google.com/go/bigquery",
     "description": "BigQuery",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "manual",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigquery/latest",
-    "release_level": "ga",
-    "library_type": "GAPIC_MANUAL"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigquery/latest",
+    "release_level": "stable",
+    "library_type": "GAPIC_MANUAL",
+    "api_shortname": "bigquery"
   },
   "cloud.google.com/go/bigquery/analyticshub/apiv1": {
     "distribution_name": "cloud.google.com/go/bigquery/analyticshub/apiv1",
     "description": "Analytics Hub API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigquery/latest/analyticshub/apiv1",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigquery/latest/analyticshub/apiv1",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "bigquery"
   },
   "cloud.google.com/go/bigquery/connection/apiv1": {
     "distribution_name": "cloud.google.com/go/bigquery/connection/apiv1",
     "description": "BigQuery Connection API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigquery/latest/connection/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigquery/latest/connection/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "bigquery"
   },
   "cloud.google.com/go/bigquery/connection/apiv1beta1": {
     "distribution_name": "cloud.google.com/go/bigquery/connection/apiv1beta1",
     "description": "BigQuery Connection API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigquery/latest/connection/apiv1beta1",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigquery/latest/connection/apiv1beta1",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "bigquery"
   },
   "cloud.google.com/go/bigquery/dataexchange/apiv1beta1": {
     "distribution_name": "cloud.google.com/go/bigquery/dataexchange/apiv1beta1",
     "description": "Analytics Hub API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigquery/latest/dataexchange/apiv1beta1",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigquery/latest/dataexchange/apiv1beta1",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "bigquery"
   },
   "cloud.google.com/go/bigquery/datapolicies/apiv1": {
     "distribution_name": "cloud.google.com/go/bigquery/datapolicies/apiv1",
     "description": "BigQuery Data Policy API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigquery/latest/datapolicies/apiv1",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigquery/latest/datapolicies/apiv1",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "bigquery"
   },
   "cloud.google.com/go/bigquery/datapolicies/apiv1beta1": {
     "distribution_name": "cloud.google.com/go/bigquery/datapolicies/apiv1beta1",
     "description": "BigQuery Data Policy API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigquery/latest/datapolicies/apiv1beta1",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigquery/latest/datapolicies/apiv1beta1",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "bigquery"
   },
   "cloud.google.com/go/bigquery/datatransfer/apiv1": {
     "distribution_name": "cloud.google.com/go/bigquery/datatransfer/apiv1",
     "description": "BigQuery Data Transfer API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigquery/latest/datatransfer/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigquery/latest/datatransfer/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "bigquery"
   },
   "cloud.google.com/go/bigquery/migration/apiv2": {
     "distribution_name": "cloud.google.com/go/bigquery/migration/apiv2",
     "description": "BigQuery Migration API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigquery/latest/migration/apiv2",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigquery/latest/migration/apiv2",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "bigquery"
   },
   "cloud.google.com/go/bigquery/migration/apiv2alpha": {
     "distribution_name": "cloud.google.com/go/bigquery/migration/apiv2alpha",
     "description": "BigQuery Migration API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigquery/latest/migration/apiv2alpha",
-    "release_level": "alpha",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigquery/latest/migration/apiv2alpha",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "bigquery"
   },
   "cloud.google.com/go/bigquery/reservation/apiv1": {
     "distribution_name": "cloud.google.com/go/bigquery/reservation/apiv1",
     "description": "BigQuery Reservation API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigquery/latest/reservation/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigquery/latest/reservation/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "bigquery"
   },
   "cloud.google.com/go/bigquery/storage/apiv1": {
     "distribution_name": "cloud.google.com/go/bigquery/storage/apiv1",
     "description": "BigQuery Storage API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigquery/latest/storage/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigquery/latest/storage/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "bigquery"
   },
   "cloud.google.com/go/bigquery/storage/apiv1beta1": {
     "distribution_name": "cloud.google.com/go/bigquery/storage/apiv1beta1",
     "description": "BigQuery Storage API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigquery/latest/storage/apiv1beta1",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigquery/latest/storage/apiv1beta1",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "bigquery"
   },
   "cloud.google.com/go/bigquery/storage/apiv1beta2": {
     "distribution_name": "cloud.google.com/go/bigquery/storage/apiv1beta2",
     "description": "BigQuery Storage API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigquery/latest/storage/apiv1beta2",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigquery/latest/storage/apiv1beta2",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "bigquery"
   },
   "cloud.google.com/go/bigtable": {
     "distribution_name": "cloud.google.com/go/bigtable",
     "description": "Cloud BigTable",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "manual",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigtable/latest",
-    "release_level": "ga",
-    "library_type": "GAPIC_MANUAL"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigtable/latest",
+    "release_level": "stable",
+    "library_type": "GAPIC_MANUAL",
+    "api_shortname": "bigtable"
   },
   "cloud.google.com/go/billing/apiv1": {
     "distribution_name": "cloud.google.com/go/billing/apiv1",
     "description": "Cloud Billing API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/billing/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/billing/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "billing"
   },
   "cloud.google.com/go/billing/budgets/apiv1": {
     "distribution_name": "cloud.google.com/go/billing/budgets/apiv1",
     "description": "Cloud Billing Budget API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/billing/latest/budgets/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/billing/latest/budgets/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "billing"
   },
   "cloud.google.com/go/billing/budgets/apiv1beta1": {
     "distribution_name": "cloud.google.com/go/billing/budgets/apiv1beta1",
     "description": "Cloud Billing Budget API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/billing/latest/budgets/apiv1beta1",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/billing/latest/budgets/apiv1beta1",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "billing"
   },
   "cloud.google.com/go/binaryauthorization/apiv1": {
     "distribution_name": "cloud.google.com/go/binaryauthorization/apiv1",
     "description": "Binary Authorization API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/binaryauthorization/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/binaryauthorization/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "binaryauthorization"
   },
   "cloud.google.com/go/binaryauthorization/apiv1beta1": {
     "distribution_name": "cloud.google.com/go/binaryauthorization/apiv1beta1",
     "description": "Binary Authorization API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/binaryauthorization/latest/apiv1beta1",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/binaryauthorization/latest/apiv1beta1",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "binaryauthorization"
   },
   "cloud.google.com/go/certificatemanager/apiv1": {
     "distribution_name": "cloud.google.com/go/certificatemanager/apiv1",
     "description": "Certificate Manager API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/certificatemanager/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/certificatemanager/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "certificatemanager"
   },
   "cloud.google.com/go/channel/apiv1": {
     "distribution_name": "cloud.google.com/go/channel/apiv1",
     "description": "Cloud Channel API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/channel/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/channel/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "channel"
   },
   "cloud.google.com/go/cloudbuild/apiv1/v2": {
     "distribution_name": "cloud.google.com/go/cloudbuild/apiv1/v2",
     "description": "Cloud Build API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/latest/cloudbuild/apiv1/v2",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/latest/cloudbuild/apiv1/v2",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "cloudbuild"
   },
   "cloud.google.com/go/cloudbuild/apiv2": {
     "distribution_name": "cloud.google.com/go/cloudbuild/apiv2",
     "description": "Cloud Build API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/cloudbuild/latest/apiv2",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/cloudbuild/latest/apiv2",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "cloudbuild"
   },
   "cloud.google.com/go/clouddms/apiv1": {
     "distribution_name": "cloud.google.com/go/clouddms/apiv1",
     "description": "Database Migration API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/clouddms/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/clouddms/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "clouddms"
   },
   "cloud.google.com/go/cloudtasks/apiv2": {
     "distribution_name": "cloud.google.com/go/cloudtasks/apiv2",
     "description": "Cloud Tasks API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/cloudtasks/latest/apiv2",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/cloudtasks/latest/apiv2",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "cloudtasks"
   },
   "cloud.google.com/go/cloudtasks/apiv2beta2": {
     "distribution_name": "cloud.google.com/go/cloudtasks/apiv2beta2",
     "description": "Cloud Tasks API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/cloudtasks/latest/apiv2beta2",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/cloudtasks/latest/apiv2beta2",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "cloudtasks"
   },
   "cloud.google.com/go/cloudtasks/apiv2beta3": {
     "distribution_name": "cloud.google.com/go/cloudtasks/apiv2beta3",
     "description": "Cloud Tasks API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/cloudtasks/latest/apiv2beta3",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/cloudtasks/latest/apiv2beta3",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "cloudtasks"
   },
   "cloud.google.com/go/compute/apiv1": {
     "distribution_name": "cloud.google.com/go/compute/apiv1",
-    "description": "Google Compute Engine API",
-    "language": "Go",
+    "description": "google Compute Engine API",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/compute/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/compute/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "compute"
   },
   "cloud.google.com/go/compute/metadata": {
     "distribution_name": "cloud.google.com/go/compute/metadata",
     "description": "Service Metadata API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "manual",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/compute/latest/metadata",
-    "release_level": "ga",
-    "library_type": "CORE"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/compute/latest/metadata",
+    "release_level": "stable",
+    "library_type": "CORE",
+    "api_shortname": "compute"
   },
   "cloud.google.com/go/confidentialcomputing/apiv1": {
     "distribution_name": "cloud.google.com/go/confidentialcomputing/apiv1",
     "description": "Confidential Computing API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/confidentialcomputing/latest/apiv1",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/confidentialcomputing/latest/apiv1",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "confidentialcomputing"
   },
   "cloud.google.com/go/confidentialcomputing/apiv1alpha1": {
     "distribution_name": "cloud.google.com/go/confidentialcomputing/apiv1alpha1",
     "description": "Confidential Computing API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/confidentialcomputing/latest/apiv1alpha1",
-    "release_level": "alpha",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/confidentialcomputing/latest/apiv1alpha1",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "confidentialcomputing"
   },
   "cloud.google.com/go/contactcenterinsights/apiv1": {
     "distribution_name": "cloud.google.com/go/contactcenterinsights/apiv1",
     "description": "Contact Center AI Insights API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/contactcenterinsights/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/contactcenterinsights/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "contactcenterinsights"
   },
   "cloud.google.com/go/container/apiv1": {
     "distribution_name": "cloud.google.com/go/container/apiv1",
     "description": "Kubernetes Engine API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/container/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/container/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "container"
   },
   "cloud.google.com/go/containeranalysis/apiv1beta1": {
     "distribution_name": "cloud.google.com/go/containeranalysis/apiv1beta1",
     "description": "Container Analysis API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/latest/containeranalysis/apiv1beta1",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/latest/containeranalysis/apiv1beta1",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "containeranalysis"
   },
   "cloud.google.com/go/datacatalog/apiv1": {
     "distribution_name": "cloud.google.com/go/datacatalog/apiv1",
-    "description": "Google Cloud Data Catalog API",
-    "language": "Go",
+    "description": "google Cloud Data Catalog API",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/datacatalog/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/datacatalog/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "datacatalog"
   },
   "cloud.google.com/go/datacatalog/apiv1beta1": {
     "distribution_name": "cloud.google.com/go/datacatalog/apiv1beta1",
-    "description": "Google Cloud Data Catalog API",
-    "language": "Go",
+    "description": "google Cloud Data Catalog API",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/datacatalog/latest/apiv1beta1",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/datacatalog/latest/apiv1beta1",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "datacatalog"
   },
   "cloud.google.com/go/datacatalog/lineage/apiv1": {
     "distribution_name": "cloud.google.com/go/datacatalog/lineage/apiv1",
     "description": "Data Lineage API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/datacatalog/latest/lineage/apiv1",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/datacatalog/latest/lineage/apiv1",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "datacatalog"
   },
   "cloud.google.com/go/dataflow/apiv1beta3": {
     "distribution_name": "cloud.google.com/go/dataflow/apiv1beta3",
     "description": "Dataflow API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/dataflow/latest/apiv1beta3",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/dataflow/latest/apiv1beta3",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "dataflow"
   },
   "cloud.google.com/go/dataform/apiv1alpha2": {
     "distribution_name": "cloud.google.com/go/dataform/apiv1alpha2",
     "description": "Dataform API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/dataform/latest/apiv1alpha2",
-    "release_level": "alpha",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/dataform/latest/apiv1alpha2",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "dataform"
   },
   "cloud.google.com/go/dataform/apiv1beta1": {
     "distribution_name": "cloud.google.com/go/dataform/apiv1beta1",
     "description": "Dataform API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/dataform/latest/apiv1beta1",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/dataform/latest/apiv1beta1",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "dataform"
   },
   "cloud.google.com/go/datafusion/apiv1": {
     "distribution_name": "cloud.google.com/go/datafusion/apiv1",
     "description": "Cloud Data Fusion API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/datafusion/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/datafusion/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "datafusion"
   },
   "cloud.google.com/go/datalabeling/apiv1beta1": {
     "distribution_name": "cloud.google.com/go/datalabeling/apiv1beta1",
     "description": "Data Labeling API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/datalabeling/latest/apiv1beta1",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/datalabeling/latest/apiv1beta1",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "datalabeling"
   },
   "cloud.google.com/go/dataplex/apiv1": {
     "distribution_name": "cloud.google.com/go/dataplex/apiv1",
     "description": "Cloud Dataplex API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/dataplex/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/dataplex/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "dataplex"
   },
   "cloud.google.com/go/dataproc/v2/apiv1": {
     "distribution_name": "cloud.google.com/go/dataproc/v2/apiv1",
     "description": "Cloud Dataproc API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/dataproc/v2/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/dataproc/v2/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "dataproc"
   },
   "cloud.google.com/go/dataqna/apiv1alpha": {
     "distribution_name": "cloud.google.com/go/dataqna/apiv1alpha",
     "description": "Data QnA API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/dataqna/latest/apiv1alpha",
-    "release_level": "alpha",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/dataqna/latest/apiv1alpha",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "dataqna"
   },
   "cloud.google.com/go/datastore": {
     "distribution_name": "cloud.google.com/go/datastore",
     "description": "Cloud Datastore",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "manual",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/datastore/latest",
-    "release_level": "ga",
-    "library_type": "GAPIC_MANUAL"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/datastore/latest",
+    "release_level": "stable",
+    "library_type": "GAPIC_MANUAL",
+    "api_shortname": "datastore"
   },
   "cloud.google.com/go/datastore/admin/apiv1": {
     "distribution_name": "cloud.google.com/go/datastore/admin/apiv1",
     "description": "Cloud Datastore API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/datastore/latest/admin/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/datastore/latest/admin/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "datastore"
   },
   "cloud.google.com/go/datastream/apiv1": {
     "distribution_name": "cloud.google.com/go/datastream/apiv1",
     "description": "Datastream API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/datastream/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/datastream/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "datastream"
   },
   "cloud.google.com/go/datastream/apiv1alpha1": {
     "distribution_name": "cloud.google.com/go/datastream/apiv1alpha1",
     "description": "Datastream API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/datastream/latest/apiv1alpha1",
-    "release_level": "alpha",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/datastream/latest/apiv1alpha1",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "datastream"
   },
   "cloud.google.com/go/debugger/apiv2": {
     "distribution_name": "cloud.google.com/go/debugger/apiv2",
     "description": "Stackdriver Debugger API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/latest/debugger/apiv2",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/latest/debugger/apiv2",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "debugger"
   },
   "cloud.google.com/go/deploy/apiv1": {
     "distribution_name": "cloud.google.com/go/deploy/apiv1",
-    "description": "Google Cloud Deploy API",
-    "language": "Go",
+    "description": "google Cloud Deploy API",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/deploy/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/deploy/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "deploy"
   },
   "cloud.google.com/go/dialogflow/apiv2": {
     "distribution_name": "cloud.google.com/go/dialogflow/apiv2",
     "description": "Dialogflow API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/dialogflow/latest/apiv2",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/dialogflow/latest/apiv2",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "dialogflow"
   },
   "cloud.google.com/go/dialogflow/apiv2beta1": {
     "distribution_name": "cloud.google.com/go/dialogflow/apiv2beta1",
     "description": "Dialogflow API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/dialogflow/latest/apiv2beta1",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/dialogflow/latest/apiv2beta1",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "dialogflow"
   },
   "cloud.google.com/go/dialogflow/cx/apiv3": {
     "distribution_name": "cloud.google.com/go/dialogflow/cx/apiv3",
     "description": "Dialogflow API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/dialogflow/latest/cx/apiv3",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/dialogflow/latest/cx/apiv3",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "dialogflow"
   },
   "cloud.google.com/go/dialogflow/cx/apiv3beta1": {
     "distribution_name": "cloud.google.com/go/dialogflow/cx/apiv3beta1",
     "description": "Dialogflow API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/dialogflow/latest/cx/apiv3beta1",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/dialogflow/latest/cx/apiv3beta1",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "dialogflow"
   },
   "cloud.google.com/go/discoveryengine/apiv1": {
     "distribution_name": "cloud.google.com/go/discoveryengine/apiv1",
     "description": "Discovery Engine API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/discoveryengine/latest/apiv1",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/discoveryengine/latest/apiv1",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "discoveryengine"
   },
   "cloud.google.com/go/discoveryengine/apiv1beta": {
     "distribution_name": "cloud.google.com/go/discoveryengine/apiv1beta",
     "description": "Discovery Engine API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/discoveryengine/latest/apiv1beta",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/discoveryengine/latest/apiv1beta",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "discoveryengine"
   },
   "cloud.google.com/go/dlp/apiv2": {
     "distribution_name": "cloud.google.com/go/dlp/apiv2",
     "description": "Cloud Data Loss Prevention (DLP) API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/dlp/latest/apiv2",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/dlp/latest/apiv2",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "dlp"
   },
   "cloud.google.com/go/documentai/apiv1": {
     "distribution_name": "cloud.google.com/go/documentai/apiv1",
     "description": "Cloud Document AI API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/documentai/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/documentai/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "documentai"
   },
   "cloud.google.com/go/documentai/apiv1beta3": {
     "distribution_name": "cloud.google.com/go/documentai/apiv1beta3",
     "description": "Cloud Document AI API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/documentai/latest/apiv1beta3",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/documentai/latest/apiv1beta3",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "documentai"
   },
   "cloud.google.com/go/domains/apiv1beta1": {
     "distribution_name": "cloud.google.com/go/domains/apiv1beta1",
     "description": "Cloud Domains API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/domains/latest/apiv1beta1",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/domains/latest/apiv1beta1",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "domains"
   },
   "cloud.google.com/go/edgecontainer/apiv1": {
     "distribution_name": "cloud.google.com/go/edgecontainer/apiv1",
     "description": "Distributed Cloud Edge Container API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/edgecontainer/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/edgecontainer/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "edgecontainer"
   },
   "cloud.google.com/go/errorreporting": {
     "distribution_name": "cloud.google.com/go/errorreporting",
     "description": "Cloud Error Reporting API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "manual",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/errorreporting/latest",
-    "release_level": "beta",
-    "library_type": "GAPIC_MANUAL"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/errorreporting/latest",
+    "release_level": "preview",
+    "library_type": "GAPIC_MANUAL",
+    "api_shortname": "errorreporting"
   },
   "cloud.google.com/go/errorreporting/apiv1beta1": {
     "distribution_name": "cloud.google.com/go/errorreporting/apiv1beta1",
     "description": "Error Reporting API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/latest/errorreporting/apiv1beta1",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/latest/errorreporting/apiv1beta1",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "errorreporting"
   },
   "cloud.google.com/go/essentialcontacts/apiv1": {
     "distribution_name": "cloud.google.com/go/essentialcontacts/apiv1",
     "description": "Essential Contacts API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/essentialcontacts/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/essentialcontacts/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "essentialcontacts"
   },
   "cloud.google.com/go/eventarc/apiv1": {
     "distribution_name": "cloud.google.com/go/eventarc/apiv1",
     "description": "Eventarc API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/eventarc/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/eventarc/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "eventarc"
   },
   "cloud.google.com/go/eventarc/publishing/apiv1": {
     "distribution_name": "cloud.google.com/go/eventarc/publishing/apiv1",
     "description": "Eventarc Publishing API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/eventarc/latest/publishing/apiv1",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/eventarc/latest/publishing/apiv1",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "eventarc"
   },
   "cloud.google.com/go/filestore/apiv1": {
     "distribution_name": "cloud.google.com/go/filestore/apiv1",
     "description": "Cloud Filestore API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/filestore/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/filestore/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "filestore"
   },
   "cloud.google.com/go/firestore": {
     "distribution_name": "cloud.google.com/go/firestore",
     "description": "Cloud Firestore API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "manual",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/firestore/latest",
-    "release_level": "ga",
-    "library_type": "GAPIC_MANUAL"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/firestore/latest",
+    "release_level": "stable",
+    "library_type": "GAPIC_MANUAL",
+    "api_shortname": "firestore"
   },
   "cloud.google.com/go/firestore/apiv1": {
     "distribution_name": "cloud.google.com/go/firestore/apiv1",
     "description": "Cloud Firestore API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/firestore/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/firestore/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "firestore"
   },
   "cloud.google.com/go/functions/apiv1": {
     "distribution_name": "cloud.google.com/go/functions/apiv1",
     "description": "Cloud Functions API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/functions/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/functions/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "functions"
   },
   "cloud.google.com/go/functions/apiv2": {
     "distribution_name": "cloud.google.com/go/functions/apiv2",
     "description": "Cloud Functions API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/functions/latest/apiv2",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/functions/latest/apiv2",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "functions"
   },
   "cloud.google.com/go/functions/apiv2beta": {
     "distribution_name": "cloud.google.com/go/functions/apiv2beta",
     "description": "Cloud Functions API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/functions/latest/apiv2beta",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/functions/latest/apiv2beta",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "functions"
   },
   "cloud.google.com/go/functions/metadata": {
     "distribution_name": "cloud.google.com/go/functions/metadata",
     "description": "Cloud Functions",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "manual",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/functions/latest/metadata",
-    "release_level": "alpha",
-    "library_type": "CORE"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/functions/latest/metadata",
+    "release_level": "preview",
+    "library_type": "CORE",
+    "api_shortname": "functions"
   },
-  "cloud.google.com/go/gaming/apiv1": {
-    "distribution_name": "cloud.google.com/go/gaming/apiv1",
+  "cloud.google.com/go/stableming/apiv1": {
+    "distribution_name": "cloud.google.com/go/stableming/apiv1",
     "description": "Game Services API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/gaming/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/stableming/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "stableming"
   },
-  "cloud.google.com/go/gaming/apiv1beta": {
-    "distribution_name": "cloud.google.com/go/gaming/apiv1beta",
+  "cloud.google.com/go/stableming/apiv1beta": {
+    "distribution_name": "cloud.google.com/go/stableming/apiv1beta",
     "description": "Game Services API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/gaming/latest/apiv1beta",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/stableming/latest/apiv1beta",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "stableming"
   },
   "cloud.google.com/go/gkebackup/apiv1": {
     "distribution_name": "cloud.google.com/go/gkebackup/apiv1",
     "description": "Backup for GKE API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/gkebackup/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/gkebackup/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "gkebackup"
   },
-  "cloud.google.com/go/gkeconnect/gateway/apiv1beta1": {
-    "distribution_name": "cloud.google.com/go/gkeconnect/gateway/apiv1beta1",
+  "cloud.google.com/go/gkeconnect/stableteway/apiv1beta1": {
+    "distribution_name": "cloud.google.com/go/gkeconnect/stableteway/apiv1beta1",
     "description": "Connect Gateway API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/gkeconnect/latest/gateway/apiv1beta1",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/gkeconnect/latest/stableteway/apiv1beta1",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "gkeconnect"
   },
   "cloud.google.com/go/gkehub/apiv1beta1": {
     "distribution_name": "cloud.google.com/go/gkehub/apiv1beta1",
     "description": "GKE Hub API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/gkehub/latest/apiv1beta1",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/gkehub/latest/apiv1beta1",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "gkehub"
   },
   "cloud.google.com/go/gkemulticloud/apiv1": {
     "distribution_name": "cloud.google.com/go/gkemulticloud/apiv1",
     "description": "Anthos Multi-Cloud API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/gkemulticloud/latest/apiv1",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/gkemulticloud/latest/apiv1",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "gkemulticloud"
   },
   "cloud.google.com/go/gsuiteaddons/apiv1": {
     "distribution_name": "cloud.google.com/go/gsuiteaddons/apiv1",
-    "description": "Google Workspace Add-ons API",
-    "language": "Go",
+    "description": "google Workspace Add-ons API",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/gsuiteaddons/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/gsuiteaddons/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "gsuiteaddons"
   },
   "cloud.google.com/go/iam": {
     "distribution_name": "cloud.google.com/go/iam",
     "description": "Cloud IAM",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "manual",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/iam/latest",
-    "release_level": "ga",
-    "library_type": "CORE"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/iam/latest",
+    "release_level": "stable",
+    "library_type": "CORE",
+    "api_shortname": "iam"
   },
   "cloud.google.com/go/iam/apiv1": {
     "distribution_name": "cloud.google.com/go/iam/apiv1",
     "description": "IAM Meta API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/iam/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/iam/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "iam"
   },
   "cloud.google.com/go/iam/apiv2": {
     "distribution_name": "cloud.google.com/go/iam/apiv2",
     "description": "Identity and Access Management (IAM) API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/iam/latest/apiv2",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/iam/latest/apiv2",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "iam"
   },
   "cloud.google.com/go/iam/credentials/apiv1": {
     "distribution_name": "cloud.google.com/go/iam/credentials/apiv1",
     "description": "IAM Service Account Credentials API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/iam/latest/credentials/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/iam/latest/credentials/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "iam"
   },
   "cloud.google.com/go/iap/apiv1": {
     "distribution_name": "cloud.google.com/go/iap/apiv1",
     "description": "Cloud Identity-Aware Proxy API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/iap/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/iap/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "iap"
   },
   "cloud.google.com/go/ids/apiv1": {
     "distribution_name": "cloud.google.com/go/ids/apiv1",
     "description": "Cloud IDS API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/ids/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/ids/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "ids"
   },
   "cloud.google.com/go/iot/apiv1": {
     "distribution_name": "cloud.google.com/go/iot/apiv1",
     "description": "Cloud IoT API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/iot/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/iot/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "iot"
   },
   "cloud.google.com/go/kms/apiv1": {
     "distribution_name": "cloud.google.com/go/kms/apiv1",
     "description": "Cloud Key Management Service (KMS) API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/kms/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/kms/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "kms"
   },
   "cloud.google.com/go/kms/inventory/apiv1": {
     "distribution_name": "cloud.google.com/go/kms/inventory/apiv1",
     "description": "KMS Inventory API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/kms/latest/inventory/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/kms/latest/inventory/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "kms"
   },
   "cloud.google.com/go/language/apiv1": {
     "distribution_name": "cloud.google.com/go/language/apiv1",
     "description": "Cloud Natural Language API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/language/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/language/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "language"
   },
   "cloud.google.com/go/language/apiv1beta2": {
     "distribution_name": "cloud.google.com/go/language/apiv1beta2",
     "description": "Cloud Natural Language API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/language/latest/apiv1beta2",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/language/latest/apiv1beta2",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "language"
   },
   "cloud.google.com/go/lifesciences/apiv2beta": {
     "distribution_name": "cloud.google.com/go/lifesciences/apiv2beta",
     "description": "Cloud Life Sciences API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/lifesciences/latest/apiv2beta",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/lifesciences/latest/apiv2beta",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "lifesciences"
   },
   "cloud.google.com/go/logging": {
     "distribution_name": "cloud.google.com/go/logging",
     "description": "Cloud Logging API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "manual",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/logging/latest",
-    "release_level": "ga",
-    "library_type": "GAPIC_MANUAL"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/logging/latest",
+    "release_level": "stable",
+    "library_type": "GAPIC_MANUAL",
+    "api_shortname": "logging"
   },
   "cloud.google.com/go/logging/apiv2": {
     "distribution_name": "cloud.google.com/go/logging/apiv2",
     "description": "Cloud Logging API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/logging/latest/apiv2",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/logging/latest/apiv2",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "logging"
   },
   "cloud.google.com/go/longrunning/autogen": {
     "distribution_name": "cloud.google.com/go/longrunning/autogen",
     "description": "Long Running Operations API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/longrunning/latest/autogen",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/longrunning/latest/autogen",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "longrunning"
   },
   "cloud.google.com/go/managedidentities/apiv1": {
     "distribution_name": "cloud.google.com/go/managedidentities/apiv1",
     "description": "Managed Service for Microsoft Active Directory API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/managedidentities/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/managedidentities/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "managedidentities"
   },
   "cloud.google.com/go/maps/addressvalidation/apiv1": {
     "distribution_name": "cloud.google.com/go/maps/addressvalidation/apiv1",
     "description": "Address Validation API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/maps/latest/addressvalidation/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/maps/latest/addressvalidation/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "maps"
   },
   "cloud.google.com/go/maps/mapsplatformdatasets/apiv1alpha": {
     "distribution_name": "cloud.google.com/go/maps/mapsplatformdatasets/apiv1alpha",
     "description": "Maps Platform Datasets API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/maps/latest/mapsplatformdatasets/apiv1alpha",
-    "release_level": "alpha",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/maps/latest/mapsplatformdatasets/apiv1alpha",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "maps"
   },
   "cloud.google.com/go/maps/places/apiv1": {
     "distribution_name": "cloud.google.com/go/maps/places/apiv1",
     "description": "Places API (New)",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/maps/latest/places/apiv1",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/maps/latest/places/apiv1",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "maps"
   },
   "cloud.google.com/go/maps/routing/apiv2": {
     "distribution_name": "cloud.google.com/go/maps/routing/apiv2",
     "description": "Routes API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/maps/latest/routing/apiv2",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/maps/latest/routing/apiv2",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "maps"
   },
   "cloud.google.com/go/mediatranslation/apiv1beta1": {
     "distribution_name": "cloud.google.com/go/mediatranslation/apiv1beta1",
     "description": "Media Translation API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/mediatranslation/latest/apiv1beta1",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/mediatranslation/latest/apiv1beta1",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "mediatranslation"
   },
   "cloud.google.com/go/memcache/apiv1": {
     "distribution_name": "cloud.google.com/go/memcache/apiv1",
     "description": "Cloud Memorystore for Memcached API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/memcache/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/memcache/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "memcache"
   },
   "cloud.google.com/go/memcache/apiv1beta2": {
     "distribution_name": "cloud.google.com/go/memcache/apiv1beta2",
     "description": "Cloud Memorystore for Memcached API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/memcache/latest/apiv1beta2",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/memcache/latest/apiv1beta2",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "memcache"
   },
   "cloud.google.com/go/metastore/apiv1": {
     "distribution_name": "cloud.google.com/go/metastore/apiv1",
     "description": "Dataproc Metastore API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/metastore/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/metastore/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "metastore"
   },
   "cloud.google.com/go/metastore/apiv1alpha": {
     "distribution_name": "cloud.google.com/go/metastore/apiv1alpha",
     "description": "Dataproc Metastore API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/metastore/latest/apiv1alpha",
-    "release_level": "alpha",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/metastore/latest/apiv1alpha",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "metastore"
   },
   "cloud.google.com/go/metastore/apiv1beta": {
     "distribution_name": "cloud.google.com/go/metastore/apiv1beta",
     "description": "Dataproc Metastore API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/metastore/latest/apiv1beta",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/metastore/latest/apiv1beta",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "metastore"
   },
   "cloud.google.com/go/migrationcenter/apiv1": {
     "distribution_name": "cloud.google.com/go/migrationcenter/apiv1",
     "description": "Migration Center API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/migrationcenter/latest/apiv1",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/migrationcenter/latest/apiv1",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "migrationcenter"
   },
   "cloud.google.com/go/monitoring/apiv3/v2": {
     "distribution_name": "cloud.google.com/go/monitoring/apiv3/v2",
     "description": "Cloud Monitoring API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/monitoring/latest/apiv3/v2",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/monitoring/latest/apiv3/v2",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "monitoring"
   },
   "cloud.google.com/go/monitoring/dashboard/apiv1": {
     "distribution_name": "cloud.google.com/go/monitoring/dashboard/apiv1",
     "description": "Cloud Monitoring API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/monitoring/latest/dashboard/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/monitoring/latest/dashboard/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "monitoring"
   },
   "cloud.google.com/go/monitoring/metricsscope/apiv1": {
     "distribution_name": "cloud.google.com/go/monitoring/metricsscope/apiv1",
     "description": "Cloud Monitoring API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/monitoring/latest/metricsscope/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/monitoring/latest/metricsscope/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "monitoring"
   },
   "cloud.google.com/go/networkconnectivity/apiv1": {
     "distribution_name": "cloud.google.com/go/networkconnectivity/apiv1",
     "description": "Network Connectivity API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/networkconnectivity/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/networkconnectivity/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "networkconnectivity"
   },
   "cloud.google.com/go/networkconnectivity/apiv1alpha1": {
     "distribution_name": "cloud.google.com/go/networkconnectivity/apiv1alpha1",
     "description": "Network Connectivity API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/networkconnectivity/latest/apiv1alpha1",
-    "release_level": "alpha",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/networkconnectivity/latest/apiv1alpha1",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "networkconnectivity"
   },
   "cloud.google.com/go/networkmanagement/apiv1": {
     "distribution_name": "cloud.google.com/go/networkmanagement/apiv1",
     "description": "Network Management API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/networkmanagement/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/networkmanagement/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "networkmanagement"
   },
   "cloud.google.com/go/networksecurity/apiv1beta1": {
     "distribution_name": "cloud.google.com/go/networksecurity/apiv1beta1",
     "description": "Network Security API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/networksecurity/latest/apiv1beta1",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/networksecurity/latest/apiv1beta1",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "networksecurity"
   },
   "cloud.google.com/go/notebooks/apiv1": {
     "distribution_name": "cloud.google.com/go/notebooks/apiv1",
     "description": "Notebooks API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/notebooks/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/notebooks/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "notebooks"
   },
   "cloud.google.com/go/notebooks/apiv1beta1": {
     "distribution_name": "cloud.google.com/go/notebooks/apiv1beta1",
     "description": "Notebooks API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/notebooks/latest/apiv1beta1",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/notebooks/latest/apiv1beta1",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "notebooks"
   },
   "cloud.google.com/go/optimization/apiv1": {
     "distribution_name": "cloud.google.com/go/optimization/apiv1",
     "description": "Cloud Optimization API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/optimization/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/optimization/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "optimization"
   },
   "cloud.google.com/go/orchestration/airflow/service/apiv1": {
     "distribution_name": "cloud.google.com/go/orchestration/airflow/service/apiv1",
     "description": "Cloud Composer API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/orchestration/latest/airflow/service/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/orchestration/latest/airflow/service/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "orchestration"
   },
   "cloud.google.com/go/orgpolicy/apiv2": {
     "distribution_name": "cloud.google.com/go/orgpolicy/apiv2",
-    "description": "Organization Policy API",
-    "language": "Go",
+    "description": "Orstablenization Policy API",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/orgpolicy/latest/apiv2",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/orgpolicy/latest/apiv2",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "orgpolicy"
   },
   "cloud.google.com/go/osconfig/agentendpoint/apiv1": {
     "distribution_name": "cloud.google.com/go/osconfig/agentendpoint/apiv1",
     "description": "OS Config API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/osconfig/latest/agentendpoint/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/osconfig/latest/agentendpoint/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "osconfig"
   },
   "cloud.google.com/go/osconfig/agentendpoint/apiv1beta": {
     "distribution_name": "cloud.google.com/go/osconfig/agentendpoint/apiv1beta",
     "description": "OS Config API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/osconfig/latest/agentendpoint/apiv1beta",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/osconfig/latest/agentendpoint/apiv1beta",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "osconfig"
   },
   "cloud.google.com/go/osconfig/apiv1": {
     "distribution_name": "cloud.google.com/go/osconfig/apiv1",
     "description": "OS Config API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/osconfig/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/osconfig/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "osconfig"
   },
   "cloud.google.com/go/osconfig/apiv1alpha": {
     "distribution_name": "cloud.google.com/go/osconfig/apiv1alpha",
     "description": "OS Config API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/osconfig/latest/apiv1alpha",
-    "release_level": "alpha",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/osconfig/latest/apiv1alpha",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "osconfig"
   },
   "cloud.google.com/go/osconfig/apiv1beta": {
     "distribution_name": "cloud.google.com/go/osconfig/apiv1beta",
     "description": "OS Config API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/osconfig/latest/apiv1beta",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/osconfig/latest/apiv1beta",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "osconfig"
   },
   "cloud.google.com/go/oslogin/apiv1": {
     "distribution_name": "cloud.google.com/go/oslogin/apiv1",
     "description": "Cloud OS Login API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/oslogin/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/oslogin/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "oslogin"
   },
   "cloud.google.com/go/oslogin/apiv1beta": {
     "distribution_name": "cloud.google.com/go/oslogin/apiv1beta",
     "description": "Cloud OS Login API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/oslogin/latest/apiv1beta",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/oslogin/latest/apiv1beta",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "oslogin"
   },
   "cloud.google.com/go/phishingprotection/apiv1beta1": {
     "distribution_name": "cloud.google.com/go/phishingprotection/apiv1beta1",
     "description": "Phishing Protection API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/phishingprotection/latest/apiv1beta1",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/phishingprotection/latest/apiv1beta1",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "phishingprotection"
   },
   "cloud.google.com/go/policytroubleshooter/apiv1": {
     "distribution_name": "cloud.google.com/go/policytroubleshooter/apiv1",
     "description": "Policy Troubleshooter API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/policytroubleshooter/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/policytroubleshooter/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "policytroubleshooter"
   },
   "cloud.google.com/go/privatecatalog/apiv1beta1": {
     "distribution_name": "cloud.google.com/go/privatecatalog/apiv1beta1",
     "description": "Cloud Private Catalog API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/privatecatalog/latest/apiv1beta1",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/privatecatalog/latest/apiv1beta1",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "privatecatalog"
   },
   "cloud.google.com/go/profiler": {
     "distribution_name": "cloud.google.com/go/profiler",
     "description": "Cloud Profiler",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "manual",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/profiler/latest",
-    "release_level": "ga",
-    "library_type": "AGENT"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/profiler/latest",
+    "release_level": "stable",
+    "library_type": "AGENT",
+    "api_shortname": "profiler"
   },
   "cloud.google.com/go/pubsub": {
     "distribution_name": "cloud.google.com/go/pubsub",
     "description": "Cloud PubSub",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "manual",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/pubsub/latest",
-    "release_level": "ga",
-    "library_type": "GAPIC_MANUAL"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/pubsub/latest",
+    "release_level": "stable",
+    "library_type": "GAPIC_MANUAL",
+    "api_shortname": "pubsub"
   },
   "cloud.google.com/go/pubsub/apiv1": {
     "distribution_name": "cloud.google.com/go/pubsub/apiv1",
     "description": "Cloud Pub/Sub API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/pubsub/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/pubsub/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "pubsub"
   },
   "cloud.google.com/go/pubsublite": {
     "distribution_name": "cloud.google.com/go/pubsublite",
     "description": "Cloud PubSub Lite",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "manual",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/pubsublite/latest",
-    "release_level": "ga",
-    "library_type": "GAPIC_MANUAL"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/pubsublite/latest",
+    "release_level": "stable",
+    "library_type": "GAPIC_MANUAL",
+    "api_shortname": "pubsublite"
   },
   "cloud.google.com/go/pubsublite/apiv1": {
     "distribution_name": "cloud.google.com/go/pubsublite/apiv1",
     "description": "Pub/Sub Lite API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/pubsublite/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/pubsublite/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "pubsublite"
   },
   "cloud.google.com/go/rapidmigrationassessment/apiv1": {
     "distribution_name": "cloud.google.com/go/rapidmigrationassessment/apiv1",
     "description": "Rapid Migration Assessment API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/rapidmigrationassessment/latest/apiv1",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/rapidmigrationassessment/latest/apiv1",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "rapidmigrationassessment"
   },
   "cloud.google.com/go/recaptchaenterprise/v2/apiv1": {
     "distribution_name": "cloud.google.com/go/recaptchaenterprise/v2/apiv1",
     "description": "reCAPTCHA Enterprise API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/recaptchaenterprise/v2/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/recaptchaenterprise/v2/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "recaptchaenterprise"
   },
   "cloud.google.com/go/recaptchaenterprise/v2/apiv1beta1": {
     "distribution_name": "cloud.google.com/go/recaptchaenterprise/v2/apiv1beta1",
     "description": "reCAPTCHA Enterprise API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/recaptchaenterprise/v2/latest/apiv1beta1",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/recaptchaenterprise/v2/latest/apiv1beta1",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "recaptchaenterprise"
   },
   "cloud.google.com/go/recommendationengine/apiv1beta1": {
     "distribution_name": "cloud.google.com/go/recommendationengine/apiv1beta1",
     "description": "Recommendations AI",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/recommendationengine/latest/apiv1beta1",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/recommendationengine/latest/apiv1beta1",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "recommendationengine"
   },
   "cloud.google.com/go/recommender/apiv1": {
     "distribution_name": "cloud.google.com/go/recommender/apiv1",
     "description": "Recommender API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/recommender/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/recommender/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "recommender"
   },
   "cloud.google.com/go/recommender/apiv1beta1": {
     "distribution_name": "cloud.google.com/go/recommender/apiv1beta1",
     "description": "Recommender API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/recommender/latest/apiv1beta1",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/recommender/latest/apiv1beta1",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "recommender"
   },
   "cloud.google.com/go/redis/apiv1": {
     "distribution_name": "cloud.google.com/go/redis/apiv1",
-    "description": "Google Cloud Memorystore for Redis API",
-    "language": "Go",
+    "description": "google Cloud Memorystore for Redis API",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/redis/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/redis/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "redis"
   },
   "cloud.google.com/go/redis/apiv1beta1": {
     "distribution_name": "cloud.google.com/go/redis/apiv1beta1",
-    "description": "Google Cloud Memorystore for Redis API",
-    "language": "Go",
+    "description": "google Cloud Memorystore for Redis API",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/redis/latest/apiv1beta1",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/redis/latest/apiv1beta1",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "redis"
   },
   "cloud.google.com/go/resourcemanager/apiv2": {
     "distribution_name": "cloud.google.com/go/resourcemanager/apiv2",
     "description": "Cloud Resource Manager API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/resourcemanager/latest/apiv2",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/resourcemanager/latest/apiv2",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "resourcemanager"
   },
   "cloud.google.com/go/resourcemanager/apiv3": {
     "distribution_name": "cloud.google.com/go/resourcemanager/apiv3",
     "description": "Cloud Resource Manager API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/resourcemanager/latest/apiv3",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/resourcemanager/latest/apiv3",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "resourcemanager"
   },
   "cloud.google.com/go/resourcesettings/apiv1": {
     "distribution_name": "cloud.google.com/go/resourcesettings/apiv1",
     "description": "Resource Settings API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/resourcesettings/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/resourcesettings/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "resourcesettings"
   },
   "cloud.google.com/go/retail/apiv2": {
     "distribution_name": "cloud.google.com/go/retail/apiv2",
     "description": "Retail API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/retail/latest/apiv2",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/retail/latest/apiv2",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "retail"
   },
   "cloud.google.com/go/retail/apiv2alpha": {
     "distribution_name": "cloud.google.com/go/retail/apiv2alpha",
     "description": "Retail API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/retail/latest/apiv2alpha",
-    "release_level": "alpha",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/retail/latest/apiv2alpha",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "retail"
   },
   "cloud.google.com/go/retail/apiv2beta": {
     "distribution_name": "cloud.google.com/go/retail/apiv2beta",
     "description": "Retail API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/retail/latest/apiv2beta",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/retail/latest/apiv2beta",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "retail"
   },
   "cloud.google.com/go/rpcreplay": {
     "distribution_name": "cloud.google.com/go/rpcreplay",
     "description": "RPC Replay",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "manual",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/latest/rpcreplay",
-    "release_level": "ga",
-    "library_type": "OTHER"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/latest/rpcreplay",
+    "release_level": "stable",
+    "library_type": "OTHER",
+    "api_shortname": "rpcreplay"
   },
   "cloud.google.com/go/run/apiv2": {
     "distribution_name": "cloud.google.com/go/run/apiv2",
     "description": "Cloud Run Admin API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/run/latest/apiv2",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/run/latest/apiv2",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "run"
   },
   "cloud.google.com/go/scheduler/apiv1": {
     "distribution_name": "cloud.google.com/go/scheduler/apiv1",
     "description": "Cloud Scheduler API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/scheduler/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/scheduler/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "scheduler"
   },
   "cloud.google.com/go/scheduler/apiv1beta1": {
     "distribution_name": "cloud.google.com/go/scheduler/apiv1beta1",
     "description": "Cloud Scheduler API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/scheduler/latest/apiv1beta1",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/scheduler/latest/apiv1beta1",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "scheduler"
   },
   "cloud.google.com/go/secretmanager/apiv1": {
     "distribution_name": "cloud.google.com/go/secretmanager/apiv1",
     "description": "Secret Manager API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/secretmanager/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/secretmanager/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "secretmanager"
   },
   "cloud.google.com/go/security/privateca/apiv1": {
     "distribution_name": "cloud.google.com/go/security/privateca/apiv1",
     "description": "Certificate Authority API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/security/latest/privateca/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/security/latest/privateca/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "security"
   },
   "cloud.google.com/go/security/publicca/apiv1beta1": {
     "distribution_name": "cloud.google.com/go/security/publicca/apiv1beta1",
     "description": "Public Certificate Authority API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/security/latest/publicca/apiv1beta1",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/security/latest/publicca/apiv1beta1",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "security"
   },
   "cloud.google.com/go/securitycenter/apiv1": {
     "distribution_name": "cloud.google.com/go/securitycenter/apiv1",
     "description": "Security Command Center API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/securitycenter/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/securitycenter/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "securitycenter"
   },
   "cloud.google.com/go/securitycenter/apiv1beta1": {
     "distribution_name": "cloud.google.com/go/securitycenter/apiv1beta1",
     "description": "Security Command Center API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/securitycenter/latest/apiv1beta1",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/securitycenter/latest/apiv1beta1",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "securitycenter"
   },
   "cloud.google.com/go/securitycenter/apiv1p1beta1": {
     "distribution_name": "cloud.google.com/go/securitycenter/apiv1p1beta1",
     "description": "Security Command Center API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/securitycenter/latest/apiv1p1beta1",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/securitycenter/latest/apiv1p1beta1",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "securitycenter"
   },
   "cloud.google.com/go/securitycenter/settings/apiv1beta1": {
     "distribution_name": "cloud.google.com/go/securitycenter/settings/apiv1beta1",
     "description": "Cloud Security Command Center API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/securitycenter/latest/settings/apiv1beta1",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/securitycenter/latest/settings/apiv1beta1",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "securitycenter"
   },
   "cloud.google.com/go/servicecontrol/apiv1": {
     "distribution_name": "cloud.google.com/go/servicecontrol/apiv1",
     "description": "Service Control API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/servicecontrol/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/servicecontrol/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "servicecontrol"
   },
   "cloud.google.com/go/servicedirectory/apiv1": {
     "distribution_name": "cloud.google.com/go/servicedirectory/apiv1",
     "description": "Service Directory API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/servicedirectory/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/servicedirectory/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "servicedirectory"
   },
   "cloud.google.com/go/servicedirectory/apiv1beta1": {
     "distribution_name": "cloud.google.com/go/servicedirectory/apiv1beta1",
     "description": "Service Directory API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/servicedirectory/latest/apiv1beta1",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/servicedirectory/latest/apiv1beta1",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "servicedirectory"
   },
   "cloud.google.com/go/servicemanagement/apiv1": {
     "distribution_name": "cloud.google.com/go/servicemanagement/apiv1",
     "description": "Service Management API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/servicemanagement/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/servicemanagement/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "servicemanagement"
   },
   "cloud.google.com/go/serviceusage/apiv1": {
     "distribution_name": "cloud.google.com/go/serviceusage/apiv1",
     "description": "Service Usage API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/serviceusage/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/serviceusage/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "serviceusage"
   },
   "cloud.google.com/go/shell/apiv1": {
     "distribution_name": "cloud.google.com/go/shell/apiv1",
     "description": "Cloud Shell API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/shell/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/shell/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "shell"
   },
   "cloud.google.com/go/spanner": {
     "distribution_name": "cloud.google.com/go/spanner",
     "description": "Cloud Spanner",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "manual",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/spanner/latest",
-    "release_level": "ga",
-    "library_type": "GAPIC_MANUAL"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/spanner/latest",
+    "release_level": "stable",
+    "library_type": "GAPIC_MANUAL",
+    "api_shortname": "spanner"
   },
   "cloud.google.com/go/spanner/admin/database/apiv1": {
     "distribution_name": "cloud.google.com/go/spanner/admin/database/apiv1",
     "description": "Cloud Spanner API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/spanner/latest/admin/database/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/spanner/latest/admin/database/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "spanner"
   },
   "cloud.google.com/go/spanner/admin/instance/apiv1": {
     "distribution_name": "cloud.google.com/go/spanner/admin/instance/apiv1",
     "description": "Cloud Spanner Instance Admin API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/spanner/latest/admin/instance/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/spanner/latest/admin/instance/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "spanner"
   },
   "cloud.google.com/go/spanner/apiv1": {
     "distribution_name": "cloud.google.com/go/spanner/apiv1",
     "description": "Cloud Spanner API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/spanner/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/spanner/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "spanner"
   },
   "cloud.google.com/go/speech/apiv1": {
     "distribution_name": "cloud.google.com/go/speech/apiv1",
     "description": "Cloud Speech-to-Text API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/speech/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/speech/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "speech"
   },
   "cloud.google.com/go/speech/apiv1p1beta1": {
     "distribution_name": "cloud.google.com/go/speech/apiv1p1beta1",
     "description": "Cloud Speech-to-Text API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/speech/latest/apiv1p1beta1",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/speech/latest/apiv1p1beta1",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "speech"
   },
   "cloud.google.com/go/speech/apiv2": {
     "distribution_name": "cloud.google.com/go/speech/apiv2",
     "description": "Cloud Speech-to-Text API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/speech/latest/apiv2",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/speech/latest/apiv2",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "speech"
   },
   "cloud.google.com/go/storage": {
     "distribution_name": "cloud.google.com/go/storage",
     "description": "Cloud Storage (GCS)",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "manual",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/storage/latest",
-    "release_level": "ga",
-    "library_type": "GAPIC_MANUAL"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/storage/latest",
+    "release_level": "stable",
+    "library_type": "GAPIC_MANUAL",
+    "api_shortname": "storage"
   },
   "cloud.google.com/go/storage/internal/apiv2": {
     "distribution_name": "cloud.google.com/go/storage/internal/apiv2",
     "description": "Cloud Storage API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/storage/latest/internal/apiv2",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/storage/latest/internal/apiv2",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "storage"
   },
   "cloud.google.com/go/storageinsights/apiv1": {
     "distribution_name": "cloud.google.com/go/storageinsights/apiv1",
     "description": "Storage Insights API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/storageinsights/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/storageinsights/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "storageinsights"
   },
   "cloud.google.com/go/storagetransfer/apiv1": {
     "distribution_name": "cloud.google.com/go/storagetransfer/apiv1",
     "description": "Storage Transfer API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/storagetransfer/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/storagetransfer/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "storagetransfer"
   },
   "cloud.google.com/go/support/apiv2": {
     "distribution_name": "cloud.google.com/go/support/apiv2",
-    "description": "Google Cloud Support API",
-    "language": "Go",
+    "description": "google Cloud Support API",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/support/latest/apiv2",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/support/latest/apiv2",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "support"
   },
   "cloud.google.com/go/talent/apiv4": {
     "distribution_name": "cloud.google.com/go/talent/apiv4",
     "description": "Cloud Talent Solution API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/talent/latest/apiv4",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/talent/latest/apiv4",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "talent"
   },
   "cloud.google.com/go/talent/apiv4beta1": {
     "distribution_name": "cloud.google.com/go/talent/apiv4beta1",
     "description": "Cloud Talent Solution API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/talent/latest/apiv4beta1",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/talent/latest/apiv4beta1",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "talent"
   },
   "cloud.google.com/go/texttospeech/apiv1": {
     "distribution_name": "cloud.google.com/go/texttospeech/apiv1",
     "description": "Cloud Text-to-Speech API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/texttospeech/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/texttospeech/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "texttospeech"
   },
   "cloud.google.com/go/tpu/apiv1": {
     "distribution_name": "cloud.google.com/go/tpu/apiv1",
     "description": "Cloud TPU API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/tpu/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/tpu/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "tpu"
   },
   "cloud.google.com/go/trace/apiv1": {
     "distribution_name": "cloud.google.com/go/trace/apiv1",
     "description": "Stackdriver Trace API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/trace/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/trace/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "trace"
   },
   "cloud.google.com/go/trace/apiv2": {
     "distribution_name": "cloud.google.com/go/trace/apiv2",
     "description": "Stackdriver Trace API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/trace/latest/apiv2",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/trace/latest/apiv2",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "trace"
   },
   "cloud.google.com/go/translate/apiv3": {
     "distribution_name": "cloud.google.com/go/translate/apiv3",
     "description": "Cloud Translation API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/translate/latest/apiv3",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/translate/latest/apiv3",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "translate"
   },
   "cloud.google.com/go/video/livestream/apiv1": {
     "distribution_name": "cloud.google.com/go/video/livestream/apiv1",
     "description": "Live Stream API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/video/latest/livestream/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/video/latest/livestream/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "video"
   },
   "cloud.google.com/go/video/stitcher/apiv1": {
     "distribution_name": "cloud.google.com/go/video/stitcher/apiv1",
     "description": "Video Stitcher API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/latest/video/stitcher/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/latest/video/stitcher/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "video"
   },
   "cloud.google.com/go/video/transcoder/apiv1": {
     "distribution_name": "cloud.google.com/go/video/transcoder/apiv1",
     "description": "Transcoder API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/video/latest/transcoder/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/video/latest/transcoder/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "video"
   },
   "cloud.google.com/go/videointelligence/apiv1": {
     "distribution_name": "cloud.google.com/go/videointelligence/apiv1",
     "description": "Cloud Video Intelligence API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/videointelligence/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/videointelligence/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "videointelligence"
   },
   "cloud.google.com/go/videointelligence/apiv1beta2": {
     "distribution_name": "cloud.google.com/go/videointelligence/apiv1beta2",
-    "description": "Google Cloud Video Intelligence API",
-    "language": "Go",
+    "description": "google Cloud Video Intelligence API",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/videointelligence/latest/apiv1beta2",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/videointelligence/latest/apiv1beta2",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "videointelligence"
   },
   "cloud.google.com/go/videointelligence/apiv1p3beta1": {
     "distribution_name": "cloud.google.com/go/videointelligence/apiv1p3beta1",
     "description": "Cloud Video Intelligence API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/videointelligence/latest/apiv1p3beta1",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/videointelligence/latest/apiv1p3beta1",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "videointelligence"
   },
   "cloud.google.com/go/vision/v2/apiv1": {
     "distribution_name": "cloud.google.com/go/vision/v2/apiv1",
     "description": "Cloud Vision API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/vision/v2/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/vision/v2/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "vision"
   },
   "cloud.google.com/go/vision/v2/apiv1p1beta1": {
     "distribution_name": "cloud.google.com/go/vision/v2/apiv1p1beta1",
     "description": "Cloud Vision API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/vision/v2/latest/apiv1p1beta1",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/vision/v2/latest/apiv1p1beta1",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "vision"
   },
   "cloud.google.com/go/vmmigration/apiv1": {
     "distribution_name": "cloud.google.com/go/vmmigration/apiv1",
     "description": "VM Migration API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/vmmigration/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/vmmigration/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "vmmigration"
   },
   "cloud.google.com/go/vmwareengine/apiv1": {
     "distribution_name": "cloud.google.com/go/vmwareengine/apiv1",
     "description": "VMware Engine API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/vmwareengine/latest/apiv1",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/vmwareengine/latest/apiv1",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "vmwareengine"
   },
   "cloud.google.com/go/vpcaccess/apiv1": {
     "distribution_name": "cloud.google.com/go/vpcaccess/apiv1",
     "description": "Serverless VPC Access API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/vpcaccess/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/vpcaccess/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "vpcaccess"
   },
   "cloud.google.com/go/webrisk/apiv1": {
     "distribution_name": "cloud.google.com/go/webrisk/apiv1",
     "description": "Web Risk API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/webrisk/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/webrisk/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "webrisk"
   },
   "cloud.google.com/go/webrisk/apiv1beta1": {
     "distribution_name": "cloud.google.com/go/webrisk/apiv1beta1",
     "description": "Web Risk API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/webrisk/latest/apiv1beta1",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/webrisk/latest/apiv1beta1",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "webrisk"
   },
   "cloud.google.com/go/websecurityscanner/apiv1": {
     "distribution_name": "cloud.google.com/go/websecurityscanner/apiv1",
     "description": "Web Security Scanner API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/websecurityscanner/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/websecurityscanner/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "websecurityscanner"
   },
   "cloud.google.com/go/workflows/apiv1": {
     "distribution_name": "cloud.google.com/go/workflows/apiv1",
     "description": "Workflows API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/workflows/latest/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/workflows/latest/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "workflows"
   },
   "cloud.google.com/go/workflows/apiv1beta": {
     "distribution_name": "cloud.google.com/go/workflows/apiv1beta",
     "description": "Workflows API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/workflows/latest/apiv1beta",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/workflows/latest/apiv1beta",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "workflows"
   },
   "cloud.google.com/go/workflows/executions/apiv1": {
     "distribution_name": "cloud.google.com/go/workflows/executions/apiv1",
     "description": "Workflow Executions API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/workflows/latest/executions/apiv1",
-    "release_level": "ga",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/workflows/latest/executions/apiv1",
+    "release_level": "stable",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "workflows"
   },
   "cloud.google.com/go/workflows/executions/apiv1beta": {
     "distribution_name": "cloud.google.com/go/workflows/executions/apiv1beta",
     "description": "Workflow Executions API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/workflows/latest/executions/apiv1beta",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/workflows/latest/executions/apiv1beta",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "workflows"
   },
   "cloud.google.com/go/workstations/apiv1": {
     "distribution_name": "cloud.google.com/go/workstations/apiv1",
     "description": "Cloud Workstations API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/workstations/latest/apiv1",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/workstations/latest/apiv1",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "workstations"
   },
   "cloud.google.com/go/workstations/apiv1beta": {
     "distribution_name": "cloud.google.com/go/workstations/apiv1beta",
     "description": "Cloud Workstations API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "generated",
-    "docs_url": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/workstations/latest/apiv1beta",
-    "release_level": "beta",
-    "library_type": "GAPIC_AUTO"
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/workstations/latest/apiv1beta",
+    "release_level": "preview",
+    "library_type": "GAPIC_AUTO",
+    "api_shortname": "workstations"
   }
 }


### PR DESCRIPTION
A couple fixes to make .repo-metadata-full.json match the current requirements for .repo-metadata.json:

* `api_shortname` is required, and should be the DNS prefix.
* `docs_url` should be `client_documentation`.
* switched language to `go`.
* `release_level` should be `stable` or `preview`.