### PR TITLE
chore(spanner): always enable AFE native metrics if direct path is used unless explicitly disabled

### DIFF
--- a/spanner/read_test.go
+++ b/spanner/read_test.go
@@ -1850,7 +1850,7 @@ func TestIteratorStopEarly(t *testing.T) {
 }
 
 func TestIteratorWithError(t *testing.T) {
-	metricsTracerFactory, err := newBuiltinMetricsTracerFactory(context.Background(), "projects/my-project/instances/my-instance/databases/my-database", noop.NewMeterProvider(), "identity")
+	metricsTracerFactory, err := newBuiltinMetricsTracerFactory(context.Background(), "projects/my-project/instances/my-instance/databases/my-database", "identity", false, false, noop.NewMeterProvider())
 	if err != nil {
 		t.Fatalf("failed to create metrics tracer factory: %v", err)
 	}


### PR DESCRIPTION
- AFE and GRPC metrics will be disabled by default.
- If direct path is enabled AFE and GRPC metrics will be enabled unless explicitly disabled by user via env `SPANNER_DISABLE_AFE_SERVER_TIMING`, `SPANNER_DISABLE_DIRECT_ACCESS_GRPC_BUILTIN_METRICS`