### PR TITLE
fix(internal/postprocessor): use approved image tag

### DIFF
--- a/internal/postprocessor/README.md
+++ b/internal/postprocessor/README.md
@@ -21,8 +21,8 @@ You can verify the name of the docker container name can be found in the
 In the `google-cloud-go` root directory:
 
 ```bash
-docker pull gcr.io/cloud-devrel-public-resources/owlbot-go:latest
-docker run --user $(id -u):$(id -g) --rm -v $(pwd):/repo -w /repo gcr.io/cloud-devrel-public-resources/owlbot-go:latest
+docker pull gcr.io/cloud-devrel-public-resources/owlbot-go:infrastructure-public-image-latest
+docker run --user $(id -u):$(id -g) --rm -v $(pwd):/repo -w /repo gcr.io/cloud-devrel-public-resources/owlbot-go:infrastructure-public-image-latest
 ```
 
 ## Making changes, rebuilding the docker container and updating the OwlBot SHA
@@ -59,15 +59,14 @@ the OwlBot lock file.
 
 After making changes to this package land in `main`, a new Docker image will be
 built and pushed automatically. To update the image version used by OwlBot, run
-the following commands (_you will need Docker installed and running_):
+the following command (_you will need Docker installed and running_):
 
 ```sh
-docker pull gcr.io/cloud-devrel-public-resources/owlbot-go:latest
-LATEST=`docker inspect --format='{{index .RepoDigests 0}}' gcr.io/cloud-devrel-public-resources/owlbot-go:latest`
-sed -i -e 's/sha256.*/'${LATEST#*@}'/g' ./.github/.OwlBot.lock.yaml
+docker pull gcr.io/cloud-devrel-public-resources/owlbot-go:infrastructure-public-image-latest
 ```
 
-_Note: If run on macOS, the `sed -i` flag will need a `''` after it._
+Extract the `sha256` Digest from the logs emitted by the `pull` and set it as
+the digest in the [lockfile](../../.github/.OwlBot.lock.yaml).
 
 Send a pull request with the updated `.github/.OwlBot.lock.yaml`.
 

--- a/internal/postprocessor/cloudbuild.yaml
+++ b/internal/postprocessor/cloudbuild.yaml
@@ -28,8 +28,16 @@ steps:
         ".",
       ]
     dir: internal/postprocessor
+  - name:  gcr.io/cloud-builders/docker
+    args: 
+      [
+        "tag",
+        "gcr.io/cloud-devrel-public-resources/owlbot-go:infrastructure-public-image-$COMMIT_SHA",
+        "gcr.io/cloud-devrel-public-resources/owlbot-go:infrastructure-public-image-latest",
+      ]
 options:
   logging: CLOUD_LOGGING_ONLY
 
 images:
   - gcr.io/cloud-devrel-public-resources/owlbot-go:infrastructure-public-image-$COMMIT_SHA
+  - gcr.io/cloud-devrel-public-resources/owlbot-go:infrastructure-public-image-latest

--- a/internal/postprocessor/cloudbuild.yaml
+++ b/internal/postprocessor/cloudbuild.yaml
@@ -22,7 +22,7 @@ steps:
       [
         "build",
         "-t",
-        "gcr.io/cloud-devrel-public-resources/owlbot-go",
+        "gcr.io/cloud-devrel-public-resources/owlbot-go:infrastructure-public-image-$COMMIT_SHA",
         "-f",
         "Dockerfile",
         ".",
@@ -32,4 +32,4 @@ options:
   logging: CLOUD_LOGGING_ONLY
 
 images:
-  - gcr.io/cloud-devrel-public-resources/owlbot-go:latest
+  - gcr.io/cloud-devrel-public-resources/owlbot-go:infrastructure-public-image-$COMMIT_SHA


### PR DESCRIPTION
Change the tag used for postprocessor image to approved prefix. Add one with `latest` suffix on approved prefix, and another using the commit sha that produced the image - this way when the next image is pushed with `latest` the dangling image(s) will still be tagged with the approved tag prefix.

Update instructions accordingly. Note: the `docker inspect` and `sed` commands weren't working for me on gLinux, so I removed them and replaced them with the slightly simpler, but not automated, steps of copying it from the `pull` output.

internal bug http://b/334181347