### PR TITLE
perf: avoid unnecessary fmt.Errorf

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -597,7 +597,7 @@ func (tp tokenProvider2LO) Token(ctx context.Context) (*Token, error) {
 	}
 	if tp.opts.UseIDToken {
 		if tokenRes.IDToken == "" {
-			return nil, fmt.Errorf("auth: response doesn't have JWT token")
+			return nil, errors.New("auth: response doesn't have JWT token")
 		}
 		token.Value = tokenRes.IDToken
 	}

--- a/auth/credentials/downscope/downscope.go
+++ b/auth/credentials/downscope/downscope.go
@@ -17,6 +17,7 @@ package downscope
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -104,23 +105,23 @@ type AvailabilityCondition struct {
 // will delegate to the base credentials for all non-token activity.
 func NewCredentials(opts *Options) (*auth.Credentials, error) {
 	if opts == nil {
-		return nil, fmt.Errorf("downscope: providing opts is required")
+		return nil, errors.New("downscope: providing opts is required")
 	}
 	if opts.Credentials == nil {
-		return nil, fmt.Errorf("downscope: Credentials cannot be nil")
+		return nil, errors.New("downscope: Credentials cannot be nil")
 	}
 	if len(opts.Rules) == 0 {
-		return nil, fmt.Errorf("downscope: length of AccessBoundaryRules must be at least 1")
+		return nil, errors.New("downscope: length of AccessBoundaryRules must be at least 1")
 	}
 	if len(opts.Rules) > 10 {
-		return nil, fmt.Errorf("downscope: length of AccessBoundaryRules may not be greater than 10")
+		return nil, errors.New("downscope: length of AccessBoundaryRules may not be greater than 10")
 	}
 	for _, val := range opts.Rules {
 		if val.AvailableResource == "" {
-			return nil, fmt.Errorf("downscope: all rules must have a nonempty AvailableResource")
+			return nil, errors.New("downscope: all rules must have a nonempty AvailableResource")
 		}
 		if len(val.AvailablePermissions) == 0 {
-			return nil, fmt.Errorf("downscope: all rules must provide at least one permission")
+			return nil, errors.New("downscope: all rules must provide at least one permission")
 		}
 	}
 	return auth.NewCredentials(&auth.CredentialsOptions{

--- a/auth/credentials/externalaccount/externalaccount.go
+++ b/auth/credentials/externalaccount/externalaccount.go
@@ -16,7 +16,7 @@ package externalaccount
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"net/http"
 
 	"cloud.google.com/go/auth"
@@ -210,7 +210,7 @@ type AwsSecurityCredentials struct {
 
 func (o *Options) validate() error {
 	if o == nil {
-		return fmt.Errorf("externalaccount: options must be provided")
+		return errors.New("externalaccount: options must be provided")
 	}
 	return nil
 }

--- a/auth/credentials/idtoken/compute.go
+++ b/auth/credentials/idtoken/compute.go
@@ -16,7 +16,7 @@ package idtoken
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"net/url"
 	"time"
 
@@ -32,7 +32,7 @@ const identitySuffix = "instance/service-accounts/default/identity"
 // tokens.
 func computeCredentials(opts *Options) (*auth.Credentials, error) {
 	if opts.CustomClaims != nil {
-		return nil, fmt.Errorf("idtoken: Options.CustomClaims can't be used with the metadata service, please provide a service account if you would like to use this feature")
+		return nil, errors.New("idtoken: Options.CustomClaims can't be used with the metadata service, please provide a service account if you would like to use this feature")
 	}
 	tp := computeIDTokenProvider{
 		audience: opts.Audience,
@@ -71,7 +71,7 @@ func (c computeIDTokenProvider) Token(ctx context.Context) (*auth.Token, error) 
 		return nil, err
 	}
 	if res == "" {
-		return nil, fmt.Errorf("idtoken: invalid empty response from metadata service")
+		return nil, errors.New("idtoken: invalid empty response from metadata service")
 	}
 	return &auth.Token{
 		Value: res,

--- a/auth/credentials/idtoken/idtoken.go
+++ b/auth/credentials/idtoken/idtoken.go
@@ -16,7 +16,6 @@ package idtoken
 
 import (
 	"errors"
-	"fmt"
 	"net/http"
 	"os"
 
@@ -100,7 +99,7 @@ func NewCredentials(opts *Options) (*auth.Credentials, error) {
 	if metadata.OnGCE() {
 		return computeCredentials(opts)
 	}
-	return nil, fmt.Errorf("idtoken: couldn't find any credentials")
+	return nil, errors.New("idtoken: couldn't find any credentials")
 }
 
 func (o *Options) jsonBytes() []byte {

--- a/auth/credentials/internal/externalaccount/externalaccount.go
+++ b/auth/credentials/internal/externalaccount/externalaccount.go
@@ -156,14 +156,14 @@ type AwsSecurityCredentials struct {
 
 func (o *Options) validate() error {
 	if o.Audience == "" {
-		return fmt.Errorf("externalaccount: Audience must be set")
+		return errors.New("externalaccount: Audience must be set")
 	}
 	if o.SubjectTokenType == "" {
-		return fmt.Errorf("externalaccount: Subject token type must be set")
+		return errors.New("externalaccount: Subject token type must be set")
 	}
 	if o.WorkforcePoolUserProject != "" {
 		if valid := validWorkforceAudiencePattern.MatchString(o.Audience); !valid {
-			return fmt.Errorf("externalaccount: workforce_pool_user_project should not be set for non-workforce pool credentials")
+			return errors.New("externalaccount: workforce_pool_user_project should not be set for non-workforce pool credentials")
 		}
 	}
 	count := 0
@@ -177,10 +177,10 @@ func (o *Options) validate() error {
 		count++
 	}
 	if count == 0 {
-		return fmt.Errorf("externalaccount: one of CredentialSource, SubjectTokenProvider, or AwsSecurityCredentialsProvider must be set")
+		return errors.New("externalaccount: one of CredentialSource, SubjectTokenProvider, or AwsSecurityCredentialsProvider must be set")
 	}
 	if count > 1 {
-		return fmt.Errorf("externalaccount: only one of CredentialSource, SubjectTokenProvider, or AwsSecurityCredentialsProvider must be set")
+		return errors.New("externalaccount: only one of CredentialSource, SubjectTokenProvider, or AwsSecurityCredentialsProvider must be set")
 	}
 	return nil
 }
@@ -321,7 +321,7 @@ func (tp *tokenProvider) Token(ctx context.Context) (*auth.Token, error) {
 	}
 	// The RFC8693 doesn't define the explicit 0 of "expires_in" field behavior.
 	if stsResp.ExpiresIn <= 0 {
-		return nil, fmt.Errorf("credentials: got invalid expiry from security token service")
+		return nil, errors.New("credentials: got invalid expiry from security token service")
 	}
 	tok.Expiry = Now().Add(time.Duration(stsResp.ExpiresIn) * time.Second)
 	return tok, nil

--- a/auth/httptransport/httptransport.go
+++ b/auth/httptransport/httptransport.go
@@ -17,7 +17,6 @@ package httptransport
 import (
 	"crypto/tls"
 	"errors"
-	"fmt"
 	"net/http"
 
 	"cloud.google.com/go/auth"
@@ -155,7 +154,7 @@ type InternalOptions struct {
 // if client or creds is nil.
 func AddAuthorizationMiddleware(client *http.Client, creds *auth.Credentials) error {
 	if client == nil || creds == nil {
-		return fmt.Errorf("httptransport: client and tp must not be nil")
+		return errors.New("httptransport: client and tp must not be nil")
 	}
 	base := client.Transport
 	if base == nil {

--- a/auth/internal/transport/cba_test.go
+++ b/auth/internal/transport/cba_test.go
@@ -17,6 +17,7 @@ package transport
 import (
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"testing"
@@ -64,7 +65,7 @@ var (
 	}
 
 	errorConfigResp = func() (string, error) {
-		return "", fmt.Errorf("error getting config")
+		return "", errors.New("error getting config")
 	}
 
 	invalidConfigResp = func() (string, error) {

--- a/bigquery/bigquery.go
+++ b/bigquery/bigquery.go
@@ -124,7 +124,7 @@ func NewClient(ctx context.Context, projectID string, opts ...option.ClientOptio
 // Calling this method twice will return an error.
 func (c *Client) EnableStorageReadClient(ctx context.Context, opts ...option.ClientOption) error {
 	if c.isStorageReadAvailable() {
-		return fmt.Errorf("failed: storage read client already set up")
+		return errors.New("failed: storage read client already set up")
 	}
 	rc, err := newReadClient(ctx, c.projectID, opts...)
 	if err != nil {

--- a/bigquery/inserter_test.go
+++ b/bigquery/inserter_test.go
@@ -16,7 +16,6 @@ package bigquery
 
 import (
 	"errors"
-	"fmt"
 	"strconv"
 	"testing"
 
@@ -149,7 +148,7 @@ func TestHandleInsertErrors(t *testing.T) {
 			in: []*bq.TableDataInsertAllResponseInsertErrors{
 				{Errors: []*bq.ErrorProto{{Message: "m0"}}, Index: 2},
 			},
-			want: fmt.Errorf("internal error: unexpected row index: 2"),
+			want: errors.New("internal error: unexpected row index: 2"),
 		},
 	} {
 		got := handleInsertErrors(test.in, rows)

--- a/bigquery/params.go
+++ b/bigquery/params.go
@@ -317,7 +317,7 @@ func (p QueryParameter) toBQ() (*bq.QueryParameter, error) {
 	}, nil
 }
 
-var errNilParam = fmt.Errorf("bigquery: nil parameter")
+var errNilParam = errors.New("bigquery: nil parameter")
 
 func paramType(t reflect.Type, v reflect.Value) (*bq.QueryParameterType, error) {
 	if t == nil {
@@ -357,7 +357,7 @@ func paramType(t reflect.Type, v reflect.Value) (*bq.QueryParameterType, error) 
 			element = iv.End
 		}
 		if element == nil {
-			return nil, fmt.Errorf("unable to determine range element type from RangeValue without a non-nil start or end value")
+			return nil, errors.New("unable to determine range element type from RangeValue without a non-nil start or end value")
 		}
 		elet, err := paramType(reflect.TypeOf(element), reflect.ValueOf(element))
 		if err != nil {

--- a/bigquery/query.go
+++ b/bigquery/query.go
@@ -17,7 +17,6 @@ package bigquery
 import (
 	"context"
 	"errors"
-	"fmt"
 	"time"
 
 	"cloud.google.com/go/internal/trace"
@@ -439,7 +438,7 @@ func (q *Query) Read(ctx context.Context) (it *RowIterator, err error) {
 // faster query path, this method returns a QueryRequest suitable for execution.
 func (q *Query) probeFastPath() (*bq.QueryRequest, error) {
 	if q.forceStorageAPI && q.client.isStorageReadAvailable() {
-		return nil, fmt.Errorf("force Storage API usage")
+		return nil, errors.New("force Storage API usage")
 	}
 	// This is a denylist of settings which prevent us from composing an equivalent
 	// bq.QueryRequest due to differences between configuration parameters accepted
@@ -459,7 +458,7 @@ func (q *Query) probeFastPath() (*bq.QueryRequest, error) {
 		q.QueryConfig.JobTimeout != 0 ||
 		// User has defined the jobID generation behavior
 		q.JobIDConfig.JobID != "" {
-		return nil, fmt.Errorf("QueryConfig incompatible with fastPath")
+		return nil, errors.New("QueryConfig incompatible with fastPath")
 	}
 	pfalse := false
 	qRequest := &bq.QueryRequest{

--- a/bigquery/storage/managedwriter/adapt/protoconversion.go
+++ b/bigquery/storage/managedwriter/adapt/protoconversion.go
@@ -16,6 +16,7 @@ package adapt
 
 import (
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -169,7 +170,7 @@ func (dm *dependencyCache) getFileDescriptorProtos() []*descriptorpb.FileDescrip
 
 func (dm *dependencyCache) add(schema *storagepb.TableSchema, descriptor protoreflect.MessageDescriptor) error {
 	if dm == nil {
-		return fmt.Errorf("cache is nil")
+		return errors.New("cache is nil")
 	}
 	b, err := proto.Marshal(schema)
 	if err != nil {
@@ -247,7 +248,7 @@ func StorageSchemaToProto3Descriptor(inSchema *storagepb.TableSchema, scope stri
 // Internal implementation of the conversion code.
 func storageSchemaToDescriptorInternal(inSchema *storagepb.TableSchema, scope string, cache *dependencyCache, useProto3 bool) (protoreflect.MessageDescriptor, error) {
 	if inSchema == nil {
-		return nil, newConversionError(scope, fmt.Errorf("no input schema was provided"))
+		return nil, newConversionError(scope, errors.New("no input schema was provided"))
 	}
 
 	var fields []*descriptorpb.FieldDescriptorProto
@@ -504,7 +505,7 @@ func NormalizeDescriptor(in protoreflect.MessageDescriptor) (*descriptorpb.Descr
 
 func normalizeDescriptorInternal(in protoreflect.MessageDescriptor, visitedTypes, enumTypes, structTypes *stringSet, root *descriptorpb.DescriptorProto) (*descriptorpb.DescriptorProto, error) {
 	if in == nil {
-		return nil, fmt.Errorf("no messagedescriptor provided")
+		return nil, errors.New("no messagedescriptor provided")
 	}
 	resultDP := &descriptorpb.DescriptorProto{}
 	if root == nil {

--- a/bigquery/storage/managedwriter/appendresult_test.go
+++ b/bigquery/storage/managedwriter/appendresult_test.go
@@ -16,7 +16,7 @@ package managedwriter
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"testing"
 	"time"
 
@@ -89,7 +89,7 @@ func TestPendingWrite(t *testing.T) {
 	}
 
 	// Verify completion behavior with an error.
-	wantErr := fmt.Errorf("foo")
+	wantErr := errors.New("foo")
 
 	testResp := &storagepb.AppendRowsResponse{
 		Response: &storagepb.AppendRowsResponse_AppendResult_{

--- a/bigquery/storage/managedwriter/client.go
+++ b/bigquery/storage/managedwriter/client.go
@@ -16,6 +16,7 @@ package managedwriter
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"runtime"
 	"strings"
@@ -204,7 +205,7 @@ func (c *Client) buildManagedStream(ctx context.Context, streamFunc streamClient
 // for constructing a new managed stream.
 func (c *Client) validateOptions(ctx context.Context, ms *ManagedStream) error {
 	if ms == nil {
-		return fmt.Errorf("no managed stream definition")
+		return errors.New("no managed stream definition")
 	}
 	if ms.streamSettings.streamID != "" {
 		// User supplied a stream, we need to verify it exists.
@@ -217,11 +218,11 @@ func (c *Client) validateOptions(ctx context.Context, ms *ManagedStream) error {
 		ms.streamSettings.destinationTable = TableParentFromStreamName(ms.streamSettings.streamID)
 	}
 	if ms.streamSettings.destinationTable == "" {
-		return fmt.Errorf("no destination table specified")
+		return errors.New("no destination table specified")
 	}
 	// we could auto-select DEFAULT here, but let's force users to be specific for now.
 	if ms.StreamType() == "" {
-		return fmt.Errorf("stream type wasn't specified")
+		return errors.New("stream type wasn't specified")
 	}
 	return nil
 }
@@ -254,7 +255,7 @@ func (c *Client) createPool(location string, streamFunc streamClientFunc) (*conn
 
 	if c.cfg == nil {
 		cancel()
-		return nil, fmt.Errorf("missing client config")
+		return nil, errors.New("missing client config")
 	}
 
 	var routingHeader string

--- a/bigquery/storage/managedwriter/connection.go
+++ b/bigquery/storage/managedwriter/connection.go
@@ -68,7 +68,7 @@ type connectionPool struct {
 // activateRouter handles wiring up a connection pool and it's router.
 func (pool *connectionPool) activateRouter(rtr poolRouter) error {
 	if pool.router != nil {
-		return fmt.Errorf("router already activated")
+		return errors.New("router already activated")
 	}
 	if err := rtr.poolAttach(pool); err != nil {
 		return fmt.Errorf("router rejected attach: %w", err)

--- a/bigquery/storage/managedwriter/connection_test.go
+++ b/bigquery/storage/managedwriter/connection_test.go
@@ -17,7 +17,6 @@ package managedwriter
 import (
 	"context"
 	"errors"
-	"fmt"
 	"io"
 	"testing"
 	"time"
@@ -218,7 +217,7 @@ func TestConnectionPool_OpenCallOptionPropagation(t *testing.T) {
 			if len(opts) == 0 {
 				t.Fatalf("no options were propagated")
 			}
-			return nil, fmt.Errorf("no real client")
+			return nil, errors.New("no real client")
 		}, ""),
 		callOptions: []gax.CallOption{
 			gax.WithGRPCOptions(grpc.MaxCallRecvMsgSize(99)),
@@ -231,7 +230,7 @@ func TestConnectionPool_OpenCallOptionPropagation(t *testing.T) {
 // This test evaluates how the receiver deals with a pending write.
 func TestConnection_Receiver(t *testing.T) {
 
-	var customErr = fmt.Errorf("foo")
+	var customErr = errors.New("foo")
 
 	testCases := []struct {
 		description       string

--- a/bigquery/storage/managedwriter/retry_test.go
+++ b/bigquery/storage/managedwriter/retry_test.go
@@ -16,7 +16,7 @@ package managedwriter
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"io"
 	"testing"
 
@@ -37,7 +37,7 @@ func TestManagedStream_AppendErrorRetries(t *testing.T) {
 			want: false,
 		},
 		{
-			err:  fmt.Errorf("random error"),
+			err:  errors.New("random error"),
 			want: false,
 		},
 		{
@@ -83,7 +83,7 @@ func TestManagedStream_ShouldReconnect(t *testing.T) {
 		want bool
 	}{
 		{
-			err:  fmt.Errorf("random error"),
+			err:  errors.New("random error"),
 			want: false,
 		},
 		{

--- a/bigquery/storage/managedwriter/routers.go
+++ b/bigquery/storage/managedwriter/routers.go
@@ -15,6 +15,7 @@
 package managedwriter
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 	"sync"
@@ -75,7 +76,7 @@ func (rtr *simpleRouter) poolDetach() error {
 
 func (rtr *simpleRouter) writerAttach(writer *ManagedStream) error {
 	if writer.id == "" {
-		return fmt.Errorf("writer has no ID")
+		return errors.New("writer has no ID")
 	}
 	rtr.mu.Lock()
 	defer rtr.mu.Unlock()
@@ -88,7 +89,7 @@ func (rtr *simpleRouter) writerAttach(writer *ManagedStream) error {
 
 func (rtr *simpleRouter) writerDetach(writer *ManagedStream) error {
 	if writer.id == "" {
-		return fmt.Errorf("writer has no ID")
+		return errors.New("writer has no ID")
 	}
 	rtr.mu.Lock()
 	defer rtr.mu.Unlock()
@@ -108,7 +109,7 @@ func (rtr *simpleRouter) pickConnection(pw *pendingWrite) (*connection, error) {
 	if rtr.conn != nil {
 		return rtr.conn, nil
 	}
-	return nil, fmt.Errorf("no connection available")
+	return nil, errors.New("no connection available")
 }
 
 func newSimpleRouter(mode connectionMode) *simpleRouter {
@@ -192,10 +193,10 @@ func (sr *sharedRouter) poolDetach() error {
 
 func (sr *sharedRouter) writerAttach(writer *ManagedStream) error {
 	if writer == nil {
-		return fmt.Errorf("invalid writer")
+		return errors.New("invalid writer")
 	}
 	if writer.id == "" {
-		return fmt.Errorf("writer has empty ID")
+		return errors.New("writer has empty ID")
 	}
 	if sr.multiplex && canMultiplex(writer.StreamName()) {
 		return sr.writerAttachMulti(writer)
@@ -306,7 +307,7 @@ func (sr *sharedRouter) rebalanceWriters() {
 
 func (sr *sharedRouter) writerDetach(writer *ManagedStream) error {
 	if writer == nil {
-		return fmt.Errorf("invalid writer")
+		return errors.New("invalid writer")
 	}
 	if sr.multiplex && canMultiplex(writer.StreamName()) {
 		return sr.writerDetachMulti(writer)
@@ -316,7 +317,7 @@ func (sr *sharedRouter) writerDetach(writer *ManagedStream) error {
 	defer sr.mu.Unlock()
 	conn := sr.exclusiveConns[writer.id]
 	if conn == nil {
-		return fmt.Errorf("writer not currently attached")
+		return errors.New("writer not currently attached")
 	}
 	conn.close()
 	delete(sr.exclusiveConns, writer.id)
@@ -343,7 +344,7 @@ func (sr *sharedRouter) writerDetachMulti(writer *ManagedStream) error {
 // or delegates too pickMultiplexConnection for the multiplex case.
 func (sr *sharedRouter) pickConnection(pw *pendingWrite) (*connection, error) {
 	if pw.writer == nil {
-		return nil, fmt.Errorf("no writer present pending write")
+		return nil, errors.New("no writer present pending write")
 	}
 	if sr.multiplex && canMultiplex(pw.writer.StreamName()) {
 		return sr.pickMultiplexConnection(pw)
@@ -363,7 +364,7 @@ func (sr *sharedRouter) pickMultiplexConnection(pw *pendingWrite) (*connection, 
 	conn := sr.multiMap[pw.writer.id]
 	if conn == nil {
 		// TODO: update map
-		return nil, fmt.Errorf("no multiplex connection assigned")
+		return nil, errors.New("no multiplex connection assigned")
 	}
 	return conn, nil
 }

--- a/bigquery/storage_client.go
+++ b/bigquery/storage_client.go
@@ -16,6 +16,7 @@ package bigquery
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"runtime"
 
@@ -87,7 +88,7 @@ func newReadClient(ctx context.Context, projectID string, opts ...option.ClientO
 // close releases resources held by the client.
 func (c *readClient) close() error {
 	if c.rawClient == nil {
-		return fmt.Errorf("already closed")
+		return errors.New("already closed")
 	}
 	c.rawClient.Close()
 	c.rawClient = nil

--- a/bigquery/storage_iterator.go
+++ b/bigquery/storage_iterator.go
@@ -86,7 +86,7 @@ func newStorageRowIteratorFromJob(ctx context.Context, j *Job) (*RowIterator, er
 	qcfg := cfg.(*QueryConfig)
 	if qcfg.Dst == nil {
 		if !job.isScript() {
-			return nil, fmt.Errorf("job has no destination table to read")
+			return nil, errors.New("job has no destination table to read")
 		}
 		lastJob, err := resolveLastChildSelectJob(ctx, job)
 		if err != nil {
@@ -115,7 +115,7 @@ func resolveLastChildSelectJob(ctx context.Context, job *Job) (*Job, error) {
 		childJobs = append(childJobs, job)
 	}
 	if len(childJobs) == 0 {
-		return nil, fmt.Errorf("failed to resolve table for script job: no child jobs found")
+		return nil, errors.New("failed to resolve table for script job: no child jobs found")
 	}
 	return childJobs[0], nil
 }

--- a/bigquery/storage_iterator_test.go
+++ b/bigquery/storage_iterator_test.go
@@ -83,9 +83,9 @@ func TestStorageIteratorRetry(t *testing.T) {
 			ctx:  cancelledCtx,
 			desc: "context cancelled/deadline exceeded",
 			errors: []error{
-				fmt.Errorf("random error"),
-				fmt.Errorf("another random error"),
-				fmt.Errorf("yet another random error"),
+				errors.New("random error"),
+				errors.New("another random error"),
+				errors.New("yet another random error"),
 			},
 			wantFail: true,
 		},

--- a/bigtable/admin.go
+++ b/bigtable/admin.go
@@ -267,7 +267,7 @@ func toAutomatedBackupConfigProto(automatedBackupConfig TableAutomatedBackupConf
 	case *TableAutomatedBackupPolicy:
 		return backupConfig.toProto()
 	default:
-		return nil, fmt.Errorf("error: Unknown type of automated backup configuration")
+		return nil, errors.New("error: Unknown type of automated backup configuration")
 	}
 }
 
@@ -660,7 +660,7 @@ func (ac *AdminClient) TableInfo(ctx context.Context, table string) (*TableInfo,
 				Frequency:       res.GetAutomatedBackupPolicy().GetFrequency().AsDuration(),
 			}
 		default:
-			return nil, fmt.Errorf("error: Unknown type of automated backup configuration")
+			return nil, errors.New("error: Unknown type of automated backup configuration")
 		}
 	}
 

--- a/bigtable/admin_test.go
+++ b/bigtable/admin_test.go
@@ -74,7 +74,7 @@ func (c *mockTableAdminClock) CopyBackup(
 	ctx context.Context, in *btapb.CopyBackupRequest, opts ...grpc.CallOption,
 ) (*longrunning.Operation, error) {
 	c.copyBackupReq = in
-	c.copyBackupError = fmt.Errorf("Mock error from client API")
+	c.copyBackupError = errors.New("Mock error from client API")
 	return nil, c.copyBackupError
 }
 

--- a/bigtable/metric_util.go
+++ b/bigtable/metric_util.go
@@ -17,7 +17,7 @@ limitations under the License.
 package bigtable
 
 import (
-	"fmt"
+	"errors"
 	"strconv"
 	"strings"
 	"time"
@@ -81,7 +81,7 @@ func extractLocation(headerMD metadata.MD, trailerMD metadata.MD) (string, strin
 	}
 
 	if len(locationMetadata) < 1 {
-		return defaultCluster, defaultZone, fmt.Errorf("failed to get location metadata")
+		return defaultCluster, defaultZone, errors.New("failed to get location metadata")
 	}
 
 	// Unmarshal binary location metadata

--- a/bigtable/metrics_monitoring_exporter.go
+++ b/bigtable/metrics_monitoring_exporter.go
@@ -56,7 +56,7 @@ var (
 		monitoredResLabelKeyZone:     true,
 	}
 
-	errShutdown = fmt.Errorf("exporter is shutdown")
+	errShutdown = errors.New("exporter is shutdown")
 )
 
 type errUnexpectedAggregationKind struct {

--- a/bigtable/metrics_test.go
+++ b/bigtable/metrics_test.go
@@ -18,6 +18,7 @@ package bigtable
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -290,7 +291,7 @@ func TestToOtelMetricAttrs(t *testing.T) {
 				attribute.String(monitoredResLabelKeyCluster, clusterID1),
 				attribute.String(monitoredResLabelKeyZone, zoneID1),
 			},
-			wantError: fmt.Errorf("unable to create attributes list for unknown metric: unknown_metric"),
+			wantError: errors.New("unable to create attributes list for unknown metric: unknown_metric"),
 		},
 	}
 
@@ -329,7 +330,7 @@ func TestGetServerLatency(t *testing.T) {
 			headerMD:    metadata.MD{},
 			trailerMD:   metadata.MD{},
 			wantLatency: 0,
-			wantError:   fmt.Errorf("strconv.ParseFloat: parsing \"\": invalid syntax"),
+			wantError:   errors.New("strconv.ParseFloat: parsing \"\": invalid syntax"),
 		},
 		{
 			desc: "Server latency in header",
@@ -405,7 +406,7 @@ func TestGetLocation(t *testing.T) {
 			trailerMD:   metadata.MD{},
 			wantCluster: defaultCluster,
 			wantZone:    defaultZone,
-			wantError:   fmt.Errorf("failed to get location metadata"),
+			wantError:   errors.New("failed to get location metadata"),
 		},
 		{
 			desc:        "Location metadata in header",
@@ -439,7 +440,7 @@ func TestGetLocation(t *testing.T) {
 			trailerMD:   metadata.MD{},
 			wantCluster: defaultCluster,
 			wantZone:    defaultZone,
-			wantError:   fmt.Errorf(invalidFormatErr),
+			wantError:   errors.New(invalidFormatErr),
 		},
 		{
 			desc:     "Invalid location metadata format in trailer",
@@ -449,7 +450,7 @@ func TestGetLocation(t *testing.T) {
 			},
 			wantCluster: defaultCluster,
 			wantZone:    defaultZone,
-			wantError:   fmt.Errorf(invalidFormatErr),
+			wantError:   errors.New(invalidFormatErr),
 		},
 	}
 

--- a/bigtable/reader.go
+++ b/bigtable/reader.go
@@ -18,6 +18,7 @@ package bigtable
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -201,7 +202,7 @@ func (cr *chunkReader) resetToNewRow() {
 
 func (cr *chunkReader) validateNewRow(cc *btpb.ReadRowsResponse_CellChunk) error {
 	if cc.GetResetRow() {
-		return fmt.Errorf("reset_row not allowed between rows")
+		return errors.New("reset_row not allowed between rows")
 	}
 	if cc.RowKey == nil || cc.FamilyName == nil || cc.Qualifier == nil {
 		return fmt.Errorf("missing key field for new row %v", cc)
@@ -265,7 +266,7 @@ func (cr *chunkReader) validateRowStatus(cc *btpb.ReadRowsResponse_CellChunk) er
 		return fmt.Errorf("reset must not be specified with other fields %v", cc)
 	}
 	if cc.GetCommitRow() && cc.ValueSize > 0 {
-		return fmt.Errorf("commit row found in between chunks in a cell")
+		return errors.New("commit row found in between chunks in a cell")
 	}
 	return nil
 }

--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -709,7 +709,7 @@ func putMutations(keys []*Key, src interface{}) ([]*pb.Mutation, error) {
 		}
 	}
 	if multiArgType == multiArgTypeInvalid {
-		return nil, fmt.Errorf("datastore: src has invalid type")
+		return nil, errors.New("datastore: src has invalid type")
 	}
 	dstLen := v.Len()
 

--- a/datastore/integration_test.go
+++ b/datastore/integration_test.go
@@ -131,7 +131,7 @@ func testMain(m *testing.M) int {
 			Key: reqParamsHeader,
 			ValuesValidator: func(values ...string) error {
 				if len(values) == 0 {
-					return fmt.Errorf("missing values")
+					return errors.New("missing values")
 				}
 				wantValue := fmt.Sprintf("project_id=%s", url.QueryEscape(testutil.ProjID()))
 				if databaseID != DefaultDatabaseID && databaseID != "" {

--- a/datastore/save.go
+++ b/datastore/save.go
@@ -131,7 +131,7 @@ func reflectFieldSave(props *[]Property, p Property, name string, opts saveOpts,
 			fallthrough
 		case reflect.Struct:
 			if !v.CanAddr() {
-				return fmt.Errorf("datastore: unsupported struct field: value is unaddressable")
+				return errors.New("datastore: unsupported struct field: value is unaddressable")
 			}
 			vi := v.Addr().Interface()
 

--- a/firestore/bulkwriter.go
+++ b/firestore/bulkwriter.go
@@ -182,7 +182,7 @@ func (bw *BulkWriter) Create(doc *DocumentRef, datum interface{}) (*BulkWriterJo
 	}
 
 	if len(w) > 1 {
-		return nil, fmt.Errorf("firestore: too many document writes sent to bulkwriter")
+		return nil, errors.New("firestore: too many document writes sent to bulkwriter")
 	}
 
 	j := bw.write(w[0])
@@ -205,7 +205,7 @@ func (bw *BulkWriter) Delete(doc *DocumentRef, preconds ...Precondition) (*BulkW
 	}
 
 	if len(w) > 1 {
-		return nil, fmt.Errorf("firestore: too many document writes sent to bulkwriter")
+		return nil, errors.New("firestore: too many document writes sent to bulkwriter")
 	}
 
 	j := bw.write(w[0])
@@ -228,7 +228,7 @@ func (bw *BulkWriter) Set(doc *DocumentRef, datum interface{}, opts ...SetOption
 	}
 
 	if len(w) > 1 {
-		return nil, fmt.Errorf("firestore: too many writes sent to bulkwriter")
+		return nil, errors.New("firestore: too many writes sent to bulkwriter")
 	}
 
 	j := bw.write(w[0])
@@ -251,7 +251,7 @@ func (bw *BulkWriter) Update(doc *DocumentRef, updates []Update, preconds ...Pre
 	}
 
 	if len(w) > 1 {
-		return nil, fmt.Errorf("firestore: too many writes sent to bulkwriter")
+		return nil, errors.New("firestore: too many writes sent to bulkwriter")
 	}
 
 	j := bw.write(w[0])

--- a/firestore/conformance_test.go
+++ b/firestore/conformance_test.go
@@ -217,7 +217,7 @@ func runTest(test *pb.Test, c *Client, srv *mockServer) error {
 		if typedTestcase.Listen.IsError {
 			_, err := iter.Next()
 			if err == nil {
-				return fmt.Errorf("got nil, want error")
+				return errors.New("got nil, want error")
 			}
 		}
 

--- a/internal/carver/cmd/carver/main.go
+++ b/internal/carver/cmd/carver/main.go
@@ -17,6 +17,7 @@ import (
 	"bytes"
 	_ "embed"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -119,7 +120,7 @@ func main() {
 
 func (c *carver) Run() ([]string, error) {
 	if c.rootMod.path == "" || c.childMod.path == "" || c.repoMetadataPath == "" {
-		return nil, fmt.Errorf("all required flags were not provided")
+		return nil, errors.New("all required flags were not provided")
 	}
 	if err := c.CreateChildCommonFiles(); err != nil {
 		return nil, fmt.Errorf("failed to create readme: %v", err)
@@ -251,7 +252,7 @@ func (c *carver) CreateChildCommonFiles() error {
 	if name == "" {
 		name = meta[c.childMod.importPath]
 		if name == "" {
-			return fmt.Errorf("unable to determine a name from API metadata, please set -name flag")
+			return errors.New("unable to determine a name from API metadata, please set -name flag")
 		}
 	}
 	readmeData := struct {

--- a/internal/gapicgen/generator/generator.go
+++ b/internal/gapicgen/generator/generator.go
@@ -20,6 +20,7 @@ package generator
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -50,7 +51,7 @@ func Generate(ctx context.Context, conf *Config) ([]*git.ChangeInfo, error) {
 		var err error
 		changes, err = gatherChanges(conf.GoogleapisDir, conf.GenprotoDir)
 		if err != nil {
-			return nil, fmt.Errorf("error gathering commit info")
+			return nil, errors.New("error gathering commit info")
 		}
 		if err := recordGoogleapisHash(conf.GoogleapisDir, conf.GenprotoDir); err != nil {
 			return nil, err

--- a/internal/godocfx/parse.go
+++ b/internal/godocfx/parse.go
@@ -23,6 +23,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"go/doc"
 	"go/format"
@@ -704,7 +705,7 @@ func (d *friendlyAPINamer) friendlyAPIName(importPath string) (string, error) {
 		return "", err
 	}
 	if d.metadata == nil {
-		return "", fmt.Errorf("no metadata found: earlier error fetching?")
+		return "", errors.New("no metadata found: earlier error fetching?")
 	}
 	pkg, ok := d.metadata[importPath]
 	if !ok {

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -213,7 +213,7 @@ func makeParent(parent string) (string, error) {
 		if parent == DetectProjectID {
 			resource := detectResourceInternal()
 			if resource == nil {
-				return parent, fmt.Errorf("could not determine project ID from environment")
+				return parent, errors.New("could not determine project ID from environment")
 			}
 			parent = resource.Labels["project_id"]
 		}
@@ -221,7 +221,7 @@ func makeParent(parent string) (string, error) {
 	}
 	prefix := strings.Split(parent, "/")[0]
 	if prefix != "projects" && prefix != "folders" && prefix != "billingAccounts" && prefix != "organizations" {
-		return parent, fmt.Errorf("parent parameter must start with 'projects/' 'folders/' 'billingAccounts/' or 'organizations/'")
+		return parent, errors.New("parent parameter must start with 'projects/' 'folders/' 'billingAccounts/' or 'organizations/'")
 	}
 	return parent, nil
 }

--- a/logging/logging_unexported_test.go
+++ b/logging/logging_unexported_test.go
@@ -18,7 +18,7 @@ package logging
 
 import (
 	"encoding/json"
-	"fmt"
+	"errors"
 	"net/http"
 	"net/url"
 	"testing"
@@ -44,7 +44,7 @@ func TestLoggerRetryer_Retry(t *testing.T) {
 	}{
 		{
 			name:      "non_status_no_retry",
-			err:       fmt.Errorf("non-API error, do not retry"),
+			err:       errors.New("non-API error, do not retry"),
 			wantRetry: false,
 		},
 		{

--- a/profiler/profiler.go
+++ b/profiler/profiler.go
@@ -520,7 +520,7 @@ func initializeAgent(c pb.ProfilerServiceClient) (*agent, error) {
 	}
 
 	if len(profileTypes) == 0 {
-		return nil, fmt.Errorf("collection is not enabled for any profile types")
+		return nil, errors.New("collection is not enabled for any profile types")
 	}
 
 	return &agent{
@@ -591,7 +591,7 @@ func initializeConfig(cfg Config) error {
 		}
 	} else {
 		if config.ProjectID == "" {
-			return fmt.Errorf("project ID must be specified in the configuration if running outside of GCP")
+			return errors.New("project ID must be specified in the configuration if running outside of GCP")
 		}
 	}
 

--- a/profiler/profiler_test.go
+++ b/profiler/profiler_test.go
@@ -702,9 +702,9 @@ func TestInitializeConfig(t *testing.T) {
 			getInstanceName = func() (string, error) { return testInstance, nil }
 		} else {
 			onGCE = func() bool { return false }
-			getProjectID = func() (string, error) { return "", fmt.Errorf("test get project id error") }
-			getZone = func() (string, error) { return "", fmt.Errorf("test get zone error") }
-			getInstanceName = func() (string, error) { return "", fmt.Errorf("test get instance error") }
+			getProjectID = func() (string, error) { return "", errors.New("test get project id error") }
+			getZone = func() (string, error) { return "", errors.New("test get zone error") }
+			getInstanceName = func() (string, error) { return "", errors.New("test get instance error") }
 		}
 		envProjectID := ""
 		if tt.envProjectID {

--- a/profiler/proftest/proftest.go
+++ b/profiler/proftest/proftest.go
@@ -500,7 +500,7 @@ func (tr *GCETestRunner) PollAndLogSerialPort(ctx context.Context, inst *Instanc
 				return output, nil
 			}
 			if strings.Contains(output, errorString) {
-				return output, fmt.Errorf("failed to execute the prober benchmark script")
+				return output, errors.New("failed to execute the prober benchmark script")
 			}
 		}
 	}

--- a/storage/grpc_client.go
+++ b/storage/grpc_client.go
@@ -1564,7 +1564,7 @@ func (r *gRPCReader) Read(p []byte) (int, error) {
 	// using the same reader. One encounters an error and the stream is closed
 	// and then reopened while the other routine attempts to read from it.
 	if r.stream == nil {
-		return 0, fmt.Errorf("storage: reader has been closed")
+		return 0, errors.New("storage: reader has been closed")
 	}
 
 	var n int
@@ -1621,7 +1621,7 @@ func (r *gRPCReader) WriteTo(w io.Writer) (int64, error) {
 	// using the same reader. One encounters an error and the stream is closed
 	// and then reopened while the other routine attempts to read from it.
 	if r.stream == nil {
-		return 0, fmt.Errorf("storage: reader has been closed")
+		return 0, errors.New("storage: reader has been closed")
 	}
 
 	// Track bytes written during before call.

--- a/storage/internal/benchmarks/main.go
+++ b/storage/internal/benchmarks/main.go
@@ -17,6 +17,7 @@ package main
 import (
 	"context"
 	"encoding/csv"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -110,7 +111,7 @@ func (b *benchmarkOptions) validate() error {
 	}
 
 	if (b.maxReadOffset != 0 || b.minReadOffset != 0) && b.rangeSize == 0 {
-		return fmt.Errorf("read offset specified but no range size specified")
+		return errors.New("read offset specified but no range size specified")
 	}
 
 	minObjSize := b.objectSize

--- a/storage/internal/benchmarks/utils.go
+++ b/storage/internal/benchmarks/utils.go
@@ -180,7 +180,7 @@ var dependencyVersions = map[string]string{
 func populateDependencyVersions() error {
 	info, ok := debug.ReadBuildInfo()
 	if !ok {
-		return fmt.Errorf("binary not built with module support, cannot read build info")
+		return errors.New("binary not built with module support, cannot read build info")
 	}
 
 	goVersion = info.GoVersion

--- a/storage/mock_test.go
+++ b/storage/mock_test.go
@@ -17,7 +17,7 @@ package storage
 import (
 	"context"
 	"encoding/json"
-	"fmt"
+	"errors"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -53,7 +53,7 @@ func (t *mockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		t.gotBody = bytes
 	}
 	if len(t.results) == 0 {
-		return nil, fmt.Errorf("error handling request")
+		return nil, errors.New("error handling request")
 	}
 	result := t.results[0]
 	t.results = t.results[1:]

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -1972,7 +1973,7 @@ func TestApplyCondsProto(t *testing.T) {
 			name: "invalid_no_generation",
 			gen:  123,
 			in:   &storagepb.WriteObjectRequest{},
-			err:  fmt.Errorf("generation not supported"),
+			err:  errors.New("generation not supported"),
 		},
 		{
 			name:  "if_match",
@@ -2000,7 +2001,7 @@ func TestApplyCondsProto(t *testing.T) {
 			gen:   -1,
 			in:    &storagepb.ReadObjectRequest{},
 			conds: &Conditions{MetagenerationMatch: 123, MetagenerationNotMatch: 123},
-			err:   fmt.Errorf("multiple conditions"),
+			err:   errors.New("multiple conditions"),
 		},
 	} {
 		if err := applyCondsProto(tst.name, tst.gen, tst.conds, tst.in); tst.err == nil && err != nil {

--- a/vertexai/genai/tokenizer/tokenizer.go
+++ b/vertexai/genai/tokenizer/tokenizer.go
@@ -21,6 +21,7 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -82,7 +83,7 @@ func (tok *Tokenizer) CountTokens(parts ...genai.Part) (*CountTokensResponse, er
 			toks := tok.processor.Encode(string(t))
 			sum += len(toks)
 		} else {
-			return nil, fmt.Errorf("Tokenizer.CountTokens only supports Text parts")
+			return nil, errors.New("Tokenizer.CountTokens only supports Text parts")
 		}
 	}
 
@@ -139,7 +140,7 @@ func loadModelData(url string, wantHash string) ([]byte, error) {
 		}
 
 		if hashString(cacheData) != wantHash {
-			return nil, fmt.Errorf("downloaded model hash mismatch")
+			return nil, errors.New("downloaded model hash mismatch")
 		}
 
 		err = os.MkdirAll(cacheDir, 0770)

--- a/vertexai/internal/sentencepiece/processor.go
+++ b/vertexai/internal/sentencepiece/processor.go
@@ -15,6 +15,7 @@
 package sentencepiece
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -114,7 +115,7 @@ func NewProcessor(protoReader io.Reader) (*Processor, error) {
 			userDefined[piece.GetPiece()] = true
 		} else if piece.GetType() == model.ModelProto_SentencePiece_UNKNOWN {
 			if unkID > 0 {
-				return nil, fmt.Errorf("unk redefined")
+				return nil, errors.New("unk redefined")
 			}
 			unkID = i
 		} else if piece.GetType() == model.ModelProto_SentencePiece_BYTE {
@@ -130,7 +131,7 @@ func NewProcessor(protoReader io.Reader) (*Processor, error) {
 	}
 
 	if unkID < 0 {
-		return nil, fmt.Errorf("unk symbol is not defined")
+		return nil, errors.New("unk symbol is not defined")
 	}
 
 	// In case byte_fallback is specified, make sure that all 256 possible byte


### PR DESCRIPTION
Fixes #9749

Automatically fixed with:

```
gofmt -w -r "fmt.Errorf(s) -> errors.New(s)" .
goimports -w .
```

Spanner related changes are in https://github.com/googleapis/google-cloud-go/pull/10736