### PR TITLE
test(pubsub): fix race condition in ordering integration

### DIFF
--- a/pubsub/integration_test.go
+++ b/pubsub/integration_test.go
@@ -1212,7 +1212,7 @@ func TestIntegration_OrderedKeys_JSON(t *testing.T) {
 	client := integrationTestClient(ctx, t, option.WithEndpoint("us-west1-pubsub.googleapis.com:443"))
 	defer client.Close()
 
-	testutil.Retry(t, 2, 0, func(r *testutil.R) {
+	testutil.Retry(t, 2, 1*time.Second, func(r *testutil.R) {
 		topic, err := createTopicWithRetry(ctx, t, client, topicIDs.New(), nil)
 		if err != nil {
 			r.Errorf("createTopicWithRetry err: %v", err)
@@ -1285,7 +1285,7 @@ func TestIntegration_OrderedKeys_JSON(t *testing.T) {
 		}
 
 		go func() {
-			if err := sub.Receive(ctx, func(ctx context.Context, msg *Message) {
+			sub.Receive(ctx, func(ctx context.Context, msg *Message) {
 				mu.Lock()
 				defer mu.Unlock()
 				// Messages are deduped using the data field, since in this case all
@@ -1298,11 +1298,7 @@ func TestIntegration_OrderedKeys_JSON(t *testing.T) {
 				receiveData = append(receiveData, testutil2.OrderedKeyMsg{Key: msg.OrderingKey, Data: string(msg.Data)})
 				wg.Done()
 				msg.Ack()
-			}); err != nil {
-				if c := status.Code(err); c != codes.Canceled {
-					r.Errorf("status.Code(err) got: %v, want cancelled", err)
-				}
-			}
+			})
 		}()
 
 		done := make(chan struct{})


### PR DESCRIPTION
This PR removes checking the return value of sub.Receive in the ordering key integration tests. `testutil.Retry` was being checked in one goroutine, while being overwritten by the next retry loop.

Also, increases the timeout between tests.

Fixes #9595