### PR TITLE
test(storage): fix go vet for test errors

### DIFF
--- a/storage/bucket_test.go
+++ b/storage/bucket_test.go
@@ -279,7 +279,7 @@ func TestBucketAttrsToRawBucket(t *testing.T) {
 		PublicAccessPrevention: "enforced",
 	}
 	if msg := testutil.Diff(got, want); msg != "" {
-		t.Errorf(msg)
+		t.Errorf("%v", msg)
 	}
 
 	// Set BucketPolicyOnly.Enabled = true --> UBLA should be set to enabled in
@@ -294,7 +294,7 @@ func TestBucketAttrsToRawBucket(t *testing.T) {
 		PublicAccessPrevention: "enforced",
 	}
 	if msg := testutil.Diff(got, want); msg != "" {
-		t.Errorf(msg)
+		t.Errorf("%v", msg)
 	}
 
 	// Set both BucketPolicyOnly.Enabled = true and
@@ -310,7 +310,7 @@ func TestBucketAttrsToRawBucket(t *testing.T) {
 		PublicAccessPrevention: "enforced",
 	}
 	if msg := testutil.Diff(got, want); msg != "" {
-		t.Errorf(msg)
+		t.Errorf("%v", msg)
 	}
 
 	// Set UBLA.Enabled=false and BucketPolicyOnly.Enabled=false --> UBLA
@@ -322,7 +322,7 @@ func TestBucketAttrsToRawBucket(t *testing.T) {
 		PublicAccessPrevention: "enforced",
 	}
 	if msg := testutil.Diff(got, want); msg != "" {
-		t.Errorf(msg)
+		t.Errorf("%v", msg)
 	}
 
 	// Test that setting PublicAccessPrevention to "unspecified" leads to the
@@ -333,7 +333,7 @@ func TestBucketAttrsToRawBucket(t *testing.T) {
 		PublicAccessPrevention: "inherited",
 	}
 	if msg := testutil.Diff(got, want); msg != "" {
-		t.Errorf(msg)
+		t.Errorf("%v", msg)
 	}
 
 	// Test that setting PublicAccessPrevention to "inherited" leads to the
@@ -344,7 +344,7 @@ func TestBucketAttrsToRawBucket(t *testing.T) {
 		PublicAccessPrevention: "inherited",
 	}
 	if msg := testutil.Diff(got, want); msg != "" {
-		t.Errorf(msg)
+		t.Errorf("%v", msg)
 	}
 
 	// Test that setting RPO to default is propagated in the proto.
@@ -352,7 +352,7 @@ func TestBucketAttrsToRawBucket(t *testing.T) {
 	got = attrs.toRawBucket()
 	want.Rpo = rpoDefault
 	if msg := testutil.Diff(got, want); msg != "" {
-		t.Errorf(msg)
+		t.Errorf("%v", msg)
 	}
 
 	// Re-enable UBLA and confirm that it does not affect the PAP setting.
@@ -365,7 +365,7 @@ func TestBucketAttrsToRawBucket(t *testing.T) {
 		PublicAccessPrevention: "inherited",
 	}
 	if msg := testutil.Diff(got, want); msg != "" {
-		t.Errorf(msg)
+		t.Errorf("%v", msg)
 	}
 
 	// Disable UBLA and reset PAP to default. Confirm that the IAM config is set
@@ -375,7 +375,7 @@ func TestBucketAttrsToRawBucket(t *testing.T) {
 	got = attrs.toRawBucket()
 	want.IamConfiguration = nil
 	if msg := testutil.Diff(got, want); msg != "" {
-		t.Errorf(msg)
+		t.Errorf("%v", msg)
 	}
 }
 
@@ -504,7 +504,7 @@ func TestBucketAttrsToUpdateToRawBucket(t *testing.T) {
 		},
 	}
 	if msg := testutil.Diff(got, want); msg != "" {
-		t.Errorf(msg)
+		t.Errorf("%v", msg)
 	}
 
 	// Set BucketPolicyOnly.Enabled = true --> UBLA should be set to enabled in
@@ -522,7 +522,7 @@ func TestBucketAttrsToUpdateToRawBucket(t *testing.T) {
 		},
 	}
 	if msg := testutil.Diff(got, want); msg != "" {
-		t.Errorf(msg)
+		t.Errorf("%v", msg)
 	}
 
 	// Set both BucketPolicyOnly.Enabled = true and
@@ -542,7 +542,7 @@ func TestBucketAttrsToUpdateToRawBucket(t *testing.T) {
 		},
 	}
 	if msg := testutil.Diff(got, want); msg != "" {
-		t.Errorf(msg)
+		t.Errorf("%v", msg)
 	}
 
 	// Set UBLA.Enabled=false and BucketPolicyOnly.Enabled=false --> UBLA
@@ -561,7 +561,7 @@ func TestBucketAttrsToUpdateToRawBucket(t *testing.T) {
 		},
 	}
 	if msg := testutil.Diff(got, want); msg != "" {
-		t.Errorf(msg)
+		t.Errorf("%v", msg)
 	}
 
 	// UBLA.Enabled will have precedence above BucketPolicyOnly.Enabled if both
@@ -580,7 +580,7 @@ func TestBucketAttrsToUpdateToRawBucket(t *testing.T) {
 		},
 	}
 	if msg := testutil.Diff(got, want); msg != "" {
-		t.Errorf(msg)
+		t.Errorf("%v", msg)
 	}
 
 	// Set an empty Lifecycle and verify that it will be sent.
@@ -595,7 +595,7 @@ func TestBucketAttrsToUpdateToRawBucket(t *testing.T) {
 		ForceSendFields: []string{"Lifecycle"},
 	}
 	if msg := testutil.Diff(got, want); msg != "" {
-		t.Errorf(msg)
+		t.Errorf("%v", msg)
 	}
 }
 
@@ -992,7 +992,7 @@ func TestBucketAttrsToProtoBucket(t *testing.T) {
 		PublicAccessPrevention: "enforced",
 	}
 	if msg := testutil.Diff(got, want); msg != "" {
-		t.Errorf(msg)
+		t.Errorf("%v", msg)
 	}
 
 	// Set BucketPolicyOnly.Enabled = true --> UBLA should be set to enabled in
@@ -1007,7 +1007,7 @@ func TestBucketAttrsToProtoBucket(t *testing.T) {
 		PublicAccessPrevention: "enforced",
 	}
 	if msg := testutil.Diff(got, want); msg != "" {
-		t.Errorf(msg)
+		t.Errorf("%v", msg)
 	}
 
 	// Set both BucketPolicyOnly.Enabled = true and
@@ -1023,7 +1023,7 @@ func TestBucketAttrsToProtoBucket(t *testing.T) {
 		PublicAccessPrevention: "enforced",
 	}
 	if msg := testutil.Diff(got, want); msg != "" {
-		t.Errorf(msg)
+		t.Errorf("%v", msg)
 	}
 
 	// Set UBLA.Enabled=false and BucketPolicyOnly.Enabled=false --> UBLA
@@ -1035,7 +1035,7 @@ func TestBucketAttrsToProtoBucket(t *testing.T) {
 		PublicAccessPrevention: "enforced",
 	}
 	if msg := testutil.Diff(got, want); msg != "" {
-		t.Errorf(msg)
+		t.Errorf("%v", msg)
 	}
 
 	// Test that setting PublicAccessPrevention to "unspecified" leads to the
@@ -1046,7 +1046,7 @@ func TestBucketAttrsToProtoBucket(t *testing.T) {
 		PublicAccessPrevention: "inherited",
 	}
 	if msg := testutil.Diff(got, want); msg != "" {
-		t.Errorf(msg)
+		t.Errorf("%v", msg)
 	}
 
 	// Test that setting PublicAccessPrevention to "inherited" leads to the
@@ -1057,7 +1057,7 @@ func TestBucketAttrsToProtoBucket(t *testing.T) {
 		PublicAccessPrevention: "inherited",
 	}
 	if msg := testutil.Diff(got, want); msg != "" {
-		t.Errorf(msg)
+		t.Errorf("%v", msg)
 	}
 
 	// Test that setting RPO to default is propagated in the proto.
@@ -1065,7 +1065,7 @@ func TestBucketAttrsToProtoBucket(t *testing.T) {
 	got = attrs.toProtoBucket()
 	want.Rpo = rpoDefault
 	if msg := testutil.Diff(got, want); msg != "" {
-		t.Errorf(msg)
+		t.Errorf("%v", msg)
 	}
 
 	// Re-enable UBLA and confirm that it does not affect the PAP setting.
@@ -1078,7 +1078,7 @@ func TestBucketAttrsToProtoBucket(t *testing.T) {
 		PublicAccessPrevention: "inherited",
 	}
 	if msg := testutil.Diff(got, want); msg != "" {
-		t.Errorf(msg)
+		t.Errorf("%v", msg)
 	}
 
 	// Disable UBLA and reset PAP to default. Confirm that the IAM config is set
@@ -1088,7 +1088,7 @@ func TestBucketAttrsToProtoBucket(t *testing.T) {
 	got = attrs.toProtoBucket()
 	want.IamConfig = nil
 	if msg := testutil.Diff(got, want); msg != "" {
-		t.Errorf(msg)
+		t.Errorf("%v", msg)
 	}
 }
 

--- a/storage/option_test.go
+++ b/storage/option_test.go
@@ -146,7 +146,8 @@ func TestApplyStorageOpt(t *testing.T) {
 				}
 			}
 			if !cmp.Equal(got, test.want, cmp.AllowUnexported(storageConfig{}, experimental.ReadStallTimeoutConfig{})) {
-				t.Errorf(cmp.Diff(got, test.want, cmp.AllowUnexported(storageConfig{}, experimental.ReadStallTimeoutConfig{})))
+				diff := cmp.Diff(got, test.want, cmp.AllowUnexported(storageConfig{}, experimental.ReadStallTimeoutConfig{}))
+				t.Errorf("options: diff got, want: %v", diff)
 			}
 		})
 	}


### PR DESCRIPTION
Calling t.Errorf without a proper format string causes an error in go 1.24.