### PR TITLE
chore(storage): remove superfluous options

### DIFF
--- a/storage/client.go
+++ b/storage/client.go
@@ -183,16 +183,6 @@ type storageOption interface {
 	Apply(s *settings)
 }
 
-func withGAXOptions(opts ...gax.CallOption) storageOption {
-	return &gaxOption{opts}
-}
-
-type gaxOption struct {
-	opts []gax.CallOption
-}
-
-func (o *gaxOption) Apply(s *settings) { s.gax = o.opts }
-
 func withRetryConfig(rc *retryConfig) storageOption {
 	return &retryOption{rc}
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -232,7 +232,6 @@ func NewClient(ctx context.Context, opts ...option.ClientOption) (*Client, error
 // You may configure the client by passing in options from the [google.golang.org/api/option]
 // package.
 func NewGRPCClient(ctx context.Context, opts ...option.ClientOption) (*Client, error) {
-	opts = append(defaultGRPCOptions(), opts...)
 	tc, err := newGRPCStorageClient(ctx, withClientOptions(opts...))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Remove gax storage option which is unused. Also, remove default options which are duplicated between constructors.