### PR TITLE
feat(bigquery): Add Clone() method to bigquery.Schema

### DIFF
--- a/bigquery/schema.go
+++ b/bigquery/schema.go
@@ -181,6 +181,7 @@ func (s Schema) Clone() Schema {
 			Scale:                  v.Scale,
 			DefaultValueExpression: v.DefaultValueExpression,
 			Collation:              v.Collation,
+			RoundingMode:           v.RoundingMode,
 		}
 		if v.RangeElementType != nil {
 			newV.RangeElementType = &RangeElementType{

--- a/bigquery/schema.go
+++ b/bigquery/schema.go
@@ -159,6 +159,47 @@ type FieldSchema struct {
 	RoundingMode RoundingMode
 }
 
+// Clone returns a duplicate of the existing schema.
+func (s Schema) Clone() Schema {
+	if s == nil {
+		return nil
+	}
+	newS := make(Schema, 0, len(s))
+	for _, v := range s {
+		if v == nil {
+			newS = append(newS, nil)
+			continue
+		}
+		newV := &FieldSchema{
+			Name:                   v.Name,
+			Description:            v.Description,
+			Type:                   v.Type,
+			Repeated:               v.Repeated,
+			Required:               v.Required,
+			MaxLength:              v.MaxLength,
+			Precision:              v.Precision,
+			Scale:                  v.Scale,
+			DefaultValueExpression: v.DefaultValueExpression,
+			Collation:              v.Collation,
+		}
+		if v.RangeElementType != nil {
+			newV.RangeElementType = &RangeElementType{
+				Type: v.RangeElementType.Type,
+			}
+		}
+		newV.Schema = v.Schema.Clone()
+		if v.PolicyTags != nil {
+			newV.PolicyTags = &PolicyTagList{}
+			if len(v.PolicyTags.Names) > 0 {
+				newV.PolicyTags.Names = make([]string, len(v.PolicyTags.Names))
+				copy(newV.PolicyTags.Names, v.PolicyTags.Names)
+			}
+		}
+		newS = append(newS, newV)
+	}
+	return newS
+}
+
 func (fs *FieldSchema) toBQ() *bq.TableFieldSchema {
 	tfs := &bq.TableFieldSchema{
 		Description:            fs.Description,

--- a/bigquery/schema_test.go
+++ b/bigquery/schema_test.go
@@ -1451,6 +1451,7 @@ func TestSchemaClone(t *testing.T) {
 					Precision:              12345,
 					Scale:                  123456,
 					DefaultValueExpression: "0",
+					RoundingMode:           "ROUND_HALF_EVEN",
 					PolicyTags: &PolicyTagList{
 						Names: []string{"b", "c"},
 					},

--- a/bigquery/schema_test.go
+++ b/bigquery/schema_test.go
@@ -1432,3 +1432,105 @@ func TestSchemaToJSONFields(t *testing.T) {
 		}
 	}
 }
+
+func TestSchemaClone(t *testing.T) {
+	testCases := []struct {
+		description string
+		schema      Schema
+	}{
+		{
+			description: "with policy",
+			schema: Schema{
+				{
+					Name:                   "a",
+					Description:            "test description",
+					Type:                   IntegerFieldType,
+					Repeated:               true,
+					Required:               true,
+					MaxLength:              1234,
+					Precision:              12345,
+					Scale:                  123456,
+					DefaultValueExpression: "0",
+					PolicyTags: &PolicyTagList{
+						Names: []string{"b", "c"},
+					},
+					Schema: Schema{
+						{
+							Name: "d",
+							Type: IntegerFieldType,
+							PolicyTags: &PolicyTagList{
+								Names: []string{"e", "f"},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "nested schema",
+			schema: Schema{
+				{
+					Name: "a",
+					Type: "RECORD",
+					Schema: Schema{
+						{
+							Name: "b",
+							Type: "RECORD",
+							Schema: Schema{
+								{
+									Name: "c",
+									Type: "INTEGER",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "array of nested schema",
+			schema: Schema{
+				{
+					Name:     "a",
+					Type:     "RECORD",
+					Repeated: true,
+					Schema: Schema{
+						{
+							Name: "b1",
+							Type: "RECORD",
+							Schema: Schema{
+								{Name: "c1", Type: "INTEGER"},
+								{
+									Name: "c2",
+									Type: "RECORD",
+									Schema: Schema{
+										{
+											Name:     "d1",
+											Type:     "RECORD",
+											Repeated: true,
+											Schema: Schema{
+												{Name: "e1", Type: "STRING"},
+											},
+										},
+									},
+								},
+							},
+						},
+						{Name: "b2", Type: "BOOLEAN"},
+					},
+				},
+			},
+		},
+		{
+			description: "nil schema",
+			schema:      nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		got := tc.schema.Clone()
+		if diff := cmp.Diff(tc.schema, got); diff != "" {
+			t.Errorf("copySchema(%v) returned an unexpected diff (-want +got): %v", tc.schema, diff)
+		}
+	}
+}


### PR DESCRIPTION
This is mostly a convenience method. It comes in handy when creating Views from BigQuery, because we want to have a subset of the fields for the View but still want to keep the original FieldSchema entries of the cloned object intact.

There is nothing here that could not be replicated in clients because all the fields of the struct are exported, but it would be good if this was supported upstream.