### PR TITLE
chore(thirdpartycheck): remove testify exemption

### DIFF
--- a/internal/actions/cmd/thirdpartycheck/main.go
+++ b/internal/actions/cmd/thirdpartycheck/main.go
@@ -50,7 +50,6 @@ var (
 
 		// Third party deps (temporary exception(s)).
 		"github.com/json-iterator/go", // https://github.com/googleapis/google-cloud-go/issues/9380
-		"github.com/stretchr/testify", // https://github.com/googleapis/google-cloud-go/issues/9378
 		"go.einride.tech/aip",         // https://github.com/googleapis/google-cloud-go/issues/9338
 		"rsc.io/binaryregexp",         // https://github.com/googleapis/google-cloud-go/issues/9376
 	}


### PR DESCRIPTION
Since `testify` was removed from spanner in #9760 we can remove the exemption for it, so that it won't be added back.

Fixes #9378