### PR TITLE
chore(spanner): fix bitSize for gfeLatency parser

### DIFF
--- a/spanner/client.go
+++ b/spanner/client.go
@@ -1516,7 +1516,7 @@ func parseServerTimingHeader(md metadata.MD) map[string]time.Duration {
 		for _, match := range matches {
 			if len(match) == 3 { // full match + 2 capture groups
 				metricName := match[1]
-				duration, err := strconv.ParseFloat(match[2], 10)
+				duration, err := strconv.ParseFloat(match[2], 64)
 				if err == nil {
 					metrics[metricName] = time.Duration(duration*1000) * time.Microsecond
 				}


### PR DESCRIPTION
It's not a bug since ParseFloat by default for any value other than 32 parses in 64 bit
Ref: https://github.com/golang/go/blob/78e86297f5cccb82a6a57081947fab8e8af32586/src/strconv/atof.go#L707