### PR TITLE
feat(aiplatform/apiv1beta1): add methods to info.go

### DIFF
--- a/aiplatform/apiv1beta1/info.go
+++ b/aiplatform/apiv1beta1/info.go
@@ -18,7 +18,7 @@
 //
 // Internal use only.
 
-package generativelanguage
+package aiplatform
 
 func (c *DatasetClient) SetGoogleClientInfo(keyval ...string) {
 	c.setGoogleClientInfo(keyval...)

--- a/aiplatform/apiv1beta1/info.go
+++ b/aiplatform/apiv1beta1/info.go
@@ -18,8 +18,144 @@
 //
 // Internal use only.
 
-package aiplatform
+package generativelanguage
+
+func (c *DatasetClient) SetGoogleClientInfo(keyval ...string) {
+	c.setGoogleClientInfo(keyval...)
+}
+
+func (c *DeploymentResourcePoolClient) SetGoogleClientInfo(keyval ...string) {
+	c.setGoogleClientInfo(keyval...)
+}
+
+func (c *EndpointClient) SetGoogleClientInfo(keyval ...string) {
+	c.setGoogleClientInfo(keyval...)
+}
+
+func (c *EvaluationClient) SetGoogleClientInfo(keyval ...string) {
+	c.setGoogleClientInfo(keyval...)
+}
+
+func (c *ExtensionExecutionClient) SetGoogleClientInfo(keyval ...string) {
+	c.setGoogleClientInfo(keyval...)
+}
+
+func (c *ExtensionRegistryClient) SetGoogleClientInfo(keyval ...string) {
+	c.setGoogleClientInfo(keyval...)
+}
+
+func (c *FeatureOnlineStoreAdminClient) SetGoogleClientInfo(keyval ...string) {
+	c.setGoogleClientInfo(keyval...)
+}
+
+func (c *FeatureOnlineStoreClient) SetGoogleClientInfo(keyval ...string) {
+	c.setGoogleClientInfo(keyval...)
+}
+
+func (c *FeatureRegistryClient) SetGoogleClientInfo(keyval ...string) {
+	c.setGoogleClientInfo(keyval...)
+}
+
+func (c *FeaturestoreClient) SetGoogleClientInfo(keyval ...string) {
+	c.setGoogleClientInfo(keyval...)
+}
+
+func (c *FeaturestoreOnlineServingClient) SetGoogleClientInfo(keyval ...string) {
+	c.setGoogleClientInfo(keyval...)
+}
+
+func (c *GenAiCacheClient) SetGoogleClientInfo(keyval ...string) {
+	c.setGoogleClientInfo(keyval...)
+}
+
+func (c *GenAiTuningClient) SetGoogleClientInfo(keyval ...string) {
+	c.setGoogleClientInfo(keyval...)
+}
+
+func (c *IndexClient) SetGoogleClientInfo(keyval ...string) {
+	c.setGoogleClientInfo(keyval...)
+}
+
+func (c *IndexEndpointClient) SetGoogleClientInfo(keyval ...string) {
+	c.setGoogleClientInfo(keyval...)
+}
+
+func (c *JobClient) SetGoogleClientInfo(keyval ...string) {
+	c.setGoogleClientInfo(keyval...)
+}
+
+func (c *LlmUtilityClient) SetGoogleClientInfo(keyval ...string) {
+	c.setGoogleClientInfo(keyval...)
+}
+
+func (c *MatchClient) SetGoogleClientInfo(keyval ...string) {
+	c.setGoogleClientInfo(keyval...)
+}
+
+func (c *MetadataClient) SetGoogleClientInfo(keyval ...string) {
+	c.setGoogleClientInfo(keyval...)
+}
+
+func (c *MigrationClient) SetGoogleClientInfo(keyval ...string) {
+	c.setGoogleClientInfo(keyval...)
+}
+
+func (c *ModelClient) SetGoogleClientInfo(keyval ...string) {
+	c.setGoogleClientInfo(keyval...)
+}
+
+func (c *ModelGardenClient) SetGoogleClientInfo(keyval ...string) {
+	c.setGoogleClientInfo(keyval...)
+}
+
+func (c *ModelMonitoringClient) SetGoogleClientInfo(keyval ...string) {
+	c.setGoogleClientInfo(keyval...)
+}
+
+func (c *NotebookClient) SetGoogleClientInfo(keyval ...string) {
+	c.setGoogleClientInfo(keyval...)
+}
+
+func (c *PersistentResourceClient) SetGoogleClientInfo(keyval ...string) {
+	c.setGoogleClientInfo(keyval...)
+}
+
+func (c *PipelineClient) SetGoogleClientInfo(keyval ...string) {
+	c.setGoogleClientInfo(keyval...)
+}
 
 func (c *PredictionClient) SetGoogleClientInfo(keyval ...string) {
+	c.setGoogleClientInfo(keyval...)
+}
+
+func (c *ReasoningEngineClient) SetGoogleClientInfo(keyval ...string) {
+	c.setGoogleClientInfo(keyval...)
+}
+
+func (c *ReasoningEngineExecutionClient) SetGoogleClientInfo(keyval ...string) {
+	c.setGoogleClientInfo(keyval...)
+}
+
+func (c *ScheduleClient) SetGoogleClientInfo(keyval ...string) {
+	c.setGoogleClientInfo(keyval...)
+}
+
+func (c *SpecialistPoolClient) SetGoogleClientInfo(keyval ...string) {
+	c.setGoogleClientInfo(keyval...)
+}
+
+func (c *TensorboardClient) SetGoogleClientInfo(keyval ...string) {
+	c.setGoogleClientInfo(keyval...)
+}
+
+func (c *VertexRagClient) SetGoogleClientInfo(keyval ...string) {
+	c.setGoogleClientInfo(keyval...)
+}
+
+func (c *VertexRagDataClient) SetGoogleClientInfo(keyval ...string) {
+	c.setGoogleClientInfo(keyval...)
+}
+
+func (c *VizierClient) SetGoogleClientInfo(keyval ...string) {
 	c.setGoogleClientInfo(keyval...)
 }

--- a/internal/gen_info.sh
+++ b/internal/gen_info.sh
@@ -1,3 +1,14 @@
+#!/bin/sh
+
+# Script to generate info.go files with methods for all clients.
+
+# Usage: gen_info.sh DIR
+
+cd $1
+
+outfile=info.go
+
+cat <<'EOF' > $outfile
 // Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,30 +31,12 @@
 
 package generativelanguage
 
-func (c *DiscussClient) SetGoogleClientInfo(keyval ...string) {
-	c.setGoogleClientInfo(keyval...)
-}
+EOF
 
-func (c *FileClient) SetGoogleClientInfo(keyval ...string) {
-	c.setGoogleClientInfo(keyval...)
-}
+awk '/^func \(c \*[A-Z].*\) setGoogleClientInfo/ {
+  printf("func (c %s SetGoogleClientInfo(keyval ...string) {\n", $3);
+	printf("  c.setGoogleClientInfo(keyval...)\n");
+  printf("}\n\n");
+}' *_client.go >> $outfile
 
-func (c *GenerativeClient) SetGoogleClientInfo(keyval ...string) {
-	c.setGoogleClientInfo(keyval...)
-}
-
-func (c *ModelClient) SetGoogleClientInfo(keyval ...string) {
-	c.setGoogleClientInfo(keyval...)
-}
-
-func (c *PermissionClient) SetGoogleClientInfo(keyval ...string) {
-	c.setGoogleClientInfo(keyval...)
-}
-
-func (c *RetrieverClient) SetGoogleClientInfo(keyval ...string) {
-	c.setGoogleClientInfo(keyval...)
-}
-
-func (c *TextClient) SetGoogleClientInfo(keyval ...string) {
-	c.setGoogleClientInfo(keyval...)
-}
+gofmt -w $outfile

--- a/internal/gen_info.sh
+++ b/internal/gen_info.sh
@@ -2,11 +2,14 @@
 
 # Script to generate info.go files with methods for all clients.
 
-# Usage: gen_info.sh DIR
-
-cd $1
+if [[ $# != 2 ]]; then
+  echo >&2 "usage: $0 DIR PACKAGE"
+  exit 1
+fi
 
 outfile=info.go
+
+cd $1
 
 cat <<'EOF' > $outfile
 // Copyright 2023 Google LLC
@@ -29,9 +32,10 @@ cat <<'EOF' > $outfile
 //
 // Internal use only.
 
-package generativelanguage
-
 EOF
+
+echo -e >> $outfile "package $2\n"
+
 
 awk '/^func \(c \*[A-Z].*\) setGoogleClientInfo/ {
   printf("func (c %s SetGoogleClientInfo(keyval ...string) {\n", $3);


### PR DESCRIPTION
Add SetGoogleClientInfo methods for each client in the GAPIC.

Also, move the script that generates the file somewhere safe
(internal, for now). In #10272 we put it in the same directory
as the GAPIC, and an automatic process deleted it.

This means it's not really usable with `go generate`, because its
relative location varies by package, so remove that functionality.
