### PR TITLE
chore(spanner): Disable connecting to metadata server for emulator tests

### DIFF
--- a/spanner/metrics.go
+++ b/spanner/metrics.go
@@ -82,6 +82,8 @@ const (
 	// Metric units
 	metricUnitMS    = "ms"
 	metricUnitCount = "1"
+
+	defaultClientLocation = "global"
 )
 
 // These are effectively const, but for testing purposes they are mutable
@@ -188,9 +190,13 @@ var (
 	}
 
 	detectClientLocation = func(ctx context.Context) string {
+		if emulatorAddr, found := os.LookupEnv("SPANNER_EMULATOR_HOST"); found && emulatorAddr != "" {
+			return defaultClientLocation
+		}
+
 		resource, err := gcp.NewDetector().Detect(ctx)
 		if err != nil {
-			return "global"
+			return defaultClientLocation
 		}
 		for _, attr := range resource.Attributes() {
 			if attr.Key == semconv.CloudRegionKey {
@@ -198,7 +204,7 @@ var (
 			}
 		}
 		// If region is not found, return global
-		return "global"
+		return defaultClientLocation
 	}
 
 	// GCM exporter should use the same options as Spanner client


### PR DESCRIPTION
**Description:**

While running tests in docker-compose with emulator, client library is trying to connect to metadata server to identify the type of client such GCE, Cloud Run..etc. When running tests with emulator, we don't have to connect to metadata server to fetch client location.