### PR TITLE
deprecate(pubsub/v2): remove and rename existing settings

### DIFF
--- a/pubsub/loadtest/loadtest.go
+++ b/pubsub/loadtest/loadtest.go
@@ -66,10 +66,9 @@ func (l *PubServer) Start(ctx context.Context, req *pb.StartRequest) (*pb.StartR
 func (l *PubServer) init(c *pubsub.Client, topicName string, msgSize, batchSize int32, batchDur time.Duration, ordered bool) {
 	topic := c.Topic(topicName)
 	topic.PublishSettings = pubsub.PublishSettings{
-		DelayThreshold:    batchDur,
-		CountThreshold:    950,
-		ByteThreshold:     9500000,
-		BufferedByteLimit: 2e9,
+		DelayThreshold: batchDur,
+		CountThreshold: 950,
+		ByteThreshold:  9500000,
 	}
 	topic.EnableMessageOrdering = ordered
 

--- a/pubsub/v2/iterator_test.go
+++ b/pubsub/v2/iterator_test.go
@@ -402,27 +402,6 @@ func TestIterator_ModifyAckContextDeadline(t *testing.T) {
 	}
 }
 
-func TestIterator_SynchronousPullCancel(t *testing.T) {
-	srv := pstest.NewServer()
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	srv.Publish(fullyQualifiedTopicName, []byte("creating a topic"), nil)
-
-	_, client, err := initConn(ctx, srv.Addr)
-	if err != nil {
-		t.Fatal(err)
-	}
-	iter := newMessageIterator(client.subc, fullyQualifiedTopicName, &pullOptions{})
-
-	// Cancelling the iterator and pulling should not result in any errors.
-	iter.cancel()
-
-	if _, err := iter.pullMessages(100); err != nil {
-		t.Fatalf("Got error in pullMessages: %v", err)
-	}
-}
-
 func TestIterator_BoundedDuration(t *testing.T) {
 	// Use exported fields for time.Duration fields so they
 	// print nicely. Otherwise, they will print as integers.

--- a/pubsub/v2/iterator_test.go
+++ b/pubsub/v2/iterator_test.go
@@ -529,7 +529,6 @@ func TestIterator_StreamingPullExactlyOnce(t *testing.T) {
 	srv.Publish(fullyQualifiedTopicName, []byte("msg"), nil)
 
 	iter := newMessageIterator(client.subc, fullyQualifiedSubName, &pullOptions{
-		synchronous:            false,
 		maxOutstandingMessages: 100,
 		maxOutstandingBytes:    1e6,
 		maxPrefetch:            30,

--- a/pubsub/v2/subscription.go
+++ b/pubsub/v2/subscription.go
@@ -26,7 +26,6 @@ import (
 	ipubsub "cloud.google.com/go/internal/pubsub"
 	"cloud.google.com/go/pubsub/internal/scheduler"
 	"github.com/google/uuid"
-	gax "github.com/googleapis/gax-go/v2"
 	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/sync/errgroup"
@@ -93,33 +92,33 @@ func (s *Subscription) ID() string {
 // ReceiveSettings configure the Receive method.
 // A zero ReceiveSettings will result in values equivalent to DefaultReceiveSettings.
 type ReceiveSettings struct {
-	// MaxExtension is the maximum period for which the Subscription should
+	// MaxExtension is the maximum period for which the subscriber should
 	// automatically extend the ack deadline for each message.
 	//
-	// The Subscription will automatically extend the ack deadline of all
+	// The subscriber will automatically extend the ack deadline of all
 	// fetched Messages up to the duration specified. Automatic deadline
 	// extension beyond the initial receipt may be disabled by specifying a
 	// duration less than 0.
 	MaxExtension time.Duration
 
-	// MaxExtensionPeriod is the maximum duration by which to extend the ack
+	// MaxDurationPerLeaseExtension is the maximum duration by which to extend the ack
 	// deadline at a time. The ack deadline will continue to be extended by up
-	// to this duration until MaxExtension is reached. Setting MaxExtensionPeriod
+	// to this duration until MaxExtension is reached. Setting MaxDurationPerLeaseExtension
 	// bounds the maximum amount of time before a message redelivery in the
 	// event the subscriber fails to extend the deadline.
 	//
-	// MaxExtensionPeriod must be between 10s and 600s (inclusive). This configuration
+	// MaxDurationPerLeaseExtension must be between 10s and 600s (inclusive). This configuration
 	// can be disabled by specifying a duration less than (or equal to) 0.
-	MaxExtensionPeriod time.Duration
+	MaxDurationPerLeaseExtension time.Duration
 
-	// MinExtensionPeriod is the the min duration for a single lease extension attempt.
+	// MinDurationPerLeaseExtension is the the min duration for a single lease extension attempt.
 	// By default the 99th percentile of ack latency is used to determine lease extension
 	// periods but this value can be set to minimize the number of extraneous RPCs sent.
 	//
-	// MinExtensionPeriod must be between 10s and 600s (inclusive). This configuration
+	// MinDurationPerLeaseExtension must be between 10s and 600s (inclusive). This configuration
 	// can be disabled by specifying a duration less than (or equal to) 0.
 	// Disabled by default but set to 60 seconds if the subscription has exactly-once delivery enabled.
-	MinExtensionPeriod time.Duration
+	MinDurationPerLeaseExtension time.Duration
 
 	// MaxOutstandingMessages is the maximum number of unprocessed messages
 	// (unacknowledged but not yet expired). If MaxOutstandingMessages is 0, it
@@ -135,12 +134,6 @@ type ReceiveSettings struct {
 	// for unprocessed messages.
 	MaxOutstandingBytes int
 
-	// UseLegacyFlowControl disables enforcing flow control settings at the Cloud
-	// PubSub server and the less accurate method of only enforcing flow control
-	// at the client side is used.
-	// The default is false.
-	UseLegacyFlowControl bool
-
 	// NumGoroutines sets the number of StreamingPull streams to pull messages
 	// from the subscription.
 	//
@@ -152,52 +145,16 @@ type ReceiveSettings struct {
 	// function passed to Receive on them. To limit the number of messages being
 	// processed concurrently, set MaxOutstandingMessages.
 	NumGoroutines int
-
-	// Synchronous switches the underlying receiving mechanism to unary Pull.
-	// When Synchronous is false, the more performant StreamingPull is used.
-	// StreamingPull also has the benefit of subscriber affinity when using
-	// ordered delivery.
-	// When Synchronous is true, NumGoroutines is set to 1 and only one Pull
-	// RPC will be made to poll messages at a time.
-	// The default is false.
-	//
-	// Deprecated.
-	// Previously, users might use Synchronous mode since StreamingPull had a limitation
-	// where MaxOutstandingMessages was not always respected with large batches of
-	// small messages. With server side flow control, this is no longer an issue
-	// and we recommend switching to the default StreamingPull mode by setting
-	// Synchronous to false.
-	// Synchronous mode does not work with exactly once delivery.
-	Synchronous bool
 }
-
-// For synchronous receive, the time to wait if we are already processing
-// MaxOutstandingMessages. There is no point calling Pull and asking for zero
-// messages, so we pause to allow some message-processing callbacks to finish.
-//
-// The wait time is large enough to avoid consuming significant CPU, but
-// small enough to provide decent throughput. Users who want better
-// throughput should not be using synchronous mode.
-//
-// Waiting might seem like polling, so it's natural to think we could do better by
-// noticing when a callback is finished and immediately calling Pull. But if
-// callbacks finish in quick succession, this will result in frequent Pull RPCs that
-// request a single message, which wastes network bandwidth. Better to wait for a few
-// callbacks to finish, so we make fewer RPCs fetching more messages.
-//
-// This value is unexported so the user doesn't have another knob to think about. Note that
-// it is the same value as the one used for nackTicker, so it matches this client's
-// idea of a duration that is short, but not so short that we perform excessive RPCs.
-const synchronousWaitTime = 100 * time.Millisecond
 
 // DefaultReceiveSettings holds the default values for ReceiveSettings.
 var DefaultReceiveSettings = ReceiveSettings{
-	MaxExtension:           60 * time.Minute,
-	MaxExtensionPeriod:     0,
-	MinExtensionPeriod:     0,
-	MaxOutstandingMessages: 1000,
-	MaxOutstandingBytes:    1e9, // 1G
-	NumGoroutines:          10,
+	MaxExtension:                 60 * time.Minute,
+	MaxDurationPerLeaseExtension: 0,
+	MinDurationPerLeaseExtension: 0,
+	MaxOutstandingMessages:       1000,
+	MaxOutstandingBytes:          1e9, // 1G
+	NumGoroutines:                1,
 }
 
 var errReceiveInProgress = errors.New("pubsub: Receive already in progress for this subscription")
@@ -255,19 +212,17 @@ func (s *Subscription) Receive(ctx context.Context, f func(context.Context, *Mes
 		// If MaxExtension is negative, disable automatic extension.
 		maxExt = 0
 	}
-	maxExtPeriod := s.ReceiveSettings.MaxExtensionPeriod
+	maxExtPeriod := s.ReceiveSettings.MaxDurationPerLeaseExtension
 	if maxExtPeriod < 0 {
-		maxExtPeriod = DefaultReceiveSettings.MaxExtensionPeriod
+		maxExtPeriod = DefaultReceiveSettings.MaxDurationPerLeaseExtension
 	}
-	minExtPeriod := s.ReceiveSettings.MinExtensionPeriod
+	minExtPeriod := s.ReceiveSettings.MinDurationPerLeaseExtension
 	if minExtPeriod < 0 {
-		minExtPeriod = DefaultReceiveSettings.MinExtensionPeriod
+		minExtPeriod = DefaultReceiveSettings.MinDurationPerLeaseExtension
 	}
 
 	var numGoroutines int
 	switch {
-	case s.ReceiveSettings.Synchronous:
-		numGoroutines = 1
 	case s.ReceiveSettings.NumGoroutines >= 1:
 		numGoroutines = s.ReceiveSettings.NumGoroutines
 	default:
@@ -279,10 +234,8 @@ func (s *Subscription) Receive(ctx context.Context, f func(context.Context, *Mes
 		maxExtensionPeriod:     maxExtPeriod,
 		minExtensionPeriod:     minExtPeriod,
 		maxPrefetch:            trunc32(int64(maxCount)),
-		synchronous:            s.ReceiveSettings.Synchronous,
 		maxOutstandingMessages: maxCount,
 		maxOutstandingBytes:    maxBytes,
-		useLegacyFlowControl:   s.ReceiveSettings.UseLegacyFlowControl,
 		clientID:               s.clientID,
 	}
 	fc := newSubscriptionFlowController(FlowControlSettings{
@@ -332,28 +285,6 @@ func (s *Subscription) Receive(ctx context.Context, f func(context.Context, *Mes
 			defer cancel2()
 			for {
 				var maxToPull int32 // maximum number of messages to pull
-				if po.synchronous {
-					if po.maxPrefetch < 0 {
-						// If there is no limit on the number of messages to
-						// pull, use a reasonable default.
-						maxToPull = 1000
-					} else {
-						// Limit the number of messages in memory to MaxOutstandingMessages
-						// (here, po.maxPrefetch). For each message currently in memory, we have
-						// called fc.acquire but not fc.release: this is fc.count(). The next
-						// call to Pull should fetch no more than the difference between these
-						// values.
-						maxToPull = po.maxPrefetch - int32(fc.count())
-						if maxToPull <= 0 {
-							// Wait for some callbacks to finish.
-							if err := gax.Sleep(ctx, synchronousWaitTime); err != nil {
-								// Return nil if the context is done, not err.
-								return nil
-							}
-							continue
-						}
-					}
-				}
 				// If the context is done, don't pull more messages.
 				select {
 				case <-ctx.Done():
@@ -503,9 +434,7 @@ type pullOptions struct {
 	maxPrefetch        int32         // the max number of outstanding messages, used to calculate maxToPull
 	// If true, use unary Pull instead of StreamingPull, and never pull more
 	// than maxPrefetch messages.
-	synchronous            bool
 	maxOutstandingMessages int
 	maxOutstandingBytes    int
-	useLegacyFlowControl   bool
 	clientID               string
 }

--- a/pubsub/v2/subscription_test.go
+++ b/pubsub/v2/subscription_test.go
@@ -66,13 +66,13 @@ func getSubIDs(subs []*Subscription) []string {
 }
 
 func TestReceive(t *testing.T) {
-	testReceive(t, true, false)
-	testReceive(t, false, false)
-	testReceive(t, false, true)
+	testReceive(t, false)
+	testReceive(t, false)
+	testReceive(t, true)
 }
 
-func testReceive(t *testing.T, synchronous, exactlyOnceDelivery bool) {
-	t.Run(fmt.Sprintf("synchronous:%t,exactlyOnceDelivery:%t", synchronous, exactlyOnceDelivery), func(t *testing.T) {
+func testReceive(t *testing.T, exactlyOnceDelivery bool) {
+	t.Run(fmt.Sprintf("exactlyOnceDelivery:%t", exactlyOnceDelivery), func(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 		defer cancel()
 		client, srv := newFake(t)
@@ -90,7 +90,6 @@ func testReceive(t *testing.T, synchronous, exactlyOnceDelivery bool) {
 		for i := 0; i < 256; i++ {
 			srv.Publish(topic.name, []byte{byte(i)}, nil)
 		}
-		sub.ReceiveSettings.Synchronous = synchronous
 		msgs, err := pullN(ctx, sub, 256, 0, func(_ context.Context, m *Message) {
 			if exactlyOnceDelivery {
 				ar := m.AckWithResult()
@@ -115,7 +114,7 @@ func testReceive(t *testing.T, synchronous, exactlyOnceDelivery bool) {
 		}
 		for i, saw := range seen {
 			if !saw {
-				t.Errorf("sync=%t, eod=%t: did not see message #%d", synchronous, exactlyOnceDelivery, i)
+				t.Errorf("eod=%t: did not see message #%d", exactlyOnceDelivery, i)
 			}
 		}
 	})

--- a/pubsub/v2/topic.go
+++ b/pubsub/v2/topic.go
@@ -108,14 +108,6 @@ type PublishSettings struct {
 	// The maximum time that the client will attempt to publish a bundle of messages.
 	Timeout time.Duration
 
-	// The maximum number of bytes that the Bundler will keep in memory before
-	// returning ErrOverflow. This is now superseded by FlowControlSettings.MaxOutstandingBytes.
-	// If MaxOutstandingBytes is set, that value will override BufferedByteLimit.
-	//
-	// Defaults to DefaultPublishSettings.BufferedByteLimit.
-	// Deprecated: Set `Topic.PublishSettings.FlowControlSettings.MaxOutstandingBytes` instead.
-	BufferedByteLimit int
-
 	// FlowControlSettings defines publisher flow control settings.
 	FlowControlSettings FlowControlSettings
 
@@ -137,10 +129,6 @@ var DefaultPublishSettings = PublishSettings{
 	CountThreshold: 100,
 	ByteThreshold:  1e6,
 	Timeout:        60 * time.Second,
-	// By default, limit the bundler to 10 times the max message size. The number 10 is
-	// chosen as a reasonable amount of messages in the worst case whilst still
-	// capping the number to a low enough value to not OOM users.
-	BufferedByteLimit: 10 * MaxPublishRequestBytes,
 	FlowControlSettings: FlowControlSettings{
 		MaxOutstandingMessages: 1000,
 		MaxOutstandingBytes:    -1,
@@ -391,24 +379,13 @@ func (t *Topic) initBundler() {
 	if t.PublishSettings.FlowControlSettings.MaxOutstandingBytes > 0 {
 		b := t.PublishSettings.FlowControlSettings.MaxOutstandingBytes
 		fcs.MaxOutstandingBytes = b
-
-		// If MaxOutstandingBytes is set, disable BufferedByteLimit by setting it to maxint.
-		// This is because there's no way to set "unlimited" for BufferedByteLimit,
-		// and simply setting it to MaxOutstandingBytes occasionally leads to issues where
-		// BufferedByteLimit is reached even though there are resources available.
-		t.PublishSettings.BufferedByteLimit = maxInt
+		t.scheduler.BufferedByteLimit = b
 	}
 	if t.PublishSettings.FlowControlSettings.MaxOutstandingMessages > 0 {
 		fcs.MaxOutstandingMessages = t.PublishSettings.FlowControlSettings.MaxOutstandingMessages
 	}
 
 	t.flowController = newTopicFlowController(fcs)
-
-	bufferedByteLimit := DefaultPublishSettings.BufferedByteLimit
-	if t.PublishSettings.BufferedByteLimit > 0 {
-		bufferedByteLimit = t.PublishSettings.BufferedByteLimit
-	}
-	t.scheduler.BufferedByteLimit = bufferedByteLimit
 
 	// Calculate the max limit of a single bundle. 5 comes from the number of bytes
 	// needed to be reserved for encoding the PubsubMessage repeated field.

--- a/pubsub/v2/topic.go
+++ b/pubsub/v2/topic.go
@@ -49,13 +49,6 @@ const (
 	MaxPublishRequestBytes = 1e7
 )
 
-const (
-	// TODO: math.MaxInt was added in Go 1.17. We should use that once 1.17
-	// becomes the minimum supported version of Go.
-	intSize = 32 << (^uint(0) >> 63)
-	maxInt  = 1<<(intSize-1) - 1
-)
-
 // ErrOversizedMessage indicates that a message's size exceeds MaxPublishRequestBytes.
 var ErrOversizedMessage = bundler.ErrOversizedItem
 


### PR DESCRIPTION
Part of #11368 

- [x] Settings refactoring (removal, renaming, default settings changes below)
  - [x] Remove data plane logic for synchronous mode
  - [x] BufferedByteLimit logic is now synonymous with MaxOutstandingBytes  

## Removal

- PublishSettings.BufferedByteLimit
- ReceiveSettings.Synchronous
- ReceiveSettings.UseLegacyFlowControl

## Rename

- MaxExtensionPeriod -> MaxDurationPerLeaseExtension
- MinExtensionPeriod -> MinDurationPerLeaseExtension

## Default changes

- NumGoroutines (aka num streams) = 10 -> 1

