### PR TITLE
chore: apply GOTOOLCHAIN change to all commands in run block

### DIFF
--- a/internal/postprocessor/Dockerfile
+++ b/internal/postprocessor/Dockerfile
@@ -22,9 +22,10 @@ WORKDIR /postprocessor
 RUN CGO_ENABLED=0 GOOS=linux go build -v -o post_processor
 
 # Install tools used in build
-RUN GOTOOLCHAIN='auto' go install honnef.co/go/tools/cmd/staticcheck@latest && \
+RUN (export=GOTOOLCHAIN='auto' && \
+    go install honnef.co/go/tools/cmd/staticcheck@latest && \
     go install github.com/jstemmer/go-junit-report@latest && \
     go install golang.org/x/lint/golint@latest && \
-    go install golang.org/x/tools/cmd/goimports@latest
+    go install golang.org/x/tools/cmd/goimports@latest)
 
 CMD [ "/postprocessor/post_processor"]


### PR DESCRIPTION
As written before the auto toolchain was only provided to the first command being run. Now it is applied to all commands in the scoped sub-shell -- denoted by the parens.