### PR TITLE
fix(bigquery): processStream check ctx done when queuing non retryable err

### DIFF
--- a/bigquery/storage_iterator.go
+++ b/bigquery/storage_iterator.go
@@ -246,17 +246,10 @@ func (it *storageArrowIterator) processStream(readStream string) {
 			Offset:     offset,
 		})
 		if err != nil {
-			if it.session.ctx.Err() != nil { // context cancelled, don't try again
+			serr := it.handleProcessStreamError(readStream, bo, err)
+			if serr != nil {
 				return
 			}
-			backoff, shouldRetry := retryReadRows(bo, err)
-			if shouldRetry {
-				if err := gax.Sleep(it.ctx, backoff); err != nil {
-					return // context cancelled
-				}
-				continue
-			}
-			it.errs <- fmt.Errorf("failed to read rows on stream %s: %w", readStream, err)
 			continue
 		}
 		offset, err = it.consumeRowStream(readStream, rowStream, offset)
@@ -264,19 +257,34 @@ func (it *storageArrowIterator) processStream(readStream string) {
 			return
 		}
 		if err != nil {
-			if it.session.ctx.Err() != nil { // context cancelled, don't queue error
+			serr := it.handleProcessStreamError(readStream, bo, err)
+			if serr != nil {
 				return
 			}
-			backoff, shouldRetry := retryReadRows(bo, err)
-			if shouldRetry {
-				if err := gax.Sleep(it.ctx, backoff); err != nil {
-					return // context cancelled
-				}
-				continue
-			}
-			it.errs <- fmt.Errorf("failed to read rows on stream %s: %w", readStream, err)
-			// try to re-open row stream with updated offset
 		}
+	}
+}
+
+// handleProcessStreamError check if err is retryable,
+// waiting with exponential backoff in that scenario.
+// If error is not retryable, queue up err to be sent to user.
+// Return error if should exit the goroutine.
+func (it *storageArrowIterator) handleProcessStreamError(readStream string, bo gax.Backoff, err error) error {
+	if it.session.ctx.Err() != nil { // context cancelled, don't try again
+		return it.session.ctx.Err()
+	}
+	backoff, shouldRetry := retryReadRows(bo, err)
+	if shouldRetry {
+		if err := gax.Sleep(it.ctx, backoff); err != nil {
+			return err // context cancelled
+		}
+		return nil
+	}
+	select {
+	case it.errs <- fmt.Errorf("failed to read rows on stream %s: %w", readStream, err):
+		return nil
+	case <-it.ctx.Done():
+		return context.Canceled
 	}
 }
 

--- a/bigquery/storage_iterator_test.go
+++ b/bigquery/storage_iterator_test.go
@@ -29,6 +29,11 @@ import (
 )
 
 func TestStorageIteratorRetry(t *testing.T) {
+	settings := defaultReadClientSettings()
+	randomErrors := []error{} // generate more errors than the # of workers
+	for i := 0; i < settings.maxWorkerCount+2; i++ {
+		randomErrors = append(randomErrors, fmt.Errorf("random error %d", i))
+	}
 	cancelledCtx, cancel := context.WithCancel(context.Background())
 	cancel()
 	testCases := []struct {
@@ -84,6 +89,11 @@ func TestStorageIteratorRetry(t *testing.T) {
 			},
 			wantFail: true,
 		},
+		{
+			desc:     "filled with non-retryable errors and context cancelled",
+			errors:   randomErrors,
+			wantFail: true,
+		},
 	}
 	for _, tc := range testCases {
 		rrc := &testReadRowsClient{
@@ -115,9 +125,9 @@ func TestStorageIteratorRetry(t *testing.T) {
 
 			it, err := newRawStorageRowIterator(&readSession{
 				ctx:          ctx,
-				settings:     defaultReadClientSettings(),
-				readRowsFunc: readRowsFunc,
+				settings:     settings,
 				bqSession:    &storagepb.ReadSession{},
+				readRowsFunc: readRowsFunc,
 			}, Schema{})
 			if err != nil {
 				t.Fatalf("case %s: newRawStorageRowIterator: %v", tc.desc, err)
@@ -125,7 +135,8 @@ func TestStorageIteratorRetry(t *testing.T) {
 
 			it.processStream("test-stream")
 
-			if errors.Is(it.ctx.Err(), context.Canceled) || errors.Is(it.ctx.Err(), context.DeadlineExceeded) {
+			if errors.Is(it.ctx.Err(), context.Canceled) ||
+				errors.Is(it.ctx.Err(), context.DeadlineExceeded) {
 				if tc.wantFail {
 					continue
 				}


### PR DESCRIPTION
When service side returns non-retryable errors faster than they are being consumed by the user (via `Next` call), the `processStream` goroutine can become locked and leak, even when context is cancelled. With this PR, we wrap the call to `it.errs` call with `select` and check for context done. 

Towards #10672