### PR TITLE
chore(internal/postprocessor): update cmd to be shell mode

### DIFF
--- a/internal/postprocessor/Dockerfile
+++ b/internal/postprocessor/Dockerfile
@@ -42,4 +42,4 @@ RUN (export GOTOOLCHAIN='auto' && \
     go install golang.org/x/lint/golint@latest && \
     go install golang.org/x/tools/cmd/goimports@latest)
 
-CMD [ "/postprocessor/post_processor"]
+CMD /postprocessor/post_processor


### PR DESCRIPTION
Trying to change up how the command is being invoked to see if the proper env gets passed through.

For more info see: https://docs.docker.com/reference/dockerfile/#shell-and-exec-form

Internal Bug: b/428197918