### PR TITLE
chore: add Protobuf warning to release notes

### DIFF
--- a/accessapproval/CHANGES.md
+++ b/accessapproval/CHANGES.md
@@ -177,3 +177,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out accessapproval as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/accesscontextmanager/CHANGES.md
+++ b/accesscontextmanager/CHANGES.md
@@ -177,3 +177,4 @@
 ## v0.1.0
 
 - feat(accesscontextmanager): start generating clients
+

--- a/advisorynotifications/CHANGES.md
+++ b/advisorynotifications/CHANGES.md
@@ -163,3 +163,4 @@
 * **advisorynotifications:** Start generating apiv1 ([#7502](https://github.com/googleapis/google-cloud-go/issues/7502)) ([6c2b06c](https://github.com/googleapis/google-cloud-go/commit/6c2b06c43873ce4f2037383b204867c8db694a83))
 
 ## Changes
+

--- a/ai/CHANGES.md
+++ b/ai/CHANGES.md
@@ -163,3 +163,4 @@
 * **ai/generativelanguage:** Start generating apiv1beta2 ([#8229](https://github.com/googleapis/google-cloud-go/issues/8229)) ([837f325](https://github.com/googleapis/google-cloud-go/commit/837f32596518d8154f43da1c70f57d1515e2ea8c))
 
 ## Changes
+

--- a/aiplatform/CHANGES.md
+++ b/aiplatform/CHANGES.md
@@ -808,3 +808,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out aiplatform as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/alloydb/CHANGES.md
+++ b/alloydb/CHANGES.md
@@ -221,3 +221,4 @@
 * **alloydb:** Start generating apiv1, apiv1beta, apiv1alpha ([#7503](https://github.com/googleapis/google-cloud-go/issues/7503)) ([25e8426](https://github.com/googleapis/google-cloud-go/commit/25e842659ef5c3941717827459e6524f024e5a26))
 
 ## Changes
+

--- a/analytics/CHANGES.md
+++ b/analytics/CHANGES.md
@@ -335,3 +335,4 @@
 
 This is the first tag to carve out analytics as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/apigateway/CHANGES.md
+++ b/apigateway/CHANGES.md
@@ -162,3 +162,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out apigateway as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/apigeeconnect/CHANGES.md
+++ b/apigeeconnect/CHANGES.md
@@ -155,3 +155,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out apigeeconnect as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/apigeeregistry/CHANGES.md
+++ b/apigeeregistry/CHANGES.md
@@ -167,3 +167,4 @@
 ### Features
 
 * **apigeeregistry:** start generating apiv1 ([#6463](https://github.com/googleapis/google-cloud-go/issues/6463)) ([55385cb](https://github.com/googleapis/google-cloud-go/commit/55385cbd1a324745b2f2f7b72b2fa33cb34c9cb5))
+

--- a/apihub/CHANGES.md
+++ b/apihub/CHANGES.md
@@ -16,3 +16,4 @@
 * **apihub:** New clients ([#10713](https://github.com/googleapis/google-cloud-go/issues/10713)) ([e265371](https://github.com/googleapis/google-cloud-go/commit/e2653715a04507ab9108f56d74606ca93017faa7))
 
 ## Changes
+

--- a/apikeys/CHANGES.md
+++ b/apikeys/CHANGES.md
@@ -162,3 +162,4 @@
 ### Features
 
 * **apikeys:** start generating apiv2 ([#6524](https://github.com/googleapis/google-cloud-go/issues/6524)) ([8b140fa](https://github.com/googleapis/google-cloud-go/commit/8b140fa8a490d7f2e038ca8a776a1dfd46b74b4f))
+

--- a/appengine/CHANGES.md
+++ b/appengine/CHANGES.md
@@ -183,3 +183,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out appengine as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/apphub/CHANGES.md
+++ b/apphub/CHANGES.md
@@ -64,3 +64,4 @@
 * **apphub:** New client(s) ([#9564](https://github.com/googleapis/google-cloud-go/issues/9564)) ([b8cf40b](https://github.com/googleapis/google-cloud-go/commit/b8cf40bcf6bd27744ce7f8f970896e68f4313f93))
 
 ## Changes
+

--- a/apps/CHANGES.md
+++ b/apps/CHANGES.md
@@ -100,3 +100,4 @@
 * **apps:** New clients ([#9142](https://github.com/googleapis/google-cloud-go/issues/9142)) ([8095c6e](https://github.com/googleapis/google-cloud-go/commit/8095c6ee342d9cca812c966b708ba48398fd91ed))
 
 ## Changes
+

--- a/area120/CHANGES.md
+++ b/area120/CHANGES.md
@@ -166,3 +166,4 @@
 
 This is the first tag to carve out area120 as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/artifactregistry/CHANGES.md
+++ b/artifactregistry/CHANGES.md
@@ -254,3 +254,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out artifactregistry as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/asset/CHANGES.md
+++ b/asset/CHANGES.md
@@ -298,3 +298,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out asset as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/assuredworkloads/CHANGES.md
+++ b/assuredworkloads/CHANGES.md
@@ -237,3 +237,4 @@
 
 This is the first tag to carve out assuredworkloads as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/automl/CHANGES.md
+++ b/automl/CHANGES.md
@@ -219,3 +219,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out automl as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/backupdr/CHANGES.md
+++ b/backupdr/CHANGES.md
@@ -105,3 +105,4 @@
 * **backupdr:** New client(s) ([#9715](https://github.com/googleapis/google-cloud-go/issues/9715)) ([a578fc1](https://github.com/googleapis/google-cloud-go/commit/a578fc1a7540a5a5499bdb8b1b921b29267ff2fa))
 
 ## Changes
+

--- a/baremetalsolution/CHANGES.md
+++ b/baremetalsolution/CHANGES.md
@@ -162,3 +162,4 @@
 ### Features
 
 * **baremetalsolution:** start generating apiv2 ([#6147](https://github.com/googleapis/google-cloud-go/issues/6147)) ([5dcbf2f](https://github.com/googleapis/google-cloud-go/commit/5dcbf2f859e2b99e5497d6ac45825a80799f32ab))
+

--- a/batch/CHANGES.md
+++ b/batch/CHANGES.md
@@ -352,3 +352,4 @@
 ### Features
 
 * **batch:** start generating apiv1 ([#6145](https://github.com/googleapis/google-cloud-go/issues/6145)) ([41525fa](https://github.com/googleapis/google-cloud-go/commit/41525fab52da7e913f3593e89cef91c022898be3))
+

--- a/beyondcorp/CHANGES.md
+++ b/beyondcorp/CHANGES.md
@@ -172,3 +172,4 @@
 * **beyondcorp/appgateways:** start generating apiv1 ([7066fed](https://github.com/googleapis/google-cloud-go/commit/7066fedc31fa4c19e851477792bd8de8e50541ab))
 * **beyondcorp/clientconnectorservices:** start generating apiv1 ([7066fed](https://github.com/googleapis/google-cloud-go/commit/7066fedc31fa4c19e851477792bd8de8e50541ab))
 * **beyondcorp/clientgateways:** start generating apiv1 ([7066fed](https://github.com/googleapis/google-cloud-go/commit/7066fedc31fa4c19e851477792bd8de8e50541ab))
+

--- a/bigquery/CHANGES.md
+++ b/bigquery/CHANGES.md
@@ -974,3 +974,4 @@ cloud.google.com/go.
 
 This is the first tag to carve out bigquery as its own module. See:
 https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository.
+

--- a/bigtable/CHANGES.md
+++ b/bigtable/CHANGES.md
@@ -420,3 +420,4 @@
 
 This is the first tag to carve out bigtable as its own module. See:
 https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository.
+

--- a/billing/CHANGES.md
+++ b/billing/CHANGES.md
@@ -289,3 +289,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out billing as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/binaryauthorization/CHANGES.md
+++ b/binaryauthorization/CHANGES.md
@@ -215,3 +215,4 @@
 
 This is the first tag to carve out binaryauthorization as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/certificatemanager/CHANGES.md
+++ b/certificatemanager/CHANGES.md
@@ -286,3 +286,4 @@
 
 * **certificatemanager:** release 0.1.0 ([#5743](https://github.com/googleapis/google-cloud-go/issues/5743)) ([24a817a](https://github.com/googleapis/google-cloud-go/commit/24a817a2a75dde10bcbecf2ced8f399cb05dc011))
 * ****certificatemanager**:** release v0.1.0 ([#5758](https://github.com/googleapis/google-cloud-go/issues/5758)) ([809f4ba](https://github.com/googleapis/google-cloud-go/commit/809f4ba385e2e9ed61df8ecbb6df7b371dc10641))
+

--- a/channel/CHANGES.md
+++ b/channel/CHANGES.md
@@ -267,3 +267,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out channel as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/chat/CHANGES.md
+++ b/chat/CHANGES.md
@@ -124,3 +124,4 @@
 * **chat:** Chat API documentation update ([1d757c6](https://github.com/googleapis/google-cloud-go/commit/1d757c66478963d6cbbef13fee939632c742759c))
 
 ## Changes
+

--- a/cloudbuild/CHANGES.md
+++ b/cloudbuild/CHANGES.md
@@ -255,3 +255,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out cloudbuild as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/cloudcontrolspartner/CHANGES.md
+++ b/cloudcontrolspartner/CHANGES.md
@@ -103,3 +103,4 @@
 * **cloudcontrolspartner:** New client(s) ([#9563](https://github.com/googleapis/google-cloud-go/issues/9563)) ([601f21a](https://github.com/googleapis/google-cloud-go/commit/601f21af3925fa43628739f314112ce4c754b4ce))
 
 ## Changes
+

--- a/clouddms/CHANGES.md
+++ b/clouddms/CHANGES.md
@@ -163,3 +163,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out clouddms as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/cloudprofiler/CHANGES.md
+++ b/cloudprofiler/CHANGES.md
@@ -86,3 +86,4 @@
 * **cloudprofiler:** New clients ([#9016](https://github.com/googleapis/google-cloud-go/issues/9016)) ([8fefcce](https://github.com/googleapis/google-cloud-go/commit/8fefcce1bdd86afb07a4c8bcfc3d3d00f61a9100))
 
 ## Changes
+

--- a/cloudquotas/CHANGES.md
+++ b/cloudquotas/CHANGES.md
@@ -104,3 +104,4 @@
 * **cloudquotas:** New clients ([#9222](https://github.com/googleapis/google-cloud-go/issues/9222)) ([57e2d7b](https://github.com/googleapis/google-cloud-go/commit/57e2d7bd2730b4acd18eac0e3a18e682b51c3e03))
 
 ## Changes
+

--- a/cloudtasks/CHANGES.md
+++ b/cloudtasks/CHANGES.md
@@ -211,3 +211,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out cloudtasks as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/commerce/CHANGES.md
+++ b/commerce/CHANGES.md
@@ -132,3 +132,4 @@
 * **commerce:** Start generating apiv1 ([#8322](https://github.com/googleapis/google-cloud-go/issues/8322)) ([db4f48b](https://github.com/googleapis/google-cloud-go/commit/db4f48bc9d5366f524f1fce82f2fea8094ea8c1e))
 
 ## Changes
+

--- a/compute/CHANGES.md
+++ b/compute/CHANGES.md
@@ -373,3 +373,4 @@ Compute metadata has been moved to its own module.
 
 This is the first tag to carve out compute as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/confidentialcomputing/CHANGES.md
+++ b/confidentialcomputing/CHANGES.md
@@ -174,3 +174,4 @@
 ### Features
 
 * **confidentialcomputing:** Start generating apiv1alpha1 ([#7846](https://github.com/googleapis/google-cloud-go/issues/7846)) ([d0a5d6e](https://github.com/googleapis/google-cloud-go/commit/d0a5d6eda292a7c87ec6d1a4147b037970242641))
+

--- a/config/CHANGES.md
+++ b/config/CHANGES.md
@@ -138,3 +138,4 @@
 * **config:** New clients ([#8493](https://github.com/googleapis/google-cloud-go/issues/8493)) ([9874485](https://github.com/googleapis/google-cloud-go/commit/9874485f0ac1f47139c903bfee4f57c64c3149d4))
 
 ## Changes
+

--- a/contactcenterinsights/CHANGES.md
+++ b/contactcenterinsights/CHANGES.md
@@ -271,3 +271,4 @@
 ## v0.1.0
 
 - feat(contactcenterinsights): start generating clients
+

--- a/container/CHANGES.md
+++ b/container/CHANGES.md
@@ -481,3 +481,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out container as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/containeranalysis/CHANGES.md
+++ b/containeranalysis/CHANGES.md
@@ -205,3 +205,4 @@
 
 This is the first tag to carve out containeranalysis as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/datacatalog/CHANGES.md
+++ b/datacatalog/CHANGES.md
@@ -342,3 +342,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out datacatalog as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/dataflow/CHANGES.md
+++ b/dataflow/CHANGES.md
@@ -172,3 +172,4 @@
 
 This is the first tag to carve out dataflow as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/dataform/CHANGES.md
+++ b/dataform/CHANGES.md
@@ -168,3 +168,4 @@
 
 * **dataform:** remove unused filter field from alpha2 version of API before release ([8a1ad06](https://github.com/googleapis/google-cloud-go/commit/8a1ad06572a65afa91a0a77a85b849e766876671))
 * **dataform:** start generating apiv1alpha2 ([#6299](https://github.com/googleapis/google-cloud-go/issues/6299)) ([1c434c6](https://github.com/googleapis/google-cloud-go/commit/1c434c6657b9bd8529760681c95aef9373c66120))
+

--- a/datafusion/CHANGES.md
+++ b/datafusion/CHANGES.md
@@ -162,3 +162,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out datafusion as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/datalabeling/CHANGES.md
+++ b/datalabeling/CHANGES.md
@@ -165,3 +165,4 @@
 
 This is the first tag to carve out datalabeling as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/dataplex/CHANGES.md
+++ b/dataplex/CHANGES.md
@@ -323,3 +323,4 @@
 ## v0.1.0
 
 - feat(dataplex): start generating clients
+

--- a/dataproc/CHANGES.md
+++ b/dataproc/CHANGES.md
@@ -283,3 +283,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out dataproc as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/dataqna/CHANGES.md
+++ b/dataqna/CHANGES.md
@@ -158,3 +158,4 @@
 
 This is the first tag to carve out dataqna as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/datastore/CHANGES.md
+++ b/datastore/CHANGES.md
@@ -241,3 +241,4 @@
 
 This is the first tag to carve out datastore as its own module. See:
 https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository.
+

--- a/datastream/CHANGES.md
+++ b/datastream/CHANGES.md
@@ -229,3 +229,4 @@
 
 This is the first tag to carve out datastream as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/deploy/CHANGES.md
+++ b/deploy/CHANGES.md
@@ -318,3 +318,4 @@
 ## v0.1.0
 
 - feat(deploy): start generating clients
+

--- a/developerconnect/CHANGES.md
+++ b/developerconnect/CHANGES.md
@@ -50,3 +50,4 @@
 * **developerconnect:** Enable new auth lib ([b95805f](https://github.com/googleapis/google-cloud-go/commit/b95805f4c87d3e8d10ea23bd7a2d68d7a4157568))
 
 ## Changes
+

--- a/dialogflow/CHANGES.md
+++ b/dialogflow/CHANGES.md
@@ -794,3 +794,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out dialogflow as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/discoveryengine/CHANGES.md
+++ b/discoveryengine/CHANGES.md
@@ -346,3 +346,4 @@
 * **discoveryengine:** Start generating apiv1beta ([#7427](https://github.com/googleapis/google-cloud-go/issues/7427)) ([0d289a0](https://github.com/googleapis/google-cloud-go/commit/0d289a07106226b4398935357ab0f30a3a30340d))
 
 ## Changes
+

--- a/dlp/CHANGES.md
+++ b/dlp/CHANGES.md
@@ -275,3 +275,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out dlp as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/documentai/CHANGES.md
+++ b/documentai/CHANGES.md
@@ -546,3 +546,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out documentai as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/domains/CHANGES.md
+++ b/domains/CHANGES.md
@@ -165,3 +165,4 @@
 
 This is the first tag to carve out domains as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/edgecontainer/CHANGES.md
+++ b/edgecontainer/CHANGES.md
@@ -156,3 +156,4 @@
 * **edgecontainer:** Start generating apiv1 ([#6694](https://github.com/googleapis/google-cloud-go/issues/6694)) ([6bc9b69](https://github.com/googleapis/google-cloud-go/commit/6bc9b69ca4dd910a9801f07bbc2b8abfdabe8628))
 
 ## Changes
+

--- a/edgenetwork/CHANGES.md
+++ b/edgenetwork/CHANGES.md
@@ -104,3 +104,4 @@
 * **edgenetwork:** New client(s) ([#8996](https://github.com/googleapis/google-cloud-go/issues/8996)) ([8e63c70](https://github.com/googleapis/google-cloud-go/commit/8e63c70b423e8c10ecd617ccf81fa0662f8f91b5))
 
 ## Changes
+

--- a/errorreporting/CHANGES.md
+++ b/errorreporting/CHANGES.md
@@ -28,3 +28,4 @@
 
 This is the first tag to carve out errorreporting as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/essentialcontacts/CHANGES.md
+++ b/essentialcontacts/CHANGES.md
@@ -162,3 +162,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out essentialcontacts as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/eventarc/CHANGES.md
+++ b/eventarc/CHANGES.md
@@ -205,3 +205,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out eventarc as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/filestore/CHANGES.md
+++ b/filestore/CHANGES.md
@@ -172,3 +172,4 @@
 ## v0.1.0
 
 - feat(filestore): start generating clients
+

--- a/firestore/CHANGES.md
+++ b/firestore/CHANGES.md
@@ -249,3 +249,4 @@
 
 This is the first tag to carve out firestore as its own module. See:
 https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository.
+

--- a/functions/CHANGES.md
+++ b/functions/CHANGES.md
@@ -284,3 +284,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out functions as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/gkebackup/CHANGES.md
+++ b/gkebackup/CHANGES.md
@@ -197,3 +197,4 @@
 ### Features
 
 * **gkebackup:** start generating apiv1 ([#6031](https://github.com/googleapis/google-cloud-go/issues/6031)) ([4816e84](https://github.com/googleapis/google-cloud-go/commit/4816e84076d62c0952eec0a7de80a230dc9074fe))
+

--- a/gkeconnect/CHANGES.md
+++ b/gkeconnect/CHANGES.md
@@ -172,3 +172,4 @@
 
 This is the first tag to carve out gkeconnect as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/gkehub/CHANGES.md
+++ b/gkehub/CHANGES.md
@@ -201,3 +201,4 @@
 
 This is the first tag to carve out gkehub as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/gkemulticloud/CHANGES.md
+++ b/gkemulticloud/CHANGES.md
@@ -177,3 +177,4 @@
 ### Features
 
 * **gkemulticloud:** start generating apiv1 ([#6036](https://github.com/googleapis/google-cloud-go/issues/6036)) ([dc2b168](https://github.com/googleapis/google-cloud-go/commit/dc2b168162ba358435c7191f9d02edaea17d19bb))
+

--- a/grafeas/CHANGES.md
+++ b/grafeas/CHANGES.md
@@ -102,3 +102,4 @@
 
 This is the first tag to carve out grafeas as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/gsuiteaddons/CHANGES.md
+++ b/gsuiteaddons/CHANGES.md
@@ -155,3 +155,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out gsuiteaddons as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/iam/CHANGES.md
+++ b/iam/CHANGES.md
@@ -222,3 +222,4 @@
 
 This is the first tag to carve out iam as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/iap/CHANGES.md
+++ b/iap/CHANGES.md
@@ -203,3 +203,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out iap as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/identitytoolkit/CHANGES.md
+++ b/identitytoolkit/CHANGES.md
@@ -50,3 +50,4 @@
 * **identitytoolkit:** Enable new auth lib ([b95805f](https://github.com/googleapis/google-cloud-go/commit/b95805f4c87d3e8d10ea23bd7a2d68d7a4157568))
 
 ## Changes
+

--- a/ids/CHANGES.md
+++ b/ids/CHANGES.md
@@ -163,3 +163,4 @@
 ## v0.1.0
 
 - feat(ids): start generating clients
+

--- a/iot/CHANGES.md
+++ b/iot/CHANGES.md
@@ -162,3 +162,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out iot as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/kms/CHANGES.md
+++ b/kms/CHANGES.md
@@ -312,3 +312,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out kms as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/language/CHANGES.md
+++ b/language/CHANGES.md
@@ -218,3 +218,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out language as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/lifesciences/CHANGES.md
+++ b/lifesciences/CHANGES.md
@@ -170,3 +170,4 @@
 
 This is the first tag to carve out lifesciences as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/logging/CHANGES.md
+++ b/logging/CHANGES.md
@@ -202,3 +202,4 @@
 
 This is the first tag to carve out logging as its own module. See:
 https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository.
+

--- a/longrunning/CHANGES.md
+++ b/longrunning/CHANGES.md
@@ -136,3 +136,4 @@
 ## v0.1.0
 
 Initial release.
+

--- a/managedidentities/CHANGES.md
+++ b/managedidentities/CHANGES.md
@@ -162,3 +162,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out managedidentities as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/managedkafka/CHANGES.md
+++ b/managedkafka/CHANGES.md
@@ -69,3 +69,4 @@
 * **managedkafka:** New clients ([#10274](https://github.com/googleapis/google-cloud-go/issues/10274)) ([3caccb5](https://github.com/googleapis/google-cloud-go/commit/3caccb556c889104fb77a6353774a8779a9ea24e))
 
 ## Changes
+

--- a/maps/CHANGES.md
+++ b/maps/CHANGES.md
@@ -393,3 +393,4 @@
 
 * **maps/addressvalidation:** Start generating apiv1 ([#7012](https://github.com/googleapis/google-cloud-go/issues/7012)) ([3e88250](https://github.com/googleapis/google-cloud-go/commit/3e882501ea196ff4f122989e5726bfd4c72e5133))
 * **maps/routing:** Start generating apiv2 ([#7056](https://github.com/googleapis/google-cloud-go/issues/7056)) ([1b7993d](https://github.com/googleapis/google-cloud-go/commit/1b7993d6931cf33bab07124da4180eeb3faffe7e))
+

--- a/mediatranslation/CHANGES.md
+++ b/mediatranslation/CHANGES.md
@@ -158,3 +158,4 @@
 
 This is the first tag to carve out mediatranslation as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/memcache/CHANGES.md
+++ b/memcache/CHANGES.md
@@ -183,3 +183,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out memcache as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/metastore/CHANGES.md
+++ b/metastore/CHANGES.md
@@ -219,3 +219,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out metastore as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/migrationcenter/CHANGES.md
+++ b/migrationcenter/CHANGES.md
@@ -119,3 +119,4 @@
 * **migrationcenter:** Migration Center API ([fa91b47](https://github.com/googleapis/google-cloud-go/commit/fa91b478a55d6347f5c4fd29f2490316b2f31072))
 
 ## Changes
+

--- a/monitoring/CHANGES.md
+++ b/monitoring/CHANGES.md
@@ -281,3 +281,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out monitoring as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/netapp/CHANGES.md
+++ b/netapp/CHANGES.md
@@ -182,3 +182,4 @@
 * **netapp:** Start generating apiv1 ([#8353](https://github.com/googleapis/google-cloud-go/issues/8353)) ([f609b3c](https://github.com/googleapis/google-cloud-go/commit/f609b3cf831fb89c45386f81d0047560120cb3f4))
 
 ## Changes
+

--- a/networkconnectivity/CHANGES.md
+++ b/networkconnectivity/CHANGES.md
@@ -221,3 +221,4 @@
 
 This is the first tag to carve out networkconnectivity as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/networkmanagement/CHANGES.md
+++ b/networkmanagement/CHANGES.md
@@ -211,3 +211,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out networkmanagement as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/networksecurity/CHANGES.md
+++ b/networksecurity/CHANGES.md
@@ -171,3 +171,4 @@
 ## v0.1.0
 
 - feat(networksecurity): start generating clients
+

--- a/networkservices/CHANGES.md
+++ b/networkservices/CHANGES.md
@@ -64,3 +64,4 @@
 * **networkservices:** New client(s) ([#10314](https://github.com/googleapis/google-cloud-go/issues/10314)) ([ee4df98](https://github.com/googleapis/google-cloud-go/commit/ee4df98e7ff89c005ee345120fb53c85086a2461))
 
 ## Changes
+

--- a/notebooks/CHANGES.md
+++ b/notebooks/CHANGES.md
@@ -230,3 +230,4 @@
 
 This is the first tag to carve out notebooks as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/optimization/CHANGES.md
+++ b/optimization/CHANGES.md
@@ -196,3 +196,4 @@
 ## v0.1.0
 
 - feat(optimization): start generating clients
+

--- a/oracledatabase/CHANGES.md
+++ b/oracledatabase/CHANGES.md
@@ -8,3 +8,4 @@
 * **oracledatabase:** New clients ([#10975](https://github.com/googleapis/google-cloud-go/issues/10975)) ([5d39a54](https://github.com/googleapis/google-cloud-go/commit/5d39a54f645b118f6de80a14f942595e2c4dc6f9))
 
 ## Changes
+

--- a/orchestration/CHANGES.md
+++ b/orchestration/CHANGES.md
@@ -197,3 +197,4 @@
 ## v0.1.0
 
 - feat(orchestration): start generating clients
+

--- a/orgpolicy/CHANGES.md
+++ b/orgpolicy/CHANGES.md
@@ -211,3 +211,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out orgpolicy as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/osconfig/CHANGES.md
+++ b/osconfig/CHANGES.md
@@ -239,3 +239,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out osconfig as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/oslogin/CHANGES.md
+++ b/oslogin/CHANGES.md
@@ -210,3 +210,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out oslogin as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/parallelstore/CHANGES.md
+++ b/parallelstore/CHANGES.md
@@ -144,3 +144,4 @@
 * **parallelstore:** New client(s) ([#9434](https://github.com/googleapis/google-cloud-go/issues/9434)) ([3410b19](https://github.com/googleapis/google-cloud-go/commit/3410b190796edbf73f439494abcbeb204ed5e395))
 
 ## Changes
+

--- a/phishingprotection/CHANGES.md
+++ b/phishingprotection/CHANGES.md
@@ -158,3 +158,4 @@
 
 This is the first tag to carve out phishingprotection as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/policysimulator/CHANGES.md
+++ b/policysimulator/CHANGES.md
@@ -106,3 +106,4 @@
 * **policysimulator:** Start generating apiv1 ([#8340](https://github.com/googleapis/google-cloud-go/issues/8340)) ([a41e5ec](https://github.com/googleapis/google-cloud-go/commit/a41e5eca56246e83670d5c0d043d7ab78db47042))
 
 ## Changes
+

--- a/policytroubleshooter/CHANGES.md
+++ b/policytroubleshooter/CHANGES.md
@@ -185,3 +185,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out policytroubleshooter as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/privatecatalog/CHANGES.md
+++ b/privatecatalog/CHANGES.md
@@ -165,3 +165,4 @@
 
 This is the first tag to carve out privatecatalog as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/privilegedaccessmanager/CHANGES.md
+++ b/privilegedaccessmanager/CHANGES.md
@@ -34,3 +34,4 @@
 * **privilegedaccessmanager:** Update dependencies ([257c40b](https://github.com/googleapis/google-cloud-go/commit/257c40bd6d7e59730017cf32bda8823d7a232758))
 
 ## Changes
+

--- a/profiler/CHANGES.md
+++ b/profiler/CHANGES.md
@@ -69,3 +69,4 @@
 
 This is the first tag to carve out profiler as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/pubsub/CHANGES.md
+++ b/pubsub/CHANGES.md
@@ -680,3 +680,4 @@ Small fix to a package name.
 
 This is the first tag to carve out pubsub as its own module. See:
 https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository.
+

--- a/pubsublite/CHANGES.md
+++ b/pubsublite/CHANGES.md
@@ -337,3 +337,4 @@ pubsublite/internal/wire implementation:
 
 This is the first tag to carve out pubsublite as its own module. See:
 https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository.
+

--- a/rapidmigrationassessment/CHANGES.md
+++ b/rapidmigrationassessment/CHANGES.md
@@ -134,3 +134,4 @@
 * **rapidmigrationassessment:** Add API summary ([ebae64d](https://github.com/googleapis/google-cloud-go/commit/ebae64d53397ec5dfe851f098754eaa1f5df7cb1))
 
 ## Changes
+

--- a/recaptchaenterprise/CHANGES.md
+++ b/recaptchaenterprise/CHANGES.md
@@ -325,3 +325,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out recaptchaenterprise as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/recommendationengine/CHANGES.md
+++ b/recommendationengine/CHANGES.md
@@ -170,3 +170,4 @@
 
 This is the first tag to carve out recommendationengine as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/recommender/CHANGES.md
+++ b/recommender/CHANGES.md
@@ -199,3 +199,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out recommender as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/redis/CHANGES.md
+++ b/redis/CHANGES.md
@@ -242,3 +242,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out redis as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/resourcemanager/CHANGES.md
+++ b/resourcemanager/CHANGES.md
@@ -191,3 +191,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out resourcemanager as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/resourcesettings/CHANGES.md
+++ b/resourcesettings/CHANGES.md
@@ -162,3 +162,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out resourcesettings as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/retail/CHANGES.md
+++ b/retail/CHANGES.md
@@ -268,3 +268,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out retail as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/run/CHANGES.md
+++ b/run/CHANGES.md
@@ -276,3 +276,4 @@
 ### Features
 
 * **run:** start generating apiv2 ([#5825](https://github.com/googleapis/google-cloud-go/issues/5825)) ([2602a20](https://github.com/googleapis/google-cloud-go/commit/2602a20ca8eba1ba2b1e59bb27a7b44132d63032))
+

--- a/scheduler/CHANGES.md
+++ b/scheduler/CHANGES.md
@@ -190,3 +190,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out scheduler as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/secretmanager/CHANGES.md
+++ b/secretmanager/CHANGES.md
@@ -211,3 +211,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out secretmanager as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/securesourcemanager/CHANGES.md
+++ b/securesourcemanager/CHANGES.md
@@ -105,3 +105,4 @@
 * **securesourcemanager:** New clients ([#8738](https://github.com/googleapis/google-cloud-go/issues/8738)) ([b02ab73](https://github.com/googleapis/google-cloud-go/commit/b02ab733edd1a74f74b244298524f72d84046c0c))
 
 ## Changes
+

--- a/security/CHANGES.md
+++ b/security/CHANGES.md
@@ -260,3 +260,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out security as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/securitycenter/CHANGES.md
+++ b/securitycenter/CHANGES.md
@@ -389,3 +389,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out securitycenter as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/securitycentermanagement/CHANGES.md
+++ b/securitycentermanagement/CHANGES.md
@@ -148,3 +148,4 @@
 * **securitycentermanagement:** Security Center Management API ([#9068](https://github.com/googleapis/google-cloud-go/issues/9068)) ([5132d0f](https://github.com/googleapis/google-cloud-go/commit/5132d0fea3a5ac902a2c9eee865241ed4509a5f4))
 
 ## Changes
+

--- a/securityposture/CHANGES.md
+++ b/securityposture/CHANGES.md
@@ -78,3 +78,4 @@
 * **securityposture:** New clients ([#9289](https://github.com/googleapis/google-cloud-go/issues/9289)) ([4a756bc](https://github.com/googleapis/google-cloud-go/commit/4a756bca314daa87101bfad16d2b8b2c352f0a4c))
 
 ## Changes
+

--- a/servicecontrol/CHANGES.md
+++ b/servicecontrol/CHANGES.md
@@ -222,3 +222,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out servicecontrol as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/servicedirectory/CHANGES.md
+++ b/servicedirectory/CHANGES.md
@@ -199,3 +199,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out servicedirectory as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/servicehealth/CHANGES.md
+++ b/servicehealth/CHANGES.md
@@ -99,3 +99,4 @@
 * **servicehealth:** New clients ([#9245](https://github.com/googleapis/google-cloud-go/issues/9245)) ([2868a43](https://github.com/googleapis/google-cloud-go/commit/2868a43805e87ec51bfb816ecb3289c4c0e6bc09))
 
 ## Changes
+

--- a/servicemanagement/CHANGES.md
+++ b/servicemanagement/CHANGES.md
@@ -190,3 +190,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out servicemanagement as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/serviceusage/CHANGES.md
+++ b/serviceusage/CHANGES.md
@@ -169,3 +169,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out serviceusage as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/shell/CHANGES.md
+++ b/shell/CHANGES.md
@@ -162,3 +162,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out shell as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/shopping/CHANGES.md
+++ b/shopping/CHANGES.md
@@ -249,3 +249,4 @@
 * **shopping:** New clients ([#8699](https://github.com/googleapis/google-cloud-go/issues/8699)) ([0e43b40](https://github.com/googleapis/google-cloud-go/commit/0e43b40184bacac8d355ea2cfd00ebe58bd9e30b))
 
 ## Changes
+

--- a/spanner/CHANGES.md
+++ b/spanner/CHANGES.md
@@ -1124,3 +1124,4 @@
 
 This is the first tag to carve out spanner as its own module. See:
 https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository.
+

--- a/speech/CHANGES.md
+++ b/speech/CHANGES.md
@@ -344,3 +344,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out speech as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/storage/CHANGES.md
+++ b/storage/CHANGES.md
@@ -659,3 +659,4 @@
 
 This is the first tag to carve out storage as its own module. See:
 https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository.
+

--- a/storageinsights/CHANGES.md
+++ b/storageinsights/CHANGES.md
@@ -135,3 +135,4 @@
 * **storageinsights:** Start generating apiv1 ([#7862](https://github.com/googleapis/google-cloud-go/issues/7862)) ([07a5ac1](https://github.com/googleapis/google-cloud-go/commit/07a5ac1965154b471d5a45e0c566803ea9edb15f))
 
 ## Changes
+

--- a/storagetransfer/CHANGES.md
+++ b/storagetransfer/CHANGES.md
@@ -187,3 +187,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out storagetransfer as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/streetview/CHANGES.md
+++ b/streetview/CHANGES.md
@@ -57,3 +57,4 @@
 * **streetview:** New client(s) ([#10075](https://github.com/googleapis/google-cloud-go/issues/10075)) ([e82cc5f](https://github.com/googleapis/google-cloud-go/commit/e82cc5f8667a4b0d9f47fe7f935d0a553c010e93))
 
 ## Changes
+

--- a/support/CHANGES.md
+++ b/support/CHANGES.md
@@ -129,3 +129,4 @@
 * **support:** Start generating apiv2 ([#7879](https://github.com/googleapis/google-cloud-go/issues/7879)) ([e882c64](https://github.com/googleapis/google-cloud-go/commit/e882c647e58564bc6e4265d1424df22ab0eb0e2b))
 
 ## Changes
+

--- a/talent/CHANGES.md
+++ b/talent/CHANGES.md
@@ -253,3 +253,4 @@
 
 This is the first tag to carve out talent as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/telcoautomation/CHANGES.md
+++ b/telcoautomation/CHANGES.md
@@ -104,3 +104,4 @@
 * **telcoautomation:** Add telcoautomation API description ([#9019](https://github.com/googleapis/google-cloud-go/issues/9019)) ([03f9190](https://github.com/googleapis/google-cloud-go/commit/03f9190c36f69458e332d4f1b2e5edfd095899ad))
 
 ## Changes
+

--- a/texttospeech/CHANGES.md
+++ b/texttospeech/CHANGES.md
@@ -176,3 +176,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out texttospeech as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/tpu/CHANGES.md
+++ b/tpu/CHANGES.md
@@ -162,3 +162,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out tpu as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/trace/CHANGES.md
+++ b/trace/CHANGES.md
@@ -209,3 +209,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out trace as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/translate/CHANGES.md
+++ b/translate/CHANGES.md
@@ -211,3 +211,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out translate as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/vertexai/CHANGES.md
+++ b/vertexai/CHANGES.md
@@ -182,3 +182,4 @@
 ### Features
 
 * **vertexai:** Vertex AI for go ([#9095](https://github.com/googleapis/google-cloud-go/issues/9095)) ([b3b293a](https://github.com/googleapis/google-cloud-go/commit/b3b293aee06690ed734bb19c404eb6c8af893fa1))
+

--- a/video/CHANGES.md
+++ b/video/CHANGES.md
@@ -300,3 +300,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out video as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/videointelligence/CHANGES.md
+++ b/videointelligence/CHANGES.md
@@ -190,3 +190,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out videointelligence as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/vision/CHANGES.md
+++ b/vision/CHANGES.md
@@ -205,3 +205,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out vision as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/visionai/CHANGES.md
+++ b/visionai/CHANGES.md
@@ -109,3 +109,4 @@
 * **visionai:** New clients ([#9333](https://github.com/googleapis/google-cloud-go/issues/9333)) ([4315cdf](https://github.com/googleapis/google-cloud-go/commit/4315cdf6bfdcd9ed6e9137254451eabbc5cb420b))
 
 ## Changes
+

--- a/vmmigration/CHANGES.md
+++ b/vmmigration/CHANGES.md
@@ -185,3 +185,4 @@
 ## v0.1.0
 
 - feat(vmmigration): start generating clients
+

--- a/vmwareengine/CHANGES.md
+++ b/vmwareengine/CHANGES.md
@@ -169,3 +169,4 @@
 * **vmwareengine:** Start generating apiv1 ([#7093](https://github.com/googleapis/google-cloud-go/issues/7093)) ([9cb00af](https://github.com/googleapis/google-cloud-go/commit/9cb00af1ad8ea1dcfd5b4a73cac75218460f9f6d))
 
 ## Changes
+

--- a/vpcaccess/CHANGES.md
+++ b/vpcaccess/CHANGES.md
@@ -162,3 +162,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out vpcaccess as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/webrisk/CHANGES.md
+++ b/webrisk/CHANGES.md
@@ -178,3 +178,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out webrisk as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/websecurityscanner/CHANGES.md
+++ b/websecurityscanner/CHANGES.md
@@ -162,3 +162,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out websecurityscanner as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/workflows/CHANGES.md
+++ b/workflows/CHANGES.md
@@ -207,3 +207,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out workflows as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/workstations/CHANGES.md
+++ b/workstations/CHANGES.md
@@ -156,3 +156,4 @@
 * **workstations:** Start generating apiv1beta ([#7599](https://github.com/googleapis/google-cloud-go/issues/7599)) ([e3d6afe](https://github.com/googleapis/google-cloud-go/commit/e3d6afe79ddc4579b54934b4884891f35cc3d1a3))
 
 ## Changes
+


### PR DESCRIPTION
BEGIN_NESTED_COMMIT
fix(redis): WARNING: On approximately Dec 1, 2024, an update to Protobuf will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go files. This change is expected to affect very few if any users of this client library. For more information, see https://github.com/googleapis/google-cloud-go/issues/11020.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(resourcemanager): WARNING: On approximately Dec 1, 2024, an update to Protobuf will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go files. This change is expected to affect very few if any users of this client library. For more information, see https://github.com/googleapis/google-cloud-go/issues/11020.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(resourcesettings): WARNING: On approximately Dec 1, 2024, an update to Protobuf will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go files. This change is expected to affect very few if any users of this client library. For more information, see https://github.com/googleapis/google-cloud-go/issues/11020.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(retail): WARNING: On approximately Dec 1, 2024, an update to Protobuf will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go files. This change is expected to affect very few if any users of this client library. For more information, see https://github.com/googleapis/google-cloud-go/issues/11020.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(run): WARNING: On approximately Dec 1, 2024, an update to Protobuf will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go files. This change is expected to affect very few if any users of this client library. For more information, see https://github.com/googleapis/google-cloud-go/issues/11020.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(scheduler): WARNING: On approximately Dec 1, 2024, an update to Protobuf will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go files. This change is expected to affect very few if any users of this client library. For more information, see https://github.com/googleapis/google-cloud-go/issues/11020.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(secretmanager): WARNING: On approximately Dec 1, 2024, an update to Protobuf will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go files. This change is expected to affect very few if any users of this client library. For more information, see https://github.com/googleapis/google-cloud-go/issues/11020.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(securesourcemanager): WARNING: On approximately Dec 1, 2024, an update to Protobuf will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go files. This change is expected to affect very few if any users of this client library. For more information, see https://github.com/googleapis/google-cloud-go/issues/11020.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(security): WARNING: On approximately Dec 1, 2024, an update to Protobuf will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go files. This change is expected to affect very few if any users of this client library. For more information, see https://github.com/googleapis/google-cloud-go/issues/11020.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(securitycenter): WARNING: On approximately Dec 1, 2024, an update to Protobuf will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go files. This change is expected to affect very few if any users of this client library. For more information, see https://github.com/googleapis/google-cloud-go/issues/11020.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(securitycentermanagement): WARNING: On approximately Dec 1, 2024, an update to Protobuf will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go files. This change is expected to affect very few if any users of this client library. For more information, see https://github.com/googleapis/google-cloud-go/issues/11020.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(securityposture): WARNING: On approximately Dec 1, 2024, an update to Protobuf will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go files. This change is expected to affect very few if any users of this client library. For more information, see https://github.com/googleapis/google-cloud-go/issues/11020.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(servicecontrol): WARNING: On approximately Dec 1, 2024, an update to Protobuf will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go files. This change is expected to affect very few if any users of this client library. For more information, see https://github.com/googleapis/google-cloud-go/issues/11020.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(servicedirectory): WARNING: On approximately Dec 1, 2024, an update to Protobuf will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go files. This change is expected to affect very few if any users of this client library. For more information, see https://github.com/googleapis/google-cloud-go/issues/11020.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(servicehealth): WARNING: On approximately Dec 1, 2024, an update to Protobuf will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go files. This change is expected to affect very few if any users of this client library. For more information, see https://github.com/googleapis/google-cloud-go/issues/11020.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(servicemanagement): WARNING: On approximately Dec 1, 2024, an update to Protobuf will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go files. This change is expected to affect very few if any users of this client library. For more information, see https://github.com/googleapis/google-cloud-go/issues/11020.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(serviceusage): WARNING: On approximately Dec 1, 2024, an update to Protobuf will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go files. This change is expected to affect very few if any users of this client library. For more information, see https://github.com/googleapis/google-cloud-go/issues/11020.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(shell): WARNING: On approximately Dec 1, 2024, an update to Protobuf will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go files. This change is expected to affect very few if any users of this client library. For more information, see https://github.com/googleapis/google-cloud-go/issues/11020.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(shopping): WARNING: On approximately Dec 1, 2024, an update to Protobuf will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go files. This change is expected to affect very few if any users of this client library. For more information, see https://github.com/googleapis/google-cloud-go/issues/11020.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(spanner): WARNING: On approximately Dec 1, 2024, an update to Protobuf will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go files. This change is expected to affect very few if any users of this client library. For more information, see https://github.com/googleapis/google-cloud-go/issues/11020.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(spanner/test/opentelemetry/test): WARNING: On approximately Dec 1, 2024, an update to Protobuf will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go files. This change is expected to affect very few if any users of this client library. For more information, see https://github.com/googleapis/google-cloud-go/issues/11020.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(speech): WARNING: On approximately Dec 1, 2024, an update to Protobuf will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go files. This change is expected to affect very few if any users of this client library. For more information, see https://github.com/googleapis/google-cloud-go/issues/11020.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(storage): WARNING: On approximately Dec 1, 2024, an update to Protobuf will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go files. This change is expected to affect very few if any users of this client library. For more information, see https://github.com/googleapis/google-cloud-go/issues/11020.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(storageinsights): WARNING: On approximately Dec 1, 2024, an update to Protobuf will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go files. This change is expected to affect very few if any users of this client library. For more information, see https://github.com/googleapis/google-cloud-go/issues/11020.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(storagetransfer): WARNING: On approximately Dec 1, 2024, an update to Protobuf will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go files. This change is expected to affect very few if any users of this client library. For more information, see https://github.com/googleapis/google-cloud-go/issues/11020.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(streetview): WARNING: On approximately Dec 1, 2024, an update to Protobuf will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go files. This change is expected to affect very few if any users of this client library. For more information, see https://github.com/googleapis/google-cloud-go/issues/11020.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(support): WARNING: On approximately Dec 1, 2024, an update to Protobuf will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go files. This change is expected to affect very few if any users of this client library. For more information, see https://github.com/googleapis/google-cloud-go/issues/11020.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(talent): WARNING: On approximately Dec 1, 2024, an update to Protobuf will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go files. This change is expected to affect very few if any users of this client library. For more information, see https://github.com/googleapis/google-cloud-go/issues/11020.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(telcoautomation): WARNING: On approximately Dec 1, 2024, an update to Protobuf will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go files. This change is expected to affect very few if any users of this client library. For more information, see https://github.com/googleapis/google-cloud-go/issues/11020.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(texttospeech): WARNING: On approximately Dec 1, 2024, an update to Protobuf will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go files. This change is expected to affect very few if any users of this client library. For more information, see https://github.com/googleapis/google-cloud-go/issues/11020.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(tpu): WARNING: On approximately Dec 1, 2024, an update to Protobuf will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go files. This change is expected to affect very few if any users of this client library. For more information, see https://github.com/googleapis/google-cloud-go/issues/11020.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(trace): WARNING: On approximately Dec 1, 2024, an update to Protobuf will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go files. This change is expected to affect very few if any users of this client library. For more information, see https://github.com/googleapis/google-cloud-go/issues/11020.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(translate): WARNING: On approximately Dec 1, 2024, an update to Protobuf will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go files. This change is expected to affect very few if any users of this client library. For more information, see https://github.com/googleapis/google-cloud-go/issues/11020.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(vertexai): WARNING: On approximately Dec 1, 2024, an update to Protobuf will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go files. This change is expected to affect very few if any users of this client library. For more information, see https://github.com/googleapis/google-cloud-go/issues/11020.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(video): WARNING: On approximately Dec 1, 2024, an update to Protobuf will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go files. This change is expected to affect very few if any users of this client library. For more information, see https://github.com/googleapis/google-cloud-go/issues/11020.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(videointelligence): WARNING: On approximately Dec 1, 2024, an update to Protobuf will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go files. This change is expected to affect very few if any users of this client library. For more information, see https://github.com/googleapis/google-cloud-go/issues/11020.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(vision): WARNING: On approximately Dec 1, 2024, an update to Protobuf will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go files. This change is expected to affect very few if any users of this client library. For more information, see https://github.com/googleapis/google-cloud-go/issues/11020.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(visionai): WARNING: On approximately Dec 1, 2024, an update to Protobuf will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go files. This change is expected to affect very few if any users of this client library. For more information, see https://github.com/googleapis/google-cloud-go/issues/11020.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(vmmigration): WARNING: On approximately Dec 1, 2024, an update to Protobuf will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go files. This change is expected to affect very few if any users of this client library. For more information, see https://github.com/googleapis/google-cloud-go/issues/11020.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(vmwareengine): WARNING: On approximately Dec 1, 2024, an update to Protobuf will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go files. This change is expected to affect very few if any users of this client library. For more information, see https://github.com/googleapis/google-cloud-go/issues/11020.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(vpcaccess): WARNING: On approximately Dec 1, 2024, an update to Protobuf will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go files. This change is expected to affect very few if any users of this client library. For more information, see https://github.com/googleapis/google-cloud-go/issues/11020.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(webrisk): WARNING: On approximately Dec 1, 2024, an update to Protobuf will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go files. This change is expected to affect very few if any users of this client library. For more information, see https://github.com/googleapis/google-cloud-go/issues/11020.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(websecurityscanner): WARNING: On approximately Dec 1, 2024, an update to Protobuf will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go files. This change is expected to affect very few if any users of this client library. For more information, see https://github.com/googleapis/google-cloud-go/issues/11020.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(workflows): WARNING: On approximately Dec 1, 2024, an update to Protobuf will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go files. This change is expected to affect very few if any users of this client library. For more information, see https://github.com/googleapis/google-cloud-go/issues/11020.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(workstations): WARNING: On approximately Dec 1, 2024, an update to Protobuf will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go files. This change is expected to affect very few if any users of this client library. For more information, see https://github.com/googleapis/google-cloud-go/issues/11020.
END_NESTED_COMMIT