### PR TITLE
feat(vertexai): explicit caching

### DIFF
--- a/vertexai/genai/aiplatformpb_veneer.gen.go
+++ b/vertexai/genai/aiplatformpb_veneer.gen.go
@@ -22,6 +22,8 @@ import (
 	pb "cloud.google.com/go/aiplatform/apiv1beta1/aiplatformpb"
 	"cloud.google.com/go/civil"
 	"cloud.google.com/go/vertexai/internal/support"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"time"
 )
 
 // Blob contains binary data like images. Use [Text] for text.
@@ -82,6 +84,78 @@ func (v BlockedReason) String() string {
 		return n
 	}
 	return fmt.Sprintf("BlockedReason(%d)", v)
+}
+
+// CachedContent is a resource used in LLM queries for users to explicitly specify what to cache
+// and how to cache.
+type CachedContent struct {
+	// Expiration time of the cached content.
+	//
+	// Types that are assignable to Expiration:
+	//
+	//	*CachedContent_ExpireTime
+	//	*CachedContent_Ttl
+	Expiration ExpireTimeOrTTL
+	// Immutable. Identifier. The resource name of the cached content
+	// Format:
+	// projects/{project}/locations/{location}/cachedContents/{cached_content}
+	Name string
+	// Immutable. The name of the publisher model to use for cached content.
+	// Format:
+	// projects/{project}/locations/{location}/publishers/{publisher}/models/{model}
+	Model string
+	// Optional. Input only. Immutable. Developer set system instruction.
+	// Currently, text only
+	SystemInstruction *Content
+	// Optional. Input only. Immutable. The content to cache
+	Contents []*Content
+	// Optional. Input only. Immutable. A list of `Tools` the model may use to
+	// generate the next response
+	Tools []*Tool
+	// Optional. Input only. Immutable. Tool config. This config is shared for all
+	// tools
+	ToolConfig *ToolConfig
+	// Output only. Creatation time of the cache entry.
+	CreateTime time.Time
+	// Output only. When the cache entry was last updated in UTC time.
+	UpdateTime time.Time
+	client     *Client
+}
+
+func (v *CachedContent) toProto() *pb.CachedContent {
+	if v == nil {
+		return nil
+	}
+	p := &pb.CachedContent{
+		Name:              v.Name,
+		Model:             v.Model,
+		SystemInstruction: v.SystemInstruction.toProto(),
+		Contents:          support.TransformSlice(v.Contents, (*Content).toProto),
+		Tools:             support.TransformSlice(v.Tools, (*Tool).toProto),
+		ToolConfig:        v.ToolConfig.toProto(),
+		CreateTime:        timestamppb.New(v.CreateTime),
+		UpdateTime:        timestamppb.New(v.UpdateTime),
+	}
+	populateCachedContentTo(p, v)
+	return p
+}
+
+func (CachedContent) fromProto(p *pb.CachedContent) *CachedContent {
+	if p == nil {
+		return nil
+	}
+	v := &CachedContent{
+		Name:              p.Name,
+		Model:             p.Model,
+		SystemInstruction: (Content{}).fromProto(p.SystemInstruction),
+		Contents:          support.TransformSlice(p.Contents, (Content{}).fromProto),
+		Tools:             support.TransformSlice(p.Tools, (Tool{}).fromProto),
+		ToolConfig:        (ToolConfig{}).fromProto(p.ToolConfig),
+		CreateTime:        support.TimeFromProto(p.CreateTime),
+		UpdateTime:        support.TimeFromProto(p.UpdateTime),
+	}
+	populateCachedContentFrom(v, p)
+	return v
 }
 
 // Candidate is a response candidate generated from the model.
@@ -592,6 +666,14 @@ type GenerationConfig struct {
 	// otherwise the behavior is undefined.
 	// This is a preview feature.
 	ResponseMIMEType string
+	// Optional. The `Schema` object allows the definition of input and output
+	// data types. These types can be objects, but also primitives and arrays.
+	// Represents a select subset of an [OpenAPI 3.0 schema
+	// object](https://spec.openapis.org/oas/v3.0.3#schema).
+	// If set, a compatible response_mime_type must also be set.
+	// Compatible mimetypes:
+	// `application/json`: Schema for JSON response.
+	ResponseSchema *Schema
 }
 
 func (v *GenerationConfig) toProto() *pb.GenerationConfig {
@@ -608,6 +690,7 @@ func (v *GenerationConfig) toProto() *pb.GenerationConfig {
 		PresencePenalty:  v.PresencePenalty,
 		FrequencyPenalty: v.FrequencyPenalty,
 		ResponseMimeType: v.ResponseMIMEType,
+		ResponseSchema:   v.ResponseSchema.toProto(),
 	}
 }
 
@@ -625,6 +708,7 @@ func (GenerationConfig) fromProto(p *pb.GenerationConfig) *GenerationConfig {
 		PresencePenalty:  p.PresencePenalty,
 		FrequencyPenalty: p.FrequencyPenalty,
 		ResponseMIMEType: p.ResponseMimeType,
+		ResponseSchema:   (Schema{}).fromProto(p.ResponseSchema),
 	}
 }
 

--- a/vertexai/genai/aiplatformpb_veneer.gen.go
+++ b/vertexai/genai/aiplatformpb_veneer.gen.go
@@ -23,7 +23,6 @@ import (
 	pb "cloud.google.com/go/aiplatform/apiv1beta1/aiplatformpb"
 	"cloud.google.com/go/civil"
 	"cloud.google.com/go/vertexai/internal/support"
-	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // Blob contains binary data like images. Use [Text] for text.
@@ -132,8 +131,8 @@ func (v *CachedContent) toProto() *pb.CachedContent {
 		Contents:          support.TransformSlice(v.Contents, (*Content).toProto),
 		Tools:             support.TransformSlice(v.Tools, (*Tool).toProto),
 		ToolConfig:        v.ToolConfig.toProto(),
-		CreateTime:        timestamppb.New(v.CreateTime),
-		UpdateTime:        timestamppb.New(v.UpdateTime),
+		CreateTime:        support.TimeToProto(v.CreateTime),
+		UpdateTime:        support.TimeToProto(v.UpdateTime),
 	}
 	populateCachedContentTo(p, v)
 	return p

--- a/vertexai/genai/aiplatformpb_veneer.gen.go
+++ b/vertexai/genai/aiplatformpb_veneer.gen.go
@@ -18,12 +18,12 @@ package genai
 
 import (
 	"fmt"
+	"time"
 
 	pb "cloud.google.com/go/aiplatform/apiv1beta1/aiplatformpb"
 	"cloud.google.com/go/civil"
 	"cloud.google.com/go/vertexai/internal/support"
 	"google.golang.org/protobuf/types/known/timestamppb"
-	"time"
 )
 
 // Blob contains binary data like images. Use [Text] for text.
@@ -119,7 +119,6 @@ type CachedContent struct {
 	CreateTime time.Time
 	// Output only. When the cache entry was last updated in UTC time.
 	UpdateTime time.Time
-	client     *Client
 }
 
 func (v *CachedContent) toProto() *pb.CachedContent {

--- a/vertexai/genai/caching.go
+++ b/vertexai/genai/caching.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vertexai/genai/caching.go
+++ b/vertexai/genai/caching.go
@@ -1,0 +1,166 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package genai
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	aiplatform "cloud.google.com/go/aiplatform/apiv1beta1"
+	pb "cloud.google.com/go/aiplatform/apiv1beta1/aiplatformpb"
+	"cloud.google.com/go/vertexai/internal/support"
+	"google.golang.org/api/iterator"
+	durationpb "google.golang.org/protobuf/types/known/durationpb"
+	fieldmaskpb "google.golang.org/protobuf/types/known/fieldmaskpb"
+	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
+)
+
+type cacheClient = aiplatform.GenAiCacheClient
+
+var (
+	newCacheClient     = aiplatform.NewGenAiCacheClient
+	newCacheRESTClient = aiplatform.NewGenAiCacheRESTClient
+)
+
+// GenerativeModelFromCachedContent returns a [GenerativeModel] that uses the given [CachedContent].
+// The argument should come from a call to [Client.CreateCachedContent] or [Client.GetCachedContent].
+func (c *Client) GenerativeModelFromCachedContent(cc *CachedContent) *GenerativeModel {
+	return &GenerativeModel{
+		c:                 c,
+		name:              cc.Model,
+		fullName:          inferFullModelName(c.projectID, c.location, cc.Model),
+		CachedContentName: cc.Name,
+	}
+}
+
+// CreateCachedContent creates a new CachedContent.
+// You can use the return value to create a model with [CachedContent.GenerativeModel].
+func (c *Client) CreateCachedContent(ctx context.Context, cc *CachedContent) (*CachedContent, error) {
+	return c.cachedContentFromProto(c.cc.CreateCachedContent(ctx, &pb.CreateCachedContentRequest{
+		Parent:        c.parent(),
+		CachedContent: cc.toProto(),
+	}))
+}
+
+// GetCachedContent retrieves the CachedContent with the given name.
+func (c *Client) GetCachedContent(ctx context.Context, name string) (*CachedContent, error) {
+	return c.cachedContentFromProto(c.cc.GetCachedContent(ctx, &pb.GetCachedContentRequest{Name: name}))
+}
+
+// DeleteCachedContent deletes the CachedContent with the given name.
+func (c *Client) DeleteCachedContent(ctx context.Context, name string) error {
+	return c.cc.DeleteCachedContent(ctx, &pb.DeleteCachedContentRequest{Name: name})
+}
+
+// CachedContentToUpdate specifies which fields of a CachedContent to modify in a call to
+// [Client.UpdateCachedContent].
+type CachedContentToUpdate struct {
+	// If non-nil, update the expire time or TTL.
+	Expiration *ExpireTimeOrTTL
+}
+
+// UpdateCachedContent modifies the [CachedContent] with the given name according to the values
+// of the [CachedContentToUpdate] struct.
+// It returns the modified CachedContent.
+func (c *Client) UpdateCachedContent(ctx context.Context, name string, ccu *CachedContentToUpdate) (*CachedContent, error) {
+	if ccu == nil || ccu.Expiration == nil {
+		return nil, errors.New("cloud.google.com/go/vertexai/genai: no update specified")
+	}
+	cc := &CachedContent{
+		Name:       name,
+		Expiration: *ccu.Expiration,
+	}
+	return c.cachedContentFromProto(c.cc.UpdateCachedContent(ctx, &pb.UpdateCachedContentRequest{
+		CachedContent: cc.toProto(),
+		UpdateMask:    &fieldmaskpb.FieldMask{Paths: []string{"expiration"}},
+	}))
+}
+
+// ListCachedContents lists all the CachedContents associated with the project and location.
+func (c *Client) ListCachedContents(ctx context.Context) *CachedContentIterator {
+	return &CachedContentIterator{
+		it: c.cc.ListCachedContents(ctx, &pb.ListCachedContentsRequest{Parent: c.parent()}),
+	}
+}
+
+// A CachedContentIterator iterates over CachedContents.
+type CachedContentIterator struct {
+	it *aiplatform.CachedContentIterator
+}
+
+// Next returns the next result. Its second return value is iterator.Done if there are no more
+// results. Once Next returns Done, all subsequent calls will return Done.
+func (it *CachedContentIterator) Next() (*CachedContent, error) {
+	m, err := it.it.Next()
+	if err != nil {
+		return nil, err
+	}
+	return (CachedContent{}).fromProto(m), nil
+}
+
+// PageInfo supports pagination. See the google.golang.org/api/iterator package for details.
+func (it *CachedContentIterator) PageInfo() *iterator.PageInfo {
+	return it.it.PageInfo()
+}
+
+func (c *Client) cachedContentFromProto(pcc *pb.CachedContent, err error) (*CachedContent, error) {
+	if err != nil {
+		return nil, err
+	}
+	cc := (CachedContent{}).fromProto(pcc)
+	cc.client = c
+	return cc, nil
+}
+
+// ExpireTimeOrTTL describes the time when a resource expires.
+// If ExpireTime is non-zero, it is the expiration time.
+// Otherwise, the expiration time is the value of TTL ("time to live") added
+// to the current time.
+type ExpireTimeOrTTL struct {
+	ExpireTime time.Time
+	TTL        time.Duration
+}
+
+// populateCachedContentTo populates some fields of p from v.
+func populateCachedContentTo(p *pb.CachedContent, v *CachedContent) {
+	exp := v.Expiration
+	if !exp.ExpireTime.IsZero() {
+		p.Expiration = &pb.CachedContent_ExpireTime{
+			ExpireTime: timestamppb.New(exp.ExpireTime),
+		}
+	} else if exp.TTL != 0 {
+		p.Expiration = &pb.CachedContent_Ttl{
+			Ttl: durationpb.New(exp.TTL),
+		}
+	}
+	// If both fields of v.Expiration are zero, leave p.Expiration unset.
+}
+
+// populateCachedContentFrom populates some fields of v from p.
+func populateCachedContentFrom(v *CachedContent, p *pb.CachedContent) {
+	if p.Expiration == nil {
+		return
+	}
+	switch e := p.Expiration.(type) {
+	case *pb.CachedContent_ExpireTime:
+		v.Expiration.ExpireTime = support.TimeFromProto(e.ExpireTime)
+	case *pb.CachedContent_Ttl:
+		v.Expiration.TTL = e.Ttl.AsDuration()
+	default:
+		panic(fmt.Sprintf("unknown type of CachedContent.Expiration: %T", p.Expiration))
+	}
+}

--- a/vertexai/genai/caching.go
+++ b/vertexai/genai/caching.go
@@ -55,7 +55,7 @@ func (c *Client) GenerativeModelFromCachedContent(cc *CachedContent) *Generative
 //
 // The return value will contain the name, which should be used to refer to the CachedContent
 // in other API calls. It will also hold various metadata like expiration and creation time.
-// The cached content will not be returned.
+// It will not contain any of the actual content provided as input.
 //
 // You can use the return value to create a model with [Client.GenerativeModelFromCachedContent].
 // Or you can set [GenerativeModel.CachedContentName] to the name of the CachedContent, in which

--- a/vertexai/genai/caching_test.go
+++ b/vertexai/genai/caching_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vertexai/genai/caching_test.go
+++ b/vertexai/genai/caching_test.go
@@ -117,7 +117,6 @@ func TestCaching(t *testing.T) {
 		}
 		cc := must(client.CreateCachedContent(ctx, argcc))
 		compare(cc, wantExpireTime)
-
 		name := cc.Name
 		cc2 := must(client.GetCachedContent(ctx, name))
 		compare(cc2, wantExpireTime)
@@ -142,12 +141,11 @@ func TestCaching(t *testing.T) {
 		compare(cc4, newExpireTime)
 
 		t.Run("update-ttl", func(t *testing.T) {
-			t.Skip("does not work")
 			// Update using TTL.
 			cc5 := must(client.UpdateCachedContent(ctx, cc4, &CachedContentToUpdate{
 				Expiration: &ExpireTimeOrTTL{TTL: ttl},
 			}))
-			compare(cc5, newExpireTime.Add(ttl))
+			compare(cc5, time.Now().Add(ttl))
 		})
 
 		if err := client.DeleteCachedContent(ctx, name); err != nil {

--- a/vertexai/genai/caching_test.go
+++ b/vertexai/genai/caching_test.go
@@ -1,0 +1,83 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package genai
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	pb "cloud.google.com/go/aiplatform/apiv1beta1/aiplatformpb"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	durationpb "google.golang.org/protobuf/types/known/durationpb"
+	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestPopulateCachedContent(t *testing.T) {
+	tm := time.Date(2030, 1, 1, 0, 0, 0, 0, time.UTC)
+	cmpOpt := cmpopts.IgnoreUnexported(
+		timestamppb.Timestamp{},
+		durationpb.Duration{},
+	)
+	for _, test := range []struct {
+		proto  *pb.CachedContent
+		veneer *CachedContent
+	}{
+		{&pb.CachedContent{}, &CachedContent{}},
+		{
+			&pb.CachedContent{Expiration: &pb.CachedContent_ExpireTime{ExpireTime: timestamppb.New(tm)}},
+			&CachedContent{Expiration: ExpireTimeOrTTL{ExpireTime: tm}},
+		},
+		{
+			&pb.CachedContent{Expiration: &pb.CachedContent_Ttl{durationpb.New(time.Hour)}},
+			&CachedContent{Expiration: ExpireTimeOrTTL{TTL: time.Hour}},
+		},
+	} {
+		var gotp pb.CachedContent
+		populateCachedContentTo(&gotp, test.veneer)
+		if g, w := gotp.Expiration, test.proto.Expiration; !cmp.Equal(g, w, cmpOpt) {
+			t.Errorf("from %v to proto: got  %v, want %v", test.veneer.Expiration, g, w)
+		}
+
+		var gotv CachedContent
+		populateCachedContentFrom(&gotv, test.proto)
+		if g, w := gotv.Expiration, test.veneer.Expiration; !cmp.Equal(g, w) {
+			t.Errorf("from %v to veneer: got  %v, want %v", test.proto.Expiration, g, w)
+		}
+	}
+}
+
+// called from client_test.go:TestLive.
+func testCaching(t *testing.T, client *Client) {
+	t.Skip("caching not yet working")
+	ctx := context.Background()
+	must := func(cc *CachedContent, err error) *CachedContent {
+		t.Helper()
+		if err != nil {
+			t.Fatal(err)
+		}
+		return cc
+	}
+
+	argcc := &CachedContent{
+		Name:              "vertex-caching-test",
+		Model:             "gemini-1.5-pro",
+		SystemInstruction: &Content{Parts: []Part{Text("si")}},
+	}
+	cc := must(client.CreateCachedContent(ctx, argcc))
+	fmt.Println(cc)
+}

--- a/vertexai/genai/chat.go
+++ b/vertexai/genai/chat.go
@@ -50,7 +50,7 @@ func (cs *ChatSession) SendMessageStream(ctx context.Context, parts ...Part) *Ge
 	req := cs.m.newGenerateContentRequest(cs.History...)
 	var cc int32 = 1
 	req.GenerationConfig.CandidateCount = &cc
-	streamClient, err := cs.m.c.c.StreamGenerateContent(ctx, req)
+	streamClient, err := cs.m.c.pc.StreamGenerateContent(ctx, req)
 	return &GenerateContentResponseIterator{
 		sc:  streamClient,
 		err: err,

--- a/vertexai/genai/client.go
+++ b/vertexai/genai/client.go
@@ -117,6 +117,8 @@ func inferLocation(location string) string {
 	return defaultLocation
 }
 
+// parent returns a Google Cloud reference to the project and location
+// for this client.
 func (c *Client) parent() string {
 	return fmt.Sprintf("projects/%s/locations/%s", c.projectID, c.location)
 }

--- a/vertexai/genai/client_test.go
+++ b/vertexai/genai/client_test.go
@@ -303,6 +303,7 @@ func TestLive(t *testing.T) {
 			}
 		})
 	})
+	t.Run("caching", func(t *testing.T) { testCaching(t, client) })
 }
 
 func TestLiveDefaultLocation(t *testing.T) {
@@ -358,6 +359,8 @@ func TestLiveREST(t *testing.T) {
 	}
 	got := responseString(resp)
 	checkMatch(t, got, `15.* cm|[1-9].* inches`)
+
+	t.Run("caching", func(t *testing.T) { testCaching(t, client) })
 }
 
 func TestJoinResponses(t *testing.T) {

--- a/vertexai/genai/client_test.go
+++ b/vertexai/genai/client_test.go
@@ -301,6 +301,7 @@ func TestLive(t *testing.T) {
 			}
 		})
 	})
+	t.Run("caching", func(t *testing.T) { testCaching(t, client) })
 }
 
 func TestLiveDefaultLocation(t *testing.T) {

--- a/vertexai/genai/client_test.go
+++ b/vertexai/genai/client_test.go
@@ -72,8 +72,6 @@ func TestLive(t *testing.T) {
 		}
 		got := responseString(resp)
 		checkMatch(t, got, `[1-9][0-9].* cm|[1-9].* inches`)
-		fmt.Println(got)
-
 	})
 
 	t.Run("streaming", func(t *testing.T) {

--- a/vertexai/genai/client_test.go
+++ b/vertexai/genai/client_test.go
@@ -303,7 +303,6 @@ func TestLive(t *testing.T) {
 			}
 		})
 	})
-	t.Run("caching", func(t *testing.T) { testCaching(t, client) })
 }
 
 func TestLiveDefaultLocation(t *testing.T) {
@@ -359,8 +358,6 @@ func TestLiveREST(t *testing.T) {
 	}
 	got := responseString(resp)
 	checkMatch(t, got, `15.* cm|[1-9].* inches`)
-
-	t.Run("caching", func(t *testing.T) { testCaching(t, client) })
 }
 
 func TestJoinResponses(t *testing.T) {

--- a/vertexai/genai/config.yaml
+++ b/vertexai/genai/config.yaml
@@ -139,6 +139,13 @@ types:
     FunctionDeclaration:
     SafetySetting:
 
+    CachedContent:
+      populateToFrom: populateCachedContentTo, populateCachedContentFrom
+      fields:
+        Expiration:
+          type: ExpireTimeOrTTL
+          noConvert: true
+
 # Omit everything that is not explicitly configured.
 omitTypes:
   - '*'

--- a/vertexai/genai/example_test.go
+++ b/vertexai/genai/example_test.go
@@ -36,10 +36,8 @@ const location = "some-gcp-location"
 // For custom models from different publishers, prepent the full publisher
 // prefix for the model, e.g.:
 //
-//	model = publishers/some-publisher/models/some-model-name
-const model = "some-model"
-
-const modelName = model
+//	modelName = publishers/some-publisher/models/some-model-name
+const modelName = "some-model"
 
 func ExampleGenerativeModel_GenerateContent() {
 	ctx := context.Background()
@@ -49,7 +47,7 @@ func ExampleGenerativeModel_GenerateContent() {
 	}
 	defer client.Close()
 
-	model := client.GenerativeModel(model)
+	model := client.GenerativeModel(modelName)
 	model.SetTemperature(0.9)
 	resp, err := model.GenerateContent(ctx, genai.Text("What is the average size of a swallow?"))
 	if err != nil {
@@ -94,7 +92,7 @@ func ExampleGenerativeModel_GenerateContentStream() {
 	}
 	defer client.Close()
 
-	model := client.GenerativeModel(model)
+	model := client.GenerativeModel(modelName)
 
 	iter := model.GenerateContentStream(ctx, genai.Text("Tell me a story about a lumberjack and his giant ox. Keep it very short."))
 	for {
@@ -117,7 +115,7 @@ func ExampleGenerativeModel_CountTokens() {
 	}
 	defer client.Close()
 
-	model := client.GenerativeModel(model)
+	model := client.GenerativeModel(modelName)
 
 	resp, err := model.CountTokens(ctx, genai.Text("What kind of fish is this?"))
 	if err != nil {
@@ -134,7 +132,7 @@ func ExampleChatSession() {
 		log.Fatal(err)
 	}
 	defer client.Close()
-	model := client.GenerativeModel(model)
+	model := client.GenerativeModel(modelName)
 	cs := model.StartChat()
 
 	send := func(msg string) *genai.GenerateContentResponse {

--- a/vertexai/go.mod
+++ b/vertexai/go.mod
@@ -5,6 +5,7 @@ go 1.20
 require (
 	cloud.google.com/go v0.114.0
 	cloud.google.com/go/aiplatform v1.67.0
+	github.com/google/go-cmp v0.6.0
 	google.golang.org/api v0.183.0
 	google.golang.org/genproto v0.0.0-20240528184218-531527333157
 	google.golang.org/protobuf v1.34.1

--- a/vertexai/go.mod
+++ b/vertexai/go.mod
@@ -6,8 +6,11 @@ require (
 	cloud.google.com/go v0.114.0
 	cloud.google.com/go/aiplatform v1.67.0
 	github.com/google/go-cmp v0.6.0
+	github.com/googleapis/gax-go/v2 v2.12.4
 	google.golang.org/api v0.183.0
 	google.golang.org/genproto v0.0.0-20240528184218-531527333157
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20240528184218-531527333157
+	google.golang.org/grpc v1.64.0
 	google.golang.org/protobuf v1.34.1
 )
 
@@ -24,7 +27,6 @@ require (
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/s2a-go v0.1.7 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.2 // indirect
-	github.com/googleapis/gax-go/v2 v2.12.4 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.49.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
@@ -39,6 +41,4 @@ require (
 	golang.org/x/text v0.15.0 // indirect
 	golang.org/x/time v0.5.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240521202816-d264139d666e // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20240528184218-531527333157 // indirect
-	google.golang.org/grpc v1.64.0 // indirect
 )

--- a/vertexai/go.sum
+++ b/vertexai/go.sum
@@ -54,6 +54,7 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/s2a-go v0.1.7 h1:60BLSyTrOV4/haCDW4zb1guZItoSq8foHCXrAnjBo/o=
 github.com/google/s2a-go v0.1.7/go.mod h1:50CgR4k1jNlWBu4UfS4AcfhVe1r6pdZPygJ3R8F0Qdw=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/vertexai/internal/support/support.go
+++ b/vertexai/internal/support/support.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import (
 	"cloud.google.com/go/civil"
 	"google.golang.org/genproto/googleapis/type/date"
 	"google.golang.org/protobuf/types/known/structpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // TransformSlice applies f to each element of from and returns
@@ -109,4 +110,12 @@ func MapFromStructPB(p *structpb.Struct) map[string]any {
 		return nil
 	}
 	return p.AsMap()
+}
+
+// TimeFromProto converts a Timestamp into a time.Time.
+func TimeFromProto(ts *timestamppb.Timestamp) time.Time {
+	if ts == nil {
+		return time.Time{}
+	}
+	return ts.AsTime()
 }

--- a/vertexai/internal/support/support_test.go
+++ b/vertexai/internal/support/support_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
Implement explicit caching.

- The CachedContent type.

- Methods to create, update, list and delete CachedContents.
  The update method follows the same pattern in some other cloud clients,
  where a separate type carries the fields to be updated.

- Two ways to set the CachedContent in a model:
  1. The GenerativeModel.CachedContentName field, which corresponds
     to the actual proto.
  2. The GenerativeModelFromCachedContent method, which requires
     a properly initialized CachedContent but guarantees that
     the model names of the CachedContent and GenerativeModel are
     the same.
