### PR TITLE
test(spanner): update max staleness bound value

### DIFF
--- a/spanner/integration_test.go
+++ b/spanner/integration_test.go
@@ -623,7 +623,7 @@ func TestIntegration_SingleUse(t *testing.T) {
 		{
 			name: "max_staleness",
 			want: [][]interface{}{{int64(1), "Marc", "Foo"}, {int64(3), "Alpha", "Beta"}, {int64(4), "Last", "End"}},
-			tb:   MaxStaleness(time.Second),
+			tb:   MaxStaleness(time.Nanosecond),
 			checkTs: func(ts time.Time) error {
 				if ts.Before(writes[3].ts) {
 					return fmt.Errorf("read got timestamp %v, want it to be no earlier than %v", ts, writes[3].ts)


### PR DESCRIPTION
`TestIntegration_SingleUse/max_staleness` is showing flaky behavior and this PR fixes it.

**Background**: The current test has a Max staleness value of `1 sec`. This Bounded staleness mode allow Spanner to pick the read timestamp, subject to a user- provided staleness bound. Spanner chooses the newest timestamp within the provided staleness bound. More details `[here](https://cloud.google.com/spanner/docs/timestamp-bounds#bounded_staleness)`.

**Flakiness Reason**: The test verifies whether the chosen read timestamp is after writes[3] timestamp. But since the staleness value is 1 sec, the chosen timestamp by spanner can be much before the writes[3] timestamp which gices a flaky behaviour with below error
```
SingleUse.Query doesn't return expected timestamp: read got timestamp 2024-05-02 07:02:58.245414 +0000 UTC, want it to be no earlier than 2024-05-02 07:02:58.289881 +0000 UTC
```

Choosing a lower value of staleness ensures that the chosen timestamp is always above the writes[3] timestamp.


Fixes #10084 