### PR TITLE
feat: use old protoc plugin for go_proto_library

### DIFF
--- a/internal/librariangen/Dockerfile
+++ b/internal/librariangen/Dockerfile
@@ -36,7 +36,7 @@ RUN apt-get update && \
 RUN wget https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz -O go.tar.gz && \
     tar -C /usr/local -xzf go.tar.gz && \
     rm go.tar.gz
-ENV PATH /usr/local/go/bin:$PATH
+ENV PATH=/usr/local/go/bin:$PATH
 RUN go version
 
 WORKDIR /src
@@ -61,7 +61,8 @@ FROM marketplace.gcr.io/google/debian12:latest
 # Set environment variables for tool versions for easy updates.
 ENV GO_VERSION=1.23.0
 ENV PROTOC_VERSION=25.7
-ENV GO_PROTOC_PLUGIN_VERSION=1.35.2
+ENV GO_PROTOC_PLUGIN_V1_VERSION=1.5.4
+ENV GO_PROTOC_PLUGIN_V2_VERSION=1.35.2
 ENV GO_GRPC_PLUGIN_VERSION=1.3.0
 ENV GAPIC_GENERATOR_VERSION=0.53.1
 ENV STATICCHECK_VERSION=2023.1.6
@@ -70,7 +71,7 @@ ENV STATICCHECK_VERSION=2023.1.6
 # Go tools will use this directory for caches, which resolves permission issues.
 ENV HOME=/home/nonroot
 # GOPATH defaults to $HOME/go, so we need to add that to the PATH.
-ENV PATH $HOME/go/bin:/usr/local/go/bin:/usr/local/bin:$PATH
+ENV PATH=$HOME/go/bin:/usr/local/go/bin:/usr/local/bin:$PATH
 
 # Install essential system packages.
 # Clean up apt cache to keep the image smaller.
@@ -96,9 +97,21 @@ RUN wget https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC
     rm protoc.zip && \
     protoc --version
 
+# Build the "old" Go protoc plugin manually; using go install just redirects to the new one.
+# Note that the "old" plugin uses the internal code in the "new" plugin, so we need to use
+# "go mod edit" to end up with a consistent version.
+# The plugin is built as protoc-gen-go_v1, so that we can use "go_v1" as the name in protoc options.
+# This is ghastly, and should all be removed as soon as possible by migrating all packages to go_grpc.
+RUN (export GOTOOLCHAIN='auto' && \
+    git clone --depth 1 --branch=v${GO_PROTOC_PLUGIN_V1_VERSION} https://github.com/golang/protobuf protoc-gen-go-v1 && \
+    cd protoc-gen-go-v1 && \
+    go mod edit -require google.golang.org/protobuf@v${GO_PROTOC_PLUGIN_V2_VERSION} && \
+    go mod tidy && \
+    go build -o $HOME/go/bin/protoc-gen-go_v1 ./protoc-gen-go)
+
 # Install required Go tools for protoc and the post-processor.
 RUN (export GOTOOLCHAIN='auto' && \
-    go install google.golang.org/protobuf/cmd/protoc-gen-go@v${GO_PROTOC_PLUGIN_VERSION} && \
+    go install google.golang.org/protobuf/cmd/protoc-gen-go@v${GO_PROTOC_PLUGIN_V2_VERSION} && \
     go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v${GO_GRPC_PLUGIN_VERSION} && \
     go install github.com/googleapis/gapic-generator-go/cmd/protoc-gen-go_gapic@v${GAPIC_GENERATOR_VERSION} && \
     go install golang.org/x/tools/cmd/goimports@latest && \

--- a/internal/librariangen/protoc/protoc.go
+++ b/internal/librariangen/protoc/protoc.go
@@ -84,11 +84,16 @@ func Build(lib *request.Request, api *request.API, apiServiceDir string, config 
 	args := []string{
 		"protoc",
 		"--experimental_allow_proto3_optional",
-		// All generated files are written to the /output directory.
-		"--go_out=" + outputDir,
 	}
+	// All generated files are written to the /output directory.
+	// Which plugin(s) we use depends on whether the Bazel rule was go_grpc_library
+	// or go_proto_library:
+	// - If we're using go_rpc, we use the newer go plugin and the go-grpc plugin
+	// - Otherwise, use the "old" plugin (built explicitly in the Dockerfile)
 	if config.HasGoGRPC() {
-		args = append(args, "--go-grpc_out="+outputDir, "--go-grpc_opt=require_unimplemented_servers=false")
+		args = append(args, "--go_out="+outputDir, "--go-grpc_out="+outputDir, "--go-grpc_opt=require_unimplemented_servers=false")
+	} else {
+		args = append(args, "--go_v1_out="+outputDir, "--go_v1_opt=plugins=grpc")
 	}
 	args = append(args, "--go_gapic_out="+outputDir)
 

--- a/internal/librariangen/protoc/protoc_test.go
+++ b/internal/librariangen/protoc/protoc_test.go
@@ -58,50 +58,97 @@ func TestBuild(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to get absolute path for sourceDir: %v", err)
 	}
-	apiServiceDir := filepath.Join(sourceDir, "google/cloud/workflows/v1")
+	tests := []struct {
+		name          string
+		apiPath       string
+		apiServiceDir string
+		reqID         string
+		config        mockConfigProvider
+		want          []string
+	}{
+		{
+			name:    "go_grpc_library rule",
+			apiPath: "google/cloud/workflows/v1",
+			reqID:   "workflows",
+			config: mockConfigProvider{
+				gapicImportPath:   "cloud.google.com/go/workflows/apiv1;workflows",
+				transport:         "grpc",
+				grpcServiceConfig: "workflows_grpc_service_config.json",
+				serviceYAML:       "workflows_v1.yaml",
+				releaseLevel:      "ga",
+				metadata:          true,
+				restNumericEnums:  true,
+				hasGoGRPC:         true,
+			},
+			want: []string{
+				"protoc",
+				"--experimental_allow_proto3_optional",
+				"--go_out=/output",
+				"--go-grpc_out=/output",
+				"--go-grpc_opt=require_unimplemented_servers=false",
+				"--go_gapic_out=/output",
+				"--go_gapic_opt=go-gapic-package=cloud.google.com/go/workflows/apiv1;workflows",
+				"--go_gapic_opt=api-service-config=" + filepath.Join(sourceDir, "google/cloud/workflows/v1/workflows_v1.yaml"),
+				"--go_gapic_opt=grpc-service-config=" + filepath.Join(sourceDir, "google/cloud/workflows/v1/workflows_grpc_service_config.json"),
+				"--go_gapic_opt=transport=grpc",
+				"--go_gapic_opt=release-level=ga",
+				"--go_gapic_opt=metadata",
+				"--go_gapic_opt=rest-numeric-enums",
+				"-I=" + sourceDir,
+				filepath.Join(sourceDir, "google/cloud/workflows/v1/workflows.proto"),
+			},
+		},
+		{
+			name:    "go_proto_library rule",
+			apiPath: "google/cloud/secretmanager/v1beta2",
+			reqID:   "secretmanager",
+			config: mockConfigProvider{
+				gapicImportPath:   "cloud.google.com/go/secretmanager/apiv1beta2;secretmanager",
+				transport:         "grpc",
+				grpcServiceConfig: "secretmanager_grpc_service_config.json",
+				serviceYAML:       "secretmanager_v1beta2.yaml",
+				releaseLevel:      "ga",
+				metadata:          true,
+				restNumericEnums:  true,
+				hasGoGRPC:         false,
+			},
+			want: []string{
+				"protoc",
+				"--experimental_allow_proto3_optional",
+				"--go_v1_out=/output",
+				"--go_v1_opt=plugins=grpc",
+				"--go_gapic_out=/output",
+				"--go_gapic_opt=go-gapic-package=cloud.google.com/go/secretmanager/apiv1beta2;secretmanager",
+				"--go_gapic_opt=api-service-config=" + filepath.Join(sourceDir, "google/cloud/secretmanager/v1beta2/secretmanager_v1beta2.yaml"),
+				"--go_gapic_opt=grpc-service-config=" + filepath.Join(sourceDir, "google/cloud/secretmanager/v1beta2/secretmanager_grpc_service_config.json"),
+				"--go_gapic_opt=transport=grpc",
+				"--go_gapic_opt=release-level=ga",
+				"--go_gapic_opt=metadata",
+				"--go_gapic_opt=rest-numeric-enums",
+				"-I=" + sourceDir,
+				filepath.Join(sourceDir, "google/cloud/secretmanager/v1beta2/secretmanager.proto"),
+			},
+		},
+	}
 
-	req := &request.Request{
-		ID: "workflows",
-	}
-	api := &request.API{
-		Path: "google/cloud/workflows/v1",
-	}
-	config := &mockConfigProvider{
-		gapicImportPath:   "cloud.google.com/go/workflows/apiv1;workflows",
-		transport:         "grpc",
-		grpcServiceConfig: "workflows_grpc_service_config.json",
-		serviceYAML:       "workflows_v1.yaml",
-		releaseLevel:      "ga",
-		metadata:          true,
-		restNumericEnums:  true,
-		hasGoGRPC:         true,
-	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := &request.Request{
+				ID: tt.reqID,
+			}
+			api := &request.API{
+				Path: tt.apiPath,
+			}
 
-	got, err := Build(req, api, apiServiceDir, config, sourceDir, "/output")
-	if err != nil {
-		t.Fatalf("Build() failed: %v", err)
-	}
+			got, err := Build(req, api, filepath.Join(sourceDir, tt.apiPath), &tt.config, sourceDir, "/output")
+			if err != nil {
+				t.Fatalf("Build() failed: %v", err)
+			}
 
-	want := []string{
-		"protoc",
-		"--experimental_allow_proto3_optional",
-		"--go_out=/output",
-		"--go-grpc_out=/output",
-		"--go-grpc_opt=require_unimplemented_servers=false",
-		"--go_gapic_out=/output",
-		"--go_gapic_opt=go-gapic-package=cloud.google.com/go/workflows/apiv1;workflows",
-		"--go_gapic_opt=api-service-config=" + filepath.Join(apiServiceDir, "workflows_v1.yaml"),
-		"--go_gapic_opt=grpc-service-config=" + filepath.Join(apiServiceDir, "workflows_grpc_service_config.json"),
-		"--go_gapic_opt=transport=grpc",
-		"--go_gapic_opt=release-level=ga",
-		"--go_gapic_opt=metadata",
-		"--go_gapic_opt=rest-numeric-enums",
-		"-I=" + sourceDir,
-		filepath.Join(apiServiceDir, "workflows.proto"),
-	}
-
-	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("Build() mismatch (-want +got):\n%s", diff)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("Build() mismatch (-want +got):\n%s", diff)
+			}
+		})
 	}
 }
 

--- a/internal/librariangen/testdata/source/google/cloud/secretmanager/v1beta2/BUILD.bazel
+++ b/internal/librariangen/testdata/source/google/cloud/secretmanager/v1beta2/BUILD.bazel
@@ -1,0 +1,39 @@
+go_proto_library(
+    name = "secretmanager_go_proto",
+    compilers = ["@io_bazel_rules_go//proto:go_grpc"],
+    importpath = "cloud.google.com/go/secretmanager/apiv1beta2/secretmanagerpb",
+    protos = [":secretmanager_proto"],
+    deps = [
+        "//google/api:annotations_go_proto",
+        "//google/iam/v1:iam_go_proto",
+    ],
+)
+
+go_gapic_library(
+    name = "secretmanager_go_gapic",
+    srcs = [":secretmanager_proto_with_info"],
+    grpc_service_config = "secretmanager_grpc_service_config.json",
+    importpath = "cloud.google.com/go/secretmanager/apiv1beta2;secretmanager",
+    metadata = True,
+    release_level = "beta",
+    rest_numeric_enums = True,
+    service_yaml = "secretmanager_v1beta2.yaml",
+    transport = "grpc+rest",
+    deps = [
+        ":secretmanager_go_proto",
+        "//google/cloud/location:location_go_proto",
+        "//google/iam/v1:iam_go_proto",
+        "@io_bazel_rules_go//proto/wkt:duration_go_proto",
+    ],
+)
+
+go_gapic_assembly_pkg(
+    name = "gapi-cloud-secretmanager-v1beta2-go",
+    deps = [
+        ":secretmanager_go_gapic",
+        ":secretmanager_go_gapic_srcjar-test.srcjar",
+        ":secretmanager_go_gapic_srcjar-metadata.srcjar",
+        ":secretmanager_go_gapic_srcjar-snippets.srcjar",
+        ":secretmanager_go_proto",
+    ],
+)

--- a/internal/librariangen/testdata/source/google/cloud/secretmanager/v1beta2/secretmanager.proto
+++ b/internal/librariangen/testdata/source/google/cloud/secretmanager/v1beta2/secretmanager.proto
@@ -1,0 +1,46 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package google.cloud.secretmanager.v1beta2;
+
+import "google/api/annotations.proto";
+
+option go_package = "cloud.google.com/go/secretmanager/apiv1beta2/secretmanagerpb;secretmanagerpb";
+
+// A Secret is a secret value.
+message Secret {
+  string name = 1;
+}
+
+// Request for the `ListSecrets` method.
+message ListSecretsRequest {
+  string parent = 1;
+}
+
+// Response for the `ListSecrets` method.
+message ListSecretsResponse {
+  repeated Secret Secrets = 1;
+}
+
+// Service for managing secrets.
+service Secrets {
+  // Lists Secrets in a given project and location.
+  rpc ListSecrets(ListSecretsRequest) returns (ListSecretsResponse) {
+    option (google.api.http) = {
+      get: "/v1/{parent=projects/*/locations/*}/Secrets"
+    };
+  }
+}

--- a/internal/librariangen/testdata/source/google/cloud/secretmanager/v1beta2/secretmanager_v1beta2.yaml
+++ b/internal/librariangen/testdata/source/google/cloud/secretmanager/v1beta2/secretmanager_v1beta2.yaml
@@ -1,0 +1,56 @@
+type: google.api.Service
+config_version: 3
+name: workflows.googleapis.com
+title: Workflows API
+
+apis:
+- name: google.cloud.location.Locations
+- name: google.cloud.workflows.v1.Workflows
+- name: google.longrunning.Operations
+
+types:
+- name: google.cloud.workflows.v1.OperationMetadata
+
+documentation:
+  summary: |-
+    Manage workflow definitions. To execute workflows and manage executions,
+    see the Workflows Executions API.
+  rules:
+  - selector: google.cloud.location.Locations.GetLocation
+    description: Gets information about a location.
+
+  - selector: google.cloud.location.Locations.ListLocations
+    description: Lists information about the supported locations for this service.
+
+http:
+  rules:
+  - selector: google.cloud.location.Locations.GetLocation
+    get: '/v1/{name=projects/*/locations/*}'
+  - selector: google.cloud.location.Locations.ListLocations
+    get: '/v1/{name=projects/*}/locations'
+  - selector: google.longrunning.Operations.DeleteOperation
+    delete: '/v1/{name=projects/*/locations/*/operations/*}'
+  - selector: google.longrunning.Operations.GetOperation
+    get: '/v1/{name=projects/*/locations/*/operations/*}'
+  - selector: google.longrunning.Operations.ListOperations
+    get: '/v1/{name=projects/*/locations/*}/operations'
+
+authentication:
+  rules:
+  - selector: google.cloud.location.Locations.GetLocation
+    oauth:
+      canonical_scopes: |-
+        https://www.googleapis.com/auth/cloud-platform
+  - selector: google.cloud.location.Locations.ListLocations
+    oauth:
+      canonical_scopes: |-
+        https://www.googleapis.com/auth/cloud-platform
+  - selector: 'google.cloud.workflows.v1.Workflows.*'
+    oauth:
+      canonical_scopes: |-
+        https://www.googleapis.com/auth/cloud-platform
+  - selector: 'google.longrunning.Operations.*'
+    oauth:
+      canonical_scopes: |-
+        https://www.googleapis.com/auth/cloud-platform
+


### PR DESCRIPTION
This mimics the behavior of Bazel for go_proto_library targets which contain a compilers attribute of `["@io_bazel_rules_go//proto:go_grpc"]`. In that case, we need to use the old version of protoc-gen-go, passing in "plugins=grpc" as an option.

We have to clone and build that explicitly within the Dockerfile, as there's a redirect from the old plugin to the new one. Furthermore, the old plugin uses the internal code from the new plugin, so we need to set the imported new plugin version to "the same one we use for everything else" directly via "go mod edit".

This is all very hacky, but appears to generate identical code to Bazel (tested with secretmanager v1beta2). We will be able to get rid of it all once we've migrated all packages to go_grpc.