### PR TITLE
fix(spanner): remove stream wrapper for direct path check

### DIFF
--- a/spanner/grpc_client.go
+++ b/spanner/grpc_client.go
@@ -192,15 +192,7 @@ func (g *grpcSpannerClient) ExecuteStreamingSql(ctx context.Context, req *spanne
 	if mt != nil && client != nil && mt.currOp.currAttempt != nil {
 		md, _ := client.Header()
 		mt.currOp.currAttempt.setServerTimingMetrics(parseServerTimingHeader(md))
-		peerInfo, ok := peer.FromContext(client.Context())
-		if ok {
-			if peerInfo.Addr != nil {
-				remoteIP := peerInfo.Addr.String()
-				if strings.HasPrefix(remoteIP, directPathIPV4Prefix) || strings.HasPrefix(remoteIP, directPathIPV6Prefix) {
-					mt.currOp.currAttempt.setDirectPathUsed(true)
-				}
-			}
-		}
+		mt.currOp.currAttempt.setDirectPathUsed(client.Context())
 	}
 	return client, err
 }
@@ -236,15 +228,7 @@ func (g *grpcSpannerClient) StreamingRead(ctx context.Context, req *spannerpb.Re
 	if mt != nil && client != nil && mt.currOp.currAttempt != nil {
 		md, _ := client.Header()
 		mt.currOp.currAttempt.setServerTimingMetrics(parseServerTimingHeader(md))
-		peerInfo, ok := peer.FromContext(client.Context())
-		if ok {
-			if peerInfo.Addr != nil {
-				remoteIP := peerInfo.Addr.String()
-				if strings.HasPrefix(remoteIP, directPathIPV4Prefix) || strings.HasPrefix(remoteIP, directPathIPV6Prefix) {
-					mt.currOp.currAttempt.setDirectPathUsed(true)
-				}
-			}
-		}
+		mt.currOp.currAttempt.setDirectPathUsed(client.Context())
 	}
 	return client, err
 }
@@ -308,15 +292,7 @@ func (g *grpcSpannerClient) BatchWrite(ctx context.Context, req *spannerpb.Batch
 	if mt != nil && client != nil && mt.currOp.currAttempt != nil {
 		md, _ := client.Header()
 		mt.currOp.currAttempt.setServerTimingMetrics(parseServerTimingHeader(md))
-		peerInfo, ok := peer.FromContext(client.Context())
-		if ok {
-			if peerInfo.Addr != nil {
-				remoteIP := peerInfo.Addr.String()
-				if strings.HasPrefix(remoteIP, directPathIPV4Prefix) || strings.HasPrefix(remoteIP, directPathIPV6Prefix) {
-					mt.currOp.currAttempt.setDirectPathUsed(true)
-				}
-			}
-		}
+		mt.currOp.currAttempt.setDirectPathUsed(client.Context())
 	}
 	return client, err
 }


### PR DESCRIPTION
Fixes: https://github.com/googleapis/google-cloud-go/issues/12600

This change fixes a race condition that could occur during streaming operations in the Spanner client. The race condition was caused by concurrent access to the metrics tracer (mt) between the main execution goroutine and a background goroutine responsible for consuming stream trailers.

The fix addresses this issue by removing the wrappedStream implementation and moving the logic for updating metrics directly into the grpcSpannerClient methods (ExecuteStreamingSql, StreamingRead, and BatchWrite).

By moving the metrics-related logic out of the stream interceptor and into the gRPC client methods, the race condition is eliminated, as the metrics are now updated in the same goroutine that initiated the RPC.
