### PR TITLE
test: isolate time travel test

### DIFF
--- a/bigquery/dataset_integration_test.go
+++ b/bigquery/dataset_integration_test.go
@@ -171,6 +171,7 @@ func TestIntegration_DatasetUpdateDefaultExpirationAndMaxTimeTravel(t *testing.T
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
+	defer ds.Delete(ctx)
 
 	wantExpiration := time.Hour
 	wantTimeTravel := 48 * time.Hour

--- a/bigquery/dataset_integration_test.go
+++ b/bigquery/dataset_integration_test.go
@@ -164,14 +164,18 @@ func TestIntegration_DatasetUpdateDefaultExpirationAndMaxTimeTravel(t *testing.T
 		t.Skip("Integration tests skipped")
 	}
 	ctx := context.Background()
-	_, err := dataset.Metadata(ctx)
+	ds := client.Dataset(datasetIDs.New())
+	err := ds.Create(ctx, &DatasetMetadata{
+		Location: "US",
+	})
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("Create: %v", err)
 	}
+
 	wantExpiration := time.Hour
 	wantTimeTravel := 48 * time.Hour
 	// Set the default expiration time.
-	md, err := dataset.Update(ctx, DatasetMetadataToUpdate{
+	md, err := ds.Update(ctx, DatasetMetadataToUpdate{
 		DefaultTableExpiration: wantExpiration,
 		MaxTimeTravel:          wantTimeTravel,
 	}, "")
@@ -185,7 +189,7 @@ func TestIntegration_DatasetUpdateDefaultExpirationAndMaxTimeTravel(t *testing.T
 		t.Fatalf("MaxTimeTravelHours want %s got %s", wantTimeTravel, md.MaxTimeTravel)
 	}
 	// Omitting DefaultTableExpiration doesn't change it.
-	md, err = dataset.Update(ctx, DatasetMetadataToUpdate{Name: "xyz"}, "")
+	md, err = ds.Update(ctx, DatasetMetadataToUpdate{Name: "xyz"}, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -193,7 +197,7 @@ func TestIntegration_DatasetUpdateDefaultExpirationAndMaxTimeTravel(t *testing.T
 		t.Fatalf("got %s, want 1h", md.DefaultTableExpiration)
 	}
 	// Setting it to 0 deletes it (which looks like a 0 duration).
-	md, err = dataset.Update(ctx, DatasetMetadataToUpdate{DefaultTableExpiration: time.Duration(0)}, "")
+	md, err = ds.Update(ctx, DatasetMetadataToUpdate{DefaultTableExpiration: time.Duration(0)}, "")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Switch test to use a newly created dataset rather than manipulate the shared dataset instance available for all tests, to avoid tickling the mutation limit.

Fixes: https://github.com/googleapis/google-cloud-go/issues/10902