### PR TITLE
feat(bigtable): Update go version for conformance tests

### DIFF
--- a/bigtable/conformance_test.sh
+++ b/bigtable/conformance_test.sh
@@ -50,10 +50,10 @@ trap cleanup EXIT
 
 # Run the conformance tests
 cd $conformanceTestsHome
-# Tests in https://github.com/googleapis/cloud-bigtable-clients-test/tree/main/tests can only be run on go1.20.2
-go install golang.org/dl/go1.20.2@latest
-go1.20.2 download
-go1.20.2 test -v -proxy_addr=:$testProxyPort | tee -a $sponge_log
+# Tests in https://github.com/googleapis/cloud-bigtable-clients-test/tree/main/tests can only be run on go1.22.5
+go install golang.org/dl/go1.22.5@latest
+go1.22.5 download
+go1.22.5 test -v -proxy_addr=:$testProxyPort | tee -a $sponge_log
 RETURN_CODE=$?
 
 echo "exiting with ${RETURN_CODE}"


### PR DESCRIPTION
The Go version has been updated in tests repository here: https://github.com/googleapis/cloud-bigtable-clients-test/commit/6de431b0921124047053658bdd896f0234530955

So, the conformance tests do not run and throw error:

```
+ tee -a /home/runner/work/google-cloud-go/google-cloud-go/google-cloud-go/bigtable/sponge_log.log
go: errors parsing go.mod:
/home/runner/work/google-cloud-go/google-cloud-go/cloud-bigtable-clients-test/go.mod:5: unknown directive: toolchain
```

This PR fixes this by updating the go version in invocation of conformance test run
