### PR TITLE
Fix a non-constant format string in aliasgen

### DIFF
--- a/internal/aliasgen/aliasgen.go
+++ b/internal/aliasgen/aliasgen.go
@@ -375,7 +375,7 @@ func (am *aliasGenerator) writeFuncs(w io.Writer) error {
 					return err
 				}
 			}
-			if _, err := fmt.Fprintf(w, p.name); err != nil {
+			if _, err := fmt.Fprintf(w, "%s", p.name); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
This breaks build with golang 1.24:

```
./aliasgen.go:378:32: non-constant format string in call to fmt.Fprintf
FAIL	cloud.google.com/go/internal/aliasgen [build failed]
```