### PR TITLE
feat(bigquery): allow users to override retry settings

### DIFF
--- a/bigquery/bigquery_test.go
+++ b/bigquery/bigquery_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//      http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,113 +15,96 @@
 package bigquery
 
 import (
-	"errors"
-	"io"
-	"net/http"
-	"net/url"
+	"context"
 	"testing"
+	"time"
 
-	"golang.org/x/xerrors"
-	"google.golang.org/api/googleapi"
+	"cloud.google.com/go/internal/testutil"
+	"github.com/google/go-cmp/cmp"
+	gax "github.com/googleapis/gax-go/v2"
 )
 
-func TestRetryableErrors(t *testing.T) {
-	for _, tc := range []struct {
-		description string
-		in          error
-		want        bool
+// Test that Client.SetRetry correctly configures the retry configuration
+// on the Client.
+func TestClientSetRetry(t *testing.T) {
+	defaultBO := defaultRetryBackoff()
+	testCases := []struct {
+		name          string
+		clientOptions []RetryOption
+		want          *retryConfig
 	}{
 		{
-			"nil error",
-			nil,
-			false,
-		},
-		{
-			"http stream closed",
-			errors.New("http2: stream closed"),
-			true,
-		},
-		{
-			"io ErrUnexpectedEOF",
-			io.ErrUnexpectedEOF,
-			true,
-		},
-		{
-			"unavailable",
-			&googleapi.Error{
-				Code:    http.StatusServiceUnavailable,
-				Message: "foo",
+			name:          "all defaults",
+			clientOptions: []RetryOption{},
+			want: &retryConfig{
+				backoff: &defaultBO,
 			},
-			true,
 		},
 		{
-			"url connection error",
-			&url.Error{Op: "blah", URL: "blah", Err: errors.New("connection refused")},
-			true,
-		},
-		{
-			"url other error",
-			&url.Error{Op: "blah", URL: "blah", Err: errors.New("blah")},
-			false,
-		},
-		{
-			"wrapped retryable",
-			xerrors.Errorf("test of wrapped retryable: %w", &googleapi.Error{
-				Code:    http.StatusServiceUnavailable,
-				Message: "foo",
-				Errors: []googleapi.ErrorItem{
-					{Reason: "backendError", Message: "foo"},
+			name: "set all options",
+			clientOptions: []RetryOption{
+				WithBackoff(gax.Backoff{
+					Initial:    2 * time.Second,
+					Max:        30 * time.Second,
+					Multiplier: 3,
+				}),
+				WithErrorFunc(func(err error) bool { return false }),
+			},
+			want: &retryConfig{
+				backoff: &gax.Backoff{
+					Initial:    2 * time.Second,
+					Max:        30 * time.Second,
+					Multiplier: 3,
 				},
-			}),
-			true,
-		},
-		{
-			"wrapped non-retryable",
-			xerrors.Errorf("test of wrapped retryable: %w", errors.New("blah")),
-			false,
-		},
-		{
-			// not retried per https://google.aip.dev/194
-			"internal error",
-			&googleapi.Error{
-				Code: http.StatusInternalServerError,
+				shouldRetry: func(err error) bool { return false },
 			},
-			true,
 		},
 		{
-			"internal w/backend reason",
-			&googleapi.Error{
-				Code:    http.StatusServiceUnavailable,
-				Message: "foo",
-				Errors: []googleapi.ErrorItem{
-					{Reason: "backendError", Message: "foo"},
-				},
+			name: "set some backoff options",
+			clientOptions: []RetryOption{
+				WithBackoff(gax.Backoff{
+					Multiplier: 3,
+				}),
 			},
-			true,
+			want: &retryConfig{
+				backoff: &gax.Backoff{
+					Multiplier: 3,
+				}},
 		},
 		{
-			"internal w/rateLimitExceeded reason",
-			&googleapi.Error{
-				Code:    http.StatusServiceUnavailable,
-				Message: "foo",
-				Errors: []googleapi.ErrorItem{
-					{Reason: "rateLimitExceeded", Message: "foo"},
-				},
+			name: "set ErrorFunc only",
+			clientOptions: []RetryOption{
+				WithErrorFunc(func(err error) bool { return false }),
 			},
-			true,
-		},
-		{
-			"bad gateway error",
-			&googleapi.Error{
-				Code:    http.StatusBadGateway,
-				Message: "foo",
+			want: &retryConfig{
+				backoff:     &defaultBO,
+				shouldRetry: func(err error) bool { return false },
 			},
-			true,
 		},
-	} {
-		got := retryableError(tc.in, defaultRetryReasons)
-		if got != tc.want {
-			t.Errorf("case (%s) mismatch:  got %t want %t", tc.description, got, tc.want)
-		}
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(s *testing.T) {
+			ctx := context.Background()
+			projectID := testutil.ProjID()
+			c, err := NewClient(ctx, projectID)
+			if err != nil {
+				t.Fatalf("NewClient: %v", err)
+			}
+			defer c.Close()
+			c.SetRetry(tc.clientOptions...)
+
+			if diff := cmp.Diff(
+				c.retry,
+				tc.want,
+				cmp.AllowUnexported(retryConfig{}, gax.Backoff{}),
+				// ErrorFunc cannot be compared directly, but we check if both are
+				// either nil or non-nil.
+				cmp.Comparer(func(a, b func(err error) bool) bool {
+					return (a == nil && b == nil) || (a != nil && b != nil)
+				}),
+			); diff != "" {
+				s.Fatalf("retry not configured correctly: %v", diff)
+			}
+		})
 	}
 }

--- a/bigquery/iam.go
+++ b/bigquery/iam.go
@@ -61,8 +61,9 @@ func (c *bqIAMClient) GetWithVersion(ctx context.Context, resource string, reque
 	call := c.bqs.Tables.GetIamPolicy(resource, iamReq).Context(ctx)
 	setClientHeader(call.Header())
 
+	retry := defaultRetryConfig()
 	var bqp *bq.Policy
-	err = runWithRetry(ctx, func() error {
+	err = runWithRetry(ctx, retry, func() error {
 		bqp, err = call.Do()
 		return err
 	})
@@ -76,10 +77,11 @@ func (c *bqIAMClient) Set(ctx context.Context, resource string, p *iampb.Policy)
 	ctx = trace.StartSpan(ctx, "cloud.google.com/go/bigquery.IAM.Set")
 	defer func() { trace.EndSpan(ctx, err) }()
 
+	retry := defaultRetryConfig()
 	bqp := iamToBigQueryPolicy(p)
 	call := c.bqs.Tables.SetIamPolicy(resource, &bq.SetIamPolicyRequest{Policy: bqp}).Context(ctx)
 	setClientHeader(call.Header())
-	return runWithRetry(ctx, func() error {
+	return runWithRetry(ctx, retry, func() error {
 		_, err := call.Do()
 		return err
 	})
@@ -92,8 +94,9 @@ func (c *bqIAMClient) Test(ctx context.Context, resource string, perms []string)
 	call := c.bqs.Tables.TestIamPermissions(resource, &bq.TestIamPermissionsRequest{Permissions: perms}).Context(ctx)
 	setClientHeader(call.Header())
 
+	retry := defaultRetryConfig()
 	var res *bq.TestIamPermissionsResponse
-	err = runWithRetry(ctx, func() error {
+	err = runWithRetry(ctx, retry, func() error {
 		res, err = call.Do()
 		return err
 	})

--- a/bigquery/inserter.go
+++ b/bigquery/inserter.go
@@ -179,8 +179,9 @@ func (u *Inserter) putMulti(ctx context.Context, src []ValueSaver) error {
 	}
 	call := u.t.c.bqs.Tabledata.InsertAll(u.t.ProjectID, u.t.DatasetID, u.t.TableID, req).Context(ctx)
 	setClientHeader(call.Header())
+	retry := defaultRetryConfig()
 	var res *bq.TableDataInsertAllResponse
-	err = runWithRetry(ctx, func() (err error) {
+	err = runWithRetry(ctx, retry, func() (err error) {
 		ctx = trace.StartSpan(ctx, "bigquery.tabledata.insertAll")
 		res, err = call.Do()
 		trace.EndSpan(ctx, err)

--- a/bigquery/iterator.go
+++ b/bigquery/iterator.go
@@ -242,7 +242,7 @@ func fetchTableResultPage(ctx context.Context, src *rowSource, schema Schema, st
 	} else {
 		go func() {
 			var bqt *bq.Table
-			err := runWithRetry(ctx, func() (err error) {
+			err := runWithRetry(ctx, src.t.retryer(), func() (err error) {
 				bqt, err = src.t.c.bqs.Tables.Get(src.t.ProjectID, src.t.DatasetID, src.t.TableID).
 					Fields("schema").
 					Context(ctx).
@@ -266,7 +266,7 @@ func fetchTableResultPage(ctx context.Context, src *rowSource, schema Schema, st
 		call.MaxResults(pageSize)
 	}
 	var res *bq.TableDataList
-	err := runWithRetry(ctx, func() (err error) {
+	err := runWithRetry(ctx, src.t.retryer(), func() (err error) {
 		res, err = call.Context(ctx).Do()
 		return err
 	})
@@ -308,7 +308,7 @@ func fetchJobResultPage(ctx context.Context, src *rowSource, schema Schema, star
 		call.MaxResults(pageSize)
 	}
 	var res *bq.GetQueryResultsResponse
-	err := runWithRetry(ctx, func() (err error) {
+	err := runWithRetry(ctx, src.j.retryer(), func() (err error) {
 		res, err = call.Do()
 		return err
 	})

--- a/bigquery/model.go
+++ b/bigquery/model.go
@@ -85,7 +85,7 @@ func (m *Model) Metadata(ctx context.Context) (mm *ModelMetadata, err error) {
 	req := m.c.bqs.Models.Get(m.ProjectID, m.DatasetID, m.ModelID).Context(ctx)
 	setClientHeader(req.Header())
 	var model *bq.Model
-	err = runWithRetry(ctx, func() (err error) {
+	err = runWithRetry(ctx, m.c.retry, func() (err error) {
 		ctx = trace.StartSpan(ctx, "bigquery.models.get")
 		model, err = req.Do()
 		trace.EndSpan(ctx, err)
@@ -112,7 +112,7 @@ func (m *Model) Update(ctx context.Context, mm ModelMetadataToUpdate, etag strin
 		call.Header().Set("If-Match", etag)
 	}
 	var res *bq.Model
-	if err := runWithRetry(ctx, func() (err error) {
+	if err := runWithRetry(ctx, m.c.retry, func() (err error) {
 		ctx = trace.StartSpan(ctx, "bigquery.models.patch")
 		res, err = call.Do()
 		trace.EndSpan(ctx, err)

--- a/bigquery/retry.go
+++ b/bigquery/retry.go
@@ -1,0 +1,208 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bigquery
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	cloudinternal "cloud.google.com/go/internal"
+	gax "github.com/googleapis/gax-go/v2"
+	"google.golang.org/api/googleapi"
+)
+
+type retryConfig struct {
+	backoff     *gax.Backoff
+	shouldRetry func(err error) bool
+}
+
+// RetryOption allows users to configure non-default retry behavior for API
+// calls made to BigQuery.
+type RetryOption interface {
+	apply(config *retryConfig)
+}
+
+// WithBackoff allows configuration of the backoff timing used for retries.
+// Available configuration options (Initial, Max and Multiplier) are described
+// at https://pkg.go.dev/github.com/googleapis/gax-go/v2#Backoff. If any fields
+// are not supplied by the user, gax default values will be used.
+func WithBackoff(backoff gax.Backoff) RetryOption {
+	return &withBackoff{
+		backoff: backoff,
+	}
+}
+
+type withBackoff struct {
+	backoff gax.Backoff
+}
+
+func (wb *withBackoff) apply(config *retryConfig) {
+	config.backoff = &wb.backoff
+}
+
+// WithErrorFunc allows users to pass a custom function to the retryer. Errors
+// will be retried if and only if `shouldRetry(err)` returns true.
+// By default, the following errors are retried (see ShouldRetry for the default
+// function):
+//
+// - HTTP responses with codes 502, 503, and 504.
+//
+// - Transient network/transport errors such as connection reset and io.ErrUnexpectedEOF.
+//
+// - Errors which are considered transient using the Temporary() interface.
+//
+// - Wrapped versions of these errors.
+//
+// This option can be used to retry on a different set of errors than the
+// default. Users can use the default ShouldRetry function inside their custom
+// function if they only want to make minor modifications to default behavior.
+func WithErrorFunc(shouldRetry func(err error) bool) RetryOption {
+	return &withErrorFunc{
+		shouldRetry: shouldRetry,
+	}
+}
+
+type withErrorFunc struct {
+	shouldRetry func(err error) bool
+}
+
+func (wef *withErrorFunc) apply(config *retryConfig) {
+	config.shouldRetry = wef.shouldRetry
+}
+
+// ShouldRetry returns true if an error is retryable, based on best practice
+// guidance from BigQuery. This function matches the suggestions in
+// https://cloud.google.com/bigquery/sla.
+//
+// If you would like to customize retryable errors, use the WithErrorFunc to
+// supply a RetryOption to your library calls. For example, to retry additional
+// errors, you can write a custom func that wraps ShouldRetry and also specifies
+// additional errors that should return true.
+func ShouldRetry(err error) bool {
+	return !retryableError(err, defaultRetryReasons)
+}
+
+// This function matches the suggestions in https://cloud.google.com/bigquery/sla.
+func defaultRetryBackoff() gax.Backoff {
+	return gax.Backoff{
+		Initial:    1 * time.Second,
+		Max:        32 * time.Second,
+		Multiplier: 2,
+	}
+}
+
+func defaultRetryConfig() *retryConfig {
+	bo := defaultRetryBackoff()
+	return &retryConfig{
+		backoff: &bo,
+	}
+}
+
+// runWithRetry calls the function until it returns nil or a non-retryable error, or
+// the context is done.
+// See the similar function in ../storage/invoke.go. The main difference is the
+// reason for retrying.
+func runWithRetry(ctx context.Context, retry *retryConfig, call func() error) error {
+	return runWithRetryExplicit(ctx, retry, call, defaultRetryReasons)
+}
+
+func runWithRetryExplicit(ctx context.Context, retry *retryConfig, call func() error, allowedReasons []string) error {
+	bo := defaultRetryBackoff()
+	if retry.backoff != nil {
+		bo.Multiplier = retry.backoff.Multiplier
+		bo.Initial = retry.backoff.Initial
+		bo.Max = retry.backoff.Max
+	}
+	return cloudinternal.Retry(ctx, bo, func() (stop bool, err error) {
+		err = call()
+		if err == nil {
+			return true, nil
+		}
+		shouldRetryFunc := func(err error) bool {
+			return !retryableError(err, allowedReasons)
+		}
+		if retry.shouldRetry != nil {
+			shouldRetryFunc = retry.shouldRetry
+		}
+		return shouldRetryFunc(err), err
+	})
+}
+
+var (
+	defaultRetryReasons = []string{"backendError", "rateLimitExceeded"}
+	jobRetryReasons     = []string{"backendError", "rateLimitExceeded", "internalError"}
+	retry5xxCodes       = []int{
+		http.StatusInternalServerError,
+		http.StatusBadGateway,
+		http.StatusServiceUnavailable,
+		http.StatusGatewayTimeout,
+	}
+)
+
+// retryableError is the unary retry predicate for this library.  In addition to structured error
+// reasons, it specifies some HTTP codes (500, 502, 503, 504) and network/transport reasons.
+func retryableError(err error, allowedReasons []string) bool {
+	if err == nil {
+		return false
+	}
+	if err == io.ErrUnexpectedEOF {
+		return true
+	}
+	// Special case due to http2: https://github.com/googleapis/google-cloud-go/issues/1793
+	// Due to Go's default being higher for streams-per-connection than is accepted by the
+	// BQ backend, it's possible to get streams refused immediately after a connection is
+	// started but before we receive SETTINGS frame from the backend.  This generally only
+	// happens when we try to enqueue > 100 requests onto a newly initiated connection.
+	if err.Error() == "http2: stream closed" {
+		return true
+	}
+
+	switch e := err.(type) {
+	case *googleapi.Error:
+		// We received a structured error from backend.
+		var reason string
+		if len(e.Errors) > 0 {
+			reason = e.Errors[0].Reason
+			for _, r := range allowedReasons {
+				if reason == r {
+					return true
+				}
+			}
+		}
+		for _, code := range retry5xxCodes {
+			if e.Code == code {
+				return true
+			}
+		}
+	case *url.Error:
+		retryable := []string{"connection refused", "connection reset"}
+		for _, s := range retryable {
+			if strings.Contains(e.Error(), s) {
+				return true
+			}
+		}
+	case interface{ Temporary() bool }:
+		if e.Temporary() {
+			return true
+		}
+	}
+	// Check wrapped error.
+	return retryableError(errors.Unwrap(err), allowedReasons)
+}

--- a/bigquery/retry_test.go
+++ b/bigquery/retry_test.go
@@ -1,0 +1,127 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bigquery
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"golang.org/x/xerrors"
+	"google.golang.org/api/googleapi"
+)
+
+func TestRetryableErrors(t *testing.T) {
+	for _, tc := range []struct {
+		description string
+		in          error
+		want        bool
+	}{
+		{
+			"nil error",
+			nil,
+			false,
+		},
+		{
+			"http stream closed",
+			errors.New("http2: stream closed"),
+			true,
+		},
+		{
+			"io ErrUnexpectedEOF",
+			io.ErrUnexpectedEOF,
+			true,
+		},
+		{
+			"unavailable",
+			&googleapi.Error{
+				Code:    http.StatusServiceUnavailable,
+				Message: "foo",
+			},
+			true,
+		},
+		{
+			"url connection error",
+			&url.Error{Op: "blah", URL: "blah", Err: errors.New("connection refused")},
+			true,
+		},
+		{
+			"url other error",
+			&url.Error{Op: "blah", URL: "blah", Err: errors.New("blah")},
+			false,
+		},
+		{
+			"wrapped retryable",
+			xerrors.Errorf("test of wrapped retryable: %w", &googleapi.Error{
+				Code:    http.StatusServiceUnavailable,
+				Message: "foo",
+				Errors: []googleapi.ErrorItem{
+					{Reason: "backendError", Message: "foo"},
+				},
+			}),
+			true,
+		},
+		{
+			"wrapped non-retryable",
+			xerrors.Errorf("test of wrapped retryable: %w", errors.New("blah")),
+			false,
+		},
+		{
+			// not retried per https://google.aip.dev/194
+			"internal error",
+			&googleapi.Error{
+				Code: http.StatusInternalServerError,
+			},
+			true,
+		},
+		{
+			"internal w/backend reason",
+			&googleapi.Error{
+				Code:    http.StatusServiceUnavailable,
+				Message: "foo",
+				Errors: []googleapi.ErrorItem{
+					{Reason: "backendError", Message: "foo"},
+				},
+			},
+			true,
+		},
+		{
+			"internal w/rateLimitExceeded reason",
+			&googleapi.Error{
+				Code:    http.StatusServiceUnavailable,
+				Message: "foo",
+				Errors: []googleapi.ErrorItem{
+					{Reason: "rateLimitExceeded", Message: "foo"},
+				},
+			},
+			true,
+		},
+		{
+			"bad gateway error",
+			&googleapi.Error{
+				Code:    http.StatusBadGateway,
+				Message: "foo",
+			},
+			true,
+		},
+	} {
+		got := ShouldRetry(tc.in)
+		if got == tc.want {
+			t.Errorf("case (%s) mismatch:  got %t want %t", tc.description, got, tc.want)
+		}
+	}
+}

--- a/bigquery/routine.go
+++ b/bigquery/routine.go
@@ -96,7 +96,7 @@ func (r *Routine) Metadata(ctx context.Context) (rm *RoutineMetadata, err error)
 	req := r.c.bqs.Routines.Get(r.ProjectID, r.DatasetID, r.RoutineID).Context(ctx)
 	setClientHeader(req.Header())
 	var routine *bq.Routine
-	err = runWithRetry(ctx, func() (err error) {
+	err = runWithRetry(ctx, r.c.retry, func() (err error) {
 		ctx = trace.StartSpan(ctx, "bigquery.routines.get")
 		routine, err = req.Do()
 		trace.EndSpan(ctx, err)
@@ -130,7 +130,7 @@ func (r *Routine) Update(ctx context.Context, upd *RoutineMetadataToUpdate, etag
 		call.Header().Set("If-Match", etag)
 	}
 	var res *bq.Routine
-	if err := runWithRetry(ctx, func() (err error) {
+	if err := runWithRetry(ctx, r.c.retry, func() (err error) {
 		ctx = trace.StartSpan(ctx, "bigquery.routines.update")
 		res, err = call.Do()
 		trace.EndSpan(ctx, err)


### PR DESCRIPTION
Allow users to set retry settings on the `bigquery.Client` with now is applied for all operations. Later it can be customized by `Table`, `Dataset` and `Job` objects and operations. 

Most of it was based on the `google-cloud-go/storage` client. 

Fixes #7526