### PR TITLE
feat(storage): send trailing checksums for gRPC resumable uploads

### DIFF
--- a/storage/grpc_writer.go
+++ b/storage/grpc_writer.go
@@ -349,7 +349,7 @@ func drainInboundStream(stream storagepb.Storage_BidiWriteObjectClient) (object 
 	return object, err
 }
 
-func bidiWriteObjectRequest(buf []byte, offset int64, flush, finishWrite bool) *storagepb.BidiWriteObjectRequest {
+func bidiWriteObjectRequest(buf []byte, offset int64, flush, finishWrite bool, objectChecksums *storagepb.ObjectChecksums) *storagepb.BidiWriteObjectRequest {
 	var data *storagepb.BidiWriteObjectRequest_ChecksummedData
 	if buf != nil {
 		data = &storagepb.BidiWriteObjectRequest_ChecksummedData{
@@ -359,11 +359,12 @@ func bidiWriteObjectRequest(buf []byte, offset int64, flush, finishWrite bool) *
 		}
 	}
 	req := &storagepb.BidiWriteObjectRequest{
-		Data:        data,
-		WriteOffset: offset,
-		FinishWrite: finishWrite,
-		Flush:       flush,
-		StateLookup: flush,
+		Data:            data,
+		WriteOffset:     offset,
+		FinishWrite:     finishWrite,
+		Flush:           flush,
+		StateLookup:     flush,
+		ObjectChecksums: objectChecksums,
 	}
 	return req
 }
@@ -393,9 +394,6 @@ func (w *gRPCWriter) newGRPCOneshotBidiWriteBufferSender() (*gRPCOneshotBidiWrit
 		},
 		CommonObjectRequestParams: toProtoCommonObjectRequestParams(w.encryptionKey),
 		// For a non-resumable upload, checksums must be sent in this message.
-		// TODO: Currently the checksums are only sent on the first message
-		// of the stream, but in the future, we must also support sending it
-		// on the *last* message of the stream (instead of the first).
 		ObjectChecksums: toProtoChecksums(w.sendCRC32C, w.attrs),
 	}
 
@@ -415,7 +413,7 @@ func (s *gRPCOneshotBidiWriteBufferSender) sendBuffer(ctx context.Context, buf [
 		}
 		firstMessage = s.firstMessage
 	}
-	req := bidiWriteObjectRequest(buf, offset, flush, finishWrite)
+	req := bidiWriteObjectRequest(buf, offset, flush, finishWrite, nil)
 	if firstMessage != nil {
 		proto.Merge(req, firstMessage)
 	}
@@ -453,16 +451,15 @@ type gRPCResumableBidiWriteBufferSender struct {
 	stream            storagepb.Storage_BidiWriteObjectClient
 	flushOffset       int64
 	settings          *settings
+	writer            *gRPCWriter
 }
 
 func (w *gRPCWriter) newGRPCResumableBidiWriteBufferSender(ctx context.Context) (*gRPCResumableBidiWriteBufferSender, error) {
 	req := &storagepb.StartResumableWriteRequest{
 		WriteObjectSpec:           w.spec,
 		CommonObjectRequestParams: toProtoCommonObjectRequestParams(w.encryptionKey),
-		// TODO: Currently the checksums are only sent on the request to initialize
-		// the upload, but in the future, we must also support sending it
-		// on the *last* message of the stream.
-		ObjectChecksums: toProtoChecksums(w.sendCRC32C, w.attrs),
+		// For resumable uploads, checksums are only sent in the final
+		// BidiWriteObjectRequest with finish_write=true, not here.
 	}
 
 	var upid string
@@ -491,6 +488,7 @@ func (w *gRPCWriter) newGRPCResumableBidiWriteBufferSender(ctx context.Context) 
 		forceFirstMessage: true,
 		stream:            stream,
 		settings:          w.settings,
+		writer:            w,
 	}, nil
 }
 
@@ -539,7 +537,11 @@ func (s *gRPCResumableBidiWriteBufferSender) sendBuffer(ctx context.Context, buf
 		return nil, nil
 	}
 
-	req := bidiWriteObjectRequest(buf, offset, flush, finishWrite)
+	var checksums *storagepb.ObjectChecksums
+	if finishWrite && s.writer != nil && s.writer.sendCRC32C {
+		checksums = toProtoChecksums(s.writer.sendCRC32C, s.writer.attrs)
+	}
+	req := bidiWriteObjectRequest(buf, offset, flush, finishWrite, checksums)
 	if s.forceFirstMessage {
 		req.FirstMessage = &storagepb.BidiWriteObjectRequest_UploadId{UploadId: s.upid}
 		s.forceFirstMessage = false
@@ -927,9 +929,9 @@ func (s *gRPCAppendBidiWriteBufferSender) sendOnConnectedStream(buf []byte, offs
 	finalizeObject := finishWrite && s.finalizeOnClose
 	if finishWrite {
 		// Always flush when finishing the Write, even if not finalizing.
-		req = bidiWriteObjectRequest(buf, offset, true, finalizeObject)
+		req = bidiWriteObjectRequest(buf, offset, true, finalizeObject, nil)
 	} else {
-		req = bidiWriteObjectRequest(buf, offset, flush, false)
+		req = bidiWriteObjectRequest(buf, offset, flush, false, nil)
 	}
 	if finalizeObject {
 		// appendable objects pass checksums on the finalize message only

--- a/storage/integration_test.go
+++ b/storage/integration_test.go
@@ -1730,6 +1730,73 @@ func TestIntegration_MultiMessageWriteGRPC(t *testing.T) {
 	})
 }
 
+func TestIntegration_TrailingChecksumsGRPC(t *testing.T) {
+	multiTransportTest(skipHTTP("gRPC implementation specific test"), t, func(t *testing.T, ctx context.Context, bucket string, _ string, client *Client) {
+		h := testHelper{t}
+
+		name := uidSpaceObjects.New()
+		obj := client.Bucket(bucket).Object(name).Retryer(WithPolicy(RetryAlways))
+		defer h.mustDeleteObject(obj)
+
+		// Use a larger blob to test multi-message logic. This is a little over 5MB.
+		content := bytes.Repeat([]byte("a"), 5<<20)
+
+		var (
+			w    = obj.NewWriter(ctx)
+			crcW = crc32.New(crc32cTable)
+			mw   = io.MultiWriter(w, crcW)
+		)
+
+		// Force multiple requests.
+		w.ChunkSize = 1 << 20
+
+		w.ProgressFunc = func(p int64) {
+			t.Logf("%s: committed %d\n", t.Name(), p)
+		}
+		w.SendCRC32C = true
+		got, err := mw.Write(content)
+		if err != nil {
+			t.Fatalf("Writer.Write: %v", err)
+		}
+
+		// Send checksum after the upload is complete.
+		expChecksum := crcW.Sum32()
+		w.CRC32C = expChecksum
+
+		// Flush the buffer to finish the upload.
+		if err := w.Close(); err != nil {
+			t.Fatalf("Writer.Close: %v", err)
+		}
+
+		want := len(content)
+		if got != want {
+			t.Errorf("While writing got: %d want %d", got, want)
+		}
+
+		// Read back the Object for verification.
+		reader, err := client.Bucket(bucket).Object(name).NewReader(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer reader.Close()
+
+		gotCrc := reader.Attrs.CRC32C
+		if gotCrc != expChecksum {
+			t.Errorf("got CRC32C = %d, want %d", gotCrc, expChecksum)
+		}
+
+		buf := make([]byte, want+4<<10)
+		b := bytes.NewBuffer(buf)
+		gotr, err := io.Copy(b, reader)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if gotr != int64(want) {
+			t.Errorf("While reading got: %d want %d", gotr, want)
+		}
+	})
+}
+
 func TestIntegration_MultiChunkWrite(t *testing.T) {
 	multiTransportTest(context.Background(), t, func(t *testing.T, ctx context.Context, bucket string, _ string, client *Client) {
 		h := testHelper{t}


### PR DESCRIPTION
Trailing checksums are most scalable way to perform integrity checks of
large uploads. Without them, users are left with two not great options:

1. Pre-calculate the checksum and include it in the initial request.
This requires two passes over the data, or an impractical amount of
in-memory buffering.

2. Send the object without an initial checksum, but calculate it
client-side as data passes through the writer. Then, after the upload is
complete, compare the client and server-generated checksums, and try to
delete the object or create a new one. This is inherently brittle and
may require users to maintain external state of "validated" objects.

The GCS gRPC API [supports] setting the checksum on the last request in
a resumable upload, but the Go client hadn't supported this so far. This
PR modifies the gRPC writer to support trailing checksums.

This PR modifies the behavior of `StartResumableWriteRequest` such that
it ignores the checksum entirely, and we only ever set checksums in the
last message. With the caveat that I haven't modified this code before,
this seemed acceptable given the options in the docs:

> May only be provided in the first or last request (either with
> first_message, or finish_write set).

The new integration test fails on `main` but succeeds on this branch.
There were some other failures on this branch but they seemed related to
me not configuring some test parameters (like KMS) or org policy
restrictions.

Trailing checksums would greatly simplify a number of our GCS use cases,
so I'd love any feedback or changes to get this merged.

[supports]: https://cloud.google.com/storage/docs/reference/rpc/storage-operations/google.storage.v2#writeobjectrequest