### PR TITLE
fix(storage): return the appropriate error for method not supported

### DIFF
--- a/storage/http_client.go
+++ b/storage/http_client.go
@@ -863,7 +863,7 @@ func (c *httpStorageClient) RewriteObject(ctx context.Context, req *rewriteObjec
 
 // NewMultiRangeDownloader is not supported by http client.
 func (c *httpStorageClient) NewMultiRangeDownloader(ctx context.Context, params *newMultiRangeDownloaderParams, opts ...storageOption) (mr *MultiRangeDownloader, err error) {
-	return nil, errMethodNotValid
+	return nil, errMethodNotSupported
 }
 
 func (c *httpStorageClient) NewRangeReader(ctx context.Context, params *newRangeReaderParams, opts ...storageOption) (r *Reader, err error) {

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -72,8 +72,8 @@ var (
 	// errMethodNotSupported indicates that the method called is not currently supported by the client.
 	// TODO: Export this error when launching the transport-agnostic client.
 	errMethodNotSupported = errors.New("storage: method is not currently supported")
-	// errMethodNotValid indicates that given HTTP method is not valid.
-	errMethodNotValid = fmt.Errorf("storage: HTTP method should be one of %v", reflect.ValueOf(signedURLMethods).MapKeys())
+	// errSignedUrlMethodNotValid indicates that given HTTP method is not valid.
+	errSignedUrlMethodNotValid = fmt.Errorf("storage: HTTP method should be one of %v", reflect.ValueOf(signedURLMethods).MapKeys())
 )
 
 var userAgent = fmt.Sprintf("gcloud-golang-storage/%s", internal.Version)
@@ -689,7 +689,7 @@ func validateOptions(opts *SignedURLOptions, now time.Time) error {
 	}
 	opts.Method = strings.ToUpper(opts.Method)
 	if _, ok := signedURLMethods[opts.Method]; !ok {
-		return errMethodNotValid
+		return errSignedUrlMethodNotValid
 	}
 	if opts.Expires.IsZero() {
 		return errors.New("storage: missing required expires option")

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -72,8 +72,8 @@ var (
 	// errMethodNotSupported indicates that the method called is not currently supported by the client.
 	// TODO: Export this error when launching the transport-agnostic client.
 	errMethodNotSupported = errors.New("storage: method is not currently supported")
-	// errSignedUrlMethodNotValid indicates that given HTTP method is not valid.
-	errSignedUrlMethodNotValid = fmt.Errorf("storage: HTTP method should be one of %v", reflect.ValueOf(signedURLMethods).MapKeys())
+	// errSignedURLMethodNotValid indicates that given HTTP method is not valid.
+	errSignedURLMethodNotValid = fmt.Errorf("storage: HTTP method should be one of %v", reflect.ValueOf(signedURLMethods).MapKeys())
 )
 
 var userAgent = fmt.Sprintf("gcloud-golang-storage/%s", internal.Version)
@@ -689,7 +689,7 @@ func validateOptions(opts *SignedURLOptions, now time.Time) error {
 	}
 	opts.Method = strings.ToUpper(opts.Method)
 	if _, ok := signedURLMethods[opts.Method]; !ok {
-		return errSignedUrlMethodNotValid
+		return errSignedURLMethodNotValid
 	}
 	if opts.Expires.IsZero() {
 		return errors.New("storage: missing required expires option")

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -540,7 +540,7 @@ func TestSignedURL_MissingOptions(t *testing.T) {
 				GoogleAccessID: "access_id",
 				PrivateKey:     pk,
 			},
-			errMethodNotValid.Error(),
+			errSignedUrlMethodNotValid.Error(),
 		},
 		{
 			&SignedURLOptions{
@@ -548,7 +548,7 @@ func TestSignedURL_MissingOptions(t *testing.T) {
 				PrivateKey:     pk,
 				Method:         "getMethod", // wrong method name
 			},
-			errMethodNotValid.Error(),
+			errSignedUrlMethodNotValid.Error(),
 		},
 		{
 			&SignedURLOptions{
@@ -563,7 +563,7 @@ func TestSignedURL_MissingOptions(t *testing.T) {
 				GoogleAccessID: "access_id",
 				SignBytes:      func(b []byte) ([]byte, error) { return b, nil },
 			},
-			errMethodNotValid.Error(),
+			errSignedUrlMethodNotValid.Error(),
 		},
 		{
 			&SignedURLOptions{
@@ -611,7 +611,7 @@ func TestSignedURL_MissingOptions(t *testing.T) {
 				Expires:        expires,
 				Scheme:         SigningSchemeV4,
 			},
-			errMethodNotValid.Error(),
+			errSignedUrlMethodNotValid.Error(),
 		},
 		{
 			&SignedURLOptions{

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -540,7 +540,7 @@ func TestSignedURL_MissingOptions(t *testing.T) {
 				GoogleAccessID: "access_id",
 				PrivateKey:     pk,
 			},
-			errSignedUrlMethodNotValid.Error(),
+			errSignedURLMethodNotValid.Error(),
 		},
 		{
 			&SignedURLOptions{
@@ -548,7 +548,7 @@ func TestSignedURL_MissingOptions(t *testing.T) {
 				PrivateKey:     pk,
 				Method:         "getMethod", // wrong method name
 			},
-			errSignedUrlMethodNotValid.Error(),
+			errSignedURLMethodNotValid.Error(),
 		},
 		{
 			&SignedURLOptions{
@@ -563,7 +563,7 @@ func TestSignedURL_MissingOptions(t *testing.T) {
 				GoogleAccessID: "access_id",
 				SignBytes:      func(b []byte) ([]byte, error) { return b, nil },
 			},
-			errSignedUrlMethodNotValid.Error(),
+			errSignedURLMethodNotValid.Error(),
 		},
 		{
 			&SignedURLOptions{
@@ -611,7 +611,7 @@ func TestSignedURL_MissingOptions(t *testing.T) {
 				Expires:        expires,
 				Scheme:         SigningSchemeV4,
 			},
-			errSignedUrlMethodNotValid.Error(),
+			errSignedURLMethodNotValid.Error(),
 		},
 		{
 			&SignedURLOptions{


### PR DESCRIPTION
The current error has information specific to signed urls which may be confusing. I changed that var name as well so as to avoid this confusion in the future.