### PR TITLE
fix(bigquery): use JobFromProject for storage iterator

### DIFF
--- a/bigquery/storage_iterator.go
+++ b/bigquery/storage_iterator.go
@@ -67,7 +67,7 @@ func newStorageRowIteratorFromTable(ctx context.Context, table *Table, ordered b
 
 func newStorageRowIteratorFromJob(ctx context.Context, j *Job) (*RowIterator, error) {
 	// Needed to fetch destination table
-	job, err := j.c.JobFromID(ctx, j.jobID)
+	job, err := j.c.JobFromProject(ctx, j.projectID, j.jobID, j.location)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
There's no guarantee that the provided client is in the same project or location as the job, so those details need to also be provided from the job object