### PR TITLE
test(storage): shadow testing.T var always

### DIFF
--- a/storage/bucket_test.go
+++ b/storage/bucket_test.go
@@ -1619,7 +1619,7 @@ func TestBucketSignedURL_Endpoint_Emulator_Host(t *testing.T) {
 	}()
 
 	for _, test := range tests {
-		t.Run(test.desc, func(s *testing.T) {
+		t.Run(test.desc, func(t *testing.T) {
 			utcNow = func() time.Time {
 				return test.now
 			}
@@ -1637,11 +1637,11 @@ func TestBucketSignedURL_Endpoint_Emulator_Host(t *testing.T) {
 
 			got, err := c.Bucket(bucketName).SignedURL(objectName, test.opts)
 			if err != nil {
-				s.Fatal(err)
+				t.Fatal(err)
 			}
 
 			if got != test.want {
-				s.Fatalf("bucket.SidnedURL:\n\tgot:\t%v\n\twant:\t%v", got, test.want)
+				t.Fatalf("bucket.SidnedURL:\n\tgot:\t%v\n\twant:\t%v", got, test.want)
 			}
 		})
 	}

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -1142,7 +1142,7 @@ func TestClientSetRetry(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		t.Run(tc.name, func(s *testing.T) {
+		t.Run(tc.name, func(t *testing.T) {
 			c, err := NewClient(context.Background(), option.WithoutAuthentication())
 			if err != nil {
 				t.Fatalf("NewClient: %v", err)
@@ -1160,7 +1160,7 @@ func TestClientSetRetry(t *testing.T) {
 					return (a == nil && b == nil) || (a != nil && b != nil)
 				}),
 			); diff != "" {
-				s.Fatalf("retry not configured correctly: %v", diff)
+				t.Fatalf("retry not configured correctly: %v", diff)
 			}
 		})
 	}
@@ -1364,7 +1364,7 @@ func TestRetryer(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		t.Run(tc.name, func(s *testing.T) {
+		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
 			c, err := NewClient(ctx, option.WithoutAuthentication())
 			if err != nil {
@@ -1415,7 +1415,7 @@ func TestRetryer(t *testing.T) {
 				},
 			}
 			for _, ac := range configHandleCases {
-				s.Run(ac.name, func(ss *testing.T) {
+				t.Run(ac.name, func(t *testing.T) {
 					if diff := cmp.Diff(
 						ac.want,
 						ac.r,
@@ -1426,7 +1426,7 @@ func TestRetryer(t *testing.T) {
 							return (a == nil && b == nil) || (a != nil && b != nil)
 						}),
 					); diff != "" {
-						ss.Fatalf("retry not configured correctly: %v", diff)
+						t.Fatalf("retry not configured correctly: %v", diff)
 					}
 				})
 			}


### PR DESCRIPTION
Consistently using `t` makes it less likely for a subtest to call failnow on the parent. I don't think we need the parent testing var in any of these cases.

These instances were picked up by recent test failures.