### PR TITLE
docs(testing): switch deprecated WithInsecure to WithTransportCredentials

### DIFF
--- a/testing.md
+++ b/testing.md
@@ -99,6 +99,7 @@ import (
         "google.golang.org/api/option"
         translatepb "google.golang.org/genproto/googleapis/cloud/translate/v3"
         "google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 func TestTranslateTextWithConcreteClient(t *testing.T) {
@@ -123,7 +124,7 @@ func TestTranslateTextWithConcreteClient(t *testing.T) {
         client, err := translate.NewTranslationClient(ctx,
                 option.WithEndpoint(fakeServerAddr),
                 option.WithoutAuthentication(),
-                option.WithGRPCDialOption(grpc.WithInsecure()),
+                option.WithGRPCDialOption(grpc.WithTransportCredentials(insecure.NewCredentials())),
         )
         if err != nil {
                 t.Fatal(err)


### PR DESCRIPTION
The public [GRPC docs](https://pkg.go.dev/google.golang.org/grpc#WithInsecure) mention the following with regards to `grpc.WithInsecure`:

> Deprecated: use WithTransportCredentials and insecure.NewCredentials() instead. Will be supported throughout 1.x.

This change updates the example to use `WithTransportCredentials()` along with `insecure.NewCredentials()` instead of the deprecated option.