### PR TITLE
chore: make librarian team full codeowners so they can approve Librarian generated PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,5 @@
 # Default owner for all directories not owned by others
 
-*                       @googleapis/yoshi-go-admins
 *                       @googleapis/cloud-sdk-librarian-team # Librarian team access for merging Librarian PRs
 *                       @googleapis/cloud-sdk-go-eng
 


### PR DESCRIPTION
As part of onboarding libraries to Librarian, the cloud sdk platform team will be taking over approving and merging the automatically generated PRs.