### PR TITLE
feat(vertexai/genai): constrained decoding

### DIFF
--- a/vertexai/genai/client.go
+++ b/vertexai/genai/client.go
@@ -95,6 +95,7 @@ type GenerativeModel struct {
 	GenerationConfig
 	SafetySettings []*SafetySetting
 	Tools          []*Tool
+	ToolConfig     *ToolConfig
 }
 
 const defaultMaxOutputTokens = 2048
@@ -145,6 +146,7 @@ func (m *GenerativeModel) newGenerateContentRequest(contents ...*Content) *pb.Ge
 		Contents:         support.TransformSlice(contents, (*Content).toProto),
 		SafetySettings:   support.TransformSlice(m.SafetySettings, (*SafetySetting).toProto),
 		Tools:            support.TransformSlice(m.Tools, (*Tool).toProto),
+		ToolConfig:       m.ToolConfig.toProto(),
 		GenerationConfig: m.GenerationConfig.toProto(),
 	}
 }

--- a/vertexai/genai/client_test.go
+++ b/vertexai/genai/client_test.go
@@ -234,32 +234,52 @@ func TestLive(t *testing.T) {
 		model := client.GenerativeModel(*modelName)
 		model.SetTemperature(0)
 		model.Tools = []*Tool{weatherTool}
-		session := model.StartChat()
-		res, err := session.SendMessage(ctx, Text("What is the weather like in New York?"))
-		if err != nil {
-			t.Fatal(err)
-		}
-		part := res.Candidates[0].Content.Parts[0]
-		funcall, ok := part.(FunctionCall)
-		if !ok {
-			t.Fatalf("want FunctionCall, got %T", part)
-		}
-		if g, w := funcall.Name, weatherTool.FunctionDeclarations[0].Name; g != w {
-			t.Errorf("FunctionCall.Name: got %q, want %q", g, w)
-		}
-		if g, c := funcall.Args["location"], "New York"; !strings.Contains(g.(string), c) {
-			t.Errorf(`FunctionCall.Args["location"]: got %q, want string containing %q`, g, c)
-		}
-		res, err = session.SendMessage(ctx, FunctionResponse{
-			Name: weatherTool.FunctionDeclarations[0].Name,
-			Response: map[string]any{
-				"weather_there": "cold",
-			},
+		t.Run("funcall-auto", func(t *testing.T) {
+			session := model.StartChat()
+			res, err := session.SendMessage(ctx, Text("What is the weather like in New York?"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			part := res.Candidates[0].Content.Parts[0]
+			funcall, ok := part.(FunctionCall)
+			if !ok {
+				t.Fatalf("want FunctionCall, got %T", part)
+			}
+			if g, w := funcall.Name, weatherTool.FunctionDeclarations[0].Name; g != w {
+				t.Errorf("FunctionCall.Name: got %q, want %q", g, w)
+			}
+			if g, c := funcall.Args["location"], "New York"; !strings.Contains(g.(string), c) {
+				t.Errorf(`FunctionCall.Args["location"]: got %q, want string containing %q`, g, c)
+			}
+			res, err = session.SendMessage(ctx, FunctionResponse{
+				Name: weatherTool.FunctionDeclarations[0].Name,
+				Response: map[string]any{
+					"weather_there": "cold",
+				},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			checkMatch(t, responseString(res), "(it's|it is|weather) .*cold")
 		})
-		if err != nil {
-			t.Fatal(err)
-		}
-		checkMatch(t, responseString(res), "(it's|it is|weather) .*cold")
+		t.Run("funcall-none", func(t *testing.T) {
+			model.ToolConfig = &ToolConfig{
+				FunctionCallingConfig: &FunctionCallingConfig{
+					Mode: FunctionCallingNone, // never return a FunctionCall part
+				},
+			}
+			session := model.StartChat()
+			res, err := session.SendMessage(ctx, Text("What is the weather like in New York?"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			// We should not find a FunctionCall part.
+			for _, p := range res.Candidates[0].Content.Parts {
+				if _, ok := p.(FunctionCall); ok {
+					t.Fatal("saw FunctionCall")
+				}
+			}
+		})
 	})
 }
 

--- a/vertexai/genai/config.yaml
+++ b/vertexai/genai/config.yaml
@@ -18,6 +18,12 @@ types:
       valueNames:
         SafetySetting_HARM_BLOCK_THRESHOLD_UNSPECIFIED: HarmBlockUnspecified
 
+    SafetySetting_HarmBlockMethod:
+      name: HarmBlockMethod
+      protoPrefix: SafetySetting_
+      veneerPrefix: HarmBlockMethod
+      doc: 'determines how harm blocking is done.'
+
     SafetyRating_HarmProbability:
       name: HarmProbability
       protoPrefix: SafetyRating_
@@ -63,11 +69,23 @@ types:
 
     FunctionResponse:
 
+    FunctionCallingConfig:
+      doc: 'holds configuration for function calling.'
+
+    FunctionCallingConfig_Mode:
+      name: FunctionCallingMode
+      protoPrefix: FunctionCallingConfig
+      veneerPrefix: FunctionCalling
+      valueNames:
+        FunctionCallingConfig_MODE_UNSPECIFIED: FunctionCallingModeUnspecified
+
     GenerationConfig:
       fields:
         TopK:
           type: '*int32'
           convertToFrom: int32pToFloat32p, float32pToInt32p
+        ResponseMimeType:
+          name: ResponseMIMEType
 
     SafetyRating:
       docVerb: 'is the'
@@ -105,9 +123,15 @@ types:
         GoogleSearchRetrieval:
           omit: true
 
+    ToolConfig:
+      doc: 'configures tools.'
+ 
     Schema:
       fields:
         Example:
+          omit: true
+        Default:
+          # TODO(jba): protoveneer should treat a *structpb.Value as an any
           omit: true
 
     CitationMetadata:


### PR DESCRIPTION
Expose FunctionCallingMode, which lets the user configure
how the model issues function calls.

By setting the new field `Model.ToolConfig`, the user can select whether
the model can call any provided function, only those in a provided list,
or no functions.

Regenerating also brought along a few other new types and values,
some of which required configuration.
