### PR TITLE
Update README.md

### DIFF
--- a/profiler/README.md
+++ b/profiler/README.md
@@ -2,7 +2,7 @@
 
 [![Go Reference](https://pkg.go.dev/badge/cloud.google.com/go/profiler.svg)](https://pkg.go.dev/cloud.google.com/go/profiler)
 
-Go Client Library for Cloud Profiler.
+The Go Agent for Cloud Profiler.
 
 ## Install
 


### PR DESCRIPTION
The client library is different from the agent. The client library for Google Cloud Profiler can be found [here] (https://github.com/googleapis/google-cloud-go/tree/main/cloudprofiler).