### PR TITLE
test(datastore): Correct read time before creating entities

### DIFF
--- a/datastore/integration_test.go
+++ b/datastore/integration_test.go
@@ -724,7 +724,7 @@ func TestIntegration_AggregationQueries(t *testing.T) {
 	}
 
 	// Create transaction with read before creating entities
-	readTime := time.Now().Truncate(time.Microsecond)
+	readTime := time.Now().Add(-59 * time.Minute).Truncate(time.Microsecond)
 	txBeforeCreate, err := client.NewTransaction(ctx, []TransactionOption{ReadOnly, WithReadTime(readTime)}...)
 	if err != nil {
 		t.Fatalf("client.NewTransaction: %v", err)


### PR DESCRIPTION
**Issue**:  Aggregation queries test fails with error: 
`integration_test.go:886: "Aggregations in transaction before creating entities": Mismatch in aggregation result got: map[avg:double_value:3.5 count:integer_value:8 sum:integer_value:28], want: map[avg:null_value:NULL_VALUE count:integer_value:0 sum:integer_value:0]`

**Cause**: The time for creation of entities is less than microseconds. The transaction read time is truncated to microseconds. 

**FIx**: Correct the time used to read data before creation of entities to more than a microsecond.