### PR TITLE
chore: fix automation for ai release

### DIFF
--- a/internal/postprocessor/releaseplease.go
+++ b/internal/postprocessor/releaseplease.go
@@ -31,8 +31,6 @@ var unreleasedModuleDir map[string]bool = map[string]bool{
 
 var individuallyReleasedModules map[string]bool = map[string]bool{
 	".":                true,
-	"ai":               true,
-	"aiplatform":       true,
 	"auth":             true,
 	"auth/oauth2adapt": true,
 	"bigquery":         true,

--- a/release-please-config-yoshi-submodules.json
+++ b/release-please-config-yoshi-submodules.json
@@ -12,6 +12,12 @@
         "advisorynotifications": {
             "component": "advisorynotifications"
         },
+        "ai": {
+            "component": "ai"
+        },
+        "aiplatform": {
+            "component": "aiplatform"
+        },
         "alloydb": {
             "component": "alloydb"
         },


### PR DESCRIPTION
We used to release these module individually. We no londer due and marking them as such in the post processor manipulates the release please configuration files.