### PR TITLE
chore(profiler): upgrade default proftest gce image to debian-11

### DIFF
--- a/profiler/proftest/proftest.go
+++ b/profiler/proftest/proftest.go
@@ -225,14 +225,14 @@ func (pr *ProfileResponse) HasSourceFile(filename string) error {
 // StartInstance starts a GCE Instance with configs specified by inst,
 // and which runs the startup script specified in inst. If image project
 // is not specified, it defaults to "debian-cloud". If image family is
-// not specified, it defaults to "debian-10".
+// not specified, it defaults to "debian-11".
 func (tr *GCETestRunner) StartInstance(ctx context.Context, inst *InstanceConfig) error {
 	imageProject, imageFamily := inst.ImageProject, inst.ImageFamily
 	if imageProject == "" {
 		imageProject = "debian-cloud"
 	}
 	if imageFamily == "" {
-		imageFamily = "debian-10"
+		imageFamily = "debian-11"
 	}
 	img, err := tr.ComputeService.Images.GetFromFamily(imageProject, imageFamily).Context(ctx).Do()
 	if err != nil {


### PR DESCRIPTION
Debian 10 image is no longer available which is causing tests using the `proftest` harness to fail with

`integration_test.go:352: failed to start GCE instance: failed to get image from family "debian-10" in project "debian-cloud": googleapi: Error 404: The resource 'projects/debian-cloud/global/images/family/debian-10' was not found, notFound`

Debian 11 is the oldest available version:
```console
$ gcloud compute images list | grep debian              
debian-11-bullseye-arm64-v20240611             debian-cloud         debian-11-arm64                                READY                                              
debian-11-bullseye-v20240611                   debian-cloud         debian-11                                      READY                                              
debian-12-bookworm-arm64-v20240701             debian-cloud         debian-12-arm64                                READY                                              
debian-12-bookworm-v20240701                   debian-cloud         debian-12                                      READY
```