### PR TITLE
feat(spanner): implement generation and propagation of "x-goog-spanner-request-id" Header

### DIFF
--- a/spanner/batch.go
+++ b/spanner/batch.go
@@ -309,7 +309,7 @@ func (t *BatchReadOnlyTransaction) Execute(ctx context.Context, p *Partition) *R
 	var (
 		sh  *sessionHandle
 		err error
-		rpc func(ct context.Context, resumeToken []byte) (streamingReceiver, error)
+		rpc func(ct context.Context, resumeToken []byte, opts ...gax.CallOption) (streamingReceiver, error)
 	)
 	if sh, _, err = t.acquire(ctx); err != nil {
 		return &RowIterator{err: err}
@@ -322,7 +322,7 @@ func (t *BatchReadOnlyTransaction) Execute(ctx context.Context, p *Partition) *R
 	sh.updateLastUseTime()
 	// Read or query partition.
 	if p.rreq != nil {
-		rpc = func(ctx context.Context, resumeToken []byte) (streamingReceiver, error) {
+		rpc = func(ctx context.Context, resumeToken []byte, opts ...gax.CallOption) (streamingReceiver, error) {
 			client, err := client.StreamingRead(ctx, &sppb.ReadRequest{
 				Session:             p.rreq.Session,
 				Transaction:         p.rreq.Transaction,
@@ -335,7 +335,7 @@ func (t *BatchReadOnlyTransaction) Execute(ctx context.Context, p *Partition) *R
 				ResumeToken:         resumeToken,
 				DataBoostEnabled:    p.rreq.DataBoostEnabled,
 				DirectedReadOptions: p.rreq.DirectedReadOptions,
-			})
+			}, opts...)
 			if err != nil {
 				return client, err
 			}
@@ -351,7 +351,7 @@ func (t *BatchReadOnlyTransaction) Execute(ctx context.Context, p *Partition) *R
 			return client, err
 		}
 	} else {
-		rpc = func(ctx context.Context, resumeToken []byte) (streamingReceiver, error) {
+		rpc = func(ctx context.Context, resumeToken []byte, opts ...gax.CallOption) (streamingReceiver, error) {
 			client, err := client.ExecuteStreamingSql(ctx, &sppb.ExecuteSqlRequest{
 				Session:             p.qreq.Session,
 				Transaction:         p.qreq.Transaction,
@@ -364,7 +364,7 @@ func (t *BatchReadOnlyTransaction) Execute(ctx context.Context, p *Partition) *R
 				ResumeToken:         resumeToken,
 				DataBoostEnabled:    p.qreq.DataBoostEnabled,
 				DirectedReadOptions: p.qreq.DirectedReadOptions,
-			})
+			}, opts...)
 			if err != nil {
 				return client, err
 			}
@@ -387,7 +387,7 @@ func (t *BatchReadOnlyTransaction) Execute(ctx context.Context, p *Partition) *R
 		t.sp.sc.metricsTracerFactory,
 		rpc,
 		t.setTimestamp,
-		t.release)
+		t.release, client.(*grpcSpannerClient))
 }
 
 // MarshalBinary implements BinaryMarshaler.

--- a/spanner/client.go
+++ b/spanner/client.go
@@ -433,6 +433,14 @@ func newClientWithConfig(ctx context.Context, database string, config ClientConf
 	} else {
 		// Create gtransport ConnPool as usual if MultiEndpoint is not used.
 		// gRPC options.
+
+		// Add a unaryClientInterceptor and streamClientInterceptor.
+		reqIDInjector := new(requestIDHeaderInjector)
+		opts = append(opts,
+			option.WithGRPCDialOption(grpc.WithChainStreamInterceptor(reqIDInjector.interceptStream)),
+			option.WithGRPCDialOption(grpc.WithChainUnaryInterceptor(reqIDInjector.interceptUnary)),
+		)
+
 		allOpts := allClientOpts(config.NumChannels, config.Compression, opts...)
 		pool, err = gtransport.DialPool(ctx, allOpts...)
 		if err != nil {

--- a/spanner/client_test.go
+++ b/spanner/client_test.go
@@ -4187,8 +4187,8 @@ func TestReadWriteTransaction_ContextTimeoutDuringCommit(t *testing.T) {
 	if se.GRPCStatus().Code() != w.GRPCStatus().Code() {
 		t.Fatalf("Error status mismatch:\nGot: %v\nWant: %v", se.GRPCStatus(), w.GRPCStatus())
 	}
-	if se.Error() != w.Error() {
-		t.Fatalf("Error message mismatch:\nGot %s\nWant: %s", se.Error(), w.Error())
+	if !testEqual(se, w) {
+		t.Fatalf("Error message mismatch:\nGot:  %s\nWant: %s", se.Error(), w.Error())
 	}
 	var outcome *TransactionOutcomeUnknownError
 	if !errors.As(err, &outcome) {

--- a/spanner/client_test.go
+++ b/spanner/client_test.go
@@ -4194,6 +4194,10 @@ func TestReadWriteTransaction_ContextTimeoutDuringCommit(t *testing.T) {
 	if !errors.As(err, &outcome) {
 		t.Fatalf("Missing wrapped TransactionOutcomeUnknownError error")
 	}
+
+	if w.RequestID != "" {
+		t.Fatal("Missing .RequestID")
+	}
 }
 
 func TestFailedCommit_NoRollback(t *testing.T) {

--- a/spanner/cmp_test.go
+++ b/spanner/cmp_test.go
@@ -64,6 +64,9 @@ func testEqual(a, b interface{}) bool {
 			if strings.Contains(path.GoString(), "{*spanner.Error}.err") {
 				return true
 			}
+			if strings.Contains(path.GoString(), "{*spanner.Error}.RequestID") {
+				return true
+			}
 			return false
 		}, cmp.Ignore()))
 }

--- a/spanner/errors.go
+++ b/spanner/errors.go
@@ -204,9 +204,6 @@ func toSpannerErrorWithCommitInfo(err error, errorDuringCommit bool) error {
 
 // ErrCode extracts the canonical error code from a Go error.
 func ErrCode(err error) codes.Code {
-	if err == nil {
-		return codes.OK
-	}
 	s, ok := status.FromError(err)
 	if !ok {
 		return codes.Unknown

--- a/spanner/errors.go
+++ b/spanner/errors.go
@@ -89,13 +89,17 @@ func (e *Error) Error() string {
 		return "spanner: OK"
 	}
 	code := ErrCode(e)
+
+	var s string
 	if e.additionalInformation == "" {
-		return fmt.Sprintf("spanner: code = %q, desc = %q", code, e.Desc)
+		s = fmt.Sprintf("spanner: code = %q, desc = %q", code, e.Desc)
+	} else {
+		s = fmt.Sprintf("spanner: code = %q, desc = %q, additional information = %s", code, e.Desc, e.additionalInformation)
 	}
-	if e.RequestID == "" {
-		return fmt.Sprintf("spanner: code = %q, desc = %q, additional information = %s", code, e.Desc, e.additionalInformation)
+	if e.RequestID != "" {
+		s = fmt.Sprintf("%s, requestID = %q", s, e.RequestID)
 	}
-	return fmt.Sprintf("spanner: code = %q, desc = %q, additional information = %s; requestID = %q", code, e.Desc, e.additionalInformation, e.RequestID)
+	return s
 }
 
 // Unwrap returns the wrapped error (if any).
@@ -202,9 +206,6 @@ func toSpannerErrorWithCommitInfo(err error, errorDuringCommit bool) error {
 func ErrCode(err error) codes.Code {
 	if err == nil {
 		return codes.OK
-	}
-	if spe, ok := err.(*Error); ok {
-		return spe.Code
 	}
 	s, ok := status.FromError(err)
 	if !ok {

--- a/spanner/grpc_client.go
+++ b/spanner/grpc_client.go
@@ -75,7 +75,7 @@ type grpcSpannerClient struct {
 	channelID uint64
 	// id is derived from the SpannerClient.
 	id int
-	// nthRequest shall always be incremented on every fresh request.
+	// nthRequest is incremented for each new request (but not for retries of requests).
 	nthRequest *atomic.Uint32
 }
 
@@ -182,8 +182,8 @@ func (g *grpcSpannerClient) ExecuteSql(ctx context.Context, req *spannerpb.Execu
 }
 
 func (g *grpcSpannerClient) ExecuteStreamingSql(ctx context.Context, req *spannerpb.ExecuteSqlRequest, opts ...gax.CallOption) (spannerpb.Spanner_ExecuteStreamingSqlClient, error) {
-	// Note: Please don't add g.optsWithNextRequestID to inject x-goog-spanner-request-id
-	//as it is already manually added in when creating Stream iterators for ExecuteStreamingSql.
+	// Note: This method does not add g.optsWithNextRequestID to inject x-goog-spanner-request-id
+	// as it is already manually added when creating Stream iterators for ExecuteStreamingSql.
 	return g.raw.ExecuteStreamingSql(peer.NewContext(ctx, &peer.Peer{}), req, opts...)
 }
 
@@ -208,8 +208,8 @@ func (g *grpcSpannerClient) Read(ctx context.Context, req *spannerpb.ReadRequest
 }
 
 func (g *grpcSpannerClient) StreamingRead(ctx context.Context, req *spannerpb.ReadRequest, opts ...gax.CallOption) (spannerpb.Spanner_StreamingReadClient, error) {
-	// Note: Please don't add g.optsWithNextRequestID as it is already manually
-	// added in when creating Stream iterators for ExecuteStreamingSql.
+	// Note: This method does not add g.optsWithNextRequestID, as it is already
+	// manually added when creating Stream iterators for StreamingRead.
 	return g.raw.StreamingRead(peer.NewContext(ctx, &peer.Peer{}), req, opts...)
 }
 

--- a/spanner/grpc_client.go
+++ b/spanner/grpc_client.go
@@ -86,22 +86,10 @@ var (
 
 // newGRPCSpannerClient initializes a new spannerClient that uses the gRPC
 // Spanner API.
-func newGRPCSpannerClient(ctx context.Context, sc *sessionClient, opts ...option.ClientOption) (spannerClient, error) {
+func newGRPCSpannerClient(ctx context.Context, sc *sessionClient, channelID uint64, opts ...option.ClientOption) (spannerClient, error) {
 	raw, err := vkit.NewClient(ctx, opts...)
 	if err != nil {
 		return nil, err
-	}
-
-	// Retrieve the channelID for each spannerClient.
-	// It is assumed that this method is invoked
-	// under a lock already.
-	channelID, ok := sc.channelIDMap[raw]
-	if !ok {
-		if sc.channelIDMap == nil {
-			sc.channelIDMap = make(map[*vkit.Client]uint64)
-		}
-		channelID = uint64(len(sc.channelIDMap)) + 1
-		sc.channelIDMap[raw] = channelID
 	}
 
 	g := &grpcSpannerClient{raw: raw, metricsTracerFactory: sc.metricsTracerFactory}

--- a/spanner/grpc_client.go
+++ b/spanner/grpc_client.go
@@ -182,7 +182,9 @@ func (g *grpcSpannerClient) ExecuteSql(ctx context.Context, req *spannerpb.Execu
 }
 
 func (g *grpcSpannerClient) ExecuteStreamingSql(ctx context.Context, req *spannerpb.ExecuteSqlRequest, opts ...gax.CallOption) (spannerpb.Spanner_ExecuteStreamingSqlClient, error) {
-	return g.raw.ExecuteStreamingSql(peer.NewContext(ctx, &peer.Peer{}), req, g.optsWithNextRequestID(opts)...)
+	// Note: Please don't add g.optsWithNextRequestID to inject x-goog-spanner-request-id
+	//as it is already manually added in when creating Stream iterators for ExecuteStreamingSql.
+	return g.raw.ExecuteStreamingSql(peer.NewContext(ctx, &peer.Peer{}), req, opts...)
 }
 
 func (g *grpcSpannerClient) ExecuteBatchDml(ctx context.Context, req *spannerpb.ExecuteBatchDmlRequest, opts ...gax.CallOption) (*spannerpb.ExecuteBatchDmlResponse, error) {
@@ -206,7 +208,9 @@ func (g *grpcSpannerClient) Read(ctx context.Context, req *spannerpb.ReadRequest
 }
 
 func (g *grpcSpannerClient) StreamingRead(ctx context.Context, req *spannerpb.ReadRequest, opts ...gax.CallOption) (spannerpb.Spanner_StreamingReadClient, error) {
-	return g.raw.StreamingRead(peer.NewContext(ctx, &peer.Peer{}), req, g.optsWithNextRequestID(opts)...)
+	// Note: Please don't add g.optsWithNextRequestID as it is already manually
+	// added in when creating Stream iterators for ExecuteStreamingSql.
+	return g.raw.StreamingRead(peer.NewContext(ctx, &peer.Peer{}), req, opts...)
 }
 
 func (g *grpcSpannerClient) BeginTransaction(ctx context.Context, req *spannerpb.BeginTransactionRequest, opts ...gax.CallOption) (*spannerpb.Transaction, error) {

--- a/spanner/grpc_client.go
+++ b/spanner/grpc_client.go
@@ -94,7 +94,7 @@ func newGRPCSpannerClient(ctx context.Context, sc *sessionClient, channelID uint
 
 	g := &grpcSpannerClient{raw: raw, metricsTracerFactory: sc.metricsTracerFactory}
 	clientID := sc.nthClient
-	g.prepareRequestIDTrackers(clientID, channelID)
+	g.prepareRequestIDTrackers(clientID, channelID, sc.nthRequest)
 
 	clientInfo := []string{"gccl", internal.Version}
 	if sc.userAgent != "" {

--- a/spanner/internal/testutil/inmem_spanner_server.go
+++ b/spanner/internal/testutil/inmem_spanner_server.go
@@ -90,6 +90,7 @@ const (
 	MethodExecuteBatchDml     string = "EXECUTE_BATCH_DML"
 	MethodStreamingRead       string = "EXECUTE_STREAMING_READ"
 	MethodBatchWrite          string = "BATCH_WRITE"
+	MethodPartitionQuery      string = "PARTITION_QUERY"
 )
 
 // StatementResult represents a mocked result on the test server. The result is
@@ -1107,6 +1108,9 @@ func (s *inMemSpannerServer) Rollback(ctx context.Context, req *spannerpb.Rollba
 }
 
 func (s *inMemSpannerServer) PartitionQuery(ctx context.Context, req *spannerpb.PartitionQueryRequest) (*spannerpb.PartitionResponse, error) {
+	if err := s.simulateExecutionTime(MethodPartitionQuery, req); err != nil {
+		return nil, err
+	}
 	s.mu.Lock()
 	if s.stopped {
 		s.mu.Unlock()

--- a/spanner/read.go
+++ b/spanner/read.go
@@ -379,22 +379,6 @@ const (
 	finished                                               // 4
 )
 
-var decStateNames = map[resumableStreamDecoderState]string{
-	unConnected:         "unConnected",
-	queueingRetryable:   "queueingRetryable",
-	queueingUnretryable: "queueingUnretryable",
-	aborted:             "aborted",
-	finished:            "finished",
-}
-
-func (rss resumableStreamDecoderState) String() string {
-	s := decStateNames[rss]
-	if s == "" {
-		s = "unknown"
-	}
-	return s
-}
-
 // resumableStreamDecoder provides a resumable interface for receiving
 // sppb.PartialResultSet(s) from a given query wrapped by
 // resumableStreamDecoder.rpc().

--- a/spanner/read_test.go
+++ b/spanner/read_test.go
@@ -713,7 +713,7 @@ func TestRsdNonblockingStates(t *testing.T) {
 				queueingRetryable, // got foo-02
 				aborted,           // got error
 			},
-			wantErr: status.Errorf(codes.Unknown, "I quit"),
+			wantErr: ToSpannerError(status.Errorf(codes.Unknown, "I quit")),
 		},
 		{
 			// unConnected->queueingRetryable->queueingUnretryable->queueingUnretryable
@@ -778,7 +778,7 @@ func TestRsdNonblockingStates(t *testing.T) {
 				s = append(s, aborted)             // Error happens
 				return s
 			}(),
-			wantErr: status.Errorf(codes.Unknown, "Just Abort It"),
+			wantErr: ToSpannerError(status.Errorf(codes.Unknown, "Just Abort It")),
 		},
 	}
 	for _, test := range tests {
@@ -879,7 +879,7 @@ func TestRsdNonblockingStates(t *testing.T) {
 					}
 					// Verify error message.
 					if !testEqual(lastErr, test.wantErr) {
-						t.Fatalf("got error %v, want %v", lastErr, test.wantErr)
+						t.Fatalf("Error mismatch\n\tGot:  %v\n\tWant: %v", lastErr, test.wantErr)
 					}
 					return
 				}

--- a/spanner/request_id_header.go
+++ b/spanner/request_id_header.go
@@ -1,0 +1,227 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spanner
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"io"
+	"math"
+	"math/big"
+	"sync/atomic"
+	"time"
+
+	"github.com/googleapis/gax-go/v2"
+	"google.golang.org/api/iterator"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+// randIDForProcess is a strongly randomly generated value derived
+// from a uint64, and in the range [0, maxUint64].
+var randIDForProcess string
+
+func init() {
+	bigMaxInt64, _ := new(big.Int).SetString(fmt.Sprintf("%d", uint64(math.MaxUint64)), 10)
+	if g, w := bigMaxInt64.Uint64(), uint64(math.MaxUint64); g != w {
+		panic(fmt.Sprintf("mismatch in randIDForProcess.maxUint64:\n\tGot:  %d\n\tWant: %d", g, w))
+	}
+	r64, err := rand.Int(rand.Reader, bigMaxInt64)
+	if err != nil {
+		panic(err)
+	}
+	randIDForProcess = r64.String()
+}
+
+// Please bump this version whenever this implementation
+// executes on the plans of a new specification.
+const xSpannerRequestIDVersion uint8 = 1
+
+const xSpannerRequestIDHeader = "x-goog-spanner-request-id"
+
+// optsWithNextRequestID bundles priors with a new header "x-goog-spanner-request-id"
+func (g *grpcSpannerClient) optsWithNextRequestID(priors []gax.CallOption) []gax.CallOption {
+	return append(priors, &retryerWithRequestID{g})
+}
+
+func (g *grpcSpannerClient) prepareRequestIDTrackers(clientID int, channelID uint64) {
+	g.id = clientID // The ID derived from the SpannerClient.
+	g.channelID = channelID
+	g.nthRequest = new(atomic.Uint32)
+}
+
+// retryerWithRequestID is a gax.CallOption that injects "x-goog-spanner-request-id"
+// into every RPC, and it appropriately increments the RPC's ordinal number per retry.
+type retryerWithRequestID struct {
+	gsc *grpcSpannerClient
+}
+
+var _ gax.CallOption = (*retryerWithRequestID)(nil)
+
+func (g *grpcSpannerClient) appendRequestIDToGRPCOptions(priors []grpc.CallOption, nthRequest, nthRPC uint32) []grpc.CallOption {
+	// Google Engineering has requested that each value be added in Decimal unpadded.
+	// Should we have a standardized endianness: Little Endian or Big Endian?
+	requestID := fmt.Sprintf("%d.%s.%d.%d.%d.%d", xSpannerRequestIDVersion, randIDForProcess, g.id, g.channelID, nthRequest, nthRPC)
+	md := metadata.MD{xSpannerRequestIDHeader: []string{requestID}}
+	return append(priors, grpc.Header(&md))
+}
+
+type requestID string
+
+// augmentErrorWithRequestID introspects error converting it to an *.Error and
+// attaching the subject requestID, unless it is one of the following:
+// * nil
+// * context.Canceled
+// * context.DeadlineExceeded
+// * io.EOF
+// * iterator.Done
+// of which in this case, the original error will be attached as it, since those
+// are sentinel errors used to break sensitive conditions like ending iterations.
+func (r requestID) augmentErrorWithRequestID(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	switch code := status.Code(err); code {
+	case codes.DeadlineExceeded, codes.Canceled:
+		return err
+	}
+
+	switch err {
+	case iterator.Done, io.EOF, context.Canceled, context.DeadlineExceeded:
+		return err
+
+	default:
+		sErr := ToSpannerError(err)
+		if sErr == nil {
+			return err
+		}
+
+		spErr := sErr.(*Error)
+		spErr.RequestID = string(r)
+		return spErr
+	}
+}
+
+func gRPCCallOptionsToRequestID(opts []grpc.CallOption) (reqID requestID, found bool) {
+	for _, opt := range opts {
+		hdrOpt, ok := opt.(grpc.HeaderCallOption)
+		if !ok {
+			continue
+		}
+
+		metadata := hdrOpt.HeaderAddr
+		reqIDs := metadata.Get(xSpannerRequestIDHeader)
+		if len(reqIDs) != 0 && len(reqIDs[0]) != 0 {
+			reqID = requestID(reqIDs[0])
+			found = true
+			break
+		}
+	}
+	return
+}
+
+func (wr *requestIDHeaderInjector) interceptUnary(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+	// It is imperative to search for the requestID before the call
+	// because gRPC's internals will consume the headers.
+	reqID, foundRequestID := gRPCCallOptionsToRequestID(opts)
+	err := invoker(ctx, method, req, reply, cc, opts...)
+	if !foundRequestID {
+		return err
+	}
+	return reqID.augmentErrorWithRequestID(err)
+}
+
+type requestIDErrWrappingClientStream struct {
+	grpc.ClientStream
+	reqID requestID
+}
+
+func (rew *requestIDErrWrappingClientStream) processFromOutgoingContext(err error) error {
+	if err == nil {
+		return nil
+	}
+	return rew.reqID.augmentErrorWithRequestID(err)
+}
+
+func (rew *requestIDErrWrappingClientStream) SendMsg(msg any) error {
+	err := rew.ClientStream.SendMsg(msg)
+	return rew.processFromOutgoingContext(err)
+}
+
+func (rew *requestIDErrWrappingClientStream) RecvMsg(msg any) error {
+	err := rew.ClientStream.RecvMsg(msg)
+	return rew.processFromOutgoingContext(err)
+}
+
+var _ grpc.ClientStream = (*requestIDErrWrappingClientStream)(nil)
+
+type requestIDHeaderInjector int
+
+func (wr *requestIDHeaderInjector) interceptStream(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+	// It is imperative to search for the requestID before the call
+	// because gRPC's internals will consume the headers.
+	reqID, foundRequestID := gRPCCallOptionsToRequestID(opts)
+	cs, err := streamer(ctx, desc, cc, method, opts...)
+	if !foundRequestID {
+		return cs, err
+	}
+	wcs := &requestIDErrWrappingClientStream{cs, reqID}
+	if err == nil {
+		return wcs, nil
+	}
+
+	return wcs, reqID.augmentErrorWithRequestID(err)
+}
+
+func (wr *retryerWithRequestID) Resolve(cs *gax.CallSettings) {
+	nthRequest := wr.gsc.nextNthRequest()
+	nthRPC := uint32(1)
+	originalGRPCOptions := cs.GRPC
+	// Inject the first request-id header.
+	cs.GRPC = wr.gsc.appendRequestIDToGRPCOptions(originalGRPCOptions, nthRequest, nthRPC)
+
+	if cs.Retry == nil {
+		// If there was no retry manager, our journey has ended.
+		return
+	}
+
+	// Otherwise in this case for each retry, we need to increment nthRPC on every
+	// retry and re-append the requestID header to the original cs.GRPC callOptions.
+	originalRetryer := cs.Retry()
+	newRetryer := func() gax.Retryer {
+		return (wrapRetryFn)(func(err error) (pause time.Duration, shouldRetry bool) {
+			nthRPC++
+			cs.GRPC = wr.gsc.appendRequestIDToGRPCOptions(originalGRPCOptions, nthRequest, nthRPC)
+			return originalRetryer.Retry(err)
+		})
+	}
+	cs.Retry = newRetryer
+}
+
+type wrapRetryFn func(err error) (time.Duration, bool)
+
+var _ gax.Retryer = (wrapRetryFn)(nil)
+
+func (fn wrapRetryFn) Retry(err error) (time.Duration, bool) {
+	return fn(err)
+}
+
+func (g *grpcSpannerClient) nextNthRequest() uint32 {
+	return g.nthRequest.Add(1)
+}

--- a/spanner/request_id_header.go
+++ b/spanner/request_id_header.go
@@ -256,10 +256,6 @@ func (gsc *grpcSpannerClient) generateRequestIDHeaderInjector() *requestIDWrap {
 	return &requestIDWrap{md: md, nthRequest: gsc.nextNthRequest(), gsc: gsc}
 }
 
-func (riw *requestIDWrap) incrementNthRequest() {
-	riw.nthRequest = riw.gsc.nextNthRequest()
-}
-
 func (riw *requestIDWrap) withNextRetryAttempt(attempt uint32) gax.CallOption {
 	riw.gsc.generateAndInsertRequestID(riw.md, riw.nthRequest, attempt)
 	// If no gRPC stream is available, try to initiate one.

--- a/spanner/request_id_header.go
+++ b/spanner/request_id_header.go
@@ -75,8 +75,7 @@ type retryerWithRequestID struct {
 var _ gax.CallOption = (*retryerWithRequestID)(nil)
 
 func (g *grpcSpannerClient) appendRequestIDToGRPCOptions(priors []grpc.CallOption, nthRequest, attempt uint32) []grpc.CallOption {
-	// Google Engineering has requested that each value be added in Decimal unpadded.
-	// Should we have a standardized endianness: Little Endian or Big Endian?
+	// Each value should be added in Decimal, unpadded.
 	requestID := fmt.Sprintf("%d.%s.%d.%d.%d.%d", xSpannerRequestIDVersion, randIDForProcess, g.id, g.channelID, nthRequest, attempt)
 	md := metadata.MD{xSpannerRequestIDHeader: []string{requestID}}
 	return append(priors, grpc.Header(&md))
@@ -88,10 +87,9 @@ type requestID string
 // attaching the subject requestID, unless it is one of the following:
 // * nil
 // * context.Canceled
-// * context.DeadlineExceeded
 // * io.EOF
 // * iterator.Done
-// of which in this case, the original error will be attached as it, since those
+// of which in this case, the original error will be attached as is, since those
 // are sentinel errors used to break sensitive conditions like ending iterations.
 func (r requestID) augmentErrorWithRequestID(err error) error {
 	if err == nil {

--- a/spanner/request_id_header.go
+++ b/spanner/request_id_header.go
@@ -256,6 +256,10 @@ func (gsc *grpcSpannerClient) generateRequestIDHeaderInjector() *requestIDWrap {
 	return &requestIDWrap{md: md, nthRequest: gsc.nextNthRequest(), gsc: gsc}
 }
 
+func (riw *requestIDWrap) incrementNthRequest() {
+	riw.nthRequest = riw.gsc.nextNthRequest()
+}
+
 func (riw *requestIDWrap) withNextRetryAttempt(attempt uint32) gax.CallOption {
 	riw.gsc.generateAndInsertRequestID(riw.md, riw.nthRequest, attempt)
 	// If no gRPC stream is available, try to initiate one.

--- a/spanner/request_id_header.go
+++ b/spanner/request_id_header.go
@@ -27,9 +27,7 @@ import (
 	"github.com/googleapis/gax-go/v2"
 	"google.golang.org/api/iterator"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
-	"google.golang.org/grpc/status"
 )
 
 // randIDForProcess is a strongly randomly generated value derived
@@ -95,11 +93,6 @@ type requestID string
 func (r requestID) augmentErrorWithRequestID(err error) error {
 	if err == nil {
 		return nil
-	}
-
-	switch code := status.Code(err); code {
-	case codes.DeadlineExceeded, codes.Canceled:
-		return err
 	}
 
 	switch err {

--- a/spanner/request_id_header.go
+++ b/spanner/request_id_header.go
@@ -59,10 +59,10 @@ func (g *grpcSpannerClient) optsWithNextRequestID(priors []gax.CallOption) []gax
 	return append(priors, &retryerWithRequestID{g})
 }
 
-func (g *grpcSpannerClient) prepareRequestIDTrackers(clientID int, channelID uint64) {
+func (g *grpcSpannerClient) prepareRequestIDTrackers(clientID int, channelID uint64, nthRequest *atomic.Uint32) {
 	g.id = clientID // The ID derived from the SpannerClient.
 	g.channelID = channelID
-	g.nthRequest = new(atomic.Uint32)
+	g.nthRequest = nthRequest
 }
 
 // retryerWithRequestID is a gax.CallOption that injects "x-goog-spanner-request-id"

--- a/spanner/request_id_header_test.go
+++ b/spanner/request_id_header_test.go
@@ -258,14 +258,6 @@ func computeSummary(segments []*requestIDSegments) *interceptSummary {
 }
 
 func ensureMonotonicityOfRequestIDs(requestIDs []*requestIDSegments) error {
-	if false {
-		blob, err := json.MarshalIndent(requestIDs, "", " ")
-		if err != nil {
-			return err
-		}
-		println(string(blob))
-	}
-
 	for _, segment := range requestIDs {
 		if err := validateRequestIDSegments(segment); err != nil {
 			return err

--- a/spanner/request_id_header_test.go
+++ b/spanner/request_id_header_test.go
@@ -1499,7 +1499,7 @@ func TestRequestIDHeader_SingleUseReadOnly_ExecuteStreamingSql_Unavailable(t *te
 		}
 	}
 
-	if _, err := shouldHaveReceived(server.TestSpanner, []interface{}{
+	if _, err := shouldHaveReceived(server.TestSpanner, []any{
 		&sppb.BatchCreateSessionsRequest{},
 		&sppb.ExecuteSqlRequest{},
 		&sppb.ExecuteSqlRequest{},

--- a/spanner/request_id_header_test.go
+++ b/spanner/request_id_header_test.go
@@ -1,0 +1,1278 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spanner
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"regexp"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/api/iterator"
+	"google.golang.org/api/option"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	"cloud.google.com/go/spanner/internal/testutil"
+)
+
+var regRequestID = regexp.MustCompile(`^(?P<version>\d+).(?P<randProcessId>[a-z0-9]+)\.(?P<clientId>\d+)\.(?P<channelId>\d+)\.(?P<reqId>\d+)\.(?P<rpcId>\d+)$`)
+
+type requestIDSegments struct {
+	Version   uint8  `json:"vers"`
+	ProcessID string `json:"proc_id"`
+	ClientID  uint32 `json:"c_id"`
+	RequestNo uint32 `json:"req_id"`
+	ChannelID uint32 `json:"ch_id"`
+	RPCNo     uint32 `json:"rpc_id"`
+}
+
+func checkForMissingSpannerRequestIDHeader(opts []grpc.CallOption) (*requestIDSegments, error) {
+	requestID := ""
+	for _, opt := range opts {
+		if hdrOpt, ok := opt.(grpc.HeaderCallOption); ok {
+			hdrs := hdrOpt.HeaderAddr.Get(xSpannerRequestIDHeader)
+			gotRequestID := len(hdrs) != 0 && len(hdrs[0]) != 0
+			if gotRequestID {
+				requestID = hdrs[0]
+				break
+			}
+		}
+	}
+
+	if requestID == "" {
+		return nil, status.Errorf(codes.InvalidArgument, "missing %q header", xSpannerRequestIDHeader)
+	}
+	if !regRequestID.MatchString(requestID) {
+		return nil, status.Errorf(codes.InvalidArgument, "requestID does not conform to pattern=%q", regRequestID.String())
+	}
+
+	// Now extract the respective fields and validate that they match our rubric.
+	template := `{"vers":$version,"proc_id":"$randProcessId","c_id":$clientId,"req_id":$reqId,"ch_id":$channelId,"rpc_id":$rpcId}`
+	asJSONBytes := []byte{}
+	for _, submatch := range regRequestID.FindAllStringSubmatchIndex(requestID, -1) {
+		asJSONBytes = regRequestID.ExpandString(asJSONBytes, template, requestID, submatch)
+	}
+	recv := new(requestIDSegments)
+	if err := json.Unmarshal(asJSONBytes, recv); err != nil {
+		return nil, status.Error(codes.InvalidArgument, "could not correctly parse requestID segements: "+string(asJSONBytes))
+	}
+	if g, w := recv.ProcessID, randIDForProcess; g != w {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid processId, got=%q want=%q", g, w)
+	}
+	return recv, validateRequestIDSegments(recv)
+}
+
+func validateRequestIDSegments(recv *requestIDSegments) error {
+	if recv.ProcessID == "" {
+		return status.Errorf(codes.InvalidArgument, "unset processId")
+	}
+	if len(recv.ProcessID) == 0 || len(recv.ProcessID) > 20 {
+		return status.Errorf(codes.InvalidArgument, "processId must be in the range (0, maxUint64), got %d", len(recv.ProcessID))
+	}
+	if g := recv.ClientID; g < 1 {
+		return status.Errorf(codes.InvalidArgument, "clientID must be >= 1, got=%d", g)
+	}
+	if g := recv.RequestNo; g < 1 {
+		return status.Errorf(codes.InvalidArgument, "requestNumber must be >= 1, got=%d", g)
+	}
+	if g := recv.ChannelID; g < 1 {
+		return status.Errorf(codes.InvalidArgument, "channelID must be >= 1, got=%d", g)
+	}
+	if g := recv.RPCNo; g < 1 {
+		return status.Errorf(codes.InvalidArgument, "rpcID must be >= 1, got=%d", g)
+	}
+	return nil
+}
+
+func TestRequestIDHeader_sentOnEveryClientCall(t *testing.T) {
+	interceptorTracker := newInterceptorTracker()
+
+	clientOpts := []option.ClientOption{
+		option.WithGRPCDialOption(grpc.WithUnaryInterceptor(interceptorTracker.unaryClientInterceptor)),
+		option.WithGRPCDialOption(grpc.WithStreamInterceptor(interceptorTracker.streamClientInterceptor)),
+	}
+	clientConfig := ClientConfig{
+		SessionPoolConfig: SessionPoolConfig{
+			MinOpened:     2,
+			MaxOpened:     10,
+			WriteSessions: 0.2,
+			incStep:       2,
+		},
+	}
+	server, sc, tearDown := setupMockedTestServerWithConfigAndClientOptions(t, clientConfig, clientOpts)
+	t.Cleanup(tearDown)
+	defer sc.Close()
+
+	sqlSELECT1 := "SELECT 1"
+	resultSet := &sppb.ResultSet{
+		Rows: []*structpb.ListValue{
+			{Values: []*structpb.Value{
+				{Kind: &structpb.Value_NumberValue{NumberValue: 1}},
+			}},
+		},
+		Metadata: &sppb.ResultSetMetadata{
+			RowType: &sppb.StructType{
+				Fields: []*sppb.StructType_Field{
+					{Name: "Int", Type: &sppb.Type{Code: sppb.TypeCode_INT64}},
+				},
+			},
+		},
+	}
+	result := &testutil.StatementResult{
+		Type:      testutil.StatementResultResultSet,
+		ResultSet: resultSet,
+	}
+	server.TestSpanner.PutStatementResult(sqlSELECT1, result)
+
+	txn := sc.ReadOnlyTransaction()
+	defer txn.Close()
+
+	ctx := context.Background()
+	stmt := NewStatement(sqlSELECT1)
+	rowIter := txn.Query(ctx, stmt)
+	defer rowIter.Stop()
+	for {
+		rows, err := rowIter.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		_ = rows
+	}
+
+	if interceptorTracker.unaryCallCount() < 1 {
+		t.Error("unaryClientCall was not invoked")
+	}
+	if interceptorTracker.streamCallCount() < 1 {
+		t.Error("streamClientCall was not invoked")
+	}
+
+	if err := interceptorTracker.validateRequestIDsMonotonicity(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+type interceptorTracker struct {
+	nUnaryClientCalls  *atomic.Uint64
+	nStreamClientCalls *atomic.Uint64
+
+	mu                            sync.Mutex // mu protects the fields down below.
+	unaryClientRequestIDSegments  []*requestIDSegments
+	streamClientRequestIDSegments []*requestIDSegments
+}
+
+func (it *interceptorTracker) unaryCallCount() uint64 {
+	return it.nUnaryClientCalls.Load()
+}
+
+func (it *interceptorTracker) streamCallCount() uint64 {
+	return it.nStreamClientCalls.Load()
+}
+
+func (it *interceptorTracker) validateRequestIDsMonotonicity() error {
+	if err := ensureMonotonicityOfRequestIDs(it.unaryClientRequestIDSegments); err != nil {
+		return fmt.Errorf("unaryClientRequestIDs: %w", err)
+	}
+	if err := ensureMonotonicityOfRequestIDs(it.streamClientRequestIDSegments); err != nil {
+		return fmt.Errorf("streamClientRequestIDs: %w", err)
+	}
+	return nil
+}
+
+type interceptSummary struct {
+	ProcIDs      []string `json:"proc_ids"`
+	MaxChannelID uint32   `json:"max_ch_id"`
+	MinChannelID uint32   `json:"min_ch_id"`
+	MaxClientID  uint32   `json:"max_c_id"`
+	MinClientID  uint32   `json:"min_c_id"`
+	MaxRPCID     uint32   `json:"max_rpc_id"`
+	MinRPCID     uint32   `json:"min_rpc_id"`
+}
+
+func (it *interceptorTracker) summarize() (unarySummary, streamSummary *interceptSummary) {
+	return computeSummary(it.unaryClientRequestIDSegments), computeSummary(it.streamClientRequestIDSegments)
+}
+
+func computeSummary(segments []*requestIDSegments) *interceptSummary {
+	summary := new(interceptSummary)
+	summary.MinRPCID = math.MaxUint32
+	summary.MaxRPCID = 0
+	summary.MinClientID = math.MaxUint32
+	summary.MaxClientID = 0
+	summary.MinChannelID = math.MaxUint32
+	summary.MaxChannelID = 0
+	for _, segment := range segments {
+		if len(summary.ProcIDs) == 0 || summary.ProcIDs[len(summary.ProcIDs)-1] != segment.ProcessID {
+			summary.ProcIDs = append(summary.ProcIDs, segment.ProcessID)
+		}
+		if segment.ClientID < summary.MinClientID {
+			summary.MinClientID = segment.ClientID
+		}
+		if segment.ClientID > summary.MaxClientID {
+			summary.MaxClientID = segment.ClientID
+		}
+		if segment.RPCNo < summary.MinRPCID {
+			summary.MinRPCID = segment.RPCNo
+		}
+		if segment.RPCNo > summary.MaxRPCID {
+			summary.MaxRPCID = segment.RPCNo
+		}
+		if segment.ChannelID < summary.MinChannelID {
+			summary.MinChannelID = segment.ChannelID
+		}
+		if segment.ChannelID > summary.MaxChannelID {
+			summary.MaxChannelID = segment.ChannelID
+		}
+		if segment.RPCNo > summary.MaxRPCID {
+			summary.MaxRPCID = segment.RPCNo
+		}
+		if segment.RPCNo < summary.MinRPCID {
+			summary.MinRPCID = segment.RPCNo
+		}
+	}
+	return summary
+}
+
+func ensureMonotonicityOfRequestIDs(requestIDs []*requestIDSegments) error {
+	if false {
+		blob, err := json.MarshalIndent(requestIDs, "", " ")
+		if err != nil {
+			return err
+		}
+		println(string(blob))
+	}
+
+	for _, segment := range requestIDs {
+		if err := validateRequestIDSegments(segment); err != nil {
+			return err
+		}
+	}
+
+	// 2. Compare the current against previous requestID which requires at least 2 elements.
+	for i := 1; i < len(requestIDs); i++ {
+		rCurr, rPrev := requestIDs[i], requestIDs[i-1]
+		if rPrev.ProcessID != rCurr.ProcessID {
+			return fmt.Errorf("processID mismatch: #[%d].ProcessID=%q, #[%d].ProcessID=%q", i, rCurr.ProcessID, i-1, rPrev.ProcessID)
+		}
+		if rPrev.ClientID == rCurr.ClientID {
+			if rPrev.ChannelID == rCurr.ChannelID {
+				if rPrev.RequestNo == rCurr.RequestNo {
+					if rPrev.RPCNo >= rCurr.RPCNo {
+						return fmt.Errorf("sameChannelID, sameRequestNo yet #[%d].RPCNo=%d >= #[%d].RPCNo=%d", i-1, rPrev.RPCNo, i, rCurr.RPCNo)
+					}
+				}
+			}
+
+			// In the case of retries, we shall might have the same request
+			// number, but rpc id must be monotonically increasing.
+			if false && rPrev.RequestNo == rCurr.RequestNo {
+				if rPrev.RPCNo >= rCurr.RPCNo {
+					return fmt.Errorf("sameClientID but rpcNo mismatch: #[%d].RPCNo=%d >= #[%d].RPCNo=%d", i-1, rPrev.RPCNo, i, rCurr.RPCNo)
+				}
+			}
+		} else if rPrev.ClientID > rCurr.ClientID {
+			// For requests that execute in parallel such as with PartitionQuery,
+			// we could have requests from previous clients executing slower than
+			// the newest client, hence this is not an error.
+		}
+	}
+
+	// All checks passed so good to go.
+	return nil
+}
+
+func TestRequestIDHeader_ensureMonotonicityOfRequestIDs(t *testing.T) {
+	procID := randIDForProcess
+	tests := []struct {
+		name    string
+		in      []*requestIDSegments
+		wantErr string
+	}{
+		{name: "no values", wantErr: ""},
+		{name: "1 value", in: []*requestIDSegments{
+			{ProcessID: procID, ClientID: 1, RequestNo: 1, ChannelID: 3, RPCNo: 1},
+		}, wantErr: ""},
+		{name: "Different processIDs", in: []*requestIDSegments{
+			{ProcessID: procID, ClientID: 1, RequestNo: 1, RPCNo: 1, ChannelID: 1},
+			{ProcessID: strings.Repeat("a", len(procID)), ClientID: 1, RequestNo: 1, RPCNo: 2, ChannelID: 1},
+		}, wantErr: "processID mismatch"},
+		{
+			name: "Different clientID, prev has higher value",
+			in: []*requestIDSegments{
+				{ProcessID: procID, ClientID: 2, RequestNo: 1, RPCNo: 1, ChannelID: 1},
+				{ProcessID: procID, ClientID: 1, RequestNo: 1, RPCNo: 1, ChannelID: 1},
+			},
+			wantErr: "", // Requests can occur in parallel.
+		},
+		{
+			name: "Different clientID, prev has lower value",
+			in: []*requestIDSegments{
+				{ProcessID: procID, ClientID: 1, RPCNo: 1, ChannelID: 1, RequestNo: 1},
+				{ProcessID: procID, ClientID: 2, RPCNo: 1, ChannelID: 1, RequestNo: 1},
+			},
+			wantErr: "",
+		},
+		{
+			name: "Same channelID, prev has same RequestNo",
+			in: []*requestIDSegments{
+				{ProcessID: procID, ClientID: 1, ChannelID: 1, RPCNo: 1, RequestNo: 8},
+				{ProcessID: procID, ClientID: 1, ChannelID: 1, RPCNo: 1, RequestNo: 8},
+			},
+			wantErr: "sameChannelID, sameRequestNo yet #[0].RPCNo=1 >= #[1].RPCNo=1",
+		},
+		{
+			name: "Same clientID, different ChannelID prev has same RequestNo",
+			in: []*requestIDSegments{
+				{ProcessID: procID, ClientID: 1, ChannelID: 1, RequestNo: 1, RPCNo: 1},
+				{ProcessID: procID, ClientID: 1, ChannelID: 2, RequestNo: 1, RPCNo: 1},
+			},
+			wantErr: "",
+		},
+		{
+			name: "Same clientID, same ChannelID, same RequestNo, different RPCNo",
+			in: []*requestIDSegments{
+				{ProcessID: procID, ClientID: 1, ChannelID: 4, RequestNo: 3, RPCNo: 1},
+				{ProcessID: procID, ClientID: 1, ChannelID: 4, RequestNo: 3, RPCNo: 4},
+			},
+			wantErr: "",
+		},
+		{
+			name: "Same clientID, prev has higher RPCNo",
+			in: []*requestIDSegments{
+				{ProcessID: procID, ClientID: 1, ChannelID: 1, RequestNo: 1, RPCNo: 2},
+				{ProcessID: procID, ClientID: 1, ChannelID: 1, RequestNo: 1, RPCNo: 1},
+			},
+			wantErr: "sameRequestNo yet #[0].RPCNo=2 >= #[1].RPCNo=1",
+		},
+		{
+			name: "Same clientID, same channelID, prev has lower RPCNo",
+			in: []*requestIDSegments{
+				{ProcessID: procID, ClientID: 1, RequestNo: 2, ChannelID: 1, RPCNo: 1},
+				{ProcessID: procID, ClientID: 1, RequestNo: 2, ChannelID: 1, RPCNo: 2},
+			},
+			wantErr: "",
+		},
+		{
+			name: "Same clientID, prev has higher clientID",
+			in: []*requestIDSegments{
+				{ProcessID: procID, ClientID: 2, RequestNo: 1, RPCNo: 1, ChannelID: 1},
+				{ProcessID: procID, ClientID: 1, RequestNo: 1, RPCNo: 1, ChannelID: 1},
+			},
+			wantErr: "", // Requests can execute in parallel.
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// 1. Each segment but be valid!
+			err := ensureMonotonicityOfRequestIDs(tt.in)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatal("Expected a non-nil error")
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("Error mismatch\n\t%q\ncould not be found in\n\t%q", tt.wantErr, err)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func (it *interceptorTracker) unaryClientInterceptor(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+	it.nUnaryClientCalls.Add(1)
+	reqID, err := checkForMissingSpannerRequestIDHeader(opts)
+	if err != nil {
+		return err
+	}
+
+	it.mu.Lock()
+	it.unaryClientRequestIDSegments = append(it.unaryClientRequestIDSegments, reqID)
+	it.mu.Unlock()
+
+	// fmt.Printf("unary.method=%q\n", method)
+	// fmt.Printf("method=%q\nReq: %#v\nRes: %#v\n", method, req, reply)
+	// Otherwise proceed with the call.
+	return invoker(ctx, method, req, reply, cc, opts...)
+}
+
+func (it *interceptorTracker) streamClientInterceptor(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+	it.nStreamClientCalls.Add(1)
+	reqID, err := checkForMissingSpannerRequestIDHeader(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	it.mu.Lock()
+	it.streamClientRequestIDSegments = append(it.streamClientRequestIDSegments, reqID)
+	it.mu.Unlock()
+
+	// fmt.Printf("stream.method=%q\n", method)
+	// Otherwise proceed with the call.
+	return streamer(ctx, desc, cc, method, opts...)
+}
+
+func newInterceptorTracker() *interceptorTracker {
+	return &interceptorTracker{
+		nUnaryClientCalls:  new(atomic.Uint64),
+		nStreamClientCalls: new(atomic.Uint64),
+	}
+}
+
+func TestRequestIDHeader_onRetriesWithFailedTransactionCommit(t *testing.T) {
+	interceptorTracker := newInterceptorTracker()
+	clientOpts := []option.ClientOption{
+		option.WithGRPCDialOption(grpc.WithUnaryInterceptor(interceptorTracker.unaryClientInterceptor)),
+		option.WithGRPCDialOption(grpc.WithStreamInterceptor(interceptorTracker.streamClientInterceptor)),
+	}
+	clientConfig := ClientConfig{
+		SessionPoolConfig: SessionPoolConfig{
+			MinOpened:     2,
+			MaxOpened:     10,
+			WriteSessions: 0.2,
+			incStep:       2,
+		},
+	}
+	server, sc, tearDown := setupMockedTestServerWithConfigAndClientOptions(t, clientConfig, clientOpts)
+	t.Cleanup(tearDown)
+	defer sc.Close()
+
+	// First commit will fail, and the retry will begin a new transaction.
+	server.TestSpanner.PutExecutionTime(testutil.MethodCommitTransaction,
+		testutil.SimulatedExecutionTime{
+			Errors: []error{newAbortedErrorWithMinimalRetryDelay()},
+		})
+
+	ctx := context.Background()
+	ms := []*Mutation{
+		Insert("Accounts", []string{"AccountId"}, []any{int64(1)}),
+	}
+
+	if _, err := sc.Apply(ctx, ms); err != nil {
+		t.Fatalf("ReadWriteTransaction retry on abort, got %v, want nil.", err)
+	}
+
+	if _, err := shouldHaveReceived(server.TestSpanner, []any{
+		&sppb.BatchCreateSessionsRequest{},
+		&sppb.BeginTransactionRequest{},
+		&sppb.CommitRequest{}, // First commit fails.
+		&sppb.BeginTransactionRequest{},
+		&sppb.CommitRequest{}, // Second commit succeeds.
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if g, w := interceptorTracker.unaryCallCount(), uint64(5); g != w {
+		t.Errorf("unaryClientCall is incorrect; got=%d want=%d", g, w)
+	}
+	if g := interceptorTracker.streamCallCount(); g > 0 {
+		t.Errorf("streamClientCall was unexpectedly invoked %d times", g)
+	}
+
+	if err := interceptorTracker.validateRequestIDsMonotonicity(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Tests that SessionNotFound errors are retried.
+func TestRequestIDHeader_retriesOnSessionNotFound(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	interceptorTracker := newInterceptorTracker()
+	clientOpts := []option.ClientOption{
+		option.WithGRPCDialOption(grpc.WithUnaryInterceptor(interceptorTracker.unaryClientInterceptor)),
+		option.WithGRPCDialOption(grpc.WithStreamInterceptor(interceptorTracker.streamClientInterceptor)),
+	}
+	clientConfig := ClientConfig{
+		SessionPoolConfig: SessionPoolConfig{
+			MinOpened:     2,
+			MaxOpened:     10,
+			WriteSessions: 0.2,
+			incStep:       2,
+		},
+	}
+	server, sc, tearDown := setupMockedTestServerWithConfigAndClientOptions(t, clientConfig, clientOpts)
+	t.Cleanup(tearDown)
+	defer sc.Close()
+
+	serverErr := newSessionNotFoundError("projects/p/instances/i/databases/d/sessions/s")
+	server.TestSpanner.PutExecutionTime(testutil.MethodBeginTransaction,
+		testutil.SimulatedExecutionTime{
+			Errors: []error{serverErr, serverErr, serverErr},
+		})
+	server.TestSpanner.PutExecutionTime(testutil.MethodCommitTransaction,
+		testutil.SimulatedExecutionTime{
+			Errors: []error{serverErr},
+		})
+
+	txn := sc.ReadOnlyTransaction()
+	defer txn.Close()
+
+	var wantErr error
+	if _, _, got := txn.acquire(ctx); !testEqual(wantErr, got) {
+		t.Fatalf("Expect acquire to succeed, got %v, want %v.", got, wantErr)
+	}
+
+	// The server error should lead to a retry of the BeginTransaction call and
+	// a valid session handle to be returned that will be used by the following
+	// requests. Note that calling txn.Query(...) does not actually send the
+	// query to the (mock) server. That is done at the first call to
+	// RowIterator.Next. The following statement only verifies that the
+	// transaction is in a valid state and received a valid session handle.
+	if got := txn.Query(ctx, NewStatement("SELECT 1")); !testEqual(wantErr, got.err) {
+		t.Fatalf("Expect Query to succeed, got %v, want %v.", got.err, wantErr)
+	}
+
+	if got := txn.Read(ctx, "Users", KeySets(Key{"alice"}, Key{"bob"}), []string{"name", "email"}); !testEqual(wantErr, got.err) {
+		t.Fatalf("Expect Read to succeed, got %v, want %v.", got.err, wantErr)
+	}
+
+	wantErr = ToSpannerError(newSessionNotFoundError("projects/p/instances/i/databases/d/sessions/s"))
+	ms := []*Mutation{
+		Insert("Accounts", []string{"AccountId", "Nickname", "Balance"}, []any{int64(1), "Foo", int64(50)}),
+		Insert("Accounts", []string{"AccountId", "Nickname", "Balance"}, []any{int64(2), "Bar", int64(1)}),
+	}
+	_, got := sc.Apply(ctx, ms, ApplyAtLeastOnce())
+	if !testEqual(wantErr, got) {
+		t.Fatalf("Expect Apply to fail\nGot:  %v\nWant: %v\n", got, wantErr)
+	}
+	gotSErr := got.(*Error)
+	if gotSErr.RequestID == "" {
+		t.Fatal("Expected a non-blank requestID")
+	}
+
+	if g, w := interceptorTracker.unaryCallCount(), uint64(8); g != w {
+		t.Errorf("unaryClientCall is incorrect; got=%d want=%d", g, w)
+	}
+	if g := interceptorTracker.streamCallCount(); g > 0 {
+		t.Errorf("streamClientCall was unexpectedly invoked %d times", g)
+	}
+
+	if err := interceptorTracker.validateRequestIDsMonotonicity(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRequestIDHeader_BatchDMLWithMultipleDML(t *testing.T) {
+	t.Parallel()
+
+	interceptorTracker := newInterceptorTracker()
+	clientOpts := []option.ClientOption{
+		option.WithGRPCDialOption(grpc.WithUnaryInterceptor(interceptorTracker.unaryClientInterceptor)),
+		option.WithGRPCDialOption(grpc.WithStreamInterceptor(interceptorTracker.streamClientInterceptor)),
+	}
+	clientConfig := ClientConfig{
+		SessionPoolConfig: SessionPoolConfig{
+			MinOpened:     2,
+			MaxOpened:     10,
+			WriteSessions: 0.2,
+			incStep:       2,
+		},
+	}
+
+	ctx := context.Background()
+	server, sc, tearDown := setupMockedTestServerWithConfigAndClientOptions(t, clientConfig, clientOpts)
+	t.Cleanup(tearDown)
+	defer sc.Close()
+
+	updateBarSetFoo := testutil.UpdateBarSetFoo
+	_, err := sc.ReadWriteTransaction(ctx, func(ctx context.Context, tx *ReadWriteTransaction) (err error) {
+		if _, err = tx.Update(ctx, Statement{SQL: updateBarSetFoo}); err != nil {
+			return err
+		}
+		if _, err = tx.BatchUpdate(ctx, []Statement{{SQL: updateBarSetFoo}, {SQL: updateBarSetFoo}}); err != nil {
+			return err
+		}
+		if _, err = tx.Update(ctx, Statement{SQL: updateBarSetFoo}); err != nil {
+			return err
+		}
+		_, err = tx.BatchUpdate(ctx, []Statement{{SQL: updateBarSetFoo}})
+		return err
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	gotReqs, err := shouldHaveReceived(server.TestSpanner, []any{
+		&sppb.BatchCreateSessionsRequest{},
+		&sppb.ExecuteSqlRequest{},
+		&sppb.ExecuteBatchDmlRequest{},
+		&sppb.ExecuteSqlRequest{},
+		&sppb.ExecuteBatchDmlRequest{},
+		&sppb.CommitRequest{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	muxCreateBuffer := 0
+	if isMultiplexEnabled {
+		muxCreateBuffer = 1
+	}
+	if got, want := gotReqs[1+muxCreateBuffer].(*sppb.ExecuteSqlRequest).Seqno, int64(1); got != want {
+		t.Errorf("got %d, want %d", got, want)
+	}
+	if got, want := gotReqs[2+muxCreateBuffer].(*sppb.ExecuteBatchDmlRequest).Seqno, int64(2); got != want {
+		t.Errorf("got %d, want %d", got, want)
+	}
+	if got, want := gotReqs[3+muxCreateBuffer].(*sppb.ExecuteSqlRequest).Seqno, int64(3); got != want {
+		t.Errorf("got %d, want %d", got, want)
+	}
+	if got, want := gotReqs[4+muxCreateBuffer].(*sppb.ExecuteBatchDmlRequest).Seqno, int64(4); got != want {
+		t.Errorf("got %d, want %d", got, want)
+	}
+
+	if g, w := interceptorTracker.unaryCallCount(), uint64(6); g != w {
+		t.Errorf("unaryClientCall is incorrect; got=%d want=%d", g, w)
+	}
+	if g := interceptorTracker.streamCallCount(); g > 0 {
+		t.Errorf("streamClientCall was unexpectedly invoked %d times", g)
+	}
+
+	if err := interceptorTracker.validateRequestIDsMonotonicity(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRequestIDHeader_clientBatchWrite(t *testing.T) {
+	t.Parallel()
+
+	interceptorTracker := newInterceptorTracker()
+	clientOpts := []option.ClientOption{
+		option.WithGRPCDialOption(grpc.WithUnaryInterceptor(interceptorTracker.unaryClientInterceptor)),
+		option.WithGRPCDialOption(grpc.WithStreamInterceptor(interceptorTracker.streamClientInterceptor)),
+	}
+	clientConfig := ClientConfig{
+		SessionPoolConfig: SessionPoolConfig{
+			MinOpened:     2,
+			MaxOpened:     10,
+			WriteSessions: 0.2,
+			incStep:       2,
+		},
+	}
+
+	server, sc, tearDown := setupMockedTestServerWithConfigAndClientOptions(t, clientConfig, clientOpts)
+	t.Cleanup(tearDown)
+	defer sc.Close()
+
+	mutationGroups := []*MutationGroup{
+		{[]*Mutation{
+			{opInsertOrUpdate, "t_test", nil, []string{"key", "val"}, []any{"foo1", 1}},
+		}},
+	}
+	iter := sc.BatchWrite(context.Background(), mutationGroups)
+	responseCount := 0
+	doFunc := func(r *sppb.BatchWriteResponse) error {
+		responseCount++
+		return nil
+	}
+	if err := iter.Do(doFunc); err != nil {
+		t.Fatal(err)
+	}
+	if responseCount != len(mutationGroups) {
+		t.Fatalf("Response count mismatch.\nGot: %v\nWant:%v", responseCount, len(mutationGroups))
+	}
+	requests := drainRequestsFromServer(server.TestSpanner)
+	if err := compareRequests([]any{
+		&sppb.BatchCreateSessionsRequest{},
+		&sppb.BatchWriteRequest{},
+	}, requests); err != nil {
+		t.Fatal(err)
+	}
+
+	if g, w := interceptorTracker.unaryCallCount(), uint64(1); g != w {
+		t.Errorf("unaryClientCall is incorrect; got=%d want=%d", g, w)
+	}
+	if g, w := interceptorTracker.streamCallCount(), uint64(1); g != w {
+		t.Errorf("streamClientCall is incorrect; got=%d want=%d", g, w)
+	}
+
+	if err := interceptorTracker.validateRequestIDsMonotonicity(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRequestIDHeader_ClientBatchWriteWithSessionNotFound(t *testing.T) {
+	t.Parallel()
+
+	interceptorTracker := newInterceptorTracker()
+	clientOpts := []option.ClientOption{
+		option.WithGRPCDialOption(grpc.WithUnaryInterceptor(interceptorTracker.unaryClientInterceptor)),
+		option.WithGRPCDialOption(grpc.WithStreamInterceptor(interceptorTracker.streamClientInterceptor)),
+	}
+	clientConfig := ClientConfig{
+		SessionPoolConfig: SessionPoolConfig{
+			MinOpened:     2,
+			MaxOpened:     10,
+			WriteSessions: 0.2,
+			incStep:       2,
+		},
+	}
+
+	server, sc, tearDown := setupMockedTestServerWithConfigAndClientOptions(t, clientConfig, clientOpts)
+	t.Cleanup(tearDown)
+	defer sc.Close()
+
+	server.TestSpanner.PutExecutionTime(
+		testutil.MethodBatchWrite,
+		testutil.SimulatedExecutionTime{Errors: []error{newSessionNotFoundError("projects/p/instances/i/databases/d/sessions/s")}},
+	)
+	mutationGroups := []*MutationGroup{
+		{[]*Mutation{
+			{opInsertOrUpdate, "t_test", nil, []string{"key", "val"}, []any{"foo1", 1}},
+		}},
+	}
+	iter := sc.BatchWrite(context.Background(), mutationGroups)
+	responseCount := 0
+	doFunc := func(r *sppb.BatchWriteResponse) error {
+		responseCount++
+		return nil
+	}
+	if err := iter.Do(doFunc); err != nil {
+		t.Fatal(err)
+	}
+	if responseCount != len(mutationGroups) {
+		t.Fatalf("Response count mismatch.\nGot: %v\nWant:%v", responseCount, len(mutationGroups))
+	}
+
+	requests := drainRequestsFromServer(server.TestSpanner)
+	if err := compareRequests([]any{
+		&sppb.BatchCreateSessionsRequest{},
+		&sppb.BatchWriteRequest{},
+		&sppb.BatchWriteRequest{},
+	}, requests); err != nil {
+		t.Fatal(err)
+	}
+
+	if g, w := interceptorTracker.unaryCallCount(), uint64(1); g != w {
+		t.Errorf("unaryClientCall is incorrect; got=%d want=%d", g, w)
+	}
+
+	// We had a retry for BatchWrite after the first SessionNotFound error, hence expecting 2 calls.
+	if g, w := interceptorTracker.streamCallCount(), uint64(2); g != w {
+		t.Errorf("streamClientCall is incorrect; got=%d want=%d", g, w)
+	}
+
+	if err := interceptorTracker.validateRequestIDsMonotonicity(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRequestIDHeader_ClientBatchWriteWithError(t *testing.T) {
+	t.Parallel()
+
+	interceptorTracker := newInterceptorTracker()
+	clientOpts := []option.ClientOption{
+		option.WithGRPCDialOption(grpc.WithUnaryInterceptor(interceptorTracker.unaryClientInterceptor)),
+		option.WithGRPCDialOption(grpc.WithStreamInterceptor(interceptorTracker.streamClientInterceptor)),
+	}
+	clientConfig := ClientConfig{
+		SessionPoolConfig: SessionPoolConfig{
+			MinOpened:     2,
+			MaxOpened:     10,
+			WriteSessions: 0.2,
+			incStep:       2,
+		},
+	}
+
+	server, sc, tearDown := setupMockedTestServerWithConfigAndClientOptions(t, clientConfig, clientOpts)
+	t.Cleanup(tearDown)
+	defer sc.Close()
+
+	injectedErr := status.Error(codes.InvalidArgument, "Invalid argument")
+	server.TestSpanner.PutExecutionTime(
+		testutil.MethodBatchWrite,
+		testutil.SimulatedExecutionTime{Errors: []error{injectedErr}},
+	)
+	mutationGroups := []*MutationGroup{
+		{[]*Mutation{
+			{opInsertOrUpdate, "t_test", nil, []string{"key", "val"}, []any{"foo1", 1}},
+		}},
+	}
+	iter := sc.BatchWrite(context.Background(), mutationGroups)
+	responseCount := 0
+	doFunc := func(r *sppb.BatchWriteResponse) error {
+		responseCount++
+		return nil
+	}
+	err := iter.Do(doFunc)
+	if err == nil {
+		t.Fatal("Expected an error")
+	}
+
+	gotSErr := err.(*Error)
+	if gotSErr.RequestID == "" {
+		t.Fatal("Expected a non-blank requestID")
+	}
+
+	if responseCount != 0 {
+		t.Fatalf("Do unexpectedly called %d times", responseCount)
+	}
+
+	if g, w := interceptorTracker.unaryCallCount(), uint64(1); g != w {
+		t.Errorf("unaryClientCall is incorrect; got=%d want=%d", g, w)
+	}
+
+	// We had a straight-up failure after the first BatchWrite call so only 1 call.
+	if g, w := interceptorTracker.streamCallCount(), uint64(1); g != w {
+		t.Errorf("streamClientCall is incorrect; got=%d want=%d", g, w)
+	}
+
+	if err := interceptorTracker.validateRequestIDsMonotonicity(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRequestIDHeader_PartitionQueryWithoutError(t *testing.T) {
+	testRequestIDHeaderPartitionQuery(t, false)
+}
+
+func TestRequestIDHeader_PartitionQueryWithError(t *testing.T) {
+	testRequestIDHeaderPartitionQuery(t, true)
+}
+
+func testRequestIDHeaderPartitionQuery(t *testing.T, mustErrorOnPartitionQuery bool) {
+	t.Parallel()
+
+	interceptorTracker := newInterceptorTracker()
+	clientOpts := []option.ClientOption{
+		option.WithGRPCDialOption(grpc.WithUnaryInterceptor(interceptorTracker.unaryClientInterceptor)),
+		option.WithGRPCDialOption(grpc.WithStreamInterceptor(interceptorTracker.streamClientInterceptor)),
+	}
+	clientConfig := ClientConfig{
+		SessionPoolConfig: SessionPoolConfig{
+			MinOpened:     2,
+			MaxOpened:     10,
+			WriteSessions: 0.2,
+			incStep:       2,
+		},
+	}
+
+	server, sc, tearDown := setupMockedTestServerWithConfigAndClientOptions(t, clientConfig, clientOpts)
+	t.Cleanup(tearDown)
+	defer sc.Close()
+
+	// The request will initially fail, and be retried.
+	server.TestSpanner.PutExecutionTime(testutil.MethodExecuteStreamingSql,
+		testutil.SimulatedExecutionTime{
+			Errors: []error{newAbortedErrorWithMinimalRetryDelay()},
+		})
+	if mustErrorOnPartitionQuery {
+		server.TestSpanner.PutExecutionTime(testutil.MethodPartitionQuery,
+			testutil.SimulatedExecutionTime{
+				Errors: []error{newAbortedErrorWithMinimalRetryDelay()},
+			})
+	}
+
+	sqlFromSingers := "SELECT * FROM Singers"
+	resultSet := &sppb.ResultSet{
+		Rows: []*structpb.ListValue{
+			{
+				Values: []*structpb.Value{
+					structpb.NewStructValue(&structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							"SingerId":  {Kind: &structpb.Value_NumberValue{NumberValue: 1}},
+							"FirstName": {Kind: &structpb.Value_StringValue{StringValue: "Bruce"}},
+							"LastName":  {Kind: &structpb.Value_StringValue{StringValue: "Wayne"}},
+						},
+					}),
+					structpb.NewStructValue(&structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							"SingerId":  {Kind: &structpb.Value_NumberValue{NumberValue: 2}},
+							"FirstName": {Kind: &structpb.Value_StringValue{StringValue: "Robin"}},
+							"LastName":  {Kind: &structpb.Value_StringValue{StringValue: "SideKick"}},
+						},
+					}),
+					structpb.NewStructValue(&structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							"SingerId":  {Kind: &structpb.Value_NumberValue{NumberValue: 3}},
+							"FirstName": {Kind: &structpb.Value_StringValue{StringValue: "Gordon"}},
+							"LastName":  {Kind: &structpb.Value_StringValue{StringValue: "Commissioner"}},
+						},
+					}),
+					structpb.NewStructValue(&structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							"SingerId":  {Kind: &structpb.Value_NumberValue{NumberValue: 4}},
+							"FirstName": {Kind: &structpb.Value_StringValue{StringValue: "Joker"}},
+							"LastName":  {Kind: &structpb.Value_StringValue{StringValue: "None"}},
+						},
+					}),
+					structpb.NewStructValue(&structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							"SingerId":  {Kind: &structpb.Value_NumberValue{NumberValue: 5}},
+							"FirstName": {Kind: &structpb.Value_StringValue{StringValue: "Riddler"}},
+							"LastName":  {Kind: &structpb.Value_StringValue{StringValue: "None"}},
+						},
+					}),
+				}},
+		},
+		Metadata: &sppb.ResultSetMetadata{
+			RowType: &sppb.StructType{
+				Fields: []*sppb.StructType_Field{
+					{Name: "SingerId", Type: &sppb.Type{Code: sppb.TypeCode_INT64}},
+					{Name: "FirstName", Type: &sppb.Type{Code: sppb.TypeCode_STRING}},
+					{Name: "LastName", Type: &sppb.Type{Code: sppb.TypeCode_STRING}},
+				},
+			},
+		},
+	}
+	result := &testutil.StatementResult{
+		Type:      testutil.StatementResultResultSet,
+		ResultSet: resultSet,
+	}
+	server.TestSpanner.PutStatementResult(sqlFromSingers, result)
+
+	ctx := context.Background()
+	txn, err := sc.BatchReadOnlyTransaction(ctx, StrongRead())
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer txn.Close()
+
+	// Singer represents the elements in a row from the Singers table.
+	type Singer struct {
+		SingerID   int64
+		FirstName  string
+		LastName   string
+		SingerInfo []byte
+	}
+	stmt := Statement{SQL: "SELECT * FROM Singers;"}
+	partitions, err := txn.PartitionQuery(ctx, stmt, PartitionOptions{})
+
+	if mustErrorOnPartitionQuery {
+		// The methods invoked should be: ['/BatchCreateSessions', '/CreateSession', '/BeginTransaction', '/PartitionQuery']
+		if g, w := interceptorTracker.unaryCallCount(), uint64(4); g != w {
+			t.Errorf("unaryClientCall is incorrect; got=%d want=%d", g, w)
+		}
+
+		// We had a straight-up failure after the first BatchWrite call so only 1 call.
+		if g, w := interceptorTracker.streamCallCount(), uint64(0); g != w {
+			t.Errorf("streamClientCall is incorrect; got=%d want=%d", g, w)
+		}
+
+		if err := interceptorTracker.validateRequestIDsMonotonicity(); err != nil {
+			t.Fatal(err)
+		}
+		return
+	}
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wg := new(sync.WaitGroup)
+	for i, p := range partitions {
+		wg.Add(1)
+		go func(i int, p *Partition) {
+			defer wg.Done()
+			iter := txn.Execute(ctx, p)
+			defer iter.Stop()
+			for {
+				row, err := iter.Next()
+				if err == iterator.Done {
+					break
+				}
+				var s Singer
+				if err := row.ToStruct(&s); err != nil {
+					_ = err
+				}
+				_ = s
+			}
+		}(i, p)
+	}
+	wg.Wait()
+
+	// The methods invoked should be: ['/BatchCreateSessions', '/CreateSession', '/BeginTransaction', '/PartitionQuery']
+	if g, w := interceptorTracker.unaryCallCount(), uint64(4); g != w {
+		t.Errorf("unaryClientCall is incorrect; got=%d want=%d", g, w)
+	}
+
+	// We had a straight-up failure after the first BatchWrite call so only 1 call.
+	if g, w := interceptorTracker.streamCallCount(), uint64(0); g != w {
+		t.Errorf("streamClientCall is incorrect; got=%d want=%d", g, w)
+	}
+
+	if err := interceptorTracker.validateRequestIDsMonotonicity(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRequestIDHeader_ReadWriteTransactionUpdate(t *testing.T) {
+	t.Parallel()
+
+	interceptorTracker := newInterceptorTracker()
+	clientOpts := []option.ClientOption{
+		option.WithGRPCDialOption(grpc.WithUnaryInterceptor(interceptorTracker.unaryClientInterceptor)),
+		option.WithGRPCDialOption(grpc.WithStreamInterceptor(interceptorTracker.streamClientInterceptor)),
+	}
+	clientConfig := ClientConfig{
+		SessionPoolConfig: SessionPoolConfig{
+			MinOpened:     2,
+			MaxOpened:     10,
+			WriteSessions: 0.2,
+			incStep:       2,
+		},
+	}
+
+	server, sc, tearDown := setupMockedTestServerWithConfigAndClientOptions(t, clientConfig, clientOpts)
+	t.Cleanup(tearDown)
+	defer sc.Close()
+
+	ctx := context.Background()
+	updateSQL := testutil.UpdateBarSetFoo
+	_, err := sc.ReadWriteTransaction(ctx, func(ctx context.Context, tx *ReadWriteTransaction) (err error) {
+		if _, err = tx.Update(ctx, Statement{SQL: updateSQL}); err != nil {
+			return err
+		}
+		if _, err = tx.BatchUpdate(ctx, []Statement{{SQL: updateSQL}, {SQL: updateSQL}}); err != nil {
+			return err
+		}
+		if _, err = tx.Update(ctx, Statement{SQL: updateSQL}); err != nil {
+			return err
+		}
+		_, err = tx.BatchUpdate(ctx, []Statement{{SQL: updateSQL}})
+		return err
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	gotReqs, err := shouldHaveReceived(server.TestSpanner, []any{
+		&sppb.BatchCreateSessionsRequest{},
+		&sppb.ExecuteSqlRequest{},
+		&sppb.ExecuteBatchDmlRequest{},
+		&sppb.ExecuteSqlRequest{},
+		&sppb.ExecuteBatchDmlRequest{},
+		&sppb.CommitRequest{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	muxCreateBuffer := 0
+	if isMultiplexEnabled {
+		muxCreateBuffer = 1
+	}
+	if got, want := gotReqs[1+muxCreateBuffer].(*sppb.ExecuteSqlRequest).Seqno, int64(1); got != want {
+		t.Errorf("got %d, want %d", got, want)
+	}
+	if got, want := gotReqs[2+muxCreateBuffer].(*sppb.ExecuteBatchDmlRequest).Seqno, int64(2); got != want {
+		t.Errorf("got %d, want %d", got, want)
+	}
+	if got, want := gotReqs[3+muxCreateBuffer].(*sppb.ExecuteSqlRequest).Seqno, int64(3); got != want {
+		t.Errorf("got %d, want %d", got, want)
+	}
+	if got, want := gotReqs[4+muxCreateBuffer].(*sppb.ExecuteBatchDmlRequest).Seqno, int64(4); got != want {
+		t.Errorf("got %d, want %d", got, want)
+	}
+
+	// The methods invoked should be: ['/BatchCreateSessions', '/ExecuteSql', '/ExecuteBatchDml', '/ExecuteSql', '/ExecuteBatchDml', '/Commit']
+	if g, w := interceptorTracker.unaryCallCount(), uint64(6); g != w {
+		t.Errorf("unaryClientCall is incorrect; got=%d want=%d", g, w)
+	}
+
+	// We had a straight-up failure after the first BatchWrite call so only 1 call.
+	if g, w := interceptorTracker.streamCallCount(), uint64(0); g != w {
+		t.Errorf("streamClientCall is incorrect; got=%d want=%d", g, w)
+	}
+
+	if err := interceptorTracker.validateRequestIDsMonotonicity(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRequestIDHeader_ReadWriteTransactionBatchUpdateWithOptions(t *testing.T) {
+	t.Parallel()
+
+	interceptorTracker := newInterceptorTracker()
+	clientOpts := []option.ClientOption{
+		option.WithGRPCDialOption(grpc.WithUnaryInterceptor(interceptorTracker.unaryClientInterceptor)),
+		option.WithGRPCDialOption(grpc.WithStreamInterceptor(interceptorTracker.streamClientInterceptor)),
+	}
+	clientConfig := ClientConfig{
+		SessionPoolConfig: SessionPoolConfig{
+			MinOpened:     2,
+			MaxOpened:     10,
+			WriteSessions: 0.2,
+			incStep:       2,
+		},
+	}
+
+	_, sc, tearDown := setupMockedTestServerWithConfigAndClientOptions(t, clientConfig, clientOpts)
+	t.Cleanup(tearDown)
+	defer sc.Close()
+
+	ctx := context.Background()
+	selectSQL := testutil.SelectSingerIDAlbumIDAlbumTitleFromAlbums
+	updateSQL := testutil.UpdateBarSetFoo
+	_, err := sc.ReadWriteTransaction(ctx, func(ctx context.Context, tx *ReadWriteTransaction) (err error) {
+		iter := tx.QueryWithOptions(ctx, NewStatement(selectSQL), QueryOptions{})
+		iter.Next()
+		iter.Stop()
+
+		qo := QueryOptions{}
+		iter = tx.ReadWithOptions(ctx, "FOO", AllKeys(), []string{"BAR"}, &ReadOptions{Priority: qo.Priority})
+		iter.Next()
+		iter.Stop()
+
+		tx.UpdateWithOptions(ctx, NewStatement(updateSQL), qo)
+		tx.BatchUpdateWithOptions(ctx, []Statement{
+			NewStatement(updateSQL),
+		}, qo)
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The methods invoked should be: ['/BatchCreateSessions', '/ExecuteSql', '/ExecuteBatchDml', '/Commit']
+	if g, w := interceptorTracker.unaryCallCount(), uint64(4); g != w {
+		t.Errorf("unaryClientCall is incorrect; got=%d want=%d", g, w)
+	}
+
+	// The methods invoked should be: ['/ExecuteStreamingSql', '/StreamingRead']
+	if g, w := interceptorTracker.streamCallCount(), uint64(2); g != w {
+		t.Errorf("streamClientCall is incorrect; got=%d want=%d", g, w)
+	}
+
+	if err := interceptorTracker.validateRequestIDsMonotonicity(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRequestIDHeader_multipleParallelCallsWithConventialCustomerCalls(t *testing.T) {
+	t.Parallel()
+
+	interceptorTracker := newInterceptorTracker()
+	clientOpts := []option.ClientOption{
+		option.WithGRPCDialOption(grpc.WithUnaryInterceptor(interceptorTracker.unaryClientInterceptor)),
+		option.WithGRPCDialOption(grpc.WithStreamInterceptor(interceptorTracker.streamClientInterceptor)),
+	}
+	clientConfig := ClientConfig{
+		SessionPoolConfig: SessionPoolConfig{
+			MinOpened:     2,
+			MaxOpened:     10,
+			WriteSessions: 0.2,
+			incStep:       2,
+		},
+	}
+
+	// We created exactly 1 client.
+	_, sc, tearDown := setupMockedTestServerWithConfigAndClientOptions(t, clientConfig, clientOpts)
+	t.Cleanup(tearDown)
+	defer sc.Close()
+
+	beginningClientID := uint32(sc.sc.nthClient)
+
+	ctx := context.Background()
+	selectSQL := testutil.SelectSingerIDAlbumIDAlbumTitleFromAlbums
+	updateSQL := testutil.UpdateBarSetFoo
+
+	// We are going to invoke 10 calls in parallel.
+	n := uint64(80)
+	wg := new(sync.WaitGroup)
+	semaCh := make(chan bool)
+	semaWg := new(sync.WaitGroup)
+	semaWg.Add(int(n))
+	for i := uint64(0); i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			semaWg.Done()
+			<-semaCh
+			_, err := sc.ReadWriteTransaction(ctx, func(ctx context.Context, tx *ReadWriteTransaction) (err error) {
+				iter := tx.QueryWithOptions(ctx, NewStatement(selectSQL), QueryOptions{})
+				iter.Next()
+				iter.Stop()
+
+				qo := QueryOptions{}
+				iter = tx.ReadWithOptions(ctx, "FOO", AllKeys(), []string{"BAR"}, &ReadOptions{Priority: qo.Priority})
+				iter.Next()
+				iter.Stop()
+
+				tx.UpdateWithOptions(ctx, NewStatement(updateSQL), qo)
+				tx.BatchUpdateWithOptions(ctx, []Statement{
+					NewStatement(updateSQL),
+				}, qo)
+				return nil
+			})
+			if err != nil {
+				panic(err)
+			}
+		}()
+	}
+
+	go func() {
+		semaWg.Wait()
+		close(semaCh)
+	}()
+
+	wg.Wait()
+
+	if err := interceptorTracker.validateRequestIDsMonotonicity(); err != nil {
+		t.Fatal(err)
+	}
+
+	gotUnarySummary, gotStreamSummary := interceptorTracker.summarize()
+	wantUnarySummary := &interceptSummary{
+		ProcIDs:      []string{randIDForProcess},
+		MaxClientID:  beginningClientID,
+		MinClientID:  beginningClientID,
+		MaxRPCID:     1,
+		MinRPCID:     1,
+		MaxChannelID: 5,
+		MinChannelID: 1,
+	}
+	if diff := cmp.Diff(gotUnarySummary, wantUnarySummary); diff != "" {
+		t.Errorf("UnarySummary mismatch: got - want +\n%s", diff)
+	}
+	wantStreamSummary := &interceptSummary{
+		ProcIDs:      []string{randIDForProcess},
+		MaxClientID:  beginningClientID,
+		MinClientID:  beginningClientID,
+		MaxRPCID:     1,
+		MinRPCID:     1,
+		MaxChannelID: 5,
+		MinChannelID: 1,
+	}
+	if diff := cmp.Diff(gotStreamSummary, wantStreamSummary); diff != "" {
+		t.Errorf("StreamSummary mismatch: got - want +\n%s", diff)
+	}
+
+	// The methods invoked should be: ['/BatchCreateSessions', '/ExecuteSql', '/ExecuteBatchDml', '/Commit']
+	if g, w := interceptorTracker.unaryCallCount(), uint64(245); g != w {
+		t.Errorf("unaryClientCall is incorrect; got=%d want=%d", g, w)
+	}
+
+	// The methods invoked should be: ['/ExecuteStreamingSql', '/StreamingRead']
+	if g, w := interceptorTracker.streamCallCount(), uint64(2)*n; g != w {
+		t.Errorf("streamClientCall is incorrect; got=%d want=%d", g, w)
+	}
+}

--- a/spanner/request_id_header_test.go
+++ b/spanner/request_id_header_test.go
@@ -1784,3 +1784,84 @@ func TestRequestIDInError(t *testing.T) {
 		})
 	}
 }
+
+func TestRequestIDHeader_SingleUseReadOnly_ExecuteStreamingSql_UnavailableDuringStream(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	interceptorTracker := newInterceptorTracker()
+	clientOpts := []option.ClientOption{
+		option.WithGRPCDialOption(grpc.WithUnaryInterceptor(interceptorTracker.unaryClientInterceptor)),
+		option.WithGRPCDialOption(grpc.WithStreamInterceptor(interceptorTracker.streamClientInterceptor)),
+	}
+	clientConfig := ClientConfig{
+		SessionPoolConfig: SessionPoolConfig{
+			MinOpened:     2,
+			MaxOpened:     10,
+			WriteSessions: 0.2,
+			incStep:       2,
+		},
+	}
+	server, sc, tearDown := setupMockedTestServerWithConfigAndClientOptions(t, clientConfig, clientOpts)
+	t.Cleanup(tearDown)
+	defer sc.Close()
+	// A stream of PartialResultSets can break halfway and be retried from that point.
+	server.TestSpanner.AddPartialResultSetError(
+		testutil.SelectSingerIDAlbumIDAlbumTitleFromAlbums,
+		testutil.PartialResultSetExecutionTime{
+			ResumeToken: testutil.EncodeResumeToken(2),
+			Err:         status.Errorf(codes.Internal, "stream terminated by RST_STREAM"),
+		},
+	)
+	server.TestSpanner.AddPartialResultSetError(
+		testutil.SelectSingerIDAlbumIDAlbumTitleFromAlbums,
+		testutil.PartialResultSetExecutionTime{
+			ResumeToken: testutil.EncodeResumeToken(3),
+			Err:         status.Errorf(codes.Unavailable, "server is unavailable"),
+		},
+	)
+	iter := sc.Single().Query(ctx, Statement{SQL: testutil.SelectSingerIDAlbumIDAlbumTitleFromAlbums})
+	defer iter.Stop()
+	for {
+		_, err := iter.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := shouldHaveReceived(server.TestSpanner, []any{
+		&sppb.BatchCreateSessionsRequest{},
+		&sppb.ExecuteSqlRequest{},
+		&sppb.ExecuteSqlRequest{},
+		&sppb.ExecuteSqlRequest{},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if g, w := interceptorTracker.unaryCallCount(), uint64(1); g != w {
+		t.Errorf("unaryClientCall is incorrect; got=%d want=%d", g, w)
+	}
+	if g, w := interceptorTracker.streamCallCount(), uint64(3); g != w {
+		t.Errorf("streamClientCall is incorrect; got=%d want=%d", g, w)
+	}
+	if err := interceptorTracker.validateRequestIDsMonotonicity(); err != nil {
+		t.Fatal(err)
+	}
+	clientID := uint32(sc.sc.nthClient)
+	procID := randIDForProcess
+	version := xSpannerRequestIDVersion
+	wantUnarySegments := []*requestIDSegments{
+		{Version: version, ProcessID: procID, ClientID: clientID, ChannelID: 1, RequestNo: 1, RPCNo: 1}, // BatchCreateSession
+	}
+	wantStreamingSegments := []*requestIDSegments{
+		{Version: version, ProcessID: procID, ClientID: clientID, ChannelID: 1, RequestNo: 2, RPCNo: 1}, // ExecuteStreamingSql (initial attempt)
+		{Version: version, ProcessID: procID, ClientID: clientID, ChannelID: 1, RequestNo: 2, RPCNo: 2}, // ExecuteStreamingSql (retry)
+		{Version: version, ProcessID: procID, ClientID: clientID, ChannelID: 1, RequestNo: 2, RPCNo: 3}, // ExecuteStreamingSql (retry)
+	}
+	if diff := cmp.Diff(interceptorTracker.unaryClientRequestIDSegments, wantUnarySegments); diff != "" {
+		t.Fatalf("RequestID unary segments mismatch: got - want +\n%s", diff)
+	}
+	if diff := cmp.Diff(interceptorTracker.streamClientRequestIDSegments, wantStreamingSegments); diff != "" {
+		t.Fatalf("RequestID streaming segments mismatch: got - want +\n%s", diff)
+	}
+}

--- a/spanner/request_id_header_test.go
+++ b/spanner/request_id_header_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"math"
 	"regexp"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -1166,7 +1167,7 @@ func TestRequestIDHeader_ReadWriteTransactionBatchUpdateWithOptions(t *testing.T
 	}
 }
 
-func TestRequestIDHeader_multipleParallelCallsWithConventialCustomerCalls(t *testing.T) {
+func TestRequestIDHeader_multipleParallelCallsWithConventionalCustomerCalls(t *testing.T) {
 	t.Parallel()
 
 	interceptorTracker := newInterceptorTracker()
@@ -1287,6 +1288,11 @@ func newUnavailableErrorWithMinimalRetryDelay() error {
 	return st.Err()
 }
 
+func newInvalidArgumentError() error {
+	st := status.New(codes.InvalidArgument, "Invalid argument")
+	return st.Err()
+}
+
 func TestRequestIDHeader_RetryOnAbortAndValidate(t *testing.T) {
 	t.Parallel()
 
@@ -1368,6 +1374,383 @@ func TestRequestIDHeader_RetryOnAbortAndValidate(t *testing.T) {
 
 	if diff := cmp.Diff(interceptorTracker.unaryClientRequestIDSegments, wantUnarySegments); diff != "" {
 		t.Fatalf("RequestID segments mismatch: got - want +\n%s", diff)
+	}
+}
+
+func TestRequestIDHeader_BatchCreateSessions_Unavailable(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	interceptorTracker := newInterceptorTracker()
+	clientOpts := []option.ClientOption{
+		option.WithGRPCDialOption(grpc.WithUnaryInterceptor(interceptorTracker.unaryClientInterceptor)),
+		option.WithGRPCDialOption(grpc.WithStreamInterceptor(interceptorTracker.streamClientInterceptor)),
+	}
+	clientConfig := ClientConfig{
+		SessionPoolConfig: SessionPoolConfig{
+			MinOpened:     2,
+			MaxOpened:     10,
+			WriteSessions: 0.2,
+			incStep:       2,
+		},
+	}
+
+	server, sc, tearDown := setupMockedTestServerWithConfigAndClientOptions(t, clientConfig, clientOpts)
+	t.Cleanup(tearDown)
+	defer sc.Close()
+
+	// BatchCreateSessions returns UNAVAILABLE and should be retried.
+	server.TestSpanner.PutExecutionTime(testutil.MethodBatchCreateSession,
+		testutil.SimulatedExecutionTime{
+			Errors: []error{
+				newUnavailableErrorWithMinimalRetryDelay(),
+			},
+		})
+	iter := sc.Single().Query(ctx, Statement{SQL: testutil.SelectFooFromBar})
+	defer iter.Stop()
+	for {
+		_, err := iter.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if _, err := shouldHaveReceived(server.TestSpanner, []interface{}{
+		&sppb.BatchCreateSessionsRequest{},
+		&sppb.BatchCreateSessionsRequest{},
+		&sppb.ExecuteSqlRequest{},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if g, w := interceptorTracker.unaryCallCount(), uint64(2); g != w {
+		t.Errorf("unaryClientCall is incorrect; got=%d want=%d", g, w)
+	}
+
+	if g, w := interceptorTracker.streamCallCount(), uint64(1); g != w {
+		t.Errorf("streamClientCall is incorrect; got=%d want=%d", g, w)
+	}
+
+	if err := interceptorTracker.validateRequestIDsMonotonicity(); err != nil {
+		t.Fatal(err)
+	}
+
+	clientID := uint32(sc.sc.nthClient)
+	procID := randIDForProcess
+	version := xSpannerRequestIDVersion
+	wantUnarySegments := []*requestIDSegments{
+		{Version: version, ProcessID: procID, ClientID: clientID, ChannelID: 1, RequestNo: 1, RPCNo: 1}, // BatchCreateSession (initial attempt)
+		{Version: version, ProcessID: procID, ClientID: clientID, ChannelID: 1, RequestNo: 1, RPCNo: 2}, // BatchCreateSession (retry)
+	}
+	wantStreamingSegments := []*requestIDSegments{
+		{Version: version, ProcessID: procID, ClientID: clientID, ChannelID: 1, RequestNo: 2, RPCNo: 1}, // ExecuteStreamingSql
+	}
+
+	if diff := cmp.Diff(interceptorTracker.unaryClientRequestIDSegments, wantUnarySegments); diff != "" {
+		t.Fatalf("RequestID unary segments mismatch: got - want +\n%s", diff)
+	}
+	if diff := cmp.Diff(interceptorTracker.streamClientRequestIDSegments, wantStreamingSegments); diff != "" {
+		t.Fatalf("RequestID streaming segments mismatch: got - want +\n%s", diff)
+	}
+}
+
+func TestRequestIDHeader_SingleUseReadOnly_ExecuteStreamingSql_Unavailable(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	interceptorTracker := newInterceptorTracker()
+	clientOpts := []option.ClientOption{
+		option.WithGRPCDialOption(grpc.WithUnaryInterceptor(interceptorTracker.unaryClientInterceptor)),
+		option.WithGRPCDialOption(grpc.WithStreamInterceptor(interceptorTracker.streamClientInterceptor)),
+	}
+	clientConfig := ClientConfig{
+		SessionPoolConfig: SessionPoolConfig{
+			MinOpened:     2,
+			MaxOpened:     10,
+			WriteSessions: 0.2,
+			incStep:       2,
+		},
+	}
+
+	server, sc, tearDown := setupMockedTestServerWithConfigAndClientOptions(t, clientConfig, clientOpts)
+	t.Cleanup(tearDown)
+	defer sc.Close()
+
+	// ExecuteStreamingSql returns UNAVAILABLE and should be retried.
+	server.TestSpanner.PutExecutionTime(testutil.MethodExecuteStreamingSql,
+		testutil.SimulatedExecutionTime{
+			Errors: []error{
+				newUnavailableErrorWithMinimalRetryDelay(),
+				newUnavailableErrorWithMinimalRetryDelay(),
+			},
+		})
+	iter := sc.Single().Query(ctx, Statement{SQL: testutil.SelectFooFromBar})
+	defer iter.Stop()
+	for {
+		_, err := iter.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if _, err := shouldHaveReceived(server.TestSpanner, []interface{}{
+		&sppb.BatchCreateSessionsRequest{},
+		&sppb.ExecuteSqlRequest{},
+		&sppb.ExecuteSqlRequest{},
+		&sppb.ExecuteSqlRequest{},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if g, w := interceptorTracker.unaryCallCount(), uint64(1); g != w {
+		t.Errorf("unaryClientCall is incorrect; got=%d want=%d", g, w)
+	}
+
+	if g, w := interceptorTracker.streamCallCount(), uint64(3); g != w {
+		t.Errorf("streamClientCall is incorrect; got=%d want=%d", g, w)
+	}
+
+	if err := interceptorTracker.validateRequestIDsMonotonicity(); err != nil {
+		t.Fatal(err)
+	}
+
+	clientID := uint32(sc.sc.nthClient)
+	procID := randIDForProcess
+	version := xSpannerRequestIDVersion
+	wantUnarySegments := []*requestIDSegments{
+		{Version: version, ProcessID: procID, ClientID: clientID, ChannelID: 1, RequestNo: 1, RPCNo: 1}, // BatchCreateSession
+	}
+	wantStreamingSegments := []*requestIDSegments{
+		{Version: version, ProcessID: procID, ClientID: clientID, ChannelID: 1, RequestNo: 2, RPCNo: 1}, // ExecuteStreamingSql (initial attempt)
+		{Version: version, ProcessID: procID, ClientID: clientID, ChannelID: 1, RequestNo: 2, RPCNo: 2}, // ExecuteStreamingSql (retry)
+		{Version: version, ProcessID: procID, ClientID: clientID, ChannelID: 1, RequestNo: 2, RPCNo: 3}, // ExecuteStreamingSql (retry)
+	}
+
+	if diff := cmp.Diff(interceptorTracker.unaryClientRequestIDSegments, wantUnarySegments); diff != "" {
+		t.Fatalf("RequestID unary segments mismatch: got - want +\n%s", diff)
+	}
+	if diff := cmp.Diff(interceptorTracker.streamClientRequestIDSegments, wantStreamingSegments); diff != "" {
+		t.Fatalf("RequestID streaming segments mismatch: got - want +\n%s", diff)
+	}
+}
+
+func TestRequestIDHeader_SingleUseReadOnly_ExecuteStreamingSql_InvalidArgument(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	interceptorTracker := newInterceptorTracker()
+	clientOpts := []option.ClientOption{
+		option.WithGRPCDialOption(grpc.WithUnaryInterceptor(interceptorTracker.unaryClientInterceptor)),
+		option.WithGRPCDialOption(grpc.WithStreamInterceptor(interceptorTracker.streamClientInterceptor)),
+	}
+	clientConfig := ClientConfig{
+		SessionPoolConfig: SessionPoolConfig{
+			MinOpened:     2,
+			MaxOpened:     10,
+			WriteSessions: 0.2,
+			incStep:       2,
+		},
+	}
+
+	server, sc, tearDown := setupMockedTestServerWithConfigAndClientOptions(t, clientConfig, clientOpts)
+	t.Cleanup(tearDown)
+	defer sc.Close()
+
+	// Simulate that ExecuteStreamingSql is slow.
+	server.TestSpanner.PutExecutionTime(testutil.MethodExecuteStreamingSql,
+		testutil.SimulatedExecutionTime{Errors: []error{newInvalidArgumentError()}})
+
+	iter := sc.Single().Query(ctx, Statement{SQL: testutil.SelectFooFromBar})
+	defer iter.Stop()
+	_, err := iter.Next()
+	if err == nil {
+		t.Fatal("missing invalid argument error")
+	}
+	if g, w := ErrCode(err), codes.InvalidArgument; g != w {
+		t.Fatalf("error code mismatch\n Got: %v\nWant: %v", g, w)
+	}
+	spannerError, ok := err.(*Error)
+	if !ok {
+		t.Fatal("not a Spanner error")
+	}
+	if spannerError.RequestID == "" {
+		t.Fatal("missing RequestID on error")
+	}
+}
+
+func TestRequestIDHeader_SingleUseReadOnly_ExecuteStreamingSql_ContextDeadlineExceeded(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	interceptorTracker := newInterceptorTracker()
+	clientOpts := []option.ClientOption{
+		option.WithGRPCDialOption(grpc.WithUnaryInterceptor(interceptorTracker.unaryClientInterceptor)),
+		option.WithGRPCDialOption(grpc.WithStreamInterceptor(interceptorTracker.streamClientInterceptor)),
+	}
+	clientConfig := ClientConfig{
+		SessionPoolConfig: SessionPoolConfig{
+			MinOpened:     2,
+			MaxOpened:     10,
+			WriteSessions: 0.2,
+			incStep:       2,
+		},
+	}
+
+	server, sc, tearDown := setupMockedTestServerWithConfigAndClientOptions(t, clientConfig, clientOpts)
+	t.Cleanup(tearDown)
+	defer sc.Close()
+
+	// Simulate that ExecuteStreamingSql is slow.
+	server.TestSpanner.PutExecutionTime(testutil.MethodExecuteStreamingSql,
+		testutil.SimulatedExecutionTime{MinimumExecutionTime: time.Second})
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
+	defer cancel()
+	iter := sc.Single().Query(ctx, Statement{SQL: testutil.SelectFooFromBar})
+	defer iter.Stop()
+	_, err := iter.Next()
+	if err == nil {
+		t.Fatal("missing deadline exceeded error")
+	}
+	if g, w := ErrCode(err), codes.DeadlineExceeded; g != w {
+		t.Fatalf("error code mismatch\n Got: %v\nWant: %v", g, w)
+	}
+	spannerError, ok := err.(*Error)
+	if !ok {
+		t.Fatal("not a Spanner error")
+	}
+	if spannerError.RequestID == "" {
+		t.Fatal("missing RequestID on error")
+	}
+}
+
+func TestRequestIDHeader_Commit_ContextDeadlineExceeded(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	interceptorTracker := newInterceptorTracker()
+	clientOpts := []option.ClientOption{
+		option.WithGRPCDialOption(grpc.WithUnaryInterceptor(interceptorTracker.unaryClientInterceptor)),
+		option.WithGRPCDialOption(grpc.WithStreamInterceptor(interceptorTracker.streamClientInterceptor)),
+	}
+	clientConfig := ClientConfig{
+		SessionPoolConfig: SessionPoolConfig{
+			MinOpened:     2,
+			MaxOpened:     10,
+			WriteSessions: 0.2,
+			incStep:       2,
+		},
+	}
+
+	server, sc, tearDown := setupMockedTestServerWithConfigAndClientOptions(t, clientConfig, clientOpts)
+	t.Cleanup(tearDown)
+	defer sc.Close()
+
+	// Simulate that Commit is slow.
+	server.TestSpanner.PutExecutionTime(testutil.MethodCommitTransaction,
+		testutil.SimulatedExecutionTime{MinimumExecutionTime: time.Second})
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
+	defer cancel()
+	_, err := sc.Apply(ctx, []*Mutation{})
+	if err == nil {
+		t.Fatal("missing deadline exceeded error")
+	}
+	if g, w := ErrCode(err), codes.DeadlineExceeded; g != w {
+		t.Fatalf("error code mismatch\n Got: %v\nWant: %v", g, w)
+	}
+	spannerError, ok := err.(*Error)
+	if !ok {
+		t.Fatal("not a Spanner error")
+	}
+	if spannerError.RequestID == "" {
+		t.Fatal("missing RequestID on error")
+	}
+}
+
+func TestRequestIDHeader_VerifyChannelNumber(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	interceptorTracker := newInterceptorTracker()
+	clientOpts := []option.ClientOption{
+		option.WithGRPCDialOption(grpc.WithUnaryInterceptor(interceptorTracker.unaryClientInterceptor)),
+		option.WithGRPCDialOption(grpc.WithStreamInterceptor(interceptorTracker.streamClientInterceptor)),
+	}
+	clientConfig := ClientConfig{
+		SessionPoolConfig: SessionPoolConfig{
+			MinOpened: 100,
+			MaxOpened: 400,
+			incStep:   25,
+		},
+		NumChannels: 4,
+	}
+
+	_, sc, tearDown := setupMockedTestServerWithConfigAndClientOptions(t, clientConfig, clientOpts)
+	t.Cleanup(tearDown)
+	defer sc.Close()
+	// Wait for the session pool to be initialized.
+	sp := sc.idleSessions
+	waitFor(t, func() error {
+		sp.mu.Lock()
+		defer sp.mu.Unlock()
+		if uint64(sp.idleList.Len()) != clientConfig.MinOpened {
+			return fmt.Errorf("num open sessions mismatch\nWant: %d\nGot: %d", sp.MinOpened, sp.numOpened)
+		}
+		return nil
+	})
+	// Verify that we've seen request IDs for each channel number.
+	for channel := uint32(1); channel <= uint32(clientConfig.NumChannels); channel++ {
+		if !slices.ContainsFunc(interceptorTracker.unaryClientRequestIDSegments, func(segments *requestIDSegments) bool {
+			return segments.ChannelID == channel
+		}) {
+			t.Fatalf("missing channel %d in unary requests", channel)
+		}
+	}
+
+	// Execute MinOpened + 1 queries without closing the iterators.
+	// This will check out MinOpened + 1 sessions, which also triggers
+	// one more BatchCreateSessions call.
+	iterators := make([]*RowIterator, 0, clientConfig.MinOpened+1)
+	for i := 0; i < int(clientConfig.MinOpened)+1; i++ {
+		iter := sc.Single().Query(ctx, Statement{SQL: testutil.SelectFooFromBar})
+		iterators = append(iterators, iter)
+		_, err := iter.Next()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Verify that we've seen request IDs for each channel number.
+	for channel := uint32(1); channel <= uint32(clientConfig.NumChannels); channel++ {
+		if !slices.ContainsFunc(interceptorTracker.streamClientRequestIDSegments, func(segments *requestIDSegments) bool {
+			return segments.ChannelID == channel
+		}) {
+			t.Fatalf("missing channel %d in unary requests", channel)
+		}
+	}
+	// Verify that we've only seen channel numbers in the range [1, config.NumChannels].
+	for _, segmentsSlice := range [][]*requestIDSegments{interceptorTracker.streamClientRequestIDSegments, interceptorTracker.unaryClientRequestIDSegments} {
+		if slices.ContainsFunc(segmentsSlice, func(segments *requestIDSegments) bool {
+			return segments.ChannelID < 1 || segments.ChannelID > uint32(clientConfig.NumChannels)
+		}) {
+			t.Fatalf("invalid channel in requests: %v", segmentsSlice)
+		}
+	}
+
+	if g, w := interceptorTracker.unaryCallCount(), uint64(5); g != w {
+		t.Errorf("unaryClientCall is incorrect; got=%d want=%d", g, w)
+	}
+
+	if g, w := interceptorTracker.streamCallCount(), uint64(101); g != w {
+		t.Errorf("streamClientCall is incorrect; got=%d want=%d", g, w)
+	}
+
+	if err := interceptorTracker.validateRequestIDsMonotonicity(); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/spanner/sessionclient.go
+++ b/spanner/sessionclient.go
@@ -106,7 +106,7 @@ type sessionClient struct {
 	callOptions          *vkit.CallOptions
 	otConfig             *openTelemetryConfig
 	metricsTracerFactory *builtinMetricsTracerFactory
-	channelIDMap         map[*vkit.Client]uint64
+	channelIDMap         map[*grpc.ClientConn]uint64
 	nthClient            int
 }
 
@@ -405,14 +405,30 @@ func (sc *sessionClient) sessionWithID(id string) (*session, error) {
 // optimal usage of server side caches.
 func (sc *sessionClient) nextClient() (spannerClient, error) {
 	var clientOpt option.ClientOption
+	var channelID uint64
 	if _, ok := sc.connPool.(*gmeWrapper); ok {
 		// Pass GCPMultiEndpoint as a pool.
 		clientOpt = gtransport.WithConnPool(sc.connPool)
 	} else {
 		// Pick a grpc.ClientConn from a regular pool.
-		clientOpt = option.WithGRPCConn(sc.connPool.Conn())
+		conn := sc.connPool.Conn()
+
+		// Retrieve the channelID for each spannerClient.
+		// It is assumed that this method is invoked
+		// under a lock already.
+		var ok bool
+		channelID, ok = sc.channelIDMap[conn]
+		if !ok {
+			if sc.channelIDMap == nil {
+				sc.channelIDMap = make(map[*grpc.ClientConn]uint64)
+			}
+			channelID = uint64(len(sc.channelIDMap)) + 1
+			sc.channelIDMap[conn] = channelID
+		}
+
+		clientOpt = option.WithGRPCConn(conn)
 	}
-	client, err := newGRPCSpannerClient(context.Background(), sc, clientOpt)
+	client, err := newGRPCSpannerClient(context.Background(), sc, channelID, clientOpt)
 	if err != nil {
 		return nil, err
 	}

--- a/spanner/transaction.go
+++ b/spanner/transaction.go
@@ -1370,7 +1370,7 @@ func (t *ReadWriteTransaction) batchUpdateWithOptions(ctx context.Context, stmts
 		return counts, errInlineBeginTransactionFailed()
 	}
 	if resp.Status != nil && resp.Status.Code != 0 {
-		return counts, t.txReadOnly.updateTxState(spannerErrorf(codes.Code(uint32(resp.Status.Code)), resp.Status.Message))
+		return counts, t.txReadOnly.updateTxState(spannerError(codes.Code(uint32(resp.Status.Code)), resp.Status.Message))
 	}
 	return counts, nil
 }

--- a/spanner/transaction.go
+++ b/spanner/transaction.go
@@ -312,7 +312,7 @@ func (t *txReadOnly) ReadWithOptions(ctx context.Context, table string, keys Key
 		contextWithOutgoingMetadata(ctx, sh.getMetadata(), t.disableRouteToLeader),
 		sh.session.logger,
 		t.sp.sc.metricsTracerFactory,
-		func(ctx context.Context, resumeToken []byte) (streamingReceiver, error) {
+		func(ctx context.Context, resumeToken []byte, opts ...gax.CallOption) (streamingReceiver, error) {
 			if t.sh != nil {
 				t.sh.updateLastUseTime()
 			}
@@ -331,7 +331,7 @@ func (t *txReadOnly) ReadWithOptions(ctx context.Context, table string, keys Key
 					DirectedReadOptions: directedReadOptions,
 					OrderBy:             orderBy,
 					LockHint:            lockHint,
-				})
+				}, opts...)
 			if err != nil {
 				if _, ok := t.getTransactionSelector().GetSelector().(*sppb.TransactionSelector_Begin); ok {
 					t.setTransactionID(nil)
@@ -357,6 +357,7 @@ func (t *txReadOnly) ReadWithOptions(ctx context.Context, table string, keys Key
 		},
 		t.setTimestamp,
 		t.release,
+		client.(*grpcSpannerClient),
 	)
 }
 
@@ -612,13 +613,13 @@ func (t *txReadOnly) query(ctx context.Context, statement Statement, options Que
 		contextWithOutgoingMetadata(ctx, sh.getMetadata(), t.disableRouteToLeader),
 		sh.session.logger,
 		t.sp.sc.metricsTracerFactory,
-		func(ctx context.Context, resumeToken []byte) (streamingReceiver, error) {
+		func(ctx context.Context, resumeToken []byte, opts ...gax.CallOption) (streamingReceiver, error) {
 			req.ResumeToken = resumeToken
 			req.Session = t.sh.getID()
 			req.Transaction = t.getTransactionSelector()
 			t.sh.updateLastUseTime()
 
-			client, err := client.ExecuteStreamingSql(ctx, req)
+			client, err := client.ExecuteStreamingSql(ctx, req, opts...)
 			if err != nil {
 				if _, ok := req.Transaction.GetSelector().(*sppb.TransactionSelector_Begin); ok {
 					t.setTransactionID(nil)
@@ -643,7 +644,8 @@ func (t *txReadOnly) query(ctx context.Context, statement Statement, options Que
 			return t.updateTxState(err)
 		},
 		t.setTimestamp,
-		t.release)
+		t.release,
+		client.(*grpcSpannerClient))
 }
 
 func (t *txReadOnly) prepareExecuteSQL(ctx context.Context, stmt Statement, options QueryOptions) (*sppb.ExecuteSqlRequest, *sessionHandle, error) {


### PR DESCRIPTION
In tandem this specification

https://orijtech.notion.site/x-goog-spanner-request-id-always-on-gRPC-header-to-aid-in-quick-debugging-of-errors-14aba6bc91348091a58fca7a505c9827

This change adds sending over the "x-goog-spanner-request-id" header
for every unary and streaming call, in the form:

    <version>.<processId>.<clientId>.<channelId>.<requestCountForClient>.<rpcCountForRequest>

where:
* version is the version of the specification
* processId is a randomly generated uint64 singleton for the lifetime of a process
* clientId is the monotonically increasing id/number of gRPC Spanner clients created
* requestCountForClient is the monotonically increasing number of requests made by the client
* channelId currently at 1 is the Id of the client for Go
* rpcCountForRequest is the number of RPCs/retries within a specific request

This header is to be sent on both unary and streaming calls and it'll
help debug latencies for customers. On an error, customers can assert against
.Error and retrieve the associated .RequestID and log it, or even better
it'll be printed out whenever errors are logged.

Importantly making randIdForProcess to be a uint6 which is 64bits and not
a UUID4 which is 128bits which surely massively reduces the possibility of collisions
to ensure that high QPS applications can function and accept bursts of traffic
without worry, as the prior design used uint32 aka 32 bits for
which just 50,000 new processes being created could get the probability
of collisions to 25%, with this new change a company would have to
create 82 million QPS every second for 1,000 years for a 1% collision
with 2.6e18 for which the collision would be 1%.
Using 64-bits still provides really good protection whereby for a 1% chance of collision,
we would need 810 million objects, so we have good protection.
However, Google Cloud Spanner's backend has to store every one of the always on
headers for a desired retention period hence 64-bits is a great balance between collision
protection vs storage.

Fixes #11073