### PR TITLE
fix(storage): check for grpc NotFound error in HMAC test

### DIFF
--- a/storage/integration_test.go
+++ b/storage/integration_test.go
@@ -5354,7 +5354,7 @@ func TestIntegration_HMACKey(t *testing.T) {
 		}
 
 		_, err = hkh.Get(ctx)
-		if err != nil && !strings.Contains(err.Error(), "404") {
+		if err != nil && !errorIsStatusCode(err, http.StatusNotFound, codes.NotFound) {
 			// If the deleted key has already been garbage collected, a 404 is expected.
 			// Other errors should cause a failure and are not expected.
 			t.Fatalf("Unexpected error: %v", err)


### PR DESCRIPTION
Fixes #10618 

Http-equivalent error in grpc was causing test to erroneously fail