### PR TITLE
test(spanner): fix retry unit tests with RESOURCE_EXHAUSTED errors

### DIFF
--- a/spanner/client_test.go
+++ b/spanner/client_test.go
@@ -3989,7 +3989,6 @@ func TestClient_WithoutCustomBatchTimeout(t *testing.T) {
 }
 
 func TestClient_CallOptions(t *testing.T) {
-	t.Skip("https://github.com/googleapis/google-cloud-go/issues/10069")
 	t.Parallel()
 	co := &vkit.CallOptions{
 		CreateSession: []gax.CallOption{
@@ -4016,7 +4015,7 @@ func TestClient_CallOptions(t *testing.T) {
 	cs := &gax.CallSettings{}
 	// This is the default retry setting.
 	c.CallOptions.CreateSession[1].Resolve(cs)
-	if got, want := fmt.Sprintf("%v", cs.Retry()), "&{{250000000 32000000000 1.3 0} [14]}"; got != want {
+	if got, want := fmt.Sprintf("%v", cs.Retry()), "&{{250000000 32000000000 1.3 0} [14 8]}"; got != want {
 		t.Fatalf("merged CallOptions is incorrect: got %v, want %v", got, want)
 	}
 

--- a/spanner/internal/testutil/inmem_spanner_server.go
+++ b/spanner/internal/testutil/inmem_spanner_server.go
@@ -731,7 +731,7 @@ func (s *inMemSpannerServer) BatchCreateSessions(ctx context.Context, req *spann
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.maxSessionsReturnedByServerInTotal > int32(0) && int32(len(s.sessions)) >= s.maxSessionsReturnedByServerInTotal {
-		return nil, gstatus.Error(codes.ResourceExhausted, "No more sessions available")
+		return nil, gstatus.Error(codes.OutOfRange, "No more sessions available")
 	}
 	if sessionsToCreate > s.maxSessionsReturnedByServerPerBatchRequest {
 		sessionsToCreate = s.maxSessionsReturnedByServerPerBatchRequest

--- a/spanner/sessionclient_test.go
+++ b/spanner/sessionclient_test.go
@@ -424,7 +424,6 @@ func TestBatchCreateSessions_ServerReturnsLessThanRequestedSessions(t *testing.T
 }
 
 func TestBatchCreateSessions_ServerExhausted(t *testing.T) {
-	t.Skip("https://github.com/googleapis/google-cloud-go/issues/10070")
 	t.Parallel()
 
 	numChannels := 4
@@ -448,7 +447,7 @@ func TestBatchCreateSessions_ServerExhausted(t *testing.T) {
 		t.Fatalf("Error count mismatch\nGot: %d\nWant: > %d", len(consumer.errors), 0)
 	}
 	for _, e := range consumer.errors {
-		if g, w := status.Code(e.err), codes.ResourceExhausted; g != w {
+		if g, w := status.Code(e.err), codes.OutOfRange; g != w {
 			t.Fatalf("Error code mismath\nGot: %v\nWant: %v", g, w)
 		}
 	}


### PR DESCRIPTION
Fixes: https://github.com/googleapis/google-cloud-go/issues/10070, https://github.com/googleapis/google-cloud-go/issues/10069