### PR TITLE
chore: Add team and remove individual owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,13 +1,13 @@
 # Default owner for all directories not owned by others
 *                       @googleapis/yoshi-go-admins
 
-/bigtable/              @bhshkh @googleapis/api-bigtable @googleapis/yoshi-go-admins
-/bigtable/cmd/cbt       @igorbernstein2 @bhshkh @googleapis/api-bigtable @googleapis/yoshi-go-admins
-/bigtable/cmd/emulator  @igorbernstein2 @bhshkh @googleapis/api-bigtable @googleapis/yoshi-go-admins
-/bigtable/bttest        @igorbernstein2 @bhshkh @googleapis/api-bigtable @googleapis/yoshi-go-admins
+/bigtable/              @googleapis/cloud-native-db-dpes @googleapis/api-bigtable @googleapis/yoshi-go-admins
+/bigtable/cmd/cbt       @igorbernstein2 @googleapis/cloud-native-db-dpes @googleapis/api-bigtable @googleapis/yoshi-go-admins
+/bigtable/cmd/emulator  @igorbernstein2 @googleapis/cloud-native-db-dpes @googleapis/api-bigtable @googleapis/yoshi-go-admins
+/bigtable/bttest        @igorbernstein2 @googleapis/cloud-native-db-dpes @googleapis/api-bigtable @googleapis/yoshi-go-admins
 /bigquery/              @googleapis/api-bigquery @googleapis/yoshi-go-admins
-/datastore/             @bhshkh @googleapis/cloud-native-db-dpes @googleapis/yoshi-go-admins
-/firestore/             @bhshkh @googleapis/cloud-native-db-dpes @googleapis/yoshi-go-admins
+/datastore/             @googleapis/cloud-native-db-dpes @googleapis/yoshi-go-admins
+/firestore/             @googleapis/cloud-native-db-dpes @googleapis/yoshi-go-admins
 /pubsub/                @googleapis/api-pubsub @googleapis/yoshi-go-admins @shollyman
 /pubsublite/            @googleapis/api-pubsub @googleapis/yoshi-go-admins @shollyman
 /spanner/               @googleapis/api-spanner-go @googleapis/yoshi-go-admins


### PR DESCRIPTION
Updating codeowners to remove bhshkh and add team since gcf owlbot incorrectly adds me as reviewer for the files I don't own. E.g.: 

https://github.com/googleapis/google-cloud-go/pull/8611
https://github.com/googleapis/google-cloud-go/pull/8602
https://github.com/googleapis/google-cloud-go/pull/8597
