### PR TITLE
chore(pubsub/v2): rename call options

### DIFF
--- a/pubsub/v2/pubsub.go
+++ b/pubsub/v2/pubsub.go
@@ -65,8 +65,17 @@ type Client struct {
 
 // ClientConfig has configurations for the client.
 type ClientConfig struct {
-	PublisherCallOptions  *vkit.TopicAdminCallOptions
-	SubscriberCallOptions *vkit.SubscriptionAdminCallOptions
+	// TopicAdminCallOptions controls the behavior (e.g. retries) of RPC
+	// calls for the underlying gRPC publisher/topic admin client.
+	// This includes both admin and data plane calls, even though
+	// this is just named SubscriptionAdminCallOptions.
+	TopicAdminCallOptions *vkit.TopicAdminCallOptions
+
+	// SubscriptionAdminCallOptions controls the behavior (e.g. retries)
+	// of RPC calls for the underlying gRPC subscriber/subscription admin client.
+	// This includes both admin and data plane calls, even though
+	// this is just named SubscriptionAdminCallOptions.
+	SubscriptionAdminCallOptions *vkit.SubscriptionAdminCallOptions
 
 	// EnableOpenTelemetryTracing enables tracing for this client.
 	// This option allows selectively disabling Pub/Sub traces.
@@ -77,9 +86,9 @@ type ClientConfig struct {
 	EnableOpenTelemetryTracing bool
 }
 
-// mergePublisherCallOptions merges two PublisherCallOptions into one and the first argument has
+// mergeTopicCallOptions merges two TopicAdminCallOptions into one and the first argument has
 // a lower order of precedence than the second one. If either is nil, return the other.
-func mergePublisherCallOptions(a *vkit.TopicAdminCallOptions, b *vkit.TopicAdminCallOptions) *vkit.TopicAdminCallOptions {
+func mergeTopicCallOptions(a *vkit.TopicAdminCallOptions, b *vkit.TopicAdminCallOptions) *vkit.TopicAdminCallOptions {
 	if a == nil {
 		return b
 	}
@@ -105,9 +114,9 @@ func mergePublisherCallOptions(a *vkit.TopicAdminCallOptions, b *vkit.TopicAdmin
 	return res
 }
 
-// mergeSubscribercallOptions merges two SubscriberCallOptions into one and the first argument has
+// mergeSubCallOptions merges two subscription call options into one and the first argument has
 // a lower order of precedence than the second one. If either is nil, the other is used.
-func mergeSubscriberCallOptions(a *vkit.SubscriptionAdminCallOptions, b *vkit.SubscriptionAdminCallOptions) *vkit.SubscriptionAdminCallOptions {
+func mergeSubCallOptions(a *vkit.SubscriptionAdminCallOptions, b *vkit.SubscriptionAdminCallOptions) *vkit.SubscriptionAdminCallOptions {
 	if a == nil {
 		return b
 	}
@@ -192,8 +201,8 @@ func NewClientWithConfig(ctx context.Context, projectID string, config *ClientCo
 		return nil, fmt.Errorf("pubsub(subscriber): %w", err)
 	}
 	if config != nil {
-		pubc.CallOptions = mergePublisherCallOptions(pubc.CallOptions, config.PublisherCallOptions)
-		subc.CallOptions = mergeSubscriberCallOptions(subc.CallOptions, config.SubscriberCallOptions)
+		pubc.CallOptions = mergeTopicCallOptions(pubc.CallOptions, config.TopicAdminCallOptions)
+		subc.CallOptions = mergeSubCallOptions(subc.CallOptions, config.SubscriptionAdminCallOptions)
 	}
 	pubc.SetGoogleClientInfo("gccl", internal.Version)
 	subc.SetGoogleClientInfo("gccl", internal.Version)

--- a/pubsub/v2/pubsub_test.go
+++ b/pubsub/v2/pubsub_test.go
@@ -47,7 +47,7 @@ func TestClient_ApplyClientConfig(t *testing.T) {
 		},
 	}
 	c, err := NewClientWithConfig(ctx, "P", &ClientConfig{
-		PublisherCallOptions: pco,
+		TopicAdminCallOptions: pco,
 	},
 		option.WithEndpoint(srv.Addr),
 		option.WithoutAuthentication(),


### PR DESCRIPTION
This renames the pubsub client's `ClientConfig` fields so that the call options matches the underlying gRPC struct `TopicAdminCallOptions` and `SubscriptionAdminCallOptions`.

Previously we had kept the old naming of `PublisherCallOptions` because it's more likely users are setting the data plane retries than admin retries, but it's better to be consistent and add comment that this is for both data plane and admin RPCs.