### PR TITLE
chore: remove aiplatform from bulk release config

### DIFF
--- a/release-please-config-yoshi-submodules.json
+++ b/release-please-config-yoshi-submodules.json
@@ -15,9 +15,6 @@
         "ai": {
             "component": "ai"
         },
-        "aiplatform": {
-            "component": "aiplatform"
-        },
         "alloydb": {
             "component": "alloydb"
         },


### PR DESCRIPTION
Accidentally added by postprocessor. Removing again.