### PR TITLE
fix(third_party/pkgsite): increase comment size limit

### DIFF
--- a/third_party/pkgsite/print_type.go
+++ b/third_party/pkgsite/print_type.go
@@ -109,7 +109,7 @@ type declVisitor struct {
 func (v *declVisitor) Visit(n ast.Node) ast.Visitor {
 	switch n := n.(type) {
 	case *ast.BasicLit:
-		if n.Kind == token.STRING && len(n.Value) > 128 {
+		if n.Kind == token.STRING && len(n.Value) > 512 {
 			v.Comments = append(v.Comments,
 				&ast.CommentGroup{List: []*ast.Comment{{
 					Slash: n.Pos(),


### PR DESCRIPTION
This package is used by `godocfx`. The limit is causing some comments to be omitted on types when they should be included.