### PR TITLE
chore(internal/kokoro): set -buildvcs=false when installing godocfx

### DIFF
--- a/internal/kokoro/publish_docs.sh
+++ b/internal/kokoro/publish_docs.sh
@@ -20,8 +20,7 @@ set -eo pipefail
 set -x
 
 cd github/google-cloud-go/internal/godocfx
-git config --global --add safe.directory $PWD
-go install
+go install -buildvcs=false
 cd -
 
 export GOOGLE_APPLICATION_CREDENTIALS=$KOKORO_KEYSTORE_DIR/72523_go_integration_service_account


### PR DESCRIPTION
Followup on #8760.