### PR TITLE
refactor(bigquery/storage/managedwriter): simplify signatures

### DIFF
--- a/bigquery/storage/managedwriter/adapt/protoconversion.go
+++ b/bigquery/storage/managedwriter/adapt/protoconversion.go
@@ -277,10 +277,7 @@ func storageSchemaToDescriptorInternal(inSchema *storagepb.TableSchema, scope st
 					deps = append(deps, foundDesc.ParentFile())
 				}
 				// Construct field descriptor for the message.
-				fdp, err := tableFieldSchemaToFieldDescriptorProto(f, fNumber, string(foundDesc.FullName()), useProto3)
-				if err != nil {
-					return nil, newConversionError(scope, fmt.Errorf("couldn't convert field to FieldDescriptorProto: %w", err))
-				}
+				fdp := tableFieldSchemaToFieldDescriptorProto(f, fNumber, string(foundDesc.FullName()), useProto3)
 				fields = append(fields, fdp)
 			} else {
 				// Wrap the current struct's fields in a TableSchema outer message, and then build the submessage.
@@ -298,10 +295,7 @@ func storageSchemaToDescriptorInternal(inSchema *storagepb.TableSchema, scope st
 				if err != nil {
 					return nil, newConversionError(currentScope, fmt.Errorf("failed to add descriptor to dependency cache: %w", err))
 				}
-				fdp, err := tableFieldSchemaToFieldDescriptorProto(f, fNumber, currentScope, useProto3)
-				if err != nil {
-					return nil, newConversionError(currentScope, fmt.Errorf("couldn't compute field schema : %w", err))
-				}
+				fdp := tableFieldSchemaToFieldDescriptorProto(f, fNumber, currentScope, useProto3)
 				fields = append(fields, fdp)
 			}
 		} else {
@@ -329,10 +323,7 @@ func storageSchemaToDescriptorInternal(inSchema *storagepb.TableSchema, scope st
 					}
 				}
 			}
-			fd, err := tableFieldSchemaToFieldDescriptorProto(f, fNumber, currentScope, useProto3)
-			if err != nil {
-				return nil, newConversionError(currentScope, err)
-			}
+			fd := tableFieldSchemaToFieldDescriptorProto(f, fNumber, currentScope, useProto3)
 			fields = append(fields, fd)
 		}
 	}
@@ -411,7 +402,7 @@ func messageDependsOnFile(msg protoreflect.MessageDescriptor, file protoreflect.
 // For proto2, we propagate the mode->label annotation as expected.
 //
 // Messages are always nullable, and repeated fields are as well.
-func tableFieldSchemaToFieldDescriptorProto(field *storagepb.TableFieldSchema, idx int32, scope string, useProto3 bool) (*descriptorpb.FieldDescriptorProto, error) {
+func tableFieldSchemaToFieldDescriptorProto(field *storagepb.TableFieldSchema, idx int32, scope string, useProto3 bool) *descriptorpb.FieldDescriptorProto {
 	name := field.GetName()
 	var fdp *descriptorpb.FieldDescriptorProto
 
@@ -474,7 +465,7 @@ func tableFieldSchemaToFieldDescriptorProto(field *storagepb.TableFieldSchema, i
 		}
 		proto.SetExtension(fdp.Options, storagepb.E_ColumnName, name)
 	}
-	return fdp, nil
+	return fdp
 }
 
 // nameRequiresAnnotation determines whether a field name requires unicode-annotation.

--- a/bigquery/storage/managedwriter/connection.go
+++ b/bigquery/storage/managedwriter/connection.go
@@ -537,7 +537,7 @@ func connRecvProcessor(ctx context.Context, co *connection, arc storagepb.BigQue
 				// TODO:  Determine if/how we should report this case, as we have no viable context for propagating.
 
 				// Because we can't tell locally if this write is done, we pass it back to the retrier for possible re-enqueue.
-				pw.writer.processRetry(pw, co, nil, doneErr)
+				pw.writer.processRetry(pw, nil, doneErr)
 			}
 		case nextWrite, ok := <-ch:
 			if !ok {
@@ -557,7 +557,7 @@ func connRecvProcessor(ctx context.Context, co *connection, arc storagepb.BigQue
 				}
 				recordStat(metricCtx, AppendResponseErrors, 1)
 
-				nextWrite.writer.processRetry(nextWrite, co, nil, err)
+				nextWrite.writer.processRetry(nextWrite, nil, err)
 				continue
 			}
 			// Record that we did in fact get a response from the backend.
@@ -573,7 +573,7 @@ func connRecvProcessor(ctx context.Context, co *connection, arc storagepb.BigQue
 				recordStat(metricCtx, AppendResponseErrors, 1)
 				respErr := grpcstatus.ErrorProto(status)
 
-				nextWrite.writer.processRetry(nextWrite, co, resp, respErr)
+				nextWrite.writer.processRetry(nextWrite, resp, respErr)
 
 				continue
 			}

--- a/bigquery/storage/managedwriter/managed_stream.go
+++ b/bigquery/storage/managedwriter/managed_stream.go
@@ -194,7 +194,7 @@ func (ms *ManagedStream) Finalize(ctx context.Context, opts ...gax.CallOption) (
 // appendWithRetry handles the details of adding sending an append request on a stream.  Appends are sent on a long
 // lived bidirectional network stream, with it's own managed context (ms.ctx), and there's a per-request context
 // attached to the pendingWrite.
-func (ms *ManagedStream) appendWithRetry(pw *pendingWrite, opts ...gax.CallOption) error {
+func (ms *ManagedStream) appendWithRetry(pw *pendingWrite) error {
 	for {
 		ms.mu.Lock()
 		err := ms.err
@@ -355,7 +355,7 @@ func (ms *ManagedStream) AppendRows(ctx context.Context, data [][]byte, opts ...
 
 // processRetry is responsible for evaluating and re-enqueing an append.
 // If the append is not retried, it is marked complete.
-func (ms *ManagedStream) processRetry(pw *pendingWrite, srcConn *connection, appendResp *storagepb.AppendRowsResponse, initialErr error) {
+func (ms *ManagedStream) processRetry(pw *pendingWrite, appendResp *storagepb.AppendRowsResponse, initialErr error) {
 	err := initialErr
 	for {
 		pause, shouldRetry := ms.statelessRetryer().Retry(err, pw.attemptCount)


### PR DESCRIPTION
Another unparam related PR, this one focused on reducing unused params in the managedwriter and its adapt subpackage.

Followup to https://github.com/googleapis/google-cloud-go/pull/11149