### PR TITLE
test: fix presubmit script to handle dirs

### DIFF
--- a/internal/kokoro/presubmit.sh
+++ b/internal/kokoro/presubmit.sh
@@ -87,7 +87,7 @@ fi
 
 # CHANGED_DIRS is the list of significant top-level directories that changed,
 # but weren't deleted by the current PR. CHANGED_DIRS will be empty when run on main.
-CHANGED_DIRS=$(echo "$SIGNIFICANT_CHANGES" | tr ' ' '\n' | grep "/" | cut -d/ -f1 | sort -u |
+CHANGED_DIRS=$(echo "$SIGNIFICANT_CHANGES" | tr ' ' '\n' | cut -d/ -f1 | sort -u |
   tr '\n' ' ' | xargs ls -d 2>/dev/null || true)
 
 echo "Running tests only in changed submodules: $CHANGED_DIRS"


### PR DESCRIPTION
It seems #10064 changed the semantics from files to dirs for significant changes. This caused `CHANGED_DIRS` to fail when the grep test was done as sometimes there is no slash now. This piping was not actually needed though and the cut should work even if the character is not there.

This failure to grep caused presubmits to run for whole repo sometimes when changes were only made in one sub-module.