### PR TITLE
feat(bigtable): expose protoToType

### DIFF
--- a/bigtable/admin.go
+++ b/bigtable/admin.go
@@ -639,7 +639,7 @@ func (ac *AdminClient) TableInfo(ctx context.Context, table string) (*TableInfo,
 			Name:         name,
 			GCPolicy:     GCRuleToString(fam.GcRule),
 			FullGCPolicy: gcRuleToPolicy(fam.GcRule),
-			ValueType:    protoToType(fam.ValueType),
+			ValueType:    ProtoToType(fam.ValueType),
 		})
 	}
 	// we expect DeletionProtection to be in the response because Table_SCHEMA_VIEW is being used in this function

--- a/bigtable/type.go
+++ b/bigtable/type.go
@@ -177,7 +177,7 @@ func (agg AggregateType) proto() *btapb.Type {
 	return &btapb.Type{Kind: &btapb.Type_AggregateType{AggregateType: protoAgg}}
 }
 
-func protoToType(pb *btapb.Type) Type {
+func ProtoToType(pb *btapb.Type) Type {
 	if pb == nil {
 		return unknown[btapb.Type]{wrapped: nil}
 	}
@@ -233,7 +233,7 @@ func aggregateProtoToType(agg *btapb.Type_Aggregate) Type {
 		return AggregateType{Input: nil, Aggregator: unknownAggregator{wrapped: agg}}
 	}
 
-	it := protoToType(agg.InputType)
+	it := ProtoToType(agg.InputType)
 	var aggregator Aggregator
 	switch agg.Aggregator.(type) {
 	case *btapb.Type_Aggregate_Sum_:

--- a/bigtable/type.go
+++ b/bigtable/type.go
@@ -177,6 +177,7 @@ func (agg AggregateType) proto() *btapb.Type {
 	return &btapb.Type{Kind: &btapb.Type_AggregateType{AggregateType: protoAgg}}
 }
 
+// ProtoToType converts a protobuf *btapb.Type to an instance of the Type interface, for use of the admin API.
 func ProtoToType(pb *btapb.Type) Type {
 	if pb == nil {
 		return unknown[btapb.Type]{wrapped: nil}

--- a/bigtable/type_test.go
+++ b/bigtable/type_test.go
@@ -108,18 +108,18 @@ func TestAggregateProto(t *testing.T) {
 
 func TestProtoBijection(t *testing.T) {
 	want := aggregateProto()
-	got := protoToType(want).proto()
+	got := ProtoToType(want).proto()
 	if !proto.Equal(got, want) {
 		t.Errorf("got type %v, want: %v", got, want)
 	}
 }
 
 func TestNilChecks(t *testing.T) {
-	// protoToType
-	if val, ok := protoToType(nil).(unknown[btapb.Type]); !ok {
+	// ProtoToType
+	if val, ok := ProtoToType(nil).(unknown[btapb.Type]); !ok {
 		t.Errorf("got: %T, wanted unknown[btapb.Type]", val)
 	}
-	if val, ok := protoToType(&btapb.Type{}).(unknown[btapb.Type]); !ok {
+	if val, ok := ProtoToType(&btapb.Type{}).(unknown[btapb.Type]); !ok {
 		t.Errorf("got: %T, wanted unknown[btapb.Type]", val)
 	}
 


### PR DESCRIPTION
protoToType needs to be reused by terraform, so we are exposing it.
The trigger for this change is we need in Terraform to accept a json string representing a protobuf of a column family type, so we can properly create and update column family types. We want to be flexible enough to not accept just hardcoded types, but also custom types, thus eliminating the need for client releases every time the server supports a new type.