### PR TITLE
Close Response Body for failed request

### DIFF
--- a/compute/metadata/metadata.go
+++ b/compute/metadata/metadata.go
@@ -456,6 +456,7 @@ func (c *Client) getETag(ctx context.Context, suffix string) (value, etag string
 			code = res.StatusCode
 		}
 		if delay, shouldRetry := retryer.Retry(code, reqErr); shouldRetry {
+			res.Body.Close()
 			if err := sleep(ctx, delay); err != nil {
 				return "", "", err
 			}


### PR DESCRIPTION
The getETag function only closes the last response at the end of the function, but does not close failed responses.

This leads to memory leaks and even out of memory if Subscribe is called in a loop.