### PR TITLE
test(auth): fix TestWithEndpointAndPoolSize

### DIFF
--- a/auth/grpctransport/pool_test.go
+++ b/auth/grpctransport/pool_test.go
@@ -84,8 +84,9 @@ func TestWithEndpointAndPoolSize(t *testing.T) {
 	_, l := mockServer(t)
 	ctx := context.Background()
 	connPool, err := Dial(ctx, false, &Options{
-		Endpoint: l.Addr().String(),
-		PoolSize: 4,
+		Endpoint:              l.Addr().String(),
+		PoolSize:              4,
+		DisableAuthentication: true,
 	})
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
I believe this test started failing because of a recent CI infra move. Test could also just be removed as it does not assert anything.