### PR TITLE
fix(auth): handle non-Transport DefaultTransport

### DIFF
--- a/auth/httptransport/httptransport.go
+++ b/auth/httptransport/httptransport.go
@@ -152,7 +152,14 @@ func AddAuthorizationMiddleware(client *http.Client, creds *auth.Credentials) er
 	}
 	base := client.Transport
 	if base == nil {
-		base = http.DefaultTransport.(*http.Transport).Clone()
+		if dt, ok := http.DefaultTransport.(*http.Transport); ok {
+			base = dt.Clone()
+		} else {
+			// Directly reuse the DefaultTransport if the application has
+			// replaced it with an implementation of RoundTripper other than
+			// http.Transport.
+			base = http.DefaultTransport
+		}
 	}
 	client.Transport = &authTransport{
 		creds: creds,

--- a/auth/httptransport/httptransport_test.go
+++ b/auth/httptransport/httptransport_test.go
@@ -87,6 +87,28 @@ func TestAddAuthorizationMiddleware(t *testing.T) {
 	}
 }
 
+func TestAddAuthorizationMiddleware_HandlesNonTransportAsDefaultTransport(t *testing.T) {
+	client := &http.Client{}
+	creds := auth.NewCredentials(&auth.CredentialsOptions{
+		TokenProvider: staticTP("fakeToken"),
+	})
+	dt := http.DefaultTransport
+
+	http.DefaultTransport = &rt{}
+	defer func() { http.DefaultTransport = dt }()
+
+	err := AddAuthorizationMiddleware(client, creds)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	at := client.Transport.(*authTransport)
+	_, ok := at.base.(*rt)
+	if !ok {
+		t.Errorf("got %T, want %T", at.base, &rt{})
+	}
+}
+
 func TestNewClient_FailsValidation(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
Since `http.DefaultTransport` is a `RoundTripper` interface and mutable global variable, it is not safe to assume it is always going to concretely be `*http.Transport`. If it is not, I suppose we should just use the value directly instead of making a `Clone`. The `http.DefaultTransport` being overridden is pretty intentional by application authors, so it is best if we respect that and just reuse it direct.

Fixes #10159