### PR TITLE
chore: bump changed modules

### DIFF
--- a/ai/CHANGES.md
+++ b/ai/CHANGES.md
@@ -264,3 +264,4 @@
 * **ai/generativelanguage:** Start generating apiv1beta2 ([#8229](https://github.com/googleapis/google-cloud-go/issues/8229)) ([837f325](https://github.com/googleapis/google-cloud-go/commit/837f32596518d8154f43da1c70f57d1515e2ea8c))
 
 ## Changes
+

--- a/alloydb/CHANGES.md
+++ b/alloydb/CHANGES.md
@@ -331,3 +331,4 @@
 * **alloydb:** Start generating apiv1, apiv1beta, apiv1alpha ([#7503](https://github.com/googleapis/google-cloud-go/issues/7503)) ([25e8426](https://github.com/googleapis/google-cloud-go/commit/25e842659ef5c3941717827459e6524f024e5a26))
 
 ## Changes
+

--- a/analytics/CHANGES.md
+++ b/analytics/CHANGES.md
@@ -415,3 +415,4 @@
 
 This is the first tag to carve out analytics as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/bigquery/CHANGES.md
+++ b/bigquery/CHANGES.md
@@ -1065,3 +1065,4 @@ cloud.google.com/go.
 
 This is the first tag to carve out bigquery as its own module. See:
 https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository.
+

--- a/dataqna/CHANGES.md
+++ b/dataqna/CHANGES.md
@@ -194,3 +194,4 @@
 
 This is the first tag to carve out dataqna as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/discoveryengine/CHANGES.md
+++ b/discoveryengine/CHANGES.md
@@ -450,3 +450,4 @@
 * **discoveryengine:** Start generating apiv1beta ([#7427](https://github.com/googleapis/google-cloud-go/issues/7427)) ([0d289a0](https://github.com/googleapis/google-cloud-go/commit/0d289a07106226b4398935357ab0f30a3a30340d))
 
 ## Changes
+

--- a/metastore/CHANGES.md
+++ b/metastore/CHANGES.md
@@ -255,3 +255,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out metastore as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/osconfig/CHANGES.md
+++ b/osconfig/CHANGES.md
@@ -268,3 +268,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out osconfig as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+


### PR DESCRIPTION
BEGIN_NESTED_COMMIT
fix(ai):upgrade Go gRPC Protobuf generation

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in #11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(alloydb):upgrade Go gRPC Protobuf generation

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in #11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(analytics):upgrade Go gRPC Protobuf generation

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in #11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(bigquery):upgrade Go gRPC Protobuf generation

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in #11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(dataqna):upgrade Go gRPC Protobuf generation

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in #11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(discoveryengine):upgrade Go gRPC Protobuf generation

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in #11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(metastore):upgrade Go gRPC Protobuf generation

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in #11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(osconfig):upgrade Go gRPC Protobuf generation

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in #11025.
END_NESTED_COMMIT