### PR TITLE
docs(auth): fix Go doc comment link

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -130,7 +130,9 @@ func (t *Token) isEmpty() bool {
 }
 
 // Credentials holds Google credentials, including
-// [Application Default Credentials](https://developers.google.com/accounts/docs/application-default-credentials).
+// [Application Default Credentials].
+//
+// [Application Default Credentials]: https://developers.google.com/accounts/docs/application-default-credentials
 type Credentials struct {
 	json           []byte
 	projectID      CredentialsPropertyProvider


### PR DESCRIPTION
Fix link in Go doc comment per https://go.dev/doc/comment#links, so that it renders properly on pkgsite.