### PR TITLE
refactor(bigtable): Rename pinger to pingAndWarm

### DIFF
--- a/bigtable/bigtable.go
+++ b/bigtable/bigtable.go
@@ -922,7 +922,7 @@ func handleExecuteStreamEnd(stream btpb.Bigtable_ExecuteQueryClient, trailerMD *
 }
 
 // Pinger pings the server and warms up the connection.
-func (c *Client) Pinger(ctx context.Context) (err error) {
+func (c *Client) PingAndWarm(ctx context.Context) (err error) {
 	md := metadata.Join(metadata.Pairs(
 		resourcePrefixHeader, c.fullInstanceName(),
 		requestParamsHeader, c.reqParamsHeaderValInstance(),

--- a/bigtable/bigtable.go
+++ b/bigtable/bigtable.go
@@ -921,7 +921,7 @@ func handleExecuteStreamEnd(stream btpb.Bigtable_ExecuteQueryClient, trailerMD *
 	return nil
 }
 
-// Pinger pings the server and warms up the connection.
+// PingAndWarm pings the server and warms up the connection.
 func (c *Client) PingAndWarm(ctx context.Context) (err error) {
 	md := metadata.Join(metadata.Pairs(
 		resourcePrefixHeader, c.fullInstanceName(),

--- a/bigtable/integration_test.go
+++ b/bigtable/integration_test.go
@@ -249,7 +249,7 @@ func TestIntegration_Pinger(t *testing.T) {
 	if !testEnv.Config().UseProd {
 		t.Skip("emulator doesn't support PingAndWarm")
 	}
-	if err := client.Pinger(ctx); err != nil {
+	if err := client.PingAndWarm(ctx); err != nil {
 		t.Fatalf("pinger failed. got %v, want %v", err, nil)
 	}
 


### PR DESCRIPTION
Renaming Pinger to PingAndWarm since rest of the methods have verb names.
Pinger has not yet been released. So, it is not a breaking change.

