### PR TITLE
fix(bigquery): missing schema for empty result set on stateless queries

### DIFF
--- a/bigquery/integration_test.go
+++ b/bigquery/integration_test.go
@@ -3581,6 +3581,9 @@ func compareRead(it *RowIterator, want [][]Value, compareTotalRows bool) (msg st
 	if err != nil {
 		return err.Error(), false
 	}
+	if want != nil && len(it.Schema) == 0 {
+		return "missing schema", false
+	}
 	if len(got) != len(want) {
 		return fmt.Sprintf("%s got %d rows, want %d", jobStr, len(got), len(want)), false
 	}

--- a/bigquery/iterator.go
+++ b/bigquery/iterator.go
@@ -257,7 +257,12 @@ func fetchPage(ctx context.Context, src *rowSource, schema Schema, startIndex ui
 			return fetchTableResultPage(ctx, src, schema, startIndex, pageSize, pageToken)
 		}
 		// No rows, but no table or job reference.  Return an empty result set.
-		return &fetchPageResult{}, nil
+		if schema == nil {
+			schema = bqToSchema(src.cachedSchema)
+		}
+		return &fetchPageResult{
+			schema: schema,
+		}, nil
 	}
 	return result, nil
 }


### PR DESCRIPTION
Fixes #10933