### PR TITLE
fix(auth): try talk to plaintext S2A if creds unavailable for mTLS-S2A

### DIFF
--- a/auth/internal/transport/cba.go
+++ b/auth/internal/transport/cba.go
@@ -133,7 +133,11 @@ func GetGRPCTransportCredsAndEndpoint(opts *Options) (credentials.TransportCrede
 		transportCredsForS2A, err = loadMTLSMDSTransportCreds(mtlsMDSRoot, mtlsMDSKey)
 		if err != nil {
 			log.Printf("Loading MTLS MDS credentials failed: %v", err)
-			return defaultTransportCreds, config.endpoint, nil
+			if config.s2aAddress != "" {
+				s2aAddr = config.s2aAddress
+			} else {
+				return defaultTransportCreds, config.endpoint, nil
+			}
 		}
 	} else if config.s2aAddress != "" {
 		s2aAddr = config.s2aAddress
@@ -177,7 +181,11 @@ func GetHTTPTransportConfig(opts *Options) (cert.Provider, func(context.Context,
 		transportCredsForS2A, err = loadMTLSMDSTransportCreds(mtlsMDSRoot, mtlsMDSKey)
 		if err != nil {
 			log.Printf("Loading MTLS MDS credentials failed: %v", err)
-			return config.clientCertSource, nil, nil
+			if config.s2aAddress != "" {
+				s2aAddr = config.s2aAddress
+			} else {
+				return config.clientCertSource, nil, nil
+			}
 		}
 	} else if config.s2aAddress != "" {
 		s2aAddr = config.s2aAddress

--- a/auth/internal/transport/cba_test.go
+++ b/auth/internal/transport/cba_test.go
@@ -63,6 +63,20 @@ var (
 		return string(configStr), nil
 	}
 
+	validConfigRespDualS2A = func() (string, error) {
+		validConfig := mtlsConfig{
+			S2A: &s2aAddresses{
+				PlaintextAddress: testS2AAddr,
+				MTLSAddress:      testMTLSS2AAddr,
+			},
+		}
+		configStr, err := json.Marshal(validConfig)
+		if err != nil {
+			return "", err
+		}
+		return string(configStr), nil
+	}
+
 	errorConfigResp = func() (string, error) {
 		return "", fmt.Errorf("error getting config")
 	}
@@ -346,6 +360,15 @@ func TestGetGRPCTransportConfigAndEndpoint_S2A(t *testing.T) {
 			validConfigRespMTLSS2A,
 			testRegularEndpoint,
 		},
+		{
+			"no client cert, dual S2A addresses, no MTLS MDS cert",
+			&Options{
+				DefaultMTLSEndpoint:     testMTLSEndpoint,
+				DefaultEndpointTemplate: testEndpointTemplate,
+			},
+			validConfigRespDualS2A,
+			testMTLSEndpoint,
+		},
 	}
 	defer setupTest(t)()
 	for _, tc := range testCases {
@@ -444,6 +467,16 @@ func TestGetHTTPTransportConfig_S2A(t *testing.T) {
 			s2ARespFn:   validConfigRespMTLSS2A,
 			want:        testRegularEndpoint,
 			isDialFnNil: true,
+		},
+		{
+			name: "no client cert, dual S2A addresses, no MTLS MDS cert",
+			opts: &Options{
+				DefaultMTLSEndpoint:     testMTLSEndpoint,
+				DefaultEndpointTemplate: testEndpointTemplate,
+			},
+			s2ARespFn:   validConfigRespDualS2A,
+			want:        testMTLSEndpoint,
+			isDialFnNil: false,
 		},
 	}
 	defer setupTest(t)()


### PR DESCRIPTION
It's now possible to have S2A run on two ports, so updating the logic here to try second address if the first choice does not work (i.e. mTLS creds can not be loaded)