### PR TITLE
chore: freeze google.golang.org/grpc at v1.64.1

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -19,7 +19,8 @@
         "go.opentelemetry.io/otel/metric",
         "go.opentelemetry.io/otel/sdk",
         "go.opentelemetry.io/otel/trace",
-        "google.golang.org/genproto"
+        "google.golang.org/genproto",
+        "google.golang.org/grpc"
     ],
     "ignorePaths": [
         "**/snippets/**"


### PR DESCRIPTION
* grpc v1.65.0 changes support policy to cover only the latest TWO releases of Go
* See https://github.com/grpc/grpc-go/releases/tag/v1.65.0