### PR TITLE
fix(auth): add UseDefaultClient: true to metadata.Options

### DIFF
--- a/auth/credentials/detect.go
+++ b/auth/credentials/detect.go
@@ -116,7 +116,8 @@ func DetectDefault(opts *DetectOptions) (*auth.Credentials, error) {
 
 	if OnGCE() {
 		metadataClient := metadata.NewWithOptions(&metadata.Options{
-			Logger: opts.logger(),
+			Logger:           opts.logger(),
+			UseDefaultClient: true,
 		})
 		return auth.NewCredentials(&auth.CredentialsOptions{
 			TokenProvider: computeTokenProvider(opts, metadataClient),

--- a/auth/go.mod
+++ b/auth/go.mod
@@ -3,7 +3,7 @@ module cloud.google.com/go/auth
 go 1.23.0
 
 require (
-	cloud.google.com/go/compute/metadata v0.7.0
+	cloud.google.com/go/compute/metadata v0.8.0
 	github.com/google/go-cmp v0.7.0
 	github.com/google/s2a-go v0.1.9
 	github.com/googleapis/enterprise-certificate-proxy v0.3.6

--- a/auth/go.sum
+++ b/auth/go.sum
@@ -1,5 +1,5 @@
-cloud.google.com/go/compute/metadata v0.7.0 h1:PBWF+iiAerVNe8UCHxdOt6eHLVc3ydFeOCw78U8ytSU=
-cloud.google.com/go/compute/metadata v0.7.0/go.mod h1:j5MvL9PprKL39t166CoB1uVHfQMs4tFQZZcKwksXUjo=
+cloud.google.com/go/compute/metadata v0.8.0 h1:HxMRIbao8w17ZX6wBnjhcDkW6lTFpgcaobyVfZWqRLA=
+cloud.google.com/go/compute/metadata v0.8.0/go.mod h1:sYOGTp851OV9bOFJ9CH7elVvyzopvWQFNNghtDQ/Biw=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=


### PR DESCRIPTION
* Enable use of custom logger combined with default internal shared http.Client
  for compute token requests. The restores the previous behavior of sharing a
  single TCP connection pool as was done previously with metadata.GetWithContext.
* Add TestDefaultCredentials_OnGCE.
* Bump cloud.google.com/go/compute/metadata dependency to v0.8.0

refs: #11078
refs: #12657