### PR TITLE
fix(internal/postprocessor): add ability to override release level

### DIFF
--- a/internal/postprocessor/config.go
+++ b/internal/postprocessor/config.go
@@ -47,16 +47,22 @@ type libraryInfo struct {
 	ServiceConfig string
 	// RelPath is the relative path to the client from the repo root.
 	RelPath string
+	// ReleaseLevel is an override for the release level of a library. It is
+	// used in cases where a release level can't be determined by looking at
+	// the import path and/or reading service `doc.go` files because there are
+	// no associated services.
+	ReleaseLevel string
 }
 
 func (p *postProcessor) loadConfig() error {
 	var postProcessorConfig struct {
 		Modules        []string `yaml:"modules"`
 		ServiceConfigs []*struct {
-			InputDirectory string `yaml:"input-directory"`
-			ServiceConfig  string `yaml:"service-config"`
-			ImportPath     string `yaml:"import-path"`
-			RelPath        string `yaml:"rel-path"`
+			InputDirectory       string `yaml:"input-directory"`
+			ServiceConfig        string `yaml:"service-config"`
+			ImportPath           string `yaml:"import-path"`
+			RelPath              string `yaml:"rel-path"`
+			ReleaseLevelOverride string `yaml:"release-level-override"`
 		} `yaml:"service-configs"`
 		ManualClients []*ManifestEntry `yaml:"manual-clients"`
 	}

--- a/internal/postprocessor/config.yaml
+++ b/internal/postprocessor/config.yaml
@@ -306,6 +306,7 @@ service-configs:
   - input-directory: google/cloud/alloydb/connectors/v1
     service-config: connectors_v1.yaml
     import-path: cloud.google.com/go/alloydb/connectors/apiv1
+    release-level-override: preview
   - input-directory: google/cloud/alloydb/connectors/v1alpha
     service-config: connectors_v1alpha.yaml
     import-path: cloud.google.com/go/alloydb/connectors/apiv1alpha


### PR DESCRIPTION
For stable client without services there is not a good way to infer the release level. Eventually it may be nice if this info is pushed into the service config rather than a blaze rule so we can extract it better. For now, lets a a manual override.

In the past for things like oslogin we just did not provide a service config entry. Although this would work here it is not ideal as there is still valuable metadata and configuration options in these files.