### PR TITLE
feat(bigtable): Add UpdateFamily to allow updating a family type

### DIFF
--- a/bigtable/admin.go
+++ b/bigtable/admin.go
@@ -671,13 +671,13 @@ type updateFamilyOption struct {
 	ignoreWarnings bool
 }
 
-// UpdateFamilyOption is the interface to update family settings
-type UpdateFamilyOption interface {
+// GCPolicyOption is deprecated, kept for backwards compatibility, use UpdateFamilyOption in new code
+type GCPolicyOption interface {
 	apply(s *updateFamilyOption)
 }
 
-// GCPolicyOption is deprecated, kept for backwards compatibility, use UpdateFamilyOption in new code
-type GCPolicyOption UpdateFamilyOption
+// UpdateFamilyOption is the interface to update family settings
+type UpdateFamilyOption GCPolicyOption
 
 type ignoreWarnings bool
 

--- a/bigtable/admin.go
+++ b/bigtable/admin.go
@@ -721,18 +721,28 @@ func (ac *AdminClient) UpdateFamily(ctx context.Context, table, familyName strin
 	}
 
 	cf := &btapb.ColumnFamily{}
+	mask := &field_mask.FieldMask{}
 	if family.GCPolicy != nil {
 		cf.GcRule = family.GCPolicy.proto()
+		mask.Paths = append(mask.Paths, "gc_rule")
+
 	}
 	if family.ValueType != nil {
 		cf.ValueType = family.ValueType.proto()
+		mask.Paths = append(mask.Paths, "value_type")
+	}
+
+	// No update
+	if len(mask.Paths) == 0 {
+		return nil
 	}
 
 	req := &btapb.ModifyColumnFamiliesRequest{
 		Name: prefix + "/tables/" + table,
 		Modifications: []*btapb.ModifyColumnFamiliesRequest_Modification{{
-			Id:  familyName,
-			Mod: &btapb.ModifyColumnFamiliesRequest_Modification_Update{Update: cf},
+			Id:         familyName,
+			Mod:        &btapb.ModifyColumnFamiliesRequest_Modification_Update{Update: cf},
+			UpdateMask: mask,
 		}},
 		IgnoreWarnings: s.ignoreWarnings,
 	}

--- a/bigtable/admin.go
+++ b/bigtable/admin.go
@@ -667,58 +667,75 @@ func (ac *AdminClient) TableInfo(ctx context.Context, table string) (*TableInfo,
 	return ti, nil
 }
 
-type gcPolicySettings struct {
+type updateFamilyOption struct {
 	ignoreWarnings bool
 }
 
-// GCPolicyOption is the interface to change GC policy settings
-type GCPolicyOption interface {
-	apply(s *gcPolicySettings)
+// UpdateFamilyOption is the interface to update family settings
+type UpdateFamilyOption interface {
+	apply(s *updateFamilyOption)
 }
+
+// GCPolicyOption is deprecated, kept for backwards compatibility, use UpdateFamilyOption in new code
+type GCPolicyOption UpdateFamilyOption
 
 type ignoreWarnings bool
 
-func (w ignoreWarnings) apply(s *gcPolicySettings) {
+func (w ignoreWarnings) apply(s *updateFamilyOption) {
 	s.ignoreWarnings = bool(w)
 }
 
-// IgnoreWarnings returns a gcPolicyOption that ignores safety checks when modifying the column families
-func IgnoreWarnings() GCPolicyOption {
+// IgnoreWarnings returns a updateFamilyOption that ignores safety checks when modifying the column families
+func IgnoreWarnings() UpdateFamilyOption {
 	return ignoreWarnings(true)
-}
-
-func (ac *AdminClient) setGCPolicy(ctx context.Context, table, family string, policy GCPolicy, opts ...GCPolicyOption) error {
-	ctx = mergeOutgoingMetadata(ctx, ac.md)
-	prefix := ac.instancePrefix()
-
-	s := gcPolicySettings{}
-	for _, opt := range opts {
-		if opt != nil {
-			opt.apply(&s)
-		}
-	}
-	req := &btapb.ModifyColumnFamiliesRequest{
-		Name: prefix + "/tables/" + table,
-		Modifications: []*btapb.ModifyColumnFamiliesRequest_Modification{{
-			Id:  family,
-			Mod: &btapb.ModifyColumnFamiliesRequest_Modification_Update{Update: &btapb.ColumnFamily{GcRule: policy.proto()}},
-		}},
-		IgnoreWarnings: s.ignoreWarnings,
-	}
-	_, err := ac.tClient.ModifyColumnFamilies(ctx, req)
-	return err
 }
 
 // SetGCPolicy specifies which cells in a column family should be garbage collected.
 // GC executes opportunistically in the background; table reads may return data
 // matching the GC policy.
 func (ac *AdminClient) SetGCPolicy(ctx context.Context, table, family string, policy GCPolicy) error {
-	return ac.SetGCPolicyWithOptions(ctx, table, family, policy)
+	return ac.UpdateFamily(ctx, table, family, Family{GCPolicy: policy})
 }
 
 // SetGCPolicyWithOptions is similar to SetGCPolicy but allows passing options
 func (ac *AdminClient) SetGCPolicyWithOptions(ctx context.Context, table, family string, policy GCPolicy, opts ...GCPolicyOption) error {
-	return ac.setGCPolicy(ctx, table, family, policy, opts...)
+	familyOpts := []UpdateFamilyOption{}
+	for _, opt := range opts {
+		familyOpts = append(familyOpts, opt.(UpdateFamilyOption))
+	}
+	return ac.UpdateFamily(ctx, table, family, Family{GCPolicy: policy}, familyOpts...)
+}
+
+// UpdateFamily updates column families' garbage colleciton policies and value type.
+func (ac *AdminClient) UpdateFamily(ctx context.Context, table, familyName string, family Family, opts ...UpdateFamilyOption) error {
+	ctx = mergeOutgoingMetadata(ctx, ac.md)
+	prefix := ac.instancePrefix()
+
+	s := updateFamilyOption{}
+	for _, opt := range opts {
+		if opt != nil {
+			opt.apply(&s)
+		}
+	}
+
+	cf := &btapb.ColumnFamily{}
+	if family.GCPolicy != nil {
+		cf.GcRule = family.GCPolicy.proto()
+	}
+	if family.ValueType != nil {
+		cf.ValueType = family.ValueType.proto()
+	}
+
+	req := &btapb.ModifyColumnFamiliesRequest{
+		Name: prefix + "/tables/" + table,
+		Modifications: []*btapb.ModifyColumnFamiliesRequest_Modification{{
+			Id:  familyName,
+			Mod: &btapb.ModifyColumnFamiliesRequest_Modification_Update{Update: cf},
+		}},
+		IgnoreWarnings: s.ignoreWarnings,
+	}
+	_, err := ac.tClient.ModifyColumnFamilies(ctx, req)
+	return err
 }
 
 // DropRowRange permanently deletes a row range from the specified table.

--- a/bigtable/admin.go
+++ b/bigtable/admin.go
@@ -686,7 +686,7 @@ func (w ignoreWarnings) apply(s *updateFamilyOption) {
 }
 
 // IgnoreWarnings returns a updateFamilyOption that ignores safety checks when modifying the column families
-func IgnoreWarnings() UpdateFamilyOption {
+func IgnoreWarnings() GCPolicyOption {
 	return ignoreWarnings(true)
 }
 

--- a/bigtable/admin.go
+++ b/bigtable/admin.go
@@ -701,7 +701,9 @@ func (ac *AdminClient) SetGCPolicy(ctx context.Context, table, family string, po
 func (ac *AdminClient) SetGCPolicyWithOptions(ctx context.Context, table, family string, policy GCPolicy, opts ...GCPolicyOption) error {
 	familyOpts := []UpdateFamilyOption{}
 	for _, opt := range opts {
-		familyOpts = append(familyOpts, opt.(UpdateFamilyOption))
+		if opt != nil {
+			familyOpts = append(familyOpts, opt.(UpdateFamilyOption))
+		}
 	}
 	return ac.UpdateFamily(ctx, table, family, Family{GCPolicy: policy}, familyOpts...)
 }

--- a/bigtable/admin_test.go
+++ b/bigtable/admin_test.go
@@ -368,7 +368,7 @@ func TestTableAdmin_UpdateTableDisableChangeStream(t *testing.T) {
 func TestTableAdmin_SetGcPolicy(t *testing.T) {
 	for _, test := range []struct {
 		desc string
-		opts GCPolicyOption
+		opts UpdateFamilyOption
 		want bool
 	}{
 		{

--- a/bigtable/bttest/inmem.go
+++ b/bigtable/bttest/inmem.go
@@ -335,10 +335,10 @@ func (s *server) ModifyColumnFamilies(ctx context.Context, req *btapb.ModifyColu
 		} else if modify := mod.GetUpdate(); modify != nil {
 			newcf := newColumnFamily(req.Name+"/columnFamilies/"+mod.Id, 0, modify)
 			cf, ok := tbl.families[mod.Id]
-			if  !ok {
+			if !ok {
 				return nil, fmt.Errorf("no such family %q", mod.Id)
-			} 
-			if !Equal(cf.valueType, newcf.valueType) {
+			}
+			if cf.valueType != newcf.valueType {
 				return nil, status.Errorf(codes.InvalidArgument, "Immutable fields 'value_type' cannot be updated")
 			}
 

--- a/bigtable/bttest/inmem.go
+++ b/bigtable/bttest/inmem.go
@@ -334,13 +334,12 @@ func (s *server) ModifyColumnFamilies(ctx context.Context, req *btapb.ModifyColu
 			})
 		} else if modify := mod.GetUpdate(); modify != nil {
 			newcf := newColumnFamily(req.Name+"/columnFamilies/"+mod.Id, 0, modify)
-
-			if cf, ok := tbl.families[mod.Id]; !ok {
+			cf, ok := tbl.families[mod.Id]
+			if  !ok {
 				return nil, fmt.Errorf("no such family %q", mod.Id)
-			} else {
-				if cf.valueType != newcf.valueType {
-					return nil, status.Errorf(codes.InvalidArgument, "Immutable fields 'value_type' cannot be updated")
-				}
+			} 
+			if !Equal(cf.valueType, newcf.valueType) {
+				return nil, status.Errorf(codes.InvalidArgument, "Immutable fields 'value_type' cannot be updated")
 			}
 
 			// assume that we ALWAYS want to replace by the new setting

--- a/bigtable/integration_test.go
+++ b/bigtable/integration_test.go
@@ -283,7 +283,7 @@ func TestIntegration_ReadRowList(t *testing.T) {
 
 func TestIntegration_Aggregates(t *testing.T) {
 	ctx := context.Background()
-	_, _, _, table, _, cleanup, err := setupIntegration(ctx, t)
+	_, _, ac, table, tableName, cleanup, err := setupIntegration(ctx, t)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -345,6 +345,18 @@ func TestIntegration_Aggregates(t *testing.T) {
 	}
 	if !testutil.Equal(row, wantRow) {
 		t.Fatalf("Read row mismatch.\n got %#v\nwant %#v", row, wantRow)
+	}
+
+	err = ac.UpdateFamily(ctx, tableName, family, Family{ValueType: AggregateType{
+		Input:      Int64Type{},
+		Aggregator: MinAggregator{},
+	}})
+	if err == nil {
+		t.Fatalf("Expected UpdateFamily to fail, but it didn't")
+	}
+	wantError := "Immutable fields 'value_type' cannot be updated"
+	if !strings.Contains(err.Error(), wantError) {
+		t.Errorf("Wrong error. Expected to containt %q but was %v", wantError, err)
 	}
 }
 


### PR DESCRIPTION
It is currently only possible to update a column GC policy. We want to be able to also update the value_type of a column family.