### PR TITLE
fix(internal/godocfx): module detection when tidy errors

### DIFF
--- a/internal/godocfx/pkgload/load.go
+++ b/internal/godocfx/pkgload/load.go
@@ -61,7 +61,7 @@ func Load(glob, workingDir string, filter []string) ([]Info, error) {
 	sort.Slice(allPkgs, func(i, j int) bool {
 		return allPkgs[i].PkgPath < allPkgs[j].PkgPath
 	})
-	module := allPkgs[0].Module
+	modulePath := getModulePath(allPkgs)
 	skippedModules := map[string]struct{}{}
 
 	// First, collect all of the files grouped by package, including test
@@ -91,7 +91,7 @@ func Load(glob, workingDir string, filter []string) ([]Info, error) {
 			idToPkg[pkg.PkgPath] = pkg
 			pkgNames = append(pkgNames, pkg.PkgPath)
 			// The test package doesn't have Module set.
-			if pkg.Module.Path != module.Path {
+			if pkg.Module.Path != modulePath {
 				skippedModules[pkg.Module.Path] = struct{}{}
 				continue
 			}
@@ -137,7 +137,7 @@ func Load(glob, workingDir string, filter []string) ([]Info, error) {
 		}
 
 		// Extra filter in case the file filtering didn't catch everything.
-		if !strings.HasPrefix(docPkg.ImportPath, module.Path) {
+		if !strings.HasPrefix(docPkg.ImportPath, modulePath) {
 			continue
 		}
 
@@ -167,6 +167,15 @@ func Load(glob, workingDir string, filter []string) ([]Info, error) {
 	}
 
 	return result, nil
+}
+
+func getModulePath(pkgs []*packages.Package) string {
+	for _, pkg := range pkgs {
+		if pkg.Module != nil && pkg.Module.Path != "" {
+			return pkg.Module.Path
+		}
+	}
+	return ""
 }
 
 // pkgStatus returns the status of the given package with the

--- a/internal/godocfx/pkgload/load_test.go
+++ b/internal/godocfx/pkgload/load_test.go
@@ -14,7 +14,11 @@
 
 package pkgload
 
-import "testing"
+import (
+	"testing"
+
+	"golang.org/x/tools/go/packages"
+)
 
 func TestPkgStatus(t *testing.T) {
 	tests := []struct {
@@ -70,5 +74,56 @@ func TestPkgStatus(t *testing.T) {
 		if got := pkgStatus(test.importPath, test.doc, test.version); got != test.want {
 			t.Errorf("pkgStatus(%q, %q, %q) got %q, want %q", test.importPath, test.doc, test.version, got, test.want)
 		}
+	}
+}
+
+func TestGetModulePath(t *testing.T) {
+	tests := []struct {
+		name string
+		pkgs []*packages.Package
+		want string
+	}{
+		{
+			name: "empty",
+			pkgs: []*packages.Package{},
+			want: "",
+		},
+		{
+			name: "no module",
+			pkgs: []*packages.Package{
+				{Module: nil},
+			},
+			want: "",
+		},
+		{
+			name: "module no path",
+			pkgs: []*packages.Package{
+				{Module: &packages.Module{}},
+			},
+			want: "",
+		},
+		{
+			name: "one with path",
+			pkgs: []*packages.Package{
+				{Module: &packages.Module{Path: "example.com/foo"}},
+			},
+			want: "example.com/foo",
+		},
+		{
+			name: "many",
+			pkgs: []*packages.Package{
+				{Module: nil},
+				{Module: &packages.Module{}},
+				{Module: &packages.Module{Path: "example.com/bar"}},
+			},
+			want: "example.com/bar",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getModulePath(tt.pkgs); got != tt.want {
+				t.Errorf("getModulePath() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Sometimes package.Load detects some untidied modules missing .sum enteries. In this case the first package being retunred in in the form 'cloud.google.com/go/foo/...'. This is not a real package and is present to only return some package level errors. We should not try to determine the module from this entry as it is not present.

Fixes a nil pointer exeception.

Updates: b/441963312