### PR TITLE
fix(storage): fix routing header for writes

### DIFF
--- a/storage/grpc_client.go
+++ b/storage/grpc_client.go
@@ -1611,7 +1611,7 @@ func (w *gRPCWriter) uploadBuffer(recvd int, start int64, doneReading bool) (*st
 		// The first message on the WriteObject stream must either be the
 		// Object or the Resumable Upload ID.
 		if first {
-			ctx := gapic.InsertMetadata(w.ctx, metadata.Pairs("x-goog-request-params", "bucket="+url.QueryEscape(w.bucket)))
+			ctx := gapic.InsertMetadata(w.ctx, metadata.Pairs("x-goog-request-params", fmt.Sprintf("bucket=projects/_/buckets/%s", url.QueryEscape(w.bucket))))
 			w.stream, err = w.c.raw.WriteObject(ctx)
 			if err != nil {
 				return nil, 0, false, err


### PR DESCRIPTION
This fixes several integration tests that were broken since GCS started enforcing new formatting. Only writes are affected; for other calls, the GAPIC handles the routing annotation.

Fixes #8142
Fixes #8143
Fixes #8144
Fixes #8145
Fixes #8149