### PR TITLE
test(auth): use the same now when checking tokenstate

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -345,13 +345,14 @@ func (c *cachedTokenProvider) tokenState() tokenState {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	t := c.cachedToken
+	now := timeNow()
 	if t == nil || t.Value == "" {
 		return invalid
 	} else if t.Expiry.IsZero() {
 		return fresh
-	} else if timeNow().After(t.Expiry.Round(0)) {
+	} else if now.After(t.Expiry.Round(0)) {
 		return invalid
-	} else if timeNow().After(t.Expiry.Round(0).Add(-c.expireEarly)) {
+	} else if now.After(t.Expiry.Round(0).Add(-c.expireEarly)) {
 		return stale
 	}
 	return fresh


### PR DESCRIPTION
I am not sure if this will fix the test, but it is a better behaviour either way I think. If this happens again my only guess is it has to do with rounding depending on the initial time captured. If this test fails again we should use a reletive offset time instead of a fully random time.

Releated: #10950