### PR TITLE
feat(bigquery): Configurable table read session project

### DIFF
--- a/bigquery/storage_client.go
+++ b/bigquery/storage_client.go
@@ -107,15 +107,8 @@ func (c *readClient) sessionForTable(ctx context.Context, table *Table, rsProjec
 		settings.maxStreamCount = 1
 	}
 
-	// configure where the read session is created
-	readSessionProjectID := table.ProjectID
-	if useClientProject {
-		readSessionProjectID = c.projectID
-	}
-
 	rs := &readSession{
 		ctx:                   ctx,
-		readSessionProjectID:  readSessionProjectID,
 		table:                 table,
 		tableID:               tableID,
 		projectID:             rsProjectID,

--- a/bigquery/storage_client.go
+++ b/bigquery/storage_client.go
@@ -107,9 +107,15 @@ func (c *readClient) sessionForTable(ctx context.Context, table *Table, rsProjec
 		settings.maxStreamCount = 1
 	}
 
+	// configure where the read session is created
+	readSessionProjectID := table.ProjectID
+	if useClientProject {
+		readSessionProjectID = c.projectID
+	}
+
 	rs := &readSession{
 		ctx:                   ctx,
-		projectID:             c.projectID,
+		readSessionProjectID:  readSessionProjectID,
 		table:                 table,
 		tableID:               tableID,
 		projectID:             rsProjectID,
@@ -144,7 +150,6 @@ func (rs *readSession) start() error {
 		preferredMinStreamCount = int32(rs.settings.maxWorkerCount)
 	}
 
-	// Create a read session on the table in the underlying readClient project.
 	createReadSessionRequest := &storagepb.CreateReadSessionRequest{
 		Parent: fmt.Sprintf("projects/%s", rs.projectID),
 		ReadSession: &storagepb.ReadSession{

--- a/bigquery/storage_client.go
+++ b/bigquery/storage_client.go
@@ -109,6 +109,7 @@ func (c *readClient) sessionForTable(ctx context.Context, table *Table, rsProjec
 
 	rs := &readSession{
 		ctx:                   ctx,
+		projectID:             c.projectID,
 		table:                 table,
 		tableID:               tableID,
 		projectID:             rsProjectID,
@@ -142,6 +143,8 @@ func (rs *readSession) start() error {
 	if maxStreamCount == 0 {
 		preferredMinStreamCount = int32(rs.settings.maxWorkerCount)
 	}
+
+	// Create a read session on the table in the underlying readClient project.
 	createReadSessionRequest := &storagepb.CreateReadSessionRequest{
 		Parent: fmt.Sprintf("projects/%s", rs.projectID),
 		ReadSession: &storagepb.ReadSession{

--- a/bigquery/storage_client.go
+++ b/bigquery/storage_client.go
@@ -142,7 +142,6 @@ func (rs *readSession) start() error {
 	if maxStreamCount == 0 {
 		preferredMinStreamCount = int32(rs.settings.maxWorkerCount)
 	}
-
 	createReadSessionRequest := &storagepb.CreateReadSessionRequest{
 		Parent: fmt.Sprintf("projects/%s", rs.projectID),
 		ReadSession: &storagepb.ReadSession{

--- a/bigquery/storage_integration_test.go
+++ b/bigquery/storage_integration_test.go
@@ -112,6 +112,15 @@ func TestIntegration_StorageReadClientProject(t *testing.T) {
 	if !strings.HasPrefix(session.bqSession.Name, expectedPrefix) {
 		t.Fatalf("expected read session to have prefix %q: but found %s:", expectedPrefix, session.bqSession.Name)
 	}
+
+	it = table.Read(ctx, WithReadSessionProject("bigquery-public-data"))
+	_, err = countIteratorRows(it)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if it.IsAccelerated() {
+		t.Fatal("expected storage api to not be used")
+	}
 }
 
 func TestIntegration_StorageReadFromSources(t *testing.T) {

--- a/bigquery/storage_integration_test.go
+++ b/bigquery/storage_integration_test.go
@@ -113,7 +113,7 @@ func TestIntegration_StorageReadClientProject(t *testing.T) {
 		t.Fatalf("expected read session to have prefix %q: but found %s:", expectedPrefix, session.bqSession.Name)
 	}
 
-	it = table.Read(ctx, WithReadSessionProject("bigquery-public-data"))
+	it = table.Read(ctx, WithReadSessionProjectID("bigquery-public-data"))
 	_, err = countIteratorRows(it)
 	if err != nil {
 		t.Fatal(err)

--- a/bigquery/storage_integration_test.go
+++ b/bigquery/storage_integration_test.go
@@ -99,7 +99,7 @@ func TestIntegration_StorageReadClientProject(t *testing.T) {
 	table.ProjectID = "bigquery-public-data"
 
 	it := table.Read(ctx)
-	_, err := countIteratorRows(it)
+	total, err := countIteratorRows(it)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -113,13 +113,17 @@ func TestIntegration_StorageReadClientProject(t *testing.T) {
 		t.Fatalf("expected read session to have prefix %q: but found %s:", expectedPrefix, session.bqSession.Name)
 	}
 
+	// create session with different project
 	it = table.Read(ctx, WithReadSessionProjectID("bigquery-public-data"))
-	_, err = countIteratorRows(it)
+	if it.IsAccelerated() {
+		t.Fatal("storage api should not be used due to lack of permissions")
+	}
+	newTotal, err := countIteratorRows(it)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if it.IsAccelerated() {
-		t.Fatal("expected storage api to not be used")
+	if total != newTotal {
+		t.Fatalf("expected total to be %d, but got %d", total, newTotal)
 	}
 }
 

--- a/bigquery/table.go
+++ b/bigquery/table.go
@@ -984,7 +984,7 @@ func WithClientProject() TableReadOption {
 
 // Read fetches the contents of the table.
 func (t *Table) Read(ctx context.Context, opts ...TableReadOption) *RowIterator {
-	return t.read(ctx, fetchPage)
+	return t.read(ctx, fetchPage, opts...)
 }
 
 func (t *Table) read(ctx context.Context, pf pageFetcher, opts ...TableReadOption) *RowIterator {

--- a/bigquery/table.go
+++ b/bigquery/table.go
@@ -968,16 +968,16 @@ func (t *Table) Delete(ctx context.Context) (err error) {
 }
 
 type tableReadOption struct {
-	readSessionProject string
+	readSessionProjectID string
 }
 
 // TableReadOption allows requests to alter the behavior of reading from a table.
 type TableReadOption func(*tableReadOption)
 
-// WithReadSessionProject allows to create the read session with the specified project that has the necessary permissions to do so.
-func WithReadSessionProject(project string) TableReadOption {
+// WithReadSessionProjectID allows to create the read session with the specified project that has the necessary permissions to do so.
+func WithReadSessionProjectID(project string) TableReadOption {
 	return func(tro *tableReadOption) {
-		tro.readSessionProject = project
+		tro.readSessionProjectID = project
 	}
 }
 
@@ -992,12 +992,13 @@ func (t *Table) read(ctx context.Context, pf pageFetcher, opts ...TableReadOptio
 		o(tro)
 	}
 
-	if tro.readSessionProject == "" {
-		tro.readSessionProject = t.c.projectID
+	//  fallback to the client's project ID.
+	if tro.readSessionProjectID == "" {
+		tro.readSessionProjectID = t.c.projectID
 	}
 
 	if t.c.isStorageReadAvailable() {
-		it, err := newStorageRowIteratorFromTable(ctx, t, tro.readSessionProject, false)
+		it, err := newStorageRowIteratorFromTable(ctx, t, tro.readSessionProjectID, false)
 		if err == nil {
 			return it
 		}

--- a/bigquery/table.go
+++ b/bigquery/table.go
@@ -976,7 +976,7 @@ type TableReadOption func(*tableReadOption)
 
 // WithClientProject allows the read session to be created from the client project
 // when reading from the table, instead of the table's project.
-func WithClientProject(b bool) TableReadOption {
+func WithClientProject() TableReadOption {
 	return func(tro *tableReadOption) {
 		tro.useClientProject = true
 	}
@@ -988,7 +988,7 @@ func (t *Table) Read(ctx context.Context, opts ...TableReadOption) *RowIterator 
 }
 
 func (t *Table) read(ctx context.Context, pf pageFetcher, opts ...TableReadOption) *RowIterator {
-	var tro *tableReadOption
+	tro := &tableReadOption{useClientProject: false}
 	for _, o := range opts {
 		o(tro)
 	}


### PR DESCRIPTION
When creating a BigQuery table RowIterator with StorageReadAPI enabled, the read session is created by default in the table's project. We should be able to overwrite this, so that we can keep the storage of the table data and the permission/cost management of the read session separate.

To accomplish this, `TableReadOption` with `WithClientProject` option is added, and if set, it will create the session using the client's project, otherwise, it keeps the default behaviour.