### PR TITLE
chore(spanner): fix executor

### DIFF
--- a/spanner/test/cloudexecutor/executor/internal/inputstream/handler.go
+++ b/spanner/test/cloudexecutor/executor/internal/inputstream/handler.go
@@ -239,7 +239,7 @@ func (h *CloudStreamHandler) newActionHandler(action *executorpb.SpannerAction, 
 			OutcomeSender: outcomeSender,
 		}, nil
 	default:
-		return nil, outcomeSender.FinishWithError(status.Error(codes.Unimplemented, fmt.Sprintf("not implemented yet %T", action.GetAction())))
+		return nil, status.Error(codes.Unimplemented, fmt.Sprintf("not implemented yet %T", action.GetAction()))
 	}
 }
 


### PR DESCRIPTION
The method `newActionHandler` returns action handlers as per input action. But in case of `unimplemented` actions, it sends the error directly to outcome sender due to which the main program running it does not get this error and proceeds further leading to `nil` pointer exceptions.

Example stack trace:
```
2024-05-21 13:10:55.338176-070014   2024/05/21 13:10:55 ExecuteActionAsync RPC called. Start handling input stream
 2024-05-21 13:10:55.338594-070014   2024/05/21 13:10:55 start handling request action:{database_path:"projects/spanner-cloud-systest/instances/cloud-systest0/databases/read_write_test" execute_change_stream_query:{name:"TestCS2" start_time:{seconds:1716322099 nanos:620329000} heartbeat_milliseconds:1000}}
 2024-05-21 13:10:55.338673-070014   2024/05/21 13:10:55 rpc error: code = Unimplemented desc = not implemented yet *executorpb.SpannerAction_ExecuteChangeStreamQuery
 2024-05-21 13:10:55.338874-070014   2024/05/21 13:10:55 sending result status:{code:12 message:"rpc error: code = Unimplemented desc = not implemented yet *executorpb.SpannerAction_ExecuteChangeStreamQuery"} actionId 0
 2024-05-21 13:10:55.339118-070014   2024/05/21 13:10:55 Sent result status:{code:12 message:"rpc error: code = Unimplemented desc = not implemented yet *executorpb.SpannerAction_ExecuteChangeStreamQuery"} actionId 0
 2024-05-21 13:10:55.342982-070014   panic: runtime error: invalid memory address or nil pointer dereference
 2024-05-21 13:10:55.343719-070014   [signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0xe27d6a]
 2024-05-21 13:10:55.343751-070014   
 2024-05-21 13:10:55.343989-070014   goroutine 276 [running]:
 2024-05-21 13:10:55.344220-070014   cloud.google.com/go/spanner/test/cloudexecutor/executor/internal/inputstream.(*CloudStreamHandler).startHandlingRequest.func1()
 2024-05-21 13:10:55.344327-070014   	/usr/local/google/home/sriharshach/github/Directed Reads/google-cloud-go-sep16/spanner/test/cloudexecutor/executor/internal/inputstream/handler.go:119 +0x2a
 2024-05-21 13:10:55.344415-070014   created by [cloud.google.com/go/spanner/test/cloudexecutor/executor/internal/inputstream.(*CloudStreamHandler).startHandlingRequest](http://cloud.google.com/go/spanner/test/cloudexecutor/executor/internal/inputstream.(*CloudStreamHandler).startHandlingRequest) in goroutine 275
 2024-05-21 13:10:55.344701-070014   	/usr/local/google/home/sriharshach/github/Directed Reads/google-cloud-go-sep16/spanner/test/cloudexecutor/executor/internal/inputstream/handler.go:118 +0x347
```

Fixes b/341988517