### PR TITLE
feat(auth): configure ALTS bound tokens in Options's validate()

### DIFF
--- a/auth/grpctransport/directpath_test.go
+++ b/auth/grpctransport/directpath_test.go
@@ -95,6 +95,52 @@ func TestIsTokenProviderDirectPathCompatible(t *testing.T) {
 	}
 }
 
+func TestIsDirectPathBoundTokenEnabled(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		opts *InternalOptions
+		want bool
+	}{
+		{
+			name: "empty list",
+			opts: &InternalOptions{
+				AllowHardBoundTokens: []string{},
+			},
+		},
+		{
+			name: "nil list",
+			opts: &InternalOptions{
+				AllowHardBoundTokens: []string{},
+			},
+		},
+		{
+			name: "list does not contain ALTS",
+			opts: &InternalOptions{
+				AllowHardBoundTokens: []string{"MTLS_S2A"},
+			},
+		},
+		{
+			name: "list only contains ALTS",
+			opts: &InternalOptions{
+				AllowHardBoundTokens: []string{"ALTS"},
+			},
+			want: true,
+		},
+		{
+			name: "list contains ALTS and others",
+			opts: &InternalOptions{
+				AllowHardBoundTokens: []string{"ALTS", "MTLS_S2A"},
+			},
+			want: true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isDirectPathBoundTokenEnabled(tt.opts); got != tt.want {
+				t.Fatalf("isDirectPathBoundTokenEnabled() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
 type errTP struct {
 }
 


### PR DESCRIPTION
This is a different approach compared with #11665. The unexported field `altsCredentials` will be resolved during the validate() at most one time and used in subsequent `dial()` calls.

@quartzmo Could you PTAL at this? If this approach makes more sense to you, I feel we should do the same thing for the existing `DetectDefault` call especially with the introduction of `MTLS_S2A` feature. Let me know if there are any caveats I am missing here. Thanks.