### PR TITLE
test(storage): run metrics enablement test only once

### DIFF
--- a/storage/integration_test.go
+++ b/storage/integration_test.go
@@ -635,7 +635,14 @@ func TestIntegration_DoNotDetectDirectConnectivityWhenDisabled(t *testing.T) {
 	}, internaloption.EnableDirectPath(false))
 }
 
+// TestIntegration_MetricsEnablement does not use multiTransportTest because it
+// only has to run once, and creating the manual reader multiple times can
+// cause it to be registered multiple times to packages that enable by default.
 func TestIntegration_MetricsEnablement(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Integration tests skipped in short mode")
+	}
+
 	var (
 		ctx           = context.Background()
 		prefix        = grpcTestPrefix


### PR DESCRIPTION
Fixes #11397

Same change should be made to currently skipped Metrics in GCE test (which may need to be merged with this test to avoid the same issue, and/or we should turn off internal logging).

This test only has to run once, and creating the manual reader multiple times causes issues.