### PR TITLE
fix(logging): Set default value for BundleByteLimit to 9.5 MiB to avoid payload size limits.

### DIFF
--- a/logging/logging.go
+++ b/logging/logging.go
@@ -84,6 +84,9 @@ const (
 	// DefaultEntryByteThreshold is the default value for the EntryByteThreshold LoggerOption.
 	DefaultEntryByteThreshold = 1 << 23 // 8MiB
 
+	// DefaultBundleByteThreshold is the default value for the BundleByteLimit LoggerOption.
+	DefaultBundleByteLimit = 9437184 // 9.5 MiB
+
 	// DefaultBufferedByteLimit is the default value for the BufferedByteLimit LoggerOption.
 	DefaultBufferedByteLimit = 1 << 30 // 1GiB
 
@@ -340,6 +343,7 @@ func (c *Client) Logger(logID string, opts ...LoggerOption) *Logger {
 	l.bundler.DelayThreshold = DefaultDelayThreshold
 	l.bundler.BundleCountThreshold = DefaultEntryCountThreshold
 	l.bundler.BundleByteThreshold = DefaultEntryByteThreshold
+	l.bundler.BundleByteLimit = DefaultBundleByteLimit
 	l.bundler.BufferedByteLimit = DefaultBufferedByteLimit
 	for _, opt := range opts {
 		opt.set(l)

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -84,7 +84,7 @@ const (
 	// DefaultEntryByteThreshold is the default value for the EntryByteThreshold LoggerOption.
 	DefaultEntryByteThreshold = 1 << 23 // 8MiB
 
-	// DefaultBundleByteThreshold is the default value for the BundleByteLimit LoggerOption.
+	// DefaultBundleByteLimit is the default value for the BundleByteLimit LoggerOption.
 	DefaultBundleByteLimit = 9437184 // 9.5 MiB
 
 	// DefaultBufferedByteLimit is the default value for the BufferedByteLimit LoggerOption.

--- a/logging/logging_unexported_test.go
+++ b/logging/logging_unexported_test.go
@@ -82,7 +82,7 @@ func TestLoggerCreation(t *testing.T) {
 		DelayThreshold:       DefaultDelayThreshold,
 		BundleCountThreshold: DefaultEntryCountThreshold,
 		BundleByteThreshold:  DefaultEntryByteThreshold,
-		BundleByteLimit:      0,
+		BundleByteLimit:      DefaultBundleByteLimit,
 		BufferedByteLimit:    DefaultBufferedByteLimit,
 	}
 	for _, test := range []struct {


### PR DESCRIPTION
Fixes #9479. Verified bugfix on customer code, and added a test that failed for original configuration of 0 and passes on new configuration of 9.5 MiB.