### PR TITLE
fix(spanner): support setting monitoring host via env

### DIFF
--- a/spanner/metrics.go
+++ b/spanner/metrics.go
@@ -170,6 +170,12 @@ var (
 	// createExporterOptions takes Spanner client options and returns exporter options
 	// Overwritten in tests
 	createExporterOptions = func(spannerOpts ...option.ClientOption) []option.ClientOption {
+		defaultMonitoringEndpoint := "monitoring.googleapis.com:443"
+		if os.Getenv("SPANNER_MONITORING_HOST") != "" {
+			defaultMonitoringEndpoint = os.Getenv("SPANNER_MONITORING_HOST")
+		}
+		// overwrite any Endpoint option
+		spannerOpts = append(spannerOpts, option.WithEndpoint(defaultMonitoringEndpoint))
 		return spannerOpts
 	}
 )


### PR DESCRIPTION
* `SPANNER_MONITORING_HOST` can be used to point to different monitoring environment.
* Fixes Endpoint override from Spanner options which will cause error

`
rpc error: code = Unimplemented desc = The GRPC target is not implemented on the server, host: spanner-host, method: /google.monitoring.v3.MetricService/CreateServiceTimeSeries.
`