### PR TITLE
chore(spanner): simplifications of code from staticcheck

### DIFF
--- a/spanner/client.go
+++ b/spanner/client.go
@@ -128,7 +128,7 @@ func createGCPMultiEndpoint(cfg *grpcgcp.GCPMultiEndpointOptions, config ClientC
 	if cfg.GRPCgcpConfig == nil {
 		cfg.GRPCgcpConfig = &grpcgcppb.ApiConfig{}
 	}
-	if cfg.GRPCgcpConfig.Method == nil || len(cfg.GRPCgcpConfig.Method) == 0 {
+	if len(cfg.GRPCgcpConfig.Method) == 0 {
 		cfg.GRPCgcpConfig.Method = []*grpcgcppb.MethodConfig{
 			{
 				Name: []string{"/google.spanner.v1.Spanner/CreateSession"},

--- a/spanner/client_test.go
+++ b/spanner/client_test.go
@@ -501,9 +501,8 @@ func TestClient_MultiplexedSession(t *testing.T) {
 				}
 				reqs := drainRequestsFromServer(server)
 				for _, s := range reqs {
-					switch s.(type) {
+					switch req := s.(type) {
 					case *sppb.ReadRequest:
-						req, _ := s.(*sppb.ReadRequest)
 						// Validate the session is multiplexed
 						if !testEqual(isMultiplexEnabled, strings.Contains(req.Session, "multiplexed")) {
 							t.Errorf("TestClient_MultiplexedSession expected multiplexed session to be used, got: %v", req.Session)
@@ -542,15 +541,13 @@ func TestClient_MultiplexedSession(t *testing.T) {
 				}
 				reqs := drainRequestsFromServer(server)
 				for _, s := range reqs {
-					switch s.(type) {
+					switch req := s.(type) {
 					case *sppb.ReadRequest:
-						req, _ := s.(*sppb.ReadRequest)
 						// Validate the session is multiplexed
 						if !testEqual(isMultiplexEnabled, strings.Contains(req.Session, "multiplexed")) {
 							t.Errorf("TestClient_MultiplexedSession expected multiplexed session to be used, got: %v", req.Session)
 						}
 					case *sppb.ExecuteSqlRequest:
-						req, _ := s.(*sppb.ExecuteSqlRequest)
 						// Validate the session is multiplexed
 						if !testEqual(isMultiplexEnabled, strings.Contains(req.Session, "multiplexed")) {
 							t.Errorf("TestClient_MultiplexedSession expected multiplexed session to be used, got: %v", req.Session)
@@ -584,9 +581,8 @@ func TestClient_MultiplexedSession(t *testing.T) {
 				}
 				reqs := drainRequestsFromServer(server)
 				for _, s := range reqs {
-					switch s.(type) {
+					switch req := s.(type) {
 					case *sppb.ReadRequest:
-						req, _ := s.(*sppb.ReadRequest)
 						// Validate the session is not multiplexed
 						if !testEqual(false, strings.Contains(req.Session, "multiplexed")) {
 							t.Errorf("TestClient_MultiplexedSession expected multiplexed session to be used, got: %v", req.Session)
@@ -621,9 +617,8 @@ func TestClient_MultiplexedSession(t *testing.T) {
 				}
 				reqs := drainRequestsFromServer(server)
 				for _, s := range reqs {
-					switch s.(type) {
+					switch req := s.(type) {
 					case *sppb.ReadRequest:
-						req, _ := s.(*sppb.ReadRequest)
 						// Verify that a multiplexed session is used when that is enabled.
 						if !testEqual(isMultiplexEnabled, strings.Contains(req.Session, "multiplexed")) {
 							t.Errorf("TestClient_MultiplexedSession expected multiplexed session to be used, got: %v", req.Session)

--- a/spanner/integration_test.go
+++ b/spanner/integration_test.go
@@ -5336,7 +5336,7 @@ func TestIntegration_Foreign_Key_Delete_Cascade_Action(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			gotErr := tt.test()
 			// convert the error to lower case because resource names are in lower case for PG dialect.
-			if gotErr != nil && strings.ToLower(gotErr.Error()) != strings.ToLower(tt.wantErr.Error()) {
+			if gotErr != nil && !strings.EqualFold(gotErr.Error(), tt.wantErr.Error()) {
 				t.Errorf("FKDC error=%v, wantErr: %v", gotErr, tt.wantErr)
 			} else {
 				tt.validate()
@@ -5629,7 +5629,7 @@ func TestIntegration_Bit_Reversed_Sequence(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			gotErr := tt.test()
-			if gotErr != nil && strings.ToLower(gotErr.Error()) != strings.ToLower(tt.wantErr.Error()) {
+			if gotErr != nil && !strings.EqualFold(gotErr.Error(), tt.wantErr.Error()) {
 				t.Errorf("BIT REVERSED SEQUENECES error=%v, wantErr: %v", gotErr, tt.wantErr)
 			}
 		})

--- a/spanner/internal/testutil/inmem_spanner_server.go
+++ b/spanner/internal/testutil/inmem_spanner_server.go
@@ -683,7 +683,7 @@ func (s *inMemSpannerServer) simulateExecutionTime(method string, req interface{
 		totalExecutionTime := time.Duration(int64(executionTime.MinimumExecutionTime) + randTime)
 		<-time.After(totalExecutionTime)
 		s.mu.Lock()
-		if executionTime.Errors != nil && len(executionTime.Errors) > 0 {
+		if len(executionTime.Errors) > 0 {
 			err := executionTime.Errors[0]
 			if !executionTime.KeepError {
 				executionTime.Errors = executionTime.Errors[1:]

--- a/spanner/spansql/parser.go
+++ b/spanner/spansql/parser.go
@@ -942,10 +942,7 @@ func (p *parser) sniffTokenType(want tokenType) bool {
 	orig := *p
 	defer func() { *p = orig }()
 
-	if p.next().typ == want {
-		return true
-	}
-	return false
+	return p.next().typ == want
 }
 
 // eat reports whether the next N tokens are as specified,

--- a/spanner/test/cloudexecutor/executor/actions/partition.go
+++ b/spanner/test/cloudexecutor/executor/actions/partition.go
@@ -168,7 +168,7 @@ func (h *ExecutePartition) ExecuteAction(ctx context.Context) error {
 	}
 
 	partitionBinary := h.Action.GetPartition().GetPartition()
-	if partitionBinary == nil || len(partitionBinary) == 0 {
+	if len(partitionBinary) == 0 {
 		return h.OutcomeSender.FinishWithError(spanner.ToSpannerError(status.Errorf(codes.InvalidArgument, "Invalid batchPartition %s", h.Action)))
 	}
 	if h.Action.GetPartition().Table != nil {

--- a/spanner/transaction_test.go
+++ b/spanner/transaction_test.go
@@ -178,9 +178,8 @@ func TestApply_Single(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, s := range requests {
-		switch s.(type) {
+		switch req := s.(type) {
 		case *sppb.CommitRequest:
-			req, _ := s.(*sppb.CommitRequest)
 			// Validate the session is multiplexed
 			if !testEqual(isMultiplexEnabled, strings.Contains(req.Session, "multiplexed")) {
 				t.Errorf("TestApply_Single expected multiplexed session to be used, got: %v", req.Session)


### PR DESCRIPTION
- chore(spanner): simplify test code with strings.EqualFold
- chore(spanner): simplify return of bool result
- chore(spanner): simplify slice non-empty checks
- chore(spanner): avoid type assertions in switch

Updates #9784 