### PR TITLE
fix(auth): restore calling DialContext

### DIFF
--- a/auth/grpctransport/grpctransport.go
+++ b/auth/grpctransport/grpctransport.go
@@ -353,7 +353,7 @@ func dial(ctx context.Context, secure bool, opts *Options) (*grpc.ClientConn, er
 	grpcOpts = addOpenTelemetryStatsHandler(grpcOpts, opts)
 	grpcOpts = append(grpcOpts, opts.GRPCDialOpts...)
 
-	return grpc.Dial(transportCreds.Endpoint, grpcOpts...)
+	return grpc.DialContext(ctx, transportCreds.Endpoint, grpcOpts...)
 }
 
 // grpcKeyProvider satisfies https://pkg.go.dev/google.golang.org/grpc/credentials#PerRPCCredentials.


### PR DESCRIPTION
We switched to `Dial` orginally because of grpc/grpc-go#7556. Now that this is fixed we can call DialContext again. In the future we still will want to migrate to the new API directly, but this will require more testing.

Related: #11118