### PR TITLE
fix: kokoro presubmit builds

### DIFF
--- a/internal/kokoro/continuous.sh
+++ b/internal/kokoro/continuous.sh
@@ -78,8 +78,8 @@ try3 go mod download
 # runDirectoryTests runs all tests in the current directory.
 # If a PATH argument is specified, it runs `go test [PATH]`.
 runDirectoryTests() {
-  if [[ $PWD != *"/internal/"* ]] ||
-    [[ $PWD != *"/third_party/"* ]] &&
+  if { [[ $PWD == *"/internal/"* ]] ||
+    [[ $PWD == *"/third_party/"* ]]; } &&
     [[ $KOKORO_JOB_NAME == *"earliest"* ]]; then
     # internal tools only expected to work with latest go version
     return

--- a/internal/kokoro/presubmit.sh
+++ b/internal/kokoro/presubmit.sh
@@ -47,8 +47,8 @@ exit_code=0
 # Run tests in the current directory and tee output to log file,
 # to be pushed to GCS as artifact.
 runPresubmitTests() {
-  if [[ $PWD != *"/internal/"* ]] ||
-    [[ $PWD != *"/third_party/"* ]]; then
+  if [[ $PWD == *"/internal/"* ]] ||
+    [[ $PWD == *"/third_party/"* ]]; then
     # internal tools only expected to work with latest go version
     return
   fi


### PR DESCRIPTION
In ideal case, the GitHub presubmit tests should run all the tests of changed submodules when a PR is raised. But this is not happening and the builds are showing green which misguides developers to assume that all tests are passing.

Example build:
<img width="559" alt="image" src="https://github.com/googleapis/google-cloud-go/assets/57220027/a97e8485-f782-4a92-8d9e-7e611944377e">

This happened because the current condition says
```
runPresubmitTests() {
  if [[ $PWD != *"/internal/"* ]] ||
    [[ $PWD != *"/third_party/"* ]]; then
    return
  fi
  // run tests
```
This says
1. If the current directory do not have `internal` or `third_party` text in the string, then return from the method with out executing further.
2. changed modules (ex: spanner) pwd will not have these strings and hence will come out of method without executing tests.
**This is affecting all the existing directories with in the google-cloud-go repository.**

This PR fixes the above issue.