### PR TITLE
fix(auth): choose quota project envvar over file when both present

### DIFF
--- a/auth/credentials/filetypes.go
+++ b/auth/credentials/filetypes.go
@@ -33,7 +33,7 @@ func fileCredentials(b []byte, opts *DetectOptions) (*auth.Credentials, error) {
 		return nil, err
 	}
 
-	var projectID, quotaProjectID, universeDomain string
+	var projectID, universeDomain string
 	var tp auth.TokenProvider
 	switch fileType {
 	case credsfile.ServiceAccountKey:
@@ -56,7 +56,6 @@ func fileCredentials(b []byte, opts *DetectOptions) (*auth.Credentials, error) {
 		if err != nil {
 			return nil, err
 		}
-		quotaProjectID = f.QuotaProjectID
 		universeDomain = f.UniverseDomain
 	case credsfile.ExternalAccountKey:
 		f, err := credsfile.ParseExternalAccount(b)
@@ -67,7 +66,6 @@ func fileCredentials(b []byte, opts *DetectOptions) (*auth.Credentials, error) {
 		if err != nil {
 			return nil, err
 		}
-		quotaProjectID = f.QuotaProjectID
 		universeDomain = resolveUniverseDomain(opts.UniverseDomain, f.UniverseDomain)
 	case credsfile.ExternalAccountAuthorizedUserKey:
 		f, err := credsfile.ParseExternalAccountAuthorizedUser(b)
@@ -78,7 +76,6 @@ func fileCredentials(b []byte, opts *DetectOptions) (*auth.Credentials, error) {
 		if err != nil {
 			return nil, err
 		}
-		quotaProjectID = f.QuotaProjectID
 		universeDomain = f.UniverseDomain
 	case credsfile.ImpersonatedServiceAccountKey:
 		f, err := credsfile.ParseImpersonatedServiceAccount(b)
@@ -108,9 +105,9 @@ func fileCredentials(b []byte, opts *DetectOptions) (*auth.Credentials, error) {
 		TokenProvider: auth.NewCachedTokenProvider(tp, &auth.CachedTokenProviderOptions{
 			ExpireEarly: opts.EarlyTokenRefresh,
 		}),
-		JSON:                   b,
-		ProjectIDProvider:      internalauth.StaticCredentialsProperty(projectID),
-		QuotaProjectIDProvider: internalauth.StaticCredentialsProperty(quotaProjectID),
+		JSON:              b,
+		ProjectIDProvider: internalauth.StaticCredentialsProperty(projectID),
+		// TODO(codyoss): only set quota project here if there was a user override
 		UniverseDomainProvider: internalauth.StaticCredentialsProperty(universeDomain),
 	}), nil
 }

--- a/auth/credentials/idtoken/integration_test.go
+++ b/auth/credentials/idtoken/integration_test.go
@@ -66,6 +66,7 @@ func TestNewCredentials_CredentialsFile(t *testing.T) {
 }
 
 func TestNewCredentials_CredentialsJSON(t *testing.T) {
+	testutil.IntegrationTestCheck(t)
 	ctx := context.Background()
 	f := os.Getenv(credsfile.GoogleAppCredsEnvVar)
 	if f == "" {


### PR DESCRIPTION
Because we were explicitly setting the value of quota project in the credentials package the logic that should have checked the environment variable was never hit if the value was set in the creds file. So for now we will not set it in this package. The getter on the creds will then default to the correct logic in internal.go.

Also mark an integration test as such so it does not run when the short flag is passed.

Fixes: #10804