### PR TITLE
feat(spanner/spansql): add support for bit functions, sequence functions and GENERATE_UUID

### DIFF
--- a/spanner/spansql/keywords.go
+++ b/spanner/spansql/keywords.go
@@ -291,4 +291,7 @@ var allFuncs = []string{
 	// Sequence functions.
 	"GET_NEXT_SEQUENCE_VALUE",
 	"GET_INTERNAL_SEQUENCE_STATE",
+
+	// Utility functions.
+	"GENERATE_UUID",
 }

--- a/spanner/spansql/keywords.go
+++ b/spanner/spansql/keywords.go
@@ -145,6 +145,9 @@ func init() {
 	// Spacial case of INTERVAL arg for TIMESTAMP_ADD, TIMESTAMP_SUB
 	funcArgParsers["TIMESTAMP_ADD"] = timestampIntervalArgParser
 	funcArgParsers["TIMESTAMP_SUB"] = timestampIntervalArgParser
+	// Special case of SEQUENCE arg for GET_NEXT_SEQUENCE_VALUE, GET_INTERNAL_SEQUENCE_STATE
+	funcArgParsers["GET_NEXT_SEQUENCE_VALUE"] = sequenceArgParser
+	funcArgParsers["GET_INTERNAL_SEQUENCE_STATE"] = sequenceArgParser
 }
 
 var allFuncs = []string{
@@ -280,4 +283,12 @@ var allFuncs = []string{
 
 	// JSON functions.
 	"JSON_VALUE",
+
+	// Bit functions.
+	"BIT_COUNT",
+	"BIT_REVERSE",
+
+	// Sequence functions.
+	"GET_NEXT_SEQUENCE_VALUE",
+	"GET_INTERNAL_SEQUENCE_STATE",
 }

--- a/spanner/spansql/parser.go
+++ b/spanner/spansql/parser.go
@@ -3386,6 +3386,17 @@ var dateIntervalArgParser = intervalArgParser((*parser).parseDateIntervalDatePar
 // Special argument parser for TIMESTAMP_ADD, TIMESTAMP_SUB
 var timestampIntervalArgParser = intervalArgParser((*parser).parseTimestampIntervalDatePart)
 
+var sequenceArgParser = func(p *parser) (Expr, *parseError) {
+	if p.eat("SEQUENCE") {
+		name, err := p.parseTableOrIndexOrColumnName()
+		if err != nil {
+			return nil, err
+		}
+		return SequenceExpr{Name: name}, nil
+	}
+	return p.parseExpr()
+}
+
 /*
 Expressions
 

--- a/spanner/spansql/parser_test.go
+++ b/spanner/spansql/parser_test.go
@@ -416,6 +416,8 @@ func TestParseExpr(t *testing.T) {
 		{`GENERATE_DATE_ARRAY('2022-01-01', CURRENT_DATE(), INTERVAL 1 MONTH)`, Func{Name: "GENERATE_DATE_ARRAY", Args: []Expr{StringLiteral("2022-01-01"), Func{Name: "CURRENT_DATE"}, IntervalExpr{Expr: IntegerLiteral(1), DatePart: "MONTH"}}}},
 		{`TIMESTAMP_ADD(CURRENT_TIMESTAMP(), INTERVAL 1 HOUR)`, Func{Name: "TIMESTAMP_ADD", Args: []Expr{Func{Name: "CURRENT_TIMESTAMP"}, IntervalExpr{Expr: IntegerLiteral(1), DatePart: "HOUR"}}}},
 		{`TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 1 MINUTE)`, Func{Name: "TIMESTAMP_SUB", Args: []Expr{Func{Name: "CURRENT_TIMESTAMP"}, IntervalExpr{Expr: IntegerLiteral(1), DatePart: "MINUTE"}}}},
+		{`GET_NEXT_SEQUENCE_VALUE(SEQUENCE MySequence)`, Func{Name: "GET_NEXT_SEQUENCE_VALUE", Args: []Expr{SequenceExpr{Name: ID("MySequence")}}}},
+		{`GET_INTERNAL_SEQUENCE_STATE(SEQUENCE MySequence)`, Func{Name: "GET_INTERNAL_SEQUENCE_STATE", Args: []Expr{SequenceExpr{Name: ID("MySequence")}}}},
 
 		// Conditional expressions
 		{

--- a/spanner/spansql/sql.go
+++ b/spanner/spansql/sql.go
@@ -892,6 +892,12 @@ func (ie IntervalExpr) addSQL(sb *strings.Builder) {
 	sb.WriteString(ie.DatePart)
 }
 
+func (se SequenceExpr) SQL() string { return buildSQL(se) }
+func (se SequenceExpr) addSQL(sb *strings.Builder) {
+	sb.WriteString("SEQUENCE ")
+	sb.WriteString(se.Name.SQL())
+}
+
 func idList(l []ID, join string) string {
 	var ss []string
 	for _, s := range l {

--- a/spanner/spansql/types.go
+++ b/spanner/spansql/types.go
@@ -798,6 +798,12 @@ type IntervalExpr struct {
 func (IntervalExpr) isBoolExpr() {} // possibly bool
 func (IntervalExpr) isExpr()     {}
 
+type SequenceExpr struct {
+	Name ID
+}
+
+func (SequenceExpr) isExpr() {}
+
 // Paren represents a parenthesised expression.
 type Paren struct {
 	Expr Expr


### PR DESCRIPTION
This PR adds support for [bit functions](https://cloud.google.com/spanner/docs/reference/standard-sql/bit_functions), [sequence functions](https://cloud.google.com/spanner/docs/reference/standard-sql/sequence_functions),  and GENERATE_UUID.

- Bit functions
  - [BIT_COUNT](https://cloud.google.com/spanner/docs/reference/standard-sql/bit_functions#bit_count)
  - [BIT_REVERSE](https://cloud.google.com/spanner/docs/reference/standard-sql/bit_functions#bit_reverse)
- Sequence functions
  - [GET_NEXT_SEQUENCE_VALUE](https://cloud.google.com/spanner/docs/reference/standard-sql/sequence_functions#get_next_sequence_value)
  - [GET_INTERNAL_SEQUENCE_STATE](https://cloud.google.com/spanner/docs/reference/standard-sql/sequence_functions#get_internal_sequence_state)
  - Including special case of `SEQUENCE sequence_identifier` arg for sequence functions.
- [GENERATE_UUID](https://cloud.google.com/spanner/docs/reference/standard-sql/utility-functions#generate_uuid)

