### PR TITLE
fix(auth): pass through client to 2LO and 3LO flows

### DIFF
--- a/auth/credentials/filetypes.go
+++ b/auth/credentials/filetypes.go
@@ -137,6 +137,7 @@ func handleServiceAccount(f *credsfile.ServiceAccountFile, opts *DetectOptions) 
 		Scopes:       opts.scopes(),
 		TokenURL:     f.TokenURL,
 		Subject:      opts.Subject,
+		Client:       opts.client(),
 	}
 	if opts2LO.TokenURL == "" {
 		opts2LO.TokenURL = jwtTokenURL
@@ -154,6 +155,7 @@ func handleUserCredential(f *credsfile.UserCredentialsFile, opts *DetectOptions)
 		AuthStyle:        auth.StyleInParams,
 		EarlyTokenExpiry: opts.EarlyTokenRefresh,
 		RefreshToken:     f.RefreshToken,
+		Client:           opts.client(),
 	}
 	return auth.New3LOTokenProvider(opts3LO)
 }


### PR DESCRIPTION
This is especially important for mtls where clients need to be overridden to include certs 