### PR TITLE
fix(spanner): enforce only one resource header

### DIFF
--- a/spanner/client.go
+++ b/spanner/client.go
@@ -390,6 +390,8 @@ type openTelemetryConfig struct {
 func contextWithOutgoingMetadata(ctx context.Context, md metadata.MD, disableRouteToLeader bool) context.Context {
 	existing, ok := metadata.FromOutgoingContext(ctx)
 	if ok {
+		// Make sure that we only send one resource header.
+		existing.Delete(resourcePrefixHeader)
 		md = metadata.Join(existing, md)
 	}
 	if !disableRouteToLeader {

--- a/spanner/client_test.go
+++ b/spanner/client_test.go
@@ -26,6 +26,7 @@ import (
 	"net"
 	"os"
 	"reflect"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -93,6 +94,19 @@ func setupMockedTestServerWithConfigAndGCPMultiendpointPool(t *testing.T, config
 			},
 		},
 	}
+	expectedResourceHeaderFormat := regexp.MustCompile("projects/.+/instances/.+/databases/.+.*")
+	grpcHeaderChecker.Checkers = append(grpcHeaderChecker.Checkers, &itestutil.HeaderChecker{
+		Key: resourcePrefixHeader,
+		ValuesValidator: func(token ...string) error {
+			if len(token) != 1 {
+				return status.Errorf(codes.Internal, "unexpected number of resource headers: %v", len(token))
+			}
+			if !expectedResourceHeaderFormat.MatchString(token[0]) {
+				return status.Errorf(codes.Internal, "invalid resource header value: %v", token[0])
+			}
+			return nil
+		},
+	})
 	if config.Compression == gzip.Name {
 		grpcHeaderChecker.Checkers = append(grpcHeaderChecker.Checkers, &itestutil.HeaderChecker{
 			Key: "x-response-encoding",
@@ -658,6 +672,30 @@ func TestClient_Single(t *testing.T) {
 	}
 }
 
+func TestClient_NonConformingHeader(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	md := metadata.Pairs(resourcePrefixHeader, "projects/foo/documents/bar")
+	ctx = metadata.NewOutgoingContext(ctx, md)
+	err := testSingleQueryWithContext(ctx, t, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Verify that even though the request is sent without the non-conforming header,
+	// it is still present in the original context.
+	if md, ok := metadata.FromOutgoingContext(ctx); ok {
+		header := md.Get(resourcePrefixHeader)
+		if g, w := len(header), 1; g != w {
+			t.Fatalf("header length mismatch\n Got: %v\nWant: %v", g, w)
+		}
+		if g, w := header[0], "projects/foo/documents/bar"; g != w {
+			t.Fatalf("header mismatch\n Got: %v\nWant: %v", g, w)
+		}
+	} else {
+		t.Fatal("could not get metadata from context")
+	}
+}
+
 func TestClient_Single_Unavailable(t *testing.T) {
 	t.Parallel()
 	err := testSingleQuery(t, serverErrorWithMinimalRetryDelay(codes.Unavailable, "Temporary unavailable"))
@@ -1191,8 +1229,11 @@ func checkReqsForTransactionOptions(t *testing.T, server InMemSpannerServer, txo
 }
 
 func testSingleQuery(t *testing.T, serverError error) error {
-	ctx := context.Background()
-	server, client, teardown := setupMockedTestServerWithConfig(t, ClientConfig{SessionPoolConfig: SessionPoolConfig{MinOpened: 1}})
+	return testSingleQueryWithContext(context.Background(), t, serverError)
+}
+
+func testSingleQueryWithContext(ctx context.Context, t *testing.T, serverError error) error {
+	server, client, teardown := setupMockedTestServerWithConfig(t, ClientConfig{DisableNativeMetrics: true, SessionPoolConfig: SessionPoolConfig{MinOpened: 1}})
 	defer teardown()
 	// Wait until all sessions have been created, so we know that those requests will not interfere with the test.
 	sp := client.idleSessions
@@ -1872,7 +1913,7 @@ func validateIsolationLevelForRWTransactions(t *testing.T, server *MockedSpanner
 
 func TestClient_ReadWriteTransactionWithNoIsolationLevelForRWTransactionAtClientConfig(t *testing.T) {
 	t.Parallel()
-	server, teardown, err := testReadWriteTransactionWithConfig(t, ClientConfig{SessionPoolConfig: DefaultSessionPoolConfig}, make(map[string]SimulatedExecutionTime), 1)
+	server, teardown, err := testReadWriteTransactionWithConfig(t, ClientConfig{DisableNativeMetrics: true, SessionPoolConfig: DefaultSessionPoolConfig}, make(map[string]SimulatedExecutionTime), 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1882,7 +1923,7 @@ func TestClient_ReadWriteTransactionWithNoIsolationLevelForRWTransactionAtClient
 
 func TestClient_ReadWriteTransactionWithIsolationLevelForRWTransactionAtClientConfig(t *testing.T) {
 	t.Parallel()
-	server, teardown, err := testReadWriteTransactionWithConfig(t, ClientConfig{SessionPoolConfig: DefaultSessionPoolConfig, TransactionOptions: TransactionOptions{IsolationLevel: sppb.TransactionOptions_REPEATABLE_READ}}, make(map[string]SimulatedExecutionTime), 1)
+	server, teardown, err := testReadWriteTransactionWithConfig(t, ClientConfig{DisableNativeMetrics: true, SessionPoolConfig: DefaultSessionPoolConfig, TransactionOptions: TransactionOptions{IsolationLevel: sppb.TransactionOptions_REPEATABLE_READ}}, make(map[string]SimulatedExecutionTime), 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1892,7 +1933,7 @@ func TestClient_ReadWriteTransactionWithIsolationLevelForRWTransactionAtClientCo
 
 func TestClient_ReadWriteTransactionWithIsolationLevelForRWTransactionAtTransactionLevel(t *testing.T) {
 	t.Parallel()
-	server, teardown, err := testReadWriteTransactionWithConfigWithTransactionOptions(t, ClientConfig{SessionPoolConfig: DefaultSessionPoolConfig, TransactionOptions: TransactionOptions{IsolationLevel: sppb.TransactionOptions_SERIALIZABLE}}, TransactionOptions{IsolationLevel: sppb.TransactionOptions_REPEATABLE_READ}, make(map[string]SimulatedExecutionTime), 1)
+	server, teardown, err := testReadWriteTransactionWithConfigWithTransactionOptions(t, ClientConfig{DisableNativeMetrics: true, SessionPoolConfig: DefaultSessionPoolConfig, TransactionOptions: TransactionOptions{IsolationLevel: sppb.TransactionOptions_SERIALIZABLE}}, TransactionOptions{IsolationLevel: sppb.TransactionOptions_REPEATABLE_READ}, make(map[string]SimulatedExecutionTime), 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2004,7 +2045,7 @@ func TestClient_ReadWriteStmtBasedTransactionWithIsolationLevelAtClientConfigLev
 }
 
 func testClientReadWriteStmtBasedTransactionWithIsolationLevelAtClientConfigLevel(t *testing.T, beginTransactionOption BeginTransactionOption) {
-	server, client, teardown := setupMockedTestServerWithConfig(t, ClientConfig{TransactionOptions: TransactionOptions{IsolationLevel: sppb.TransactionOptions_SERIALIZABLE}})
+	server, client, teardown := setupMockedTestServerWithConfig(t, ClientConfig{DisableNativeMetrics: true, TransactionOptions: TransactionOptions{IsolationLevel: sppb.TransactionOptions_SERIALIZABLE}})
 	defer teardown()
 	ctx := context.Background()
 	tx, err := NewReadWriteStmtBasedTransactionWithOptions(
@@ -2034,7 +2075,7 @@ func TestClient_ReadWriteStmtBasedTransactionWithNoIsolationLevelWithInlineBegin
 }
 
 func testClientReadWriteStmtBasedTransactionWithNoIsolationLevel(t *testing.T, beginTransactionOption BeginTransactionOption) {
-	server, client, teardown := setupMockedTestServerWithConfig(t, ClientConfig{TransactionOptions: TransactionOptions{}})
+	server, client, teardown := setupMockedTestServerWithConfig(t, ClientConfig{DisableNativeMetrics: true, TransactionOptions: TransactionOptions{}})
 	defer teardown()
 	ctx := context.Background()
 	tx, err := NewReadWriteStmtBasedTransactionWithOptions(
@@ -3734,7 +3775,7 @@ func TestClient_ReadWriteTransaction_WithCancelledContext(t *testing.T) {
 }
 
 func testReadWriteTransaction(t *testing.T, executionTimes map[string]SimulatedExecutionTime, expectedAttempts int) error {
-	_, teardown, err := testReadWriteTransactionWithConfig(t, ClientConfig{SessionPoolConfig: DefaultSessionPoolConfig}, executionTimes, expectedAttempts)
+	_, teardown, err := testReadWriteTransactionWithConfig(t, ClientConfig{DisableNativeMetrics: true, SessionPoolConfig: DefaultSessionPoolConfig}, executionTimes, expectedAttempts)
 	defer teardown()
 	return err
 }

--- a/spanner/read_test.go
+++ b/spanner/read_test.go
@@ -32,6 +32,7 @@ import (
 	"google.golang.org/api/iterator"
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -806,7 +807,9 @@ func TestRsdNonblockingStates(t *testing.T) {
 					}, opts...)
 				}
 			}
-			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			md := metadata.Pairs(resourcePrefixHeader, "projects/p/instances/i/databases/d")
+			ctx := metadata.NewOutgoingContext(context.Background(), md)
+			ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 			defer cancel()
 			mt := c.metricsTracerFactory.createBuiltinMetricsTracer(ctx)
 			r := newResumableStreamDecoder(
@@ -1108,7 +1111,9 @@ func TestRsdBlockingStates(t *testing.T) {
 					}, opts...)
 				}
 			}
-			ctx, cancel := context.WithCancel(context.Background())
+			md := metadata.Pairs(resourcePrefixHeader, "projects/p/instances/i/databases/d")
+			ctx := metadata.NewOutgoingContext(context.Background(), md)
+			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
 			mt := c.metricsTracerFactory.createBuiltinMetricsTracer(ctx)
 			r := newResumableStreamDecoder(
@@ -1276,7 +1281,9 @@ func TestQueueBytes(t *testing.T) {
 	sr := &sReceiver{
 		c: make(chan int, 1000), // will never block in this test
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	md := metadata.Pairs(resourcePrefixHeader, "projects/p/instances/i/databases/d")
+	ctx := metadata.NewOutgoingContext(context.Background(), md)
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 	mt := c.metricsTracerFactory.createBuiltinMetricsTracer(ctx)
 	decoder := newResumableStreamDecoder(
@@ -1379,8 +1386,10 @@ func TestResumeToken(t *testing.T) {
 	}
 	rows := []*Row{}
 
+	md := metadata.Pairs(resourcePrefixHeader, "projects/p/instances/i/databases/d")
+	ctx := metadata.NewOutgoingContext(context.Background(), md)
 	streaming := func() *RowIterator {
-		return stream(context.Background(), nil,
+		return stream(ctx, nil,
 			c.metricsTracerFactory,
 			func(ct context.Context, resumeToken []byte, opts ...gax.CallOption) (streamingReceiver, error) {
 				r, err := mc.ExecuteStreamingSql(ct, &sppb.ExecuteSqlRequest{
@@ -1523,10 +1532,12 @@ func TestGrpcReconnect(t *testing.T) {
 		},
 	)
 
+	md := metadata.Pairs(resourcePrefixHeader, "projects/p/instances/i/databases/d")
+	ctx := metadata.NewOutgoingContext(context.Background(), md)
 	// The retry is counted from the second call.
 	r := -1
 	// Establish a stream to mock cloud spanner server.
-	iter := stream(context.Background(), nil, c.metricsTracerFactory,
+	iter := stream(ctx, nil, c.metricsTracerFactory,
 		func(ct context.Context, resumeToken []byte, opts ...gax.CallOption) (streamingReceiver, error) {
 			r++
 			return mc.ExecuteStreamingSql(ct, &sppb.ExecuteSqlRequest{
@@ -1580,10 +1591,12 @@ func TestRetryResourceExhaustedWithoutRetryInfo(t *testing.T) {
 		},
 	)
 
+	md := metadata.Pairs(resourcePrefixHeader, "projects/p/instances/i/databases/d")
+	ctx := metadata.NewOutgoingContext(context.Background(), md)
 	// The retry is counted from the second call.
 	r := -1
 	// Establish a stream to mock cloud spanner server.
-	iter := stream(context.Background(), nil, c.metricsTracerFactory,
+	iter := stream(ctx, nil, c.metricsTracerFactory,
 		func(ct context.Context, resumeToken []byte, opts ...gax.CallOption) (streamingReceiver, error) {
 			r++
 			return mc.ExecuteStreamingSql(ct, &sppb.ExecuteSqlRequest{
@@ -1644,10 +1657,12 @@ func TestRetryResourceExhaustedWithRetryInfo(t *testing.T) {
 		},
 	)
 
+	md := metadata.Pairs(resourcePrefixHeader, "projects/p/instances/i/databases/d")
+	ctx := metadata.NewOutgoingContext(context.Background(), md)
 	// The retry is counted from the second call.
 	r := -1
 	// Establish a stream to mock cloud spanner server.
-	iter := stream(context.Background(), nil, c.metricsTracerFactory,
+	iter := stream(ctx, nil, c.metricsTracerFactory,
 		func(ct context.Context, resumeToken []byte, opts ...gax.CallOption) (streamingReceiver, error) {
 			r++
 			return mc.ExecuteStreamingSql(ct, &sppb.ExecuteSqlRequest{
@@ -1696,8 +1711,9 @@ func TestCancelTimeout(t *testing.T) {
 	}
 	done := make(chan int)
 
+	md := metadata.Pairs(resourcePrefixHeader, "projects/p/instances/i/databases/d")
 	// Test cancelling query.
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(metadata.NewOutgoingContext(context.Background(), md))
 	go func() {
 		// Establish a stream to mock cloud spanner server.
 		iter := stream(ctx, nil, c.metricsTracerFactory,
@@ -1733,7 +1749,7 @@ func TestCancelTimeout(t *testing.T) {
 	}
 
 	// Test query timeout.
-	ctx, cancel = context.WithTimeout(context.Background(), 100*time.Millisecond)
+	ctx, cancel = context.WithTimeout(metadata.NewOutgoingContext(context.Background(), md), 100*time.Millisecond)
 	defer cancel()
 	go func() {
 		// Establish a stream to mock cloud spanner server.
@@ -1886,7 +1902,9 @@ func TestRowIteratorDo(t *testing.T) {
 	}
 
 	nRows := 0
-	iter := stream(context.Background(), nil, c.metricsTracerFactory,
+	md := metadata.Pairs(resourcePrefixHeader, "projects/p/instances/i/databases/d")
+	ctx := metadata.NewOutgoingContext(context.Background(), md)
+	iter := stream(ctx, nil, c.metricsTracerFactory,
 		func(ct context.Context, resumeToken []byte, opts ...gax.CallOption) (streamingReceiver, error) {
 			return mc.ExecuteStreamingSql(ct, &sppb.ExecuteSqlRequest{
 				Session:     session.Name,
@@ -1921,7 +1939,9 @@ func TestRowIteratorDoWithError(t *testing.T) {
 		t.Fatalf("failed to create a session")
 	}
 
-	iter := stream(context.Background(), nil, c.metricsTracerFactory,
+	md := metadata.Pairs(resourcePrefixHeader, "projects/p/instances/i/databases/d")
+	ctx := metadata.NewOutgoingContext(context.Background(), md)
+	iter := stream(ctx, nil, c.metricsTracerFactory,
 		func(ct context.Context, resumeToken []byte, opts ...gax.CallOption) (streamingReceiver, error) {
 			return mc.ExecuteStreamingSql(ct, &sppb.ExecuteSqlRequest{
 				Session:     session.Name,
@@ -1955,6 +1975,8 @@ func TestIteratorStopEarly(t *testing.T) {
 		t.Fatalf("failed to create a session")
 	}
 
+	md := metadata.Pairs(resourcePrefixHeader, "projects/p/instances/i/databases/d")
+	ctx = metadata.NewOutgoingContext(ctx, md)
 	iter := stream(ctx, nil, c.metricsTracerFactory,
 		func(ct context.Context, resumeToken []byte, opts ...gax.CallOption) (streamingReceiver, error) {
 			return mc.ExecuteStreamingSql(ct, &sppb.ExecuteSqlRequest{
@@ -1996,5 +2018,8 @@ func createSession(client spannerClient) (*sppb.Session, error) {
 		Database: formattedDatabase,
 		Session:  &sppb.Session{},
 	}
-	return client.CreateSession(context.Background(), request)
+	ctx := context.Background()
+	md := metadata.Pairs(resourcePrefixHeader, "projects/p/instances/i/databases/d")
+	ctx = metadata.NewOutgoingContext(ctx, md)
+	return client.CreateSession(ctx, request)
 }

--- a/spanner/session_test.go
+++ b/spanner/session_test.go
@@ -36,6 +36,7 @@ import (
 	"google.golang.org/api/iterator"
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 )
 
@@ -129,8 +130,10 @@ loop:
 			}
 		}
 	}
+	md := metadata.Pairs(resourcePrefixHeader, "projects/p/instances/i/databases/d")
+	ctx = metadata.NewOutgoingContext(ctx, md)
 	for _, sh := range shs {
-		if _, err := sh.getClient().GetSession(context.Background(), &sppb.GetSessionRequest{
+		if _, err := sh.getClient().GetSession(ctx, &sppb.GetSessionRequest{
 			Name: sh.getID(),
 		}); err != nil {
 			t.Fatalf("error getting expected session from server: %v", err)

--- a/spanner/transaction_test.go
+++ b/spanner/transaction_test.go
@@ -1690,7 +1690,8 @@ func TestReadWriteStmtBasedTransaction_UsesMultiplexedSession(t *testing.T) {
 		enableMultiplexedSessionForRW: true,
 	}
 	server, client, teardown := setupMockedTestServerWithConfig(t, ClientConfig{
-		SessionPoolConfig: cfg,
+		SessionPoolConfig:    cfg,
+		DisableNativeMetrics: true,
 	})
 	defer teardown()
 	server.TestSpanner.PutExecutionTime(MethodCommitTransaction,
@@ -1741,7 +1742,8 @@ func TestReadWriteStmtBasedTransaction_UsesPreviousTransactionIDForMultiplexedSe
 		enableMultiplexedSessionForRW: true,
 	}
 	server, client, teardown := setupMockedTestServerWithConfig(t, ClientConfig{
-		SessionPoolConfig: cfg,
+		SessionPoolConfig:    cfg,
+		DisableNativeMetrics: true,
 	})
 	defer teardown()
 	server.TestSpanner.PutExecutionTime(MethodCommitTransaction,
@@ -1804,7 +1806,8 @@ func TestReadWriteStmtBasedTransaction_SetsPrecommitToken(t *testing.T) {
 		enableMultiplexedSessionForRW: true,
 	}
 	server, client, teardown := setupMockedTestServerWithConfig(t, ClientConfig{
-		SessionPoolConfig: cfg,
+		SessionPoolConfig:    cfg,
+		DisableNativeMetrics: true,
 	})
 	defer teardown()
 


### PR DESCRIPTION
Only one resource header (google-cloud-resource-prefix) should be included in requests that are sent to Spanner. If the context that is used for a request already contains a resource header, then that header value will be removed, and only the resource header that is set by the Spanner client will be included in the request.