### PR TITLE
chore: allow go toolchain to upgrade just for installing tools

### DIFF
--- a/internal/postprocessor/Dockerfile
+++ b/internal/postprocessor/Dockerfile
@@ -22,7 +22,7 @@ WORKDIR /postprocessor
 RUN CGO_ENABLED=0 GOOS=linux go build -v -o post_processor
 
 # Install tools used in build
-RUN go install honnef.co/go/tools/cmd/staticcheck@latest && \
+RUN GOTOOLCHAIN='auto' go install honnef.co/go/tools/cmd/staticcheck@latest && \
     go install github.com/jstemmer/go-junit-report@latest && \
     go install golang.org/x/lint/golint@latest && \
     go install golang.org/x/tools/cmd/goimports@latest


### PR DESCRIPTION
We do this in our CI images as well. Some of our tools now require 1.22+ and this gets around the issue while preserving the version used to run the app. Not having this was causing postprocess image builds to fail.