### PR TITLE
chore(internal/postprocessor): address logic inversion

### DIFF
--- a/internal/postprocessor/main_test.go
+++ b/internal/postprocessor/main_test.go
@@ -190,3 +190,27 @@ func TestUpdateManifestFile(t *testing.T) {
 		t.Errorf("updateConfigFile() mismatch (-want +got):\n%s", diff)
 	}
 }
+
+func TestDetectModules(t *testing.T) {
+	p := &postProcessor{
+		googleapisDir:  googleapisDir,
+		googleCloudDir: "../..",
+	}
+	p.loadConfig()
+	mods, err := detectModules(p.googleCloudDir, p.config.SkipModuleScanPaths)
+	if err != nil {
+		t.Fatalf("detectModules: %v", err)
+	}
+
+	// Assert that none of the detected modules are present in the SkipModuleScanPaths
+	foundMap := make(map[string]bool)
+	for _, m := range mods {
+		foundMap[m] = true
+	}
+	for _, sk := range p.config.SkipModuleScanPaths {
+		if foundMap[sk] {
+			t.Errorf("detected module %q but it was present in the SkipModuleScanPaths", sk)
+		}
+	}
+
+}

--- a/internal/postprocessor/releaseplease.go
+++ b/internal/postprocessor/releaseplease.go
@@ -129,7 +129,7 @@ func detectModules(dir string, skipPaths []string) ([]string, error) {
 		if err != nil {
 			log.Fatal(err)
 		}
-		if !d.IsDir() && d.Name() == "go.mod" && !strings.Contains(path, "internal") && skipMap[filepath.Dir(path)] {
+		if !d.IsDir() && d.Name() == "go.mod" && !strings.Contains(path, "internal") && !skipMap[filepath.Dir(path)] {
 			mods = append(mods, filepath.Dir(path))
 		}
 		return nil


### PR DESCRIPTION
In https://github.com/googleapis/google-cloud-go/pull/12541 the config for modules to skip was transitioned from being hardcoded into the implementation to a config file.  In the course of that refactor the detect logic was inverted, so instead of a skiplist the new config mechanism acted as an allowlist.

This PR corrects that issue, and adds another test to assert the property that skip paths don't appear in the detected module list.

To fully address this issue, we'll also need to bump the owlbot lock once this PR is submitted.