### PR TITLE
chore(storage): remove usage of setClientHeader where possible

### DIFF
--- a/storage/acl.go
+++ b/storage/acl.go
@@ -16,8 +16,6 @@ package storage
 
 import (
 	"context"
-	"net/http"
-	"reflect"
 
 	"cloud.google.com/go/internal/trace"
 	"cloud.google.com/go/storage/internal/apiv2/storagepb"
@@ -160,15 +158,6 @@ func (a *ACLHandle) objectSet(ctx context.Context, entity ACLEntity, role ACLRol
 func (a *ACLHandle) objectDelete(ctx context.Context, entity ACLEntity) error {
 	opts := makeStorageOpts(false, a.retry, a.userProject)
 	return a.c.tc.DeleteObjectACL(ctx, a.bucket, a.object, entity, opts...)
-}
-
-func (a *ACLHandle) configureCall(ctx context.Context, call interface{ Header() http.Header }) {
-	vc := reflect.ValueOf(call)
-	vc.MethodByName("Context").Call([]reflect.Value{reflect.ValueOf(ctx)})
-	if a.userProject != "" {
-		vc.MethodByName("UserProject").Call([]reflect.Value{reflect.ValueOf(a.userProject)})
-	}
-	setClientHeader(call.Header())
 }
 
 func toObjectACLRules(items []*raw.ObjectAccessControl) []ACLRule {

--- a/storage/hmac.go
+++ b/storage/hmac.go
@@ -272,7 +272,6 @@ func (it *HMACKeysIterator) fetch(pageSize int, pageToken string) (token string,
 	// TODO: Remove fetch method upon integration. This method is internalized into
 	// httpStorageClient.ListHMACKeys() as it is the only caller.
 	call := it.raw.List(it.projectID)
-	setClientHeader(call.Header())
 	if pageToken != "" {
 		call = call.PageToken(pageToken)
 	}

--- a/storage/http_client.go
+++ b/storage/http_client.go
@@ -176,7 +176,6 @@ func (c *httpStorageClient) CreateBucket(ctx context.Context, project, bucket st
 		bkt.Location = "US"
 	}
 	req := c.raw.Buckets.Insert(project, bkt)
-	setClientHeader(req.Header())
 	if attrs != nil && attrs.PredefinedACL != "" {
 		req.PredefinedAcl(attrs.PredefinedACL)
 	}
@@ -207,7 +206,6 @@ func (c *httpStorageClient) ListBuckets(ctx context.Context, project string, opt
 
 	fetch := func(pageSize int, pageToken string) (token string, err error) {
 		req := c.raw.Buckets.List(it.projectID)
-		setClientHeader(req.Header())
 		req.Projection("full")
 		req.Prefix(it.Prefix)
 		req.PageToken(pageToken)
@@ -245,7 +243,6 @@ func (c *httpStorageClient) ListBuckets(ctx context.Context, project string, opt
 func (c *httpStorageClient) DeleteBucket(ctx context.Context, bucket string, conds *BucketConditions, opts ...storageOption) error {
 	s := callSettings(c.settings, opts...)
 	req := c.raw.Buckets.Delete(bucket)
-	setClientHeader(req.Header())
 	if err := applyBucketConds("httpStorageClient.DeleteBucket", conds, req); err != nil {
 		return err
 	}
@@ -259,7 +256,6 @@ func (c *httpStorageClient) DeleteBucket(ctx context.Context, bucket string, con
 func (c *httpStorageClient) GetBucket(ctx context.Context, bucket string, conds *BucketConditions, opts ...storageOption) (*BucketAttrs, error) {
 	s := callSettings(c.settings, opts...)
 	req := c.raw.Buckets.Get(bucket).Projection("full")
-	setClientHeader(req.Header())
 	err := applyBucketConds("httpStorageClient.GetBucket", conds, req)
 	if err != nil {
 		return nil, err
@@ -287,7 +283,6 @@ func (c *httpStorageClient) UpdateBucket(ctx context.Context, bucket string, uat
 	s := callSettings(c.settings, opts...)
 	rb := uattrs.toRawBucket()
 	req := c.raw.Buckets.Patch(bucket, rb).Projection("full")
-	setClientHeader(req.Header())
 	err := applyBucketConds("httpStorageClient.UpdateBucket", conds, req)
 	if err != nil {
 		return nil, err
@@ -340,7 +335,6 @@ func (c *httpStorageClient) ListObjects(ctx context.Context, bucket string, q *Q
 		if it.query.SoftDeleted {
 			req.SoftDeleted(it.query.SoftDeleted)
 		}
-		setClientHeader(req.Header())
 		projection := it.query.Projection
 		if projection == ProjectionDefault {
 			projection = ProjectionFull
@@ -666,7 +660,7 @@ func (c *httpStorageClient) UpdateBucketACL(ctx context.Context, bucket string, 
 	}, s.retry, s.idempotent)
 }
 
-// configureACLCall sets the context, user project and headers on the apiary library call.
+// configureACLCall sets the context and user project on the apiary library call.
 // This will panic if the call does not have the correct methods.
 func configureACLCall(ctx context.Context, userProject string, call interface{ Header() http.Header }) {
 	vc := reflect.ValueOf(call)
@@ -674,7 +668,6 @@ func configureACLCall(ctx context.Context, userProject string, call interface{ H
 	if userProject != "" {
 		vc.MethodByName("UserProject").Call([]reflect.Value{reflect.ValueOf(userProject)})
 	}
-	setClientHeader(call.Header())
 }
 
 // Object ACL methods.
@@ -760,7 +753,6 @@ func (c *httpStorageClient) ComposeObject(ctx context.Context, req *composeObjec
 		return nil, err
 	}
 	var obj *raw.Object
-	setClientHeader(call.Header())
 
 	var err error
 	retryCall := func(ctx context.Context) error { obj, err = call.Context(ctx).Do(); return err }
@@ -809,7 +801,6 @@ func (c *httpStorageClient) RewriteObject(ctx context.Context, req *rewriteObjec
 
 	var res *raw.RewriteResponse
 	var err error
-	setClientHeader(call.Header())
 
 	retryCall := func(ctx context.Context) error { res, err = call.Context(ctx).Do(); return err }
 
@@ -1004,7 +995,6 @@ func (c *httpStorageClient) OpenWriter(params *openWriterParams, opts ...storage
 func (c *httpStorageClient) GetIamPolicy(ctx context.Context, resource string, version int32, opts ...storageOption) (*iampb.Policy, error) {
 	s := callSettings(c.settings, opts...)
 	call := c.raw.Buckets.GetIamPolicy(resource).OptionsRequestedPolicyVersion(int64(version))
-	setClientHeader(call.Header())
 	if s.userProject != "" {
 		call.UserProject(s.userProject)
 	}
@@ -1025,7 +1015,6 @@ func (c *httpStorageClient) SetIamPolicy(ctx context.Context, resource string, p
 
 	rp := iamToStoragePolicy(policy)
 	call := c.raw.Buckets.SetIamPolicy(resource, rp)
-	setClientHeader(call.Header())
 	if s.userProject != "" {
 		call.UserProject(s.userProject)
 	}
@@ -1039,7 +1028,6 @@ func (c *httpStorageClient) SetIamPolicy(ctx context.Context, resource string, p
 func (c *httpStorageClient) TestIamPermissions(ctx context.Context, resource string, permissions []string, opts ...storageOption) ([]string, error) {
 	s := callSettings(c.settings, opts...)
 	call := c.raw.Buckets.TestIamPermissions(resource, permissions)
-	setClientHeader(call.Header())
 	if s.userProject != "" {
 		call.UserProject(s.userProject)
 	}
@@ -1088,7 +1076,6 @@ func (c *httpStorageClient) ListHMACKeys(ctx context.Context, project, serviceAc
 	}
 	fetch := func(pageSize int, pageToken string) (token string, err error) {
 		call := c.raw.Projects.HmacKeys.List(project)
-		setClientHeader(call.Header())
 		if pageToken != "" {
 			call = call.PageToken(pageToken)
 		}


### PR DESCRIPTION
- Also removes an unused `configureCall` method that has been superseded by `configureACLCall`
- `setClientHeader` remains in usage for uploads