### PR TITLE
fix(storage): ZB Reader redirect support

### DIFF
--- a/storage/invoke.go
+++ b/storage/invoke.go
@@ -154,6 +154,9 @@ func ShouldRetry(err error) bool {
 	if errors.Is(err, net.ErrClosed) {
 		return true
 	}
+	if errors.Is(err, bidiReadObjectRedirectionError{}) {
+		return true
+	}
 
 	switch e := err.(type) {
 	case *googleapi.Error:


### PR DESCRIPTION
Fixes an issue with out of region redirects for storage.Reader.

This should allow kokoro to handle some out-of-region ZB tests.