### PR TITLE
chore(internal/librariangen): optimize Docker build for caching

### DIFF
--- a/internal/librariangen/Dockerfile
+++ b/internal/librariangen/Dockerfile
@@ -37,13 +37,17 @@ RUN wget https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz -O go.tar.gz && \
     tar -C /usr/local -xzf go.tar.gz && \
     rm go.tar.gz
 ENV PATH /usr/local/go/bin:$PATH
+RUN go version
 
 WORKDIR /src
 
+# Copy go.mod and go.sum to download dependencies before copying all the source.
+# This allows Docker to cache the dependencies layer.
+COPY go.mod go.sum ./
+RUN go mod download
+
 # Copy all source code.
 COPY . .
-
-RUN go version
 
 # Build the librariangen binary.
 RUN CGO_ENABLED=0 GOOS=linux go build -v -o /librariangen .
@@ -55,6 +59,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -v -o /librariangen .
 FROM marketplace.gcr.io/google/debian12:latest
 
 # Set environment variables for tool versions for easy updates.
+ENV GO_VERSION=1.23.0
 ENV PROTOC_VERSION=25.7
 ENV GO_PROTOC_PLUGIN_VERSION=1.35.2
 ENV GO_GRPC_PLUGIN_VERSION=1.3.0
@@ -77,6 +82,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Install the specific Go version required for compatibility.
+# Note: This is needed for the go install commands below.
 RUN wget https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz -O go.tar.gz && \
     tar -C /usr/local -xzf go.tar.gz && \
     rm go.tar.gz

--- a/internal/librariangen/cloudbuild-exitgate.yaml
+++ b/internal/librariangen/cloudbuild-exitgate.yaml
@@ -17,10 +17,19 @@
 
 timeout: 7200s # 2 hours
 steps:
+  # Attempt to pull the latest image to use as a cache source.
+  - name: gcr.io/cloud-builders/docker
+    entrypoint: 'bash'
+    args:
+      - -c
+      - |
+        docker pull us-central1-docker.pkg.dev/cloud-sdk-production-pipeline/images-dev/librarian-go:infrastructure-public-image-latest || exit 0
   - name: gcr.io/cloud-builders/docker
     args:
       [
         "build",
+        "--cache-from",
+        "us-central1-docker.pkg.dev/cloud-sdk-production-pipeline/images-dev/librarian-go:infrastructure-public-image-latest",
         "-t",
         "us-central1-docker.pkg.dev/cloud-sdk-production-pipeline/images-dev/librarian-go:infrastructure-public-image-$COMMIT_SHA",
         "-f",
@@ -29,10 +38,11 @@ steps:
       ]
     dir: internal/librariangen
   - name:  gcr.io/cloud-builders/docker
-    args: 
+    args:
       [
         "tag",
         "us-central1-docker.pkg.dev/cloud-sdk-production-pipeline/images-dev/librarian-go:infrastructure-public-image-$COMMIT_SHA",
+        "us-central1-docker.pkg.dev/cloud-sdk-production-pipeline/images-dev/librarian-go:infrastructure-public-image-latest",
       ]
 options:
     machineType: 'E2_HIGHCPU_8'
@@ -40,3 +50,5 @@ options:
 
 images:
   - us-central1-docker.pkg.dev/cloud-sdk-production-pipeline/images-dev/librarian-go:infrastructure-public-image-$COMMIT_SHA
+  - us-central1-docker.pkg.dev/cloud-sdk-production-pipeline/images-dev/librarian-go:infrastructure-public-image-latest
+

--- a/internal/librariangen/cloudbuild.yaml
+++ b/internal/librariangen/cloudbuild.yaml
@@ -17,10 +17,19 @@
 
 timeout: 7200s # 2 hours
 steps:
+  # Attempt to pull the latest image to use as a cache source.
+  - name: gcr.io/cloud-builders/docker
+    entrypoint: 'bash'
+    args:
+      - -c
+      - |
+        docker pull gcr.io/cloud-devrel-public-resources/librarian-go:infrastructure-public-image-latest || exit 0
   - name: gcr.io/cloud-builders/docker
     args:
       [
         "build",
+        "--cache-from",
+        "gcr.io/cloud-devrel-public-resources/librarian-go:infrastructure-public-image-latest",
         "-t",
         "gcr.io/cloud-devrel-public-resources/librarian-go:infrastructure-public-image-$COMMIT_SHA",
         "-f",
@@ -29,7 +38,7 @@ steps:
       ]
     dir: internal/librariangen
   - name:  gcr.io/cloud-builders/docker
-    args: 
+    args:
       [
         "tag",
         "gcr.io/cloud-devrel-public-resources/librarian-go:infrastructure-public-image-$COMMIT_SHA",
@@ -41,3 +50,4 @@ options:
 images:
   - gcr.io/cloud-devrel-public-resources/librarian-go:infrastructure-public-image-$COMMIT_SHA
   - gcr.io/cloud-devrel-public-resources/librarian-go:infrastructure-public-image-latest
+


### PR DESCRIPTION
* Optimize the builder stage to cache Go module dependencies separately.
* Enable remote layer caching in cloudbuild.yaml and cloudbuild-exitgate.yaml by using the --cache-from flag.
* Correct the docker tag command in cloudbuild-exitgate.yaml to properly tag the latest image for the cache.