### PR TITLE
chore(internal/kokoro): fix doc upload

### DIFF
--- a/internal/kokoro/publish_docs.sh
+++ b/internal/kokoro/publish_docs.sh
@@ -23,6 +23,7 @@ cd github/google-cloud-go/internal/godocfx
 go install -buildvcs=false
 cd -
 
+# Use the google-cloud-go service account to store godocfx state.
 export GOOGLE_APPLICATION_CREDENTIALS=$KOKORO_KEYSTORE_DIR/72523_go_integration_service_account
 # Keep GCLOUD_TESTS_GOLANG_PROJECT_ID in sync with continuous.sh.
 export GCLOUD_TESTS_GOLANG_PROJECT_ID=dulcet-port-762
@@ -37,13 +38,21 @@ else
   godocfx -project $GCLOUD_TESTS_GOLANG_PROJECT_ID -new-modules cloud.google.com/go google.golang.org/appengine
 fi
 
+# Use the docuploader service account to upload docs.
+gcloud auth activate-service-account --key-file "$KOKORO_KEYSTORE_DIR/73713_docuploader_service_account"
+
 for f in $(find obj/api -name docs.metadata); do
   d=$(dirname $f)
-  cd $d
-  python3 -m docuploader upload \
-    --staging-bucket docs-staging-v2 \
-    --destination-prefix docfx \
-    --credentials "$KOKORO_KEYSTORE_DIR/73713_docuploader_service_account" \
+  # Extract the module and version from the docs.metadata file.
+  module=$(cat $d/docs.metadata  | grep name    | sed 's/.*"\(.*\)"/\1/')
+  version=$(cat $d/docs.metadata | grep version | sed 's/.*"\(.*\)"/\1/')
+  name="docfx-go-$module-$version.tar.gz"
+  mkdir -p $(dirname $name)
+  tar \
+    --create \
+    --directory=$d \
+    --file=$name \
+    --gzip \
     .
-  cd -
+  gsutil cp $name gs://docs-staging-v2
 done


### PR DESCRIPTION
Python dependencies were removed to reduce the maintenance costs. The old `docuploader` tool didn't do anything fancy -- it just tarred the directory and uploaded it. See https://github.com/googleapis/docuploader/blob/0077f780e1bfaf0e0d7585d4a5cba5bc122f0ce9/docuploader/__main__.py#L69.