### PR TITLE
chore(internal/postprocessor): don't format pb.go files

### DIFF
--- a/.github/workflows/vet.sh
+++ b/.github/workflows/vet.sh
@@ -33,8 +33,7 @@ done
 git diff '*go.mod' :^internal/generated/snippets | tee /dev/stderr | (! read)
 git diff '*go.sum' :^internal/generated/snippets | tee /dev/stderr | (! read)
 
-gofmt -s -d -l . 2>&1 | tee /dev/stderr | (! read)
-goimports -l . 2>&1 | tee /dev/stderr | (! read)
+goimports -l . 2>&1 | grep -vE ".pb.go" | tee /dev/stderr | (! read)
 
 # Runs the linter. Regrettably the linter is very simple and does not provide the ability to exclude rules or files,
 # so we rely on inverse grepping to do this for us.

--- a/internal/postprocessor/execv/gocmd/gocmd.go
+++ b/internal/postprocessor/execv/gocmd/gocmd.go
@@ -105,18 +105,21 @@ func Build(dir string) error {
 	return nil
 }
 
-// Vet runs linters on all .go files recursively from the given directory.
-func Vet(dir string) error {
-	log.Println("vetting generated code")
+// Format runs goimports on all .go files recursively from the given directory.
+func Format(dir string) error {
+	log.Println("formatting generated code")
 	c := execv.Command("goimports", "-w", ".")
 	c.Dir = dir
 	if err := c.Run(); err != nil {
 		return err
 	}
-
-	c = execv.Command("gofmt", "-s", "-d", "-w", "-l", ".")
-	c.Dir = dir
-	return c.Run()
+	// Undo formatting to pb.go files
+	c2 := execv.Command("git", "checkout", "--", "**/*.pb.go")
+	c2.Dir = dir
+	if err := c2.Run(); err != nil {
+		return err
+	}
+	return nil
 }
 
 // CurrentMod returns the module name of the provided directory.

--- a/internal/postprocessor/main.go
+++ b/internal/postprocessor/main.go
@@ -194,7 +194,7 @@ func (p *postProcessor) run(ctx context.Context) error {
 	if err := p.UpdateReleaseFiles(); err != nil {
 		return err
 	}
-	if err := gocmd.Vet(p.googleCloudDir); err != nil {
+	if err := gocmd.Format(p.googleCloudDir); err != nil {
 		return err
 	}
 	if err := p.WritePRInfoToFile(prTitle, prBody); err != nil {


### PR DESCRIPTION
Today we currently run goimports in our post processor over all files in the repo. Because of this the purposed changes from owlbot always has a large diff from what is landed in our repo. This in turn causes a lot of churn in the owlbot PRs as well as everyone gettings added as reviewers onto the PR. With this change we will no longer format the files that we don't contorl the generation of -- the raw proto gen. The files are still valid go code and the only difference is that imports won't be sorted in the style goimports likes. The upside is it fixes the other issues outlined above.

gofmt was removed as goimports is a super-set of features.