### PR TITLE
fix(internal/godocfx): better support for v2 modules

### DIFF
--- a/internal/godocfx/main.go
+++ b/internal/godocfx/main.go
@@ -174,6 +174,7 @@ func process(mod indexEntry, workingDir, outDir string, namer *friendlyAPINamer,
 		"cloud.google.com/go/gsuiteaddons",
 
 		"google.golang.org/appengine/v2/cmd",
+		"cloud.google.com/go/spanner/benchmarks",
 	}
 	if hasPrefix(mod.Path, filter) {
 		log.Printf("%q filtered out, nothing to do: here is the filter: %q", mod.Path, filter)

--- a/internal/godocfx/pkgload/load.go
+++ b/internal/godocfx/pkgload/load.go
@@ -57,6 +57,10 @@ func Load(glob, workingDir string, filter []string) ([]Info, error) {
 		return nil, fmt.Errorf("pattern %q matched 0 packages", glob)
 	}
 
+	// To sort v1 modules before v2+
+	sort.Slice(allPkgs, func(i, j int) bool {
+		return allPkgs[i].PkgPath < allPkgs[j].PkgPath
+	})
 	module := allPkgs[0].Module
 	skippedModules := map[string]struct{}{}
 


### PR DESCRIPTION
Added sorting to package processing so v1 module sort before v2, avoids a panic that was filtering away all results.

Also added one more module to skiplist.

Internal Bug: b/441963312