### PR TITLE
fix: Fix default service account tests on GCE.

### DIFF
--- a/storage/bucket_test.go
+++ b/storage/bucket_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"cloud.google.com/go/compute/metadata"
 	"cloud.google.com/go/internal/testutil"
 	"cloud.google.com/go/storage/internal/apiv2/storagepb"
 	"github.com/google/go-cmp/cmp"
@@ -1305,6 +1306,16 @@ func TestDetectDefaultGoogleAccessID(t *testing.T) {
 				}
 				if id != tc.serviceAccount {
 					t.Errorf("service account not found correctly; got: %s, want: %s", id, tc.serviceAccount)
+				}
+			} else if metadata.OnGCE() {
+				// On GCE, we fall back to the default service account. Check that's
+				// what happened.
+				defaultServiceAccount, err := metadata.Email("default")
+				if err != nil {
+					t.Errorf("could not load metadata service account for fallback: %v", err)
+				}
+				if id != defaultServiceAccount {
+					t.Errorf("service account not found correctly on fallback; got: %s, want: %s", id, defaultServiceAccount)
 				}
 			} else if err == nil {
 				t.Error("expected error but detectDefaultGoogleAccessID did not return one")


### PR DESCRIPTION
Tests running on GCE VMs automatically fall back to using the local metadata service to detect the local default service account. In those cases, tests for malformed creds won't fail, but they should return a VM-specific default service account email.