### PR TITLE
fix(storage/dataflux): address deadlock when reading from ranges

### DIFF
--- a/storage/dataflux/integration_test.go
+++ b/storage/dataflux/integration_test.go
@@ -70,7 +70,6 @@ func TestMain(m *testing.M) {
 
 // Lists the all the objects in the bucket.
 func TestIntegration_NextBatch_All(t *testing.T) {
-	t.Skip("#11198")
 	if testing.Short() {
 		t.Skip("Integration tests skipped in short mode")
 	}
@@ -97,7 +96,6 @@ func TestIntegration_NextBatch_All(t *testing.T) {
 }
 
 func TestIntegration_NextBatch(t *testing.T) {
-	t.Skip("#11196")
 	// Accessing public bucket to list large number of files in batches.
 	// See https://cloud.google.com/storage/docs/public-datasets/landsat
 	if testing.Short() {

--- a/storage/dataflux/range_splitter.go
+++ b/storage/dataflux/range_splitter.go
@@ -328,6 +328,8 @@ func (rs *rangeSplitter) convertStringRangeToMinimalIntRange(
 
 // charPosition returns the index of the character in the alphabet set.
 func (rs *rangeSplitter) charPosition(ch rune) (int, error) {
+	rs.mu.Lock()         // Acquire the lock
+	defer rs.mu.Unlock() // Release the lock when the function exits
 	if idx, ok := rs.alphabetMap[ch]; ok {
 		return idx, nil
 	}
@@ -337,6 +339,8 @@ func (rs *rangeSplitter) charPosition(ch rune) (int, error) {
 // convertRangeStringToArray transforms the range string into a rune slice while
 // verifying the presence of each character in the alphabets.
 func (rs *rangeSplitter) convertRangeStringToArray(rangeString string) ([]rune, error) {
+	rs.mu.Lock()         // Acquire the lock
+	defer rs.mu.Unlock() // Release the lock when the function exits
 	for _, char := range rangeString {
 		if _, exists := rs.alphabetMap[char]; !exists {
 			return nil, fmt.Errorf("character %c in range string %q is not found in the alphabet array", char, rangeString)

--- a/storage/dataflux/worksteal_test.go
+++ b/storage/dataflux/worksteal_test.go
@@ -22,7 +22,6 @@ import (
 )
 
 func TestWorkstealListingEmulated(t *testing.T) {
-	t.Skip("https://github.com/googleapis/google-cloud-go/issues/11205")
 	transportClientTest(context.Background(), t, func(t *testing.T, ctx context.Context, project, bucket string, client *storage.Client) {
 
 		attrs := &storage.BucketAttrs{


### PR DESCRIPTION
This change addresses an intermittent deadlock issue when reading from the range channel. The fix introduces a 200ms timeout on all reads off of range, opting to re-check for available work if the timeout is triggered. Since this timeout is only applied to reads off of the channel it should not introduce any new blocking behavior.