### PR TITLE
chore(internal/gapicgen): support Go 1.23

### DIFF
--- a/internal/gapicgen/cmd/genbot/Dockerfile
+++ b/internal/gapicgen/cmd/genbot/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22-alpine as godist
+FROM golang:1.23-alpine as godist
 RUN go version
 
 FROM docker:25.0


### PR DESCRIPTION
* Update cmd/genbot/Dockerfile to 1.23-alpine