### PR TITLE
chore(storage): adding request-id in the stall-retry log

### DIFF
--- a/storage/http_client.go
+++ b/storage/http_client.go
@@ -901,11 +901,12 @@ func (c *httpStorageClient) newRangeReaderXML(ctx context.Context, params *newRa
 				done <- true
 			}()
 
-			// Wait until timeout or request is successful.
-			timer := time.After(c.dynamicReadReqStallTimeout.getValue(params.bucket))
+			// Wait until stall timeout or request is successful.
+			stallTimeout := c.dynamicReadReqStallTimeout.getValue(params.bucket)
+			timer := time.After(stallTimeout)
 			select {
 			case <-timer:
-				log.Printf("stalled read-req cancelled after %fs", c.dynamicReadReqStallTimeout.getValue(params.bucket).Seconds())
+				log.Printf("stalled read-req (%p) cancelled after %fs", req, stallTimeout.Seconds())
 				cancel()
 				err = context.DeadlineExceeded
 				if res != nil && res.Body != nil {


### PR DESCRIPTION
1. Fixing the stall-timeout value in the log.
2. Adding request-id in the log - this will be helpful for debugging.

Sample log:
```
2024/11/01 11:56:35 stalled read-req (0xc000232640) cancelled after 0.500000s
2024/11/01 11:56:37 stalled read-req (0xc000232640) cancelled after 0.523647s
2024/11/01 11:56:40 stalled read-req (0xc000232640) cancelled after 0.548412s
```