### PR TITLE
chore(internal/kokoro): filter changes down to unique dir

### DIFF
--- a/internal/kokoro/presubmit.sh
+++ b/internal/kokoro/presubmit.sh
@@ -78,7 +78,7 @@ runPresubmitTests() {
 }
 
 SIGNIFICANT_CHANGES=$(git --no-pager diff --name-only origin/main...$KOKORO_GIT_COMMIT_google_cloud_go |
-  grep -Ev '(\.md$|^\.github|\.json$|\.yaml$)' || true)
+  grep -Ev '(\.md$|^\.github|\.json$|\.yaml$)' | xargs dirname | sort -u || true)
 
 if [ -z $SIGNIFICANT_CHANGES ]; then
   echo "No changes detected, skipping tests"


### PR DESCRIPTION
In #9777 there are so many `.go` files being changed that the `internal/kokoro/presubmit.sh` bash scripting was overflowing the conditional check and returning an error. Oddly enough, things would keep going.

We don't really need to check for changes on the `.go` file level if we are just going to run the directory's tests anyways, so let's filter the changes down to unique directory instead.

Ran these commands locally against #9777 and it will fix the bash error we are seeing.