### PR TITLE
fix(bigquery): use timestamppb.Timestamp when generating protobufs from table schemas

### DIFF
--- a/bigquery/storage/managedwriter/adapt/protoconversion_test.go
+++ b/bigquery/storage/managedwriter/adapt/protoconversion_test.go
@@ -29,6 +29,7 @@ import (
 	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/descriptorpb"
 	"google.golang.org/protobuf/types/dynamicpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // TestSchemaToProtoConversion validates behavior around converting table schemas to
@@ -348,6 +349,7 @@ func TestSchemaToProtoConversion(t *testing.T) {
 					},
 				},
 				NestedType: []*descriptorpb.DescriptorProto{
+					expectedTimestampDescriptor(),
 					{
 						Name: proto.String("rangemessage_range_date"),
 						Field: []*descriptorpb.FieldDescriptorProto{
@@ -386,16 +388,18 @@ func TestSchemaToProtoConversion(t *testing.T) {
 						Name: proto.String("rangemessage_range_timestamp"),
 						Field: []*descriptorpb.FieldDescriptorProto{
 							{
-								Name:   proto.String("start"),
-								Number: proto.Int32(1),
-								Type:   descriptorpb.FieldDescriptorProto_TYPE_INT64.Enum(),
-								Label:  descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL.Enum(),
+								Name:     proto.String("start"),
+								Number:   proto.Int32(1),
+								Type:     descriptorpb.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
+								TypeName: proto.String("google_protobuf_Timestamp"),
+								Label:    descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL.Enum(),
 							},
 							{
-								Name:   proto.String("end"),
-								Number: proto.Int32(2),
-								Type:   descriptorpb.FieldDescriptorProto_TYPE_INT64.Enum(),
-								Label:  descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL.Enum(),
+								Name:     proto.String("end"),
+								Number:   proto.Int32(2),
+								Type:     descriptorpb.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
+								TypeName: proto.String("google_protobuf_Timestamp"),
+								Label:    descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL.Enum(),
 							},
 						},
 					},
@@ -1956,4 +1960,15 @@ func TestNormalizeDescriptor(t *testing.T) {
 			t.Errorf("%s: -got, +want:\n%s", tc.description, diff)
 		}
 	}
+}
+
+func expectedTimestampDescriptor() *descriptorpb.DescriptorProto {
+	msg := new(timestamppb.Timestamp).ProtoReflect().Descriptor()
+	desc := protodesc.ToDescriptorProto(msg)
+	desc.Name = proto.String("google_protobuf_Timestamp")
+	for _, f := range desc.Field {
+		// doesn't seem to get pulled over in the conversion
+		f.DefaultValue = proto.String("0")
+	}
+	return desc
 }


### PR DESCRIPTION
Closes #12569 

# Summary

`adapt. StorageSchemaToProto2Descriptor` generates a message descriptor that can be passed to `dynamicpb.NewMessage(desc)`. This can be used to convert JSON payloads to protobuf for the storage write API. 

When the destination table has a `TIMESTAMP` column, and the source JSON has `RFC3339` timestamp strings, it's impossible to use without further preprocessing; the generated message selects `int64` field types. [BigQuery supports `timestamp.Timestamp` for `TIMESTAMP` columns](https://cloud.google.com/bigquery/docs/supported-data-types), and `timtestamppb.Timestamp` supports `RFC3339` strings.

This changes the dynamic descriptors to prefer `timestamp.Timestamp` over `int64` for those fields. I believe it should be backward-compatible with pre-existing programs, as long as clients pass the generated descriptor to `adapt.WithSchemaDescriptor` like the documentation demonstrates. Existing programs may have implemented work-arounds for this, but those shouldn't break.

# Test Plan

```
> go test ./bigquery/storage/managedwriter/adapt/...
ok      cloud.google.com/go/bigquery/storage/managedwriter/adapt        0.709s
```