### PR TITLE
fix(bigquery): align return time.Time values to UTC

### DIFF
--- a/bigquery/value.go
+++ b/bigquery/value.go
@@ -958,7 +958,7 @@ func convertBasicType(val string, typ FieldType) (Value, error) {
 		if err != nil {
 			return nil, err
 		}
-		return time.UnixMicro(i), nil
+		return time.UnixMicro(i).UTC(), nil
 	case DateFieldType:
 		return civil.ParseDate(val)
 	case TimeFieldType:

--- a/bigquery/value_test.go
+++ b/bigquery/value_test.go
@@ -95,6 +95,11 @@ func TestConvertTime(t *testing.T) {
 			t.Errorf("#%d: got:\n%v\nwant:\n%v", i, g, w)
 		}
 	}
+	// Ensure that the times are returned in UTC timezone.
+	// https://github.com/googleapis/google-cloud-go/issues/9407
+	if gotTZ := got[0].(time.Time).Location(); gotTZ != time.UTC {
+		t.Errorf("expected time zone UTC: got:\n%v", gotTZ)
+	}
 }
 
 func TestConvertSmallTimes(t *testing.T) {


### PR DESCRIPTION
The changes in https://github.com/googleapis/google-cloud-go/pull/9368 changed the expectation that constructed time.Time objects would use UTC time for location.  This PR returns to the old behavior by forcing the values to be returned aligned to UTC time, and avoid using the local timezone for construction.

Fixes: https://github.com/googleapis/google-cloud-go/issues/9407