### PR TITLE
feat(auth): Add workload X509 cert provider as a default cert provider

### DIFF
--- a/auth/internal/transport/cert/default_cert.go
+++ b/auth/internal/transport/cert/default_cert.go
@@ -50,11 +50,14 @@ var errSourceUnavailable = errors.New("certificate source is unavailable")
 // returned to indicate that a default certificate source is unavailable.
 func DefaultProvider() (Provider, error) {
 	defaultCert.once.Do(func() {
-		defaultCert.provider, defaultCert.err = NewEnterpriseCertificateProxyProvider("")
+		defaultCert.provider, defaultCert.err = NewWorkloadX509CertProvider("")
 		if errors.Is(defaultCert.err, errSourceUnavailable) {
-			defaultCert.provider, defaultCert.err = NewSecureConnectProvider("")
+			defaultCert.provider, defaultCert.err = NewEnterpriseCertificateProxyProvider("")
 			if errors.Is(defaultCert.err, errSourceUnavailable) {
-				defaultCert.provider, defaultCert.err = nil, nil
+				defaultCert.provider, defaultCert.err = NewSecureConnectProvider("")
+				if errors.Is(defaultCert.err, errSourceUnavailable) {
+					defaultCert.provider, defaultCert.err = nil, nil
+				}
 			}
 		}
 	})

--- a/auth/internal/transport/cert/workload_cert.go
+++ b/auth/internal/transport/cert/workload_cert.go
@@ -99,7 +99,7 @@ func getCertAndKeyFiles(configFilePath string) (string, string, error) {
 	}
 
 	if config.CertConfigs.Workload == nil {
-		return "", "", errors.New("no Workload Identity Federation certificate information found in the certificate configuration file")
+		return "", "", errSourceUnavailable
 	}
 
 	certFile := config.CertConfigs.Workload.CertPath

--- a/auth/internal/transport/cert/workload_cert_test.go
+++ b/auth/internal/transport/cert/workload_cert_test.go
@@ -34,6 +34,9 @@ func TestWorkloadCertSource_EmptyConfig(t *testing.T) {
 	if err == nil {
 		t.Fatal("got nil, want non-nil error")
 	}
+	if !errors.Is(err, errSourceUnavailable) {
+		t.Errorf("got %v, want errSourceUnavailable", err)
+	}
 	if source != nil {
 		t.Errorf("got %v, want nil source", source)
 	}


### PR DESCRIPTION
Side Note: Verified this is compatible with existing OAuth2 3-legged auth flow. This is expected to immediately work with X509 workload identity auth flow once that feature is released.