### PR TITLE
chore: re-onboard cloudbuild apiv1 /w OwlBot

### DIFF
--- a/.github/.OwlBot.yaml
+++ b/.github/.OwlBot.yaml
@@ -54,7 +54,7 @@ deep-remove-regex:
   - /binaryauthorization/apiv1beta1/
   - /certificatemanager/apiv1/
   - /channel/apiv1/
-  # - /cloudbuild/apiv1/v2/
+  - /cloudbuild/apiv1/v2/
   - /cloudbuild/apiv2/
   - /clouddms/apiv1/
   - /cloudtasks/apiv2/
@@ -166,7 +166,7 @@ deep-remove-regex:
   - /internal/generated/snippets/binaryauthorization/apiv1beta1/
   - /internal/generated/snippets/certificatemanager/apiv1/
   - /internal/generated/snippets/channel/apiv1/
-  # - /internal/generated/snippets/cloudbuild/apiv1/v2/
+  - /internal/generated/snippets/cloudbuild/apiv1/v2/
   - /internal/generated/snippets/cloudbuild/apiv2/
   - /internal/generated/snippets/clouddms/apiv1/
   - /internal/generated/snippets/cloudtasks/apiv2/
@@ -596,8 +596,8 @@ deep-copy-regex:
     dest: /
   - source: /google/cloud/channel/v1/cloud.google.com/go
     dest: /
-  # - source: /google/devtools/cloudbuild/v1/cloud.google.com/go
-  #   dest: /
+  - source: /google/devtools/cloudbuild/v1/cloud.google.com/go
+    dest: /
   - source: /google/devtools/cloudbuild/v2/cloud.google.com/go
     dest: /
   - source: /google/cloud/clouddms/v1/cloud.google.com/go


### PR DESCRIPTION
The git history is not super clear here to why this one was disablbed to begin with. I suspect this may cause generation errors of some sorts, but lets re-enable for now and see what/if it breaks.