### PR TITLE
feat(spanner): add support of checking row not found errors from ReadRow and ReadRowUsingIndex

### DIFF
--- a/spanner/errors.go
+++ b/spanner/errors.go
@@ -28,8 +28,8 @@ import (
 )
 
 var (
-	// ErrRowNotFound record not found error
-	ErrRowNotFound = errors.New("record not found")
+	// ErrRowNotFound row not found error
+	ErrRowNotFound = errors.New("row not found")
 )
 
 // Error is the structured error returned by Cloud Spanner client.

--- a/spanner/errors.go
+++ b/spanner/errors.go
@@ -18,12 +18,18 @@ package spanner
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/googleapis/gax-go/v2/apierror"
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+)
+
+var (
+	// ErrRecordNotFound record not found error
+	ErrRecordNotFound = errors.New("record not found")
 )
 
 // Error is the structured error returned by Cloud Spanner client.

--- a/spanner/errors.go
+++ b/spanner/errors.go
@@ -28,8 +28,8 @@ import (
 )
 
 var (
-	// ErrRecordNotFound record not found error
-	ErrRecordNotFound = errors.New("record not found")
+	// ErrRowNotFound record not found error
+	ErrRowNotFound = errors.New("record not found")
 )
 
 // Error is the structured error returned by Cloud Spanner client.

--- a/spanner/integration_test.go
+++ b/spanner/integration_test.go
@@ -1731,6 +1731,9 @@ func TestIntegration_Reads(t *testing.T) {
 	if ErrCode(err) != codes.NotFound {
 		t.Fatalf("got %v, want NotFound", err)
 	}
+	if !errors.Is(err, ErrRecordNotFound) {
+		t.Fatalf("got %v, want spanner.ErrRecordNotFound", err)
+	}
 	verifyDirectPathRemoteAddress(t)
 
 	// Index point read.
@@ -1750,6 +1753,9 @@ func TestIntegration_Reads(t *testing.T) {
 	_, err = client.Single().ReadRowUsingIndex(ctx, testTable, testTableIndex, Key{"v999"}, testTableColumns)
 	if ErrCode(err) != codes.NotFound {
 		t.Fatalf("got %v, want NotFound", err)
+	}
+	if !errors.Is(err, ErrRecordNotFound) {
+		t.Fatalf("got %v, want spanner.ErrRecordNotFound", err)
 	}
 	verifyDirectPathRemoteAddress(t)
 	rangeReads(ctx, t, client)

--- a/spanner/integration_test.go
+++ b/spanner/integration_test.go
@@ -1731,8 +1731,8 @@ func TestIntegration_Reads(t *testing.T) {
 	if ErrCode(err) != codes.NotFound {
 		t.Fatalf("got %v, want NotFound", err)
 	}
-	if !errors.Is(err, ErrRecordNotFound) {
-		t.Fatalf("got %v, want spanner.ErrRecordNotFound", err)
+	if !errors.Is(err, ErrRowNotFound) {
+		t.Fatalf("got %v, want spanner.ErrRowNotFound", err)
 	}
 	verifyDirectPathRemoteAddress(t)
 
@@ -1754,8 +1754,8 @@ func TestIntegration_Reads(t *testing.T) {
 	if ErrCode(err) != codes.NotFound {
 		t.Fatalf("got %v, want NotFound", err)
 	}
-	if !errors.Is(err, ErrRecordNotFound) {
-		t.Fatalf("got %v, want spanner.ErrRecordNotFound", err)
+	if !errors.Is(err, ErrRowNotFound) {
+		t.Fatalf("got %v, want spanner.ErrRowNotFound", err)
 	}
 	verifyDirectPathRemoteAddress(t)
 	rangeReads(ctx, t, client)

--- a/spanner/transaction.go
+++ b/spanner/transaction.go
@@ -327,14 +327,14 @@ func (t *txReadOnly) ReadWithOptions(ctx context.Context, table string, keys Key
 // key.
 func errRowNotFound(table string, key Key) error {
 	err := spannerErrorf(codes.NotFound, "row not found(Table: %v, PrimaryKey: %v)", table, key)
-	err.(*Error).err = ErrRecordNotFound
+	err.(*Error).err = ErrRowNotFound
 	return err
 }
 
 // errRowNotFoundByIndex returns error for not being able to read the row by index.
 func errRowNotFoundByIndex(table string, key Key, index string) error {
 	err := spannerErrorf(codes.NotFound, "row not found(Table: %v, IndexKey: %v, Index: %v)", table, key, index)
-	err.(*Error).err = ErrRecordNotFound
+	err.(*Error).err = ErrRowNotFound
 	return err
 }
 
@@ -350,8 +350,14 @@ func errInlineBeginTransactionFailed() error {
 
 // ReadRow reads a single row from the database.
 //
-// If no row is present with the given key, then ReadRow returns an error(spanner.ErrRecordNotFound) where
+// If no row is present with the given key, then ReadRow returns an error(spanner.ErrRowNotFound) where
 // spanner.ErrCode(err) is codes.NotFound.
+//
+// To check if the error is spanner.ErrRecordNotFound:
+//
+//	if errors.Is(err, ErrRecordNotFound) {
+//			...
+//	}
 func (t *txReadOnly) ReadRow(ctx context.Context, table string, key Key, columns []string) (*Row, error) {
 	return t.ReadRowWithOptions(ctx, table, key, columns, nil)
 }
@@ -360,6 +366,12 @@ func (t *txReadOnly) ReadRow(ctx context.Context, table string, key Key, columns
 //
 // If no row is present with the given key, then ReadRowWithOptions returns an error where
 // spanner.ErrCode(err) is codes.NotFound.
+//
+// To check if the error is spanner.ErrRecordNotFound:
+//
+//	if errors.Is(err, ErrRecordNotFound) {
+//			...
+//	}
 func (t *txReadOnly) ReadRowWithOptions(ctx context.Context, table string, key Key, columns []string, opts *ReadOptions) (*Row, error) {
 	iter := t.ReadWithOptions(ctx, table, key, columns, opts)
 	defer iter.Stop()
@@ -377,7 +389,13 @@ func (t *txReadOnly) ReadRowWithOptions(ctx context.Context, table string, key K
 // ReadRowUsingIndex reads a single row from the database using an index.
 //
 // If no row is present with the given index, then ReadRowUsingIndex returns an
-// error(spanner.ErrRecordNotFound) where spanner.ErrCode(err) is codes.NotFound.
+// error(spanner.ErrRowNotFound) where spanner.ErrCode(err) is codes.NotFound.
+//
+// To check if the error is spanner.ErrRecordNotFound:
+//
+//	if errors.Is(err, ErrRecordNotFound) {
+//			...
+//	}
 //
 // If more than one row received with the given index, then ReadRowUsingIndex
 // returns an error where spanner.ErrCode(err) is codes.FailedPrecondition.

--- a/spanner/transaction.go
+++ b/spanner/transaction.go
@@ -353,9 +353,9 @@ func errInlineBeginTransactionFailed() error {
 // If no row is present with the given key, then ReadRow returns an error(spanner.ErrRowNotFound) where
 // spanner.ErrCode(err) is codes.NotFound.
 //
-// To check if the error is spanner.ErrRecordNotFound:
+// To check if the error is spanner.ErrRowNotFound:
 //
-//	if errors.Is(err, ErrRecordNotFound) {
+//	if errors.Is(err, spanner.ErrRowNotFound) {
 //			...
 //	}
 func (t *txReadOnly) ReadRow(ctx context.Context, table string, key Key, columns []string) (*Row, error) {
@@ -367,9 +367,9 @@ func (t *txReadOnly) ReadRow(ctx context.Context, table string, key Key, columns
 // If no row is present with the given key, then ReadRowWithOptions returns an error where
 // spanner.ErrCode(err) is codes.NotFound.
 //
-// To check if the error is spanner.ErrRecordNotFound:
+// To check if the error is spanner.ErrRowNotFound:
 //
-//	if errors.Is(err, ErrRecordNotFound) {
+//	if errors.Is(err, spanner.ErrRowNotFound) {
 //			...
 //	}
 func (t *txReadOnly) ReadRowWithOptions(ctx context.Context, table string, key Key, columns []string, opts *ReadOptions) (*Row, error) {
@@ -391,9 +391,9 @@ func (t *txReadOnly) ReadRowWithOptions(ctx context.Context, table string, key K
 // If no row is present with the given index, then ReadRowUsingIndex returns an
 // error(spanner.ErrRowNotFound) where spanner.ErrCode(err) is codes.NotFound.
 //
-// To check if the error is spanner.ErrRecordNotFound:
+// To check if the error is spanner.ErrRowNotFound:
 //
-//	if errors.Is(err, ErrRecordNotFound) {
+//	if errors.Is(err, spanner.ErrRowNotFound) {
 //			...
 //	}
 //

--- a/spanner/transaction.go
+++ b/spanner/transaction.go
@@ -326,12 +326,16 @@ func (t *txReadOnly) ReadWithOptions(ctx context.Context, table string, keys Key
 // errRowNotFound returns error for not being able to read the row identified by
 // key.
 func errRowNotFound(table string, key Key) error {
-	return spannerErrorf(codes.NotFound, "row not found(Table: %v, PrimaryKey: %v)", table, key)
+	err := spannerErrorf(codes.NotFound, "row not found(Table: %v, PrimaryKey: %v)", table, key)
+	err.(*Error).err = ErrRecordNotFound
+	return err
 }
 
 // errRowNotFoundByIndex returns error for not being able to read the row by index.
 func errRowNotFoundByIndex(table string, key Key, index string) error {
-	return spannerErrorf(codes.NotFound, "row not found(Table: %v, IndexKey: %v, Index: %v)", table, key, index)
+	err := spannerErrorf(codes.NotFound, "row not found(Table: %v, IndexKey: %v, Index: %v)", table, key, index)
+	err.(*Error).err = ErrRecordNotFound
+	return err
 }
 
 // errMultipleRowsFound returns error for receiving more than one row when reading a single row using an index.
@@ -346,7 +350,7 @@ func errInlineBeginTransactionFailed() error {
 
 // ReadRow reads a single row from the database.
 //
-// If no row is present with the given key, then ReadRow returns an error where
+// If no row is present with the given key, then ReadRow returns an error(spanner.ErrRecordNotFound) where
 // spanner.ErrCode(err) is codes.NotFound.
 func (t *txReadOnly) ReadRow(ctx context.Context, table string, key Key, columns []string) (*Row, error) {
 	return t.ReadRowWithOptions(ctx, table, key, columns, nil)
@@ -373,7 +377,7 @@ func (t *txReadOnly) ReadRowWithOptions(ctx context.Context, table string, key K
 // ReadRowUsingIndex reads a single row from the database using an index.
 //
 // If no row is present with the given index, then ReadRowUsingIndex returns an
-// error where spanner.ErrCode(err) is codes.NotFound.
+// error(spanner.ErrRecordNotFound) where spanner.ErrCode(err) is codes.NotFound.
 //
 // If more than one row received with the given index, then ReadRowUsingIndex
 // returns an error where spanner.ErrCode(err) is codes.FailedPrecondition.


### PR DESCRIPTION
Fixes: https://github.com/googleapis/google-cloud-go/issues/10031

Customers can check row not found cases with below condition
```
if errors.Is(err, spanner.ErrRecordNotFound) {
```

- [x] Add test case for checking row not found with errors.Is
- [x] Ensure backward compatibility