### PR TITLE
chore(deps): ignore arrow and go-github

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -18,6 +18,15 @@
     "ignorePaths": [
         "**/snippets/**"
     ],
+    "packageRules": [
+        {
+            "matchPackageNames": [
+                "^github.com/google/go-github/v",
+                "^github.com/apache/arrow/go/v"
+            ],
+            "enabled": false
+        }
+    ],
     "force": {
         "constraints": {
             "go": "1.20"


### PR DESCRIPTION
Similar to https://github.com/googleapis/google-api-go-client/pull/2465, we want to ignore renovate updates to `google/go-github` and `apache/arrow` b.c they version via module path, which requires code changes to import paths whenever they change.

Hopefully this closes #9404