### PR TITLE
[Bigtable] Update to return cluster error

### DIFF
--- a/bigtable/admin.go
+++ b/bigtable/admin.go
@@ -1091,7 +1091,7 @@ func (iac *InstanceAdminClient) UpdateInstanceWithClusters(ctx context.Context, 
 				return fmt.Errorf("UpdateCluster %q failed %w; however UpdateInstance succeeded",
 					cluster.ClusterID, clusterErr)
 			}
-			return err
+			return clusterErr
 		}
 	}
 


### PR DESCRIPTION
### Summary
While using `bigtableAdminClient.UpdateInstanceWithClusters`, we couldn't happen to get the cluster error even though `bigtableAdminClient.SetAutoscaling` returns the error.

For example, we were trying to update the BT instance (node-count: 3) with the desired autoscaling config (min/max: 1/2).  We know that we cannot set max serving nodes less than the current size. However we cannot get any error message while updating cluster configs. So this PR is to fix the returning values to get the corresponding error as below.

```
Error found while updating instance with autoscaling config ({MinNodes:1 MaxNodes:2 CPUTargetPercent:50 StorageUtilizationPerNode:0}): rpc error: code = InvalidArgument desc = max_serve_nodes (2) must be equal to or greater than current cluster size (3)
```