### PR TITLE
chore(postprocessor): fix videointelligence config

### DIFF
--- a/internal/postprocessor/config.yaml
+++ b/internal/postprocessor/config.yaml
@@ -932,7 +932,7 @@ service-configs:
     service-config: videointelligence_v1.yaml
     import-path: cloud.google.com/go/videointelligence/apiv1
   - input-directory: google/cloud/videointelligence/v1beta2
-    service-config: ../videointelligence_v1beta2.yaml
+    service-config: videointelligence_v1beta2.yaml
     import-path: cloud.google.com/go/videointelligence/apiv1beta2
   - input-directory: google/cloud/videointelligence/v1p3beta1
     service-config: videointelligence_v1p3beta1.yaml


### PR DESCRIPTION
cl/625277786 rehomes some config files to the proper place for ease of publishing. Let's make sure to reference the correct one.