### PR TITLE
fix(auth): check compute cred type before non-default flag for DP

### DIFF
--- a/auth/grpctransport/directpath.go
+++ b/auth/grpctransport/directpath.go
@@ -66,11 +66,11 @@ func isTokenProviderDirectPathCompatible(tp auth.TokenProvider, o *Options) bool
 	if tok == nil {
 		return false
 	}
-	if o.InternalOptions != nil && o.InternalOptions.EnableNonDefaultSAForDirectPath {
-		return true
-	}
 	if tok.MetadataString("auth.google.tokenSource") != "compute-metadata" {
 		return false
+	}
+	if o.InternalOptions != nil && o.InternalOptions.EnableNonDefaultSAForDirectPath {
+		return true
 	}
 	if tok.MetadataString("auth.google.serviceAccount") != "default" {
 		return false

--- a/auth/grpctransport/directpath_test.go
+++ b/auth/grpctransport/directpath_test.go
@@ -41,13 +41,27 @@ func TestIsTokenProviderDirectPathCompatible(t *testing.T) {
 		},
 		{
 			name: "EnableNonDefaultSAForDirectPath",
-			tp:   &staticTP{tok: &auth.Token{Value: "fakeToken"}},
+			tp: &staticTP{
+				tok: token(map[string]interface{}{
+					"auth.google.tokenSource": "compute-metadata",
+				}),
+			},
 			opts: &Options{
 				InternalOptions: &InternalOptions{
 					EnableNonDefaultSAForDirectPath: true,
 				},
 			},
 			want: true,
+		},
+		{
+			name: "EnableNonDefaultSAForDirectPathButNotCompute",
+			tp:   &staticTP{},
+			opts: &Options{
+				InternalOptions: &InternalOptions{
+					EnableNonDefaultSAForDirectPath: true,
+				},
+			},
+			want: false,
 		},
 		{
 			name: "non-compute token source",


### PR DESCRIPTION
We need to first ensure a token is a compute type before we enforce the option to allow for a non-default service account. This was leading to a strange XDS error if say a user credential was supplied and this option was enabled.