### PR TITLE
chore: reassign bigquery blunderbuss to alvarowolfx

### DIFF
--- a/.github/blunderbuss.yml
+++ b/.github/blunderbuss.yml
@@ -12,7 +12,7 @@ assign_issues_by:
 - labels:
   - 'api: bigquery'
   to:
-  - shollyman
+  - alvarowolfx
 - labels:
   - 'api: pubsub'
   to:


### PR DESCRIPTION
This PR points the blunderbuss at alvaro while I'm OOO.

Longer term we need to find a better way to articulate the intersection of go + bigquery, but not today.