### PR TITLE
chore: update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,7 @@
 # Default owner for all directories not owned by others
 *                       @googleapis/yoshi-go-admins
 
+/alloydb                @googleapis/infra-db-sdk @googleapis/yoshi-go-admins
 /bigtable/              @googleapis/cloud-native-db-dpes @googleapis/api-bigtable @googleapis/yoshi-go-admins
 /bigtable/cmd/cbt       @igorbernstein2 @googleapis/cloud-native-db-dpes @googleapis/api-bigtable-partners @googleapis/api-bigtable @googleapis/yoshi-go-admins
 /bigtable/cmd/emulator  @igorbernstein2 @googleapis/cloud-native-db-dpes @googleapis/api-bigtable-partners @googleapis/api-bigtable @googleapis/yoshi-go-admins


### PR DESCRIPTION
Add infra-db-sdk (and yoshi-go-admins) as codeowners of AlloyDB.