### PR TITLE
fix(bigquery): reduce default backoffs

### DIFF
--- a/bigquery/bigquery.go
+++ b/bigquery/bigquery.go
@@ -234,9 +234,9 @@ func runWithRetry(ctx context.Context, call func() error) error {
 func runWithRetryExplicit(ctx context.Context, call func() error, allowedReasons []string) error {
 	// These parameters match the suggestions in https://cloud.google.com/bigquery/sla.
 	backoff := gax.Backoff{
-		Initial:    50 * time.Millisecond,
+		Initial:    1 * time.Second,
 		Max:        32 * time.Second,
-		Multiplier: 1.3,
+		Multiplier: 2,
 	}
 	return cloudinternal.Retry(ctx, backoff, func() (stop bool, err error) {
 		err = call()

--- a/bigquery/bigquery.go
+++ b/bigquery/bigquery.go
@@ -234,9 +234,9 @@ func runWithRetry(ctx context.Context, call func() error) error {
 func runWithRetryExplicit(ctx context.Context, call func() error, allowedReasons []string) error {
 	// These parameters match the suggestions in https://cloud.google.com/bigquery/sla.
 	backoff := gax.Backoff{
-		Initial:    1 * time.Second,
+		Initial:    50 * time.Millisecond,
 		Max:        32 * time.Second,
-		Multiplier: 2,
+		Multiplier: 1.3,
 	}
 	return cloudinternal.Retry(ctx, backoff, func() (stop bool, err error) {
 		err = call()

--- a/bigquery/job.go
+++ b/bigquery/job.go
@@ -356,8 +356,8 @@ func (j *Job) waitForQuery(ctx context.Context, projectID string) (Schema, uint6
 	call = call.FormatOptionsUseInt64Timestamp(true)
 	setClientHeader(call.Header())
 	backoff := gax.Backoff{
-		Initial:    1 * time.Second,
-		Multiplier: 2,
+		Initial:    50 * time.Millisecond,
+		Multiplier: 1.3,
 		Max:        60 * time.Second,
 	}
 	var res *bq.GetQueryResultsResponse


### PR DESCRIPTION
fix(bigquery): reduce the initial backoff for job polling

This PR reduces initial backoffs and multipliers used during job polling.  Previously we used a 1s starting backoff, this has been reduced to 50ms.  In job execution most time is typically spent in server, waiting for the hanging GetQueryResults response.

This should in generally reduce wasted wait for jobs that poll for multiple iterations.

Fixes: https://github.com/googleapis/google-cloud-go/issues/10555