### PR TITLE
fix(auth/credentials): error on bad file name if explicitly set

### DIFF
--- a/auth/credentials/detect.go
+++ b/auth/credentials/detect.go
@@ -76,7 +76,10 @@ func DetectDefault(opts *DetectOptions) (*auth.Credentials, error) {
 	if opts.CredentialsJSON != nil {
 		return readCredentialsFileJSON(opts.CredentialsJSON, opts)
 	}
-	if filename := credsfile.GetFileNameFromEnv(opts.CredentialsFile); filename != "" {
+	if opts.CredentialsFile != "" {
+		return readCredentialsFile(opts.CredentialsFile, opts)
+	}
+	if filename := os.Getenv(credsfile.GoogleAppCredsEnvVar); filename != "" {
 		if creds, err := readCredentialsFile(filename, opts); err == nil {
 			return creds, err
 		}

--- a/auth/credentials/detect_test.go
+++ b/auth/credentials/detect_test.go
@@ -688,6 +688,15 @@ func TestDefaultCredentials_BadFiletype(t *testing.T) {
 	}
 }
 
+func TestDefaultCredentials_BadFileName(t *testing.T) {
+	if _, err := DetectDefault(&DetectOptions{
+		CredentialsFile: "a/bad/filepath",
+		Scopes:          []string{"https://www.googleapis.com/auth/cloud-platform"},
+	}); err == nil {
+		t.Fatal("got nil, want non-nil err")
+	}
+}
+
 func TestDefaultCredentials_Validate(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
Only want our fall-through logic to work for ADC specified behaviour, not explicit credential options.

Fixes: #9809