### PR TITLE
refactor(auth): refactor GetGRPCTransportCredsAndEndpoint return type to struct

### DIFF
--- a/auth/grpctransport/grpctransport.go
+++ b/auth/grpctransport/grpctransport.go
@@ -262,13 +262,13 @@ func dial(ctx context.Context, secure bool, opts *Options) (*grpc.ClientConn, er
 		tOpts.EnableDirectPath = io.EnableDirectPath
 		tOpts.EnableDirectPathXds = io.EnableDirectPathXds
 	}
-	transportCreds, endpoint, err := transport.GetGRPCTransportCredsAndEndpoint(tOpts)
+	transportCreds, err := transport.GetGRPCTransportCredsAndEndpoint(tOpts)
 	if err != nil {
 		return nil, err
 	}
 
 	if !secure {
-		transportCreds = grpcinsecure.NewCredentials()
+		transportCreds.TransportCredentials = grpcinsecure.NewCredentials()
 	}
 
 	// Initialize gRPC dial options with transport-level security options.
@@ -324,9 +324,8 @@ func dial(ctx context.Context, secure bool, opts *Options) (*grpc.ClientConn, er
 				clientUniverseDomain: opts.UniverseDomain,
 			}),
 		)
-
 		// Attempt Direct Path
-		grpcOpts, endpoint = configureDirectPath(grpcOpts, opts, endpoint, creds)
+		grpcOpts, transportCreds.Endpoint = configureDirectPath(grpcOpts, opts, transportCreds.Endpoint, creds)
 	}
 
 	// Add tracing, but before the other options, so that clients can override the
@@ -335,7 +334,7 @@ func dial(ctx context.Context, secure bool, opts *Options) (*grpc.ClientConn, er
 	grpcOpts = addOpenTelemetryStatsHandler(grpcOpts, opts)
 	grpcOpts = append(grpcOpts, opts.GRPCDialOpts...)
 
-	return grpc.Dial(endpoint, grpcOpts...)
+	return grpc.Dial(transportCreds.Endpoint, grpcOpts...)
 }
 
 // grpcKeyProvider satisfies https://pkg.go.dev/google.golang.org/grpc/credentials#PerRPCCredentials.

--- a/auth/internal/transport/cba_test.go
+++ b/auth/internal/transport/cba_test.go
@@ -413,9 +413,9 @@ func TestGetGRPCTransportConfigAndEndpoint_S2A(t *testing.T) {
 			} else {
 				t.Setenv(googleAPIUseCertSource, "false")
 			}
-			_, endpoint, _ := GetGRPCTransportCredsAndEndpoint(tc.opts)
-			if tc.want != endpoint {
-				t.Fatalf("want endpoint: %s, got %s", tc.want, endpoint)
+			transportCreds, _ := GetGRPCTransportCredsAndEndpoint(tc.opts)
+			if tc.want != transportCreds.Endpoint {
+				t.Fatalf("want endpoint: %s, got %s", tc.want, transportCreds.Endpoint)
 			}
 		})
 	}
@@ -764,12 +764,12 @@ func TestGetGRPCTransportCredsAndEndpoint_UniverseDomain(t *testing.T) {
 			} else {
 				t.Setenv(googleAPIUseCertSource, "false")
 			}
-			_, endpoint, err := GetGRPCTransportCredsAndEndpoint(tc.opts)
+			transportCreds, err := GetGRPCTransportCredsAndEndpoint(tc.opts)
 			if err != nil {
 				t.Fatalf("err: %v", err)
 			} else {
-				if tc.wantEndpoint != endpoint {
-					t.Errorf("want endpoint: %s, got %s", tc.wantEndpoint, endpoint)
+				if tc.wantEndpoint != transportCreds.Endpoint {
+					t.Errorf("want endpoint: %s, got %s", tc.wantEndpoint, transportCreds.Endpoint)
 				}
 			}
 		})


### PR DESCRIPTION
* Embed `google.golang.org/grpc/credentials.TransportCredentials` interface in new struct type with additional data.

refs: #11588

See:

* [“Accept interfaces, return structs” in Go](https://bryanftan.medium.com/accept-interfaces-return-structs-in-go-d4cab29a301b)
* [Embedding in Go: Part 3 - interfaces in structs](https://eli.thegreenplace.net/2020/embedding-in-go-part-3-interfaces-in-structs/)