### PR TITLE
testing(bigquery/storage/managedwriter): fix go-cmp diff usage

### DIFF
--- a/bigquery/storage/managedwriter/options_test.go
+++ b/bigquery/storage/managedwriter/options_test.go
@@ -342,7 +342,7 @@ func TestWriterOptions(t *testing.T) {
 
 		if diff := cmp.Diff(got, tc.want,
 			cmp.AllowUnexported(ManagedStream{}, streamSettings{}),
-			cmp.AllowUnexported(sync.Mutex{}),
+			cmpopts.IgnoreTypes(sync.Mutex{}),
 			cmp.AllowUnexported(versionedTemplate{}),
 			cmpopts.IgnoreFields(versionedTemplate{}, "versionTime", "hashVal"),
 			protocmp.Transform(), // versionedTemplate embeds proto messages.


### PR DESCRIPTION
This switches usage of sync.Mutex in options testing from allowing unexported to ignoring outright.  There's changes to the sync package in the latest versions of go head that aren't compatible with AllowUnexported, and the comparison isn't relevant to the code under test.