### PR TITLE
fix(storage): fix CreateBucket logic for gRPC

### DIFF
--- a/storage/grpc_client.go
+++ b/storage/grpc_client.go
@@ -154,7 +154,6 @@ func (c *grpcStorageClient) GetServiceAccount(ctx context.Context, project strin
 func (c *grpcStorageClient) CreateBucket(ctx context.Context, project, bucket string, attrs *BucketAttrs, opts ...storageOption) (*BucketAttrs, error) {
 	s := callSettings(c.settings, opts...)
 	b := attrs.toProtoBucket()
-	b.Name = bucket
 	b.Project = toProjectResource(project)
 	// If there is lifecycle information but no location, explicitly set
 	// the location. This is a GCS quirk/bug.
@@ -165,7 +164,7 @@ func (c *grpcStorageClient) CreateBucket(ctx context.Context, project, bucket st
 	req := &storagepb.CreateBucketRequest{
 		Parent:   fmt.Sprintf("projects/%s", globalProjectAlias),
 		Bucket:   b,
-		BucketId: b.GetName(),
+		BucketId: bucket,
 	}
 	if attrs != nil {
 		req.PredefinedAcl = attrs.PredefinedACL

--- a/storage/integration_test.go
+++ b/storage/integration_test.go
@@ -80,7 +80,6 @@ var (
 	record = flag.Bool("record", false, "record RPCs")
 
 	uidSpace        *uid.Space
-	uidSpaceGRPC    *uid.Space
 	uidSpaceObjects *uid.Space
 	bucketName      string
 	grpcBucketName  string
@@ -209,11 +208,10 @@ func initIntegrationTest() func() error {
 }
 
 func initUIDsAndRand(t time.Time) {
-	uidSpace = uid.NewSpace(testPrefix, &uid.Options{Time: t, Short: true})
-	bucketName = uidSpace.New()
+	uidSpace = uid.NewSpace("", &uid.Options{Time: t, Short: true})
+	bucketName = testPrefix + uidSpace.New()
 	uidSpaceObjects = uid.NewSpace("obj", &uid.Options{Time: t})
-	uidSpaceGRPC = uid.NewSpace(grpcTestPrefix, &uid.Options{Time: t, Short: true})
-	grpcBucketName = uidSpaceGRPC.New()
+	grpcBucketName = grpcTestPrefix + uidSpace.New()
 	// Use our own random source, to avoid other parts of the program taking
 	// random numbers from the global source and putting record and replay
 	// out of sync.
@@ -281,10 +279,10 @@ func multiTransportTest(ctx context.Context, t *testing.T,
 			}
 
 			bucket := bucketName
-			var prefix string
+			prefix := testPrefix
 			if transport == "grpc" {
 				bucket = grpcBucketName
-				prefix = grpcTestPrefix + "-"
+				prefix = grpcTestPrefix
 			}
 
 			test(t, ctx, bucket, prefix, client)


### PR DESCRIPTION
This was causing some of the failures that I thought I had addressed in #8159. Fix by specifying the bucket name using CreateBucketRequest.BucketID rather than CreateBucketRequest.Bucket.Name.

Also cleans up some messy logic around specifying bucket names for integration tests that I ended up looking at.

Fixes #8162