### PR TITLE
chore(internal/godocfx): set stem for vertexai

### DIFF
--- a/internal/godocfx/main.go
+++ b/internal/godocfx/main.go
@@ -290,5 +290,7 @@ language: "go"
 		fmt.Fprintf(w, "stem: \"/appengine/docs/legacy/standard/go111/reference\"\n")
 	case "google.golang.org/appengine/v2":
 		fmt.Fprintf(w, "stem: \"/appengine/docs/standard/go/reference/services/bundled\"\n")
+	case "cloud.google.com/go/vertexai":
+		fmt.Fprintf(w, "stem: \"/vertex-ai/generative-ai/docs/reference/go\"\n")
 	}
 }


### PR DESCRIPTION
The cloud.google.com/go/vertexai module should be published under a different path.