### PR TITLE
chore: bump changed modules

### DIFF
--- a/accessapproval/CHANGES.md
+++ b/accessapproval/CHANGES.md
@@ -213,3 +213,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out accessapproval as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/advisorynotifications/CHANGES.md
+++ b/advisorynotifications/CHANGES.md
@@ -192,3 +192,4 @@
 * **advisorynotifications:** Start generating apiv1 ([#7502](https://github.com/googleapis/google-cloud-go/issues/7502)) ([6c2b06c](https://github.com/googleapis/google-cloud-go/commit/6c2b06c43873ce4f2037383b204867c8db694a83))
 
 ## Changes
+

--- a/ai/CHANGES.md
+++ b/ai/CHANGES.md
@@ -279,3 +279,4 @@
 * **ai/generativelanguage:** Start generating apiv1beta2 ([#8229](https://github.com/googleapis/google-cloud-go/issues/8229)) ([837f325](https://github.com/googleapis/google-cloud-go/commit/837f32596518d8154f43da1c70f57d1515e2ea8c))
 
 ## Changes
+

--- a/aiplatform/CHANGES.md
+++ b/aiplatform/CHANGES.md
@@ -1539,3 +1539,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out aiplatform as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/alloydb/CHANGES.md
+++ b/alloydb/CHANGES.md
@@ -382,3 +382,4 @@
 * **alloydb:** Start generating apiv1, apiv1beta, apiv1alpha ([#7503](https://github.com/googleapis/google-cloud-go/issues/7503)) ([25e8426](https://github.com/googleapis/google-cloud-go/commit/25e842659ef5c3941717827459e6524f024e5a26))
 
 ## Changes
+

--- a/apigateway/CHANGES.md
+++ b/apigateway/CHANGES.md
@@ -198,3 +198,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out apigateway as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/apigeeconnect/CHANGES.md
+++ b/apigeeconnect/CHANGES.md
@@ -191,3 +191,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out apigeeconnect as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/apikeys/CHANGES.md
+++ b/apikeys/CHANGES.md
@@ -198,3 +198,4 @@
 ### Features
 
 * **apikeys:** start generating apiv2 ([#6524](https://github.com/googleapis/google-cloud-go/issues/6524)) ([8b140fa](https://github.com/googleapis/google-cloud-go/commit/8b140fa8a490d7f2e038ca8a776a1dfd46b74b4f))
+

--- a/appengine/CHANGES.md
+++ b/appengine/CHANGES.md
@@ -219,3 +219,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out appengine as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/apps/CHANGES.md
+++ b/apps/CHANGES.md
@@ -159,3 +159,4 @@
 * **apps:** New clients ([#9142](https://github.com/googleapis/google-cloud-go/issues/9142)) ([8095c6e](https://github.com/googleapis/google-cloud-go/commit/8095c6ee342d9cca812c966b708ba48398fd91ed))
 
 ## Changes
+

--- a/area120/CHANGES.md
+++ b/area120/CHANGES.md
@@ -202,3 +202,4 @@
 
 This is the first tag to carve out area120 as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/bigtable/CHANGES.md
+++ b/bigtable/CHANGES.md
@@ -508,3 +508,4 @@
 
 This is the first tag to carve out bigtable as its own module. See:
 https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository.
+

--- a/chat/CHANGES.md
+++ b/chat/CHANGES.md
@@ -225,3 +225,4 @@
 * **chat:** Chat API documentation update ([1d757c6](https://github.com/googleapis/google-cloud-go/commit/1d757c66478963d6cbbef13fee939632c742759c))
 
 ## Changes
+

--- a/cloudquotas/CHANGES.md
+++ b/cloudquotas/CHANGES.md
@@ -156,3 +156,4 @@
 * **cloudquotas:** New clients ([#9222](https://github.com/googleapis/google-cloud-go/issues/9222)) ([57e2d7b](https://github.com/googleapis/google-cloud-go/commit/57e2d7bd2730b4acd18eac0e3a18e682b51c3e03))
 
 ## Changes
+


### PR DESCRIPTION
BEGIN_NESTED_COMMIT
fix(accessapproval): fix: upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(advisorynotifications): fix: upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(ai): fix: upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(aiplatform): fix: upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(alloydb): fix: upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(apigateway): fix: upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(apigeeconnect): fix: upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(apikeys): fix: upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(appengine): fix: upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(apps): fix: upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(area120): fix: upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(bigtable): fix: upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(chat): fix: upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(cloudquotas): fix: upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT