### PR TITLE
test(datastore): Truncate transaction read time to millisecond

### DIFF
--- a/datastore/integration_test.go
+++ b/datastore/integration_test.go
@@ -724,7 +724,7 @@ func TestIntegration_AggregationQueries(t *testing.T) {
 	}
 
 	// Create transaction with read before creating entities
-	readTime := time.Now()
+	readTime := time.Now().Truncate(time.Millisecond)
 	txBeforeCreate, err := client.NewTransaction(ctx, []TransactionOption{ReadOnly, WithReadTime(readTime)}...)
 	if err != nil {
 		t.Fatalf("client.NewTransaction: %v", err)
@@ -742,7 +742,7 @@ func TestIntegration_AggregationQueries(t *testing.T) {
 	}()
 
 	// Create transaction with read after creating entities
-	readTime = time.Now()
+	readTime = time.Now().Truncate(time.Millisecond)
 	txAfterCreate, err := client.NewTransaction(ctx, []TransactionOption{ReadOnly, WithReadTime(readTime)}...)
 	if err != nil {
 		t.Fatalf("client.NewTransaction: %v", err)

--- a/datastore/integration_test.go
+++ b/datastore/integration_test.go
@@ -724,7 +724,7 @@ func TestIntegration_AggregationQueries(t *testing.T) {
 	}
 
 	// Create transaction with read before creating entities
-	readTime := time.Now().Truncate(time.Millisecond)
+	readTime := time.Now().Truncate(time.Microsecond)
 	txBeforeCreate, err := client.NewTransaction(ctx, []TransactionOption{ReadOnly, WithReadTime(readTime)}...)
 	if err != nil {
 		t.Fatalf("client.NewTransaction: %v", err)
@@ -742,7 +742,7 @@ func TestIntegration_AggregationQueries(t *testing.T) {
 	}()
 
 	// Create transaction with read after creating entities
-	readTime = time.Now().Truncate(time.Millisecond)
+	readTime = time.Now().Truncate(time.Microsecond)
 	txAfterCreate, err := client.NewTransaction(ctx, []TransactionOption{ReadOnly, WithReadTime(readTime)}...)
 	if err != nil {
 		t.Fatalf("client.NewTransaction: %v", err)


### PR DESCRIPTION
**Issue**: Aggregation queries integration test fails with error:
```
=== RUN   TestIntegration_AggregationQueries
    integration_test.go:730: client.NewTransaction: rpc error: code = InvalidArgument desc = timestamp cannot have more than microseconds precision
--- FAIL: TestIntegration_AggregationQueries (0.07s)
```
**Cause**: readTime passed to transaction is generated using time.Now() which provides current local time upto nanoseconds precision. The exact precision depends on operating system. On FreeBSD, time upto millisecond precision is returned while on Linux, time upto nanosecond precision is returned. 

Datastore does not support readtime more than microseconds precision. So, 'TestIntegration_AggregationQueries' integration test fails on Linux machines.

**Fix**: Explicitly truncate  the timestamp to microseconds before sending request to Datastore
