### PR TITLE
feat(spanner): support option to explicitly begin transactions for ReadOnly txn

### DIFF
--- a/spanner/client_test.go
+++ b/spanner/client_test.go
@@ -5078,8 +5078,8 @@ func TestReadOnlyTransaction_ExplicitBegin(t *testing.T) {
 
 	// Verify that the ExecuteSqlRequest uses the transaction ID from the explicit begin
 	for _, req := range requests {
-		if execSqlReq, ok := req.(*sppb.ExecuteSqlRequest); ok {
-			if _, ok := execSqlReq.Transaction.GetSelector().(*sppb.TransactionSelector_Id); !ok {
+		if execSQLReq, ok := req.(*sppb.ExecuteSqlRequest); ok {
+			if _, ok := execSQLReq.Transaction.GetSelector().(*sppb.TransactionSelector_Id); !ok {
 				t.Fatal("expected query to use transaction ID from explicit begin")
 			}
 		}


### PR DESCRIPTION
```
// Default behavior (implicit begin)
ro := client.ReadOnlyTransaction()
defer ro.Close()

// With explicit begin
ro := client.ReadOnlyTransaction().WithExplicitBegin(true)
defer ro.Close()
```
The changes maintain backward compatibility since:

1. The default behavior (implicit begin) remains unchanged.
2. The WithExplicitBegin method can only be called before any operations are performed.
3. Existing code will continue to work without modification

When WithExplicitBegin(true) is used:

- The transaction will be started immediately during initialization
- The transaction ID will be available before the first operation
- All subsequent operations will use the same transaction ID

This is particularly useful when you want to ensure the transaction is started at a specific point, rather than waiting for the first operation to trigger it implicitly.