### PR TITLE
Adjust priority of quota project sources

### DIFF
--- a/auth/credentials/detect.go
+++ b/auth/credentials/detect.go
@@ -158,6 +158,9 @@ type DetectOptions struct {
 	// The default value is "googleapis.com". This option is ignored for
 	// authentication flows that do not support universe domain. Optional.
 	UniverseDomain string
+	// QuotaProjectID allow overriding the project ID used for quota management.
+	// Optional.
+	QuotaProjectID string
 }
 
 func (o *DetectOptions) validate() error {

--- a/auth/internal/transport/transport.go
+++ b/auth/internal/transport/transport.go
@@ -45,6 +45,7 @@ func CloneDetectOptions(oldDo *credentials.DetectOptions) *credentials.DetectOpt
 		CredentialsFile:   oldDo.CredentialsFile,
 		UseSelfSignedJWT:  oldDo.UseSelfSignedJWT,
 		UniverseDomain:    oldDo.UniverseDomain,
+		QuotaProjectID:    oldDo.QuotaProjectID,
 
 		// These fields are are pointer types that we just want to use exactly
 		// as the user set, copy the ref


### PR DESCRIPTION
'GOOGLE_CLOUD_QUOTA_PROJECT' env variable should override quota project setting from credentials file. This is a behavior of previous auth code: https://github.com/googleapis/google-api-go-client/blob/main/internal/creds.go#L242-L261

It is trying to solve issue described in https://github.com/googleapis/google-cloud-go/issues/10804

To activate it would required additional change in https://github.com/googleapis/google-api-go-client: https://github.com/googleapis/google-api-go-client/pull/2767