### PR TITLE
chore(internal/postprocessor): fix containeranalysis/v1beta1 doc url flake

### DIFF
--- a/internal/postprocessor/README.md
+++ b/internal/postprocessor/README.md
@@ -36,8 +36,8 @@ the OwlBot lock file.
 2. Make changes to the post-processor.
 3. Test your changes. You can run the post-processor locally on selected
    clients or on all of the clients in the root directory. If the `branch`
-   flag is not set to a non-empty value, the post-processor will exit early
-   without changes. In the `google-cloud-go/internal/postprocessor` directory:
+   flag is empty/unset, the post-processor will exit early without changes.
+   In the `google-cloud-go/internal/postprocessor` directory:
 
    ```bash
    go run . -client-root="../.." -googleapis-dir="/path/to/local/googleapis" -branch="my-branch"

--- a/internal/postprocessor/config.yaml
+++ b/internal/postprocessor/config.yaml
@@ -972,10 +972,11 @@ service-configs:
     service-config: storagetransfer_v1.yaml
     import-path: cloud.google.com/go/storagetransfer/apiv1
     # All entries below are clients that are not currently copied by owlbot. They
-    # explicitly express thier import path for some code gen.
+    # explicitly express their import path for some code gen.
   - input-directory: google/devtools/containeranalysis/v1beta1/grafeas
     service-config: ../containeranalysis_v1beta1.yaml
     import-path: cloud.google.com/go/containeranalysis/apiv1beta1
+    rel-path: /containeranalysis/apiv1beta1
   - input-directory: google/cloud/video/stitcher/v1
     service-config: videostitcher_v1.yaml
     import-path: cloud.google.com/go/video/stitcher/apiv1


### PR DESCRIPTION
Adds missing `rel-path` argument to the grafeas specific post processor config entry. This config being missing combined with the shared import-path of it and its parent package meant that the doc url wasn't being calculated relative to the root module correctly and only showing up some of the time when the grafeas entry was visited last.

Also fixes a typo in a config config, and clarifies a double negative in the post processor cli docs.