### PR TITLE
fix(spanner): check errors in tests

### DIFF
--- a/spanner/client_test.go
+++ b/spanner/client_test.go
@@ -4725,10 +4725,10 @@ func TestClient_EmulatorWithCredentialsFile(t *testing.T) {
 		"localhost:1234",
 		opts...,
 	)
-	defer client.Close()
 	if err != nil {
 		t.Fatalf("Failed to create a client with credentials file when running against an emulator: %v", err)
 	}
+	defer client.Close()
 }
 
 func TestBatchReadOnlyTransaction_QueryOptions(t *testing.T) {

--- a/spanner/client_test.go
+++ b/spanner/client_test.go
@@ -3149,7 +3149,6 @@ func TestClient_ReadWriteTransactionConcurrentQueries(t *testing.T) {
 				}
 				rowCount++
 			}
-			return
 		}
 		wg.Add(2)
 		go query(&firstTransactionID)

--- a/spanner/session.go
+++ b/spanner/session.go
@@ -762,7 +762,6 @@ func newSessionPool(sc *sessionClient, config SessionPoolConfig) (*sessionPool, 
 			// wait for the session to be created
 			case <-pool.mayGetMultiplexedSession:
 			}
-			return
 		}()
 	}
 	pool.recordStat(context.Background(), MaxAllowedSessionsCount, int64(config.MaxOpened))

--- a/spanner/transaction_test.go
+++ b/spanner/transaction_test.go
@@ -566,6 +566,10 @@ func TestReadWriteStmtBasedTransactionWithOptions(t *testing.T) {
 			client,
 			TransactionOptions{CommitOptions: CommitOptions{ReturnCommitStats: true}},
 		)
+		if err != nil {
+			t.Fatalf("failed to create transaction: %v", err)
+		}
+
 		_, err = f(tx)
 		if err != nil && status.Code(err) != codes.Aborted {
 			tx.Rollback(ctx)
@@ -593,6 +597,10 @@ func TestBatchDML_StatementBased_WithMultipleDML(t *testing.T) {
 	defer teardown()
 
 	tx, err := NewReadWriteStmtBasedTransaction(ctx, client)
+	if err != nil {
+		t.Fatalf("failed to create transaction: %v", err)
+	}
+
 	if _, err = tx.Update(ctx, Statement{SQL: UpdateBarSetFoo}); err != nil {
 		tx.Rollback(ctx)
 		t.Fatal(err)
@@ -654,6 +662,10 @@ func TestPriorityInQueryOptions(t *testing.T) {
 	defer teardown()
 
 	tx, err := NewReadWriteStmtBasedTransaction(ctx, client)
+	if err != nil {
+		t.Fatalf("failed to create transaction: %v", err)
+	}
+
 	var iter *RowIterator
 	iter = tx.txReadOnly.Query(ctx, NewStatement("SELECT 1"))
 	err = iter.Do(func(r *Row) error { return nil })


### PR DESCRIPTION
- fix(spanner): add missing error checks to tests
- fix(spanner): check error before using client in test
- chore(spanner): remove redundant return-s
