### PR TITLE
feat(bigtable): Custom meter provider options

### DIFF
--- a/bigtable/go.mod
+++ b/bigtable/go.mod
@@ -25,6 +25,7 @@ require (
 require (
 	cloud.google.com/go/monitoring v1.20.2
 	github.com/google/uuid v1.6.0
+	go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v1.24.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20240722135656-d784300faade
 )
 

--- a/bigtable/go.sum
+++ b/bigtable/go.sum
@@ -98,6 +98,8 @@ go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 h1:jq9TW8u
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0/go.mod h1:p8pYQP+m5XfbZm9fxtSKAbM6oIllS7s2AfxrChvc7iw=
 go.opentelemetry.io/otel v1.24.0 h1:0LAOdjNmQeSTzGBzduGe/rU4tZhMwL5rWgtp9Ku5Jfo=
 go.opentelemetry.io/otel v1.24.0/go.mod h1:W7b9Ozg4nkF5tWI5zsXkaKKDjdVjpD4oAt9Qi/MArHo=
+go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v1.24.0 h1:JYE2HM7pZbOt5Jhk8ndWZTUWYOVift2cHjXVMkPdmdc=
+go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v1.24.0/go.mod h1:yMb/8c6hVsnma0RpsBMNo0fEiQKeclawtgaIaOp2MLY=
 go.opentelemetry.io/otel/metric v1.24.0 h1:6EhoGWWK28x1fbpA4tYTOWBkPefTDQnb8WSGXlc88kI=
 go.opentelemetry.io/otel/metric v1.24.0/go.mod h1:VYhLe1rFfxuTXLgj4CBiyz+9WYBA8pNGJgDcSFRKBco=
 go.opentelemetry.io/otel/sdk v1.24.0 h1:YMPPDNymmQN3ZgczicBY3B6sf9n62Dlj9pWD3ucgoDw=

--- a/bigtable/metric_adapt.go
+++ b/bigtable/metric_adapt.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2024 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bigtable
+
+import (
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+)
+
+type MetricOption struct {
+	option sdkmetric.Option
+}
+
+func OtelSdkMetricOptions(btOptions []MetricOption) []sdkmetric.Option {
+	if btOptions == nil {
+		return nil
+	}
+	otelOpts := []sdkmetric.Option{}
+	for _, btOpt := range btOptions {
+
+		otelOpts = append(otelOpts, OtelSdkMetricOption(btOpt))
+	}
+	return otelOpts
+}
+
+func OtelSdkMetricOption(btOption MetricOption) sdkmetric.Option {
+	return btOption.option
+}

--- a/bigtable/metric_adapt.go
+++ b/bigtable/metric_adapt.go
@@ -20,10 +20,13 @@ import (
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 )
 
+// MetricOption is a wrapper over sdkmetric.Option
+// This is to avoid third-party project dependency into the Cloud Bigtable public surface
 type MetricOption struct {
 	option sdkmetric.Option
 }
 
+// OtelSdkMetricOptions returns the underlying sdkmetric.Option array
 func OtelSdkMetricOptions(btOptions []MetricOption) []sdkmetric.Option {
 	if btOptions == nil {
 		return nil
@@ -36,6 +39,7 @@ func OtelSdkMetricOptions(btOptions []MetricOption) []sdkmetric.Option {
 	return otelOpts
 }
 
+// OtelSdkMetricOption returns the underlying sdkmetric.Option
 func OtelSdkMetricOption(btOption MetricOption) sdkmetric.Option {
 	return btOption.option
 }

--- a/bigtable/metric_adapt_test.go
+++ b/bigtable/metric_adapt_test.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2024 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bigtable
+
+import (
+	"testing"
+
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+)
+
+func TestOtelSdkMetricOptions(t *testing.T) {
+	tests := []struct {
+		name        string
+		btOptions   []MetricOption
+		wantOtelOpt []sdkmetric.Option
+	}{
+		{
+			name:        "nil input",
+			btOptions:   nil,
+			wantOtelOpt: nil,
+		},
+		{
+			name:        "empty input",
+			btOptions:   []MetricOption{},
+			wantOtelOpt: []sdkmetric.Option{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotOtelOpt := OtelSdkMetricOptions(tt.btOptions)
+			if len(gotOtelOpt) != len(tt.wantOtelOpt) {
+				t.Errorf("OtelSdkMetricOptions() got %v options, want %v options", len(gotOtelOpt), len(tt.wantOtelOpt))
+				return
+			}
+			for i := range gotOtelOpt {
+				if got, want := gotOtelOpt[i], tt.wantOtelOpt[i]; got != want {
+					t.Errorf("OtelSdkMetricOptions() got %v, want %v", got, want)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds support for custom meter provider options. For e.g. if a user wants to export built-in clientside metrics to stdout and GCM, below code can be used:
```Go
	stdoutExporter, err := stdoutmetric.New()
	if err != nil {
		// Handle error
	}
	usersMeterProviderOpts := metric.WithReader(metric.NewPeriodicReader(stdoutExporter))

	// Built-in client side meter provider options
	builtInMeterProviderOpts, err := bigtable.MeterProviderOptions(project)
	if err != nil {
		// Handle error
	}
	bigtableMeterProviderOpts := bigtable.OtelSdkMetricOptions(builtInMeterProviderOpts)

	// All meter provider options
	meterProviderOpts := append(bigtableMeterProviderOpts, usersMeterProviderOpts)

	// Create custom meter provider which exports to user's metrics aggregator and GCM
	customMeterProvider := sdkmetric.NewMeterProvider(meterProviderOpts...)
	clientConfig := bigtable.ClientConfig{
		MetricsProvider: bigtable.CustomOpenTelemetryMetricsProvider{
			MeterProvider: customMeterProvider,
		},
	}

	// Create client
	client, err = bigtable.NewClientWithConfig(context.Background(), project, instance, clientConfig)

```

Here, a wrapper has been added over sdkmetric.Option to address this comment: https://github.com/googleapis/google-cloud-go/pull/10046#discussion_r1681729816