### PR TITLE
chore(bigquery): reconfigure bigquery v1 release definition

### DIFF
--- a/release-please-config-individual.json
+++ b/release-please-config-individual.json
@@ -12,7 +12,8 @@
       "component": "auth/oauth2adapt"
     },
     "bigquery": {
-      "component": "bigquery"
+      "component": "bigquery",
+      "exclude-paths": ["bigquery/v2"]
     },
     "bigtable": {
       "component": "bigtable"


### PR DESCRIPTION
This PR excludes the v2 directory from the v1 release-please config.