### PR TITLE
fix: add mutex to internal trace otel test variable

### DIFF
--- a/internal/trace/trace.go
+++ b/internal/trace/trace.go
@@ -51,18 +51,22 @@ const (
 )
 
 var (
+	//
+	openTelemetryTracingEnabledMu = sync.RWMutex{}
 	// OpenTelemetryTracingEnabled is true if the environment variable
 	// GOOGLE_API_GO_EXPERIMENTAL_TELEMETRY_PLATFORM_TRACING is set to the
 	// case-insensitive value "opentelemetry".
-	//
-	// Do not access directly. Use instead IsOpenTelemetryTracingEnabled or
-	// IsOpenCensusTracingEnabled. Intended for use only in unit tests. Restore
-	// original value after each test.
-	OpenTelemetryTracingEnabled bool = strings.EqualFold(strings.TrimSpace(
+	openTelemetryTracingEnabled bool = strings.EqualFold(strings.TrimSpace(
 		os.Getenv(TelemetryPlatformTracingVar)), TelemetryPlatformTracingOpenTelemetry)
-
-	OpenTelemetryTracingEnabledMu = sync.RWMutex{}
 )
+
+// Do not invoke SetOpenTelemetryTracingEnabledField directly. Set GOOGLE_API_GO_EXPERIMENTAL_TELEMETRY_PLATFORM_TRACING
+// environment variable instead. Intended for use only in unit tests. Restore original value after each test.
+func SetOpenTelemetryTracingEnabledField(enabled bool) {
+	openTelemetryTracingEnabledMu.Lock()
+	defer openTelemetryTracingEnabledMu.Unlock()
+	openTelemetryTracingEnabled = enabled
+}
 
 // IsOpenCensusTracingEnabled returns true if the environment variable
 // GOOGLE_API_GO_EXPERIMENTAL_TELEMETRY_PLATFORM_TRACING is NOT set to the
@@ -75,9 +79,9 @@ func IsOpenCensusTracingEnabled() bool {
 // GOOGLE_API_GO_EXPERIMENTAL_TELEMETRY_PLATFORM_TRACING is set to the
 // case-insensitive value "opentelemetry".
 func IsOpenTelemetryTracingEnabled() bool {
-	OpenTelemetryTracingEnabledMu.RLock()
-	defer OpenTelemetryTracingEnabledMu.RUnlock()
-	return OpenTelemetryTracingEnabled
+	openTelemetryTracingEnabledMu.RLock()
+	defer openTelemetryTracingEnabledMu.RUnlock()
+	return openTelemetryTracingEnabled
 }
 
 // StartSpan adds a span to the trace with the given name. If IsOpenCensusTracingEnabled

--- a/internal/trace/trace.go
+++ b/internal/trace/trace.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync"
 
 	"go.opencensus.io/trace"
 	"go.opentelemetry.io/otel"
@@ -59,6 +60,8 @@ var (
 	// original value after each test.
 	OpenTelemetryTracingEnabled bool = strings.EqualFold(strings.TrimSpace(
 		os.Getenv(TelemetryPlatformTracingVar)), TelemetryPlatformTracingOpenTelemetry)
+
+	OpenTelemetryTracingEnabledMu = sync.RWMutex{}
 )
 
 // IsOpenCensusTracingEnabled returns true if the environment variable
@@ -72,6 +75,8 @@ func IsOpenCensusTracingEnabled() bool {
 // GOOGLE_API_GO_EXPERIMENTAL_TELEMETRY_PLATFORM_TRACING is set to the
 // case-insensitive value "opentelemetry".
 func IsOpenTelemetryTracingEnabled() bool {
+	OpenTelemetryTracingEnabledMu.RLock()
+	defer OpenTelemetryTracingEnabledMu.RUnlock()
 	return OpenTelemetryTracingEnabled
 }
 

--- a/internal/trace/trace.go
+++ b/internal/trace/trace.go
@@ -51,17 +51,17 @@ const (
 )
 
 var (
-	//
+	// openTelemetryTracingEnabledMu guards access to openTelemetryTracingEnabled field
 	openTelemetryTracingEnabledMu = sync.RWMutex{}
-	// OpenTelemetryTracingEnabled is true if the environment variable
+	// openTelemetryTracingEnabled is true if the environment variable
 	// GOOGLE_API_GO_EXPERIMENTAL_TELEMETRY_PLATFORM_TRACING is set to the
 	// case-insensitive value "opentelemetry".
 	openTelemetryTracingEnabled bool = strings.EqualFold(strings.TrimSpace(
 		os.Getenv(TelemetryPlatformTracingVar)), TelemetryPlatformTracingOpenTelemetry)
 )
 
-// Do not invoke SetOpenTelemetryTracingEnabledField directly. Set GOOGLE_API_GO_EXPERIMENTAL_TELEMETRY_PLATFORM_TRACING
-// environment variable instead. Intended for use only in unit tests. Restore original value after each test.
+// SetOpenTelemetryTracingEnabledField programmatically sets the value provided by GOOGLE_API_GO_EXPERIMENTAL_TELEMETRY_PLATFORM_TRACING for the purpose of unit testing.
+// Do not invoke it directly. Intended for use only in unit tests. Restore original value after each test.
 func SetOpenTelemetryTracingEnabledField(enabled bool) {
 	openTelemetryTracingEnabledMu.Lock()
 	defer openTelemetryTracingEnabledMu.Unlock()

--- a/internal/trace/trace_test.go
+++ b/internal/trace/trace_test.go
@@ -41,11 +41,11 @@ var (
 )
 
 func TestStartSpan_OpenCensus(t *testing.T) {
-	old := OpenTelemetryTracingEnabled
-	OpenTelemetryTracingEnabled = false
+	old := IsOpenTelemetryTracingEnabled()
+	SetOpenTelemetryTracingEnabledField(false)
 	te := testutil.NewTestExporter()
 	t.Cleanup(func() {
-		OpenTelemetryTracingEnabled = old
+		SetOpenTelemetryTracingEnabledField(old)
 		te.Unregister()
 	})
 
@@ -95,12 +95,12 @@ func TestStartSpan_OpenCensus(t *testing.T) {
 }
 
 func TestStartSpan_OpenTelemetry(t *testing.T) {
-	old := OpenTelemetryTracingEnabled
-	OpenTelemetryTracingEnabled = true
+	old := IsOpenTelemetryTracingEnabled()
+	SetOpenTelemetryTracingEnabledField(true)
 	ctx := context.Background()
 	te := testutil.NewOpenTelemetryTestExporter()
 	t.Cleanup(func() {
-		OpenTelemetryTracingEnabled = old
+		SetOpenTelemetryTracingEnabledField(old)
 		te.Unregister(ctx)
 	})
 

--- a/spanner/test/opentelemetry/test/ot_traces_test.go
+++ b/spanner/test/opentelemetry/test/ot_traces_test.go
@@ -33,17 +33,11 @@ import (
 func TestSpannerTracesWithOpenTelemetry(t *testing.T) {
 	ctx := context.Background()
 	te := newOpenTelemetryTestExporter(false, true)
-	trace.OpenTelemetryTracingEnabledMu.RLock()
-	old := trace.OpenTelemetryTracingEnabled
-	trace.OpenTelemetryTracingEnabledMu.RUnlock()
-	trace.OpenTelemetryTracingEnabledMu.Lock()
-	trace.OpenTelemetryTracingEnabled = true
-	trace.OpenTelemetryTracingEnabledMu.Unlock()
+	old := trace.IsOpenTelemetryTracingEnabled()
+	trace.SetOpenTelemetryTracingEnabledField(true)
 
 	t.Cleanup(func() {
-		trace.OpenTelemetryTracingEnabledMu.Lock()
-		defer trace.OpenTelemetryTracingEnabledMu.Unlock()
-		trace.OpenTelemetryTracingEnabled = old
+		trace.SetOpenTelemetryTracingEnabledField(old)
 		te.Unregister(ctx)
 	})
 

--- a/spanner/test/opentelemetry/test/ot_traces_test.go
+++ b/spanner/test/opentelemetry/test/ot_traces_test.go
@@ -33,10 +33,16 @@ import (
 func TestSpannerTracesWithOpenTelemetry(t *testing.T) {
 	ctx := context.Background()
 	te := newOpenTelemetryTestExporter(false, true)
+	trace.OpenTelemetryTracingEnabledMu.RLock()
 	old := trace.OpenTelemetryTracingEnabled
+	trace.OpenTelemetryTracingEnabledMu.RUnlock()
+	trace.OpenTelemetryTracingEnabledMu.Lock()
 	trace.OpenTelemetryTracingEnabled = true
+	trace.OpenTelemetryTracingEnabledMu.Unlock()
 
 	t.Cleanup(func() {
+		trace.OpenTelemetryTracingEnabledMu.Lock()
+		defer trace.OpenTelemetryTracingEnabledMu.Unlock()
 		trace.OpenTelemetryTracingEnabled = old
 		te.Unregister(ctx)
 	})


### PR DESCRIPTION
Fixes #9388

The variable `OpenTelemetryTracingEnabled` is set by client library for testing purposes. However, there is a datarace condition that occurs when this variable is getting read in `trace` package and set in client library.
[Sigma link](https://btx-internal.corp.google.com/invocations/5c02ac3b-2911-4293-889a-6bbe392689fa/targets/cloud-devrel%2Fclient-libraries%2Fgo%2Fgoogle-cloud-go%2Fcontinuous%2Flatest-version/log)
Interestingly this is not reproducible on local with `-race` argument and not in presubmits too. But it failed in continuous build.

**Stack trace**
```
=== RUN   TestSpannerTracesWithOpenTelemetry
==================
WARNING: DATA RACE
Write at 0x0000026759b0 by goroutine 536:
  cloud.google.com/go/spanner/test.TestSpannerTracesWithOpenTelemetry()
      /tmpfs/src/google-cloud-go/spanner/test/opentelemetry/test/ot_traces_test.go:37 +0x6b
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1595 +0x238
  testing.(*T).Run.func1()
      /usr/local/go/src/testing/testing.go:1648 +0x44

Previous read at 0x0000026759b0 by goroutine 500:
  cloud.google.com/go/internal/trace.TracePrintf()
      /tmpfs/src/google-cloud-go/internal/trace/trace.go:190 +0x72
  cloud.google.com/go/spanner.(*sessionClient).executeBatchCreateSessions()
      /tmpfs/src/google-cloud-go/spanner/sessionclient.go:310 +0x1c5a
  cloud.google.com/go/spanner.(*sessionClient).batchCreateSessions.func2()
      /tmpfs/src/google-cloud-go/spanner/sessionclient.go:234 +0x8c

Goroutine 536 (running) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:1648 +0x82a
  testing.runTests.func1()
      /usr/local/go/src/testing/testing.go:2054 +0x84
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1595 +0x238
  testing.runTests()
      /usr/local/go/src/testing/testing.go:2052 +0x896
  testing.(*M).Run()
      /usr/local/go/src/testing/testing.go:1925 +0xb57
  main.main()
      _testmain.go:57 +0x2bd

Goroutine 500 (finished) created at:
  cloud.google.com/go/spanner.(*sessionClient).batchCreateSessions()
      /tmpfs/src/google-cloud-go/spanner/sessionclient.go:234 +0x4ec
  cloud.google.com/go/spanner.(*sessionPool).growPoolLocked()
      /tmpfs/src/google-cloud-go/spanner/session.go:812 +0x187
  cloud.google.com/go/spanner.(*sessionPool).take()
      /tmpfs/src/google-cloud-go/spanner/session.go:1074 +0x788
  cloud.google.com/go/spanner.(*ReadOnlyTransaction).acquireSingleUse()
      /tmpfs/src/google-cloud-go/spanner/transaction.go:803 +0x553
  cloud.google.com/go/spanner.(*ReadOnlyTransaction).acquire()
      /tmpfs/src/google-cloud-go/spanner/transaction.go:780 +0x7b
  cloud.google.com/go/spanner.(*txReadOnly).ReadWithOptions()
      /tmpfs/src/google-cloud-go/spanner/transaction.go:228 +0x276
  cloud.google.com/go/spanner.(*txReadOnly).Read()
      /tmpfs/src/google-cloud-go/spanner/transaction.go:148 +0xb04
  cloud.google.com/go/spanner/test.TestOTMetrics_GFELatency()
      /tmpfs/src/google-cloud-go/spanner/test/opentelemetry/test/ot_metrics_test.go:288 +0xa4f
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1595 +0x238
  testing.(*T).Run.func1()
      /usr/local/go/src/testing/testing.go:1648 +0x44
==================
    testing.go:1465: race detected during execution of test
--- FAIL: TestSpannerTracesWithOpenTelemetry (0.02s)
=== NAME  
    testing.go:1465: race detected during execution of test
```