### PR TITLE
chore: update go postprocessor version

### DIFF
--- a/internal/postprocessor/main.go
+++ b/internal/postprocessor/main.go
@@ -45,7 +45,7 @@ const (
 	// This is the default Go version that will be generated into new go.mod
 	// files. It should be updated every time we drop support for old Go
 	// versions.
-	defaultGoModuleVersion = "1.22"
+	defaultGoModuleVersion = "1.22.7"
 )
 
 var (


### PR DESCRIPTION
We need to pin the go version used for creating modules in the postprocessor. If it is not pinned the latest is assumed -- which will go out of date each time a new version of Go is released.