### PR TITLE
fix(bigquery): totalRows returned by fetchCachedPage

### DIFF
--- a/bigquery/iterator_test.go
+++ b/bigquery/iterator_test.go
@@ -80,11 +80,12 @@ func TestRowIteratorCacheBehavior(t *testing.T) {
 		{
 			// primary success case: schema in cache
 			inSource: &rowSource{
-				cachedSchema: testSchema,
-				cachedRows:   testRows,
+				cachedSchema:    testSchema,
+				cachedRows:      testRows,
+				cachedTotalRows: 10,
 			},
 			wantResult: &fetchPageResult{
-				totalRows: uint64(len(convertedRows)),
+				totalRows: uint64(10),
 				schema:    convertedSchema,
 				rows:      convertedRows,
 			},
@@ -94,10 +95,11 @@ func TestRowIteratorCacheBehavior(t *testing.T) {
 			inSource: &rowSource{
 				cachedRows:      testRows,
 				cachedNextToken: "foo",
+				cachedTotalRows: 20,
 			},
 			inSchema: convertedSchema,
 			wantResult: &fetchPageResult{
-				totalRows: uint64(len(convertedRows)),
+				totalRows: uint64(20),
 				schema:    convertedSchema,
 				rows:      convertedRows,
 				pageToken: "foo",

--- a/bigquery/query.go
+++ b/bigquery/query.go
@@ -418,6 +418,7 @@ func (q *Query) Read(ctx context.Context) (it *RowIterator, err error) {
 			cachedRows:      resp.Rows,
 			cachedSchema:    resp.Schema,
 			cachedNextToken: resp.PageToken,
+			cachedTotalRows: resp.TotalRows,
 		}
 		return newRowIterator(ctx, rowSource, fetchPage), nil
 	}


### PR DESCRIPTION
The RowIterator.TotalRows is wrong when hitting the cached page on the fast path (e.g. not changing start index or updating the page info).

fixes: #11873