### PR TITLE
fix(pubsub/v2): acquire bounded limits in flow controller

### DIFF
--- a/pubsub/flow_controller.go
+++ b/pubsub/flow_controller.go
@@ -147,7 +147,7 @@ func (f *flowController) acquire(ctx context.Context, size int) error {
 		}
 		if f.semSize != nil {
 			// Try to acquire the full size of the message here.
-			if !f.semSize.TryAcquire(int64(size)) {
+			if !f.semSize.TryAcquire(f.bound(size)) {
 				if f.semCount != nil {
 					f.semCount.Release(1)
 				}

--- a/pubsub/flow_controller.go
+++ b/pubsub/flow_controller.go
@@ -222,6 +222,6 @@ func (f *flowController) recordOutstandingBytes(ctx context.Context, n int64) {
 		return
 	}
 
-	// Otherwise record this as subscriber outstanding .
+	// Otherwise record this as subscriber outstanding bytes.
 	recordStat(ctx, OutstandingBytes, n)
 }

--- a/pubsub/flow_controller.go
+++ b/pubsub/flow_controller.go
@@ -125,8 +125,6 @@ func newSubscriptionFlowController(fc FlowControlSettings) flowController {
 // as if it were equal to maxSize.
 func (f *flowController) acquire(ctx context.Context, size int) error {
 	switch f.limitBehavior {
-	case FlowControlIgnore:
-		return nil
 	case FlowControlBlock:
 		if f.semCount != nil {
 			if err := f.semCount.Acquire(ctx, 1); err != nil {
@@ -156,6 +154,7 @@ func (f *flowController) acquire(ctx context.Context, size int) error {
 				return ErrFlowControllerMaxOutstandingBytes
 			}
 		}
+	case FlowControlIgnore:
 	}
 
 	if f.semCount != nil {
@@ -172,19 +171,19 @@ func (f *flowController) acquire(ctx context.Context, size int) error {
 
 // release notes that one message of size bytes is no longer outstanding.
 func (f *flowController) release(ctx context.Context, size int) {
-	if f.limitBehavior == FlowControlIgnore {
-		return
-	}
-
 	if f.semCount != nil {
 		outstandingMessages := atomic.AddInt64(&f.countRemaining, -1)
 		f.recordOutstandingMessages(ctx, outstandingMessages)
-		f.semCount.Release(1)
+		if f.limitBehavior != FlowControlIgnore {
+			f.semCount.Release(1)
+		}
 	}
 	if f.semSize != nil {
 		outstandingBytes := atomic.AddInt64(&f.bytesRemaining, -1*f.bound(size))
 		f.recordOutstandingBytes(ctx, outstandingBytes)
-		f.semSize.Release(f.bound(size))
+		if f.limitBehavior != FlowControlIgnore {
+			f.semSize.Release(f.bound(size))
+		}
 	}
 }
 
@@ -195,10 +194,16 @@ func (f *flowController) bound(size int) int64 {
 	return int64(size)
 }
 
-// count returns the number of outstanding messages.
+// count returns the number of outstanding messages availalble.
 // if maxCount is 0, this will always return 0.
 func (f *flowController) count() int {
 	return int(atomic.LoadInt64(&f.countRemaining))
+}
+
+// size returns the size of outstanding messages.
+// if maxSize is 0, this will always return 0.
+func (f *flowController) size() int {
+	return int(atomic.LoadInt64(&f.bytesRemaining))
 }
 
 func (f *flowController) recordOutstandingMessages(ctx context.Context, n int64) {
@@ -207,6 +212,7 @@ func (f *flowController) recordOutstandingMessages(ctx context.Context, n int64)
 		return
 	}
 
+	// Otherwise record this as subscriber outstanding messages.
 	recordStat(ctx, OutstandingMessages, n)
 }
 
@@ -216,5 +222,6 @@ func (f *flowController) recordOutstandingBytes(ctx context.Context, n int64) {
 		return
 	}
 
+	// Otherwise record this as subscriber outstanding .
 	recordStat(ctx, OutstandingBytes, n)
 }

--- a/pubsub/flow_controller.go
+++ b/pubsub/flow_controller.go
@@ -147,7 +147,7 @@ func (f *flowController) acquire(ctx context.Context, size int) error {
 		}
 		if f.semSize != nil {
 			// Try to acquire the full size of the message here.
-			if !f.semSize.TryAcquire(f.bound(size)) {
+			if !f.semSize.TryAcquire(int64(size)) {
 				if f.semCount != nil {
 					f.semCount.Release(1)
 				}

--- a/pubsub/v2/flow_controller.go
+++ b/pubsub/v2/flow_controller.go
@@ -147,7 +147,7 @@ func (f *flowController) acquire(ctx context.Context, size int) error {
 		}
 		if f.semSize != nil {
 			// Try to acquire the full size of the message here.
-			if !f.semSize.TryAcquire(int64(size)) {
+			if !f.semSize.TryAcquire(f.bound(size)) {
 				if f.semCount != nil {
 					f.semCount.Release(1)
 				}

--- a/pubsub/v2/flow_controller.go
+++ b/pubsub/v2/flow_controller.go
@@ -212,6 +212,7 @@ func (f *flowController) recordOutstandingMessages(ctx context.Context, n int64)
 		return
 	}
 
+	// Otherwise record this as subscriber outstanding messages.
 	recordStat(ctx, OutstandingMessages, n)
 }
 
@@ -221,5 +222,6 @@ func (f *flowController) recordOutstandingBytes(ctx context.Context, n int64) {
 		return
 	}
 
+	// Otherwise record this as subscriber outstanding bytes.
 	recordStat(ctx, OutstandingBytes, n)
 }

--- a/pubsub/v2/flow_controller.go
+++ b/pubsub/v2/flow_controller.go
@@ -147,7 +147,7 @@ func (f *flowController) acquire(ctx context.Context, size int) error {
 		}
 		if f.semSize != nil {
 			// Try to acquire the full size of the message here.
-			if !f.semSize.TryAcquire(f.bound(size)) {
+			if !f.semSize.TryAcquire(int64(size)) {
 				if f.semCount != nil {
 					f.semCount.Release(1)
 				}

--- a/pubsub/v2/flow_controller.go
+++ b/pubsub/v2/flow_controller.go
@@ -125,8 +125,6 @@ func newSubscriberFlowController(fc FlowControlSettings) flowController {
 // as if it were equal to maxSize.
 func (f *flowController) acquire(ctx context.Context, size int) error {
 	switch f.limitBehavior {
-	case FlowControlIgnore:
-		return nil
 	case FlowControlBlock:
 		if f.semCount != nil {
 			if err := f.semCount.Acquire(ctx, 1); err != nil {
@@ -156,6 +154,7 @@ func (f *flowController) acquire(ctx context.Context, size int) error {
 				return ErrFlowControllerMaxOutstandingBytes
 			}
 		}
+	case FlowControlIgnore:
 	}
 
 	if f.semCount != nil {
@@ -172,19 +171,19 @@ func (f *flowController) acquire(ctx context.Context, size int) error {
 
 // release notes that one message of size bytes is no longer outstanding.
 func (f *flowController) release(ctx context.Context, size int) {
-	if f.limitBehavior == FlowControlIgnore {
-		return
-	}
-
 	if f.semCount != nil {
 		outstandingMessages := atomic.AddInt64(&f.countRemaining, -1)
 		f.recordOutstandingMessages(ctx, outstandingMessages)
-		f.semCount.Release(1)
+		if f.limitBehavior != FlowControlIgnore {
+			f.semCount.Release(1)
+		}
 	}
 	if f.semSize != nil {
 		outstandingBytes := atomic.AddInt64(&f.bytesRemaining, -1*f.bound(size))
 		f.recordOutstandingBytes(ctx, outstandingBytes)
-		f.semSize.Release(f.bound(size))
+		if f.limitBehavior != FlowControlIgnore {
+			f.semSize.Release(f.bound(size))
+		}
 	}
 }
 
@@ -199,6 +198,12 @@ func (f *flowController) bound(size int) int64 {
 // if maxCount is 0, this will always return 0.
 func (f *flowController) count() int {
 	return int(atomic.LoadInt64(&f.countRemaining))
+}
+
+// size returns the size of outstanding messages.
+// if maxSize is 0, this will always return 0.
+func (f *flowController) size() int {
+	return int(atomic.LoadInt64(&f.bytesRemaining))
 }
 
 func (f *flowController) recordOutstandingMessages(ctx context.Context, n int64) {


### PR DESCRIPTION
This change makes flow controller continue to track and record outstanding messages/bytes even when flow control mechanisms are disabled.

Fixes #12447 
