### PR TITLE
chore(librarian): run yamlfmt on state.yaml

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,24 +1,24 @@
 image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go:latest
-libraries:    
-    - id: dlp
-      version: 1.24.0
-      last_generated_commit: 8ee3aad1fd2f2376373a030cafc61b3e9788e48a
-      apis:
-        - path: google/privacy/dlp/v2
-          service_config: ""
-      source_roots:
-        - dlp
-        - internal/generated/snippets/dlp
-      preserve_regex: []
-      remove_regex:
-        - ^internal/generated/snippets/dlp/
-        - ^dlp/apiv2/[^/]*_client\.go$
-        - ^dlp/apiv2/[^/]*_client_example_go123_test\.go$
-        - ^dlp/apiv2/[^/]*_client_example_test\.go$
-        - ^dlp/apiv2/auxiliary\.go$
-        - ^dlp/apiv2/auxiliary_go123\.go$
-        - ^dlp/apiv2/doc\.go$
-        - ^dlp/apiv2/gapic_metadata\.json$
-        - ^dlp/apiv2/helpers\.go$
-        - ^dlp/apiv2/dlppb/.*$
-      tag_format: '{id}/v{version}'
+libraries:
+  - id: dlp
+    version: 1.24.0
+    last_generated_commit: 8ee3aad1fd2f2376373a030cafc61b3e9788e48a
+    apis:
+      - path: google/privacy/dlp/v2
+        service_config: ""
+    source_roots:
+      - dlp
+      - internal/generated/snippets/dlp
+    preserve_regex: []
+    remove_regex:
+      - ^internal/generated/snippets/dlp/
+      - ^dlp/apiv2/[^/]*_client\.go$
+      - ^dlp/apiv2/[^/]*_client_example_go123_test\.go$
+      - ^dlp/apiv2/[^/]*_client_example_test\.go$
+      - ^dlp/apiv2/auxiliary\.go$
+      - ^dlp/apiv2/auxiliary_go123\.go$
+      - ^dlp/apiv2/doc\.go$
+      - ^dlp/apiv2/gapic_metadata\.json$
+      - ^dlp/apiv2/helpers\.go$
+      - ^dlp/apiv2/dlppb/.*$
+    tag_format: '{id}/v{version}'


### PR DESCRIPTION
Ran the following to fix the formatting in `.librarian/state.yaml`

```
go install github.com/google/yamlfmt/cmd/yamlfmt@latest
export PATH="/usr/local/google/home/partheniou/go/bin:$PATH"
yamlfmt .librarian/state.yaml
```

We can run `yamlfmt` any time we make changes to `.librarian/state.yaml` to reduce the diff due to formatting differences as librarian uses `yamlfmt`