### PR TITLE
chore: set gcs-sdk-team as GCS CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,8 +13,8 @@
 /pubsub/                @googleapis/api-pubsub @googleapis/yoshi-go-admins @shollyman
 /pubsublite/            @googleapis/api-pubsub @googleapis/yoshi-go-admins @shollyman
 /spanner/               @googleapis/spanner-client-libraries-go @googleapis/yoshi-go-admins
-/storage/               @googleapis/cloud-storage-dpe @googleapis/yoshi-go-admins
-/httpreplay/            @googleapis/cloud-storage-dpe @googleapis/yoshi-go-admins
+/storage/               @googleapis/gcs-ssdk-team @googleapis/yoshi-go-admins
+/httpreplay/            @googleapis/gcs-sdk-team @googleapis/yoshi-go-admins
 /errorreporting/        @googleapis/api-logging @googleapis/api-logging-partners @googleapis/yoshi-go-admins
 /logging/               @googleapis/api-logging @googleapis/api-logging-partners @googleapis/yoshi-go-admins
 /profiler/              @googleapis/api-profiler @googleapis/yoshi-go-admins

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,7 +13,7 @@
 /pubsub/                @googleapis/api-pubsub @googleapis/yoshi-go-admins @shollyman
 /pubsublite/            @googleapis/api-pubsub @googleapis/yoshi-go-admins @shollyman
 /spanner/               @googleapis/spanner-client-libraries-go @googleapis/yoshi-go-admins
-/storage/               @googleapis/gcs-ssdk-team @googleapis/yoshi-go-admins
+/storage/               @googleapis/gcs-sdk-team @googleapis/yoshi-go-admins
 /httpreplay/            @googleapis/gcs-sdk-team @googleapis/yoshi-go-admins
 /errorreporting/        @googleapis/api-logging @googleapis/api-logging-partners @googleapis/yoshi-go-admins
 /logging/               @googleapis/api-logging @googleapis/api-logging-partners @googleapis/yoshi-go-admins


### PR DESCRIPTION
Replace outdated cloud-storage-dpes group name with gcs-sdk-team