### PR TITLE
chore(internal/protoveneer): support time

### DIFF
--- a/internal/protoveneer/cmd/protoveneer/testdata/basic/basic.pb.go
+++ b/internal/protoveneer/cmd/protoveneer/testdata/basic/basic.pb.go
@@ -19,6 +19,7 @@ import (
 	date "google.golang.org/genproto/googleapis/type/date"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	"google.golang.org/protobuf/types/known/structpb"
+	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 )
 
 const (
@@ -120,4 +121,5 @@ type Citation struct {
 	// Output only. Publication date of the attribution.
 	PublicationDate *date.Date `protobuf:"bytes,6,opt,name=publication_date,json=publicationDate,proto3" json:"publication_date,omitempty"`
 	Struct          *structpb.Struct
+	CreateTime      *timestamppb.Timestamp
 }

--- a/internal/protoveneer/cmd/protoveneer/testdata/basic/golden
+++ b/internal/protoveneer/cmd/protoveneer/testdata/basic/golden
@@ -8,6 +8,8 @@ import (
 	"cloud.google.com/go/civil"
 	pb "example.com/basic"
 	"example.com/protoveneer/support"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"time"
 )
 
 // Blob contains raw media bytes.
@@ -47,6 +49,7 @@ type Citation struct {
 	// Output only. Publication date of the attribution.
 	PublicationDate civil.Date
 	Struct          map[string]any
+	CreateTime      time.Time
 }
 
 func (v *Citation) toProto() *pb.Citation {
@@ -57,6 +60,7 @@ func (v *Citation) toProto() *pb.Citation {
 		Uri:             v.URI,
 		PublicationDate: support.CivilDateToProto(v.PublicationDate),
 		Struct:          support.MapToStructPB(v.Struct),
+		CreateTime:      timestamppb.New(v.CreateTime),
 	}
 }
 
@@ -68,6 +72,7 @@ func (Citation) fromProto(p *pb.Citation) *Citation {
 		URI:             p.Uri,
 		PublicationDate: support.CivilDateFromProto(p.PublicationDate),
 		Struct:          support.MapFromStructPB(p.Struct),
+		CreateTime:      support.TimeFromProto(p.CreateTime),
 	}
 }
 

--- a/internal/protoveneer/support/support.go
+++ b/internal/protoveneer/support/support.go
@@ -22,6 +22,7 @@ import (
 	"cloud.google.com/go/civil"
 	"google.golang.org/genproto/googleapis/type/date"
 	"google.golang.org/protobuf/types/known/structpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // TransformSlice applies f to each element of from and returns
@@ -109,4 +110,12 @@ func MapFromStructPB(p *structpb.Struct) map[string]any {
 		return nil
 	}
 	return p.AsMap()
+}
+
+// TimeFromProto converts a Timestamp into a time.Time.
+func TimeFromProto(ts *timestamppb.Timestamp) time.Time {
+	if ts == nil {
+		return time.Time{}
+	}
+	return ts.AsTime()
 }


### PR DESCRIPTION
Protos represent time using the timestamppb.Timestamp type.
Support converting that to and from a time.Time.
