### PR TITLE
test(internal/docfx): fix expected number of pages in test

### DIFF
--- a/internal/godocfx/godocfx_test.go
+++ b/internal/godocfx/godocfx_test.go
@@ -70,7 +70,7 @@ func TestParse(t *testing.T) {
 	if got, want := len(r.toc), 1; got != want {
 		t.Fatalf("Parse got len(toc) = %d, want %d", got, want)
 	}
-	if got, want := len(r.pages), 29; got != want {
+	if got, want := len(r.pages), 33; got != want {
 		t.Errorf("Parse got len(pages) = %d, want %d", got, want)
 	}
 	if got := r.module.Path; got != mod {


### PR DESCRIPTION
With the addition of the `biglake` package under `bigquery` the expected number of pages in the `docfx` test that targets `bigquery` needed to be changed. Probably not the best thing to have a moving target for a test, but it's easy enough to fix.

Fixes #8435