### PR TITLE
fix(auth): set Content-Type in userTokenProvider.exchangeToken

### DIFF
--- a/auth/credentials/impersonate/user.go
+++ b/auth/credentials/impersonate/user.go
@@ -179,6 +179,7 @@ func (u userTokenProvider) exchangeToken(ctx context.Context, signedJWT string) 
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	u.logger.DebugContext(ctx, "impersonated user token exchange request", "request", internallog.HTTPRequest(req, []byte(v.Encode())))
 	resp, body, err := internal.DoRequest(u.client, req)
 	if err != nil {

--- a/auth/credentials/impersonate/user_test.go
+++ b/auth/credentials/impersonate/user_test.go
@@ -119,6 +119,9 @@ func TestNewCredentials_user(t *testing.T) {
 						}
 					}
 					if strings.Contains(req.URL.Path, "/token") {
+						if got, want := req.Header.Get("Content-Type"), "application/x-www-form-urlencoded"; got != want {
+							t.Errorf("got %v, want %v", got, want)
+						}
 						resp := exchangeTokenResponse{
 							AccessToken: userTok,
 							TokenType:   internal.TokenTypeBearer,


### PR DESCRIPTION
Fixes #12633. Added required header and updated `user_test.go` to check for the new header value.