### PR TITLE
fix(spanner): wrap errors in inline begin transaction to avoid masking 

### DIFF
--- a/spanner/session.go
+++ b/spanner/session.go
@@ -1496,7 +1496,7 @@ func isFailedInlineBeginTransaction(err error) bool {
 	if err == nil {
 		return false
 	}
-	return ErrCode(err) == codes.Internal && strings.Contains(err.Error(), errInlineBeginTransactionFailed().Error())
+	return strings.Contains(err.Error(), errInlineBeginTransactionFailed().Error())
 }
 
 // isClientClosing returns true if the given error is a

--- a/spanner/transaction.go
+++ b/spanner/transaction.go
@@ -264,7 +264,7 @@ func (t *txReadOnly) ReadWithOptions(ctx context.Context, table string, keys Key
 			if err != nil {
 				if _, ok := t.getTransactionSelector().GetSelector().(*sppb.TransactionSelector_Begin); ok {
 					t.setTransactionID(nil)
-					return client, errInlineBeginTransactionFailed()
+					return client, toSpannerErrorDuringInlineBegin(err)
 				}
 				return client, err
 			}
@@ -301,7 +301,7 @@ func errMultipleRowsFound(table string, key Key, index string) error {
 
 // errInlineBeginTransactionFailed returns error for read-write transaction to explicitly begin the transaction
 func errInlineBeginTransactionFailed() error {
-	return spannerErrorf(codes.Internal, "failed inline begin transaction")
+	return spannerErrorf(codes.Internal, inlineBeginTransactionFailedMsg)
 }
 
 // ReadRow reads a single row from the database.
@@ -500,7 +500,7 @@ func (t *txReadOnly) query(ctx context.Context, statement Statement, options Que
 			if err != nil {
 				if _, ok := req.Transaction.GetSelector().(*sppb.TransactionSelector_Begin); ok {
 					t.setTransactionID(nil)
-					return client, errInlineBeginTransactionFailed()
+					return client, toSpannerErrorDuringInlineBegin(err)
 				}
 				return client, err
 			}
@@ -1071,7 +1071,7 @@ func (t *ReadWriteTransaction) update(ctx context.Context, stmt Statement, opts 
 	if err != nil {
 		if hasInlineBeginTransaction {
 			t.setTransactionID(nil)
-			return 0, errInlineBeginTransactionFailed()
+			return 0, toSpannerErrorDuringInlineBegin(err)
 		}
 		return 0, ToSpannerError(err)
 	}
@@ -1166,7 +1166,7 @@ func (t *ReadWriteTransaction) batchUpdateWithOptions(ctx context.Context, stmts
 	if err != nil {
 		if hasInlineBeginTransaction {
 			t.setTransactionID(nil)
-			return nil, errInlineBeginTransactionFailed()
+			return nil, toSpannerErrorDuringInlineBegin(err)
 		}
 		return nil, ToSpannerError(err)
 	}


### PR DESCRIPTION
When inline begin transaction was added, the error messages were getting masked with 
```
spanner: code = "Internal", desc = "failed inline begin transaction"
```
This PR fixes this by wrapping the error to unmask original errors.