### PR TITLE
spanner: fix otel server-timing metadata panic

### DIFF
--- a/spanner/ot_metrics.go
+++ b/spanner/ot_metrics.go
@@ -245,8 +245,10 @@ func recordGFELatencyMetricsOT(ctx context.Context, md metadata.MD, keyMethod st
 		return nil
 	}
 	attr := otConfig.attributeMap
-	if len(md.Get("server-timing")) == 0 && otConfig.gfeHeaderMissingCount != nil {
-		otConfig.gfeHeaderMissingCount.Add(ctx, 1, metric.WithAttributes(attr...))
+	if len(md.Get("server-timing")) == 0 {
+		if otConfig.gfeHeaderMissingCount != nil {
+			otConfig.gfeHeaderMissingCount.Add(ctx, 1, metric.WithAttributes(attr...))
+		}
 		return nil
 	}
 	serverTiming := md.Get("server-timing")[0]


### PR DESCRIPTION
If OTel metrics is enabled and the server-timing response metadata is missing, this code panics.