### PR TITLE
chore(github): pin staticcheck in vet.yml to v0.4.7 

### DIFF
--- a/.github/workflows/vet.yml
+++ b/.github/workflows/vet.yml
@@ -21,6 +21,6 @@ jobs:
       run: |
         go install golang.org/x/lint/golint@latest && \
         go install golang.org/x/tools/cmd/goimports@latest && \
-        go install honnef.co/go/tools/cmd/staticcheck@latest
+        go install honnef.co/go/tools/cmd/staticcheck@v0.4.7
     - name: Execute vet.sh
       run: ./.github/workflows/vet.sh


### PR DESCRIPTION
* Fixes go 1.20 error honnef.co/go/tools@v0.5.0: invalid go version