### PR TITLE
chore(storage): remove benchmark from go.work

### DIFF
--- a/go.work
+++ b/go.work
@@ -148,7 +148,6 @@ use (
 	./spanner/test/opentelemetry/test
 	./speech
 	./storage
-	./storage/internal/benchmarks
 	./storageinsights
 	./storagetransfer
 	./support


### PR DESCRIPTION
This module is actually depending on 1.22 APIs which tries to pull dependencies too far forward for other projects. Removing this from go.work for now. If we lower the Go API level of this module it can be reintroduced. This will have the effect of you needing to open VS code from the root of this module to resolve deps correctly.

This is related to using newer open census and slices package I believe, but could be more