### PR TITLE
chore: freeze opentelemetry-operations-go/exporter/trace at v1.22.0

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -13,6 +13,7 @@
     "commitMessageAction": "update",
     "groupName": "deps",
     "ignoreDeps": [
+        "github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace",
         "go.opentelemetry.io/contrib/detectors/gcp",
         "go.opentelemetry.io/otel",
         "go.opentelemetry.io/otel/metric",


### PR DESCRIPTION
* go.opentelemetry.io/otel 1.25.0 and submodules no longer support Go 1.20