### PR TITLE
fix(auth/oauth2adapt): convert token metadata where possible

### DIFF
--- a/auth/oauth2adapt/oauth2adapt.go
+++ b/auth/oauth2adapt/oauth2adapt.go
@@ -26,6 +26,13 @@ import (
 	"golang.org/x/oauth2/google"
 )
 
+const (
+	oauth2TokenSourceKey    = "oauth2.google.tokenSource"
+	oauth2ServiceAccountKey = "oauth2.google.serviceAccount"
+	authTokenSourceKey      = "auth.google.tokenSource"
+	authServiceAccountKey   = "auth.google.serviceAccount"
+)
+
 // TokenProviderFromTokenSource converts any [golang.org/x/oauth2.TokenSource]
 // into a [cloud.google.com/go/auth.TokenProvider].
 func TokenProviderFromTokenSource(ts oauth2.TokenSource) auth.TokenProvider {
@@ -47,10 +54,21 @@ func (tp *tokenProviderAdapter) Token(context.Context) (*auth.Token, error) {
 		}
 		return nil, err
 	}
+	// Preserve compute token metadata, for both types of tokens.
+	metadata := map[string]interface{}{}
+	if val, ok := tok.Extra(oauth2TokenSourceKey).(string); ok {
+		metadata[authTokenSourceKey] = val
+		metadata[oauth2TokenSourceKey] = val
+	}
+	if val, ok := tok.Extra(oauth2ServiceAccountKey).(string); ok {
+		metadata[authServiceAccountKey] = val
+		metadata[oauth2ServiceAccountKey] = val
+	}
 	return &auth.Token{
-		Value:  tok.AccessToken,
-		Type:   tok.Type(),
-		Expiry: tok.Expiry,
+		Value:    tok.AccessToken,
+		Type:     tok.Type(),
+		Expiry:   tok.Expiry,
+		Metadata: metadata,
 	}, nil
 }
 
@@ -76,11 +94,24 @@ func (ts *tokenSourceAdapter) Token() (*oauth2.Token, error) {
 		}
 		return nil, err
 	}
-	return &oauth2.Token{
+	tok2 := &oauth2.Token{
 		AccessToken: tok.Value,
 		TokenType:   tok.Type,
 		Expiry:      tok.Expiry,
-	}, nil
+	}
+	// Preserve token metadata.
+	metadata := tok.Metadata
+	if metadata != nil {
+		// Append compute token metadata in converted form.
+		if val, ok := metadata[authTokenSourceKey].(string); ok && val != "" {
+			metadata[oauth2TokenSourceKey] = val
+		}
+		if val, ok := metadata[authServiceAccountKey].(string); ok && val != "" {
+			metadata[oauth2ServiceAccountKey] = val
+		}
+		tok2 = tok2.WithExtra(metadata)
+	}
+	return tok2, nil
 }
 
 // AuthCredentialsFromOauth2Credentials converts a [golang.org/x/oauth2/google.Credentials]


### PR DESCRIPTION
This was missed in the orginal implmentation. The code is still not prefect as converting from an oauth2.Token to auth.Token is lossy because there is no way to extract out the whole metadata context. Converting from auth.Token -> oauth2.Token is not lossy though.

This bug was discovered because some direct path checks look for theses metadata values. Just to be safe we will preserve both forms of these values in the final token metadata, if present.

Internal Bug: 376281562