### PR TITLE
feat(compute/metadata): add logging

### DIFF
--- a/compute/metadata/go.mod
+++ b/compute/metadata/go.mod
@@ -2,4 +2,7 @@ module cloud.google.com/go/compute/metadata
 
 go 1.21
 
-require golang.org/x/sys v0.25.0
+require (
+	github.com/googleapis/gax-go/v2 v2.13.0
+	golang.org/x/sys v0.25.0
+)

--- a/compute/metadata/go.sum
+++ b/compute/metadata/go.sum
@@ -1,2 +1,4 @@
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 golang.org/x/sys v0.25.0 h1:r+8e+loiHxRqhXVl6ML1nO3l1+oFoWbnlu2Ehimmi34=
 golang.org/x/sys v0.25.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/compute/metadata/metadata_test.go
+++ b/compute/metadata/metadata_test.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"log"
 	"net/http"
 	"os"
 	"strings"
@@ -70,7 +69,6 @@ func TestGetFailsOnBadURL(t *testing.T) {
 	c := NewClient(http.DefaultClient)
 	t.Setenv(metadataHostEnv, "host:-1")
 	_, err := c.GetWithContext(ctx, "suffix")
-	log.Printf("%v", err)
 	if err == nil {
 		t.Errorf("got %v, want non-nil error", err)
 	}

--- a/go.work.sum
+++ b/go.work.sum
@@ -65,6 +65,7 @@ go.opentelemetry.io/otel/metric v1.23.1/go.mod h1:mpG2QPlAfnK8yNhNJAxDZruU9Y1/Hu
 go.opentelemetry.io/otel/sdk v1.27.0/go.mod h1:Ha9vbLwJE6W86YstIywK2xFfPjbWlCuwPtMkKdz/Y4A=
 go.opentelemetry.io/otel/sdk/metric v1.27.0/go.mod h1:we7jJVrYN2kh3mVBlswtPU22K0SA+769l93J6bsyvqw=
 go.opentelemetry.io/otel/trace v1.23.1/go.mod h1:4IpnpJFwr1mo/6HL8XIPJaE9y0+u1KcVmuW7dwFSVrI=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 golang.org/x/mod v0.9.0 h1:KENHtAZL2y3NLMYZeHY9DW8HW8V+kQyJsY/V9JlKvCs=
 golang.org/x/mod v0.11.0 h1:bUO06HqtnRcc/7l71XBe4WcqTZ+3AH1J59zWDDwLKgU=
 golang.org/x/mod v0.16.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
@@ -81,4 +82,6 @@ google.golang.org/genproto/googleapis/bytestream v0.0.0-20231120223509-83a465c02
 google.golang.org/genproto/googleapis/bytestream v0.0.0-20240102182953-50ed04b92917/go.mod h1:O9TvT7A9NLgdqqF0JJXJ+axpaoYiEb8txGmkvy+AvLc=
 google.golang.org/genproto/googleapis/bytestream v0.0.0-20240513163218-0867130af1f8/go.mod h1:RCpt0+3mpEDPldc32vXBM8ADXlFL95T8Chxx0nv0/zE=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20230725213213-b022f6e96895/go.mod h1:TUfxEVdsvPg18p6AslUXFoLdpED4oBnGwyqk3dV1XzM=
+google.golang.org/grpc v1.66.1 h1:hO5qAXR19+/Z44hmvIM4dQFMSYX9XcWsByfoxutBpAM=
+google.golang.org/grpc v1.66.1/go.mod h1:s3/l6xSSCURdVfAnL+TqCNMyTDAGN6+lZeVxnZR128Y=
 sigs.k8s.io/yaml v1.3.0/go.mod h1:GeOyir5tyXNByN85N/dRIT9es5UQNerPYEKK56eTBm8=


### PR DESCRIPTION
In order to add this correctly the default metadataClient needs to be initalized lazily. This is because calling clog.New has some logic that freezes logging configuration, so we need to ensure the user has a chance to set this config before global variables from a package are loaded.