### PR TITLE
Add query profiling

### DIFF
--- a/datastore/integration_test.go
+++ b/datastore/integration_test.go
@@ -1543,7 +1543,6 @@ func isEqualResultSetStats(got *ResultSetStats, want *ResultSetStats) error {
 			return fmt.Errorf("Stats.QueryPlan.PlanInfo: got: %+v, want: %+v", got.QueryPlan, want.QueryPlan)
 		}
 
-		// Compare query stats maps except 'total_execution_time' key
 		if !testutil.Equal(got.QueryStats, want.QueryStats, cmp.FilterPath(ignoreStatsFields, cmp.Ignore())) {
 			return fmt.Errorf("Stats.QueryPlan.QueryStats: got: %+v, want: %+v", got.QueryStats, want.QueryStats)
 		}


### PR DESCRIPTION
Introducing query modes:

- NORMAL: Plans and executes the query. Only returns the query results.
- EXPLAIN: Plans but does not execute the query. Only returns planner stage information. Can be used to check that a query has the necessary indexes and understand which indexes are used.
- EXPLAIN ANALYZE: Plans and executes the query. Returns query results, planner stage information and execution statistics.