### PR TITLE
revert: "chore(internal/gapicgen): update base image (#12388)"

### DIFF
--- a/internal/gapicgen/cmd/genbot/Dockerfile
+++ b/internal/gapicgen/cmd/genbot/Dockerfile
@@ -1,17 +1,4 @@
-FROM marketplace.gcr.io/google/debian12:latest
-
-# Set environment variables for the Go version and installation
-ENV GO_VERSION 1.23.0
-ENV PATH /usr/local/go/bin:$PATH
-
-RUN apt-get update && \
-    apt-get install -y wget ca-certificates && \
-    rm -rf /var/lib/apt/lists/*
-
-RUN wget https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz -O go.tar.gz && \
-    tar -C /usr/local -xzf go.tar.gz && \
-    rm go.tar.gz
-
+FROM golang:1.23-alpine as godist
 RUN go version
 
 FROM docker:25.0


### PR DESCRIPTION
This reverts commit 66e454825f8a31085273a51cdadf0b377302dba5.

More changes are required for this to work correctly. This will be reenstated in a future PR with some other changes as well.

Internal Bug: 422147709