### PR TITLE
feat(bigquery): RANGE type StandardSQLDataType support

### DIFF
--- a/bigquery/routine_integration_test.go
+++ b/bigquery/routine_integration_test.go
@@ -53,6 +53,44 @@ func TestIntegration_RoutineScalarUDF(t *testing.T) {
 	}
 }
 
+func TestIntegration_RoutineRangeType(t *testing.T) {
+	if client == nil {
+		t.Skip("Integration tests skipped")
+	}
+	ctx := context.Background()
+
+	routineID := routineIDs.New()
+	routine := dataset.Routine(routineID)
+	err := routine.Create(ctx, &RoutineMetadata{
+		Type:     "SCALAR_FUNCTION",
+		Language: "SQL",
+		Body:     "RANGE_CONTAINS(r1,r2)",
+		Arguments: []*RoutineArgument{
+			{
+				Name: "r1",
+				DataType: &StandardSQLDataType{
+					TypeKind: "RANGE",
+					RangeElementType: &StandardSQLDataType{
+						TypeKind: "TIMESTAMP",
+					},
+				},
+			},
+			{
+				Name: "r2",
+				DataType: &StandardSQLDataType{
+					TypeKind: "RANGE",
+					RangeElementType: &StandardSQLDataType{
+						TypeKind: "TIMESTAMP",
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+}
+
 func TestIntegration_RoutineDataGovernance(t *testing.T) {
 	if client == nil {
 		t.Skip("Integration tests skipped")

--- a/bigquery/standardsql_test.go
+++ b/bigquery/standardsql_test.go
@@ -49,6 +49,20 @@ func TestBQToStandardSQLDataType(t *testing.T) {
 				},
 			},
 		},
+		{
+			&bq.StandardSqlDataType{
+				TypeKind: "RANGE",
+				RangeElementType: &bq.StandardSqlDataType{
+					TypeKind: "DATETIME",
+				},
+			},
+			&StandardSQLDataType{
+				TypeKind: "RANGE",
+				RangeElementType: &StandardSQLDataType{
+					TypeKind: "DATETIME",
+				},
+			},
+		},
 	} {
 		got, err := bqToStandardSQLDataType(test.in)
 		if err != nil {


### PR DESCRIPTION
This PR augments the StandardSQLDataRepresentation(s) to support range-specific augmentations, and adds some testing.  Astute observers will note that this does include mapping changes to param handling, which will be tested in a subsequent PR that expands RANGE coverage to that area of the library.

Towards: https://github.com/googleapis/google-cloud-go/issues/9017