### PR TITLE
chore(internal/postprocessor): restore go version 1.21 in Dockerfile

### DIFF
--- a/internal/postprocessor/Dockerfile
+++ b/internal/postprocessor/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.20 as builder
+FROM golang:1.21 as builder
 
 # Copy local code to the container image.
 COPY . /postprocessor/


### PR DESCRIPTION
* Fix broken new module command go get go@1.19.

refs: #9718