### PR TITLE
chore: promote clients to GA

### DIFF
--- a/backupdr/CHANGES.md
+++ b/backupdr/CHANGES.md
@@ -1,5 +1,6 @@
 # Changelog
 
+
 ## [0.1.1](https://github.com/googleapis/google-cloud-go/compare/backupdr/v0.1.0...backupdr/v0.1.1) (2024-05-01)
 
 

--- a/cloudcontrolspartner/CHANGES.md
+++ b/cloudcontrolspartner/CHANGES.md
@@ -1,5 +1,6 @@
 # Changelog
 
+
 ## [0.2.1](https://github.com/googleapis/google-cloud-go/compare/cloudcontrolspartner/v0.2.0...cloudcontrolspartner/v0.2.1) (2024-05-01)
 
 

--- a/cloudquotas/CHANGES.md
+++ b/cloudquotas/CHANGES.md
@@ -1,5 +1,6 @@
 # Changelog
 
+
 ## [0.2.1](https://github.com/googleapis/google-cloud-go/compare/cloudquotas/v0.2.0...cloudquotas/v0.2.1) (2024-05-01)
 
 

--- a/edgenetwork/CHANGES.md
+++ b/edgenetwork/CHANGES.md
@@ -1,5 +1,6 @@
 # Changelog
 
+
 ## [0.2.4](https://github.com/googleapis/google-cloud-go/compare/edgenetwork/v0.2.3...edgenetwork/v0.2.4) (2024-05-01)
 
 

--- a/securesourcemanager/CHANGES.md
+++ b/securesourcemanager/CHANGES.md
@@ -1,5 +1,6 @@
 # Changelog
 
+
 ## [0.1.5](https://github.com/googleapis/google-cloud-go/compare/securesourcemanager/v0.1.4...securesourcemanager/v0.1.5) (2024-05-01)
 
 

--- a/securitycentermanagement/CHANGES.md
+++ b/securitycentermanagement/CHANGES.md
@@ -1,5 +1,6 @@
 # Changelog
 
+
 ## [0.3.0](https://github.com/googleapis/google-cloud-go/compare/securitycentermanagement/v0.2.1...securitycentermanagement/v0.3.0) (2024-06-18)
 
 

--- a/telcoautomation/CHANGES.md
+++ b/telcoautomation/CHANGES.md
@@ -1,5 +1,6 @@
 # Changelog
 
+
 ## [0.2.2](https://github.com/googleapis/google-cloud-go/compare/telcoautomation/v0.2.1...telcoautomation/v0.2.2) (2024-05-01)
 
 


### PR DESCRIPTION
BEGIN_PUBLIC
chore(backupdr): release v1.0.0

Release-As: 1.0.0
END_PUBLIC
BEGIN_PUBLIC
chore(cloudcontrolspartner): release v1.0.0

Release-As: 1.0.0
END_PUBLIC
BEGIN_PUBLIC
chore(cloudquotas): release v1.0.0

Release-As: 1.0.0
END_PUBLIC
BEGIN_PUBLIC
chore(edgenetwork): release v1.0.0

Release-As: 1.0.0
END_PUBLIC
BEGIN_PUBLIC
chore(securesourcemanager): release v1.0.0

Release-As: 1.0.0
END_PUBLIC
BEGIN_PUBLIC
chore(securitycentermanagement): release v1.0.0

Release-As: 1.0.0
END_PUBLIC
BEGIN_PUBLIC
chore(telcoautomation): release v1.0.0

Release-As: 1.0.0
END_PUBLIC