### PR TITLE
chore(chat): add config to generate apiv1

### DIFF
--- a/.github/.OwlBot.yaml
+++ b/.github/.OwlBot.yaml
@@ -66,6 +66,7 @@ deep-remove-regex:
   - /binaryauthorization/apiv1beta1/
   - /certificatemanager/apiv1/
   - /channel/apiv1/
+  - /chat/apiv1/
   - /cloudbuild/apiv1/v2/
   - /cloudbuild/apiv2/
   - /cloudcontrolspartner/apiv1/
@@ -195,6 +196,7 @@ deep-remove-regex:
   - /internal/generated/snippets/binaryauthorization/apiv1beta1/
   - /internal/generated/snippets/certificatemanager/apiv1/
   - /internal/generated/snippets/channel/apiv1/
+  - /internal/generated/snippets/chat/apiv1/
   - /internal/generated/snippets/cloudbuild/apiv1/v2/
   - /internal/generated/snippets/cloudbuild/apiv2/
   - /internal/generated/snippets/cloudcontrolspartner/apiv1/
@@ -704,6 +706,8 @@ deep-copy-regex:
   - source: /google/cloud/certificatemanager/v1/cloud.google.com/go
     dest: /
   - source: /google/cloud/channel/v1/cloud.google.com/go
+    dest: /
+  - source: /google/cloud/chat/v1/cloud.google.com/go
     dest: /
   - source: /google/devtools/cloudbuild/v1/cloud.google.com/go
     dest: /

--- a/.github/.OwlBot.yaml
+++ b/.github/.OwlBot.yaml
@@ -707,7 +707,7 @@ deep-copy-regex:
     dest: /
   - source: /google/cloud/channel/v1/cloud.google.com/go
     dest: /
-  - source: /google/cloud/chat/v1/cloud.google.com/go
+  - source: /google/chat/v1/cloud.google.com/go
     dest: /
   - source: /google/devtools/cloudbuild/v1/cloud.google.com/go
     dest: /

--- a/internal/postprocessor/config.yaml
+++ b/internal/postprocessor/config.yaml
@@ -28,6 +28,7 @@ modules:
   - binaryauthorization
   - certificatemanager
   - channel
+  - chat
   - cloudbuild
   - cloudcontrolspartner
   - clouddms
@@ -459,6 +460,9 @@ service-configs:
   - input-directory: google/cloud/channel/v1
     service-config: cloudchannel_v1.yaml
     import-path: cloud.google.com/go/channel/apiv1
+  - input-directory: google/cloud/chat/v1
+    service-config: chat_v1.yaml
+    import-path: cloud.google.com/go/chat/apiv1
   - input-directory: google/cloud/cloudcontrolspartner/v1
     service-config: cloudcontrolspartner_v1.yaml
     import-path: cloud.google.com/go/cloudcontrolspartner/apiv1

--- a/internal/postprocessor/config.yaml
+++ b/internal/postprocessor/config.yaml
@@ -460,7 +460,7 @@ service-configs:
   - input-directory: google/cloud/channel/v1
     service-config: cloudchannel_v1.yaml
     import-path: cloud.google.com/go/channel/apiv1
-  - input-directory: google/cloud/chat/v1
+  - input-directory: google/chat/v1
     service-config: chat_v1.yaml
     import-path: cloud.google.com/go/chat/apiv1
   - input-directory: google/cloud/cloudcontrolspartner/v1


### PR DESCRIPTION
PiperOrigin-RevId: 609795940

This reverts commit 3d1f8a73c5927beb2a557f9c4704723af981131e.

Separate but required types added at https://github.com/googleapis/go-genproto/tree/main/googleapis/apps/card/v1 in https://github.com/googleapis/go-genproto/pull/1112