### PR TITLE
fix(bigquery): Increase timeout for storage api test and remove usage of deprecated pkg

### DIFF
--- a/bigquery/benchmarks/bench.go
+++ b/bigquery/benchmarks/bench.go
@@ -23,7 +23,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"strings"
@@ -181,7 +180,7 @@ func measureSelectQuery(ctx context.Context, q *bigquery.Query) *timingInfo {
 // It currently instruments queries serially to reduce variance due to concurrent execution on either the backend or in this client.
 func runBenchmarks(ctx context.Context, client *bigquery.Client, filename string, tags *tags, reruns int) (profiles []*profiledQuery, err error) {
 
-	queriesJSON, err := ioutil.ReadFile(filename)
+	queriesJSON, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read queries files: %v", err)
 	}

--- a/bigquery/storage_integration_test.go
+++ b/bigquery/storage_integration_test.go
@@ -92,7 +92,7 @@ func TestIntegration_StorageReadClientProject(t *testing.T) {
 	if client == nil {
 		t.Skip("Integration tests skipped")
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 
 	table := storageOptimizedClient.Dataset("usa_names").Table("usa_1910_current")


### PR DESCRIPTION
Fixes #11801 