### PR TITLE
feat(vertexai): export merged response

### DIFF
--- a/vertexai/genai/client.go
+++ b/vertexai/genai/client.go
@@ -250,6 +250,13 @@ func protoToResponse(resp *pb.GenerateContentResponse) (*GenerateContentResponse
 	return gcp, nil
 }
 
+// MergedResponse returns the result of combining all the streamed responses seen so far.
+// After iteration completes, the merged response should match the response obtained without streaming
+// (that is, if [GenerativeModel.GenerateContent] were called).
+func (iter *GenerateContentResponseIterator) MergedResponse() *GenerateContentResponse {
+	return iter.merged
+}
+
 // CountTokens counts the number of tokens in the content.
 func (m *GenerativeModel) CountTokens(ctx context.Context, parts ...Part) (*CountTokensResponse, error) {
 	req := m.newCountTokensRequest(newUserContent(parts))


### PR DESCRIPTION
Allow users to get the merged response from an iterator.
