### PR TITLE
fix(bigquery/storage/managedwriter): automatic retry for multiplex test

### DIFF
--- a/bigquery/storage/managedwriter/integration_test.go
+++ b/bigquery/storage/managedwriter/integration_test.go
@@ -1498,6 +1498,7 @@ func TestIntegration_MultiplexWrites(t *testing.T) {
 				WithDestinationTable(TableParentFromParts(testTable.tbl.ProjectID, testTable.tbl.DatasetID, testTable.tbl.TableID)),
 				WithType(DefaultStream),
 				WithSchemaDescriptor(testTable.dp),
+				EnableWriteRetries(true),
 			)
 			if err != nil {
 				t.Fatalf("NewManagedStream %d: %v", k, err)


### PR DESCRIPTION
In #8599 we caught a flake related to DeadlineExceeded errors.  This class of error is retryable, so we set the EnableWriteRetries option when constructing writers to address this.

The DE was likely raised from the service side, as in this case the test ran for ~32s (deadline is 90) and normal execution time should be sub-10s.  This is also borne out by the problematic writes, which were both destined for the same table.

Fixes: https://github.com/googleapis/google-cloud-go/issues/8599