### PR TITLE
chore(internal/actions): fix missing space in commit message

### DIFF
--- a/internal/actions/cmd/changefinder/main.go
+++ b/internal/actions/cmd/changefinder/main.go
@@ -107,7 +107,7 @@ func output(s []string) error {
 	case "commit":
 		for _, m := range s {
 			fmt.Println("BEGIN_NESTED_COMMIT")
-			fmt.Printf("%s(%s):%s\n", *commitScope, m, *commitMessage)
+			fmt.Printf("%s(%s): %s\n", *commitScope, m, *commitMessage)
 			fmt.Println("END_NESTED_COMMIT")
 		}
 	case "plain":


### PR DESCRIPTION
Currently: `fix(ai):upgrade deps`
Should be: `fix(ai): upgrade deps`