### PR TITLE
chore(.github): pin golang.org/x/mod and golang.org/x/tools in renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -13,6 +13,8 @@
     "commitMessageAction": "update",
     "groupName": "deps",
     "ignoreDeps": [
+        "golang.org/x/mod",
+        "golang.org/x/tools",
         "google.golang.org/genproto",
         "github.com/google/pprof"
     ],


### PR DESCRIPTION
* Pin golang.org/x/mod at v0.20.0
  * golang.org/x/mod@v0.21.0 requires go >= 1.22.0
* Pin golang.org/x/tools at v0.24.0
  * golang.org/x/tools@v0.25.0 requires go >= 1.22.0