### PR TITLE
fix(profiler): migrate to protobuf-go v2

### DIFF
--- a/profiler/go.mod
+++ b/profiler/go.mod
@@ -7,7 +7,6 @@ require (
 	cloud.google.com/go/compute/metadata v0.2.3
 	cloud.google.com/go/storage v1.30.1
 	github.com/golang/mock v1.6.0
-	github.com/golang/protobuf v1.5.3
 	github.com/google/pprof v0.0.0-20230602150820-91b7bce49751
 	github.com/googleapis/gax-go/v2 v2.12.0
 	golang.org/x/oauth2 v0.8.0
@@ -15,12 +14,14 @@ require (
 	google.golang.org/genproto v0.0.0-20230530153820-e85fd2cbaebc
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230530153820-e85fd2cbaebc
 	google.golang.org/grpc v1.56.1
+	google.golang.org/protobuf v1.31.0
 )
 
 require (
 	cloud.google.com/go/compute v1.19.3 // indirect
 	cloud.google.com/go/iam v0.13.0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
+	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/google/s2a-go v0.1.4 // indirect
 	github.com/google/uuid v1.3.0 // indirect
@@ -33,5 +34,4 @@ require (
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20230530153820-e85fd2cbaebc // indirect
-	google.golang.org/protobuf v1.31.0 // indirect
 )

--- a/profiler/profiler_test.go
+++ b/profiler/profiler_test.go
@@ -35,8 +35,6 @@ import (
 	"cloud.google.com/go/profiler/mocks"
 	"cloud.google.com/go/profiler/testdata"
 	"github.com/golang/mock/gomock"
-	"github.com/golang/protobuf/proto"
-	"github.com/golang/protobuf/ptypes"
 	"github.com/google/pprof/profile"
 	gax "github.com/googleapis/gax-go/v2"
 	"google.golang.org/api/option"
@@ -47,6 +45,8 @@ import (
 	"google.golang.org/grpc/codes"
 	grpcmd "google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/durationpb"
 )
 
 const (
@@ -82,7 +82,7 @@ func createTestAgent(psc pb.ProfilerServiceClient) *agent {
 
 func createTrailers(dur time.Duration) map[string]string {
 	b, _ := proto.Marshal(&edpb.RetryInfo{
-		RetryDelay: ptypes.DurationProto(dur),
+		RetryDelay: durationpb.New(dur),
 	})
 	return map[string]string{
 		retryInfoMetadata: string(b),
@@ -238,7 +238,7 @@ func TestProfileAndUpload(t *testing.T) {
 		}
 		p := &pb.Profile{ProfileType: tt.profileType}
 		if tt.duration != nil {
-			p.Duration = ptypes.DurationProto(*tt.duration)
+			p.Duration = durationpb.New(*tt.duration)
 		}
 		if tt.wantBytes != nil {
 			wantProfile := &pb.Profile{
@@ -777,7 +777,7 @@ func (fs *fakeProfilerServer) CreateProfile(ctx context.Context, in *pb.CreatePr
 	fs.count++
 	switch fs.count % 2 {
 	case 1:
-		return &pb.Profile{Name: "testCPU", ProfileType: pb.ProfileType_CPU, Duration: ptypes.DurationProto(testProfileDuration)}, nil
+		return &pb.Profile{Name: "testCPU", ProfileType: pb.ProfileType_CPU, Duration: durationpb.New(testProfileDuration)}, nil
 	default:
 		return &pb.Profile{Name: "testHeap", ProfileType: pb.ProfileType_HEAP}, nil
 	}


### PR DESCRIPTION
Refactors all protobuf-go v1 references in `cloud.google.com/go/profiler` to protobuf-go v2. This does remove a number of error scenarios and I'm not sure if those are actually real or not, I am just doing an in place refactor.

Updates #8585