### PR TITLE
chore: fix publish job

### DIFF
--- a/internal/kokoro/publish_docs.sh
+++ b/internal/kokoro/publish_docs.sh
@@ -19,6 +19,7 @@ set -eo pipefail
 # Display commands being run.
 set -x
 
+git config --global --add safe.directory $PWD
 cd github/google-cloud-go/internal/godocfx
 go install
 cd -


### PR DESCRIPTION
Noticed this was broke. Had to do the same thing in https://github.com/googleapis/google-api-go-client/pull/2147 when we upgraded our images.