### PR TITLE
fix(spanner): use json.Number for decoding unknown values from spanner

### DIFF
--- a/spanner/integration_test.go
+++ b/spanner/integration_test.go
@@ -2021,10 +2021,12 @@ func TestIntegration_BasicTypes(t *testing.T) {
 		Body string
 		Time int64
 	}
-	msg := Message{"Alice", "Hello", 1294706395881547000}
-	jsonStr := `{"Name":"Alice","Body":"Hello","Time":1294706395881547000}`
-	var unmarshalledJSONstruct interface{}
-	json.Unmarshal([]byte(jsonStr), &unmarshalledJSONstruct)
+	msg := Message{"Alice", "Hello", 145688415796432520}
+	unmarshalledJSONstruct := map[string]interface{}{
+		"Name": "Alice",
+		"Body": "Hello",
+		"Time": 145688415796432520,
+	}
 
 	tests := []struct {
 		col  string


### PR DESCRIPTION
1) First commit added to [show](https://btx-internal.corp.google.com/invocations/56043758-85e8-4103-a93b-9f4b25810ba5/targets/cloud-devrel%2Fclient-libraries%2Fgo%2Fgoogle-cloud-go%2Fpresubmit%2Fearliest-version/log) reading integer values back from Spanner in NullJson type results into loss of precision.
<img width="1720" alt="Screenshot 2023-12-08 at 15 24 11" src="https://github.com/googleapis/google-cloud-go/assets/18293335/9d38aefc-fd36-4665-9169-263f508b965e">
