### PR TITLE
fix(spanner): ReadWriteStmtBasedTransaction would not remember options for retries

### DIFF
--- a/spanner/transaction.go
+++ b/spanner/transaction.go
@@ -1886,6 +1886,7 @@ func newReadWriteStmtBasedTransactionWithSessionHandle(ctx context.Context, c *C
 		return err
 	}
 
+	t.options = options
 	t.txOpts = c.txo.merge(options)
 	t.ct = c.ct
 	t.otConfig = c.otConfig

--- a/spanner/transaction_test.go
+++ b/spanner/transaction_test.go
@@ -888,10 +888,13 @@ func testReadWriteStmtBasedTransaction(t *testing.T, executionTimes map[string]S
 		if attempts > 1 {
 			tx, err = tx.ResetForRetry(ctx)
 		} else {
-			tx, err = NewReadWriteStmtBasedTransaction(ctx, client)
+			tx, err = NewReadWriteStmtBasedTransactionWithOptions(ctx, client, TransactionOptions{TransactionTag: "test"})
 		}
 		if err != nil {
 			return 0, attempts, fmt.Errorf("failed to begin a transaction: %v", err)
+		}
+		if g, w := tx.options.TransactionTag, "test"; g != w {
+			t.Errorf("transaction tag mismatch\n Got: %v\nWant: %v", g, w)
 		}
 		rowCount, err = f(tx)
 		if err != nil && status.Code(err) != codes.Aborted {


### PR DESCRIPTION
Any TransactionOptions that had been set for a ReadWriteStmtBasedTransaction would not be remember and carried over if the transaction was retried. This would cause the retry to for example miss the transaction tag.