### PR TITLE
chore: remove bigquery/v2 from the yoshi release config

### DIFF
--- a/.release-please-manifest-individual.json
+++ b/.release-please-manifest-individual.json
@@ -2,6 +2,7 @@
   "auth": "0.16.2",
   "auth/oauth2adapt": "0.2.8",
   "bigquery": "1.69.0",
+  "bigquery/v2": "0.0.0",
   "bigtable": "1.37.0",
   "datastore": "1.20.0",
   "errorreporting": "0.3.2",

--- a/.release-please-manifest-submodules.json
+++ b/.release-please-manifest-submodules.json
@@ -23,7 +23,6 @@
     "baremetalsolution": "1.3.6",
     "batch": "1.12.2",
     "beyondcorp": "1.1.6",
-    "bigquery/v2": "0.0.0",
     "billing": "1.20.4",
     "binaryauthorization": "1.9.5",
     "certificatemanager": "1.9.5",

--- a/release-please-config-yoshi-submodules.json
+++ b/release-please-config-yoshi-submodules.json
@@ -75,9 +75,6 @@
         "beyondcorp": {
             "component": "beyondcorp"
         },
-        "bigquery/v2": {
-            "component": "bigquery/v2"
-        },
         "billing": {
             "component": "billing"
         },


### PR DESCRIPTION
This entry appears to have been added as a side effect of https://github.com/googleapis/google-cloud-go/pull/12421 but bigquery/v2 is configured using the individual configs:

https://github.com/googleapis/google-cloud-go/blob/6dec2e299b391c4f57d54b0977bf3f19e05abd1f/release-please-config-individual.json#L17-L21

Removing the config from the yoshi list should avoid bigquery/v2 being released under the main release.

This PR also moves the bigquery/v2 from the submodule manifest to the individual manifest, which may be related.