### PR TITLE
test(storage): use long uidSpace for buckets

### DIFF
--- a/storage/integration_test.go
+++ b/storage/integration_test.go
@@ -214,7 +214,7 @@ func initIntegrationTest() func() error {
 }
 
 func initUIDsAndRand(t time.Time) {
-	uidSpace = uid.NewSpace("", &uid.Options{Time: t, Short: true})
+	uidSpace = uid.NewSpace("", &uid.Options{Time: t})
 	bucketName = testPrefix + uidSpace.New()
 	uidSpaceObjects = uid.NewSpace("obj", &uid.Options{Time: t})
 	grpcBucketName = grpcTestPrefix + uidSpace.New()


### PR DESCRIPTION
Short uids are too short for the number of tests we have now. Use a long space (6 digits instead of 2). Tested locally and ensured that bucket names are still within GCS limits (63 chars max).

Fixes #10338
Fixes #10337
Fixes #10336
Fixes #10335
Fixes #10334
Fixes #10333