### PR TITLE
chore: generate audit protos in genproto

### DIFF
--- a/internal/gapicgen/generator/genproto.go
+++ b/internal/gapicgen/generator/genproto.go
@@ -132,6 +132,7 @@ var generateList = []string{
 	"google.golang.org/genproto/googleapis/firebase/fcm/connection/v1alpha1",
 	"google.golang.org/genproto/googleapis/assistant/embedded/v1alpha2",
 	"google.golang.org/genproto/googleapis/apps/card/v1",
+	"google.golang.org/genproto/googleapis/cloud/audit",
 }
 
 // Regen regenerates the genproto repository.


### PR DESCRIPTION
We should consider moving this proto to google-cloud-go in the future but for now we should just start generating them again over in genproto.

Updates: https://github.com/googleapis/go-genproto/issues/1236