### PR TITLE
testing(bigquery): test refactor to subtests

### DIFF
--- a/bigquery/params_test.go
+++ b/bigquery/params_test.go
@@ -17,6 +17,7 @@ package bigquery
 import (
 	"context"
 	"errors"
+	"fmt"
 	"math"
 	"math/big"
 	"reflect"
@@ -30,103 +31,104 @@ import (
 )
 
 var scalarTests = []struct {
+	name     string
 	val      interface{}            // input value sent as query param
 	wantNil  bool                   // whether the value returned in a query field should be nil.
 	wantVal  string                 // the string form of the scalar value in QueryParameterValue.
 	wantType *bq.QueryParameterType // paramType's desired output
 	wantStat interface{}            // val when roundtripped and represented as part of job statistics.
 }{
-	{int64(0), false, "0", int64ParamType, int64(0)},
-	{NullInt64{Int64: 3, Valid: true}, false, "3", int64ParamType, int64(3)},
-	{NullInt64{Valid: false}, true, "", int64ParamType, NullInt64{Valid: false}},
-	{3.14, false, "3.14", float64ParamType, 3.14},
-	{3.14159e-87, false, "3.14159e-87", float64ParamType, 3.14159e-87},
-	{NullFloat64{Float64: 3.14, Valid: true}, false, "3.14", float64ParamType, 3.14},
-	{NullFloat64{Valid: false}, true, "", float64ParamType, NullFloat64{Valid: false}},
-	{math.NaN(), false, "NaN", float64ParamType, math.NaN()},
-	{true, false, "true", boolParamType, true},
-	{NullBool{Bool: true, Valid: true}, false, "true", boolParamType, true},
-	{NullBool{Valid: false}, true, "", boolParamType, NullBool{Valid: false}},
-	{"string", false, "string", stringParamType, "string"},
-	{"\u65e5\u672c\u8a9e\n", false, "\u65e5\u672c\u8a9e\n", stringParamType, "\u65e5\u672c\u8a9e\n"},
-	{NullString{StringVal: "string2", Valid: true}, false, "string2", stringParamType, "string2"},
-	{NullString{Valid: false}, true, "", stringParamType, NullString{Valid: false}},
-	{[]byte("foo"), false, "Zm9v", bytesParamType, []byte("foo")}, // base64 encoding of "foo"
-	{time.Date(2016, 3, 20, 4, 22, 9, 5000, time.FixedZone("neg1-2", -3720)),
+	{"Int64Default", int64(0), false, "0", int64ParamType, int64(0)},
+	{"NullInt64Valued", NullInt64{Int64: 3, Valid: true}, false, "3", int64ParamType, int64(3)},
+	{"NullInt64Null", NullInt64{Valid: false}, true, "", int64ParamType, NullInt64{Valid: false}},
+	{"FloatLiteral", 3.14, false, "3.14", float64ParamType, 3.14},
+	{"FloatLiteralExponent", 3.14159e-87, false, "3.14159e-87", float64ParamType, 3.14159e-87},
+	{"NullFloatValued", NullFloat64{Float64: 3.14, Valid: true}, false, "3.14", float64ParamType, 3.14},
+	{"NullFloatNull", NullFloat64{Valid: false}, true, "", float64ParamType, NullFloat64{Valid: false}},
+	{"FloatNaN", math.NaN(), false, "NaN", float64ParamType, math.NaN()},
+	{"Boolean", true, false, "true", boolParamType, true},
+	{"NullBoolValued", NullBool{Bool: true, Valid: true}, false, "true", boolParamType, true},
+	{"NullBoolNull", NullBool{Valid: false}, true, "", boolParamType, NullBool{Valid: false}},
+	{"String", "string", false, "string", stringParamType, "string"},
+	{"StringUnicode", "\u65e5\u672c\u8a9e\n", false, "\u65e5\u672c\u8a9e\n", stringParamType, "\u65e5\u672c\u8a9e\n"},
+	{"NullStringValued", NullString{StringVal: "string2", Valid: true}, false, "string2", stringParamType, "string2"},
+	{"NullStringNull", NullString{Valid: false}, true, "", stringParamType, NullString{Valid: false}},
+	{"Bytes", []byte("foo"), false, "Zm9v", bytesParamType, []byte("foo")}, // base64 encoding of "foo"
+	{"TimestampFixed", time.Date(2016, 3, 20, 4, 22, 9, 5000, time.FixedZone("neg1-2", -3720)),
 		false,
 		"2016-03-20 04:22:09.000005-01:02",
 		timestampParamType,
 		time.Date(2016, 3, 20, 4, 22, 9, 5000, time.FixedZone("neg1-2", -3720))},
-	{NullTimestamp{Timestamp: time.Date(2016, 3, 22, 4, 22, 9, 5000, time.FixedZone("neg1-2", -3720)), Valid: true},
+	{"NullTimestampValued", NullTimestamp{Timestamp: time.Date(2016, 3, 22, 4, 22, 9, 5000, time.FixedZone("neg1-2", -3720)), Valid: true},
 		false,
 		"2016-03-22 04:22:09.000005-01:02",
 		timestampParamType,
 		time.Date(2016, 3, 22, 4, 22, 9, 5000, time.FixedZone("neg1-2", -3720))},
-	{NullTimestamp{Valid: false},
+	{"NullTimestampNull", NullTimestamp{Valid: false},
 		true,
 		"",
 		timestampParamType,
 		NullTimestamp{Valid: false}},
-	{civil.Date{Year: 2016, Month: 3, Day: 20},
+	{"Date", civil.Date{Year: 2016, Month: 3, Day: 20},
 		false,
 		"2016-03-20",
 		dateParamType,
 		civil.Date{Year: 2016, Month: 3, Day: 20}},
-	{NullDate{
+	{"NullDateValued", NullDate{
 		Date: civil.Date{Year: 2016, Month: 3, Day: 24}, Valid: true},
 		false,
 		"2016-03-24",
 		dateParamType,
 		civil.Date{Year: 2016, Month: 3, Day: 24}},
-	{NullDate{Valid: false},
+	{"NullDateNull", NullDate{Valid: false},
 		true,
 		"",
 		dateParamType,
 		NullDate{Valid: false}},
-	{civil.Time{Hour: 4, Minute: 5, Second: 6, Nanosecond: 789000000},
+	{"Time", civil.Time{Hour: 4, Minute: 5, Second: 6, Nanosecond: 789000000},
 		false,
 		"04:05:06.789000",
 		timeParamType,
 		civil.Time{Hour: 4, Minute: 5, Second: 6, Nanosecond: 789000000}},
-	{NullTime{
+	{"NullTimeValued", NullTime{
 		Time: civil.Time{Hour: 6, Minute: 7, Second: 8, Nanosecond: 789000000}, Valid: true},
 		false,
 		"06:07:08.789000",
 		timeParamType,
 		civil.Time{Hour: 6, Minute: 7, Second: 8, Nanosecond: 789000000}},
-	{NullTime{Valid: false},
+	{"NullTimeNull", NullTime{Valid: false},
 		true,
 		"",
 		timeParamType,
 		NullTime{Valid: false}},
-	{civil.DateTime{Date: civil.Date{Year: 2016, Month: 3, Day: 20}, Time: civil.Time{Hour: 4, Minute: 5, Second: 6, Nanosecond: 789000000}},
+	{"Datetime", civil.DateTime{Date: civil.Date{Year: 2016, Month: 3, Day: 20}, Time: civil.Time{Hour: 4, Minute: 5, Second: 6, Nanosecond: 789000000}},
 		false,
 		"2016-03-20 04:05:06.789000",
 		dateTimeParamType,
 		civil.DateTime{Date: civil.Date{Year: 2016, Month: 3, Day: 20}, Time: civil.Time{Hour: 4, Minute: 5, Second: 6, Nanosecond: 789000000}}},
-	{NullDateTime{
+	{"NullDateTimeValued", NullDateTime{
 		DateTime: civil.DateTime{Date: civil.Date{Year: 2016, Month: 3, Day: 21}, Time: civil.Time{Hour: 4, Minute: 5, Second: 6, Nanosecond: 789000000}}, Valid: true},
 		false,
 		"2016-03-21 04:05:06.789000",
 		dateTimeParamType,
 		civil.DateTime{Date: civil.Date{Year: 2016, Month: 3, Day: 21}, Time: civil.Time{Hour: 4, Minute: 5, Second: 6, Nanosecond: 789000000}}},
-	{NullDateTime{Valid: false},
+	{"NullDateTimeNull", NullDateTime{Valid: false},
 		true,
 		"",
 		dateTimeParamType,
 		NullDateTime{Valid: false}},
-	{big.NewRat(12345, 1000), false, "12.345000000", numericParamType, big.NewRat(12345, 1000)},
-	{&QueryParameterValue{
+	{"Numeric", big.NewRat(12345, 1000), false, "12.345000000", numericParamType, big.NewRat(12345, 1000)},
+	{"BignumericParam", &QueryParameterValue{
 		Type: StandardSQLDataType{
 			TypeKind: "BIGNUMERIC",
 		},
 		Value: BigNumericString(big.NewRat(12345, 10e10)),
 	}, false, "0.00000012345000000000000000000000000000", bigNumericParamType, big.NewRat(12345, 10e10)},
-	{&IntervalValue{Years: 1, Months: 2, Days: 3}, false, "1-2 3 0:0:0", intervalParamType, &IntervalValue{Years: 1, Months: 2, Days: 3}},
-	{NullGeography{GeographyVal: "POINT(-122.335503 47.625536)", Valid: true}, false, "POINT(-122.335503 47.625536)", geographyParamType, "POINT(-122.335503 47.625536)"},
-	{NullGeography{Valid: false}, true, "", geographyParamType, NullGeography{Valid: false}},
-	{NullJSON{Valid: true, JSONVal: "{\"alpha\":\"beta\"}"}, false, "{\"alpha\":\"beta\"}", jsonParamType, "{\"alpha\":\"beta\"}"},
-	{NullJSON{Valid: false}, true, "", jsonParamType, NullJSON{Valid: false}},
+	{"IntervalValue", &IntervalValue{Years: 1, Months: 2, Days: 3}, false, "1-2 3 0:0:0", intervalParamType, &IntervalValue{Years: 1, Months: 2, Days: 3}},
+	{"NullGeographyValued", NullGeography{GeographyVal: "POINT(-122.335503 47.625536)", Valid: true}, false, "POINT(-122.335503 47.625536)", geographyParamType, "POINT(-122.335503 47.625536)"},
+	{"NullGeographyNull", NullGeography{Valid: false}, true, "", geographyParamType, NullGeography{Valid: false}},
+	{"NullJsonValued", NullJSON{Valid: true, JSONVal: "{\"alpha\":\"beta\"}"}, false, "{\"alpha\":\"beta\"}", jsonParamType, "{\"alpha\":\"beta\"}"},
+	{"NullJsonNull", NullJSON{Valid: false}, true, "", jsonParamType, NullJSON{Valid: false}},
 }
 
 type (
@@ -189,21 +191,23 @@ func TestParamValueScalar(t *testing.T) {
 		NullFields: []string{"Value"},
 	}
 
-	for _, test := range scalarTests {
-		got, err := paramValue(reflect.ValueOf(test.val))
-		if err != nil {
-			t.Errorf("%v: got err %v", test.val, err)
-		}
-		if test.wantNil {
-			if !testutil.Equal(got, nilValue) {
-				t.Errorf("%#v: wanted empty QueryParameterValue, got %v", test.val, got)
+	for _, tc := range scalarTests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := paramValue(reflect.ValueOf(tc.val))
+			if err != nil {
+				t.Errorf("%v: got err %v", tc.val, err)
 			}
-		} else {
-			want := sval(test.wantVal)
-			if !testutil.Equal(got, &want) {
-				t.Errorf("%#v:\ngot  %+v\nwant %+v", test.val, got, want)
+			if tc.wantNil {
+				if !testutil.Equal(got, nilValue) {
+					t.Errorf("%#v: wanted empty QueryParameterValue, got %v", tc.val, got)
+				}
+			} else {
+				want := sval(tc.wantVal)
+				if !testutil.Equal(got, &want) {
+					t.Errorf("%#v:\ngot  %+v\nwant %+v", tc.val, got, want)
+				}
 			}
-		}
+		})
 	}
 }
 
@@ -213,21 +217,22 @@ func TestParamValueArray(t *testing.T) {
 		{Value: "2"},
 	},
 	}
-	for _, test := range []struct {
+	for _, tc := range []struct {
+		name string
 		val  interface{}
 		want *bq.QueryParameterValue
 	}{
-		{[]int(nil), &bq.QueryParameterValue{}},
-		{[]int{}, &bq.QueryParameterValue{}},
-		{[]int{1, 2}, qpv},
-		{[2]int{1, 2}, qpv},
+		{"nilIntSlice", []int(nil), &bq.QueryParameterValue{}},
+		{"emptyIntSlice", []int{}, &bq.QueryParameterValue{}},
+		{"slice", []int{1, 2}, qpv},
+		{"array", [2]int{1, 2}, qpv},
 	} {
-		got, err := paramValue(reflect.ValueOf(test.val))
+		got, err := paramValue(reflect.ValueOf(tc.val))
 		if err != nil {
 			t.Fatal(err)
 		}
-		if !testutil.Equal(got, test.want) {
-			t.Errorf("%#v:\ngot  %+v\nwant %+v", test.val, got, test.want)
+		if !testutil.Equal(got, tc.want) {
+			t.Errorf("%#v:\ngot  %+v\nwant %+v", tc.val, got, tc.want)
 		}
 	}
 }
@@ -254,32 +259,37 @@ func TestParamValueErrors(t *testing.T) {
 }
 
 func TestParamType(t *testing.T) {
-	for _, test := range scalarTests {
-		got, err := paramType(reflect.TypeOf(test.val), reflect.ValueOf(test.val))
-		if err != nil {
-			t.Fatal(err)
-		}
-		if d := testutil.Diff(got, test.wantType); d != "" {
-			t.Errorf("%v (%T): \n%s", test.val, test.val, d)
-		}
+	for _, tc := range scalarTests {
+		t.Run(fmt.Sprintf("scalar-%s", tc.name), func(t *testing.T) {
+			got, err := paramType(reflect.TypeOf(tc.val), reflect.ValueOf(tc.val))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if d := testutil.Diff(got, tc.wantType); d != "" {
+				t.Errorf("%v (%T): \n%s", tc.val, tc.val, d)
+			}
+		})
 	}
-	for _, test := range []struct {
+	for _, tc := range []struct {
+		name string
 		val  interface{}
 		want *bq.QueryParameterType
 	}{
-		{uint32(32767), int64ParamType},
-		{[]byte("foo"), bytesParamType},
-		{[]int{}, &bq.QueryParameterType{Type: "ARRAY", ArrayType: int64ParamType}},
-		{[3]bool{}, &bq.QueryParameterType{Type: "ARRAY", ArrayType: boolParamType}},
-		{S1{}, s1ParamType},
+		{"uint32", uint32(32767), int64ParamType},
+		{"byteSlice", []byte("foo"), bytesParamType},
+		{"intArray", []int{}, &bq.QueryParameterType{Type: "ARRAY", ArrayType: int64ParamType}},
+		{"boolArray", [3]bool{}, &bq.QueryParameterType{Type: "ARRAY", ArrayType: boolParamType}},
+		{"emptyStruct", S1{}, s1ParamType},
 	} {
-		got, err := paramType(reflect.TypeOf(test.val), reflect.ValueOf(test.val))
-		if err != nil {
-			t.Fatal(err)
-		}
-		if d := testutil.Diff(got, test.want); d != "" {
-			t.Errorf("%v (%T): \n%s", test.val, test.val, d)
-		}
+		t.Run(fmt.Sprintf("complex-%s", tc.name), func(t *testing.T) {
+			got, err := paramType(reflect.TypeOf(tc.val), reflect.ValueOf(tc.val))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if d := testutil.Diff(got, tc.want); d != "" {
+				t.Errorf("%v (%T): \n%s", tc.val, tc.val, d)
+			}
+		})
 	}
 }
 func TestParamTypeErrors(t *testing.T) {
@@ -332,104 +342,119 @@ func TestParamTypeErrors(t *testing.T) {
 
 func TestConvertParamValue(t *testing.T) {
 	// Scalars.
-	for _, test := range scalarTests {
-		pval, err := paramValue(reflect.ValueOf(test.val))
-		if err != nil {
-			t.Fatal(err)
-		}
-		ptype, err := paramType(reflect.TypeOf(test.val), reflect.ValueOf(test.val))
-		if err != nil {
-			t.Fatal(err)
-		}
-		got, err := convertParamValue(pval, ptype)
-		if err != nil {
-			t.Fatalf("convertParamValue(%+v, %+v): %v", pval, ptype, err)
-		}
-		if !testutil.Equal(got, test.wantStat) {
-			t.Errorf("%#v: wanted stat as %#v, got %#v", test.val, test.wantStat, got)
-		}
+	for _, tc := range scalarTests {
+		t.Run(fmt.Sprintf("scalar-%s", tc.name), func(t *testing.T) {
+			pval, err := paramValue(reflect.ValueOf(tc.val))
+			if err != nil {
+				t.Fatal(err)
+			}
+			ptype, err := paramType(reflect.TypeOf(tc.val), reflect.ValueOf(tc.val))
+			if err != nil {
+				t.Fatal(err)
+			}
+			got, err := convertParamValue(pval, ptype)
+			if err != nil {
+				t.Fatalf("convertParamValue(%+v, %+v): %v", pval, ptype, err)
+			}
+			if !testutil.Equal(got, tc.wantStat) {
+				t.Errorf("%#v: wanted stat as %#v, got %#v", tc.val, tc.wantStat, got)
+			}
+		})
 	}
 	// Arrays.
-	for _, test := range []struct {
+	for _, tc := range []struct {
+		name string
 		pval *bq.QueryParameterValue
 		want []interface{}
 	}{
 		{
+			"empty",
 			&bq.QueryParameterValue{},
 			nil,
 		},
 		{
+			"intArray",
 			&bq.QueryParameterValue{
 				ArrayValues: []*bq.QueryParameterValue{{Value: "1"}, {Value: "2"}},
 			},
 			[]interface{}{int64(1), int64(2)},
 		},
 	} {
-		ptype := &bq.QueryParameterType{Type: "ARRAY", ArrayType: int64ParamType}
-		got, err := convertParamValue(test.pval, ptype)
-		if err != nil {
-			t.Fatalf("%+v: %v", test.pval, err)
-		}
-		if !testutil.Equal(got, test.want) {
-			t.Errorf("%+v: got %+v, want %+v", test.pval, got, test.want)
-		}
+		t.Run(fmt.Sprintf("array-%s", tc.name), func(t *testing.T) {
+			ptype := &bq.QueryParameterType{Type: "ARRAY", ArrayType: int64ParamType}
+			got, err := convertParamValue(tc.pval, ptype)
+			if err != nil {
+				t.Fatalf("%+v: %v", tc.pval, err)
+			}
+			if !testutil.Equal(got, tc.want) {
+				t.Errorf("%+v: got %+v, want %+v", tc.pval, got, tc.want)
+			}
+		})
 	}
 	// Structs.
-	got, err := convertParamValue(&s1ParamValue, s1ParamType)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !testutil.Equal(got, s1ParamReturnValue) {
-		t.Errorf("got %+v, want %+v", got, s1ParamReturnValue)
-	}
+	t.Run("s1struct", func(t *testing.T) {
+		got, err := convertParamValue(&s1ParamValue, s1ParamType)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !testutil.Equal(got, s1ParamReturnValue) {
+			t.Errorf("got %+v, want %+v", got, s1ParamReturnValue)
+		}
+	})
 }
 
 func TestIntegration_ScalarParam(t *testing.T) {
 	roundToMicros := cmp.Transformer("RoundToMicros",
 		func(t time.Time) time.Time { return t.Round(time.Microsecond) })
 	c := getClient(t)
-	for _, test := range scalarTests {
-		gotData, gotParam, err := paramRoundTrip(c, test.val)
-		if err != nil {
-			t.Errorf("input %#v errored: %v", test.val, err)
-		}
-		// first, check the returned query value
-		if test.wantNil {
-			if gotData != nil {
-				t.Errorf("data value %#v expected nil, got %#v", test.val, gotData)
+	for _, tc := range scalarTests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotData, gotParam, err := paramRoundTrip(c, tc.val)
+			if err != nil {
+				t.Errorf("input %#v errored: %v", tc.val, err)
 			}
-		} else {
-			if !testutil.Equal(gotData, test.wantStat, roundToMicros) {
-				t.Errorf("\ngot data value %#v (%T)\nwant %#v (%T)", gotData, gotData, test.wantStat, test.wantStat)
+			// first, check the returned query value
+			if tc.wantNil {
+				if gotData != nil {
+					t.Errorf("data value %#v expected nil, got %#v", tc.val, gotData)
+				}
+			} else {
+				if !testutil.Equal(gotData, tc.wantStat, roundToMicros) {
+					t.Errorf("\ngot data value %#v (%T)\nwant %#v (%T)", gotData, gotData, tc.wantStat, tc.wantStat)
+				}
 			}
-		}
-		// then, check the stat value
-		if !testutil.Equal(gotParam, test.wantStat, roundToMicros) {
-			t.Errorf("\ngot param stat %#v (%T)\nwant %#v (%T)", gotParam, gotParam, test.wantStat, test.wantStat)
-		}
+			// then, check the stat value
+			if !testutil.Equal(gotParam, tc.wantStat, roundToMicros) {
+				t.Errorf("\ngot param stat %#v (%T)\nwant %#v (%T)", gotParam, gotParam, tc.wantStat, tc.wantStat)
+			}
+		})
 	}
 }
 
 func TestIntegration_OtherParam(t *testing.T) {
 	c := getClient(t)
-	for _, test := range []struct {
+	for _, tc := range []struct {
+		name      string
 		val       interface{}
 		wantData  interface{}
 		wantParam interface{}
 	}{
-		{[]int(nil), []Value(nil), []interface{}(nil)},
-		{[]int{}, []Value(nil), []interface{}(nil)},
+		{"nil", []int(nil), []Value(nil), []interface{}(nil)},
+		{"emptyIntSlice", []int{}, []Value(nil), []interface{}(nil)},
 		{
+			"intSlice",
 			[]int{1, 2},
 			[]Value{int64(1), int64(2)},
 			[]interface{}{int64(1), int64(2)},
 		},
 		{
+			"intArray",
 			[3]int{1, 2, 3},
 			[]Value{int64(1), int64(2), int64(3)},
 			[]interface{}{int64(1), int64(2), int64(3)},
 		},
 		{
+			"emptyStruct",
 			S1{},
 			[]Value{int64(0), nil, false},
 			map[string]interface{}{
@@ -439,23 +464,26 @@ func TestIntegration_OtherParam(t *testing.T) {
 			},
 		},
 		{
+			"s1struct",
 			s1,
 			[]Value{int64(1), []Value{"s"}, true},
 			s1ParamReturnValue,
 		},
 	} {
-		gotData, gotParam, err := paramRoundTrip(c, test.val)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if !testutil.Equal(gotData, test.wantData) {
-			t.Errorf("%#v:\ngot  %#v (%T)\nwant %#v (%T)",
-				test.val, gotData, gotData, test.wantData, test.wantData)
-		}
-		if !testutil.Equal(gotParam, test.wantParam) {
-			t.Errorf("%#v:\ngot  %#v (%T)\nwant %#v (%T)",
-				test.val, gotParam, gotParam, test.wantParam, test.wantParam)
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			gotData, gotParam, err := paramRoundTrip(c, tc.val)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !testutil.Equal(gotData, tc.wantData) {
+				t.Errorf("%#v:\ngot  %#v (%T)\nwant %#v (%T)",
+					tc.val, gotData, gotData, tc.wantData, tc.wantData)
+			}
+			if !testutil.Equal(gotParam, tc.wantParam) {
+				t.Errorf("%#v:\ngot  %#v (%T)\nwant %#v (%T)",
+					tc.val, gotParam, gotParam, tc.wantParam, tc.wantParam)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
This PR does not add any tests nor change any expectations.  What it does is expand our many table-driven tests into using the subtest pattern.  As I've been recently working on datatypes support, having individually-addressable subtest cases both improves readability when failures occur, and allows for better isolation to exercise specific tests within a table.