### PR TITLE
fix(aliasfix): handle import paths correctly

### DIFF
--- a/internal/aliasfix/aliasfix_test.go
+++ b/internal/aliasfix/aliasfix_test.go
@@ -74,8 +74,12 @@ func TestGolden(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			GenprotoPkgMigration["example.com/old/foo"] = Pkg{
+			GenprotoPkgMigration["example.com/old/foo/v1"] = Pkg{
 				ImportPath: "example.com/new/foopb",
+				Status:     tc.status,
+			}
+			GenprotoPkgMigration["example.com/old/bar/v1/bar"] = Pkg{
+				ImportPath: "example.com/new/barpb",
 				Status:     tc.status,
 			}
 			var w bytes.Buffer

--- a/internal/aliasfix/testdata/golden/input2
+++ b/internal/aliasfix/testdata/golden/input2
@@ -3,7 +3,9 @@ package golden
 import (
 	"net"
 
+	bar "example.com/new/barpb"
 	foo "example.com/new/foopb"
 )
 
 func Bar1(foo foo.Baz, addr net.Addr) {}
+func Bar2(foo bar.Baz, addr net.Addr) {}

--- a/internal/aliasfix/testdata/input1
+++ b/internal/aliasfix/testdata/input1
@@ -1,5 +1,5 @@
 package golden
 
-import "example.com/old/foo"
+import "example.com/old/foo/v1"
 
 func Bar1(foo foo.Baz) {}

--- a/internal/aliasfix/testdata/input2
+++ b/internal/aliasfix/testdata/input2
@@ -3,7 +3,9 @@ package golden
 import (
 	"net"
 
-	"example.com/old/foo"
+	"example.com/old/foo/v1"
+	"example.com/old/bar/v1/bar"
 )
 
 func Bar1(foo foo.Baz, addr net.Addr) {}
+func Bar2(foo bar.Baz, addr net.Addr) {}

--- a/internal/aliasfix/testdata/input4
+++ b/internal/aliasfix/testdata/input4
@@ -1,5 +1,5 @@
 package golden
 
-import foopb "example.com/old/foo"
+import foopb "example.com/old/foo/v1"
 
 func Bar4(baz foopb.Baz) {}

--- a/internal/aliasfix/testdata/input5
+++ b/internal/aliasfix/testdata/input5
@@ -3,7 +3,7 @@ package golden
 import (
 	"net"
 
-	blah "example.com/old/foo"
+	blah "example.com/old/foo/v1"
 )
 
 func Bar2(baz blah.Baz, addr net.Addr) {}

--- a/internal/aliasfix/testdata/input6
+++ b/internal/aliasfix/testdata/input6
@@ -3,7 +3,7 @@ package golden
 import (
 	"net"
 
-	blah "example.com/old/foo"
+	blah "example.com/old/foo/v1"
 )
 
 func Bar2(baz blah.Baz, addr net.Addr) {}


### PR DESCRIPTION
The last component in import path of the old genproto path does not correspond to the import path -- usually.

The import paths usually look like `google.golang.org/genproto/googleapis/analytics/admin/v1alpha`, however the imported package name is `admin`. This uses a heuristic to detect whether the last path component is a version,

There are some packages that do not fit that description though, e.g. `google.golang.org/genproto/googleapis/devtools/containeranalysis/v1beta1/grafeas`.