### PR TITLE
chore(bigquery/v2): remove release-please config temporarily

### DIFF
--- a/.release-please-manifest-individual.json
+++ b/.release-please-manifest-individual.json
@@ -2,7 +2,6 @@
   "auth": "0.16.5",
   "auth/oauth2adapt": "0.2.8",
   "bigquery": "1.69.0",
-  "bigquery/v2": "0.0.0",
   "bigtable": "1.38.0",
   "datastore": "1.20.0",
   "errorreporting": "0.3.2",

--- a/release-please-config-individual.json
+++ b/release-please-config-individual.json
@@ -14,11 +14,6 @@
     "bigquery": {
       "component": "bigquery"
     },
-    "bigquery/v2": {
-      "component": "bigquery/v2",
-      "prerelease": true,
-      "prerelease-type": "alpha"
-    },
     "bigtable": {
       "component": "bigtable"
     },


### PR DESCRIPTION
This PR removes the release-please config and manifest entry for bigquery/v2.  Due to issues with how release-please constructs branches we can only have one bigquery release PR open at a time, and the bigquery/v2 release is effectively blocking releases for bigquery.

When we're ready to resume this, we'll revert these changes.

related: b/433324760