### PR TITLE
chore: move ai libs back to main release train

### DIFF
--- a/.release-please-manifest-individual.json
+++ b/.release-please-manifest-individual.json
@@ -1,6 +1,4 @@
 {
-  "ai": "0.9.0",
-  "aiplatform": "1.69.0",
   "auth": "0.10.2",
   "auth/oauth2adapt": "0.2.5",
   "bigquery": "1.64.0",

--- a/.release-please-manifest-submodules.json
+++ b/.release-please-manifest-submodules.json
@@ -1,4 +1,6 @@
 {
+    "ai": "0.9.0",
+    "aiplatform": "1.69.0",
     "accessapproval": "1.8.2",
     "accesscontextmanager": "1.9.2",
     "advisorynotifications": "1.5.2",

--- a/release-please-config-individual.json
+++ b/release-please-config-individual.json
@@ -5,12 +5,6 @@
   "separate-pull-requests": true,
   "tag-separator": "/",
   "packages": {
-    "ai": {
-      "component": "ai"
-    },
-    "aiplatform": {
-      "component": "aiplatform"
-    },
     "auth": {
       "component": "auth"
     },

--- a/release-please-config-yoshi-submodules.json
+++ b/release-please-config-yoshi-submodules.json
@@ -3,6 +3,12 @@
     "include-component-in-tag": true,
     "tag-separator": "/",
     "packages": {
+        "ai": {
+            "component": "ai"
+        },
+        "aiplatform": {
+            "component": "aiplatform"
+        },
         "accessapproval": {
             "component": "accessapproval"
         },


### PR DESCRIPTION
There was a time when these releases were being handled more by other teams, but this is no longer the case. Let's bring them back in the fold for timely releases.