### PR TITLE
ci(spanner): fix failing tests due to t.Parallel

### DIFF
--- a/spanner/metrics_test.go
+++ b/spanner/metrics_test.go
@@ -41,7 +41,6 @@ func TestNewBuiltinMetricsTracerFactory(t *testing.T) {
 	if testing.Short() {
 		t.Skip("TestNewBuiltinMetricsTracerFactory tests skipped in -short mode.")
 	}
-	t.Parallel()
 
 	ctx := context.Background()
 	clientUID := "test-uid"


### PR DESCRIPTION
**Why?**

Test `TestNewBuiltinMetricsTracerFactory` was recently made as parallel but internally one of the [test](https://github.com/googleapis/google-cloud-go/blob/main/spanner/metrics_test.go#L1530) uses t.SetEnv. 

It's failing with `panic: testing: t.Setenv called after t.Parallel; cannot set environment variables in parallel tests`.

As per https://go.dev/cl/431101, it's not allowed to use t.SetEnv inside parallel tests.

