### PR TITLE
feat: provide minimal onboarding for Librarian

### DIFF
--- a/.librarian/generator-input/repo-config.yaml
+++ b/.librarian/generator-input/repo-config.yaml
@@ -1,0 +1,3 @@
+# Configuration file for libraries where the container needs
+# more information than is readily available.
+

--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,0 +1,36 @@
+image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go:latest
+libraries:
+    - id: aiplatform
+      version: 1.100.0
+      last_generated_commit: ""
+      apis:
+        - path: google/cloud/aiplatform/v1
+          service_config: ""
+        - path: google/cloud/aiplatform/v1beta1
+          service_config: ""
+      source_roots:
+        - aiplatform
+        - internal/generated/snippets/aiplatform
+      preserve_regex: []
+      remove_regex:
+        - ^aiplatform/go\.mod$
+        - ^aiplatform/go\.sum$
+        - ^internal/generated/snippets/aiplatform/
+        - ^aiplatform/apiv1/[^/]*_client\.go$
+        - ^aiplatform/apiv1/[^/]*_client_example_go123_test\.go$
+        - ^aiplatform/apiv1/[^/]*_client_example_test\.go$
+        - ^aiplatform/apiv1/auxiliary\.go$
+        - ^aiplatform/apiv1/auxiliary_go123\.go$
+        - ^aiplatform/apiv1/doc\.go$
+        - ^aiplatform/apiv1/gapic_metadata\.json$
+        - ^aiplatform/apiv1/helpers\.go$
+        - ^aiplatform/apiv1/aiplatformpb/.*$
+        - ^aiplatform/apiv1beta1/[^/]*_client\.go$
+        - ^aiplatform/apiv1beta1/[^/]*_client_example_go123_test\.go$
+        - ^aiplatform/apiv1beta1/[^/]*_client_example_test\.go$
+        - ^aiplatform/apiv1beta1/auxiliary\.go$
+        - ^aiplatform/apiv1beta1/auxiliary_go123\.go$
+        - ^aiplatform/apiv1beta1/doc\.go$
+        - ^aiplatform/apiv1beta1/gapic_metadata\.json$
+        - ^aiplatform/apiv1beta1/helpers\.go$
+        - ^aiplatform/apiv1beta1/aiplatformpb/.*$

--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -34,3 +34,4 @@ libraries:
         - ^aiplatform/apiv1beta1/gapic_metadata\.json$
         - ^aiplatform/apiv1beta1/helpers\.go$
         - ^aiplatform/apiv1beta1/aiplatformpb/.*$
+      tag_format: "{id}/v{version}"


### PR DESCRIPTION
This adds a state file with AI Platform, but does *not* make the other one-off changes (e.g. reordering imports, removing the executable bit) as those would then be undone by OwlBot.

The intention of this change is to allow the automation that creates generation PRs to be tested, but we should not merge the resulting PRs.

Fixes https://github.com/googleapis/librarian/issues/1982