### PR TITLE
feat(spanner): add mTLS support external spanner hosts

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -87,6 +87,7 @@ golang.org/x/tools v0.15.0/go.mod h1:hpksKq4dtpQWS1uQ61JkdqWM3LscIS6Slf+VVkm+wQk
 golang.org/x/tools v0.19.0/go.mod h1:qoJWxmGSIBmAeriMx19ogtrEPrGtDbPK634QFIcLAhc=
 golang.org/x/tools v0.23.0/go.mod h1:pnu6ufv6vQkll6szChhK3C3L/ruaIv5eBeztNG8wtsI=
 google.golang.org/api v0.174.0/go.mod h1:aC7tB6j0HR1Nl0ni5ghpx6iLasmAX78Zkh/wgxAAjLg=
+google.golang.org/genproto v0.0.0-20200806141610-86f49bd18e98/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20230725213213-b022f6e96895/go.mod h1:0ggbjUrZYpy1q+ANUS30SEoGZ53cdfwtbuG7Ptgy108=
 google.golang.org/genproto v0.0.0-20230731193218-e0aa005b6bdf/go.mod h1:oH/ZOT02u4kWEp7oYBGYFFkCdKS/uYR9Z7+0/xuuFp8=
 google.golang.org/genproto/googleapis/api v0.0.0-20230725213213-b022f6e96895/go.mod h1:rsr7RhLuwsDKL7RmgDDCUc6yaGr1iqceVb5Wv6f6YvQ=
@@ -98,4 +99,5 @@ google.golang.org/genproto/googleapis/bytestream v0.0.0-20240513163218-0867130af
 google.golang.org/genproto/googleapis/rpc v0.0.0-20230725213213-b022f6e96895/go.mod h1:TUfxEVdsvPg18p6AslUXFoLdpED4oBnGwyqk3dV1XzM=
 google.golang.org/grpc v1.67.0/go.mod h1:1gLDyUQU7CTLJI90u3nXZ9ekeghjeM7pTDZlqFNg2AA=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.3.0/go.mod h1:Dk1tviKTvMCz5tvh7t+fh94dhmQVHuCt2OzJB3CTW9Y=
+google.golang.org/grpc/examples v0.0.0-20201112215255-90f1b3ee835b/go.mod h1:IBqQ7wSUJ2Ep09a8rMWFsg4fmI2r38zwsq8a0GgxXpM=
 sigs.k8s.io/yaml v1.3.0/go.mod h1:GeOyir5tyXNByN85N/dRIT9es5UQNerPYEKK56eTBm8=

--- a/spanner/client.go
+++ b/spanner/client.go
@@ -1424,12 +1424,18 @@ func CertPool(caCertFile string) (*x509.CertPool, error) {
 // - clientCertificateKey: Path to the private key associated with the client certificate.
 // - The returned gRPC connection can be passed to `option.WithGRPCConn(grpcConn)` to create a client using mTLS.
 func NewMtlsConn(endpoint, caCertificate, clientCertificate, clientCertificateKey string) (*grpc.ClientConn, error) {
+	if clientCertificate == "" || clientCertificateKey == "" {
+		return nil, fmt.Errorf("client certificate and key are mandatory for mTLS connection")
+	}
 	cert, err := tls.LoadX509KeyPair(clientCertificate, clientCertificateKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load client cert and key: %w", err)
 	}
 	clientCerts := []tls.Certificate{cert}
 
+	if caCertificate == "" {
+		return nil, fmt.Errorf("ca certificate is required for mTLS connection")
+	}
 	// Create a TLSConfig with the client certificate source.
 	capool, err := CertPool(caCertificate)
 	if err != nil {

--- a/spanner/client.go
+++ b/spanner/client.go
@@ -1432,7 +1432,6 @@ func NewMtlsConn(endpoint, caCertificate, clientCertificate, clientCertificateKe
 
 	// Create a TLSConfig with the client certificate source.
 	capool, err := CertPool(caCertificate)
-
 	if err != nil {
 		return nil, fmt.Errorf("failed to load root CA: %w", err)
 	}
@@ -1448,17 +1447,13 @@ func NewMtlsConn(endpoint, caCertificate, clientCertificate, clientCertificateKe
 	}
 
 	creds, err := advancedtls.NewClientCreds(options)
-
 	if err != nil {
 		return nil, fmt.Errorf("failed to create mTLS credentials: %w", err)
 	}
-
 	grpcConn, err := grpc.NewClient(endpoint, grpc.WithTransportCredentials(creds))
-
 	if err != nil {
 		return nil, err
 	}
-
 	return grpcConn, nil
 }
 

--- a/spanner/go.mod
+++ b/spanner/go.mod
@@ -53,4 +53,5 @@ require (
 	golang.org/x/sys v0.28.0 // indirect
 	golang.org/x/text v0.21.0 // indirect
 	golang.org/x/time v0.8.0 // indirect
+	google.golang.org/grpc/security/advancedtls v1.0.0 // indirect
 )

--- a/spanner/go.sum
+++ b/spanner/go.sum
@@ -1540,6 +1540,8 @@ google.golang.org/grpc v1.56.3/go.mod h1:I9bI3vqKfayGqPUAwGdOSu7kt6oIJLixfffKrpX
 google.golang.org/grpc v1.67.3 h1:OgPcDAFKHnH8X3O4WcO4XUc8GRDeKsKReqbQtiCj7N8=
 google.golang.org/grpc v1.67.3/go.mod h1:YGaHCc6Oap+FzBJTZLBzkGSYt/cvGPFTPxkn7QfSU8s=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
+google.golang.org/grpc/security/advancedtls v1.0.0 h1:/KQ7VP/1bs53/aopk9QhuPyFAp9Dm9Ejix3lzYkCrDA=
+google.golang.org/grpc/security/advancedtls v1.0.0/go.mod h1:o+s4go+e1PJ2AjuQMY5hU82W7lDlefjJA6FqEHRVHWk=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=


### PR DESCRIPTION
Add support for creating gRPC client connection using mutual TLS (mTLS) for external spanner hosts