### PR TITLE
testing(bigquery/v2): add some basic smoketesting for bigquery/v2

### DIFF
--- a/bigquery/v2/apiv2_smoketests/dataset_integration_test.go
+++ b/bigquery/v2/apiv2_smoketests/dataset_integration_test.go
@@ -1,0 +1,114 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package smoketests
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/bigquery/v2/apiv2/bigquerypb"
+	"github.com/googleapis/gax-go/v2/apierror"
+	"github.com/googleapis/gax-go/v2/callctx"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+)
+
+func TestDatasetLifeCycle(t *testing.T) {
+	for k, client := range testClients {
+		t.Run(k, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+			defer cancel()
+			dsRef := &bigquerypb.DatasetReference{
+				ProjectId: testProjectID,
+				DatasetId: fmt.Sprintf("testdataset_%s_%d", k, time.Now().UnixNano()),
+			}
+			t.Logf("target dataset ID: %q", dsRef.GetDatasetId())
+
+			req := &bigquerypb.InsertDatasetRequest{
+				ProjectId: testProjectID,
+				Dataset: &bigquerypb.Dataset{
+					DatasetReference: dsRef,
+					Location:         "US",
+					FriendlyName:     &wrapperspb.StringValue{Value: "test dataset for apiv2 smoketests"},
+					DefaultTableExpirationMs: &wrapperspb.Int64Value{
+						Value: 10 * 86400 * 1000, // 10 days
+					},
+				},
+			}
+			// Insert the dataset
+			ds, err := client.InsertDataset(ctx, req)
+			if err != nil {
+				t.Errorf("InsertDataset: %v", err)
+			}
+
+			// Now, update the dataset
+			updateReq := &bigquerypb.UpdateOrPatchDatasetRequest{
+				ProjectId: testProjectID,
+				DatasetId: dsRef.GetDatasetId(),
+				Dataset: &bigquerypb.Dataset{
+					FriendlyName:             &wrapperspb.StringValue{Value: "updated friendly name"},
+					DefaultTableExpirationMs: &wrapperspb.Int64Value{},
+				},
+			}
+
+			// Use Etag preconditions to validate concurrent update behavior.
+			badCtx := callctx.SetHeaders(ctx, "if-match", "badetagvalue")
+			goodCtx := callctx.SetHeaders(ctx, "if-match", ds.GetEtag())
+
+			// First, send a patch with a bad concurrent-update etag
+			updateResp, err := client.PatchDataset(badCtx, updateReq)
+			if err == nil {
+				t.Errorf("expected Patch failure, but succeeded: %s", protojson.Format(updateResp))
+			} else {
+				if apiErr, ok := err.(*apierror.APIError); ok {
+					if httpCode := apiErr.HTTPCode(); httpCode != -1 {
+						// HTTP transport path
+						if httpCode != http.StatusPreconditionFailed {
+							t.Errorf("expected HTTP precondition failure code, got %d", httpCode)
+						}
+					} else {
+						// GRPC transport path
+						if gotCode := apiErr.GRPCStatus().Code(); gotCode != codes.FailedPrecondition {
+							t.Errorf("expected FailedPrecondition, got %q", gotCode)
+						}
+					}
+				} else {
+					t.Errorf("unknown patch error: %v", err)
+				}
+			}
+
+			// Send update with a matching etag
+			_, err = client.PatchDataset(goodCtx, updateReq)
+			if err != nil {
+				t.Errorf("patch failed: %v", err)
+			}
+
+			delReq := &bigquerypb.DeleteDatasetRequest{
+				ProjectId:      testProjectID,
+				DatasetId:      dsRef.GetDatasetId(),
+				DeleteContents: true,
+			}
+
+			if err := client.DeleteDataset(ctx, delReq); err != nil {
+				t.Errorf("DeleteDataset: %v", err)
+			}
+		})
+	}
+
+}

--- a/bigquery/v2/apiv2_smoketests/job_integration_test.go
+++ b/bigquery/v2/apiv2_smoketests/job_integration_test.go
@@ -1,0 +1,64 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package smoketests
+
+import (
+	"context"
+	"testing"
+
+	"cloud.google.com/go/bigquery/v2/apiv2/bigquerypb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+)
+
+func TestInitStatelessQuery(t *testing.T) {
+	for k, client := range testClients {
+		t.Run(k, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+			defer cancel()
+
+			req := &bigquerypb.PostQueryRequest{
+				ProjectId: testProjectID,
+				QueryRequest: &bigquerypb.QueryRequest{
+					Query:           "SELECT CURRENT_TIMESTAMP() as foo, SESSION_USER() as bar",
+					JobCreationMode: bigquerypb.QueryRequest_JOB_CREATION_OPTIONAL,
+					UseLegacySql:    &wrapperspb.BoolValue{Value: false},
+					FormatOptions: &bigquerypb.DataFormatOptions{
+						UseInt64Timestamp: true,
+					},
+				},
+			}
+
+			queryResp, err := client.Query(ctx, req)
+			if err != nil {
+				t.Fatalf("Query() error: %v", err)
+			}
+			// Make some assertions if the job finished after the first poll.
+			// This _should_ be the case, but the contract doesn't allow us to
+			// assert that it must be the case.
+			if bv := queryResp.GetJobComplete(); bv != nil && bv.Value {
+				if jobRef := queryResp.GetJobReference(); jobRef != nil {
+					// We ended up with a job.  Ensure there's a reason at least.
+					if queryResp.GetJobCreationReason() != nil {
+						t.Error("there's a job reference in the response but no reason for it")
+					}
+				} else {
+					if rowcount := len(queryResp.GetRows()); rowcount != 1 {
+						t.Errorf("expected one row of data, got %d", rowcount)
+					}
+				}
+			}
+		})
+	}
+}

--- a/bigquery/v2/apiv2_smoketests/main_test.go
+++ b/bigquery/v2/apiv2_smoketests/main_test.go
@@ -1,0 +1,66 @@
+package smoketests
+
+import (
+	"context"
+	"log"
+	"os"
+	"testing"
+	"time"
+
+	bigquery "cloud.google.com/go/bigquery/v2/apiv2"
+	"cloud.google.com/go/bigquery/v2/apiv2_client"
+
+	"cloud.google.com/go/internal/testutil"
+	"google.golang.org/api/option"
+)
+
+var testClients map[string]*apiv2_client.Client
+var testProjectID string
+var defaultTestTimeout = 30 * time.Second
+
+func TestMain(m *testing.M) {
+	err := setup(context.Background())
+	if err != nil {
+		log.Printf("failure setting up test environment, skipping test execution: %v", err)
+		os.Exit(1)
+	}
+	code := m.Run()
+	shutdown()
+	os.Exit(code)
+}
+
+func setup(ctx context.Context) error {
+	projID := testutil.ProjID()
+	if projID == "" {
+		log.Fatal("Integration tests skipped. See CONTRIBUTING.md for details")
+	}
+	testProjectID = projID
+	ts := testutil.TokenSource(ctx, bigquery.DefaultAuthScopes()...)
+	if ts == nil {
+		log.Fatal("Integration tests skipped. See CONTRIBUTING.md for details")
+	}
+	var opts []option.ClientOption
+	opts = append(opts, option.WithTokenSource(ts))
+	testClients = make(map[string]*apiv2_client.Client)
+	var err error
+
+	testClients["GRPC"], err = apiv2_client.NewClient(ctx, opts...)
+	if err != nil {
+		return err
+	}
+	//opts = append(opts, option.WithHTTPClient(&c))
+	testClients["REST"], err = apiv2_client.NewRESTClient(ctx, opts...)
+	if err != nil {
+		testClients["GRPC"].Close()
+		return err
+	}
+	return nil
+}
+
+func shutdown() {
+	for k, v := range testClients {
+		if err := v.Close(); err != nil {
+			log.Printf("closing client %q had error: %v", k, err)
+		}
+	}
+}


### PR DESCRIPTION
This PR adds some utility functionality and sets up a basic pattern for testing the generated code.  It includes some test setup that produces both a REST and GRPC aggregate client, and uses them to exercise basic functionality via subtests.