### PR TITLE
feat(ai): direct users to google.golang.org/genai

### DIFF
--- a/.github/.OwlBot.yaml
+++ b/.github/.OwlBot.yaml
@@ -612,6 +612,7 @@ deep-preserve-regex:
   - /.*/info.go
   - /.*/path_funcs.go
   - /.*/version.go
+  - /ai/generativelanguage/apiv1/doc.go
   - /container/apiv1/ListClusters_smoke_test.go
   - /kms/apiv1/iam.go
   - /kms/apiv1/iam_example_test.go

--- a/ai/README.md
+++ b/ai/README.md
@@ -4,6 +4,9 @@
 
 Go Client Library for Generative Language API.
 
+NOTE: New users are encouraged to use the Google GenAI Go SDK available at
+[google.golang.org/genai](google.golang.org/genai)
+
 ## Install
 
 ```bash

--- a/ai/generativelanguage/apiv1/doc.go
+++ b/ai/generativelanguage/apiv1/doc.go
@@ -17,6 +17,9 @@
 // Package generativelanguage is an auto-generated package for the
 // Generative Language API.
 //
+// NOTE: New users are encouraged to use the Google GenAI Go SDK
+// available at [google.golang.org/genai]
+//
 // The Gemini API allows developers to build generative AI applications using
 // Gemini models. Gemini is our most capable model, built from the ground up
 // to be multimodal. It can generalize and seamlessly understand, operate


### PR DESCRIPTION
Direct new users of this module to google.golang.org/genai
