### PR TITLE
chore(deps): ignore go.opentelemetry.io/contrib/detectors/gcp

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -13,6 +13,7 @@
     "commitMessageAction": "update",
     "groupName": "deps",
     "ignoreDeps": [
+        "go.opentelemetry.io/contrib/detectors/gcp",
         "go.opentelemetry.io/otel",
         "go.opentelemetry.io/otel/metric",
         "go.opentelemetry.io/otel/sdk",


### PR DESCRIPTION
Disable `go.opentelemetry.io/contrib/detectors/gcp` dependency updates since it requires a newer version of Go.