### PR TITLE
fix(auth): make default client creation more lenient

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -493,7 +493,7 @@ func (o *Options2LO) client() *http.Client {
 	if o.Client != nil {
 		return o.Client
 	}
-	return internal.CloneDefaultClient()
+	return internal.DefaultClient()
 }
 
 func (o *Options2LO) validate() error {

--- a/auth/credentials/detect.go
+++ b/auth/credentials/detect.go
@@ -190,7 +190,7 @@ func (o *DetectOptions) client() *http.Client {
 	if o.Client != nil {
 		return o.Client
 	}
-	return internal.CloneDefaultClient()
+	return internal.DefaultClient()
 }
 
 func readCredentialsFile(filename string, opts *DetectOptions) (*auth.Credentials, error) {

--- a/auth/credentials/downscope/downscope.go
+++ b/auth/credentials/downscope/downscope.go
@@ -55,7 +55,7 @@ func (o *Options) client() *http.Client {
 	if o.Client != nil {
 		return o.Client
 	}
-	return internal.CloneDefaultClient()
+	return internal.DefaultClient()
 }
 
 // identityBindingEndpoint returns the identity binding endpoint with the

--- a/auth/credentials/externalaccount/externalaccount.go
+++ b/auth/credentials/externalaccount/externalaccount.go
@@ -219,7 +219,7 @@ func (o *Options) client() *http.Client {
 	if o.Client != nil {
 		return o.Client
 	}
-	return internal.CloneDefaultClient()
+	return internal.DefaultClient()
 }
 
 func (o *Options) toInternalOpts() *iexacc.Options {

--- a/auth/credentials/idtoken/idtoken.go
+++ b/auth/credentials/idtoken/idtoken.go
@@ -72,7 +72,7 @@ type Options struct {
 
 func (o *Options) client() *http.Client {
 	if o == nil || o.Client == nil {
-		return internal.CloneDefaultClient()
+		return internal.DefaultClient()
 	}
 	return o.Client
 }

--- a/auth/credentials/idtoken/idtoken_test.go
+++ b/auth/credentials/idtoken/idtoken_test.go
@@ -79,7 +79,7 @@ func (m mockTransport) RoundTrip(r *http.Request) (*http.Response, error) {
 
 func TestNewCredentials_ImpersonatedServiceAccount(t *testing.T) {
 	wantTok, _ := createRS256JWT(t)
-	client := internal.CloneDefaultClient()
+	client := internal.DefaultClient()
 	client.Transport = mockTransport{
 		handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Write([]byte(fmt.Sprintf(`{"token": %q}`, wantTok)))

--- a/auth/credentials/idtoken/validate.go
+++ b/auth/credentials/idtoken/validate.go
@@ -40,7 +40,7 @@ const (
 )
 
 var (
-	defaultValidator = &Validator{client: newCachingClient(internal.CloneDefaultClient())}
+	defaultValidator = &Validator{client: newCachingClient(internal.DefaultClient())}
 	// now aliases time.Now for testing.
 	now = time.Now
 )
@@ -83,7 +83,7 @@ func NewValidator(opts *ValidatorOptions) (*Validator, error) {
 	if opts != nil && opts.Client != nil {
 		client = opts.Client
 	} else {
-		client = internal.CloneDefaultClient()
+		client = internal.DefaultClient()
 	}
 	return &Validator{client: newCachingClient(client)}, nil
 }

--- a/auth/credentials/impersonate/idtoken.go
+++ b/auth/credentials/impersonate/idtoken.go
@@ -103,7 +103,7 @@ func NewIDTokenCredentials(opts *IDTokenOptions) (*auth.Credentials, error) {
 		}
 	} else if opts.Client == nil {
 		creds = opts.Credentials
-		client = internal.CloneDefaultClient()
+		client = internal.DefaultClient()
 		if err := httptransport.AddAuthorizationMiddleware(client, opts.Credentials); err != nil {
 			return nil, err
 		}

--- a/auth/credentials/impersonate/impersonate.go
+++ b/auth/credentials/impersonate/impersonate.go
@@ -79,7 +79,7 @@ func NewCredentials(opts *CredentialsOptions) (*auth.Credentials, error) {
 		}
 	} else if opts.Credentials != nil {
 		creds = opts.Credentials
-		client = internal.CloneDefaultClient()
+		client = internal.DefaultClient()
 		if err := httptransport.AddAuthorizationMiddleware(client, opts.Credentials); err != nil {
 			return nil, err
 		}

--- a/auth/credentials/internal/externalaccount/executable_provider_test.go
+++ b/auth/credentials/internal/externalaccount/executable_provider_test.go
@@ -96,7 +96,7 @@ func TestCreateExecutableCredential(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ecs, err := newSubjectTokenProvider(&Options{
-				Client: internal.CloneDefaultClient(),
+				Client: internal.DefaultClient(),
 				CredentialSource: &credsfile.CredentialSource{
 					Executable: &tt.executableConfig,
 				},

--- a/auth/credentials/internal/externalaccount/externalaccount_test.go
+++ b/auth/credentials/internal/externalaccount/externalaccount_test.go
@@ -52,7 +52,7 @@ var (
 		ClientID:         "rbrgnognrhongo3bi4gb9ghg9g",
 		CredentialSource: testBaseCredSource,
 		Scopes:           []string{"https://www.googleapis.com/auth/devstorage.full_control"},
-		Client:           internal.CloneDefaultClient(),
+		Client:           internal.DefaultClient(),
 	}
 	testBaseCredSource = &credsfile.CredentialSource{
 		File:   textBaseCredPath,
@@ -223,7 +223,7 @@ func TestNonworkforceWithWorkforcePoolUserProject(t *testing.T) {
 		CredentialSource:         testBaseCredSource,
 		Scopes:                   []string{"https://www.googleapis.com/auth/devstorage.full_control"},
 		WorkforcePoolUserProject: "myProject",
-		Client:                   internal.CloneDefaultClient(),
+		Client:                   internal.DefaultClient(),
 	}
 
 	_, err := NewTokenProvider(opts)
@@ -320,7 +320,7 @@ func run(t *testing.T, opts *Options, tets *testExchangeTokenServer) (*auth.Toke
 	}
 	tp := &tokenProvider{
 		opts:   opts,
-		client: internal.CloneDefaultClient(),
+		client: internal.DefaultClient(),
 		stp:    stp,
 	}
 
@@ -349,7 +349,7 @@ func cloneTestOpts() *Options {
 		ServiceAccountImpersonationURL: "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/service-gcs-admin@$PROJECT_ID.iam.gserviceaccount.com:generateAccessToken",
 		ClientSecret:                   "notsosecret",
 		ClientID:                       "rbrgnognrhongo3bi4gb9ghg9g",
-		Client:                         internal.CloneDefaultClient(),
+		Client:                         internal.DefaultClient(),
 	}
 }
 
@@ -373,7 +373,7 @@ func TestOptionsValidate(t *testing.T) {
 				ServiceAccountImpersonationURL: "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/service-gcs-admin@$PROJECT_ID.iam.gserviceaccount.com:generateAccessToken",
 				ClientSecret:                   "notsosecret",
 				ClientID:                       "rbrgnognrhongo3bi4gb9ghg9g",
-				Client:                         internal.CloneDefaultClient(),
+				Client:                         internal.DefaultClient(),
 				CredentialSource:               testBaseCredSource,
 			},
 		},
@@ -386,7 +386,7 @@ func TestOptionsValidate(t *testing.T) {
 				ServiceAccountImpersonationURL: "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/service-gcs-admin@$PROJECT_ID.iam.gserviceaccount.com:generateAccessToken",
 				ClientSecret:                   "notsosecret",
 				ClientID:                       "rbrgnognrhongo3bi4gb9ghg9g",
-				Client:                         internal.CloneDefaultClient(),
+				Client:                         internal.DefaultClient(),
 				CredentialSource:               testBaseCredSource,
 			},
 			wantErr: true,
@@ -400,7 +400,7 @@ func TestOptionsValidate(t *testing.T) {
 				ServiceAccountImpersonationURL: "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/service-gcs-admin@$PROJECT_ID.iam.gserviceaccount.com:generateAccessToken",
 				ClientSecret:                   "notsosecret",
 				ClientID:                       "rbrgnognrhongo3bi4gb9ghg9g",
-				Client:                         internal.CloneDefaultClient(),
+				Client:                         internal.DefaultClient(),
 				CredentialSource:               testBaseCredSource,
 			},
 			wantErr: true,
@@ -416,7 +416,7 @@ func TestOptionsValidate(t *testing.T) {
 				ServiceAccountImpersonationURL: "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/service-gcs-admin@$PROJECT_ID.iam.gserviceaccount.com:generateAccessToken",
 				ClientSecret:                   "notsosecret",
 				ClientID:                       "rbrgnognrhongo3bi4gb9ghg9g",
-				Client:                         internal.CloneDefaultClient(),
+				Client:                         internal.DefaultClient(),
 				CredentialSource:               testBaseCredSource,
 			},
 			wantErr: true,
@@ -431,7 +431,7 @@ func TestOptionsValidate(t *testing.T) {
 				ServiceAccountImpersonationURL: "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/service-gcs-admin@$PROJECT_ID.iam.gserviceaccount.com:generateAccessToken",
 				ClientSecret:                   "notsosecret",
 				ClientID:                       "rbrgnognrhongo3bi4gb9ghg9g",
-				Client:                         internal.CloneDefaultClient(),
+				Client:                         internal.DefaultClient(),
 			},
 			wantErr: true,
 		},
@@ -445,7 +445,7 @@ func TestOptionsValidate(t *testing.T) {
 				ServiceAccountImpersonationURL: "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/service-gcs-admin@$PROJECT_ID.iam.gserviceaccount.com:generateAccessToken",
 				ClientSecret:                   "notsosecret",
 				ClientID:                       "rbrgnognrhongo3bi4gb9ghg9g",
-				Client:                         internal.CloneDefaultClient(),
+				Client:                         internal.DefaultClient(),
 				CredentialSource:               testBaseCredSource,
 				SubjectTokenProvider:           fakeSubjectTokenProvider{},
 			},

--- a/auth/credentials/internal/externalaccount/externalaccount_test.go
+++ b/auth/credentials/internal/externalaccount/externalaccount_test.go
@@ -477,7 +477,7 @@ func TestClient(t *testing.T) {
 	}
 	t.Setenv("GOOGLE_API_CERTIFICATE_CONFIG", "testdata/certificate_config_workload.json")
 
-	client := internal.CloneDefaultClient()
+	client := internal.DefaultClient()
 
 	tests := []struct {
 		name              string

--- a/auth/credentials/internal/externalaccount/impersonate_test.go
+++ b/auth/credentials/internal/externalaccount/impersonate_test.go
@@ -114,7 +114,7 @@ func TestImpersonation(t *testing.T) {
 			testImpersonateOpts := tt.opts
 			testImpersonateOpts.ServiceAccountImpersonationURL = ts.URL + "/impersonate"
 			testImpersonateOpts.TokenURL = ts.URL + "/target"
-			testImpersonateOpts.Client = internal.CloneDefaultClient()
+			testImpersonateOpts.Client = internal.DefaultClient()
 
 			tp, err := NewTokenProvider(testImpersonateOpts)
 			if err != nil {

--- a/auth/credentials/internal/externalaccount/x509_provider_test.go
+++ b/auth/credentials/internal/externalaccount/x509_provider_test.go
@@ -57,7 +57,7 @@ func TestCreateX509Credential(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := newSubjectTokenProvider(&Options{
-				Client: internal.CloneDefaultClient(),
+				Client: internal.DefaultClient(),
 				CredentialSource: &credsfile.CredentialSource{
 					Certificate: &tt.certificateConfig,
 				},

--- a/auth/credentials/internal/externalaccountuser/externalaccountuser_test.go
+++ b/auth/credentials/internal/externalaccountuser/externalaccountuser_test.go
@@ -57,7 +57,7 @@ func TestExernalAccountAuthorizedUser_TokenRefreshWithRefreshTokenInResponse(t *
 		TokenURL:     s.server.URL,
 		ClientID:     "CLIENT_ID",
 		ClientSecret: "CLIENT_SECRET",
-		Client:       internal.CloneDefaultClient(),
+		Client:       internal.DefaultClient(),
 	}
 	tp, err := NewTokenProvider(opts)
 	if err != nil {
@@ -96,7 +96,7 @@ func TestExernalAccountAuthorizedUser_MinimumFieldsRequiredForRefresh(t *testing
 		TokenURL:     s.server.URL,
 		ClientID:     "CLIENT_ID",
 		ClientSecret: "CLIENT_SECRET",
-		Client:       internal.CloneDefaultClient(),
+		Client:       internal.DefaultClient(),
 	}
 	ts, err := NewTokenProvider(opts)
 	if err != nil {

--- a/auth/credentials/internal/gdch/gdch_test.go
+++ b/auth/credentials/internal/gdch/gdch_test.go
@@ -106,7 +106,7 @@ func TestTokenProvider(t *testing.T) {
 
 	cred, err := NewTokenProvider(f, &Options{
 		STSAudience: aud,
-		Client:      internal.CloneDefaultClient(),
+		Client:      internal.DefaultClient(),
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/auth/credentials/internal/impersonate/impersonate_test.go
+++ b/auth/credentials/internal/impersonate/impersonate_test.go
@@ -83,7 +83,7 @@ func TestNewImpersonatedTokenProvider(t *testing.T) {
 		URL:       ts.URL,
 		Delegates: []string{"sa1@developer.gserviceaccount.com", "sa2@developer.gserviceaccount.com"},
 		Scopes:    []string{"https://www.googleapis.com/auth/cloud-platform"},
-		Client:    internal.CloneDefaultClient(),
+		Client:    internal.DefaultClient(),
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/auth/credentials/internal/stsexchange/sts_exchange_test.go
+++ b/auth/credentials/internal/stsexchange/sts_exchange_test.go
@@ -86,7 +86,7 @@ func TestExchangeToken(t *testing.T) {
 	headers.Set("Content-Type", "application/x-www-form-urlencoded")
 
 	resp, err := ExchangeToken(context.Background(), &Options{
-		Client:         internal.CloneDefaultClient(),
+		Client:         internal.DefaultClient(),
 		Endpoint:       ts.URL,
 		Request:        &tokReq,
 		Authentication: clientAuth,
@@ -112,7 +112,7 @@ func TestExchangeToken_Err(t *testing.T) {
 	headers := http.Header{}
 	headers.Set("Content-Type", "application/x-www-form-urlencoded")
 	if _, err := ExchangeToken(context.Background(), &Options{
-		Client:         internal.CloneDefaultClient(),
+		Client:         internal.DefaultClient(),
 		Endpoint:       ts.URL,
 		Request:        &tokReq,
 		Authentication: clientAuth,
@@ -202,7 +202,7 @@ func TestExchangeToken_Opts(t *testing.T) {
 	inputOpts["two"] = secondOption
 
 	ExchangeToken(context.Background(), &Options{
-		Client:         internal.CloneDefaultClient(),
+		Client:         internal.DefaultClient(),
 		Endpoint:       ts.URL,
 		Request:        &tokReq,
 		Authentication: clientAuth,

--- a/auth/httptransport/httptransport_test.go
+++ b/auth/httptransport/httptransport_test.go
@@ -49,12 +49,12 @@ func TestAddAuthorizationMiddleware(t *testing.T) {
 		},
 		{
 			name:    "missing creds field",
-			client:  internal.CloneDefaultClient(),
+			client:  internal.DefaultClient(),
 			wantErr: true,
 		},
 		{
 			name:   "works",
-			client: internal.CloneDefaultClient(),
+			client: internal.DefaultClient(),
 			creds:  creds,
 			want:   "fakeToken",
 		},

--- a/auth/internal/internal.go
+++ b/auth/internal/internal.go
@@ -46,10 +46,24 @@ const (
 	DefaultUniverseDomain = "googleapis.com"
 )
 
-// CloneDefaultClient returns a [http.Client] with some good defaults.
-func CloneDefaultClient() *http.Client {
+type clonableTransport interface {
+	Clone() *http.Transport
+}
+
+// DefaultClient returns an [http.Client] with some defaults set. If
+// the current [http.DefaultTransport] is a [clonableTransport], as
+// is the case for an [*http.Transport], the clone will be used.
+// Otherwise the [http.DefaultTransport] is used directly.
+func DefaultClient() *http.Client {
+	if transport, ok := http.DefaultTransport.(clonableTransport); ok {
+		return &http.Client{
+			Transport: transport.Clone(),
+			Timeout:   30 * time.Second,
+		}
+	}
+
 	return &http.Client{
-		Transport: http.DefaultTransport.(*http.Transport).Clone(),
+		Transport: http.DefaultTransport,
 		Timeout:   30 * time.Second,
 	}
 }

--- a/auth/internal/testutil/testdns/dns.go
+++ b/auth/internal/testutil/testdns/dns.go
@@ -35,7 +35,7 @@ type Client struct {
 // NewClient creates a [Client] using the provided
 // [cloud.google.com/go/auth.TokenProvider] for authentication.
 func NewClient(tp auth.TokenProvider) *Client {
-	client := internal.CloneDefaultClient()
+	client := internal.DefaultClient()
 	httptransport.AddAuthorizationMiddleware(client, auth.NewCredentials(&auth.CredentialsOptions{
 		TokenProvider: tp,
 	}))

--- a/auth/internal/testutil/testgcs/storage.go
+++ b/auth/internal/testutil/testgcs/storage.go
@@ -37,7 +37,7 @@ type Client struct {
 // NewClient creates a [Client] using the provided
 // [cloud.google.com/go/auth.TokenProvider] for authentication.
 func NewClient(tp auth.TokenProvider) *Client {
-	client := internal.CloneDefaultClient()
+	client := internal.DefaultClient()
 	httptransport.AddAuthorizationMiddleware(client, auth.NewCredentials(&auth.CredentialsOptions{
 		TokenProvider: tp,
 	}))

--- a/auth/threelegged.go
+++ b/auth/threelegged.go
@@ -128,7 +128,7 @@ func (o *Options3LO) client() *http.Client {
 	if o.Client != nil {
 		return o.Client
 	}
-	return internal.CloneDefaultClient()
+	return internal.DefaultClient()
 }
 
 // authCodeURL returns a URL that points to a OAuth2 consent page.


### PR DESCRIPTION
Before this commit, `CloneDefaultClient` would panic if `http.DefaultTransport`
was set to something that's not an `*http.Transport`. It is very much possible
that this is the case if users assign a different `http.RoundTripper` to
`http.DefaultTransport`, for example for tracing purposes.

This commit renames `CloneDefaultClient` to `DefaultClient`, and changes its
behavior to check if the `http.DefaultTransport` can be cloned, and uses the
clone if possible. If it can't be cloned, it'll use the `http.DefaultTransport`
directly.

Fixes: #10638