### PR TITLE
fix(storage): retry broken pipe error

### DIFF
--- a/storage/invoke.go
+++ b/storage/invoke.go
@@ -132,7 +132,7 @@ func ShouldRetry(err error) bool {
 		// Retry socket-level errors ECONNREFUSED and ECONNRESET (from syscall).
 		// Unfortunately the error type is unexported, so we resort to string
 		// matching.
-		retriable := []string{"connection refused", "connection reset"}
+		retriable := []string{"connection refused", "connection reset", "broken pipe"}
 		for _, s := range retriable {
 			if strings.Contains(e.Error(), s) {
 				return true


### PR DESCRIPTION
This is another retryable net.OpError that can arise when a connection has been closed. So far we've only seen this in TestRetryConformance cases rather than in customer issues, but there is no reason not to do a retry and we think it can cut down on flakes from this test.

I'm going to do another PR to add this to google-api-go-client since it often occurs on uploads.

Updates #9178