### PR TITLE
fix(spanner): always set open telemetry config during client initialization

### DIFF
--- a/spanner/ot_metrics.go
+++ b/spanner/ot_metrics.go
@@ -49,26 +49,20 @@ var (
 )
 
 func createOpenTelemetryConfig(mp metric.MeterProvider, logger *log.Logger, sessionClientID string, db string) (*openTelemetryConfig, error) {
-	config := &openTelemetryConfig{
-		attributeMap: []attribute.KeyValue{},
-	}
-	if !IsOpenTelemetryMetricsEnabled() {
-		return config, nil
-	}
 	_, instance, database, err := parseDatabaseName(db)
 	if err != nil {
 		return nil, err
 	}
 
 	// Construct attributes for Metrics
-	attributeMap := []attribute.KeyValue{
-		attributeKeyClientID.String(sessionClientID),
-		attributeKeyDatabase.String(database),
-		attributeKeyInstance.String(instance),
-		attributeKeyLibVersion.String(internal.Version),
+	config := &openTelemetryConfig{
+		attributeMap: []attribute.KeyValue{
+			attributeKeyClientID.String(sessionClientID),
+			attributeKeyDatabase.String(database),
+			attributeKeyInstance.String(instance),
+			attributeKeyLibVersion.String(internal.Version),
+		},
 	}
-	config.attributeMap = append(config.attributeMap, attributeMap...)
-
 	setOpenTelemetryMetricProvider(config, mp, logger)
 	return config, nil
 }
@@ -83,9 +77,6 @@ func setOpenTelemetryMetricProvider(config *openTelemetryConfig, mp metric.Meter
 }
 
 func initializeMetricInstruments(config *openTelemetryConfig, logger *log.Logger) {
-	if !IsOpenTelemetryMetricsEnabled() {
-		return
-	}
 	meter := config.meterProvider.Meter(OtInstrumentationScope, metric.WithInstrumentationVersion(internal.Version))
 
 	openSessionCountInstrument, err := meter.Int64ObservableGauge(

--- a/spanner/test/opentelemetry/test/ot_metrics_test.go
+++ b/spanner/test/opentelemetry/test/ot_metrics_test.go
@@ -259,9 +259,11 @@ func TestOTMetrics_GFELatency(t *testing.T) {
 	t.Cleanup(func() {
 		te.Unregister(ctx)
 	})
-	spanner.EnableOpenTelemetryMetrics()
 	server, client, teardown := setupMockedTestServerWithConfig(t, spanner.ClientConfig{OpenTelemetryMeterProvider: te.mp})
 	defer teardown()
+
+	// enabling OpenTelemetry metrics after spanner client initialization
+	spanner.EnableOpenTelemetryMetrics()
 
 	if err := server.TestSpanner.PutStatementResult("SELECT email FROM Users", &stestutil.StatementResult{
 		Type: stestutil.StatementResultResultSet,


### PR DESCRIPTION
Fixes: https://github.com/googleapis/google-cloud-go/issues/9519