### PR TITLE
fix(auth): default gRPC token type to Bearer if not set

### DIFF
--- a/auth/grpctransport/dial_socketopt_test.go
+++ b/auth/grpctransport/dial_socketopt_test.go
@@ -109,7 +109,7 @@ func TestDialWithDirectPathEnabled(t *testing.T) {
 
 	pool, err := Dial(ctx, true, &Options{
 		Credentials: auth.NewCredentials(&auth.CredentialsOptions{
-			TokenProvider: staticTP("hey"),
+			TokenProvider: &staticTP{tok: &auth.Token{Value: "hey"}},
 		}),
 		GRPCDialOpts: []grpc.DialOption{userDialer},
 		Endpoint:     "example.google.com:443",

--- a/auth/grpctransport/grpctransport.go
+++ b/auth/grpctransport/grpctransport.go
@@ -287,13 +287,22 @@ func (c *grpcCredentialsProvider) GetRequestMetadata(ctx context.Context, uri ..
 			return nil, fmt.Errorf("unable to transfer credentials PerRPCCredentials: %v", err)
 		}
 	}
-	metadata := map[string]string{
-		"authorization": token.Type + " " + token.Value,
-	}
+	metadata := make(map[string]string, len(c.metadata)+1)
+	setAuthMetadata(token, metadata)
 	for k, v := range c.metadata {
 		metadata[k] = v
 	}
 	return metadata, nil
+}
+
+// setAuthMetadata uses the provided token to set the Authorization metadata.
+// If the token.Type is empty, the type is assumed to be Bearer.
+func setAuthMetadata(token *auth.Token, m map[string]string) {
+	typ := token.Type
+	if typ == "" {
+		typ = internal.TokenTypeBearer
+	}
+	m["authorization"] = typ + " " + token.Value
 }
 
 func (c *grpcCredentialsProvider) RequireTransportSecurity() bool {


### PR DESCRIPTION
As documented on auth.Token.Type, if the value of Type is "" it should be treated as a Bearer token. Added a similar helper method as we have in the httptransport package to default this.