### PR TITLE
fix(spanner): fix test flakiness in lastUseTime unit test

### DIFF
--- a/spanner/client_test.go
+++ b/spanner/client_test.go
@@ -1047,18 +1047,18 @@ func TestClient_ReadOnlyTransaction_WhenMultipleOperations_SessionLastUseTimeSho
 			MaxOpened: 1,
 			InactiveTransactionRemovalOptions: InactiveTransactionRemovalOptions{
 				actionOnInactiveTransaction: WarnAndClose,
-				idleTimeThreshold:           30 * time.Millisecond,
+				idleTimeThreshold:           300 * time.Millisecond,
 			},
 		},
 	})
 	defer teardown()
 	server.TestSpanner.PutExecutionTime(MethodExecuteStreamingSql,
 		SimulatedExecutionTime{
-			MinimumExecutionTime: 20 * time.Millisecond,
+			MinimumExecutionTime: 200 * time.Millisecond,
 		})
 	server.TestSpanner.PutExecutionTime(MethodStreamingRead,
 		SimulatedExecutionTime{
-			MinimumExecutionTime: 20 * time.Millisecond,
+			MinimumExecutionTime: 200 * time.Millisecond,
 		})
 	ctx := context.Background()
 	p := client.idleSessions
@@ -1090,11 +1090,11 @@ func TestClient_ReadOnlyTransaction_WhenMultipleOperations_SessionLastUseTimeSho
 		t.Fatalf("Session lastUseTime times should not be equal")
 	}
 
-	if (time.Now().Sub(sessionPrevLastUseTime)).Milliseconds() < 40 {
-		t.Fatalf("Expected session to be checkedout for more than 40 milliseconds")
+	if (time.Now().Sub(sessionPrevLastUseTime)).Milliseconds() < 400 {
+		t.Fatalf("Expected session to be checkedout for more than 400 milliseconds")
 	}
-	if (time.Now().Sub(sessionCheckoutTime)).Milliseconds() < 40 {
-		t.Fatalf("Expected session to be checkedout for more than 40 milliseconds")
+	if (time.Now().Sub(sessionCheckoutTime)).Milliseconds() < 400 {
+		t.Fatalf("Expected session to be checkedout for more than 400 milliseconds")
 	}
 	// force run task to clean up unexpected long-running sessions whose lastUseTime >= 3sec.
 	// The session should not be cleaned since the latest operation on the transaction has updated the lastUseTime.


### PR DESCRIPTION
This PR fixes flakiness in `lastUseTime` unit test.
This changes was added in https://github.com/googleapis/google-cloud-go/pull/8942 to fix an issue with cleaning long-running transactions.