### PR TITLE
chore(internal/postprocessor): make module scanning config-based

### DIFF
--- a/internal/postprocessor/config.go
+++ b/internal/postprocessor/config.go
@@ -36,6 +36,11 @@ type config struct {
 	// ManualClientInfo contains information on manual clients used to generate
 	// the manifest file.
 	ManualClientInfo []*ManifestEntry
+	// SkipModuleScanPaths are the set of directory paths relative to the
+	// the repository root which are ignored when autodetecting new modules for
+	// inclusion in the common set of released modules.  Paths to modules that are
+	// either not released, or released individually should be included here.
+	SkipModuleScanPaths []string
 }
 
 type serviceConfigEntry struct {
@@ -47,9 +52,10 @@ type serviceConfigEntry struct {
 }
 
 type postProcessorConfig struct {
-	Modules        []string              `yaml:"modules"`
-	ServiceConfigs []*serviceConfigEntry `yaml:"service-configs"`
-	ManualClients  []*ManifestEntry      `yaml:"manual-clients"`
+	Modules             []string              `yaml:"modules"`
+	ServiceConfigs      []*serviceConfigEntry `yaml:"service-configs"`
+	ManualClients       []*ManifestEntry      `yaml:"manual-clients"`
+	SkipModuleScanPaths []string              `yaml:"skip-module-scan-paths"`
 }
 
 type deepCopyConfig struct {
@@ -111,6 +117,7 @@ func (p *postProcessor) loadConfig() error {
 		ClientRelPaths:         make([]string, 0),
 		GoogleapisToImportPath: make(map[string]*libraryInfo),
 		ManualClientInfo:       ppc.ManualClients,
+		SkipModuleScanPaths:    ppc.SkipModuleScanPaths,
 	}
 	for _, v := range ppc.ServiceConfigs {
 		c.GoogleapisToImportPath[v.InputDirectory] = &libraryInfo{

--- a/internal/postprocessor/config.yaml
+++ b/internal/postprocessor/config.yaml
@@ -1256,3 +1256,25 @@ service-configs:
   - input-directory: google/cloud/video/stitcher/v1
     service-config: videostitcher_v1.yaml
     import-path: cloud.google.com/go/video/stitcher/apiv1
+
+skip-module-scan-paths:
+  # ignore the root module
+  - .
+  # individually released modules
+  - auth
+  - auth/oauth2adapt
+  - bigquery
+  - bigquery/v2
+  - bigtable
+  - datastore
+  - errorreporting
+  - firestore
+  - logging
+  - profiler
+  - pubsub
+  - pubsublite
+  - spanner
+  - storage
+  - vertexai
+  # unreleased modules
+  - spanner/test/opentelemetry/test

--- a/internal/postprocessor/config_test.go
+++ b/internal/postprocessor/config_test.go
@@ -38,4 +38,16 @@ func TestLoadConfig(t *testing.T) {
 	if got, want := li.ReleaseLevel, "preview"; got != want {
 		t.Errorf("got %v, want %v", got, want)
 	}
+
+	wantSkipPath := "bigquery/v2"
+	found := false
+	for _, p := range p.config.SkipModuleScanPaths {
+		if p == wantSkipPath {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("entry %q not found in SkipModuleScanPaths", wantSkipPath)
+	}
 }

--- a/internal/postprocessor/releaseplease.go
+++ b/internal/postprocessor/releaseplease.go
@@ -25,29 +25,6 @@ import (
 	"strings"
 )
 
-var unreleasedModuleDir map[string]bool = map[string]bool{
-	"spanner/test/opentelemetry/test": true,
-}
-
-var individuallyReleasedModules map[string]bool = map[string]bool{
-	".":                true,
-	"auth":             true,
-	"auth/oauth2adapt": true,
-	"bigquery":         true,
-	"bigquery/v2":      true,
-	"bigtable":         true,
-	"datastore":        true,
-	"errorreporting":   true,
-	"firestore":        true,
-	"logging":          true,
-	"profiler":         true,
-	"pubsub":           true,
-	"pubsublite":       true,
-	"spanner":          true,
-	"storage":          true,
-	"vertexai":         true,
-}
-
 var defaultReleasePleaseConfig = &releasePleaseConfig{
 	ReleaseType:           "go-yoshi",
 	IncludeComponentInTag: true,
@@ -71,7 +48,7 @@ type releasePleasePackage struct {
 // updateReleaseFiles reconciles release-please configure based of the state of
 // the repo. It will auto-detect and add configure for new modules.
 func (p *postProcessor) UpdateReleaseFiles() error {
-	mods, err := detectModules(p.googleCloudDir)
+	mods, err := detectModules(p.googleCloudDir, p.config.SkipModuleScanPaths)
 	if err != nil {
 		return err
 	}
@@ -140,14 +117,19 @@ func updateManifestFile(w io.Writer, existingContents []byte, mods []string) err
 
 // detectModules returns a list of relative paths to module roots that are
 // managed by release-please.
-func detectModules(dir string) ([]string, error) {
+func detectModules(dir string, skipPaths []string) ([]string, error) {
 	var mods []string
+	// make it easier to probe the paths as a map.
+	skipMap := make(map[string]bool)
+	for _, p := range skipPaths {
+		skipMap[p] = true
+	}
 	fileSystem := os.DirFS(dir)
 	err := fs.WalkDir(fileSystem, ".", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			log.Fatal(err)
 		}
-		if !d.IsDir() && d.Name() == "go.mod" && !strings.Contains(path, "internal") && !individuallyReleasedModules[filepath.Dir(path)] && !unreleasedModuleDir[filepath.Dir(path)] {
+		if !d.IsDir() && d.Name() == "go.mod" && !strings.Contains(path, "internal") && skipMap[filepath.Dir(path)] {
 			mods = append(mods, filepath.Dir(path))
 		}
 		return nil


### PR DESCRIPTION
This PR is a small refactor to the postprocessor, and makes some internal implementation details configurable via the common config.yaml file.

Doing this as we've recently been defining new individually-released modules (bigquery and pubsub), and thus we've needed to modify and re-release the postprocessor itself, not just update configs.