### PR TITLE
fix(bigquery): create read session with client or job projectID

### DIFF
--- a/bigquery/storage_iterator.go
+++ b/bigquery/storage_iterator.go
@@ -47,12 +47,12 @@ type storageArrowIterator struct {
 
 var _ ArrowIterator = &storageArrowIterator{}
 
-func newStorageRowIteratorFromTable(ctx context.Context, table *Table, ordered bool) (*RowIterator, error) {
+func newStorageRowIteratorFromTable(ctx context.Context, table *Table, rsProjectID string, ordered bool) (*RowIterator, error) {
 	md, err := table.Metadata(ctx)
 	if err != nil {
 		return nil, err
 	}
-	rs, err := table.c.rc.sessionForTable(ctx, table, ordered)
+	rs, err := table.c.rc.sessionForTable(ctx, table, rsProjectID, ordered)
 	if err != nil {
 		return nil, err
 	}
@@ -95,7 +95,7 @@ func newStorageRowIteratorFromJob(ctx context.Context, j *Job) (*RowIterator, er
 		return newStorageRowIteratorFromJob(ctx, lastJob)
 	}
 	ordered := query.HasOrderedResults(qcfg.Q)
-	return newStorageRowIteratorFromTable(ctx, qcfg.Dst, ordered)
+	return newStorageRowIteratorFromTable(ctx, qcfg.Dst, job.projectID, ordered)
 }
 
 func resolveLastChildSelectJob(ctx context.Context, job *Job) (*Job, error) {

--- a/bigquery/table.go
+++ b/bigquery/table.go
@@ -974,7 +974,7 @@ func (t *Table) Read(ctx context.Context) *RowIterator {
 
 func (t *Table) read(ctx context.Context, pf pageFetcher) *RowIterator {
 	if t.c.isStorageReadAvailable() {
-		it, err := newStorageRowIteratorFromTable(ctx, t, false)
+		it, err := newStorageRowIteratorFromTable(ctx, t, t.c.projectID, false)
 		if err == nil {
 			return it
 		}


### PR DESCRIPTION
When reading result sets using the Storage Read API Acceleration enabled, currently the read session is created by default in the table's project. This works for cases where the destination table is not specified and automatically created, which defaults to the project where the the query or job was created. But when reading a table directly or specifying a destination table, it doesn't work in cases where the client doesn't have BQ Storage permissions (just table read permission for example). This is a common use case where some customers have a main billing project and this project has access to other GCP projects with just permission to read data from BigQuery tables.

With this PR, we default to use the defined Query/Job projectID (which defaults to the current `bigquery.Client.projectID`   or when reading the a table directly, we also use default to the `bigquery.Client.projectID`.

Reported initially on PR #10924

~Supersedes #10924~