### PR TITLE
chore(internal/gapicgen): upgrade protoc to google.golang.org/grpc/cmd/protoc-gen-go-grpc

### DIFF
--- a/internal/gapicgen/cmd/genbot/Dockerfile
+++ b/internal/gapicgen/cmd/genbot/Dockerfile
@@ -27,7 +27,8 @@ ENV PATH /usr/local/go/bin:$PATH
 RUN go version
 
 # Install Go tools.
-RUN go install github.com/golang/protobuf/protoc-gen-go@v1.5.3 && \
+RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.36.6 && \
+    go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.5.1 && \
     go install golang.org/x/lint/golint@latest && \
     go install golang.org/x/tools/cmd/goimports@latest && \
     go install honnef.co/go/tools/cmd/staticcheck@latest && \

--- a/internal/gapicgen/generator/genproto.go
+++ b/internal/gapicgen/generator/genproto.go
@@ -246,7 +246,8 @@ func goPkg(fileName string) (string, error) {
 func (g *GenprotoGenerator) protoc(fileNames []string) error {
 	args := []string{
 		"--experimental_allow_proto3_optional",
-		fmt.Sprintf("--go_out=plugins=grpc:%s/generated", g.genprotoDir),
+		fmt.Sprintf("--go_out=%s/generated", g.genprotoDir),
+		fmt.Sprintf("--go-grpc_out=%s/generated", g.genprotoDir),
 		"-I", g.googleapisDir,
 		"-I", g.protoSrcDir,
 	}


### PR DESCRIPTION
closes: googleapis/go-genproto#1040