### PR TITLE
testing(bigquery): correct an integration test expectation

### DIFF
--- a/bigquery/integration_test.go
+++ b/bigquery/integration_test.go
@@ -2901,11 +2901,10 @@ func TestIntegration_ExportDataStatistics(t *testing.T) {
 				break
 			}
 			if err != nil {
-				t.Logf("failed to delete bucket: %v", err)
+				t.Logf("failed to iterate through bucket %q: %v", bucketName, err)
 				continue
 			}
 			err = storageClient.Bucket(bucketName).Object(obj.Name).Delete(ctx)
-			t.Logf("deleted object %s: %v", obj.Name, err)
 		}
 	}()
 

--- a/bigquery/params_test.go
+++ b/bigquery/params_test.go
@@ -673,7 +673,7 @@ func TestIntegration_OtherParam(t *testing.T) {
 			},
 			&RangeValue{
 				Start: time.Date(2016, 3, 22, 4, 22, 9, 5000, time.FixedZone("neg1-2", -3720)),
-				End:   NullTimestamp{},
+				End:   nil,
 			},
 		},
 	} {


### PR DESCRIPTION
This PR corrects a test expectation around range representation (nil vs a NullTimestamp), and cleans up some spurious logging in a testing cleanup function that it overly noisy.