### PR TITLE
chore: update remaining usages of Go 1.21 to 1.22

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-ARG VARIANT="1-1.21-bullseye"
+ARG VARIANT="1-1.22-bullseye"
 FROM mcr.microsoft.com/devcontainers/go:${VARIANT}
 
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/go
 {
-	"name": "Go 1.21.0",
+	"name": "Go 1.22.0",
 	"build": {
 		"dockerfile": "Dockerfile"
 	},

--- a/.github/workflows/vet.sh
+++ b/.github/workflows/vet.sh
@@ -80,7 +80,7 @@ golint ./... 2>&1 | (
 ) |
   tee /dev/stderr | (! read)
 
-staticcheck -go 1.15 ./... 2>&1 | (
+staticcheck -go 1.22 ./... 2>&1 | (
   grep -v SA1019 |
     grep -v go-cloud-debug-agent |
     grep -v internal/btree/btree.go |

--- a/.github/workflows/vet.yml
+++ b/.github/workflows/vet.yml
@@ -21,10 +21,9 @@ jobs:
       with:
         go-version: '1.22.x'
     - name: Install tools
-      # go: golang.org/x/tools/cmd/goimports@latest: golang.org/x/tools@v0.25.0 requires go >= 1.22.0
       run: |
         go install golang.org/x/lint/golint@latest && \
-        go install golang.org/x/tools/cmd/goimports@v0.24.0 && \
-        go install honnef.co/go/tools/cmd/staticcheck@v0.4.7
+        go install golang.org/x/tools/cmd/goimports@v0.29.0 && \
+        go install honnef.co/go/tools/cmd/staticcheck@v0.5.1
     - name: Execute vet.sh
       run: ./.github/workflows/vet.sh

--- a/internal/postprocessor/Dockerfile
+++ b/internal/postprocessor/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.21 as builder
+FROM golang:1.22 as builder
 
 # Copy local code to the container image.
 COPY . /postprocessor/

--- a/internal/postprocessor/main.go
+++ b/internal/postprocessor/main.go
@@ -45,7 +45,7 @@ const (
 	// This is the default Go version that will be generated into new go.mod
 	// files. It should be updated every time we drop support for old Go
 	// versions.
-	defaultGoModuleVersion = "1.21"
+	defaultGoModuleVersion = "1.22"
 )
 
 var (

--- a/profiler/kokoro/integration_test.sh
+++ b/profiler/kokoro/integration_test.sh
@@ -36,8 +36,8 @@ export GOOGLE_APPLICATION_CREDENTIALS="${KOKORO_KEYSTORE_DIR}/72935_cloud-profil
 export GCLOUD_TESTS_GOLANG_PROJECT_ID="cloud-profiler-e2e"
 
 # Ensure a newer version of Go is used so it is compatible with newer libraries.
-# Here we install v1.21.3 which is the current version as of October 2023.
-GOVERSION="1.21.3"
+# Here we install v1.22.10 which is the current version as of January 2025.
+GOVERSION="1.22.10"
 retry curl -LO https://go.dev/dl/go${GOVERSION}.linux-amd64.tar.gz
 sudo rm -rf /usr/local/go && tar -C /usr/local -xzf go${GOVERSION}.linux-amd64.tar.gz
 export PATH=$PATH:/usr/local/go/bin

--- a/storage/internal/benchmarks/continuous_reads.go
+++ b/storage/internal/benchmarks/continuous_reads.go
@@ -19,7 +19,7 @@ import (
 	"math/rand"
 	"os"
 	"path"
-	"sort"
+	"slices"
 	"sync"
 	"time"
 
@@ -183,10 +183,7 @@ func (r *continuousReads) run(ctx context.Context) error {
 }
 
 func (r *continuousReads) compileResults() {
-	// TO-DO: switch to slices.Sort(r.results) when Go<1.21 support is dropped
-	sort.Slice(r.results, func(i, j int) bool {
-		return r.results[i] < r.results[j]
-	})
+	slices.Sort(r.results)
 	l := len(r.results)
 
 	percentiles := map[string]time.Duration{

--- a/storage/transfermanager/downloader.go
+++ b/storage/transfermanager/downloader.go
@@ -815,14 +815,6 @@ type DownloadOutput struct {
 	crc32c      uint32
 }
 
-// TODO: use built-in after go < 1.21 is dropped.
-func min(a, b int64) int64 {
-	if a < b {
-		return a
-	}
-	return b
-}
-
 // numShards calculates how many shards the given range should be divided into
 // given the part size.
 func numShards(attrs *storage.ReaderObjectAttrs, r *DownloadRange, partSize int64) int {


### PR DESCRIPTION
I found a few places in the codebase where Go 1.21 is still used after support for it has officially been dropped. This updates those to Go 1.22.