### PR TITLE
chore(ci): update Go version to 1.21

### DIFF
--- a/.github/workflows/apidiff.yml
+++ b/.github/workflows/apidiff.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v4
       with:
-        go-version: '1.20.1'
+        go-version: '1.21.x'
     - name: Get changed directories
       id: changed_dirs
       # Ignore changes to the internal and root directories.
@@ -49,7 +49,7 @@ jobs:
     steps:
     - uses: actions/setup-go@v4
       with:
-        go-version: '1.20.1'
+        go-version: '1.21.x'
     - name: Install latest apidiff
       run: go install golang.org/x/exp/cmd/apidiff@latest
     - uses: actions/checkout@v3

--- a/.github/workflows/new_client.yml
+++ b/.github/workflows/new_client.yml
@@ -21,7 +21,7 @@ jobs:
         fetch-depth: 2
     - uses: actions/setup-go@v4
       with:
-        go-version: 1.20.x
+        go-version: 1.21.x
     - name: Find new version files
       id: versions
       # Ignore changes to the internal and root directories.

--- a/.github/workflows/vet.yml
+++ b/.github/workflows/vet.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v4
       with:
-        go-version: '1.21'
+        go-version: '1.21.x'
     - name: Install tools
       run: |
         go install golang.org/x/lint/golint@latest && \

--- a/.github/workflows/vet.yml
+++ b/.github/workflows/vet.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v4
       with:
-        go-version: '1.20'
+        go-version: '1.21'
     - name: Install tools
       run: |
         go install golang.org/x/lint/golint@latest && \

--- a/go.work.sum
+++ b/go.work.sum
@@ -19,12 +19,13 @@ github.com/mmcloughlin/avo v0.5.0/go.mod h1:ChHFdoV7ql95Wi7vuq2YT1bwCJqiWdZrQ1im
 github.com/prometheus/client_model v0.4.0/go.mod h1:oMQmHW1/JoDwqLtg57MGgP/Fb1CJEYF2imWWhWtMkYU=
 github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-golang.org/x/crypto v0.14.0 h1:wBqGXzWJW6m1XrIKlAH0Hs1JJ7+9KBwnIO8v66Q9cHc=
-golang.org/x/crypto v0.14.0/go.mod h1:MVFd36DqK4CsrnJYDkBA3VC4m2GkXAM0PvzMCn4JQf4=
+golang.org/x/crypto v0.13.0/go.mod h1:y6Z2r+Rw4iayiXXAIxJIDAJ1zMW4yaTpebo8fPOliYc=
 golang.org/x/mod v0.9.0 h1:KENHtAZL2y3NLMYZeHY9DW8HW8V+kQyJsY/V9JlKvCs=
 golang.org/x/mod v0.11.0 h1:bUO06HqtnRcc/7l71XBe4WcqTZ+3AH1J59zWDDwLKgU=
 golang.org/x/mod v0.11.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/net v0.11.0/go.mod h1:2L/ixqYpgIVXmeoSA/4Lu7BzTG4KIyPIryS4IsOd1oQ=
+golang.org/x/net v0.15.0/go.mod h1:idbUs1IY1+zTqbi8yxTbhexhEEk5ur9LInksu6HrEpk=
+golang.org/x/sys v0.12.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.12.0/go.mod h1:owVbMEjm3cBLCHdkQu9b1opXd4ETQWc3BhuQGKgXgvU=
 golang.org/x/term v0.13.0/go.mod h1:LTmsnFJwVN6bCy1rVCoS+qHT1HhALEFxKncY3WNNh4U=
 golang.org/x/tools v0.7.0 h1:W4OVu8VVOaIO0yzWMNdepAulS7YfoS3Zabrm8DOXXU4=


### PR DESCRIPTION
Updates GitHub Action Go version to 1.21 where it wasn't already.