### PR TITLE
docs(ai): fix README.md title

### DIFF
--- a/ai/README.md
+++ b/ai/README.md
@@ -1,8 +1,8 @@
-# Vertex AI API
+# Generative Language API
 
 [![Go Reference](https://pkg.go.dev/badge/cloud.google.com/go/ai.svg)](https://pkg.go.dev/cloud.google.com/go/ai)
 
-Go Client Library for Vertex AI API.
+Go Client Library for Generative Language API.
 
 ## Install
 


### PR DESCRIPTION
I'm not sure how "Vertex AI" was incorrectly used in this README when it was initially configured in #8212. Running the post-processor locally produced the change (to the correct title) in this PR.