### PR TITLE
test(storage): allow short tests to run without creds

### DIFF
--- a/storage/bucket_test.go
+++ b/storage/bucket_test.go
@@ -1595,7 +1595,7 @@ func TestBucketSignedURL_Endpoint_Emulator_Host(t *testing.T) {
 
 			var opts []option.ClientOption
 			if test.endpoint != nil {
-				opts = append(opts, option.WithEndpoint(*test.endpoint))
+				opts = append(opts, option.WithEndpoint(*test.endpoint), option.WithoutAuthentication())
 			}
 			c, err := NewClient(context.Background(), opts...)
 			if err != nil {

--- a/storage/integration_test.go
+++ b/storage/integration_test.go
@@ -5385,6 +5385,11 @@ func TestIntegration_Scopes(t *testing.T) {
 }
 
 func TestIntegration_SignedURL_WithCreds(t *testing.T) {
+	// Skip before getting creds if running with -short
+	if testing.Short() {
+		t.Skip("Integration tests skipped in short mode")
+	}
+
 	ctx := context.Background()
 
 	creds, err := findTestCredentials(ctx, "GCLOUD_TESTS_GOLANG_KEY", ScopeFullControl, "https://www.googleapis.com/auth/cloud-platform")
@@ -5416,6 +5421,11 @@ func TestIntegration_SignedURL_WithCreds(t *testing.T) {
 }
 
 func TestIntegration_SignedURL_DefaultSignBytes(t *testing.T) {
+	// Skip before getting creds if running with -short
+	if testing.Short() {
+		t.Skip("Integration tests skipped in short mode")
+	}
+
 	ctx := context.Background()
 
 	// Create another client to test the sign byte function as well
@@ -5456,6 +5466,11 @@ func TestIntegration_SignedURL_DefaultSignBytes(t *testing.T) {
 }
 
 func TestIntegration_PostPolicyV4_WithCreds(t *testing.T) {
+	// Skip before getting creds if running with -short
+	if testing.Short() {
+		t.Skip("Integration tests skipped in short mode")
+	}
+
 	// By default we are authed with a token source, so don't have the context to
 	// read some of the fields from the keyfile.
 	// Here we explictly send the key to the client.

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -1135,7 +1135,7 @@ func TestClientSetRetry(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(s *testing.T) {
-			c, err := NewClient(context.Background())
+			c, err := NewClient(context.Background(), option.WithoutAuthentication())
 			if err != nil {
 				t.Fatalf("NewClient: %v", err)
 			}
@@ -1358,7 +1358,7 @@ func TestRetryer(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(s *testing.T) {
 			ctx := context.Background()
-			c, err := NewClient(ctx)
+			c, err := NewClient(ctx, option.WithoutAuthentication())
 			if err != nil {
 				t.Fatalf("NewClient: %v", err)
 			}
@@ -2151,7 +2151,7 @@ func TestWithEndpoint(t *testing.T) {
 	ctx := context.Background()
 	for _, tc := range testCases {
 		os.Setenv("STORAGE_EMULATOR_HOST", tc.StorageEmulatorHost)
-		c, err := NewClient(ctx, option.WithEndpoint(tc.CustomEndpoint))
+		c, err := NewClient(ctx, option.WithEndpoint(tc.CustomEndpoint), option.WithoutAuthentication())
 		if err != nil {
 			t.Fatalf("error creating client: %v", err)
 		}


### PR DESCRIPTION
A few tests required credentials to run in short mode. Fixed this by disabling auth for unit tests and making sure integration tests are entirely skipped (including logic to surface necessary creds).