### PR TITLE
fix(auth): return error if envvar detected file returns an error

### DIFF
--- a/auth/credentials/detect.go
+++ b/auth/credentials/detect.go
@@ -80,9 +80,11 @@ func DetectDefault(opts *DetectOptions) (*auth.Credentials, error) {
 		return readCredentialsFile(opts.CredentialsFile, opts)
 	}
 	if filename := os.Getenv(credsfile.GoogleAppCredsEnvVar); filename != "" {
-		if creds, err := readCredentialsFile(filename, opts); err == nil {
-			return creds, err
+		creds, err := readCredentialsFile(filename, opts)
+		if err != nil {
+			return nil, err
 		}
+		return creds, nil
 	}
 
 	fileName := credsfile.GetWellKnownFileName()

--- a/auth/credentials/detect_test.go
+++ b/auth/credentials/detect_test.go
@@ -450,6 +450,20 @@ func TestDefaultCredentials_ServiceAccountKeySelfSigned_UniverseDomain(t *testin
 	}
 }
 
+func TestDefaultCredentials_ServiceAccountKey_NoFile(t *testing.T) {
+	t.Setenv(credsfile.GoogleAppCredsEnvVar, "/a/path/that/most/certainly/does/not/exist.json")
+	_, err := DetectDefault(&DetectOptions{
+		Scopes:           []string{"https://www.googleapis.com/auth/cloud-platform"},
+		UseSelfSignedJWT: true,
+	})
+	if err == nil {
+		t.Fatal("DetectDefault() = nil error, expected non-nil error")
+	}
+	if !strings.Contains(err.Error(), "no such file or directory") {
+		t.Fatalf("got %v, want a does not exist error", err)
+	}
+}
+
 func TestDefaultCredentials_ClientCredentials(t *testing.T) {
 	ctx := context.Background()
 	b, err := os.ReadFile("../internal/testdata/clientcreds_installed.json")
@@ -667,7 +681,7 @@ func TestDefaultCredentials_ExternalAccountAuthorizedUserKey(t *testing.T) {
 }
 
 func TestDefaultCredentials_Fails(t *testing.T) {
-	t.Setenv(credsfile.GoogleAppCredsEnvVar, "nothingToSeeHere")
+	t.Setenv(credsfile.GoogleAppCredsEnvVar, "")
 	t.Setenv("HOME", "nothingToSeeHere")
 	t.Setenv("APPDATA", "nothingToSeeHere")
 	allowOnGCECheck = false


### PR DESCRIPTION
This matches the behaviour of the old library.