### PR TITLE
fix(storage): retry SignBlob call for URL signing

### DIFF
--- a/storage/bucket.go
+++ b/storage/bucket.go
@@ -326,12 +326,16 @@ func (b *BucketHandle) defaultSignBytesFunc(email string) func([]byte) ([]byte, 
 		if err != nil {
 			return nil, fmt.Errorf("unable to create iamcredentials client: %w", err)
 		}
-
-		resp, err := svc.Projects.ServiceAccounts.SignBlob(fmt.Sprintf("projects/-/serviceAccounts/%s", email), &iamcredentials.SignBlobRequest{
-			Payload: base64.StdEncoding.EncodeToString(in),
-		}).Do()
-		if err != nil {
+		// Do the SignBlob call with a retry for transient errors.
+		var resp *iamcredentials.SignBlobResponse
+		if err := run(ctx, func(ctx context.Context) error {
+			resp, err = svc.Projects.ServiceAccounts.SignBlob(fmt.Sprintf("projects/-/serviceAccounts/%s", email), &iamcredentials.SignBlobRequest{
+				Payload: base64.StdEncoding.EncodeToString(in),
+			}).Do()
+			return err
+		}, b.retry, true); err != nil {
 			return nil, fmt.Errorf("unable to sign bytes: %w", err)
+
 		}
 		out, err := base64.StdEncoding.DecodeString(resp.SignedBlob)
 		if err != nil {


### PR DESCRIPTION
Adds a retry to the SignBlob call made by the default SignBytes function from BucketHandle.SignedURL().

This is an idempotent call so fully safe to retry.

Signed URL integration tests pass locally.