### PR TITLE
testing(internal/kokoro): improve escaping for no-change bailout

### DIFF
--- a/internal/kokoro/presubmit.sh
+++ b/internal/kokoro/presubmit.sh
@@ -81,7 +81,7 @@ runPresubmitTests() {
 SIGNIFICANT_CHANGES=$(git --no-pager diff --name-only origin/main...$KOKORO_GIT_COMMIT_google_cloud_go |
   grep -Ev '(\.md$|^\.github|\.json$|\.yaml$)' | xargs dirname | sort -u || true)
 
-if [ -z $SIGNIFICANT_CHANGES ]; then
+if [ -z "${SIGNIFICANT_CHANGES}" ]; then
   echo "No changes detected, skipping tests"
   exit 0
 fi


### PR DESCRIPTION
This PR changes the bash operator slightly for the case where we attempt to exit testing earlier if there are no significant changes.

I noticed when testing an unrelated change that the error log for this file complains about this line because -z is a unary operator.  This change quotes the variable so that the it doesn't get split by the bash test.

Sample output where things went wrong:
```
+ SIGNIFICANT_CHANGES='bigquery/v2
bigquery/v2/apiv2_smoketests'
+ '[' -z bigquery/v2 bigquery/v2/apiv2_smoketests ']'
github/google-cloud-go/internal/kokoro/presubmit.sh: line 84: [: bigquery/v2: binary operator expected
++ echo 'bigquery/v2
bigquery/v2/apiv2_smoketests'
++ tr ' ' '\n'
++ cut -d/ -f1
++ tr '\n' ' '
++ sort -u
++ xargs ls -d
+ CHANGED_DIRS=bigquery
```