### PR TITLE
feat(firestore): Add rest of the input stages

### DIFF
--- a/firestore/pipeline_result.go
+++ b/firestore/pipeline_result.go
@@ -90,23 +90,24 @@ func newPipelineResult(ref *DocumentRef, proto *pb.Document, c *Client, executio
 //	p.DataTo(&m)
 //
 // except that it returns nil if the document does not exist.
-func (p *PipelineResult) Data() map[string]interface{} {
-	if !p.Exists() {
-		return nil
+
+func (p *PipelineResult) Data() (map[string]interface{}, error) {
+	if p == nil {
+		return nil, status.Errorf(codes.NotFound, "document does not exist")
 	}
 	m, err := createMapFromValueMap(p.proto.Fields, p.c)
 	// Any error here is a bug in the client.
 	if err != nil {
 		panic(fmt.Sprintf("firestore: %v", err))
 	}
-	return m
+	return m, nil
 }
 
 // DataTo uses the PipelineResult's fields to populate v, which can be a pointer to a
 // map[string]interface{} or a pointer to a struct.
 // This is similar to [DocumentSnapshot.DataTo]
 func (p *PipelineResult) DataTo(v interface{}) error {
-	if !p.Exists() {
+	if p == nil {
 		return status.Errorf(codes.NotFound, "document does not exist")
 	}
 	return setFromProtoValue(v, &pb.Value{ValueType: &pb.Value_MapValue{MapValue: &pb.MapValue{Fields: p.proto.Fields}}}, p.c)

--- a/firestore/pipeline_result.go
+++ b/firestore/pipeline_result.go
@@ -88,9 +88,6 @@ func newPipelineResult(ref *DocumentRef, proto *pb.Document, c *Client, executio
 //
 //	var m map[string]interface{}
 //	p.DataTo(&m)
-//
-// except that it returns nil if the document does not exist.
-
 func (p *PipelineResult) Data() (map[string]interface{}, error) {
 	if p == nil {
 		return nil, status.Errorf(codes.NotFound, "document does not exist")

--- a/firestore/pipeline_result.go
+++ b/firestore/pipeline_result.go
@@ -90,7 +90,7 @@ func newPipelineResult(ref *DocumentRef, proto *pb.Document, c *Client, executio
 //	p.DataTo(&m)
 func (p *PipelineResult) Data() (map[string]interface{}, error) {
 	if p == nil {
-		return nil, status.Errorf(codes.NotFound, "document does not exist")
+		return nil, status.Errorf(codes.NotFound, "result does not exist")
 	}
 	m, err := createMapFromValueMap(p.proto.Fields, p.c)
 	// Any error here is a bug in the client.

--- a/firestore/pipeline_source.go
+++ b/firestore/pipeline_source.go
@@ -20,7 +20,39 @@ type PipelineSource struct {
 	client *Client
 }
 
-// Collection returns all documents from the entire collection.
+// Collection creates a new [Pipeline] that operates on the specified Firestore collection.
 func (ps *PipelineSource) Collection(path string) *Pipeline {
 	return newPipeline(ps.client, newInputStageCollection(path))
+}
+
+// CollectionGroup creates a new [Pipeline] that operates on all documents in a group
+// of collections that include the given ID, regardless of parent document.
+//
+// For example, consider:
+// France/Cities/Paris = {population: 100}
+// Canada/Cities/Montreal = {population: 90}
+//
+// CollectionGroup can be used to query across all "Cities" regardless of
+// its parent "Countries".
+func (ps *PipelineSource) CollectionGroup(collectionID string) *Pipeline {
+	return newPipeline(ps.client, newInputStageCollectionGroup("", collectionID))
+}
+
+// CollectionGroupWithAncestor creates a new [Pipeline] that operates on all documents in a group
+// of collections that include the given ID, that are underneath a given document.
+//
+// For example, consider:
+// /continents/Europe/Germany/Cities/Paris = {population: 100}
+// /continents/Europe/France/Cities/Paris = {population: 100}
+// /continents/NorthAmerica/Canada/Cities/Montreal = {population: 90}
+//
+// CollectionGroupWithAncestor can be used to query across all "Cities" in "/continents/Europe".
+// TODO(bhshkh): Subcollections are not yet supported in enterprise DB. Check with Firestore team whether ancestors should be added.
+func (ps *PipelineSource) CollectionGroupWithAncestor(ancestor, collectionID string) *Pipeline {
+	return newPipeline(ps.client, newInputStageCollectionGroup(ancestor, collectionID))
+}
+
+// Database creates a new [Pipeline] that operates on all documents in the Firestore database.
+func (ps *PipelineSource) Database() *Pipeline {
+	return newPipeline(ps.client, newInputStageDatabase())
 }

--- a/firestore/pipeline_source.go
+++ b/firestore/pipeline_source.go
@@ -47,7 +47,6 @@ func (ps *PipelineSource) CollectionGroup(collectionID string) *Pipeline {
 // /continents/NorthAmerica/Canada/Cities/Montreal = {population: 90}
 //
 // CollectionGroupWithAncestor can be used to query across all "Cities" in "/continents/Europe".
-// TODO(bhshkh): Subcollections are not yet supported in enterprise DB. Check with Firestore team whether ancestors should be added.
 func (ps *PipelineSource) CollectionGroupWithAncestor(ancestor, collectionID string) *Pipeline {
 	return newPipeline(ps.client, newInputStageCollectionGroup(ancestor, collectionID))
 }

--- a/firestore/pipeline_source_test.go
+++ b/firestore/pipeline_source_test.go
@@ -50,3 +50,99 @@ func TestPipelineSource_Collection(t *testing.T) {
 		t.Errorf("toExecutePipelineRequest mismatch for collection stage (-want +got):\n%s", diff)
 	}
 }
+
+func TestPipelineSource_CollectionGroup(t *testing.T) {
+	client := newTestClient()
+	ps := &PipelineSource{client: client}
+	p := ps.CollectionGroup("cities")
+
+	if p.err != nil {
+		t.Fatalf("CollectionGroup: %v", p.err)
+	}
+	if len(p.stages) != 1 {
+		t.Fatalf("initial stages: got %d, want 1", len(p.stages))
+	}
+
+	req, err := p.toExecutePipelineRequest()
+	if err != nil {
+		t.Fatalf("toExecutePipelineRequest: %v", err)
+	}
+
+	wantStage := &pb.Pipeline_Stage{
+		Name: "collection_group",
+		Args: []*pb.Value{
+			{ValueType: &pb.Value_ReferenceValue{ReferenceValue: ""}},
+			{ValueType: &pb.Value_StringValue{StringValue: "cities"}},
+		},
+	}
+
+	if len(req.GetStructuredPipeline().GetPipeline().GetStages()) != 1 {
+		t.Fatalf("stage in proto: got %d, want 1", len(req.GetStructuredPipeline().GetPipeline().GetStages()))
+	}
+	if diff := testutil.Diff(wantStage, req.GetStructuredPipeline().GetPipeline().GetStages()[0]); diff != "" {
+		t.Errorf("toExecutePipelineRequest mismatch for collectionGroup stage (-want +got):\n%s", diff)
+	}
+}
+
+func TestPipelineSource_CollectionGroupWithAncestor(t *testing.T) {
+	client := newTestClient()
+	ps := &PipelineSource{client: client}
+	p := ps.CollectionGroupWithAncestor("ancestor/path", "items")
+
+	if p.err != nil {
+		t.Fatalf("CollectionGroupWithAncestor: %v", p.err)
+	}
+	if len(p.stages) != 1 {
+		t.Fatalf("initial stages: got %d, want 1", len(p.stages))
+	}
+
+	req, err := p.toExecutePipelineRequest()
+	if err != nil {
+		t.Fatalf("toExecutePipelineRequest: %v", err)
+	}
+
+	wantStage := &pb.Pipeline_Stage{
+		Name: "collection_group",
+		Args: []*pb.Value{
+			{ValueType: &pb.Value_ReferenceValue{ReferenceValue: "ancestor/path"}},
+			{ValueType: &pb.Value_StringValue{StringValue: "items"}},
+		},
+	}
+
+	if len(req.GetStructuredPipeline().GetPipeline().GetStages()) != 1 {
+		t.Fatalf("stage in proto: got %d, want 1", len(req.GetStructuredPipeline().GetPipeline().GetStages()))
+	}
+	if diff := testutil.Diff(wantStage, req.GetStructuredPipeline().GetPipeline().GetStages()[0]); diff != "" {
+		t.Errorf("toExecutePipelineRequest mismatch for collectionGroupWithAncestor stage (-want +got):\n%s", diff)
+	}
+}
+
+func TestPipelineSource_Database(t *testing.T) {
+	client := newTestClient()
+	ps := &PipelineSource{client: client}
+	p := ps.Database()
+
+	if p.err != nil {
+		t.Fatalf("Database: %v", p.err)
+	}
+	if len(p.stages) != 1 {
+		t.Fatalf("initial stages: got %d, want 1", len(p.stages))
+	}
+
+	req, err := p.toExecutePipelineRequest()
+	if err != nil {
+		t.Fatalf("toExecutePipelineRequest: %v", err)
+	}
+
+	wantStage := &pb.Pipeline_Stage{
+		Name: "database",
+		Args: nil,
+	}
+
+	if len(req.GetStructuredPipeline().GetPipeline().GetStages()) != 1 {
+		t.Fatalf("stage in proto: got %d, want 1", len(req.GetStructuredPipeline().GetPipeline().GetStages()))
+	}
+	if diff := testutil.Diff(wantStage, req.GetStructuredPipeline().GetPipeline().GetStages()[0]); diff != "" {
+		t.Errorf("toExecutePipelineRequest mismatch for database stage (-want +got):\n%s", diff)
+	}
+}

--- a/firestore/pipeline_stage.go
+++ b/firestore/pipeline_stage.go
@@ -46,6 +46,40 @@ func (s *inputStageCollection) toProto() (*pb.Pipeline_Stage, error) {
 	}, nil
 }
 
+// inputStageCollection returns all documents from the entire collection.
+type inputStageCollectionGroup struct {
+	collectionID string
+	ancestor     string
+}
+
+func newInputStageCollectionGroup(ancestor, collectionID string) *inputStageCollectionGroup {
+	return &inputStageCollectionGroup{ancestor: ancestor, collectionID: collectionID}
+}
+func (s *inputStageCollectionGroup) name() string { return "collection_group" }
+func (s *inputStageCollectionGroup) toProto() (*pb.Pipeline_Stage, error) {
+	ancestor := &pb.Value{ValueType: &pb.Value_ReferenceValue{ReferenceValue: s.ancestor}}
+	collectionID := &pb.Value{ValueType: &pb.Value_StringValue{StringValue: s.collectionID}}
+	return &pb.Pipeline_Stage{
+		Name: s.name(),
+		Args: []*pb.Value{ancestor, collectionID},
+	}, nil
+}
+
+// inputStageDatabase returns all documents from the entire database.
+type inputStageDatabase struct {
+	path string
+}
+
+func newInputStageDatabase() *inputStageDatabase {
+	return &inputStageDatabase{}
+}
+func (s *inputStageDatabase) name() string { return "database" }
+func (s *inputStageDatabase) toProto() (*pb.Pipeline_Stage, error) {
+	return &pb.Pipeline_Stage{
+		Name: s.name(),
+	}, nil
+}
+
 type limitStage struct {
 	limit int
 }


### PR DESCRIPTION
Add rest of the pipeline stages: collectionGroup and database

Once the [protos](https://github.com/googleapis/googleapis-gen/tree/preview/google/firestore/v1) are public, kokoro and apidiff checks will pass

More context:
- Previous Pipeline Queries PRs:
   - https://github.com/googleapis/google-cloud-go/pull/12217
- Java pipeline input stages:
   - https://github.com/googleapis/java-firestore/blob/6f640d021aeeb7f79c89d3d5e3dc6f6897e92456/google-cloud-firestore/src/main/java/com/google/cloud/firestore/PipelineSource.java#L68-L113  