### PR TITLE
feat(auth): Add hard-bound token request to compute token provider.

### DIFF
--- a/auth/credentials/compute.go
+++ b/auth/credentials/compute.go
@@ -39,8 +39,9 @@ var (
 // uses the metadata service to retrieve tokens.
 func computeTokenProvider(opts *DetectOptions, client *metadata.Client) auth.TokenProvider {
 	return auth.NewCachedTokenProvider(&computeProvider{
-		scopes: opts.Scopes,
-		client: client,
+		scopes:           opts.Scopes,
+		client:           client,
+		tokenBindingType: opts.TokenBindingType,
 	}, &auth.CachedTokenProviderOptions{
 		ExpireEarly:         opts.EarlyTokenRefresh,
 		DisableAsyncRefresh: opts.DisableAsyncRefresh,
@@ -49,8 +50,9 @@ func computeTokenProvider(opts *DetectOptions, client *metadata.Client) auth.Tok
 
 // computeProvider fetches tokens from the google cloud metadata service.
 type computeProvider struct {
-	scopes []string
-	client *metadata.Client
+	scopes           []string
+	client           *metadata.Client
+	tokenBindingType string
 }
 
 type metadataTokenResp struct {
@@ -64,9 +66,19 @@ func (cs *computeProvider) Token(ctx context.Context) (*auth.Token, error) {
 	if err != nil {
 		return nil, err
 	}
-	if len(cs.scopes) > 0 {
+	hasScopes := len(cs.scopes) > 0
+	if hasScopes || cs.tokenBindingType != "" {
 		v := url.Values{}
-		v.Set("scopes", strings.Join(cs.scopes, ","))
+		if hasScopes {
+			v.Set("scopes", strings.Join(cs.scopes, ","))
+		}
+		switch cs.tokenBindingType {
+		case "MTLS_S2A":
+			v.Set("transport", "mtls")
+			v.Set("binding-enforcement", "on")
+		case "ALTS":
+			v.Set("transport", "alts")
+		}
 		tokenURI.RawQuery = v.Encode()
 	}
 	tokenJSON, err := cs.client.GetWithContext(ctx, tokenURI.String())

--- a/auth/credentials/detect.go
+++ b/auth/credentials/detect.go
@@ -121,6 +121,10 @@ type DetectOptions struct {
 	// https://www.googleapis.com/auth/cloud-platform. Required if Audience is
 	// not provided.
 	Scopes []string
+	// TokenBindingType specifies the type of binding used when requesting a
+	// token whether to request a hard-bound identity token using mTLS or an
+	// instance-bound token using ALTS. Optional.
+	TokenBindingType string
 	// Audience that credentials tokens should have. Only applicable for 2LO
 	// flows with service accounts. If specified, scopes should not be provided.
 	Audience string

--- a/auth/internal/transport/cba_test.go
+++ b/auth/internal/transport/cba_test.go
@@ -413,7 +413,7 @@ func TestGetGRPCTransportConfigAndEndpoint_S2A(t *testing.T) {
 			} else {
 				t.Setenv(googleAPIUseCertSource, "false")
 			}
-			_, endpoint, _ := GetGRPCTransportCredsAndEndpoint(tc.opts)
+			_, endpoint, _, _ := GetGRPCTransportCredsAndEndpoint(tc.opts)
 			if tc.want != endpoint {
 				t.Fatalf("want endpoint: %s, got %s", tc.want, endpoint)
 			}


### PR DESCRIPTION
This PR allows auth to request a hard-bound token when two conditions are met:
1. Client is allowed to request hard-bound token using the InternalOptions.AllowHardBoundTokens
2. The transport used is mTLS using S2A.

If the two conditions are met, the compute provider will add two query parameters: transport=mtls & binding-enforcement=on to the request sent to the metadata service which will return a hard-bound token.