### PR TITLE
chore(internal): Truncate long commit body

### DIFF
--- a/internal/gapicgen/git/git_test.go
+++ b/internal/gapicgen/git/git_test.go
@@ -41,6 +41,7 @@ func TestFormatChanges(t *testing.T) {
 		changes    []*ChangeInfo
 		onlyGapics bool
 		want       string
+		truncate   bool
 	}{
 		{
 			name:    "basic",
@@ -68,11 +69,27 @@ func TestFormatChanges(t *testing.T) {
 			onlyGapics: true,
 			want:       "",
 		},
+		{
+			name:     "truncate long title",
+			changes:  []*ChangeInfo{{Title: "fix: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod ", Body: "tempor incididunt ut\nPiperOrigin-RevId: bar"}},
+			truncate: true,
+			want:     "\nChanges:\n\nfix: Lorem ipsum dolor si...\n  PiperOrigin-RevId: bar\n\n",
+		},
+		{
+			name:     "truncate short title",
+			changes:  []*ChangeInfo{{Title: "fix: Lorem ipsum dolor", Body: "tempor incididunt ut\nPiperOrigin-RevId: bar"}},
+			truncate: true,
+			want:     "\nChanges:\n\nfix: Lorem ipsum dolor\n  PiperOrigin-RevId: bar\n\n",
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := FormatChanges(tc.changes, tc.onlyGapics); got != tc.want {
+			got, err := FormatChanges(tc.changes, tc.onlyGapics, true)
+			if err != nil {
+				t.Errorf("FormatChanges err: %v\n", err)
+			}
+			if got != tc.want {
 				t.Errorf("FormatChanges() = %q, want %q", got, tc.want)
 			}
 		})

--- a/internal/gapicgen/git/github.go
+++ b/internal/gapicgen/git/github.go
@@ -47,9 +47,13 @@ If you have been assigned to review this PR, please:
 - Approve and submit this PR if you believe it's ready to ship. That will prompt
 genbot to assign reviewers to the google-cloud-go PR.
 `
+	maxCommitBodyLen = 65536
 )
 
-var conventionalCommitScopeRe = regexp.MustCompile(`.*\((.*)\): .*`)
+var (
+	conventionalCommitScopeRe = regexp.MustCompile(`.*\((.*)\): .*`)
+	maxChangesLen             = maxCommitBodyLen - len(genprotoCommitBody)
+)
 
 // PullRequest represents a GitHub pull request.
 type PullRequest struct {
@@ -163,7 +167,11 @@ func (gc *GithubClient) CreateGenprotoPR(ctx context.Context, genprotoDir string
 	sb.WriteString(genprotoCommitBody)
 	if !hasCorrespondingPR {
 		sb.WriteString("\n\nThere is no corresponding google-cloud-go PR.\n")
-		sb.WriteString(FormatChanges(changes, false))
+		formatted, err := FormatChanges(changes, false, false)
+		if err != nil {
+			return 0, err
+		}
+		sb.WriteString(formatted)
 	}
 	body := sb.String()
 


### PR DESCRIPTION
**Issue**: genbot build fails with error
```
error creating PR for genproto (may need to check logs for more errors): POST https://api.github.com/repos/googleapis/go-genproto/pulls: 422 Validation Failed [{Resource:Issue Field:body Code:custom Message:body is too long (maximum is 65536 characters)}]
```

**Cause**: Generated PR commit body is too long

**Fix**: 
- Truncate change title to 25 characters
- Truncate change body to include only piper revision ID

Current body length is ~94k. After truncate, body length is ~63k

Sample before truncate:
```
feat: add ResourceManagerTags API to attach tags on the underlying Compute Engine VMs of GKE Nodes which can be used to selectively enforce Cloud Firewall network firewall policies
  ---
  feat: add CompleteConvertToAutopilot API to commit Autopilot conversion operation
  
  ---
  docs: updated comments
  PiperOrigin-RevId: 577928708
  Source-Link: https://github.com/googleapis/googleapis/commit/facb658ce05eba41ced16ca79bfe468494c97705
```

Sample after truncate:
```
feat: add ResourceManager...
  PiperOrigin-RevId: 577928708
  Source-Link: https://github.com/googleapis/googleapis/commit/facb658ce05eba41ced16ca79bfe468494c97705

```