### PR TITLE
test(firestore): Retry GetAll

### DIFF
--- a/firestore/integration_test.go
+++ b/firestore/integration_test.go
@@ -1232,7 +1232,15 @@ func TestIntegration_QueryDocuments_WhereEntity(t *testing.T) {
 		if test.orderBy {
 			test.q = test.q.OrderBy("height", Asc)
 		}
-		gotDocs, err := test.q.Documents(ctx).GetAll()
+
+		var gotDocs []*DocumentSnapshot
+		var err error
+		testutil.Retry(t, 5, 5*time.Second, func(r *testutil.R) {
+			gotDocs, err = test.q.Documents(ctx).GetAll()
+			if err != nil {
+				r.Errorf(err.Error())
+			}
+		})
 		if err != nil {
 			t.Errorf("#%d: %+v: %v", i, test.q, err)
 			continue


### PR DESCRIPTION
The test fails with error
`rpc error: code = FailedPrecondition desc = The query requires an index. That index is currently building and cannot be used yet. See its status here: https://console.firebase.google.com/v1/r/project/gcloud-golang-firestore-tests/firestore/indexes?create_composite=CpEBcHJvamVjdHMvZ2Nsb3VkLWdvbGFuZy1maXJlc3RvcmUtdGVzdHMvZGF0YWJhc2VzLyhkZWZhdWx0KS9jb2xsZWN0aW9uR3JvdXBzL2dvLWludGVncmF0aW9uLXRlc3QtMjAyNDEyMjAtNzExNTE0MjkxOTc4MTEtMDAwMS9pbmRleGVzL0NJQ0FnS1N2Mlo0SxABGgoKBndlaWdodBABGgoKBmhlaWdodBABGgwKCF9fbmFtZV9fEAE`

So, retry the GetAll