### PR TITLE
feat(vertexai): add UsageMetadata

### DIFF
--- a/vertexai/genai/aiplatformpb_veneer.gen.go
+++ b/vertexai/genai/aiplatformpb_veneer.gen.go
@@ -442,6 +442,40 @@ func (FunctionResponse) fromProto(p *pb.FunctionResponse) *FunctionResponse {
 	}
 }
 
+// GenerateContentResponse is the response from a GenerateContent or GenerateContentStream call.
+type GenerateContentResponse struct {
+	// Output only. Generated candidates.
+	Candidates []*Candidate
+	// Output only. Content filter results for a prompt sent in the request.
+	// Note: Sent only in the first stream chunk.
+	// Only happens when no candidates were generated due to content violations.
+	PromptFeedback *PromptFeedback
+	// Usage metadata about the response(s).
+	UsageMetadata *UsageMetadata
+}
+
+func (v *GenerateContentResponse) toProto() *pb.GenerateContentResponse {
+	if v == nil {
+		return nil
+	}
+	return &pb.GenerateContentResponse{
+		Candidates:     support.TransformSlice(v.Candidates, (*Candidate).toProto),
+		PromptFeedback: v.PromptFeedback.toProto(),
+		UsageMetadata:  v.UsageMetadata.toProto(),
+	}
+}
+
+func (GenerateContentResponse) fromProto(p *pb.GenerateContentResponse) *GenerateContentResponse {
+	if p == nil {
+		return nil
+	}
+	return &GenerateContentResponse{
+		Candidates:     support.TransformSlice(p.Candidates, (Candidate{}).fromProto),
+		PromptFeedback: (PromptFeedback{}).fromProto(p.PromptFeedback),
+		UsageMetadata:  (UsageMetadata{}).fromProto(p.UsageMetadata),
+	}
+}
+
 // GenerationConfig is generation config.
 type GenerationConfig struct {
 	// Optional. Controls the randomness of predictions.
@@ -803,4 +837,35 @@ func (v Type) String() string {
 		return n
 	}
 	return fmt.Sprintf("Type(%d)", v)
+}
+
+// UsageMetadata is usage metadata about response(s).
+type UsageMetadata struct {
+	// Number of tokens in the request.
+	PromptTokenCount int32
+	// Number of tokens in the response(s).
+	CandidatesTokenCount int32
+	TotalTokenCount      int32
+}
+
+func (v *UsageMetadata) toProto() *pb.GenerateContentResponse_UsageMetadata {
+	if v == nil {
+		return nil
+	}
+	return &pb.GenerateContentResponse_UsageMetadata{
+		PromptTokenCount:     v.PromptTokenCount,
+		CandidatesTokenCount: v.CandidatesTokenCount,
+		TotalTokenCount:      v.TotalTokenCount,
+	}
+}
+
+func (UsageMetadata) fromProto(p *pb.GenerateContentResponse_UsageMetadata) *UsageMetadata {
+	if p == nil {
+		return nil
+	}
+	return &UsageMetadata{
+		PromptTokenCount:     p.PromptTokenCount,
+		CandidatesTokenCount: p.CandidatesTokenCount,
+		TotalTokenCount:      p.TotalTokenCount,
+	}
 }

--- a/vertexai/genai/client.go
+++ b/vertexai/genai/client.go
@@ -178,28 +178,21 @@ func (iter *GenerateContentResponseIterator) Next() (*GenerateContentResponse, e
 	return gcp, nil
 }
 
-// GenerateContentResponse is the response from a GenerateContent or GenerateContentStream call.
-type GenerateContentResponse struct {
-	Candidates     []*Candidate
-	PromptFeedback *PromptFeedback
-}
-
 func protoToResponse(resp *pb.GenerateContentResponse) (*GenerateContentResponse, error) {
+	gcp := (GenerateContentResponse{}).fromProto(resp)
 	// Assume a non-nil PromptFeedback is an error.
 	// TODO: confirm.
-	pf := (PromptFeedback{}).fromProto(resp.PromptFeedback)
-	if pf != nil {
-		return nil, &BlockedError{PromptFeedback: pf}
+	if gcp.PromptFeedback != nil {
+		return nil, &BlockedError{PromptFeedback: gcp.PromptFeedback}
 	}
-	cands := support.TransformSlice(resp.Candidates, (Candidate{}).fromProto)
 	// If any candidate is blocked, error.
 	// TODO: is this too harsh?
-	for _, c := range cands {
+	for _, c := range gcp.Candidates {
 		if c.FinishReason == FinishReasonSafety {
 			return nil, &BlockedError{Candidate: c}
 		}
 	}
-	return &GenerateContentResponse{Candidates: cands}, nil
+	return gcp, nil
 }
 
 // CountTokens counts the number of tokens in the content.

--- a/vertexai/genai/config.yaml
+++ b/vertexai/genai/config.yaml
@@ -87,9 +87,15 @@ types:
           type: string
 
 
+    GenerateContentResponse:
+      doc: 'is the response from a GenerateContent or GenerateContentStream call.'
+
     GenerateContentResponse_PromptFeedback:
       name: PromptFeedback
       docVerb: contains
+
+    GenerateContentResponse_UsageMetadata:
+      name: UsageMetadata
 
     CountTokensResponse:
 

--- a/vertexai/internal/cmd/protoveneer/config.go
+++ b/vertexai/internal/cmd/protoveneer/config.go
@@ -54,7 +54,10 @@ type typeConfig struct {
 	Fields map[string]fieldConfig
 	// Custom conversion functions: "tofunc, fromfunc"
 	ConvertToFrom string `yaml:"convertToFrom"`
+	// Doc string for the type, omitting the initial type name.
+	Doc string
 	// Verb to place after type name in doc. Default: "is".
+	// Ignored if Doc is non-empty.
 	DocVerb string `yaml:"docVerb"`
 }
 

--- a/vertexai/internal/cmd/protoveneer/protoveneer_test.go
+++ b/vertexai/internal/cmd/protoveneer/protoveneer_test.go
@@ -95,3 +95,52 @@ func TestCamelToUpperSnakeCase(t *testing.T) {
 		}
 	}
 }
+
+func TestAdjustDoc(t *testing.T) {
+	const protoName = "PName"
+	const veneerName = "VName"
+	for i, test := range []struct {
+		origDoc string
+		verb    string
+		newDoc  string
+		want    string
+	}{
+		{
+			origDoc: "",
+			verb:    "foo",
+			newDoc:  "",
+			want:    "",
+		},
+		{
+			origDoc: "",
+			verb:    "",
+			newDoc:  "is new doc.",
+			want:    "VName is new doc.",
+		},
+		{
+			origDoc: "The harm category is dangerous content.",
+			verb:    "means",
+			want:    "VName means the harm category is dangerous content.",
+		},
+		{
+			origDoc: "URI for the file.",
+			verb:    "is the",
+			want:    "VName is the URI for the file.",
+		},
+		{
+			origDoc: "PName is a thing.",
+			newDoc:  "contains something else.",
+			want:    "VName contains something else.",
+		},
+		{
+			origDoc: "PName is a thing.",
+			verb:    "ignored",
+			want:    "VName is a thing.",
+		},
+	} {
+		got := adjustDoc(test.origDoc, protoName, veneerName, test.verb, test.newDoc)
+		if got != test.want {
+			t.Errorf("#%d: got %q, want %q", i, got, test.want)
+		}
+	}
+}


### PR DESCRIPTION
- Add the UsageMetadata type, and the field of GenerateContentResponse that holds it.

- Use protoveneer for GenerateContentResponse instead of writing it by hand.

- Enable protoveneer to completely replace a doc comment.

- Improve protoveneer doc comment handling.