### PR TITLE
fix(storage): fix MultiRangeDownloader deadlock

### DIFF
--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -1529,8 +1529,8 @@ func TestMultiRangeDownloaderEmulated(t *testing.T) {
 		reader.Wait()
 		for _, k := range res {
 			if !bytes.Equal(k.buf.Bytes(), content[k.offset:k.offset+k.limit]) {
-				t.Errorf("Error in read range offset %v, limit %v, got: %v; want: %v",
-					k.offset, k.limit, k.buf.Bytes(), content[k.offset:k.offset+k.limit])
+				t.Errorf("Error in read range offset %v, limit %v, got: %v bytes; want: %v bytes",
+					k.offset, k.limit, len(k.buf.Bytes()), len(content[k.offset:k.offset+k.limit]))
 			}
 			if k.err != nil {
 				t.Errorf("read range %v to %v : %v", k.offset, k.limit, k.err)

--- a/storage/grpc_client.go
+++ b/storage/grpc_client.go
@@ -1284,8 +1284,9 @@ func (c *grpcStorageClient) NewMultiRangeDownloader(ctx context.Context, params 
 					arr := resp.GetObjectDataRanges()
 					for _, val := range arr {
 						id := val.GetReadRange().GetReadId()
-						mrd.mu.Lock()
 						func() {
+							mrd.mu.Lock()
+							defer mrd.mu.Unlock()
 							currRange, ok := mrd.activeRanges[id]
 							if !ok {
 								// it's ok to ignore responses for read_id not in map as user would have been notified by callback.
@@ -1314,8 +1315,6 @@ func (c *grpcStorageClient) NewMultiRangeDownloader(ctx context.Context, params 
 								delete(mrd.activeRanges, id)
 							}
 						}()
-
-						mrd.mu.Unlock()
 					}
 				}
 			}

--- a/storage/grpc_client.go
+++ b/storage/grpc_client.go
@@ -1297,7 +1297,7 @@ func (c *grpcStorageClient) NewMultiRangeDownloader(ctx context.Context, params 
 								mrd.numActiveRanges--
 								delete(mrd.activeRanges, id)
 							} else {
-								mrd.activeRanges[id] = mrdRange{
+								currRange = mrdRange{
 									readID:              currRange.readID,
 									writer:              currRange.writer,
 									offset:              currRange.offset,
@@ -1306,6 +1306,7 @@ func (c *grpcStorageClient) NewMultiRangeDownloader(ctx context.Context, params 
 									totalBytesWritten:   currRange.totalBytesWritten + int64(len(val.GetChecksummedData().GetContent())),
 									callback:            currRange.callback,
 								}
+								mrd.activeRanges[id] = currRange
 							}
 							if val.GetRangeEnd() {
 								currRange.callback(currRange.offset, currRange.totalBytesWritten, nil)


### PR DESCRIPTION
This fixes some potential deadlocks in MultiRangeDownloader which were caused by not releasing a lock on early return, or holding it when it wasn't needed (when sending on a chan).