### PR TITLE
test(storage): skip warmup if duration is 0

### DIFF
--- a/storage/internal/benchmarks/warmup.go
+++ b/storage/internal/benchmarks/warmup.go
@@ -24,6 +24,11 @@ import (
 )
 
 func warmupW1R3(ctx context.Context, opts *benchmarkOptions) error {
+	// Return immediately if warmup duration is zero.
+	if opts.warmup == 0 {
+		return nil
+	}
+
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 


### PR DESCRIPTION
The benchmark warmup method seems to have a race condition bug when the duration is very short. Skip the warmup entirely if duration is zero (which is the default).

Updates #8515