### PR TITLE
fix(auth): handle ENOTDIR when opening cert config

### DIFF
--- a/auth/internal/transport/cert/secureconnect_cert.go
+++ b/auth/internal/transport/cert/secureconnect_cert.go
@@ -62,11 +62,11 @@ func NewSecureConnectProvider(configFilePath string) (Provider, error) {
 
 	file, err := os.ReadFile(configFilePath)
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			// Config file missing means Secure Connect is not supported.
-			return nil, errSourceUnavailable
-		}
-		return nil, err
+		// Config file missing means Secure Connect is not supported.
+		// There are non-os.ErrNotExist errors that may be returned.
+		// (e.g. if the home directory is /dev/null, *nix systems will
+		// return ENOTDIR instead of ENOENT)
+		return nil, errSourceUnavailable
 	}
 
 	var metadata secureConnectMetadata


### PR DESCRIPTION
Some users explicitly have their home directories set to `/dev/null`. When opening a file that's "under that directory", instead of getting the normal `ENOENT`, one should expect to get `ENOTDIR`.

Unfortunately, due to the variety of cases under which `ENOTDIR` is returned, the go team has declined to include ENOTDIR in `ErrNotExist`. (https://golang.org/issues/18974)

The most robust solution in this case (following [1]) is to treat any
read error as `errSourceUnavailable`. This has the mixed-benefit of also
covering EPERM. (hopefully this doesn't make it too hard to track down
permissions problems for secure connect users)
    
   
Resolves: #10696

 [1]: https://go-review.googlesource.com/c/oauth2/+/493695