### PR TITLE
Documentation: MinExtensionPeriod defaults to 60 seconds

### DIFF
--- a/pubsub/subscription.go
+++ b/pubsub/subscription.go
@@ -899,8 +899,7 @@ type ReceiveSettings struct {
 	//
 	// MinExtensionPeriod must be between 10s and 600s (inclusive). This configuration
 	// can be disabled by specifying a duration less than (or equal to) 0.
-	// Defaults to off but set to 60 seconds if the subscription has exactly-once delivery enabled,
-	// which will be added in a future release.
+	// Defaults to off but set to 60 seconds if the subscription has exactly-once delivery enabled.
 	MinExtensionPeriod time.Duration
 
 	// MaxOutstandingMessages is the maximum number of unprocessed messages


### PR DESCRIPTION
The comment in the documentation is confusing.

From what I read through the code:

https://github.com/googleapis/google-cloud-go/blob/897539ddaadaa5aa5951d409b0d555d9b2e12f5a/pubsub/iterator.go#L62 `minDurationPerLeaseExtensionExactlyOnce`  is set to 60 seconds

and if `exactlyOnce` it calls maxDuration which sets it to indeed 60 s https://github.com/googleapis/google-cloud-go/blob/897539ddaadaa5aa5951d409b0d555d9b2e12f5a/pubsub/iterator.go#L948 