### PR TITLE
chore(firestore): use internal/detect

### DIFF
--- a/firestore/client.go
+++ b/firestore/client.go
@@ -27,11 +27,11 @@ import (
 	vkit "cloud.google.com/go/firestore/apiv1"
 	pb "cloud.google.com/go/firestore/apiv1/firestorepb"
 	"cloud.google.com/go/firestore/internal"
+	"cloud.google.com/go/internal/detect"
 	"cloud.google.com/go/internal/trace"
 	gax "github.com/googleapis/gax-go/v2"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
-	"google.golang.org/api/transport"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
@@ -62,7 +62,7 @@ func reqParamsHeaderVal(dbPath string) string {
 // if no credentials were provided. When providing credentials, not all
 // options will allow NewClient to extract the project ID. Specifically a JWT
 // does not have the project ID encoded.
-const DetectProjectID = "*detect-project-id*"
+const DetectProjectID = detect.ProjectIDSentinel
 
 // DefaultDatabaseID is name of the default database
 const DefaultDatabaseID = "(default)"
@@ -88,21 +88,16 @@ func NewClient(ctx context.Context, projectID string, opts ...option.ClientOptio
 			return nil, fmt.Errorf("firestore: dialing address from env var FIRESTORE_EMULATOR_HOST: %s", err)
 		}
 		o = []option.ClientOption{option.WithGRPCConn(conn)}
-		if projectID == DetectProjectID {
-			projectID, _ = detectProjectID(ctx, opts...)
-			if projectID == "" {
-				projectID = "dummy-emulator-firestore-project"
-			}
+		projectID, _ = detect.ProjectID(ctx, projectID, "", opts...)
+		if projectID == "" {
+			projectID = "dummy-emulator-firestore-project"
 		}
 	}
 	o = append(o, opts...)
 
-	if projectID == DetectProjectID {
-		detected, err := detectProjectID(ctx, o...)
-		if err != nil {
-			return nil, err
-		}
-		projectID = detected
+	projectID, err := detect.ProjectID(ctx, projectID, "", o...)
+	if err != nil {
+		return nil, err
 	}
 
 	vc, err := vkit.NewClient(ctx, o...)
@@ -133,17 +128,6 @@ func NewClientWithDatabase(ctx context.Context, projectID string, databaseID str
 
 	client.databaseID = databaseID
 	return client, nil
-}
-
-func detectProjectID(ctx context.Context, opts ...option.ClientOption) (string, error) {
-	creds, err := transport.Creds(ctx, opts...)
-	if err != nil {
-		return "", fmt.Errorf("fetching creds: %w", err)
-	}
-	if creds.ProjectID == "" {
-		return "", errors.New("firestore: see the docs on DetectProjectID")
-	}
-	return creds.ProjectID, nil
 }
 
 // Close closes any resources held by the client.

--- a/internal/detect/detect.go
+++ b/internal/detect/detect.go
@@ -27,7 +27,9 @@ import (
 )
 
 const (
-	projectIDSentinel = "*detect-project-id*"
+	// ProjectIDSentinel is the value that users should pass for the project ID
+	// to enable detection.
+	ProjectIDSentinel = "*detect-project-id*"
 	envProjectID      = "GOOGLE_CLOUD_PROJECT"
 )
 
@@ -41,8 +43,8 @@ var (
 //  1. GOOGLE_CLOUD_PROJECT envvar
 //  2. ADC creds.ProjectID
 //  3. A static value if the environment is emulated.
-func ProjectID(ctx context.Context, projectID string, emulatorEnvVar string, opts ...option.ClientOption) (string, error) {
-	if projectID != projectIDSentinel {
+func ProjectID(ctx context.Context, projectID, emulatorEnvVar string, opts ...option.ClientOption) (string, error) {
+	if projectID != ProjectIDSentinel {
 		return projectID, nil
 	}
 	// 1. Try a well known environment variable

--- a/internal/detect/detect_test.go
+++ b/internal/detect/detect_test.go
@@ -37,19 +37,19 @@ func TestIt(t *testing.T) {
 		},
 		{
 			name:      "environment project id",
-			projectID: projectIDSentinel,
+			projectID: ProjectIDSentinel,
 			env:       map[string]string{envProjectID: "environment-project-id"},
 			want:      "environment-project-id",
 		},
 		{
 			name:         "adc project id",
-			projectID:    projectIDSentinel,
+			projectID:    ProjectIDSentinel,
 			adcProjectID: "adc-project-id",
 			want:         "adc-project-id",
 		},
 		{
 			name:      "emulator project id",
-			projectID: projectIDSentinel,
+			projectID: ProjectIDSentinel,
 			env:       map[string]string{"EMULATOR_HOST": "something"},
 			want:      "emulated-project",
 		},


### PR DESCRIPTION
Use the internal/detect package to detect the project ID, instead
of a custom function.

Also, export the sentinel value from internal/detect.
