### PR TITLE
fix(spanner): handle unused errors

### DIFF
--- a/spanner/spansql/parser.go
+++ b/spanner/spansql/parser.go
@@ -1372,6 +1372,9 @@ func (p *parser) parseCreateView() (*CreateView, *parseError) {
 		return nil, err
 	}
 	vname, err := p.parseTableOrIndexOrColumnName()
+	if err != nil {
+		return nil, err
+	}
 	if err := p.expect("SQL", "SECURITY"); err != nil {
 		return nil, err
 	}

--- a/spanner/test/cloudexecutor/executor/actions/admin.go
+++ b/spanner/test/cloudexecutor/executor/actions/admin.go
@@ -347,6 +347,9 @@ func executeGetCloudInstance(ctx context.Context, action *executorpb.GetCloudIns
 	instanceObj, err := instanceAdminClient.GetInstance(ctx, &instancepb.GetInstanceRequest{
 		Name: fmt.Sprintf("projects/%s/instances/%s", projectID, instanceID),
 	})
+	if err != nil {
+		return err
+	}
 	spannerActionOutcome := &executorpb.SpannerActionOutcome{
 		Status: &spb.Status{Code: int32(codes.OK)},
 		AdminResult: &executorpb.AdminResult{

--- a/spanner/test/cloudexecutor/executor/actions/mutation.go
+++ b/spanner/test/cloudexecutor/executor/actions/mutation.go
@@ -139,6 +139,9 @@ func createMutation(action *executorpb.MutationAction, tableMetadata *utility.Ta
 				return nil, err
 			}
 			keySet, err := utility.KeySetProtoToCloudKeySet(mod.DeleteKeys, keyColTypes)
+			if err != nil {
+				return nil, err
+			}
 			m = append(m, spanner.Delete(table, keySet))
 		default:
 			return nil, spanner.ToSpannerError(status.Errorf(codes.InvalidArgument, "unsupported mod: %s", mod.String()))


### PR DESCRIPTION
The error return values were not being used. Caught by staticcheck.