### PR TITLE
fix: Update offset on resumable upload retry

### DIFF
--- a/storage/grpc_writer.go
+++ b/storage/grpc_writer.go
@@ -464,6 +464,7 @@ func (s *gRPCResumableBidiWriteBufferSender) sendBuffer(ctx context.Context, buf
 			trim = int64(len(buf))
 		}
 		buf = buf[trim:]
+		offset += trim
 	}
 	if len(buf) == 0 && !flush && !finishWrite {
 		// no need to send anything


### PR DESCRIPTION
When resumable uploads retry, they may observe a flush offset which is past the start of the current send (in fact the whole send might have already completed). In that case, we avoided re-sending unnecessary data, but we didn't update the offset to account for the data not sent.