### PR TITLE
feat(spanner): wrap proto mutation

### DIFF
--- a/spanner/client_test.go
+++ b/spanner/client_test.go
@@ -5937,7 +5937,7 @@ func TestClient_BatchWrite(t *testing.T) {
 	defer teardown()
 	mutationGroups := []*MutationGroup{
 		{[]*Mutation{
-			{opInsertOrUpdate, "t_test", nil, []string{"key", "val"}, []interface{}{"foo1", 1}},
+			{opInsertOrUpdate, "t_test", nil, []string{"key", "val"}, []interface{}{"foo1", 1}, nil},
 		}},
 	}
 	iter := client.BatchWrite(context.Background(), mutationGroups)
@@ -5972,7 +5972,7 @@ func TestClient_BatchWrite_SessionNotFound(t *testing.T) {
 	)
 	mutationGroups := []*MutationGroup{
 		{[]*Mutation{
-			{opInsertOrUpdate, "t_test", nil, []string{"key", "val"}, []interface{}{"foo1", 1}},
+			{opInsertOrUpdate, "t_test", nil, []string{"key", "val"}, []interface{}{"foo1", 1}, nil},
 		}},
 	}
 	iter := client.BatchWrite(context.Background(), mutationGroups)
@@ -6010,7 +6010,7 @@ func TestClient_BatchWrite_Error(t *testing.T) {
 	)
 	mutationGroups := []*MutationGroup{
 		{[]*Mutation{
-			{opInsertOrUpdate, "t_test", nil, []string{"key", "val"}, []interface{}{"foo1", 1}},
+			{opInsertOrUpdate, "t_test", nil, []string{"key", "val"}, []interface{}{"foo1", 1}, nil},
 		}},
 	}
 	iter := client.BatchWrite(context.Background(), mutationGroups)
@@ -6085,7 +6085,7 @@ func TestClient_BatchWrite_Options(t *testing.T) {
 
 			mutationGroups := []*MutationGroup{
 				{[]*Mutation{
-					{opInsertOrUpdate, "t_test", nil, []string{"key", "val"}, []interface{}{"foo1", 1}},
+					{opInsertOrUpdate, "t_test", nil, []string{"key", "val"}, []interface{}{"foo1", 1}, nil},
 				}},
 			}
 			iter := client.BatchWriteWithOptions(context.Background(), mutationGroups, tt.write)
@@ -6131,7 +6131,7 @@ func checkBatchWriteSpan(t *testing.T, errors []error, code codes.Code) {
 	)
 	mutationGroups := []*MutationGroup{
 		{[]*Mutation{
-			{opInsertOrUpdate, "t_test", nil, []string{"key", "val"}, []interface{}{"foo1", 1}},
+			{opInsertOrUpdate, "t_test", nil, []string{"key", "val"}, []interface{}{"foo1", 1}, nil},
 		}},
 	}
 	iter := client.BatchWrite(context.Background(), mutationGroups)
@@ -6683,7 +6683,7 @@ func TestClient_BatchWriteExcludeTxnFromChangeStreams(t *testing.T) {
 
 	mutationGroups := []*MutationGroup{
 		{[]*Mutation{
-			{opInsertOrUpdate, "t_test", nil, []string{"key", "val"}, []interface{}{"foo1", 1}},
+			{opInsertOrUpdate, "t_test", nil, []string{"key", "val"}, []interface{}{"foo1", 1}, nil},
 		}},
 	}
 	iter := client.BatchWriteWithOptions(context.Background(), mutationGroups, BatchWriteOptions{ExcludeTxnFromChangeStreams: true})

--- a/spanner/mutation.go
+++ b/spanner/mutation.go
@@ -17,6 +17,7 @@ limitations under the License.
 package spanner
 
 import (
+	"fmt"
 	"math/rand"
 	"reflect"
 	"time"
@@ -141,6 +142,10 @@ type Mutation struct {
 	// values specifies the new values for the target columns
 	// named by Columns.
 	values []interface{}
+
+	// wrapped is the protobuf mutation that is the source for this Mutation.
+	// This is only set if the [WrapMutation] function was used to create the Mutation.
+	wrapped *sppb.Mutation
 }
 
 // A MutationGroup is a list of Mutation to be committed atomically.
@@ -356,6 +361,37 @@ func Delete(table string, ks KeySet) *Mutation {
 	}
 }
 
+// WrapMutation creates a mutation that wraps an existing protobuf mutation object.
+func WrapMutation(proto *sppb.Mutation) (*Mutation, error) {
+	if proto == nil {
+		return nil, fmt.Errorf("protobuf mutation may not be nil")
+	}
+	op, table, err := getTableAndSpannerOperation(proto)
+	if err != nil {
+		return nil, err
+	}
+	return &Mutation{
+		op:      op,
+		table:   table,
+		wrapped: proto,
+	}, nil
+}
+
+func getTableAndSpannerOperation(proto *sppb.Mutation) (op, string, error) {
+	if proto.GetInsert() != nil {
+		return opInsert, proto.GetInsert().Table, nil
+	} else if proto.GetUpdate() != nil {
+		return opUpdate, proto.GetUpdate().Table, nil
+	} else if proto.GetReplace() != nil {
+		return opReplace, proto.GetReplace().Table, nil
+	} else if proto.GetDelete() != nil {
+		return opDelete, proto.GetDelete().Table, nil
+	} else if proto.GetInsertOrUpdate() != nil {
+		return opInsertOrUpdate, proto.GetInsertOrUpdate().Table, nil
+	}
+	return 0, "", spannerErrorf(codes.InvalidArgument, "unknown op type: %d", proto.Operation)
+}
+
 // prepareWrite generates sppb.Mutation_Write from table name, column names
 // and new column values.
 func prepareWrite(table string, columns []string, vals []interface{}) (*sppb.Mutation_Write, error) {
@@ -375,9 +411,13 @@ func errInvdMutationOp(m Mutation) error {
 	return spannerErrorf(codes.InvalidArgument, "Unknown op type: %d", m.op)
 }
 
-// proto converts spanner.Mutation to sppb.Mutation, in preparation to send
+// proto converts a spanner.Mutation to sppb.Mutation, in preparation to send
 // RPCs.
 func (m Mutation) proto() (*sppb.Mutation, error) {
+	if m.wrapped != nil {
+		return m.wrapped, nil
+	}
+
 	var pb *sppb.Mutation
 	switch m.op {
 	case opDelete:

--- a/spanner/request_id_header_test.go
+++ b/spanner/request_id_header_test.go
@@ -710,7 +710,7 @@ func TestRequestIDHeader_clientBatchWrite(t *testing.T) {
 
 	mutationGroups := []*MutationGroup{
 		{[]*Mutation{
-			{opInsertOrUpdate, "t_test", nil, []string{"key", "val"}, []any{"foo1", 1}},
+			{opInsertOrUpdate, "t_test", nil, []string{"key", "val"}, []any{"foo1", 1}, nil},
 		}},
 	}
 	iter := sc.BatchWrite(context.Background(), mutationGroups)
@@ -777,7 +777,7 @@ func TestRequestIDHeader_ClientBatchWriteWithSessionNotFound(t *testing.T) {
 	)
 	mutationGroups := []*MutationGroup{
 		{[]*Mutation{
-			{opInsertOrUpdate, "t_test", nil, []string{"key", "val"}, []any{"foo1", 1}},
+			{opInsertOrUpdate, "t_test", nil, []string{"key", "val"}, []any{"foo1", 1}, nil},
 		}},
 	}
 	iter := sc.BatchWrite(context.Background(), mutationGroups)
@@ -849,7 +849,7 @@ func TestRequestIDHeader_ClientBatchWriteWithError(t *testing.T) {
 	)
 	mutationGroups := []*MutationGroup{
 		{[]*Mutation{
-			{opInsertOrUpdate, "t_test", nil, []string{"key", "val"}, []any{"foo1", 1}},
+			{opInsertOrUpdate, "t_test", nil, []string{"key", "val"}, []any{"foo1", 1}, nil},
 		}},
 	}
 	iter := sc.BatchWrite(context.Background(), mutationGroups)


### PR DESCRIPTION
Add an API for wrapping an existing protobuf mutation in a Spanner mutation. This allows applications or libraries that use protobuf mutations to use these directly with the Spanner client library, without first having to translate these to a spanner.Mutation struct, and then having the client library convert it back to a protobuf definition.