### PR TITLE
fix(storage): fix append writer hang

### DIFF
--- a/storage/integration_test.go
+++ b/storage/integration_test.go
@@ -3557,6 +3557,9 @@ func TestIntegration_WriterAppendEdgeCases(t *testing.T) {
 		if _, err := w.Write(randomBytes3MiB); err != nil {
 			t.Fatalf("w.Write: %v", err)
 		}
+		if _, err := w.Flush(); err != nil {
+			t.Fatalf("w.Flush: %v", err)
+		}
 
 		tw, _, err := obj.Generation(w.Attrs().Generation).NewWriterFromAppendableObject(ctx, nil)
 		if err != nil {


### PR DESCRIPTION
After a Flush call, we weren't correctly tracking the pipe reader to close to signal to Write that an error had happened. Fixes that issue and adds another flush to the test, which triggers the hang without this fix.