### PR TITLE
chore(release-please): remove extra aiplatform entry

### DIFF
--- a/.github/.OwlBot.lock.yaml
+++ b/.github/.OwlBot.lock.yaml
@@ -13,4 +13,4 @@
 # limitations under the License.
 docker:
   image: gcr.io/cloud-devrel-public-resources/owlbot-go:latest
-  digest: sha256:a459e37470bb47e698d2ac1eea329f74ca6171701c4442c5d574610de0f01095
+  digest: sha256:ffa0c9efa7a7217d08ba3c5a6f3d4d2cb07dcf110cff997cafce16e61297bfe7

--- a/.release-please-manifest-submodules.json
+++ b/.release-please-manifest-submodules.json
@@ -3,7 +3,6 @@
     "accesscontextmanager": "1.8.6",
     "advisorynotifications": "1.3.2",
     "ai": "0.3.4",
-    "aiplatform": "0.0.0",
     "alloydb": "1.10.1",
     "analytics": "0.23.1",
     "apigateway": "1.6.6",


### PR DESCRIPTION
The post-processor was updated to consider `aiplatform` an individual module re:releases. This cleans up an accidentally added manifest entry for it, and updates the digest of the post-processor image that should contain the code change.