### PR TITLE
chore(storage): fix go vet issue

### DIFF
--- a/storage/go.mod
+++ b/storage/go.mod
@@ -9,7 +9,6 @@ require (
 	cloud.google.com/go/compute/metadata v0.3.0
 	cloud.google.com/go/iam v1.1.8
 	cloud.google.com/go/longrunning v0.5.7
-	github.com/golang/protobuf v1.5.4
 	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.6.0
 	github.com/googleapis/gax-go/v2 v2.12.4
@@ -29,6 +28,7 @@ require (
 	github.com/go-logr/logr v1.4.1 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
+	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/martian/v3 v3.3.3 // indirect
 	github.com/google/s2a-go v0.1.7 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.2 // indirect


### PR DESCRIPTION
This PR fixes go vet issue in mainline caused by https://github.com/googleapis/google-cloud-go/pull/10257.
Failure: https://github.com/googleapis/google-cloud-go/actions/runs/9218291661/job/25361579548?pr=10253