### PR TITLE
test(all): fix multiple files in significant changes in continuous tests

### DIFF
--- a/internal/kokoro/continuous.sh
+++ b/internal/kokoro/continuous.sh
@@ -159,7 +159,7 @@ if [[ $KOKORO_JOB_NAME == *"continuous"* ]]; then
   # Continuous jobs only run root tests & tests in submodules changed by the PR.
   SIGNIFICANT_CHANGES=$(git --no-pager diff --name-only $KOKORO_GIT_COMMIT^..$KOKORO_GIT_COMMIT | grep -Ev '(\.md$|^\.github|\.json$|\.yaml$)' || true)
 
-  if [ -z $SIGNIFICANT_CHANGES ]; then
+  if [[ -z $SIGNIFICANT_CHANGES ]]; then
     echo "No changes detected, skipping tests"
     exit 0
   fi


### PR DESCRIPTION
`if [ -z $SIGNIFICANT_CHANGES ]; then`

gets translated to for example:

```
+ '[' -z storage/grpc_client.go storage/integration_test.go ']'
```
Which causes the error:
```
github/google-cloud-go/internal/kokoro/continuous.sh: line 162: [: storage/grpc_client.go: binary operator expected
```