### PR TITLE
fix(storage): fix unfinalized write size

### DIFF
--- a/storage/grpc_client.go
+++ b/storage/grpc_client.go
@@ -1782,7 +1782,7 @@ func (c *grpcStorageClient) OpenWriter(params *openWriterParams, opts ...storage
 		params.setTakeoverOffset(wbs.takeoverOffset)
 		offset = wbs.takeoverOffset
 		gw.streamSender = wbs
-		o = wbs.takeoverObj
+		o = wbs.objResource
 	}
 
 	// This function reads the data sent to the pipe and sends sets of messages

--- a/storage/grpc_writer.go
+++ b/storage/grpc_writer.go
@@ -96,7 +96,7 @@ func (w *gRPCWriter) newGRPCAppendTakeoverWriteBufferSender(ctx context.Context)
 	if err := s.connect(ctx); err != nil {
 		return nil, fmt.Errorf("storage: opening appendable write stream: %w", err)
 	}
-	_, err := s.sendOnConnectedStream(nil, 0, true, false, true)
+	_, err := s.sendOnConnectedStream(nil, 0, false, false, true)
 	if err != nil {
 		return nil, err
 	}

--- a/storage/integration_test.go
+++ b/storage/integration_test.go
@@ -3280,6 +3280,10 @@ func TestIntegration_WriterAppend(t *testing.T) {
 
 				// Write remaining data.
 				h.mustWrite(w, content)
+				// Check that local Writer.Attrs() is populated as expected.
+				if w.Attrs() == nil || w.Attrs().Size != int64(len(tc.content)) {
+					t.Errorf("Writer.Attrs(): got %+v, expected size = %v", w.Attrs().Size, int64(len(tc.content)))
+				}
 
 				// Download content again and validate.
 				// Disabled due to b/395944605; unskip after this is resolved.


### PR DESCRIPTION
This makes Writer.Attrs().Size true to the last persisted size value received from GCS.
Also fixes a hang in some takeover cases introduced by #12012