### PR TITLE
chore(internal/librariangen): add Cloud Build trigger configuration for Dockerfile

### DIFF
--- a/internal/librariangen/cloudbuild-exitgate.yaml
+++ b/internal/librariangen/cloudbuild-exitgate.yaml
@@ -1,0 +1,42 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# note: /workspace is a special directory in the docker image where all the files in this folder
+# get placed on your behalf
+
+timeout: 7200s # 2 hours
+steps:
+  - name: gcr.io/cloud-builders/docker
+    args:
+      [
+        "build",
+        "-t",
+        "us-central1-docker.pkg.dev/cloud-sdk-production-pipeline/images-dev/librarian-go:infrastructure-public-image-$COMMIT_SHA",
+        "-f",
+        "Dockerfile",
+        ".",
+      ]
+    dir: internal/librariangen
+  - name:  gcr.io/cloud-builders/docker
+    args: 
+      [
+        "tag",
+        "us-central1-docker.pkg.dev/cloud-sdk-production-pipeline/images-dev/librarian-go:infrastructure-public-image-$COMMIT_SHA",
+      ]
+options:
+    machineType: 'E2_HIGHCPU_8'
+    requestedVerifyOption: VERIFIED  # For provenance attestation generation
+
+images:
+  - us-central1-docker.pkg.dev/cloud-sdk-production-pipeline/images-dev/librarian-go:infrastructure-public-image-$COMMIT_SHA

--- a/internal/librariangen/cloudbuild.yaml
+++ b/internal/librariangen/cloudbuild.yaml
@@ -1,0 +1,43 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# note: /workspace is a special directory in the docker image where all the files in this folder
+# get placed on your behalf
+
+timeout: 7200s # 2 hours
+steps:
+  - name: gcr.io/cloud-builders/docker
+    args:
+      [
+        "build",
+        "-t",
+        "gcr.io/cloud-devrel-public-resources/librarian-go:infrastructure-public-image-$COMMIT_SHA",
+        "-f",
+        "Dockerfile",
+        ".",
+      ]
+    dir: internal/librariangen
+  - name:  gcr.io/cloud-builders/docker
+    args: 
+      [
+        "tag",
+        "gcr.io/cloud-devrel-public-resources/librarian-go:infrastructure-public-image-$COMMIT_SHA",
+        "gcr.io/cloud-devrel-public-resources/librarian-go:infrastructure-public-image-latest",
+      ]
+options:
+  logging: CLOUD_LOGGING_ONLY
+
+images:
+  - gcr.io/cloud-devrel-public-resources/librarian-go:infrastructure-public-image-$COMMIT_SHA
+  - gcr.io/cloud-devrel-public-resources/librarian-go:infrastructure-public-image-latest


### PR DESCRIPTION
This configuration uses the short name "librarian-go" for the Librariangen container. Let me know if it should be something that is less likely to collide with the Librarian parent project, for example, "librariangen-go" or just "librariangen".