### PR TITLE
fix(storage): No progress report for oneshot write

### DIFF
--- a/storage/grpc_writer.go
+++ b/storage/grpc_writer.go
@@ -320,7 +320,8 @@ func (w *gRPCWriter) pickBufferSender() gRPCBidiWriteBufferSender {
 		return w.newGRPCAppendableObjectBufferSender()
 	}
 	if w.forceOneShot {
-		// One shot semantics
+		// One shot semantics - no progress reports
+		w.progress = func(int64) {}
 		return w.newGRPCOneshotBidiWriteBufferSender()
 	}
 	// Resumable write semantics


### PR DESCRIPTION
Oneshot writes did not report progress prior to
https://github.com/googleapis/google-cloud-go/pull/12422. This fixes them so that they also don't report progress after that.

Also add an emulator test, since it turns out our first test of that behavior was in the integration tests!

Fixes https://github.com/googleapis/google-cloud-go/issues/12739