### PR TITLE
chore(profiler): upgrade go version used in kokoro integration test

### DIFF
--- a/profiler/kokoro/integration_test.sh
+++ b/profiler/kokoro/integration_test.sh
@@ -36,9 +36,10 @@ export GOOGLE_APPLICATION_CREDENTIALS="${KOKORO_KEYSTORE_DIR}/72935_cloud-profil
 export GCLOUD_TESTS_GOLANG_PROJECT_ID="cloud-profiler-e2e"
 
 # Ensure a newer version of Go is used so it is compatible with newer libraries.
-# Here we install v1.18.4 which is the current version as of July 2022.
-retry curl -LO https://go.dev/dl/go1.18.4.linux-amd64.tar.gz
-sudo rm -rf /usr/local/go && tar -C /usr/local -xzf go1.18.4.linux-amd64.tar.gz
+# Here we install v1.21.3 which is the current version as of October 2023.
+GOVERSION="1.21.3"
+retry curl -LO https://go.dev/dl/go${GOVERSION}.linux-amd64.tar.gz
+sudo rm -rf /usr/local/go && tar -C /usr/local -xzf go${GOVERSION}.linux-amd64.tar.gz
 export PATH=$PATH:/usr/local/go/bin
 
 # Run test.


### PR DESCRIPTION
This fixes the build which was failing with

```
+ go test -run TestAgentIntegration -run_only_profiler_backoff_test -timeout 1h
# [google.golang.org/grpc](https://www.google.com/url?q=http://google.golang.org/grpc&sa=D)
/root/go/pkg/mod/[google.golang.org/grpc@v1.59.0/server.go:2082:14](https://www.google.com/url?q=http://google.golang.org/grpc@v1.59.0/server.go:2082:14&sa=D): undefined: atomic.Int64
note: module requires Go 1.19
FAIL	[cloud.google.com/go/profiler](http://cloud.google.com/go/profiler) [build failed]
```