### PR TITLE
feat(bigquery/storage/managedwriter): graceful connection drains

### DIFF
--- a/bigquery/storage/managedwriter/connection.go
+++ b/bigquery/storage/managedwriter/connection.go
@@ -37,6 +37,8 @@ const (
 
 var (
 	errNoRouterForPool = errors.New("no router for connection pool")
+	// TODO: consider if this should be user configurable
+	gracefulReconnectDuration = 20 * time.Second
 )
 
 // connectionPool represents a pooled set of connections.
@@ -491,10 +493,9 @@ func (co *connection) getStream(arc *storagepb.BigQueryWrite_AppendRowsClient, f
 	}
 	if co.cancel != nil {
 		// Delay cancellation to give queued writes a chance to drain normally.
-		// TODO: Revisit this to see if this should be user configurable.
 		oldCancel := co.cancel
 		go func() {
-			time.Sleep(20 * time.Second)
+			time.Sleep(gracefulReconnectDuration)
 			oldCancel()
 		}()
 		co.ctx, co.cancel = context.WithCancel(co.pool.ctx)

--- a/bigquery/storage/managedwriter/connection.go
+++ b/bigquery/storage/managedwriter/connection.go
@@ -37,7 +37,7 @@ const (
 
 var (
 	errNoRouterForPool = errors.New("no router for connection pool")
-	// TODO: consider if this should be user configurable
+	// TODO(https://github.com/googleapis/google-cloud-go/issues/11460): revisit if this should be user configurable
 	gracefulReconnectDuration = 20 * time.Second
 )
 

--- a/bigquery/storage/managedwriter/managed_stream_test.go
+++ b/bigquery/storage/managedwriter/managed_stream_test.go
@@ -519,7 +519,7 @@ func TestManagedStream_LeakingGoroutinesReconnect(t *testing.T) {
 		[]byte("foo"),
 	}
 
-	appendCount := 10
+	appendCount := 15
 	// Give a small budget for additional goroutines to account for jitter.
 	threshold := runtime.NumGoroutine() + 5
 
@@ -545,7 +545,7 @@ func TestManagedStream_LeakingGoroutinesReconnect(t *testing.T) {
 		// and a graceful cancellation, but this should recover over time.
 		threshold = threshold + 2
 
-		if i%10 == 0 {
+		if i%5 == 0 {
 			if current := runtime.NumGoroutine(); current > threshold {
 				t.Errorf("potential goroutine leak, append %d: current %d, threshold %d", i, current, threshold)
 			}

--- a/bigquery/storage/managedwriter/managed_stream_test.go
+++ b/bigquery/storage/managedwriter/managed_stream_test.go
@@ -552,7 +552,7 @@ func TestManagedStream_LeakingGoroutinesReconnect(t *testing.T) {
 		}
 	}
 	// Verify goroutine count drops after graceful shutdowns should have concluded.
-	time.Sleep(22 * time.Second)
+	time.Sleep(gracefulReconnectDuration)
 	threshold = threshold - (2 * appendCount)
 
 	if current := runtime.NumGoroutine(); current > threshold {


### PR DESCRIPTION
This PR enables a more graceful shutdown when we're doing client initiated reconnects, typically in response to things like schema changes.

With this PR, rather than immediately cancelling the previous connection context, we instead use a goroutine to defer this by a fixed interval, which gives our recv goroutine more time to process any incoming notifications from the service.

This can yield reductions in duplicate rows for some scenarios, particularly when EnableWriteRetries is enabled and we see sequential disconnects (e.g. a multiplex connection observing a number of schema updates).

It does, however, yield possible short term increases in resource usage, as we're now potentially retaining goroutines/channels/connections for a longer interval during these reconnect events.  This PR updates testing that looks for leaking resources with this new understanding accordingly.

Towards: https://github.com/googleapis/google-cloud-go/issues/11460