### PR TITLE
chore(internal/protoveneer): use nil timestamp for zero time

### DIFF
--- a/internal/protoveneer/cmd/protoveneer/protoveneer.go
+++ b/internal/protoveneer/cmd/protoveneer/protoveneer.go
@@ -889,8 +889,8 @@ var externalTypes = []*externalType{
 	{
 		qualifiedName: "time.Time",
 		replaces:      "*timestamppb.Timestamp",
-		importPaths:   []string{"time", "google.golang.org/protobuf/types/known/timestamppb"},
-		convertTo:     "timestamppb.New",
+		importPaths:   []string{"time"},
+		convertTo:     "support.TimeToProto",
 		convertFrom:   "support.TimeFromProto",
 	},
 	{

--- a/internal/protoveneer/cmd/protoveneer/testdata/basic/golden
+++ b/internal/protoveneer/cmd/protoveneer/testdata/basic/golden
@@ -11,7 +11,6 @@ import (
 	"example.com/protoveneer/support"
 	"github.com/googleapis/gax-go/v2/apierror"
 	"google.golang.org/protobuf/types/known/durationpb"
-	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // Blob contains raw media bytes.
@@ -62,7 +61,7 @@ func (v *Citation) toProto() *pb.Citation {
 		Uri:             v.URI,
 		PublicationDate: support.CivilDateToProto(v.PublicationDate),
 		Struct:          support.MapToStructPB(v.Struct),
-		CreateTime:      timestamppb.New(v.CreateTime),
+		CreateTime:      support.TimeToProto(v.CreateTime),
 	}
 }
 

--- a/internal/protoveneer/support/support.go
+++ b/internal/protoveneer/support/support.go
@@ -116,6 +116,14 @@ func MapFromStructPB(p *structpb.Struct) map[string]any {
 	return p.AsMap()
 }
 
+// TimeToProto converts a time.Time into a Timestamp.
+func TimeToProto(t time.Time) *timestamppb.Timestamp {
+	if t.IsZero() {
+		return nil
+	}
+	return timestamppb.New(t)
+}
+
 // TimeFromProto converts a Timestamp into a time.Time.
 func TimeFromProto(ts *timestamppb.Timestamp) time.Time {
 	if ts == nil {


### PR DESCRIPTION
Convert a zero time.Time to a nil timestamp proto, instead
of a non-nil proto representing the zero time.

This can matter to services that care whether a timestamp
field is present or not. For example, the UpdateCachedContent
RPC of vertex/genai behaves differently depending on whether
an update time is passed to it.
