### PR TITLE
test(firestore): Fix flaky tests

### DIFF
--- a/firestore/integration_test.go
+++ b/firestore/integration_test.go
@@ -645,10 +645,7 @@ func TestIntegration_GetAll_WithRunOptions(t *testing.T) {
 	for _, wantRef := range wantDocRefs {
 		snapshotRefIDs = append(snapshotRefIDs, wantRef.ID)
 	}
-
-	defer func() {
-		deleteDocuments(wantDocRefs)
-	}()
+	t.Cleanup(func() { deleteDocuments(wantDocRefs) })
 
 	for _, testcase := range testcases {
 		t.Run(testcase.desc, func(t *testing.T) {
@@ -694,14 +691,11 @@ func TestIntegration_Query_WithRunOptions(t *testing.T) {
 	coll := integrationColl(t)
 	ctx := context.Background()
 	testcases, wantDocRefs := getRunWithOptionsTestcases(t)
+	t.Cleanup(func() { deleteDocuments(wantDocRefs) })
 	snapshotRefIDs := []string{}
 	for _, wantRef := range wantDocRefs {
 		snapshotRefIDs = append(snapshotRefIDs, wantRef.ID)
 	}
-
-	defer func() {
-		deleteDocuments(wantDocRefs)
-	}()
 
 	for _, testcase := range testcases {
 		gotIDs := []string{}
@@ -1398,42 +1392,59 @@ func TestIntegration_QueryDocuments_LimitToLast_Fail(t *testing.T) {
 func TestIntegration_QueryUnary(t *testing.T) {
 	ctx := context.Background()
 	coll := integrationColl(t)
+
+	// Create required indexes
+	indexFields := [][]string{
+		{"testNull", "x", "q"},
+		{"testNaN", "x", "q"},
+	}
+	adminCtx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
+	indexNames := createIndexes(adminCtx, wantDBPath, indexFields)
+	t.Cleanup(func() {
+		deleteIndexes(adminCtx, indexNames)
+		cancel()
+	})
+
 	h := testHelper{t}
 	docRefs := []*DocumentRef{coll.NewDoc(), coll.NewDoc(), coll.NewDoc()}
-	h.mustCreate(docRefs[0], map[string]interface{}{"x": 2, "q": "a", "testNull": true, "testNaN": true})
-	h.mustCreate(docRefs[1], map[string]interface{}{"x": 2, "q": nil, "testNull": true, "testNaN": false})
-	h.mustCreate(docRefs[2], map[string]interface{}{"x": 2, "q": math.NaN(), "testNull": false, "testNaN": true})
-	wantNull := map[string]interface{}{"q": nil}
-	wantNaN := map[string]interface{}{"q": math.NaN()}
-	wantA := map[string]interface{}{"q": "a"}
+	t.Cleanup(func() { deleteDocuments(docRefs) })
+	h.mustCreate(docRefs[0], map[string]any{"x": 2, "q": "a", "testNull": true, "testNaN": true})
+	h.mustCreate(docRefs[1], map[string]any{"x": 2, "q": nil, "testNull": true, "testNaN": false})
+	h.mustCreate(docRefs[2], map[string]any{"x": 2, "q": math.NaN(), "testNull": false, "testNaN": true})
+	wantNull := map[string]any{"q": nil}
+	wantNaN := map[string]any{"q": math.NaN()}
+	wantA := map[string]any{"q": "a"}
 
 	base := coll.Select("q").Where("x", "==", 2)
 	baseNull := base.Where("testNull", "==", true)
 	baseNaN := base.Where("testNaN", "==", true)
 	for _, test := range []struct {
+		desc string
 		q    Query
-		want map[string]interface{}
+		want map[string]any
 	}{
-		{baseNull.Where("q", "==", nil), wantNull},
-		{baseNull.Where("q", "!=", nil), wantA},
-		{baseNaN.Where("q", "==", math.NaN()), wantNaN},
-		{baseNaN.Where("q", "!=", math.NaN()), wantA},
+		{desc: "IS NULL", q: baseNull.Where("q", "==", nil), want: wantNull},
+		{desc: "IS NOT NULL", q: baseNull.Where("q", "!=", nil), want: wantA},
+		{desc: "IS NaN", q: baseNaN.Where("q", "==", math.NaN()), want: wantNaN},
+		{desc: "IS NOT NaN", q: baseNaN.Where("q", "!=", math.NaN()), want: wantA},
 	} {
-		got, err := test.q.Documents(ctx).GetAll()
-		if err != nil {
-			t.Fatal(err)
-		}
-		if len(got) != 1 {
-			t.Errorf("got %d responses, want 1", len(got))
-			continue
-		}
-		if g, w := got[0].Data(), test.want; !testEqual(g, w) {
-			t.Errorf("%v: got %v, want %v", test.q, g, w)
-		}
+		t.Run(test.desc, func(t *testing.T) {
+			testutil.Retry(t, 5, 5*time.Second, func(r *testutil.R) {
+				got, err := test.q.Documents(ctx).GetAll()
+				if err != nil {
+					r.Errorf(err.Error())
+					return
+				}
+				if len(got) != 1 {
+					t.Errorf("got %d responses, want 1", len(got))
+					return
+				}
+				if g, w := got[0].Data(), test.want; !testEqual(g, w) {
+					t.Errorf("%v: got %v, want %v", test.q, g, w)
+				}
+			})
+		})
 	}
-	t.Cleanup(func() {
-		deleteDocuments(docRefs)
-	})
 }
 
 // Test the special DocumentID field in queries.
@@ -1589,6 +1600,7 @@ func TestIntegration_RunTransaction_WithRunOptions(t *testing.T) {
 	ctx := context.Background()
 	client := integrationClient(t)
 	testcases, wantDocRefs := getRunWithOptionsTestcases(t)
+	t.Cleanup(func() { deleteDocuments(wantDocRefs) })
 	numDocs := len(wantDocRefs)
 	for _, testcase := range testcases {
 		t.Run(testcase.desc, func(t *testing.T) {
@@ -1630,9 +1642,6 @@ func TestIntegration_RunTransaction_WithRunOptions(t *testing.T) {
 		})
 	}
 
-	t.Cleanup(func() {
-		deleteDocuments(wantDocRefs)
-	})
 }
 
 func TestIntegration_TransactionGetAll(t *testing.T) {
@@ -2753,6 +2762,31 @@ func TestIntegration_BulkWriter(t *testing.T) {
 	})
 }
 
+func aggResultsEquals(r *testutil.R, m1, m2 AggregationResult) bool {
+	if len(m1) != len(m2) {
+		r.Errorf("aggResultsEquals: length mismatch, len(m1)=%d, len(m2)=%d", len(m1), len(m2))
+		return false
+	}
+	for k, v1 := range m1 {
+		v2, ok := m2[k]
+		if !ok {
+			r.Errorf("aggResultsEquals: key %q not found in m2", k)
+			return false
+		}
+		pbVal1, ok1 := v1.(*pb.Value)
+		pbVal2, ok2 := v2.(*pb.Value)
+		if !ok1 || !ok2 {
+			r.Errorf("aggResultsEquals: type assertion to *pb.Value failed for key %q (ok1=%t, ok2=%t)", k, ok1, ok2)
+			return false
+		}
+		if diff := testutil.Diff(pbVal1, pbVal2, cmpopts.IgnoreUnexported(pb.Value{})); diff != "" {
+			r.Errorf("aggResultsEquals: failed for key %q\nv1=%v\nv2=%v\ndiff: got=-, want=+\n%v", k, pbVal1, pbVal2, diff)
+			return false
+		}
+	}
+	return true
+}
+
 func TestIntegration_AggregationQueries(t *testing.T) {
 	ctx := context.Background()
 	coll := integrationColl(t)
@@ -2807,13 +2841,13 @@ func TestIntegration_AggregationQueries(t *testing.T) {
 		aggregationQuery *AggregationQuery
 		wantErr          bool
 		runInTransaction bool
-		result           AggregationResult
+		wantResult       AggregationResult
 	}{
 		{
 			desc:             "Multiple aggregations",
 			aggregationQuery: query.NewAggregationQuery().WithCount("count1").WithAvg("weight", "weight_avg1").WithAvg("volume", "height_avg1").WithSum("weight", "weight_sum1").WithSum("volume", "height_sum1"),
 			wantErr:          false,
-			result: map[string]interface{}{
+			wantResult: map[string]interface{}{
 				"count1":      &pb.Value{ValueType: &pb.Value_IntegerValue{IntegerValue: int64(8)}},
 				"weight_sum1": &pb.Value{ValueType: &pb.Value_DoubleValue{DoubleValue: float64(39.8)}},
 				"height_sum1": &pb.Value{ValueType: &pb.Value_IntegerValue{IntegerValue: int64(765)}},
@@ -2826,7 +2860,7 @@ func TestIntegration_AggregationQueries(t *testing.T) {
 			aggregationQuery: query.NewAggregationQuery().WithCount("count1").WithAvg("weight", "weight_avg1").WithAvg("volume", "height_avg1").WithSum("weight", "weight_sum1").WithSum("volume", "height_sum1"),
 			wantErr:          false,
 			runInTransaction: true,
-			result: map[string]interface{}{
+			wantResult: map[string]interface{}{
 				"count1":      &pb.Value{ValueType: &pb.Value_IntegerValue{IntegerValue: int64(8)}},
 				"weight_sum1": &pb.Value{ValueType: &pb.Value_DoubleValue{DoubleValue: float64(39.8)}},
 				"height_sum1": &pb.Value{ValueType: &pb.Value_IntegerValue{IntegerValue: int64(765)}},
@@ -2838,7 +2872,7 @@ func TestIntegration_AggregationQueries(t *testing.T) {
 			desc:             "WithSum aggregation without alias",
 			aggregationQuery: query.NewAggregationQuery().WithSum("weight", ""),
 			wantErr:          false,
-			result: map[string]interface{}{
+			wantResult: map[string]interface{}{
 				"field_1": &pb.Value{ValueType: &pb.Value_DoubleValue{DoubleValue: float64(39.8)}},
 			},
 		},
@@ -2846,7 +2880,7 @@ func TestIntegration_AggregationQueries(t *testing.T) {
 			desc:             "WithSumPath aggregation without alias",
 			aggregationQuery: query.NewAggregationQuery().WithSumPath([]string{"weight"}, ""),
 			wantErr:          false,
-			result: map[string]interface{}{
+			wantResult: map[string]interface{}{
 				"field_1": &pb.Value{ValueType: &pb.Value_DoubleValue{DoubleValue: float64(39.8)}},
 			},
 		},
@@ -2854,7 +2888,7 @@ func TestIntegration_AggregationQueries(t *testing.T) {
 			desc:             "WithAvg aggregation without alias",
 			aggregationQuery: query.NewAggregationQuery().WithAvg("weight", ""),
 			wantErr:          false,
-			result: map[string]interface{}{
+			wantResult: map[string]interface{}{
 				"field_1": &pb.Value{ValueType: &pb.Value_DoubleValue{DoubleValue: float64(4.975)}},
 			},
 		},
@@ -2862,7 +2896,7 @@ func TestIntegration_AggregationQueries(t *testing.T) {
 			desc:             "WithAvgPath aggregation without alias",
 			aggregationQuery: query.NewAggregationQuery().WithAvgPath([]string{"weight"}, ""),
 			wantErr:          false,
-			result: map[string]interface{}{
+			wantResult: map[string]interface{}{
 				"field_1": &pb.Value{ValueType: &pb.Value_DoubleValue{DoubleValue: float64(4.975)}},
 			},
 		},
@@ -2870,7 +2904,7 @@ func TestIntegration_AggregationQueries(t *testing.T) {
 			desc:             "Aggregations with limit",
 			aggregationQuery: (&limitQuery).NewAggregationQuery().WithCount("count1").WithAvgPath([]string{"weight"}, "weight_avg1").WithSumPath([]string{"weight"}, "weight_sum1"),
 			wantErr:          false,
-			result: map[string]interface{}{
+			wantResult: map[string]interface{}{
 				"count1":      &pb.Value{ValueType: &pb.Value_IntegerValue{IntegerValue: int64(4)}},
 				"weight_sum1": &pb.Value{ValueType: &pb.Value_DoubleValue{DoubleValue: float64(12.6)}},
 				"weight_avg1": &pb.Value{ValueType: &pb.Value_DoubleValue{DoubleValue: float64(3.15)}},
@@ -2880,7 +2914,7 @@ func TestIntegration_AggregationQueries(t *testing.T) {
 			desc:             "Aggregations with StartAt",
 			aggregationQuery: (&startAtQuery).NewAggregationQuery().WithCount("count1").WithAvgPath([]string{"weight"}, "weight_avg1").WithSumPath([]string{"weight"}, "weight_sum1"),
 			wantErr:          false,
-			result: map[string]interface{}{
+			wantResult: map[string]interface{}{
 				"count1":      &pb.Value{ValueType: &pb.Value_IntegerValue{IntegerValue: int64(6)}},
 				"weight_sum1": &pb.Value{ValueType: &pb.Value_DoubleValue{DoubleValue: float64(35.7)}},
 				"weight_avg1": &pb.Value{ValueType: &pb.Value_DoubleValue{DoubleValue: float64(5.95)}},
@@ -2890,7 +2924,7 @@ func TestIntegration_AggregationQueries(t *testing.T) {
 			desc:             "Aggregations with StartAfter",
 			aggregationQuery: (&startAfterQuery).NewAggregationQuery().WithCount("count1").WithAvgPath([]string{"weight"}, "weight_avg1").WithSumPath([]string{"weight"}, "weight_sum1"),
 			wantErr:          false,
-			result: map[string]interface{}{
+			wantResult: map[string]interface{}{
 				"count1":      &pb.Value{ValueType: &pb.Value_IntegerValue{IntegerValue: int64(5)}},
 				"weight_sum1": &pb.Value{ValueType: &pb.Value_DoubleValue{DoubleValue: float64(32)}},
 				"weight_avg1": &pb.Value{ValueType: &pb.Value_DoubleValue{DoubleValue: float64(6.4)}},
@@ -2900,7 +2934,7 @@ func TestIntegration_AggregationQueries(t *testing.T) {
 			desc:             "Aggregations with EndAt",
 			aggregationQuery: (&endAtQuery).NewAggregationQuery().WithCount("count1").WithAvgPath([]string{"weight"}, "weight_avg1").WithSumPath([]string{"weight"}, "weight_sum1"),
 			wantErr:          false,
-			result: map[string]interface{}{
+			wantResult: map[string]interface{}{
 				"count1":      &pb.Value{ValueType: &pb.Value_IntegerValue{IntegerValue: int64(6)}},
 				"weight_sum1": &pb.Value{ValueType: &pb.Value_DoubleValue{DoubleValue: float64(30.1)}},
 				"weight_avg1": &pb.Value{ValueType: &pb.Value_DoubleValue{DoubleValue: float64(5.016666666666667)}},
@@ -2910,7 +2944,7 @@ func TestIntegration_AggregationQueries(t *testing.T) {
 			desc:             "Aggregations with EndBefore",
 			aggregationQuery: (&endBeforeQuery).NewAggregationQuery().WithCount("count1").WithAvgPath([]string{"weight"}, "weight_avg1").WithSumPath([]string{"weight"}, "weight_sum1"),
 			wantErr:          false,
-			result: map[string]interface{}{
+			wantResult: map[string]interface{}{
 				"count1":      &pb.Value{ValueType: &pb.Value_IntegerValue{IntegerValue: int64(5)}},
 				"weight_sum1": &pb.Value{ValueType: &pb.Value_DoubleValue{DoubleValue: float64(23)}},
 				"weight_avg1": &pb.Value{ValueType: &pb.Value_DoubleValue{DoubleValue: float64(4.6)}},
@@ -2920,7 +2954,7 @@ func TestIntegration_AggregationQueries(t *testing.T) {
 			desc:             "Aggregations with LimitToLast",
 			aggregationQuery: (&limitToLastQuery).NewAggregationQuery().WithCount("count1").WithAvgPath([]string{"weight"}, "weight_avg1").WithSumPath([]string{"weight"}, "weight_sum1"),
 			wantErr:          false,
-			result: map[string]interface{}{
+			wantResult: map[string]interface{}{
 				"count1":      &pb.Value{ValueType: &pb.Value_IntegerValue{IntegerValue: int64(4)}},
 				"weight_sum1": &pb.Value{ValueType: &pb.Value_DoubleValue{DoubleValue: float64(27.2)}},
 				"weight_avg1": &pb.Value{ValueType: &pb.Value_DoubleValue{DoubleValue: float64(6.8)}},
@@ -2930,7 +2964,7 @@ func TestIntegration_AggregationQueries(t *testing.T) {
 			desc:             "Aggregations on empty results",
 			aggregationQuery: emptyResultsQueryPtr.NewAggregationQuery().WithCount("count1").WithAvg("weight", "weight_avg1").WithSum("weight", "weight_sum1"),
 			wantErr:          false,
-			result: map[string]interface{}{
+			wantResult: map[string]interface{}{
 				"count1":      &pb.Value{ValueType: &pb.Value_IntegerValue{IntegerValue: int64(0)}},
 				"weight_sum1": &pb.Value{ValueType: &pb.Value_IntegerValue{IntegerValue: int64(0)}},
 				"weight_avg1": &pb.Value{ValueType: &pb.Value_NullValue{NullValue: structpb.NullValue_NULL_VALUE}},
@@ -2940,7 +2974,7 @@ func TestIntegration_AggregationQueries(t *testing.T) {
 			desc:             "Aggregation on non-numeric field",
 			aggregationQuery: query.NewAggregationQuery().WithAvg("model", "model_avg1").WithSum("model", "model_sum1"),
 			wantErr:          false,
-			result: map[string]interface{}{
+			wantResult: map[string]interface{}{
 				"model_sum1": &pb.Value{ValueType: &pb.Value_IntegerValue{IntegerValue: int64(0)}},
 				"model_avg1": &pb.Value{ValueType: &pb.Value_NullValue{NullValue: structpb.NullValue_NULL_VALUE}},
 			},
@@ -2955,15 +2989,15 @@ func TestIntegration_AggregationQueries(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.desc, func(t *testing.T) {
 			testutil.Retry(t, 5, 5*time.Second, func(r *testutil.R) {
-				var aggResult AggregationResult
+				var gotResult AggregationResult
 				var err error
 				if tc.runInTransaction {
 					client.RunTransaction(ctx, func(ctx context.Context, tx *Transaction) error {
-						aggResult, err = tc.aggregationQuery.Transaction(tx).Get(ctx)
+						gotResult, err = tc.aggregationQuery.Transaction(tx).Get(ctx)
 						return err
 					})
 				} else {
-					aggResult, err = tc.aggregationQuery.Get(ctx)
+					gotResult, err = tc.aggregationQuery.Get(ctx)
 				}
 
 				// Retry only if index building is in progress
@@ -2976,13 +3010,16 @@ func TestIntegration_AggregationQueries(t *testing.T) {
 
 				// Compare expected and actual results
 				if err != nil && !tc.wantErr {
-					r.Fatalf("got: %v, want: nil", err)
+					r.Errorf("got: %v, want: nil", err)
+					return
 				}
 				if err == nil && tc.wantErr {
-					r.Fatalf("got: %v, wanted error", err)
+					r.Errorf("got: %v, wanted error", err)
+					return
 				}
-				if !reflect.DeepEqual(aggResult, tc.result) {
-					r.Fatalf("got: %v, want: %v", aggResult, tc.result)
+				if !aggResultsEquals(r, gotResult, tc.wantResult) {
+					r.Errorf("got: %v, want: %v", gotResult, tc.wantResult)
+					return
 				}
 			})
 		})
@@ -3081,7 +3118,7 @@ func TestIntegration_AggregationQueries_WithRunOptions(t *testing.T) {
 				r.Errorf("%s: Mismatch in error got: %v, want: %v", testcase.desc, gotErr, testcase.wantErrMsg)
 				return
 			}
-			if !gotFailed && !testutil.Equal(gotRes.Result, testcase.wantRes.Result) {
+			if !gotFailed && !aggResultsEquals(r, gotRes.Result, testcase.wantRes.Result) {
 				r.Errorf("%q: Mismatch in aggregation result got: %v, want: %v", testcase.desc, gotRes.Result, testcase.wantRes.Result)
 				return
 			}
@@ -3350,22 +3387,14 @@ func TestIntegration_FindNearest(t *testing.T) {
 				// Get all documents
 				iter := tc.vq.Documents(ctx)
 				gotDocs, err := iter.GetAll()
-
-				// Retry only if index building is in progress
-				s, ok := status.FromError(err)
-				if err != nil && ok && s != nil && s.Code() != codes.FailedPrecondition &&
-					strings.Contains(s.Message(), indexBuilding) {
-					r.Errorf("GetAll: %v", err)
-					return
-				}
-
 				if err != nil {
-					t.Fatalf("GetAll: %+v", err)
+					r.Errorf("GetAll: %+v", err)
+					return
 				}
 
 				// Compare expected and actual results length
 				if len(gotDocs) != len(tc.wantBeans) {
-					t.Fatalf("Expected %v results, got %d", len(tc.wantBeans), len(gotDocs))
+					r.Errorf("Expected %v results, got %d", len(tc.wantBeans), len(gotDocs))
 				}
 
 				// Compare results
@@ -3376,18 +3405,18 @@ func TestIntegration_FindNearest(t *testing.T) {
 					if len(tc.wantResField) != 0 {
 						_, ok := doc.Data()[tc.wantResField]
 						if !ok {
-							t.Errorf("Expected %v field to exist in %v", tc.wantResField, doc.Data())
+							r.Errorf("Expected %v field to exist in %v", tc.wantResField, doc.Data())
 						}
 					}
 
 					// Compare expected and actual document ID
 					err := doc.DataTo(&gotBean)
 					if err != nil {
-						t.Errorf("#%v: DataTo: %+v", doc.Ref.ID, err)
-						continue
+						r.Errorf("#%v: DataTo: %+v", doc.Ref.ID, err)
+						return
 					}
 					if tc.wantBeans[i].ID != gotBean.ID {
-						t.Errorf("#%v: want: %v, got: %v", i, beans[i].ID, gotBean.ID)
+						r.Errorf("#%v: want: %v, got: %v", i, beans[i].ID, gotBean.ID)
 					}
 				}
 			})


### PR DESCRIPTION
1. Fixes: https://github.com/googleapis/google-cloud-go/issues/10842
    ```go
    === RUN   TestIntegration_AggregationQueries/Aggregation_on_non-numeric_field
        retry.go:49: Fatal failure after 1 attempts:
            retry.go:112: got: rpc error: code = FailedPrecondition desc = The query requires an index. That index is currently building and cannot be used yet. See its status here: https://console.firebase.google.com/v1/r/project/gcloud-golang-firestore-tests/firestore/indexes?create_composite=CpEBcHJvamVjdHMvZ2Nsb3VkLWdvbGFuZy1maXJlc3RvcmUtdGVzdHMvZGF0YWJhc2VzLyhkZWZhdWx0KS9jb2xsZWN0aW9uR3JvdXBzL2dvLWludGVncmF0aW9uLXRlc3QtMjAyNDEyMjMtMzA3NDY5NzY1MjIyOTgtMDAwMS9pbmRleGVzL0NJQ0FnTlRnczVNSxABGgoKBndlaWdodBABGgkKBW1vZGVsEAEaDAoIX19uYW1lX18QAQ, want: nil
            retry.go:112: got: map[], want: map[model_avg1:null_value:NULL_VALUE model_sum1:integer_value:0]
    ```
     **Cause**: 'Index is building' is not grpc Status error. So, existing check to retry test does not retry the test when index is building.
    **Fix**: retry test on error
    
  
2. Fixes: https://github.com/googleapis/google-cloud-go/issues/11794
    ```go
    === RUN   TestIntegration_QueryUnary
        integration_test.go:1424: rpc error: code = FailedPrecondition desc = The query requires an index. You can create it here: https://console.firebase.google.com/v1/r/project/gcloud-golang-firestore-tests/firestore/indexes?create_composite=CoMBcHJvamVjdHMvZ2Nsb3VkLWdvbGFuZy1maXJlc3RvcmUtdGVzdHMvZGF0YWJhc2VzLyhkZWZhdWx0KS9jb2xsZWN0aW9uR3JvdXBzL2dvLWludGVncmF0aW9uLXRlc3QtMjAyNTA1MjMtNTYxODQ0OTM4NDQtMDAwMS9pbmRleGVzL18QARoMCgh0ZXN0TnVsbBABGgUKAXgQARoFCgFxEAEaDAoIX19uYW1lX18QAQ
    --- FAIL: TestIntegration_QueryUnary (0.73s)
    ```
    **Cause**: The query requires index but no indexes are created while running test.
    **Fix**: Create indexes
3.  Fixes https://github.com/googleapis/google-cloud-go/issues/11795
    ```go
    === RUN   TestIntegration_RunTransaction_WithRunOptions
    === RUN   TestIntegration_RunTransaction_WithRunOptions/No_ExplainOptions
    === RUN   TestIntegration_RunTransaction_WithRunOptions/ExplainOptions.Analyze_is_false
    === RUN   TestIntegration_RunTransaction_WithRunOptions/ExplainOptions.Analyze_is_true
        integration_test.go:1628: ExplainMetrics ExecutionStats: mismatch (-want +got):
              &firestore.ExecutionStats{
            - 	ResultsReturned: 5,
            + 	ResultsReturned: 8,
          	    ... // 1 ignored field
            - 	ReadOperations: 5,
            + 	ReadOperations: 8,
          	    ... // 1 ignored field
              }
            
    --- FAIL: TestIntegration_RunTransaction_WithRunOptions (1.70s)
        --- PASS: TestIntegration_RunTransaction_WithRunOptions/No_ExplainOptions (0.22s)
        --- PASS: TestIntegration_RunTransaction_WithRunOptions/ExplainOptions.Analyze_is_false (0.20s)
        --- FAIL: TestIntegration_RunTransaction_WithRunOptions/ExplainOptions.Analyze_is_true (0.24s)
    ```
     **Cause**: Old documents were not getting deleted
     **Fix**: Ensure test documents are cleaned up
4. Fixes