### PR TITLE
feat(auth): Enable client certificates by default

### DIFF
--- a/auth/internal/transport/cba.go
+++ b/auth/internal/transport/cba.go
@@ -216,10 +216,6 @@ func getTransportConfig(opts *Options) (*transportConfig, error) {
 // A nil default source can be returned if the source does not exist. Any exceptions
 // encountered while initializing the default source will be reported as client
 // error (ex. corrupt metadata file).
-//
-// Important Note: For now, the environment variable GOOGLE_API_USE_CLIENT_CERTIFICATE
-// must be set to "true" to allow certificate to be used (including user provided
-// certificates). For details, see AIP-4114.
 func getClientCertificateSource(opts *Options) (cert.Provider, error) {
 	if !isClientCertificateEnabled() {
 		return nil, nil
@@ -230,11 +226,14 @@ func getClientCertificateSource(opts *Options) (cert.Provider, error) {
 
 }
 
+// isClientCertificateEnabled returns true by default, unless explicitly set to false via env var.
 func isClientCertificateEnabled() bool {
-	// TODO(andyrzhao): Update default to return "true" after DCA feature is fully released.
-	// error as false is a good default
-	b, _ := strconv.ParseBool(os.Getenv(googleAPIUseCertSource))
-	return b
+	if value, ok := os.LookupEnv(googleAPIUseCertSource); ok {
+		// error as false is OK
+		b, _ := strconv.ParseBool(value)
+		return b
+	}
+	return true
 }
 
 type transportConfig struct {


### PR DESCRIPTION
Implications of this change:
1. If no default certificate sources are available in the environment (i.e. no SecureConnect or ECP cert), then the before & after behavior are identical.
2. If SecureConnect cert source is available (i.e. Googlers with EndpointVerification installed), then connections are automatically upgraded to mTLS. This is deemed a safe upgrade from policy enforcement perspective. From a latency perspective, since this does not impact workload use-cases, there should be negligible impact, even if the SecureConnect cert is from a TPM.
3. ECP cert source is enabled via certificate_config.json, which is not widely rolled out at the moment. Those with certificate_config.json configured already have the intention to enable client certificates anyway, so this saves them an extra flag to manage.