### PR TITLE
test(storage): set ACL for reqpays buckets on creation

### DIFF
--- a/storage/integration_test.go
+++ b/storage/integration_test.go
@@ -6716,14 +6716,10 @@ func setUpRequesterPaysBucket(ctx context.Context, t *testing.T, bucket, object 
 
 	requesterPaysBucket := client.Bucket(bucket)
 
-	// Create a requester-pays bucket.
-	h.mustCreate(requesterPaysBucket, testutil.ProjID(), &BucketAttrs{RequesterPays: true})
+	// Create a requester-pays bucket with ownership.
+	addACL := []ACLRule{ACLRule{Entity: ACLEntity(fmt.Sprintf("user-%s", addOwnerEmail)), Role: RoleOwner}}
+	h.mustCreate(requesterPaysBucket, testutil.ProjID(), &BucketAttrs{RequesterPays: true, ACL: addACL})
 	t.Cleanup(func() { h.mustDeleteBucket(requesterPaysBucket) })
-
-	// Grant ownership
-	if err := requesterPaysBucket.ACL().Set(ctx, ACLEntity("user-"+addOwnerEmail), RoleOwner); err != nil {
-		t.Fatalf("set ACL: %v", err)
-	}
 
 	h.mustWrite(requesterPaysBucket.Object(object).NewWriter(ctx), []byte("hello"))
 	t.Cleanup(func() {


### PR DESCRIPTION
Fixes #10607

If this does not fix the issue, we should just wrap these calls in retry loops for the permission issue.


Internal: see yaqs 5039777572167090176