### PR TITLE
feat(spanner): add support of multiplexed session support in writeAtleastOnce mutations

### DIFF
--- a/spanner/client.go
+++ b/spanner/client.go
@@ -1112,7 +1112,7 @@ func (c *Client) BatchWriteWithOptions(ctx context.Context, mgs []*MutationGroup
 	}
 
 	var sh *sessionHandle
-	sh, err = c.idleSessions.take(ctx)
+	sh, err = c.idleSessions.takeMultiplexed(ctx)
 	if err != nil {
 		return &BatchWriteResponseIterator{err: err}
 	}
@@ -1143,7 +1143,7 @@ func (c *Client) BatchWriteWithOptions(ctx context.Context, mgs []*MutationGroup
 			sh.destroy()
 		}
 		var sessionErr error
-		sh, sessionErr = c.idleSessions.take(ct)
+		sh, sessionErr = c.idleSessions.takeMultiplexed(ct)
 		return sessionErr
 	}
 

--- a/spanner/client.go
+++ b/spanner/client.go
@@ -1112,7 +1112,7 @@ func (c *Client) BatchWriteWithOptions(ctx context.Context, mgs []*MutationGroup
 	}
 
 	var sh *sessionHandle
-	sh, err = c.idleSessions.takeMultiplexed(ctx)
+	sh, err = c.idleSessions.take(ctx)
 	if err != nil {
 		return &BatchWriteResponseIterator{err: err}
 	}
@@ -1143,7 +1143,7 @@ func (c *Client) BatchWriteWithOptions(ctx context.Context, mgs []*MutationGroup
 			sh.destroy()
 		}
 		var sessionErr error
-		sh, sessionErr = c.idleSessions.takeMultiplexed(ct)
+		sh, sessionErr = c.idleSessions.take(ct)
 		return sessionErr
 	}
 

--- a/spanner/client_test.go
+++ b/spanner/client_test.go
@@ -5604,9 +5604,6 @@ func TestClient_BatchWrite(t *testing.T) {
 
 func TestClient_BatchWrite_SessionNotFound(t *testing.T) {
 	t.Parallel()
-	if isMultiplexEnabled {
-		t.Skip("TestClient_BatchWrite_SessionNotFound not applicable in multiplexed sessions")
-	}
 
 	server, client, teardown := setupMockedTestServer(t)
 	defer teardown()

--- a/spanner/transaction.go
+++ b/spanner/transaction.go
@@ -1890,7 +1890,7 @@ func (t *writeOnlyTransaction) applyAtLeastOnce(ctx context.Context, ms ...*Muta
 		for {
 			if sh == nil || sh.getID() == "" || sh.getClient() == nil {
 				// No usable session for doing the commit, take one from pool.
-				sh, err = t.sp.take(ctx)
+				sh, err = t.sp.takeMultiplexed(ctx)
 				if err != nil {
 					// sessionPool.Take already retries for session
 					// creations/retrivals.
@@ -1912,6 +1912,7 @@ func (t *writeOnlyTransaction) applyAtLeastOnce(ctx context.Context, ms ...*Muta
 				RequestOptions: createRequestOptions(t.commitPriority, "", t.transactionTag),
 			})
 			if err != nil && !isAbortedErr(err) {
+				// should not be the case with multiplexed sessions
 				if isSessionNotFoundError(err) {
 					// Discard the bad session.
 					sh.destroy()


### PR DESCRIPTION
* This PR add support of using Multiplexed session if enabled with `client.Apply(context.Background(), {mutations}, spanner.ApplyAtLeastOnce())`

- [X] Integration tests with multiplex session enabled pass http://sponge2/9fb45f05-a741-4efd-8252-85a1d94d8f0b
