### PR TITLE
test(storage): add max attempts to common functions

### DIFF
--- a/storage/integration_test.go
+++ b/storage/integration_test.go
@@ -7071,6 +7071,7 @@ type testHelper struct {
 
 func (h testHelper) mustCreate(b *BucketHandle, projID string, attrs *BucketAttrs) {
 	h.t.Helper()
+	b = b.Retryer(WithMaxAttempts(10))
 	if err := b.Create(context.Background(), projID, attrs); err != nil {
 		h.t.Fatalf("BucketHandle(%q).Create: %v", b.BucketName(), err)
 	}
@@ -7111,6 +7112,7 @@ func (h testHelper) mustDeleteBucket(b *BucketHandle) {
 
 func (h testHelper) mustBucketAttrs(b *BucketHandle) *BucketAttrs {
 	h.t.Helper()
+	b = b.Retryer(WithMaxAttempts(10))
 	attrs, err := b.Attrs(context.Background())
 	if err != nil {
 		h.t.Fatalf("BucketHandle(%q).Attrs: %v", b.BucketName(), err)
@@ -7138,6 +7140,7 @@ func (h testHelper) mustUpdateBucket(b *BucketHandle, ua BucketAttrsToUpdate, me
 
 func (h testHelper) mustObjectAttrs(o *ObjectHandle) *ObjectAttrs {
 	h.t.Helper()
+	o = o.Retryer(WithMaxAttempts(10))
 	attrs, err := o.Attrs(context.Background())
 	if err != nil {
 		h.t.Fatalf("get object %q from bucket %q: %v", o.ObjectName(), o.BucketName(), err)
@@ -7163,6 +7166,7 @@ func (h testHelper) mustDeleteObject(o *ObjectHandle) {
 // mustUpdateObject will assume success if it receives a failed precondition response.
 func (h testHelper) mustUpdateObject(o *ObjectHandle, ua ObjectAttrsToUpdate, metageneration int64) *ObjectAttrs {
 	h.t.Helper()
+	o = o.Retryer(WithMaxAttempts(10))
 	attrs, err := o.If(Conditions{MetagenerationMatch: metageneration}).Update(context.Background(), ua)
 	if err != nil {
 		if errorIsStatusCode(err, http.StatusPreconditionFailed, codes.FailedPrecondition) {


### PR DESCRIPTION
This will let us get a better error message (instead of a hang) in the case of permanent "transient" errors. 

The number of attempts is not important and was not chosen for any particular reason other than probably being "enough". We can adjust if ever needed.