### PR TITLE
feat(bigtable): Create first_response_latencies instrument

### DIFF
--- a/bigtable/bigtable.go
+++ b/bigtable/bigtable.go
@@ -49,12 +49,15 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-// UNIVERSE_DOMAIN placeholder is replaced by the UniverseDomain from DialSettings while creating GRPC connection/dial pool.
-const prodAddr = "bigtable.UNIVERSE_DOMAIN:443"
-const mtlsProdAddr = "bigtable.mtls.googleapis.com:443"
-const featureFlagsHeaderKey = "bigtable-features"
-const queryExpiredViolationType = "PREPARED_QUERY_EXPIRED"
-const preparedQueryExpireEarlyDuration = time.Second
+const (
+	// UNIVERSE_DOMAIN placeholder is replaced by the UniverseDomain from DialSettings while creating GRPC connection/dial pool.
+	prodAddr                         = "bigtable.UNIVERSE_DOMAIN:443"
+	mtlsProdAddr                     = "bigtable.mtls.googleapis.com:443"
+	featureFlagsHeaderKey            = "bigtable-features"
+	queryExpiredViolationType        = "PREPARED_QUERY_EXPIRED"
+	preparedQueryExpireEarlyDuration = time.Second
+	methodNameReadRows               = "ReadRows"
+)
 
 var errNegativeRowLimit = errors.New("bigtable: row limit cannot be negative")
 
@@ -987,7 +990,7 @@ func (t *Table) readRows(ctx context.Context, arg RowSet, f func(Row) bool, mt *
 		return errNegativeRowLimit
 	}
 
-	err = gaxInvokeWithRecorder(ctx, mt, "ReadRows", func(ctx context.Context, headerMD, trailerMD *metadata.MD, _ gax.CallSettings) error {
+	err = gaxInvokeWithRecorder(ctx, mt, methodNameReadRows, func(ctx context.Context, headerMD, trailerMD *metadata.MD, _ gax.CallSettings) error {
 		if rowLimitSet && numRowsRead >= intialRowLimit {
 			return nil
 		}


### PR DESCRIPTION
This PR creates the metrics instrument for 

[first_response_latencies](https://cloud.google.com/bigtable/docs/client-side-metrics-descriptions#first-response-latencies)

The actual recording of metric is done in https://github.com/googleapis/google-cloud-go/pull/10616