### PR TITLE
fix(auth): use new context for non-blocking token refresh

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -328,7 +328,9 @@ func (c *cachedTokenProvider) tokenNonBlocking(ctx context.Context) (*Token, err
 		defer c.mu.Unlock()
 		return c.cachedToken, nil
 	case stale:
-		c.tokenAsync(ctx)
+		// Call tokenAsync with a new Context because the user-provided context
+		// may have a short timeout incompatible with async token refresh.
+		c.tokenAsync(context.Background())
 		// Return the stale token immediately to not block customer requests to Cloud services.
 		c.mu.Lock()
 		defer c.mu.Unlock()


### PR DESCRIPTION
* Avoid user-provided context timeouts incompatible with async token refresh.