### PR TITLE
tools(stategen): complete state file generation tool

### DIFF
--- a/internal/stategen/config.go
+++ b/internal/stategen/config.go
@@ -1,0 +1,49 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Copied from https://github.com/googleapis/google-cloud-go/blob/main/internal/postprocessor/config.go
+// (and then trimmed)
+
+type serviceConfigEntry struct {
+	InputDirectory       string `yaml:"input-directory"`
+	ServiceConfig        string `yaml:"service-config"`
+	ImportPath           string `yaml:"import-path"`
+	RelPath              string `yaml:"rel-path"`
+	ReleaseLevelOverride string `yaml:"release-level-override"`
+}
+
+type postProcessorConfig struct {
+	ServiceConfigs []*serviceConfigEntry `yaml:"service-configs"`
+}
+
+func loadPostProcessorConfig(path string) (*postProcessorConfig, error) {
+	bytes, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var config postProcessorConfig
+	if err := yaml.Unmarshal(bytes, &config); err != nil {
+		return nil, fmt.Errorf("unmarshaling post-processor config: %w", err)
+	}
+	return &config, nil
+}

--- a/internal/stategen/main.go
+++ b/internal/stategen/main.go
@@ -47,17 +47,25 @@ func run(args []string) error {
 		return errors.New("stategen: expected a root directory and at least one module")
 	}
 	repoRoot := args[0]
+
+	postProcessorConfigPath := filepath.Join(repoRoot, "internal/postprocessor/config.yaml")
+	ppc, err := loadPostProcessorConfig(postProcessorConfigPath)
+	if err != nil {
+		return err
+	}
+
 	stateFilePath := filepath.Join(repoRoot, ".librarian/state.yaml")
 	state, err := parseLibrarianState(stateFilePath)
 	if err != nil {
 		return err
 	}
+
 	for _, moduleName := range args[1:] {
 		if stateContainsModule(state, moduleName) {
 			slog.Info("skipping existing module", "module", moduleName)
 			continue
 		}
-		if err := addModule(repoRoot, state, moduleName); err != nil {
+		if err := addModule(repoRoot, ppc, state, moduleName); err != nil {
 			return err
 		}
 	}
@@ -73,7 +81,7 @@ func stateContainsModule(state *LibrarianState, moduleName string) bool {
 	return false
 }
 
-func addModule(repoRoot string, state *LibrarianState, moduleName string) error {
+func addModule(repoRoot string, ppc *postProcessorConfig, state *LibrarianState, moduleName string) error {
 	slog.Info("adding module", "module", moduleName)
 	moduleRoot := filepath.Join(repoRoot, moduleName)
 
@@ -85,11 +93,9 @@ func addModule(repoRoot string, state *LibrarianState, moduleName string) error 
 			"internal/generated/snippets/" + moduleName,
 		},
 		RemoveRegex: []string{
-			moduleName + "/README\\.md",
-			moduleName + "/go\\.mod",
-			moduleName + "/go\\.sum",
-			moduleName + "/internal/version\\.go",
-			"internal/generated/snippets/" + moduleName,
+			"^" + moduleName + "/go\\.mod$",
+			"^" + moduleName + "/go\\.sum$",
+			"^internal/generated/snippets/" + moduleName + "/",
 		},
 	}
 
@@ -99,9 +105,7 @@ func addModule(repoRoot string, state *LibrarianState, moduleName string) error 
 	}
 	library.Version = version
 
-	if err := addAPIProtoPaths(repoRoot, moduleName, library); err != nil {
-		return err
-	}
+	addAPIProtoPaths(ppc, moduleName, library)
 
 	if err := addGeneratedCodeRemovals(repoRoot, moduleRoot, library); err != nil {
 		return err
@@ -111,25 +115,19 @@ func addModule(repoRoot string, state *LibrarianState, moduleName string) error 
 	return nil
 }
 
-// addAPIProtoPaths walks the generates snippets directory to find the API proto paths for the library.
-func addAPIProtoPaths(repoRoot, moduleName string, library *LibraryState) error {
-	return filepath.WalkDir(filepath.Join(repoRoot, "internal/generated/snippets/"+moduleName), func(path string, d os.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		if d.IsDir() {
-			return nil
-		}
-		if match, _ := filepath.Match("snippet_metadata.*.json", d.Name()); match {
-			parts := strings.Split(d.Name(), ".")
-			parts = parts[1 : len(parts)-1]
+// addAPIProtoPaths uses the legacy post-processor config to determine which API paths contribute
+// to the specified module.
+func addAPIProtoPaths(ppc *postProcessorConfig, moduleName string, library *LibraryState) {
+	importPrefix := "cloud.google.com/go/" + moduleName + "/"
+
+	for _, serviceConfig := range ppc.ServiceConfigs {
+		if strings.HasPrefix(serviceConfig.ImportPath, importPrefix) {
 			api := &API{
-				Path: strings.Join(parts, "/"),
+				Path: serviceConfig.InputDirectory,
 			}
 			library.APIs = append(library.APIs, api)
 		}
-		return nil
-	})
+	}
 }
 
 // addApiPaths walk the module source directory to find the files to remove.
@@ -149,7 +147,7 @@ func addGeneratedCodeRemovals(repoRoot, moduleRoot string, library *LibraryState
 			return err
 		}
 		apiParts := strings.Split(path, "/")
-		protobufDir := apiParts[len(apiParts)-2] + "pb"
+		protobufDir := apiParts[len(apiParts)-2] + "pb/.*"
 		generatedPaths := []string{
 			"[^/]*_client\\.go",
 			"[^/]*_client_example_go123_test\\.go",
@@ -159,11 +157,10 @@ func addGeneratedCodeRemovals(repoRoot, moduleRoot string, library *LibraryState
 			"doc\\.go",
 			"gapic_metadata\\.json",
 			"helpers\\.go",
-			"version\\.go",
 			protobufDir,
 		}
 		for _, generatedPath := range generatedPaths {
-			library.RemoveRegex = append(library.RemoveRegex, repoRelativePath+"/"+generatedPath)
+			library.RemoveRegex = append(library.RemoveRegex, "^"+repoRelativePath+"/"+generatedPath+"$")
 		}
 		return nil
 	})


### PR DESCRIPTION
- Use the legacy post-processor config to determine proto paths per library
- Update path removal regexes to be much more precise

With these changes in place, the generated state file only needs tweaking for a handful of libraries. See
go/sdk-librarian-go-migration-planning for those tweaks.