### PR TITLE
test(bigquery): skip storage billing model tests

### DIFF
--- a/bigquery/dataset_integration_test.go
+++ b/bigquery/dataset_integration_test.go
@@ -289,7 +289,7 @@ func TestIntegration_DatasetStorageBillingModel(t *testing.T) {
 	if client == nil {
 		t.Skip("Integration tests skipped")
 	}
-	t.Skip("Enterprise feature skipped")
+	t.Skip("BigQuery flat-rate commitments enabled for project, feature skipped")
 
 	ctx := context.Background()
 	md, err := dataset.Metadata(ctx)
@@ -323,7 +323,7 @@ func TestIntegration_DatasetStorageUpdateBillingModel(t *testing.T) {
 	if client == nil {
 		t.Skip("Integration tests skipped")
 	}
-	t.Skip("Enterprise feature skipped")
+	t.Skip("BigQuery flat-rate commitments enabled for project, feature skipped")
 
 	ctx := context.Background()
 	ds := client.Dataset(datasetIDs.New())

--- a/bigquery/dataset_integration_test.go
+++ b/bigquery/dataset_integration_test.go
@@ -289,6 +289,7 @@ func TestIntegration_DatasetStorageBillingModel(t *testing.T) {
 	if client == nil {
 		t.Skip("Integration tests skipped")
 	}
+	t.Skip("Enterprise feature skipped")
 
 	ctx := context.Background()
 	md, err := dataset.Metadata(ctx)
@@ -318,10 +319,11 @@ func TestIntegration_DatasetStorageBillingModel(t *testing.T) {
 	}
 }
 
-func TestIntegration_DatasetUpdateStorageBillingModel(t *testing.T) {
+func TestIntegration_DatasetStorageUpdateBillingModel(t *testing.T) {
 	if client == nil {
 		t.Skip("Integration tests skipped")
 	}
+	t.Skip("Enterprise feature skipped")
 
 	ctx := context.Background()
 	ds := client.Dataset(datasetIDs.New())


### PR DESCRIPTION
Skip tests related to Storage Billing Model as tests are going to fail due to changes related to BigQuery editions. This feature is not available in our CI/CD environment as we have BigQuery commitments on it.

Fixes #8194 and #8193