### PR TITLE
fix(storage): allow empty soft delete on Create

### DIFF
--- a/storage/bucket.go
+++ b/storage/bucket.go
@@ -2123,8 +2123,11 @@ func (p *SoftDeletePolicy) toRawSoftDeletePolicy() *raw.BucketSoftDeletePolicy {
 		return nil
 	}
 	// Excluding read only field EffectiveTime.
+	// ForceSendFields must be set to send a zero value for RetentionDuration and disable
+	// soft delete.
 	return &raw.BucketSoftDeletePolicy{
 		RetentionDurationSeconds: int64(p.RetentionDuration.Seconds()),
+		ForceSendFields:          []string{"RetentionDurationSeconds"},
 	}
 }
 

--- a/storage/bucket_test.go
+++ b/storage/bucket_test.go
@@ -172,7 +172,7 @@ func TestBucketAttrsToRawBucket(t *testing.T) {
 		Logging:               &raw.BucketLogging{LogBucket: "lb", LogObjectPrefix: "p"},
 		Website:               &raw.BucketWebsite{MainPageSuffix: "mps", NotFoundPage: "404"},
 		Autoclass:             &raw.BucketAutoclass{Enabled: true, TerminalStorageClass: "NEARLINE"},
-		SoftDeletePolicy:      &raw.BucketSoftDeletePolicy{RetentionDurationSeconds: 60 * 60},
+		SoftDeletePolicy:      &raw.BucketSoftDeletePolicy{RetentionDurationSeconds: 60 * 60, ForceSendFields: []string{"RetentionDurationSeconds"}},
 		HierarchicalNamespace: &raw.BucketHierarchicalNamespace{Enabled: true},
 		Lifecycle: &raw.BucketLifecycle{
 			Rule: []*raw.BucketLifecycleRule{{
@@ -448,7 +448,7 @@ func TestBucketAttrsToUpdateToRawBucket(t *testing.T) {
 		Website:          &raw.BucketWebsite{MainPageSuffix: "mps", NotFoundPage: "404"},
 		StorageClass:     "NEARLINE",
 		Autoclass:        &raw.BucketAutoclass{Enabled: true, TerminalStorageClass: "ARCHIVE", ForceSendFields: []string{"Enabled"}},
-		SoftDeletePolicy: &raw.BucketSoftDeletePolicy{RetentionDurationSeconds: 3600},
+		SoftDeletePolicy: &raw.BucketSoftDeletePolicy{RetentionDurationSeconds: 3600, ForceSendFields: []string{"RetentionDurationSeconds"}},
 		ForceSendFields:  []string{"DefaultEventBasedHold", "Lifecycle", "Autoclass"},
 	}
 	if msg := testutil.Diff(got, want); msg != "" {


### PR DESCRIPTION
Currently setting an empty soft delete policy to disable the feature does not work on bucket creation (only update). This fixes the issue by forcing the library to send a zero value in this case (sending a null does not seem to work).

Also adds this case to the relevant integration test.

Fixes #10380