### PR TITLE
testing(bigquery): relax stats validation testing

### DIFF
--- a/bigquery/integration_test.go
+++ b/bigquery/integration_test.go
@@ -1474,10 +1474,12 @@ func TestIntegration_QueryStatistics(t *testing.T) {
 		t.Errorf("expected positive final execution duration, %s reported", status.Statistics.FinalExecutionDuration.String())
 	}
 
-	switch status.Statistics.Edition {
-	case ReservationEditionUnspecified, ReservationEditionStandard, ReservationEditionEnterprise, ReservationEditionEnterprisePlus:
-	default:
-		t.Errorf("expected known reservation edition, %s reported", status.Statistics.Edition)
+	if edition := status.Statistics.Edition; edition != "" {
+		switch edition {
+		case ReservationEditionUnspecified, ReservationEditionStandard, ReservationEditionEnterprise, ReservationEditionEnterprisePlus:
+		default:
+			t.Errorf("expected known reservation edition, %s reported", status.Statistics.Edition)
+		}
 	}
 
 	if status.Statistics.Details == nil {

--- a/bigquery/integration_test.go
+++ b/bigquery/integration_test.go
@@ -1478,7 +1478,7 @@ func TestIntegration_QueryStatistics(t *testing.T) {
 		switch edition {
 		case ReservationEditionUnspecified, ReservationEditionStandard, ReservationEditionEnterprise, ReservationEditionEnterprisePlus:
 		default:
-			t.Errorf("expected known reservation edition, %s reported", status.Statistics.Edition)
+			t.Errorf("expected known reservation edition, %q reported", edition)
 		}
 	}
 


### PR DESCRIPTION
This PR relaxes edition validation to handle the unpopulated case.

Fixes: https://github.com/googleapis/google-cloud-go/issues/12223