### PR TITLE
test(storage): fix metrics exporter test

### DIFF
--- a/storage/go.mod
+++ b/storage/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/googleapis/gax-go/v2 v2.13.0
 	go.opentelemetry.io/contrib/detectors/gcp v1.29.0
 	go.opentelemetry.io/otel v1.29.0
+	go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v1.29.0
 	go.opentelemetry.io/otel/sdk v1.29.0
 	go.opentelemetry.io/otel/sdk/metric v1.29.0
 	golang.org/x/oauth2 v0.23.0

--- a/storage/go.sum
+++ b/storage/go.sum
@@ -115,6 +115,8 @@ go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.54.0 h1:TT4fX+n
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.54.0/go.mod h1:L7UH0GbB0p47T4Rri3uHjbpCFYrVrwc1I25QhNPiGK8=
 go.opentelemetry.io/otel v1.29.0 h1:PdomN/Al4q/lN6iBJEN3AwPvUiHPMlt93c8bqTG5Llw=
 go.opentelemetry.io/otel v1.29.0/go.mod h1:N/WtXPs1CNCUEx+Agz5uouwCba+i+bJGFicT8SR4NP8=
+go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v1.29.0 h1:WDdP9acbMYjbKIyJUhTvtzj601sVJOqgWdUxSdR/Ysc=
+go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v1.29.0/go.mod h1:BLbf7zbNIONBLPwvFnwNHGj4zge8uTCM/UPIVW1Mq2I=
 go.opentelemetry.io/otel/metric v1.29.0 h1:vPf/HFWTNkPu1aYeIsc98l4ktOQaL6LeSoeV2g+8YLc=
 go.opentelemetry.io/otel/metric v1.29.0/go.mod h1:auu/QWieFVWx+DmQOUMgj0F8LHWdgalxXqvp7BII/W8=
 go.opentelemetry.io/otel/sdk v1.29.0 h1:vkqKjk7gwhS8VaWb0POZKmIEDimRCMsopNYnriHyryo=

--- a/storage/option_test.go
+++ b/storage/option_test.go
@@ -20,8 +20,8 @@ import (
 	"time"
 
 	"cloud.google.com/go/storage/experimental"
-	mexporter "github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric"
 	"github.com/google/go-cmp/cmp"
+	"go.opentelemetry.io/otel/exporters/stdout/stdoutmetric"
 	"google.golang.org/api/option"
 )
 
@@ -153,7 +153,7 @@ func TestApplyStorageOpt(t *testing.T) {
 }
 
 func TestSetCustomExporter(t *testing.T) {
-	exporter, err := mexporter.New()
+	exporter, err := stdoutmetric.New()
 	if err != nil {
 		t.Errorf("TestSetCustomExporter: %v", err)
 	}


### PR DESCRIPTION
Since this is a short test it should work locally without requiring any project permissions. The current exporter fails without a project with cloud monitoring permissions. Replace with an exporter to stdout instead.