### PR TITLE
fix(spanner): retract versions with bug with use of previous transaction ID using regular session

### DIFF
--- a/spanner/go.mod
+++ b/spanner/go.mod
@@ -2,6 +2,8 @@ module cloud.google.com/go/spanner
 
 go 1.23.0
 
+retract v1.76.0 // due to https://github.com/googleapis/google-cloud-go/issues/11630
+
 require (
 	cloud.google.com/go v0.118.2
 	cloud.google.com/go/iam v1.4.0


### PR DESCRIPTION
Retract spanner releases affected by https://github.com/googleapis/google-cloud-go/issues/11630. This will prevent the Go tool from selecting these versions using MVS. Builds where these releases are currently selected will still work, but the user will receive a warning.
