### PR TITLE
feat(auth): add trust boundary support for external accounts

### DIFF
--- a/auth/credentials/detect.go
+++ b/auth/credentials/detect.go
@@ -130,9 +130,9 @@ func DetectDefault(opts *DetectOptions) (*auth.Credentials, error) {
 
 		tp := computeTokenProvider(opts, metadataClient)
 		if trustBoundaryEnabled {
-			gceTBConfigProvider := trustboundary.NewGCETrustBoundaryConfigProvider(gceUniverseDomainProvider)
+			gceConfigProvider := trustboundary.NewGCEConfigProvider(gceUniverseDomainProvider)
 			var err error
-			tp, err = trustboundary.NewProvider(opts.client(), gceTBConfigProvider, opts.logger(), tp)
+			tp, err = trustboundary.NewProvider(opts.client(), gceConfigProvider, opts.logger(), tp)
 			if err != nil {
 				return nil, fmt.Errorf("credentials: failed to initialize GCE trust boundary provider: %w", err)
 			}

--- a/auth/internal/trustboundary/external_accounts_config_providers.go
+++ b/auth/internal/trustboundary/external_accounts_config_providers.go
@@ -30,8 +30,8 @@ var (
 	workloadAudiencePattern  = regexp.MustCompile(`//iam\.([^/]+)/projects/([^/]+)/locations/global/workloadIdentityPools/([^/]+)`)
 )
 
-// NewExternalAccountTrustBoundaryConfigProvider creates a new ConfigProvider for external accounts.
-func NewExternalAccountTrustBoundaryConfigProvider(audience, inputUniverseDomain string) (ConfigProvider, error) {
+// NewExternalAccountConfigProvider creates a new ConfigProvider for external accounts.
+func NewExternalAccountConfigProvider(audience, inputUniverseDomain string) (ConfigProvider, error) {
 	var audienceDomain, projectNumber, poolID string
 	var isWorkload bool
 

--- a/auth/internal/trustboundary/external_accounts_config_providers_test.go
+++ b/auth/internal/trustboundary/external_accounts_config_providers_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 )
 
-func TestNewExternalAccountTrustBoundaryConfigProvider(t *testing.T) {
+func TestNewExternalAccountConfigProvider(t *testing.T) {
 	tests := []struct {
 		name           string
 		audience       string
@@ -88,33 +88,33 @@ func TestNewExternalAccountTrustBoundaryConfigProvider(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			provider, err := NewExternalAccountTrustBoundaryConfigProvider(tt.audience, tt.universeDomain)
+			provider, err := NewExternalAccountConfigProvider(tt.audience, tt.universeDomain)
 
 			if tt.wantErr != "" {
 				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
-					t.Errorf("NewExternalAccountTrustBoundaryConfigProvider() error = %v, wantErr %q", err, tt.wantErr)
+					t.Errorf("NewExternalAccountConfigProvider() error = %v, wantErr %q", err, tt.wantErr)
 				}
 				return
 			}
 			if err != nil {
-				t.Fatalf("NewExternalAccountTrustBoundaryConfigProvider() unexpected error: %v", err)
+				t.Fatalf("NewExternalAccountConfigProvider() unexpected error: %v", err)
 			}
 			switch want := tt.wantProvider.(type) {
 			case *workloadIdentityPoolConfigProvider:
 				got, ok := provider.(*workloadIdentityPoolConfigProvider)
 				if !ok {
-					t.Fatalf("NewExternalAccountTrustBoundaryConfigProvider() got provider type %T, want %T", provider, want)
+					t.Fatalf("NewExternalAccountConfigProvider() got provider type %T, want %T", provider, want)
 				}
 				if *got != *want {
-					t.Errorf("NewExternalAccountTrustBoundaryConfigProvider() got = %v, want %v", got, want)
+					t.Errorf("NewExternalAccountConfigProvider() got = %v, want %v", got, want)
 				}
 			case *workforcePoolConfigProvider:
 				got, ok := provider.(*workforcePoolConfigProvider)
 				if !ok {
-					t.Fatalf("NewExternalAccountTrustBoundaryConfigProvider() got provider type %T, want %T", provider, want)
+					t.Fatalf("NewExternalAccountConfigProvider() got provider type %T, want %T", provider, want)
 				}
 				if *got != *want {
-					t.Errorf("NewExternalAccountTrustBoundaryConfigProvider() got = %v, want %v", got, want)
+					t.Errorf("NewExternalAccountConfigProvider() got = %v, want %v", got, want)
 				}
 			default:
 				t.Fatalf("unexpected provider type in test setup: %T", want)


### PR DESCRIPTION
This PR adds the trust boundary feature for external accounts.
See [go/trust-boundaries-auth-sdk-v2](http://goto.google.com/trust-boundaries-auth-sdk-v2) for the most up to date design. 