### PR TITLE
fix(internal/librariangen): remove go mod init/tidy from postprocessor

### DIFF
--- a/internal/librariangen/postprocessor/postprocessor.go
+++ b/internal/librariangen/postprocessor/postprocessor.go
@@ -38,9 +38,7 @@ var (
 // formatters and other tools to ensure code quality. The high-level steps are:
 //
 //  1. Modify the generated snippets to specify the current version
-//  2. Run `go mod init`.
-//  3. Run `goimports` to format the code.
-//  4. Run `go mod tidy` to clean up the `go.mod` file.
+//  2. Run `goimports` to format the code.
 func PostProcess(ctx context.Context, req *request.Request, outputDir, moduleDir string, moduleConfig *config.ModuleConfig) error {
 	slog.Debug("librariangen: starting post-processing", "directory", moduleDir)
 
@@ -57,16 +55,8 @@ func PostProcess(ctx context.Context, req *request.Request, outputDir, moduleDir
 		return fmt.Errorf("librariangen: failed to update snippets metadata: %w", err)
 	}
 
-	if err := goModInit(ctx, moduleConfig.GetModulePath(), moduleDir); err != nil {
-		return fmt.Errorf("librariangen: failed to run 'go mod init': %w", err)
-	}
-
 	if err := goimports(ctx, moduleDir); err != nil {
 		return fmt.Errorf("librariangen: failed to run 'goimports': %w", err)
-	}
-
-	if err := goModTidy(ctx, moduleDir); err != nil {
-		return fmt.Errorf("librariangen: failed to run 'go mod tidy': %w", err)
 	}
 
 	slog.Debug("librariangen: post-processing finished successfully")
@@ -80,20 +70,6 @@ func goimports(ctx context.Context, dir string) error {
 	// The `.` argument will make goimports process all go files in the directory
 	// and its subdirectories. The -w flag writes results back to source files.
 	args := []string{"goimports", "-w", "."}
-	return execvRun(ctx, args, dir)
-}
-
-// goModInit initializes a go.mod file in the given directory.
-func goModInit(ctx context.Context, modulePath, dir string) error {
-	slog.Debug("librariangen: running go mod init", "directory", dir, "modulePath", modulePath)
-	args := []string{"go", "mod", "init", modulePath}
-	return execvRun(ctx, args, dir)
-}
-
-// goModTidy tidies the go.mod file, adding missing and removing unused dependencies.
-func goModTidy(ctx context.Context, dir string) error {
-	slog.Debug("librariangen: running go mod tidy", "directory", dir)
-	args := []string{"go", "mod", "tidy"}
 	return execvRun(ctx, args, dir)
 }
 

--- a/internal/librariangen/postprocessor/postprocessor_test.go
+++ b/internal/librariangen/postprocessor/postprocessor_test.go
@@ -28,21 +28,17 @@ import (
 
 func TestPostProcess(t *testing.T) {
 	tests := []struct {
-		name                string
-		mockexecvRun        func(ctx context.Context, args []string, dir string) error
-		wantGoModInitCalled bool
-		wantGoModTidyCalled bool
-		wantErr             bool
-		noVersion           bool
+		name         string
+		mockexecvRun func(ctx context.Context, args []string, dir string) error
+		wantErr      bool
+		noVersion    bool
 	}{
 		{
 			name: "success",
 			mockexecvRun: func(ctx context.Context, args []string, dir string) error {
 				return nil
 			},
-			wantGoModInitCalled: true,
-			wantGoModTidyCalled: true,
-			wantErr:             false,
+			wantErr: false,
 		},
 		{
 			name: "goimports fails (fatal)",
@@ -52,40 +48,12 @@ func TestPostProcess(t *testing.T) {
 				}
 				return nil
 			},
-			wantGoModInitCalled: true,
-			wantGoModTidyCalled: false,
-			wantErr:             true,
+			wantErr: true,
 		},
 		{
-			name: "go mod init fails (fatal)",
-			mockexecvRun: func(ctx context.Context, args []string, dir string) error {
-				if args[0] == "go" && args[1] == "mod" && args[2] == "init" {
-					return errors.New("go mod init failed")
-				}
-				return nil
-			},
-			wantGoModInitCalled: true,
-			wantGoModTidyCalled: false,
-			wantErr:             true,
-		},
-		{
-			name: "go mod tidy fails (fatal)",
-			mockexecvRun: func(ctx context.Context, args []string, dir string) error {
-				if args[0] == "go" && args[1] == "mod" && args[2] == "tidy" {
-					return errors.New("go mod tidy failed")
-				}
-				return nil
-			},
-			wantGoModInitCalled: true,
-			wantGoModTidyCalled: true,
-			wantErr:             true,
-		},
-		{
-			name:                "fail without version",
-			noVersion:           true,
-			wantGoModInitCalled: false,
-			wantGoModTidyCalled: false,
-			wantErr:             true,
+			name:      "fail without version",
+			noVersion: true,
+			wantErr:   true,
 		},
 	}
 
@@ -131,16 +99,7 @@ func TestPostProcess(t *testing.T) {
 				return
 			}
 
-			var goModInitCalled, goModTidyCalled bool
-			execvRun = func(ctx context.Context, args []string, dir string) error {
-				if len(args) > 2 && args[0] == "go" && args[1] == "mod" && args[2] == "init" {
-					goModInitCalled = true
-				}
-				if len(args) > 2 && args[0] == "go" && args[1] == "mod" && args[2] == "tidy" {
-					goModTidyCalled = true
-				}
-				return tt.mockexecvRun(ctx, args, dir)
-			}
+			execvRun = tt.mockexecvRun
 
 			req := &request.Request{
 				ID: "chronicle",
@@ -165,13 +124,6 @@ func TestPostProcess(t *testing.T) {
 
 			if tt.wantErr {
 				return
-			}
-
-			if goModInitCalled != tt.wantGoModInitCalled {
-				t.Errorf("goModInitCalled = %v; want %v", goModInitCalled, tt.wantGoModInitCalled)
-			}
-			if goModTidyCalled != tt.wantGoModTidyCalled {
-				t.Errorf("goModTidyCalled = %v; want %v", goModTidyCalled, tt.wantGoModTidyCalled)
 			}
 
 			for _, snippetMetadataFile := range snippetMetadataFiles {

--- a/internal/stategen/main.go
+++ b/internal/stategen/main.go
@@ -93,8 +93,6 @@ func addModule(repoRoot string, ppc *postProcessorConfig, state *LibrarianState,
 			"internal/generated/snippets/" + moduleName,
 		},
 		RemoveRegex: []string{
-			"^" + moduleName + "/go\\.mod$",
-			"^" + moduleName + "/go\\.sum$",
 			"^internal/generated/snippets/" + moduleName + "/",
 		},
 	}


### PR DESCRIPTION
For now, we're going to make the generate command not touch these at all. The command doesn't have enough context to use the right dependencies, so we should leave them as they are.

We therefore shouldn't have go.mod and go.sum in the state file in the remove regexes.

See https://github.com/googleapis/librarian/issues/1921 for context.