### PR TITLE
feat(bigquery): job creation mode GA

### DIFF
--- a/bigquery/integration_test.go
+++ b/bigquery/integration_test.go
@@ -776,10 +776,10 @@ func TestIntegration_SimpleRowResults(t *testing.T) {
 	if client == nil {
 		t.Skip("Integration tests skipped")
 	}
-	beforePreview := client.enableQueryPreview
+	beforeMode := client.customConfig.jobCreationMode
 	// ensure we restore the preview setting on test exit
 	defer func() {
-		client.enableQueryPreview = beforePreview
+		client.customConfig.jobCreationMode = beforeMode
 	}()
 	ctx := context.Background()
 
@@ -820,8 +820,8 @@ func TestIntegration_SimpleRowResults(t *testing.T) {
 		},
 	}
 
-	t.Run("nopreview_group", func(t *testing.T) {
-		client.enableQueryPreview = false
+	t.Run("jobrequired_group", func(t *testing.T) {
+		client.customConfig.jobCreationMode = JobCreationModeRequired
 		for _, tc := range testCases {
 			curCase := tc
 			t.Run(curCase.description, func(t *testing.T) {
@@ -835,8 +835,8 @@ func TestIntegration_SimpleRowResults(t *testing.T) {
 			})
 		}
 	})
-	t.Run("preview_group", func(t *testing.T) {
-		client.enableQueryPreview = true
+	t.Run("joboptional_group", func(t *testing.T) {
+		client.customConfig.jobCreationMode = JobCreationModeOptional
 		for _, tc := range testCases {
 			curCase := tc
 			t.Run(curCase.description, func(t *testing.T) {

--- a/bigquery/options.go
+++ b/bigquery/options.go
@@ -1,0 +1,72 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bigquery
+
+import (
+	"google.golang.org/api/option"
+	"google.golang.org/api/option/internaloption"
+)
+
+// type for collecting custom ClientOption values.
+type customClientConfig struct {
+	jobCreationMode JobCreationMode
+}
+
+type customClientOption interface {
+	option.ClientOption
+	ApplyCustomClientOpt(*customClientConfig)
+}
+
+func newCustomClientConfig(opts ...option.ClientOption) *customClientConfig {
+	conf := &customClientConfig{
+		jobCreationMode: JobCreationModeOptional,
+	}
+	for _, opt := range opts {
+		if cOpt, ok := opt.(customClientOption); ok {
+			cOpt.ApplyCustomClientOpt(conf)
+		}
+	}
+	return conf
+}
+
+type JobCreationMode string
+
+var (
+	// JobCreationModeUnspecified is the default (unspecified) option.
+	JobCreationModeUnspecified JobCreationMode = "JOB_CREATION_MODE_UNSPECIFIED"
+	// JobCreationModeRequired indicates job creation is required.
+	JobCreationModeRequired JobCreationMode = "JOB_CREATION_REQUIRED"
+	// JobCreationModeOptional indicates job creation is optional, and returning
+	// results immediately is prioritized.  The conditions under which BigQuery
+	// can choose to avoid job creation are internal and subject to change.
+	JobCreationModeOptional JobCreationMode = "JOB_CREATION_OPTIONAL"
+)
+
+// WithDefaultJobCreationMode is a ClientOption that governs the job creation
+// mode used when executing queries that can be accelerated via the jobs.Query
+// API.  If not specified, the client will use JOB_CREATION_OPTIONAL
+func WithDefaultJobCreationMode(mode JobCreationMode) option.ClientOption {
+	return &applierJobCreationMode{mode: mode}
+}
+
+// applier for propagating the custom client option to the config object
+type applierJobCreationMode struct {
+	internaloption.EmbeddableAdapter
+	mode JobCreationMode
+}
+
+func (s *applierJobCreationMode) ApplyCustomClientOpt(c *customClientConfig) {
+	c.jobCreationMode = s.mode
+}

--- a/bigquery/options_test.go
+++ b/bigquery/options_test.go
@@ -1,0 +1,55 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bigquery
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/api/option"
+)
+
+func TestCustomClientOptions(t *testing.T) {
+	testCases := []struct {
+		desc    string
+		options []option.ClientOption
+		want    *customClientConfig
+	}{
+		{
+			desc: "no options",
+			want: &customClientConfig{
+				jobCreationMode: JobCreationModeOptional,
+			},
+		},
+		{
+			desc: "jobmode required",
+			options: []option.ClientOption{
+				WithDefaultJobCreationMode(JobCreationModeRequired),
+			},
+			want: &customClientConfig{
+				jobCreationMode: JobCreationModeRequired,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			gotCfg := newCustomClientConfig(tc.options...)
+			if diff := cmp.Diff(gotCfg, tc.want, cmp.AllowUnexported(customClientConfig{})); diff != "" {
+				t.Errorf("diff in case (%s):\n%v", tc.desc, diff)
+			}
+		})
+	}
+}

--- a/bigquery/query.go
+++ b/bigquery/query.go
@@ -501,8 +501,9 @@ func (q *Query) probeFastPath() (*bq.QueryRequest, error) {
 			DatasetId: q.QueryConfig.DefaultDatasetID,
 		}
 	}
-	if q.client.enableQueryPreview {
-		qRequest.JobCreationMode = "JOB_CREATION_OPTIONAL"
+
+	if custCfg := q.client.customConfig; custCfg != nil {
+		qRequest.JobCreationMode = string(custCfg.jobCreationMode)
 	}
 	return qRequest, nil
 }


### PR DESCRIPTION
Previously, use of the QUERY_PREVIEW_ENABLED environmental variable governed whether this client would attempt to execute queries without creating jobs.  Now that this feature is GA, this client has been updated so that it defaults to using optional job mode, and exposes a new ClientOption (`WithDefaultJobCreationMode`) to override this behavior.