### PR TITLE
fixing bigtable proxy readrows error response

### DIFF
--- a/bigtable/internal/testproxy/proxy.go
+++ b/bigtable/internal/testproxy/proxy.go
@@ -601,13 +601,7 @@ func (s *goTestProxyServer) ReadRows(ctx context.Context, req *pb.ReadRowsReques
 	}
 
 	if err != nil {
-		log.Printf("error from Table.ReadRows: %v\n", err)
-		if st, ok := stat.FromError(err); ok {
-			res.Status = &statpb.Status{
-				Code:    st.Proto().Code,
-				Message: st.Message(),
-			}
-		}
+		res.Status = statusFromError(err)
 		return res, nil
 	}
 


### PR DESCRIPTION
Fixes an issue where the proxy read rows handler would return an OK status when an error was not parsable by `stat.FromError`