### PR TITLE
feat(spanner): make randIDForProcess hexadecimal in x-goog-spanner-request-id

### DIFF
--- a/spanner/request_id_header.go
+++ b/spanner/request_id_header.go
@@ -46,7 +46,7 @@ func init() {
 	if err != nil {
 		panic(err)
 	}
-	randIDForProcess = r64.String()
+	randIDForProcess = fmt.Sprintf("%016x", r64.Uint64())
 }
 
 // Please bump this version whenever this implementation

--- a/spanner/request_id_header_test.go
+++ b/spanner/request_id_header_test.go
@@ -16,6 +16,7 @@ package spanner
 
 import (
 	"context"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"math"
@@ -1923,5 +1924,15 @@ func TestRequestIDHeader_SingleUseReadOnly_ExecuteStreamingSql_UnavailableDuring
 	}
 	if diff := cmp.Diff(interceptorTracker.streamClientRequestIDSegments, wantStreamingSegments); diff != "" {
 		t.Fatalf("RequestID streaming segments mismatch: got - want +\n%s", diff)
+	}
+}
+
+func TestRequestID_randIDForProcessIsHexadecimal(t *testing.T) {
+	decoded, err := hex.DecodeString(randIDForProcess)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(decoded) == 0 {
+		t.Fatal("Expected a non-empty decoded result")
 	}
 }


### PR DESCRIPTION
Implements a new requirement that randIDForProcess should be a hexadecimal value with the format specifier "%016x".

Fixes #11545