### PR TITLE
docs(impersonate): Address TODO in impersonate/example_test.go

### DIFF
--- a/auth/credentials/impersonate/example_test.go
+++ b/auth/credentials/impersonate/example_test.go
@@ -33,9 +33,9 @@ func ExampleNewCredentials_serviceAccount() {
 		log.Fatal(err)
 	}
 
-	// TODO(codyoss): link to option once it exists.
-
-	// Use this Credentials with a client library
+	// Use this Credentials with a client library like
+	// cloud.google.com/go/storage and WithAuthCredentials ClientOption
+	// from the google.golang.org/api/option package
 	_ = creds
 }
 

--- a/auth/credentials/impersonate/example_test.go
+++ b/auth/credentials/impersonate/example_test.go
@@ -35,7 +35,7 @@ func ExampleNewCredentials_serviceAccount() {
 
 	// Use this Credentials with a client library like
 	// cloud.google.com/go/storage and WithAuthCredentials ClientOption
-	// from the google.golang.org/api/option package
+	// from the google.golang.org/api/option package.
 	_ = creds
 }
 


### PR DESCRIPTION
Stumbled upon this TODO while I was exploring the `storage` package and how to write to GCS Bucket by impersonating a specific GSA. 

I am not 100% whether the author of the TODO meant what I did. Nevertheless I opened the PR.

Also I am aware that I didn't open an issue first. I wasn't sure whether it is needed for a small change like this one.