### PR TITLE
fix(spanner): row mismatch in SelectAll using custom type

### DIFF
--- a/spanner/row.go
+++ b/spanner/row.go
@@ -464,7 +464,7 @@ func SelectAll(rows rowIterator, destination interface{}, options ...DecodeOptio
 	var err error
 	return rows.Do(func(row *Row) error {
 		sliceItem := reflect.New(itemType)
-		if isFirstRow && !isPrimitive {
+		if !isPrimitive {
 			defer func() {
 				isFirstRow = false
 			}()

--- a/spanner/row.go
+++ b/spanner/row.go
@@ -471,7 +471,7 @@ func SelectAll(rows rowIterator, destination interface{}, options ...DecodeOptio
 			if pointers, err = structPointers(sliceItem.Elem(), row.fields, s.Lenient); err != nil {
 				return err
 			}
-		} else if isPrimitive {
+		} else {
 			if len(row.fields) > 1 && !s.Lenient {
 				return errTooManyColumns()
 			}


### PR DESCRIPTION
Fixes #11101 

**Why is it an issue?**
We are creating a new pointers for each columns only once while decoding the first row and reusing it in subsequent rows. In the decoding, if customer didn't set certain values, it's picking up values from previous column since pointers always same when DecodeSpanner is called. When we try to call DecodeSpanner, we need to make sure we have to use new memory instead of reusing it.