### PR TITLE
chore(spanner): fix executor code to handle nil type struct slice

### DIFF
--- a/spanner/test/cloudexecutor/executor/actions/execution_flow_context.go
+++ b/spanner/test/cloudexecutor/executor/actions/execution_flow_context.go
@@ -48,7 +48,7 @@ type ExecutionFlowContext struct {
 	rwTxn                    *spanner.ReadWriteStmtBasedTransaction // Current read-write transaction
 	roTxn                    *spanner.ReadOnlyTransaction           // Current read-only transaction
 	batchTxn                 *spanner.BatchReadOnlyTransaction      // Current batch read-only transaction
-	dbClient                 *spanner.Client                        // Current database client
+	DbClient                 *spanner.Client                        // Current database client
 	tableMetadata            *utility.TableMetadataHelper           // If in a txn (except batch), this has metadata info about table columns
 	numPendingReads          int64                                  // Number of pending read/query actions.
 	readAborted              bool                                   // Indicate whether there's a read/query action got aborted and the transaction need to be reset.

--- a/spanner/test/cloudexecutor/executor/actions/mutation.go
+++ b/spanner/test/cloudexecutor/executor/actions/mutation.go
@@ -46,7 +46,7 @@ func (h *WriteActionHandler) ExecuteAction(ctx context.Context) error {
 		return h.OutcomeSender.FinishWithError(err)
 	}
 
-	_, err = h.FlowContext.dbClient.Apply(ctx, m)
+	_, err = h.FlowContext.DbClient.Apply(ctx, m)
 	if err != nil {
 		return h.OutcomeSender.FinishWithError(err)
 	}

--- a/spanner/test/cloudexecutor/executor/actions/partition.go
+++ b/spanner/test/cloudexecutor/executor/actions/partition.go
@@ -209,7 +209,7 @@ func (h *PartitionedUpdate) ExecuteAction(ctx context.Context) error {
 
 	opts := h.Action.GetOptions()
 	stmt := spanner.Statement{SQL: h.Action.GetUpdate().GetSql()}
-	count, err := h.FlowContext.dbClient.PartitionedUpdateWithOptions(ctx, stmt, spanner.QueryOptions{
+	count, err := h.FlowContext.DbClient.PartitionedUpdateWithOptions(ctx, stmt, spanner.QueryOptions{
 		Priority:   opts.GetRpcPriority(),
 		RequestTag: opts.GetTag(),
 	})

--- a/spanner/test/cloudexecutor/executor/actions/transaction.go
+++ b/spanner/test/cloudexecutor/executor/actions/transaction.go
@@ -58,7 +58,7 @@ func (h *StartTxnHandler) ExecuteAction(ctx context.Context) error {
 	if err != nil {
 		return h.OutcomeSender.FinishWithError(err)
 	}
-	h.FlowContext.dbClient = client
+	h.FlowContext.DbClient = client
 	if h.FlowContext.isTransactionActiveLocked() {
 		return h.OutcomeSender.FinishWithError(spanner.ToSpannerError(status.Error(codes.InvalidArgument, "already in a transaction")))
 	}

--- a/spanner/test/cloudexecutor/executor/internal/inputstream/handler.go
+++ b/spanner/test/cloudexecutor/executor/internal/inputstream/handler.go
@@ -70,6 +70,10 @@ func (h *CloudStreamHandler) Execute() error {
 		req, err := h.Stream.Recv()
 		if err == io.EOF {
 			log.Println("Client called Done, half-closed the stream")
+			if h.executionFlowContext != nil && h.executionFlowContext.DbClient != nil {
+				log.Println("Closing the client object in execution flow context")
+				h.executionFlowContext.DbClient.Close()
+			}
 			break
 		}
 		if err != nil {

--- a/spanner/test/cloudexecutor/executor/internal/utility/executor_to_spanner_value_converter.go
+++ b/spanner/test/cloudexecutor/executor/internal/utility/executor_to_spanner_value_converter.go
@@ -295,7 +295,10 @@ func executorArrayValueToSpannerValue(t *spannerpb.Type, v *executorpb.Value, nu
 			return nil, err
 		}
 		goStructType := reflect.TypeOf(dummyStructPtr)
-
+		if null {
+			log.Printf("returning nil slice of struct : %q", reflect.Zero(reflect.SliceOf(goStructType)).Interface())
+			return reflect.Zero(reflect.SliceOf(goStructType)).Interface(), nil
+		}
 		out := reflect.MakeSlice(reflect.SliceOf(goStructType), 0, len(in.GetValue()))
 		for _, value := range in.GetValue() {
 			cv, err := executorStructValueToSpannerValue(structElemType, value.GetStructValue(), false)

--- a/spanner/test/cloudexecutor/executor/internal/utility/executor_to_spanner_value_converter.go
+++ b/spanner/test/cloudexecutor/executor/internal/utility/executor_to_spanner_value_converter.go
@@ -283,7 +283,8 @@ func executorArrayValueToSpannerValue(t *spannerpb.Type, v *executorpb.Value, nu
 		return out, nil
 	case spannerpb.TypeCode_STRUCT:
 		if null {
-			log.Println("Failing again due to passing untyped nil value for array of structs. Might need to change to typed nil similar to other types")
+			// TODO(sriharshach): will remove this after few successful systest runs. Need this to debug logs.
+			log.Println("Failing again due to passing untyped nil value for array of structs. Might need to change to typed nil similar to other types (made a fix below)")
 		}
 		// Non-NULL array of structs
 		structElemType := t.GetArrayElementType()


### PR DESCRIPTION
This PR adds the following fixes to executor framework code:
1. When executor code receives a parameter which array of struct whose value is null like shown below,
```
    params {
      name: "p4"
      type {
        code: ARRAY
        array_element_type {
          code: STRUCT
          struct_type {
            fields {
              name: "int64_f"
              type {
                code: INT64
              }
            }
          }
        }
      }
      value {
        **is_null: true**
      }
    }
``` 
In this case, the current code returns a zero sized slice of struct `reflect.MakeSlice(reflect.SliceOf(goStructType), 0, len(in.GetValue()))` which is causing a problem in systests by giving incorrect query results. Instead, we should return a typed nil `reflect.Zero(reflect.SliceOf(goStructType)).Interface()`.

2. Spanner client created during `StartTransactionAction` is not closed anywhere, and could possibly create so many resources without freeing them up (ex: sessions). In this PR we close the client object when `FinishTransaction` is called.