### PR TITLE
feat(spanner): default enable multiplex session for all operations unless explicitly set to false

### DIFF
--- a/spanner/benchmarks/README.md
+++ b/spanner/benchmarks/README.md
@@ -36,8 +36,8 @@ Please look at the [Configurations](#configurations) section for allowed options
 
 To enable some application specific configurations, you can reference the following table.
 
-| Description                | Environment variable                           |
-|----------------------------|------------------------------------------------|
-| Enabling multiplex session | GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS=true |
-| Enabling directpath        | GOOGLE_SPANNER_ENABLE_DIRECT_ACCESS=true       |
+| Description                 | Environment variable                            |
+|-----------------------------|-------------------------------------------------|
+| Disabling multiplex session | GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS=false |
+| Enabling directpath         | GOOGLE_SPANNER_ENABLE_DIRECT_ACCESS=true        |
 

--- a/spanner/client.go
+++ b/spanner/client.go
@@ -551,21 +551,23 @@ func newClientWithConfig(ctx context.Context, database string, config ClientConf
 	if isAFEBuiltInMetricEnabled {
 		md.Append(afeMetricHeader, "true")
 	}
-
-	if isMultiplexed := strings.ToLower(os.Getenv("GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS")); isMultiplexed != "" && !config.enableMultiplexSession {
+	config.enableMultiplexSession = true
+	if isMultiplexed := strings.ToLower(os.Getenv("GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS")); isMultiplexed != "" {
 		config.enableMultiplexSession, err = strconv.ParseBool(isMultiplexed)
 		if err != nil {
 			return nil, spannerErrorf(codes.InvalidArgument, "GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS must be either true or false")
 		}
 	}
-	if isMultiplexForRW := os.Getenv("GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS_FOR_RW"); isMultiplexForRW != "" && !config.enableMultiplexedSessionForRW {
+	config.enableMultiplexedSessionForRW = config.enableMultiplexSession
+	if isMultiplexForRW := os.Getenv("GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS_FOR_RW"); isMultiplexForRW != "" {
 		config.enableMultiplexedSessionForRW, err = strconv.ParseBool(isMultiplexForRW)
 		if err != nil {
 			return nil, spannerErrorf(codes.InvalidArgument, "GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS_FOR_RW must be either true or false")
 		}
 		config.enableMultiplexedSessionForRW = config.enableMultiplexedSessionForRW && config.SessionPoolConfig.enableMultiplexSession
 	}
-	if isMultiplexForPartitionOps := os.Getenv("GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS_PARTITIONED_OPS"); isMultiplexForPartitionOps != "" && !config.enableMultiplexedSessionForPartitionedOps {
+	config.enableMultiplexedSessionForPartitionedOps = config.enableMultiplexSession
+	if isMultiplexForPartitionOps := os.Getenv("GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS_PARTITIONED_OPS"); isMultiplexForPartitionOps != "" {
 		config.enableMultiplexedSessionForPartitionedOps, err = strconv.ParseBool(isMultiplexForPartitionOps)
 		if err != nil {
 			return nil, spannerErrorf(codes.InvalidArgument, "GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS_PARTITIONED_OPS must be either true or false")

--- a/spanner/integration_test.go
+++ b/spanner/integration_test.go
@@ -411,7 +411,7 @@ func getInstanceConfig() string {
 }
 
 func getMultiplexEnableFlag() bool {
-	return os.Getenv("GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS") == "true"
+	return os.Getenv("GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS") != "false"
 }
 
 const (

--- a/spanner/kokoro/presubmit.sh
+++ b/spanner/kokoro/presubmit.sh
@@ -44,11 +44,11 @@ set +e # Run all tests, don't stop after the first failure.
 exit_code=0
 
 case $JOB_TYPE in
-integration-with-multiplexed-session )
-  GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS=true
-  GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS_FOR_RW=true
-  GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS_PARTITIONED_OPS=true
-  echo "running presubmit with multiplexed sessions enabled: $GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS"
+integration-with-regular-session )
+  GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS=false
+  GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS_FOR_RW=false
+  GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS_PARTITIONED_OPS=false
+  echo "running presubmit with multiplexed sessions disabled: $GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS"
   ;;
 esac
 

--- a/spanner/session.go
+++ b/spanner/session.go
@@ -509,9 +509,13 @@ type SessionPoolConfig struct {
 	enableMultiplexSession bool
 
 	// enableMultiplexedSessionForRW is a flag to enable multiplexed session for read/write transactions
+	//
+	// Defaults to true.
 	enableMultiplexedSessionForRW bool
 
 	// enableMultiplexedSessionForPartitionedOps is a flag to enable multiplexed session for partitioned DML and read/query operations
+	//
+	// Defaults to true.
 	enableMultiplexedSessionForPartitionedOps bool
 
 	// healthCheckSampleInterval is how often the health checker samples live

--- a/spanner/test/opentelemetry/test/test_util.go
+++ b/spanner/test/opentelemetry/test/test_util.go
@@ -36,7 +36,7 @@ var (
 )
 
 func getMultiplexEnableFlag() bool {
-	return os.Getenv("GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS") == "true"
+	return os.Getenv("GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS") != "false"
 }
 
 func setupMockedTestServerWithConfig(t *testing.T, config spanner.ClientConfig, clientOpts ...option.ClientOption) (server *stestutil.MockedSpannerInMemTestServer, client *spanner.Client, teardown func()) {


### PR DESCRIPTION
Read-Only, Read-Write and Partition Ops transactions now use a single multiplexed session, instead of a session from the session pool. Multiplexed sessions can handle any number of queries and read-only, read-write and partition ops transactions transactions at the same time.

The use of multiplexed sessions can be disabled for read-only, read-write and partition-ops transactions by setting the environment variables.

GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS=false
GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS_FOR_RW=false.
GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS_PARTITIONED_OPS=false.

See https://cloud.google.com/spanner/docs/sessions#multiplexed_sessions for more background information about multiplexed sessions.