### PR TITLE
chore: Fix exitgate GCB configuration

### DIFF
--- a/internal/librariangen/cloudbuild-exitgate.yaml
+++ b/internal/librariangen/cloudbuild-exitgate.yaml
@@ -31,24 +31,16 @@ steps:
         "--cache-from",
         "us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-dev/librarian-go:latest",
         "-t",
-        "us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-dev/librarian-go:infrastructure-public-image-$COMMIT_SHA",
+        "us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-dev/librarian-go:latest",
         "-f",
         "Dockerfile",
         ".",
       ]
     dir: internal/librariangen
-  - name:  gcr.io/cloud-builders/docker
-    args:
-      [
-        "tag",
-        "us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-dev/librarian-go:infrastructure-public-image-$COMMIT_SHA",
-        "us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-dev/librarian-go:latest",
-      ]
 options:
     machineType: 'E2_HIGHCPU_8'
     requestedVerifyOption: VERIFIED  # For provenance attestation generation
     logging: CLOUD_LOGGING_ONLY
 images:
-  - us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-dev/librarian-go:infrastructure-public-image-$COMMIT_SHA
   - us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-dev/librarian-go:latest
 

--- a/internal/librariangen/cloudbuild-exitgate.yaml
+++ b/internal/librariangen/cloudbuild-exitgate.yaml
@@ -47,7 +47,7 @@ steps:
 options:
     machineType: 'E2_HIGHCPU_8'
     requestedVerifyOption: VERIFIED  # For provenance attestation generation
-
+    logging: CLOUD_LOGGING_ONLY
 images:
   - us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-dev/librarian-go:infrastructure-public-image-$COMMIT_SHA
   - us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-dev/librarian-go:latest

--- a/internal/librariangen/cloudbuild-exitgate.yaml
+++ b/internal/librariangen/cloudbuild-exitgate.yaml
@@ -23,13 +23,13 @@ steps:
     args:
       - -c
       - |
-        docker pull us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-dev/librarian-go:infrastructure-public-image-latest || exit 0
+        docker pull us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-dev/librarian-go:latest || exit 0
   - name: gcr.io/cloud-builders/docker
     args:
       [
         "build",
         "--cache-from",
-        "us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-dev/librarian-go:infrastructure-public-image-latest",
+        "us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-dev/librarian-go:latest",
         "-t",
         "us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-dev/librarian-go:infrastructure-public-image-$COMMIT_SHA",
         "-f",
@@ -42,7 +42,6 @@ steps:
       [
         "tag",
         "us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-dev/librarian-go:infrastructure-public-image-$COMMIT_SHA",
-        "us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-dev/librarian-go:infrastructure-public-image-latest",
         "us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-dev/librarian-go:latest",
       ]
 options:
@@ -51,6 +50,5 @@ options:
 
 images:
   - us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-dev/librarian-go:infrastructure-public-image-$COMMIT_SHA
-  - us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-dev/librarian-go:infrastructure-public-image-latest
   - us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-dev/librarian-go:latest
 


### PR DESCRIPTION
1) remove extra tags, will only use latest going forward
2) added cloud logging option