### PR TITLE
perf(bigtable): Refactor metric attributes for performance

### DIFF
--- a/bigtable/bigtable.go
+++ b/bigtable/bigtable.go
@@ -2237,14 +2237,14 @@ func recordOperationCompletion(mt *builtinMetricsTracer) {
 
 	// Record operation_latencies
 	opLatAttrs, _ := mt.toOtelMetricAttrs(metricNameOperationLatencies)
-	mt.instrumentOperationLatencies.Record(mt.ctx, elapsedTimeMs, metric.WithAttributes(opLatAttrs...))
+	mt.instrumentOperationLatencies.Record(mt.ctx, elapsedTimeMs, metric.WithAttributeSet(opLatAttrs))
 
 	// Record retry_count
 	retryCntAttrs, _ := mt.toOtelMetricAttrs(metricNameRetryCount)
 	if mt.currOp.attemptCount > 1 {
 		// Only record when retry count is greater than 0 so the retry
 		// graph will be less confusing
-		mt.instrumentRetryCount.Add(mt.ctx, mt.currOp.attemptCount-1, metric.WithAttributes(retryCntAttrs...))
+		mt.instrumentRetryCount.Add(mt.ctx, mt.currOp.attemptCount-1, metric.WithAttributeSet(retryCntAttrs))
 	}
 }
 
@@ -2315,11 +2315,11 @@ func recordAttemptCompletion(mt *builtinMetricsTracer) {
 
 	// Record attempt_latencies
 	attemptLatAttrs, _ := mt.toOtelMetricAttrs(metricNameAttemptLatencies)
-	mt.instrumentAttemptLatencies.Record(mt.ctx, elapsedTime, metric.WithAttributes(attemptLatAttrs...))
+	mt.instrumentAttemptLatencies.Record(mt.ctx, elapsedTime, metric.WithAttributeSet(attemptLatAttrs))
 
 	// Record server_latencies
 	serverLatAttrs, _ := mt.toOtelMetricAttrs(metricNameServerLatencies)
 	if mt.currOp.currAttempt.serverLatencyErr == nil {
-		mt.instrumentServerLatencies.Record(mt.ctx, mt.currOp.currAttempt.serverLatency, metric.WithAttributes(serverLatAttrs...))
+		mt.instrumentServerLatencies.Record(mt.ctx, mt.currOp.currAttempt.serverLatency, metric.WithAttributeSet(serverLatAttrs))
 	}
 }

--- a/bigtable/metrics.go
+++ b/bigtable/metrics.go
@@ -402,7 +402,7 @@ func (tf *builtinMetricsTracerFactory) createBuiltinMetricsTracer(ctx context.Co
 // - converts metric attributes values captured throughout the operation / attempt
 // to OpenTelemetry attributes format,
 // - combines these with common client attributes and returns
-func (mt *builtinMetricsTracer) toOtelMetricAttrs(metricName string) ([]attribute.KeyValue, error) {
+func (mt *builtinMetricsTracer) toOtelMetricAttrs(metricName string) (attribute.Set, error) {
 	// Create attribute key value pairs for attributes common to all metricss
 	attrKeyValues := []attribute.KeyValue{
 		attribute.String(metricLabelKeyMethod, mt.method),
@@ -422,7 +422,7 @@ func (mt *builtinMetricsTracer) toOtelMetricAttrs(metricName string) ([]attribut
 	// Get metric details
 	mDetails, found := metricsDetails[metricName]
 	if !found {
-		return attrKeyValues, fmt.Errorf("unable to create attributes list for unknown metric: %v", metricName)
+		return attribute.Set{}, fmt.Errorf("unable to create attributes list for unknown metric: %v", metricName)
 	}
 
 	status := mt.currOp.status
@@ -438,9 +438,10 @@ func (mt *builtinMetricsTracer) toOtelMetricAttrs(metricName string) ([]attribut
 		case metricLabelKeyStreamingOperation:
 			attrKeyValues = append(attrKeyValues, attribute.Bool(metricLabelKeyStreamingOperation, mt.isStreaming))
 		default:
-			return attrKeyValues, fmt.Errorf("unknown additional attribute: %v", attrKey)
+			return attribute.Set{}, fmt.Errorf("unknown additional attribute: %v", attrKey)
 		}
 	}
 
-	return attrKeyValues, nil
+	attrSet := attribute.NewSet(attrKeyValues...)
+	return attrSet, nil
 }


### PR DESCRIPTION
Documentation of [WithAttributes](https://github.com/open-telemetry/opentelemetry-go/blob/metric/v1.36.0/metric/instrument.go#L372)  is :
```
It converts attributes into an attribute Set and sets the Set to be associated with a measurement. This is shorthand for:

cp := make([]attribute.KeyValue, len(attributes)) 
copy(cp, attributes) 
WithAttributeSet(attribute.NewSet(cp...))

attribute.NewSet may modify the passed attributes so this will make a copy of attributes before creating a set in order to ensure this function is concurrent safe. This makes this option function less optimized in comparison to WithAttributeSet. Therefore, WithAttributeSet should be preferred for performance sensitive code.
```
In this PR, the `toOtelMetricAttrs` function in `bigtable/metrics.go` has been modified to return an `attribute.Set` instead of a `[]attribute.KeyValue` slice. This allows for more efficient attribute handling.
So, earlier 
```
toOtelMetricAttrs created []attribute.KeyValue
WithAttributes made a copy of the above attributes
WithAttributes created attribute set using the above copied attributes
```

Now, 
```
toOtelMetricAttrs creates attribute set from []attribute.KeyValue
WithAttributeSet uses the attribute set
```
This should lead to performance gain since the copy step is eliminated