### PR TITLE
fix(auth): use default client for universe metadata lookup

### DIFF
--- a/auth/internal/internal.go
+++ b/auth/internal/internal.go
@@ -181,8 +181,9 @@ func (c *ComputeUniverseDomainProvider) GetProperty(ctx context.Context) (string
 
 // httpGetMetadataUniverseDomain is a package var for unit test substitution.
 var httpGetMetadataUniverseDomain = func(ctx context.Context) (string, error) {
-	client := metadata.NewClient(&http.Client{Timeout: time.Second})
-	return client.GetWithContext(ctx, "universe/universe_domain")
+	ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
+	defer cancel()
+	return metadata.GetWithContext(ctx, "universe/universe_domain")
 }
 
 func getMetadataUniverseDomain(ctx context.Context) (string, error) {


### PR DESCRIPTION
When this code was first introduced we did not have the context methods in the metadata package so we set the timeout on the client. Now that we do we should use context to set the timeout and use the default client the metadata package provides.

Fixes: #10544