### PR TITLE
chore: add release level for datastore

### DIFF
--- a/internal/gapicgen/generator/genproto_test.go
+++ b/internal/gapicgen/generator/genproto_test.go
@@ -25,9 +25,8 @@ func TestFilterPackages(t *testing.T) {
 		"google.golang.org/genproto/do/not/generate/me": {"foo.proto"},
 	}
 	want := map[string][]string{
-		"google.golang.org/genproto/googleapis/api/distribution":  {"foo.proto"},
-		"google.golang.org/genproto/googleapis/type/date_range":   {"foo.proto"},
-		"google.golang.org/genproto/googleapis/bigtable/admin/v2": {"foo.proto"},
+		"google.golang.org/genproto/googleapis/api/distribution": {"foo.proto"},
+		"google.golang.org/genproto/googleapis/type/date_range":  {"foo.proto"},
 	}
 	out, err := filterPackages(in)
 	if err != nil {

--- a/internal/postprocessor/config.yaml
+++ b/internal/postprocessor/config.yaml
@@ -1047,6 +1047,7 @@ service-configs:
   - input-directory: google/datastore/v1
     service-config: datastore_v1.yaml
     import-path: cloud.google.com/go/datastore/apiv1
+    release-level-override: stable
   - input-directory: google/devtools/artifactregistry/v1
     service-config: artifactregistry_v1.yaml
     import-path: cloud.google.com/go/artifactregistry/apiv1

--- a/internal/postprocessor/main.go
+++ b/internal/postprocessor/main.go
@@ -45,7 +45,7 @@ const (
 	// This is the default Go version that will be generated into new go.mod
 	// files. It should be updated every time we drop support for old Go
 	// versions.
-	defaultGoModuleVersion = "1.19"
+	defaultGoModuleVersion = "1.21"
 )
 
 var (


### PR DESCRIPTION
Follow-up fix for post-processor error from: #10708

Also fix go.mod version for new clients.

Fixes: #10715