### PR TITLE
chore(deps): temporarily ignore grpc dep

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,7 +12,8 @@
     "commitMessageAction": "update",
     "groupName": "deps",
     "ignoreDeps": [
-        "google.golang.org/genproto"
+        "google.golang.org/genproto",
+        "google.golang.org/grpc"
     ],
     "ignorePaths": [
         "**/snippets/**"


### PR DESCRIPTION
Temporarily ignore the grpc-go dep until we can increase the floor Go version to Go 1.19: #8550