### PR TITLE
chore(postprocessor): update manual entries

### DIFF
--- a/internal/.repo-metadata-full.json
+++ b/internal/.repo-metadata-full.json
@@ -310,13 +310,13 @@
     "library_type": "GAPIC_AUTO"
   },
   "cloud.google.com/go/bigquery": {
-    "api_shortname": "",
+    "api_shortname": "bigquery",
     "distribution_name": "cloud.google.com/go/bigquery",
     "description": "BigQuery",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "manual",
-    "client_documentation": "",
-    "release_level": "ga",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigquery/latest",
+    "release_level": "stable",
     "library_type": "GAPIC_MANUAL"
   },
   "cloud.google.com/go/bigquery/analyticshub/apiv1": {
@@ -450,13 +450,13 @@
     "library_type": "GAPIC_AUTO"
   },
   "cloud.google.com/go/bigtable": {
-    "api_shortname": "",
+    "api_shortname": "bigtable",
     "distribution_name": "cloud.google.com/go/bigtable",
     "description": "Cloud BigTable",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "manual",
-    "client_documentation": "",
-    "release_level": "ga",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigtable/latest",
+    "release_level": "stable",
     "library_type": "GAPIC_MANUAL"
   },
   "cloud.google.com/go/billing/apiv1": {
@@ -600,13 +600,13 @@
     "library_type": "GAPIC_AUTO"
   },
   "cloud.google.com/go/compute/metadata": {
-    "api_shortname": "",
+    "api_shortname": "compute-metadata",
     "distribution_name": "cloud.google.com/go/compute/metadata",
     "description": "Service Metadata API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "manual",
-    "client_documentation": "",
-    "release_level": "ga",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/compute/latest/metadata",
+    "release_level": "stable",
     "library_type": "CORE"
   },
   "cloud.google.com/go/confidentialcomputing/apiv1": {
@@ -655,7 +655,7 @@
     "description": "Container Analysis API",
     "language": "go",
     "client_library_type": "generated",
-    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/latest/containeranalysis/apiv1beta1",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/containeranalysis/latest/apiv1beta1",
     "release_level": "preview",
     "library_type": "GAPIC_AUTO"
   },
@@ -770,13 +770,13 @@
     "library_type": "GAPIC_AUTO"
   },
   "cloud.google.com/go/datastore": {
-    "api_shortname": "",
+    "api_shortname": "datastore",
     "distribution_name": "cloud.google.com/go/datastore",
     "description": "Cloud Datastore",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "manual",
-    "client_documentation": "",
-    "release_level": "ga",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/datastore/latest",
+    "release_level": "stable",
     "library_type": "GAPIC_MANUAL"
   },
   "cloud.google.com/go/datastore/admin/apiv1": {
@@ -940,13 +940,13 @@
     "library_type": "GAPIC_AUTO"
   },
   "cloud.google.com/go/errorreporting": {
-    "api_shortname": "",
+    "api_shortname": "errorreporting",
     "distribution_name": "cloud.google.com/go/errorreporting",
     "description": "Cloud Error Reporting API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "manual",
-    "client_documentation": "",
-    "release_level": "beta",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/errorreporting/latest",
+    "release_level": "preview",
     "library_type": "GAPIC_MANUAL"
   },
   "cloud.google.com/go/errorreporting/apiv1beta1": {
@@ -1000,13 +1000,13 @@
     "library_type": "GAPIC_AUTO"
   },
   "cloud.google.com/go/firestore": {
-    "api_shortname": "",
+    "api_shortname": "firestore",
     "distribution_name": "cloud.google.com/go/firestore",
     "description": "Cloud Firestore API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "manual",
-    "client_documentation": "",
-    "release_level": "ga",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/firestore/latest",
+    "release_level": "stable",
     "library_type": "GAPIC_MANUAL"
   },
   "cloud.google.com/go/firestore/apiv1": {
@@ -1050,13 +1050,13 @@
     "library_type": "GAPIC_AUTO"
   },
   "cloud.google.com/go/functions/metadata": {
-    "api_shortname": "",
+    "api_shortname": "firestore-metadata",
     "distribution_name": "cloud.google.com/go/functions/metadata",
     "description": "Cloud Functions",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "manual",
-    "client_documentation": "",
-    "release_level": "alpha",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/functions/latest/metadata",
+    "release_level": "preview",
     "library_type": "CORE"
   },
   "cloud.google.com/go/gaming/apiv1": {
@@ -1130,13 +1130,13 @@
     "library_type": "GAPIC_AUTO"
   },
   "cloud.google.com/go/iam": {
-    "api_shortname": "",
+    "api_shortname": "iam",
     "distribution_name": "cloud.google.com/go/iam",
     "description": "Cloud IAM",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "manual",
-    "client_documentation": "",
-    "release_level": "ga",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/iam/latest",
+    "release_level": "stable",
     "library_type": "CORE"
   },
   "cloud.google.com/go/iam/apiv1": {
@@ -1250,13 +1250,13 @@
     "library_type": "GAPIC_AUTO"
   },
   "cloud.google.com/go/logging": {
-    "api_shortname": "",
+    "api_shortname": "logging",
     "distribution_name": "cloud.google.com/go/logging",
     "description": "Cloud Logging API",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "manual",
-    "client_documentation": "",
-    "release_level": "ga",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/logging/latest",
+    "release_level": "stable",
     "library_type": "GAPIC_MANUAL"
   },
   "cloud.google.com/go/logging/apiv2": {
@@ -1620,23 +1620,23 @@
     "library_type": "GAPIC_AUTO"
   },
   "cloud.google.com/go/profiler": {
-    "api_shortname": "",
+    "api_shortname": "profiler",
     "distribution_name": "cloud.google.com/go/profiler",
     "description": "Cloud Profiler",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "manual",
-    "client_documentation": "",
-    "release_level": "ga",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/profiler/latest",
+    "release_level": "stable",
     "library_type": "AGENT"
   },
   "cloud.google.com/go/pubsub": {
-    "api_shortname": "",
+    "api_shortname": "pubsub",
     "distribution_name": "cloud.google.com/go/pubsub",
     "description": "Cloud PubSub",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "manual",
-    "client_documentation": "",
-    "release_level": "ga",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/pubsub/latest",
+    "release_level": "stable",
     "library_type": "GAPIC_MANUAL"
   },
   "cloud.google.com/go/pubsub/apiv1": {
@@ -1650,13 +1650,13 @@
     "library_type": "GAPIC_AUTO"
   },
   "cloud.google.com/go/pubsublite": {
-    "api_shortname": "",
+    "api_shortname": "pubsublite",
     "distribution_name": "cloud.google.com/go/pubsublite",
     "description": "Cloud PubSub Lite",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "manual",
-    "client_documentation": "",
-    "release_level": "ga",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/pubsublite/latest",
+    "release_level": "stable",
     "library_type": "GAPIC_MANUAL"
   },
   "cloud.google.com/go/pubsublite/apiv1": {
@@ -1810,13 +1810,13 @@
     "library_type": "GAPIC_AUTO"
   },
   "cloud.google.com/go/rpcreplay": {
-    "api_shortname": "",
+    "api_shortname": "rpcreplay",
     "distribution_name": "cloud.google.com/go/rpcreplay",
     "description": "RPC Replay",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "manual",
-    "client_documentation": "",
-    "release_level": "ga",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/latest/rpcreplay",
+    "release_level": "stable",
     "library_type": "OTHER"
   },
   "cloud.google.com/go/run/apiv2": {
@@ -1980,13 +1980,13 @@
     "library_type": "GAPIC_AUTO"
   },
   "cloud.google.com/go/spanner": {
-    "api_shortname": "",
+    "api_shortname": "spanner",
     "distribution_name": "cloud.google.com/go/spanner",
     "description": "Cloud Spanner",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "manual",
-    "client_documentation": "",
-    "release_level": "ga",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/spanner/latest",
+    "release_level": "stable",
     "library_type": "GAPIC_MANUAL"
   },
   "cloud.google.com/go/spanner/admin/database/apiv1": {
@@ -2050,13 +2050,13 @@
     "library_type": "GAPIC_AUTO"
   },
   "cloud.google.com/go/storage": {
-    "api_shortname": "",
+    "api_shortname": "storage",
     "distribution_name": "cloud.google.com/go/storage",
     "description": "Cloud Storage (GCS)",
-    "language": "Go",
+    "language": "go",
     "client_library_type": "manual",
-    "client_documentation": "",
-    "release_level": "ga",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/storage/latest",
+    "release_level": "stable",
     "library_type": "GAPIC_MANUAL"
   },
   "cloud.google.com/go/storage/internal/apiv2": {

--- a/internal/postprocessor/config.yaml
+++ b/internal/postprocessor/config.yaml
@@ -140,7 +140,7 @@ manual-clients:
     description: BigQuery
     language: go
     client-library-type: manual
-    client_documentation: https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigquery/latest
+    client-documentation: https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigquery/latest
     release-level: stable
     library-type: GAPIC_MANUAL
   - api-shortname: bigtable
@@ -148,7 +148,7 @@ manual-clients:
     description: Cloud BigTable
     language: go
     client-library-type: manual
-    client_documentation: https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigtable/latest
+    client-documentation: https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigtable/latest
     release-level: stable
     library-type: GAPIC_MANUAL
   - api-shortname: compute-metadata
@@ -156,7 +156,7 @@ manual-clients:
     description: Service Metadata API
     language: go
     client-library-type: manual
-    client_documentation: https://cloud.google.com/go/docs/reference/cloud.google.com/go/compute/latest/metadata
+    client-documentation: https://cloud.google.com/go/docs/reference/cloud.google.com/go/compute/latest/metadata
     release-level: stable
     library-type: CORE
   - api-shortname: datastore
@@ -164,7 +164,7 @@ manual-clients:
     description: Cloud Datastore
     language: go
     client-library-type: manual
-    client_documentation: https://cloud.google.com/go/docs/reference/cloud.google.com/go/datastore/latest
+    client-documentation: https://cloud.google.com/go/docs/reference/cloud.google.com/go/datastore/latest
     release-level: stable
     library-type: GAPIC_MANUAL
   - api-shortname: errorreporting
@@ -172,7 +172,7 @@ manual-clients:
     description: Cloud Error Reporting API
     language: go
     client-library-type: manual
-    client_documentation: https://cloud.google.com/go/docs/reference/cloud.google.com/go/errorreporting/latest
+    client-documentation: https://cloud.google.com/go/docs/reference/cloud.google.com/go/errorreporting/latest
     release-level: preview
     library-type: GAPIC_MANUAL
   - api-shortname: firestore
@@ -180,7 +180,7 @@ manual-clients:
     description: Cloud Firestore API
     language: go
     client-library-type: manual
-    client_documentation: https://cloud.google.com/go/docs/reference/cloud.google.com/go/firestore/latest
+    client-documentation: https://cloud.google.com/go/docs/reference/cloud.google.com/go/firestore/latest
     release-level: stable
     library-type: GAPIC_MANUAL
   - api-shortname: firestore-metadata
@@ -188,7 +188,7 @@ manual-clients:
     description: Cloud Functions
     language: go
     client-library-type: manual
-    client_documentation: https://cloud.google.com/go/docs/reference/cloud.google.com/go/functions/latest/metadata
+    client-documentation: https://cloud.google.com/go/docs/reference/cloud.google.com/go/functions/latest/metadata
     release-level: preview
     library-type: CORE
   - api-shortname: iam
@@ -196,7 +196,7 @@ manual-clients:
     description: Cloud IAM
     language: go
     client-library-type: manual
-    client_documentation: https://cloud.google.com/go/docs/reference/cloud.google.com/go/iam/latest
+    client-documentation: https://cloud.google.com/go/docs/reference/cloud.google.com/go/iam/latest
     release-level: stable
     library-type: CORE
   - api-shortname: logging
@@ -204,7 +204,7 @@ manual-clients:
     description: Cloud Logging API
     language: go
     client-library-type: manual
-    client_documentation: https://cloud.google.com/go/docs/reference/cloud.google.com/go/logging/latest
+    client-documentation: https://cloud.google.com/go/docs/reference/cloud.google.com/go/logging/latest
     release-level: stable
     library-type: GAPIC_MANUAL
   - api-shortname: profiler
@@ -212,7 +212,7 @@ manual-clients:
     description: Cloud Profiler
     language: go
     client-library-type: manual
-    client_documentation: https://cloud.google.com/go/docs/reference/cloud.google.com/go/profiler/latest
+    client-documentation: https://cloud.google.com/go/docs/reference/cloud.google.com/go/profiler/latest
     release-level: stable
     library-type: AGENT
   - api-shortname: pubsub
@@ -220,7 +220,7 @@ manual-clients:
     description: Cloud PubSub
     language: go
     client-library-type: manual
-    client_documentation: https://cloud.google.com/go/docs/reference/cloud.google.com/go/pubsub/latest
+    client-documentation: https://cloud.google.com/go/docs/reference/cloud.google.com/go/pubsub/latest
     release-level: stable
     library-type: GAPIC_MANUAL
   - api-shortname: pubsublite
@@ -228,7 +228,7 @@ manual-clients:
     description: Cloud PubSub Lite
     language: go
     client-library-type: manual
-    client_documentation: https://cloud.google.com/go/docs/reference/cloud.google.com/go/pubsublite/latest
+    client-documentation: https://cloud.google.com/go/docs/reference/cloud.google.com/go/pubsublite/latest
     release-level: stable
     library-type: GAPIC_MANUAL
   - api-shortname: rpcreplay
@@ -236,7 +236,7 @@ manual-clients:
     description: RPC Replay
     language: go
     client-library-type: manual
-    client_documentation: https://cloud.google.com/go/docs/reference/cloud.google.com/go/latest/rpcreplay
+    client-documentation: https://cloud.google.com/go/docs/reference/cloud.google.com/go/latest/rpcreplay
     release-level: stable
     library-type: OTHER
   - api-shortname: spanner
@@ -244,7 +244,7 @@ manual-clients:
     description: Cloud Spanner
     language: go
     client-library-type: manual
-    client_documentation: https://cloud.google.com/go/docs/reference/cloud.google.com/go/spanner/latest
+    client-documentation: https://cloud.google.com/go/docs/reference/cloud.google.com/go/spanner/latest
     release-level: stable
     library-type: GAPIC_MANUAL
   - api-shortname: storage
@@ -252,7 +252,7 @@ manual-clients:
     description: Cloud Storage (GCS)
     language: go
     client-library-type: manual
-    client_documentation: https://cloud.google.com/go/docs/reference/cloud.google.com/go/storage/latest
+    client-documentation: https://cloud.google.com/go/docs/reference/cloud.google.com/go/storage/latest
     release-level: stable
     library-type: GAPIC_MANUAL
 

--- a/internal/postprocessor/config.yaml
+++ b/internal/postprocessor/config.yaml
@@ -135,110 +135,125 @@ modules:
   - workstations
 
 manual-clients:
-  - distribution-name: cloud.google.com/go/bigquery
+  - api-shortname: bigquery
+    distribution-name: cloud.google.com/go/bigquery
     description: BigQuery
     language: Go
     client-library-type: manual
-    docs-url: https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigquery/latest
-    release-level: ga
+    client_documentation: https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigquery/latest
+    release-level: stable
     library-type: GAPIC_MANUAL
-  - distribution-name: cloud.google.com/go/bigtable
+  - api-shortname: bigtable
+    distribution-name: cloud.google.com/go/bigtable
     description: Cloud BigTable
     language: Go
     client-library-type: manual
-    docs-url: https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigtable/latest
-    release-level: ga
+    client_documentation: https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigtable/latest
+    release-level: stable
     library-type: GAPIC_MANUAL
-  - distribution-name: cloud.google.com/go/compute/metadata
+  - api-shortname: compute-metadata
+    distribution-name: cloud.google.com/go/compute/metadata
     description: Service Metadata API
     language: Go
     client-library-type: manual
-    docs-url: https://cloud.google.com/go/docs/reference/cloud.google.com/go/compute/latest/metadata
-    release-level: ga
+    client_documentation: https://cloud.google.com/go/docs/reference/cloud.google.com/go/compute/latest/metadata
+    release-level: stable
     library-type: CORE
-  - distribution-name: cloud.google.com/go/datastore
+  - api-shortname: datastore
+    distribution-name: cloud.google.com/go/datastore
     description: Cloud Datastore
     language: Go
     client-library-type: manual
-    docs-url: https://cloud.google.com/go/docs/reference/cloud.google.com/go/datastore/latest
-    release-level: ga
+    client_documentation: https://cloud.google.com/go/docs/reference/cloud.google.com/go/datastore/latest
+    release-level: stable
     library-type: GAPIC_MANUAL
-  - distribution-name: cloud.google.com/go/errorreporting
+  - api-shortname: errorreporting
+    distribution-name: cloud.google.com/go/errorreporting
     description: Cloud Error Reporting API
     language: Go
     client-library-type: manual
-    docs-url: https://cloud.google.com/go/docs/reference/cloud.google.com/go/errorreporting/latest
-    release-level: beta
+    client_documentation: https://cloud.google.com/go/docs/reference/cloud.google.com/go/errorreporting/latest
+    release-level: preview
     library-type: GAPIC_MANUAL
-  - distribution-name: cloud.google.com/go/firestore
+  - api-shortname: firestore
+    distribution-name: cloud.google.com/go/firestore
     description: Cloud Firestore API
     language: Go
     client-library-type: manual
-    docs-url: https://cloud.google.com/go/docs/reference/cloud.google.com/go/firestore/latest
-    release-level: ga
+    client_documentation: https://cloud.google.com/go/docs/reference/cloud.google.com/go/firestore/latest
+    release-level: stable
     library-type: GAPIC_MANUAL
-  - distribution-name: cloud.google.com/go/functions/metadata
+  - api-shortname: firestore-metadata
+    distribution-name: cloud.google.com/go/functions/metadata
     description: Cloud Functions
     language: Go
     client-library-type: manual
-    docs-url: https://cloud.google.com/go/docs/reference/cloud.google.com/go/functions/latest/metadata
-    release-level: alpha
+    client_documentation: https://cloud.google.com/go/docs/reference/cloud.google.com/go/functions/latest/metadata
+    release-level: preview
     library-type: CORE
-  - distribution-name: cloud.google.com/go/iam
+  - api-shortname: iam
+    distribution-name: cloud.google.com/go/iam
     description: Cloud IAM
     language: Go
     client-library-type: manual
-    docs-url: https://cloud.google.com/go/docs/reference/cloud.google.com/go/iam/latest
-    release-level: ga
+    client_documentation: https://cloud.google.com/go/docs/reference/cloud.google.com/go/iam/latest
+    release-level: stable
     library-type: CORE
-  - distribution-name: cloud.google.com/go/logging
+  - api-shortname: logging
+    distribution-name: cloud.google.com/go/logging
     description: Cloud Logging API
     language: Go
     client-library-type: manual
-    docs-url: https://cloud.google.com/go/docs/reference/cloud.google.com/go/logging/latest
-    release-level: ga
+    client_documentation: https://cloud.google.com/go/docs/reference/cloud.google.com/go/logging/latest
+    release-level: stable
     library-type: GAPIC_MANUAL
-  - distribution-name: cloud.google.com/go/profiler
+  - api-shortname: profiler
+    distribution-name: cloud.google.com/go/profiler
     description: Cloud Profiler
     language: Go
     client-library-type: manual
-    docs-url: https://cloud.google.com/go/docs/reference/cloud.google.com/go/profiler/latest
-    release-level: ga
+    client_documentation: https://cloud.google.com/go/docs/reference/cloud.google.com/go/profiler/latest
+    release-level: stable
     library-type: AGENT
-  - distribution-name: cloud.google.com/go/pubsub
+  - api-shortname: pubsub
+    distribution-name: cloud.google.com/go/pubsub
     description: Cloud PubSub
     language: Go
     client-library-type: manual
-    docs-url: https://cloud.google.com/go/docs/reference/cloud.google.com/go/pubsub/latest
-    release-level: ga
+    client_documentation: https://cloud.google.com/go/docs/reference/cloud.google.com/go/pubsub/latest
+    release-level: stable
     library-type: GAPIC_MANUAL
-  - distribution-name: cloud.google.com/go/pubsublite
+  - api-shortname: pubsublite
+    distribution-name: cloud.google.com/go/pubsublite
     description: Cloud PubSub Lite
     language: Go
     client-library-type: manual
-    docs-url: https://cloud.google.com/go/docs/reference/cloud.google.com/go/pubsublite/latest
-    release-level: ga
+    client_documentation: https://cloud.google.com/go/docs/reference/cloud.google.com/go/pubsublite/latest
+    release-level: stable
     library-type: GAPIC_MANUAL
-  - distribution-name: cloud.google.com/go/rpcreplay
+  - api-shortname: rpcreplay
+    distribution-name: cloud.google.com/go/rpcreplay
     description: RPC Replay
     language: Go
     client-library-type: manual
-    docs-url: https://cloud.google.com/go/docs/reference/cloud.google.com/go/latest/rpcreplay
-    release-level: ga
+    client_documentation: https://cloud.google.com/go/docs/reference/cloud.google.com/go/latest/rpcreplay
+    release-level: stable
     library-type: OTHER
-  - distribution-name: cloud.google.com/go/spanner
+  - api-shortname: spanner
+    distribution-name: cloud.google.com/go/spanner
     description: Cloud Spanner
     language: Go
     client-library-type: manual
-    docs-url: https://cloud.google.com/go/docs/reference/cloud.google.com/go/spanner/latest
-    release-level: ga
+    client_documentation: https://cloud.google.com/go/docs/reference/cloud.google.com/go/spanner/latest
+    release-level: stable
     library-type: GAPIC_MANUAL
-  - distribution-name: cloud.google.com/go/storage
+  - api-shortname: storage
+    distribution-name: cloud.google.com/go/storage
     description: Cloud Storage (GCS)
     language: Go
     client-library-type: manual
-    docs-url: https://cloud.google.com/go/docs/reference/cloud.google.com/go/storage/latest
-    release-level: ga
+    client_documentation: https://cloud.google.com/go/docs/reference/cloud.google.com/go/storage/latest
+    release-level: stable
     library-type: GAPIC_MANUAL
 
 service-configs:

--- a/internal/postprocessor/config.yaml
+++ b/internal/postprocessor/config.yaml
@@ -138,7 +138,7 @@ manual-clients:
   - api-shortname: bigquery
     distribution-name: cloud.google.com/go/bigquery
     description: BigQuery
-    language: Go
+    language: go
     client-library-type: manual
     client_documentation: https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigquery/latest
     release-level: stable
@@ -146,7 +146,7 @@ manual-clients:
   - api-shortname: bigtable
     distribution-name: cloud.google.com/go/bigtable
     description: Cloud BigTable
-    language: Go
+    language: go
     client-library-type: manual
     client_documentation: https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigtable/latest
     release-level: stable
@@ -154,7 +154,7 @@ manual-clients:
   - api-shortname: compute-metadata
     distribution-name: cloud.google.com/go/compute/metadata
     description: Service Metadata API
-    language: Go
+    language: go
     client-library-type: manual
     client_documentation: https://cloud.google.com/go/docs/reference/cloud.google.com/go/compute/latest/metadata
     release-level: stable
@@ -162,7 +162,7 @@ manual-clients:
   - api-shortname: datastore
     distribution-name: cloud.google.com/go/datastore
     description: Cloud Datastore
-    language: Go
+    language: go
     client-library-type: manual
     client_documentation: https://cloud.google.com/go/docs/reference/cloud.google.com/go/datastore/latest
     release-level: stable
@@ -170,7 +170,7 @@ manual-clients:
   - api-shortname: errorreporting
     distribution-name: cloud.google.com/go/errorreporting
     description: Cloud Error Reporting API
-    language: Go
+    language: go
     client-library-type: manual
     client_documentation: https://cloud.google.com/go/docs/reference/cloud.google.com/go/errorreporting/latest
     release-level: preview
@@ -178,7 +178,7 @@ manual-clients:
   - api-shortname: firestore
     distribution-name: cloud.google.com/go/firestore
     description: Cloud Firestore API
-    language: Go
+    language: go
     client-library-type: manual
     client_documentation: https://cloud.google.com/go/docs/reference/cloud.google.com/go/firestore/latest
     release-level: stable
@@ -186,7 +186,7 @@ manual-clients:
   - api-shortname: firestore-metadata
     distribution-name: cloud.google.com/go/functions/metadata
     description: Cloud Functions
-    language: Go
+    language: go
     client-library-type: manual
     client_documentation: https://cloud.google.com/go/docs/reference/cloud.google.com/go/functions/latest/metadata
     release-level: preview
@@ -194,7 +194,7 @@ manual-clients:
   - api-shortname: iam
     distribution-name: cloud.google.com/go/iam
     description: Cloud IAM
-    language: Go
+    language: go
     client-library-type: manual
     client_documentation: https://cloud.google.com/go/docs/reference/cloud.google.com/go/iam/latest
     release-level: stable
@@ -202,7 +202,7 @@ manual-clients:
   - api-shortname: logging
     distribution-name: cloud.google.com/go/logging
     description: Cloud Logging API
-    language: Go
+    language: go
     client-library-type: manual
     client_documentation: https://cloud.google.com/go/docs/reference/cloud.google.com/go/logging/latest
     release-level: stable
@@ -210,7 +210,7 @@ manual-clients:
   - api-shortname: profiler
     distribution-name: cloud.google.com/go/profiler
     description: Cloud Profiler
-    language: Go
+    language: go
     client-library-type: manual
     client_documentation: https://cloud.google.com/go/docs/reference/cloud.google.com/go/profiler/latest
     release-level: stable
@@ -218,7 +218,7 @@ manual-clients:
   - api-shortname: pubsub
     distribution-name: cloud.google.com/go/pubsub
     description: Cloud PubSub
-    language: Go
+    language: go
     client-library-type: manual
     client_documentation: https://cloud.google.com/go/docs/reference/cloud.google.com/go/pubsub/latest
     release-level: stable
@@ -226,7 +226,7 @@ manual-clients:
   - api-shortname: pubsublite
     distribution-name: cloud.google.com/go/pubsublite
     description: Cloud PubSub Lite
-    language: Go
+    language: go
     client-library-type: manual
     client_documentation: https://cloud.google.com/go/docs/reference/cloud.google.com/go/pubsublite/latest
     release-level: stable
@@ -234,7 +234,7 @@ manual-clients:
   - api-shortname: rpcreplay
     distribution-name: cloud.google.com/go/rpcreplay
     description: RPC Replay
-    language: Go
+    language: go
     client-library-type: manual
     client_documentation: https://cloud.google.com/go/docs/reference/cloud.google.com/go/latest/rpcreplay
     release-level: stable
@@ -242,7 +242,7 @@ manual-clients:
   - api-shortname: spanner
     distribution-name: cloud.google.com/go/spanner
     description: Cloud Spanner
-    language: Go
+    language: go
     client-library-type: manual
     client_documentation: https://cloud.google.com/go/docs/reference/cloud.google.com/go/spanner/latest
     release-level: stable
@@ -250,7 +250,7 @@ manual-clients:
   - api-shortname: storage
     distribution-name: cloud.google.com/go/storage
     description: Cloud Storage (GCS)
-    language: Go
+    language: go
     client-library-type: manual
     client_documentation: https://cloud.google.com/go/docs/reference/cloud.google.com/go/storage/latest
     release-level: stable


### PR DESCRIPTION
Forgot to update the manual entries in #8101 

Fixes #8108

Note: Some manual entries are not associated with a live service e.g. compute/metadata, functions/metadata, etc.