### PR TITLE
test(bigtable): Correct the known conformance failures

### DIFF
--- a/bigtable/internal/testproxy/known_failures.txt
+++ b/bigtable/internal/testproxy/known_failures.txt
@@ -3,4 +3,4 @@ TestReadRow_Retry_WithRoutingCookie\|
 TestReadRows_Retry_WithRoutingCookie\|
 TestReadRows_Retry_WithRoutingCookie_MultipleErrorResponses\|
 TestReadRows_Retry_WithRetryInfo_MultipleErrorResponse\|
-TestSampleRowKeys_Retry_WithRoutingCookie\|
+TestSampleRowKeys_Retry_WithRoutingCookie


### PR DESCRIPTION
In [latest run](https://github.com/googleapis/google-cloud-go/actions/runs/15199197073/job/42749998915), the conformance tests are not running and shows  `testing: warning: no tests to run`
```go
++ go1.23.0 test -v -proxy_addr=:9999 -skip 'TestMutateRows_Retry_WithRoutingCookie|TestReadRow_Retry_WithRoutingCookie|TestReadRows_Retry_WithRoutingCookie|TestReadRows_Retry_WithRoutingCookie_MultipleErrorResponses|TestReadRows_Retry_WithRetryInfo_MultipleErrorResponse|TestSampleRowKeys_Retry_WithRoutingCookie|'
++ tee -a /home/runner/work/google-cloud-go/google-cloud-go/google-cloud-go/bigtable/sponge_log.log
go: downloading github.com/golang/protobuf v1.5.4
go: downloading github.com/stretchr/testify v1.10.0
go: downloading google.golang.org/genproto v0.0.0-20241216192217-9240e9c98484
go: downloading google.golang.org/genproto/googleapis/rpc v0.0.0-20241216192217-9240e9c98484
go: downloading google.golang.org/grpc v1.68.0
go: downloading google.golang.org/protobuf v1.36.0
go: downloading github.com/google/go-cmp v0.6.0
go: downloading google.golang.org/genproto/googleapis/api v0.0.0-20241209162323-e6fa225c2576
go: downloading github.com/davecgh/go-spew v1.1.1
go: downloading github.com/pmezard/go-difflib v1.0.0
go: downloading golang.org/x/net v0.32.0
go: downloading cloud.google.com/go/bigtable v1.33.0
go: downloading gopkg.in/yaml.v3 v3.0.1
go: downloading golang.org/x/sys v0.28.0
go: downloading cloud.google.com/go v0.117.0
go: downloading golang.org/x/text v0.21.0
testing: warning: no tests to run
PASS
ok  	github.com/googleapis/cloud-bigtable-clients-test/tests	0.008s
```

This is because of trailing symbols in known failures file.
**Fix**: Remove the trailing symbols


