### PR TITLE
chore(internal/kokoro): skip tests for empty commits

### DIFF
--- a/internal/kokoro/continuous.sh
+++ b/internal/kokoro/continuous.sh
@@ -140,6 +140,12 @@ exit_code=0
 if [[ $KOKORO_JOB_NAME == *"continuous"* ]]; then
   # Continuous jobs only run root tests & tests in submodules changed by the PR.
   SIGNIFICANT_CHANGES=$(git --no-pager diff --name-only $KOKORO_GIT_COMMIT^..$KOKORO_GIT_COMMIT | grep -Ev '(\.md$|^\.github)' || true)
+
+  if [ -z $SIGNIFICANT_CHANGES ]; then
+    echo "No changes detected, skipping tests"
+    exit 0
+  fi
+
   # CHANGED_DIRS is the list of significant top-level directories that changed,
   # but weren't deleted by the current PR. CHANGED_DIRS will be empty when run on main.
   CHANGED_DIRS=$(echo "$SIGNIFICANT_CHANGES" | tr ' ' '\n' | grep "/" | cut -d/ -f1 | sort -u | tr '\n' ' ' | xargs ls -d 2>/dev/null || true)

--- a/internal/kokoro/presubmit.sh
+++ b/internal/kokoro/presubmit.sh
@@ -79,6 +79,12 @@ runPresubmitTests() {
 
 SIGNIFICANT_CHANGES=$(git --no-pager diff --name-only origin/main...$KOKORO_GIT_COMMIT_google_cloud_go |
   grep -Ev '(\.md$|^\.github)' || true)
+
+if [ -z $SIGNIFICANT_CHANGES ]; then
+  echo "No changes detected, skipping tests"
+  exit 0
+fi
+
 # CHANGED_DIRS is the list of significant top-level directories that changed,
 # but weren't deleted by the current PR. CHANGED_DIRS will be empty when run on main.
 CHANGED_DIRS=$(echo "$SIGNIFICANT_CHANGES" | tr ' ' '\n' | grep "/" | cut -d/ -f1 | sort -u |


### PR DESCRIPTION
When there are no changes in the PR, we can skip* presubmits and exit early. This is useful for forcing releases with empty commits, github workflow-only changes, etc.

Same change applied to the continuous job as well, when there are no changes in the merged commit, the tests are skipped.

*the job logs that there were no changes and exits early with `0` exit code.