### PR TITLE
[POC] Retry on read stall

### DIFF
--- a/storage/bucket_test.go
+++ b/storage/bucket_test.go
@@ -1107,7 +1107,8 @@ func TestBucketRetryer(t *testing.T) {
 					}),
 					WithPolicy(RetryAlways),
 					WithMaxAttempts(5),
-					WithErrorFunc(func(err error) bool { return false }))
+					WithErrorFunc(func(err error) bool { return false }),
+					WithReadStallTimeout(time.Second))
 			},
 			want: &retryConfig{
 				backoff: &gax.Backoff{
@@ -1115,9 +1116,10 @@ func TestBucketRetryer(t *testing.T) {
 					Max:        30 * time.Second,
 					Multiplier: 3,
 				},
-				policy:      RetryAlways,
-				maxAttempts: expectedAttempts(5),
-				shouldRetry: func(err error) bool { return false },
+				policy:           RetryAlways,
+				maxAttempts:      expectedAttempts(5),
+				shouldRetry:      func(err error) bool { return false },
+				readStallTimeout: time.Second,
 			},
 		},
 		{
@@ -1159,6 +1161,16 @@ func TestBucketRetryer(t *testing.T) {
 			},
 			want: &retryConfig{
 				shouldRetry: func(err error) bool { return false },
+			},
+		},
+		{
+			name: "set read stall timeout only",
+			call: func(b *BucketHandle) *BucketHandle {
+				return b.Retryer(
+					WithReadStallTimeout(10 * time.Second))
+			},
+			want: &retryConfig{
+				readStallTimeout: 10 * time.Second,
 			},
 		},
 	}

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -15,9 +15,11 @@
 package storage
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"log"
 	"net/url"
 	"os"
@@ -1440,7 +1442,7 @@ func TestTimeoutErrorEmulated(t *testing.T) {
 }
 
 // Test that server-side DEADLINE_EXCEEDED errors are retried as expected with gRPC.
-func TestRetryDeadlineExceedeEmulated(t *testing.T) {
+func TestRetryDeadlineExceededEmulated(t *testing.T) {
 	transportClientTest(t, func(t *testing.T, project, bucket string, client storageClient) {
 		ctx := context.Background()
 		instructions := map[string][]string{"storage.buckets.get": {"return-504", "return-504"}}
@@ -1450,6 +1452,53 @@ func TestRetryDeadlineExceedeEmulated(t *testing.T) {
 		if _, err := client.GetBucket(ctx, bucket, nil, idempotent(true), withRetryConfig(config)); err != nil {
 			t.Fatalf("GetBucket: got unexpected error %v, want nil", err)
 		}
+	})
+}
+
+// Test that a stall during a read request is retried when ReadStallTimeout is set.
+func TestRetryReadStallEmulated(t *testing.T) {
+	transportClientTest(t, func(t *testing.T, project, bucket string, client storageClient) {
+		ctx := context.Background()
+
+		// Setup bucket and upload object.
+		if _, err := client.CreateBucket(context.Background(), project, bucket, &BucketAttrs{Name: bucket}, nil); err != nil {
+			t.Fatalf("client.CreateBucket: %v", err)
+		}
+		name, _, _, err := createObject(ctx, bucket)
+		if err != nil {
+			t.Fatalf("createObject: %v", err)
+		}
+
+		// This causes a stall after reading 256k bytes for up to 10s.
+		ctx = callctx.SetHeaders(ctx, "x-goog-emulator-instructions", "stall-at-256KiB")
+		ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+		defer cancel()
+
+		config := &retryConfig{
+			maxAttempts:      expectedAttempts(4),
+			backoff:          &gax.Backoff{Initial: 10 * time.Millisecond},
+			readStallTimeout: 20 * time.Millisecond,
+		}
+		r, err := client.NewRangeReader(ctx, &newRangeReaderParams{
+			bucket: bucket,
+			object: name,
+			gen:    defaultGen,
+			offset: 0,
+			length: -1,
+		}, withRetryConfig(config), idempotent(true))
+		if err != nil {
+			t.Fatalf("NewRangeReader: %v", err)
+		}
+		defer r.Close()
+
+		buf := &bytes.Buffer{}
+		if _, err := io.Copy(buf, r); err != nil {
+			t.Fatalf("io.Copy: %v", err)
+		}
+		if !bytes.Equal(buf.Bytes(), randomBytes3MiB) {
+			t.Errorf("content does not match, got len %v, want len %v", buf.Len(), len(randomBytes3MiB))
+		}
+
 	})
 }
 
@@ -1494,7 +1543,7 @@ func createObject(ctx context.Context, bucket string) (string, int64, int64, err
 	objName := fmt.Sprintf("%d-object", prefix)
 
 	w := veneerClient.Bucket(bucket).Object(objName).NewWriter(ctx)
-	if _, err := w.Write(randomBytesToWrite); err != nil {
+	if _, err := w.Write(randomBytes3MiB); err != nil {
 		return "", 0, 0, fmt.Errorf("failed to populate test data: %w", err)
 	}
 	if err := w.Close(); err != nil {

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -1502,6 +1502,53 @@ func TestRetryReadStallEmulated(t *testing.T) {
 	})
 }
 
+// Test that a stall during a read request is retried when ReadStallTimeout is set.
+func TestRetryReadStallAlwaysEmulated(t *testing.T) {
+	transportClientTest(t, func(t *testing.T, project, bucket string, client storageClient) {
+		ctx := context.Background()
+
+		// Setup bucket and upload object.
+		if _, err := client.CreateBucket(context.Background(), project, bucket, &BucketAttrs{Name: bucket}, nil); err != nil {
+			t.Fatalf("client.CreateBucket: %v", err)
+		}
+		name, _, _, err := createObject(ctx, bucket)
+		if err != nil {
+			t.Fatalf("createObject: %v", err)
+		}
+
+		// This causes a stall after reading 256k bytes for up to 10s.
+		ctx = callctx.SetHeaders(ctx, "x-goog-emulator-instructions", "stall-always")
+		ctx, cancel := context.WithTimeout(ctx, 4*time.Second)
+		defer cancel()
+
+		config := &retryConfig{
+			maxAttempts:      expectedAttempts(4),
+			backoff:          &gax.Backoff{Initial: 200 * time.Millisecond},
+			readStallTimeout: 1 * time.Second,
+		}
+		r, err := client.NewRangeReader(ctx, &newRangeReaderParams{
+			bucket: bucket,
+			object: name,
+			gen:    defaultGen,
+			offset: 0,
+			length: -1,
+		}, withRetryConfig(config), idempotent(true))
+		if err != nil {
+			t.Fatalf("NewRangeReader: %v", err)
+		}
+		defer r.Close()
+
+		buf := &bytes.Buffer{}
+		if _, err := io.Copy(buf, r); err != nil {
+			t.Fatalf("io.Copy: %v", err)
+		}
+		if !bytes.Equal(buf.Bytes(), randomBytes3MiB[1:]) {
+			t.Errorf("content does not match, got len %v, want len %v", buf.Len(), len(randomBytes3MiB))
+		}
+
+	})
+}
+
 // createRetryTest creates a bucket in the emulator and sets up a test using the
 // Retry Test API for the given instructions. This is intended for emulator tests
 // of retry behavior that are not covered by conformance tests.

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -2250,11 +2250,30 @@ func (wef *withErrorFunc) apply(config *retryConfig) {
 	config.shouldRetry = wef.shouldRetry
 }
 
+// WithReadStallTimeout returns a retry option that proactively terminates the
+// connection and retries if a download using storage.Reader hangs for longer
+// than the provided timeout. The default value is no timeout. This only is
+// applied for HTTP requests currently (not gRPC).
+func WithReadStallTimeout(timeout time.Duration) RetryOption {
+	return &withReadStallTimeout{
+		readStallTimeout: timeout,
+	}
+}
+
+type withReadStallTimeout struct {
+	readStallTimeout time.Duration
+}
+
+func (wrst *withReadStallTimeout) apply(config *retryConfig) {
+	config.readStallTimeout = wrst.readStallTimeout
+}
+
 type retryConfig struct {
-	backoff     *gax.Backoff
-	policy      RetryPolicy
-	shouldRetry func(err error) bool
-	maxAttempts *int
+	backoff          *gax.Backoff
+	policy           RetryPolicy
+	shouldRetry      func(err error) bool
+	maxAttempts      *int
+	readStallTimeout time.Duration
 }
 
 func (r *retryConfig) clone() *retryConfig {
@@ -2272,10 +2291,11 @@ func (r *retryConfig) clone() *retryConfig {
 	}
 
 	return &retryConfig{
-		backoff:     bo,
-		policy:      r.policy,
-		shouldRetry: r.shouldRetry,
-		maxAttempts: r.maxAttempts,
+		backoff:          bo,
+		policy:           r.policy,
+		shouldRetry:      r.shouldRetry,
+		maxAttempts:      r.maxAttempts,
+		readStallTimeout: r.readStallTimeout,
 	}
 }
 

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -983,7 +983,8 @@ func TestObjectRetryer(t *testing.T) {
 					}),
 					WithMaxAttempts(5),
 					WithPolicy(RetryAlways),
-					WithErrorFunc(func(err error) bool { return false }))
+					WithErrorFunc(func(err error) bool { return false }),
+					WithReadStallTimeout(time.Second))
 			},
 			want: &retryConfig{
 				backoff: &gax.Backoff{
@@ -991,9 +992,10 @@ func TestObjectRetryer(t *testing.T) {
 					Max:        30 * time.Second,
 					Multiplier: 3,
 				},
-				maxAttempts: expectedAttempts(5),
-				policy:      RetryAlways,
-				shouldRetry: func(err error) bool { return false },
+				maxAttempts:      expectedAttempts(5),
+				policy:           RetryAlways,
+				shouldRetry:      func(err error) bool { return false },
+				readStallTimeout: time.Second,
 			},
 		},
 		{
@@ -1035,6 +1037,15 @@ func TestObjectRetryer(t *testing.T) {
 			},
 			want: &retryConfig{
 				shouldRetry: func(err error) bool { return false },
+			},
+		},
+		{
+			name: "set read stall timeout only",
+			call: func(o *ObjectHandle) *ObjectHandle {
+				return o.Retryer(WithReadStallTimeout(time.Second))
+			},
+			want: &retryConfig{
+				readStallTimeout: time.Second,
 			},
 		},
 	}
@@ -1081,6 +1092,7 @@ func TestClientSetRetry(t *testing.T) {
 				WithMaxAttempts(5),
 				WithPolicy(RetryAlways),
 				WithErrorFunc(func(err error) bool { return false }),
+				WithReadStallTimeout(time.Second),
 			},
 			want: &retryConfig{
 				backoff: &gax.Backoff{
@@ -1088,9 +1100,10 @@ func TestClientSetRetry(t *testing.T) {
 					Max:        30 * time.Second,
 					Multiplier: 3,
 				},
-				maxAttempts: expectedAttempts(5),
-				policy:      RetryAlways,
-				shouldRetry: func(err error) bool { return false },
+				maxAttempts:      expectedAttempts(5),
+				policy:           RetryAlways,
+				shouldRetry:      func(err error) bool { return false },
+				readStallTimeout: time.Second,
 			},
 		},
 		{
@@ -1130,6 +1143,15 @@ func TestClientSetRetry(t *testing.T) {
 			},
 			want: &retryConfig{
 				shouldRetry: func(err error) bool { return false },
+			},
+		},
+		{
+			name: "set read stall timeout only",
+			clientOptions: []RetryOption{
+				WithReadStallTimeout(time.Second),
+			},
+			want: &retryConfig{
+				readStallTimeout: time.Second,
 			},
 		},
 	}


### PR DESCRIPTION
- Adding logic to retry in case of stall while making read request.
- Changes to retry in case of stall while reading from http response. (tritone's changes: [link](https://github.com/tritone/google-cloud-go/tree/read-stall-timeout))