### PR TITLE
fix(storage): force first message on next sendBuffer when nothing sent on current

### DIFF
--- a/storage/grpc_client.go
+++ b/storage/grpc_client.go
@@ -2863,6 +2863,9 @@ func (s *gRPCResumableBidiWriteBufferSender) sendBuffer(ctx context.Context, buf
 		buf = buf[trim:]
 	}
 	if len(buf) == 0 && !flush && !finishWrite {
+		if reconnected {
+			s.forceFirstMessage = true
+		}
 		// no need to send anything
 		return nil, nil
 	}

--- a/storage/retry_conformance_test.go
+++ b/storage/retry_conformance_test.go
@@ -613,8 +613,9 @@ var methods = map[string][]retryFunc{
 				obj = obj.If(Conditions{DoesNotExist: true})
 			}
 			w := obj.NewWriter(ctx)
-			// Set Writer.ChunkSize to 2 MiB to perform resumable uploads.
-			w.ChunkSize = 2097152
+			// Set Writer.ChunkSize to 4MiB to perform resumable uploads on a smaller object size.
+			// Set it larger than 2MiB so it can test boundaries for max message size.
+			w.ChunkSize = 4 * MiB
 
 			if _, err := w.Write(randomBytes9MiB); err != nil {
 				return fmt.Errorf("writing object: %v", err)


### PR DESCRIPTION
If nothing is sent but the stream is reconnected, next send will not recognize the stream as reconnected without this change.

Also, update the conformance tests to catch this.