### PR TITLE
fix(internal/librariangen): add link to source commit in release notes

### DIFF
--- a/internal/librariangen/release/release.go
+++ b/internal/librariangen/release/release.go
@@ -148,10 +148,10 @@ func updateChangelog(cfg *Config, lib *Library, t time.Time) error {
 					shortHash = shortHash[:7]
 				}
 				commitURL := fmt.Sprintf("https://github.com/googleapis/google-cloud-go/commit/%s", change.SourceCommitHash)
-				commitLink = fmt.Sprintf(" ([%s](%s))", shortHash, commitURL)
+				commitLink = fmt.Sprintf("([%s](%s))", shortHash, commitURL)
 			}
 
-			fmt.Fprintf(&newEntry, "* **%s:** %s%s\n", lib.ID, change.Subject, commitLink)
+			fmt.Fprintf(&newEntry, "* %s %s\n", change.Subject, commitLink)
 
 		}
 		newEntry.WriteString("\n")

--- a/internal/librariangen/release/release.go
+++ b/internal/librariangen/release/release.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 
@@ -117,22 +118,41 @@ func updateChangelog(cfg *Config, lib *Library, t time.Time) error {
 	date := t.Format("2006-01-02")
 	fmt.Fprintf(&newEntry, "## [%s](%s) (%s)\n\n", lib.Version, releaseURL, date)
 
-	changesByType := make(map[string]map[string]bool)
+	changesByType := make(map[string]map[string]*Change)
 	for _, change := range lib.Changes {
 		if changesByType[change.Type] == nil {
-			changesByType[change.Type] = make(map[string]bool)
+			changesByType[change.Type] = make(map[string]*Change)
 		}
-		changesByType[change.Type][change.Subject] = true
+		changesByType[change.Type][change.Subject] = change
 	}
 
 	for _, section := range changelogSections {
-		subjects := changesByType[section.Type]
-		if len(subjects) == 0 {
+		subjectsMap := changesByType[section.Type]
+		if len(subjectsMap) == 0 {
 			continue
 		}
 		fmt.Fprintf(&newEntry, "### %s\n\n", section.Section)
-		for subj := range subjects {
-			fmt.Fprintf(&newEntry, "* %s\n", subj)
+
+		var subjects []string
+		for subj := range subjectsMap {
+			subjects = append(subjects, subj)
+		}
+		sort.Strings(subjects)
+
+		for _, subj := range subjects {
+			change := subjectsMap[subj]
+			var commitLink string
+			if change.SourceCommitHash != "" {
+				shortHash := change.SourceCommitHash
+				if len(shortHash) > 7 {
+					shortHash = shortHash[:7]
+				}
+				commitURL := fmt.Sprintf("https://github.com/googleapis/google-cloud-go/commit/%s", change.SourceCommitHash)
+				commitLink = fmt.Sprintf(" ([%s](%s))", shortHash, commitURL)
+			}
+
+			fmt.Fprintf(&newEntry, "* **%s:** %s%s\n", lib.ID, change.Subject, commitLink)
+
 		}
 		newEntry.WriteString("\n")
 	}

--- a/internal/librariangen/release/release_test.go
+++ b/internal/librariangen/release/release_test.go
@@ -139,7 +139,7 @@ func TestInit(t *testing.T) {
 			},
 			wantChangelogSubstr: "## [1.16.0](https://github.com/googleapis/google-cloud-go/releases/tag/secretmanager%2Fv1.16.0) (2025-09-11)\n\n### Features\n\n* **secretmanager:** add new GetSecret API ([abcdef1](https://github.com/googleapis/google-cloud-go/commit/abcdef123456))\n* **secretmanager:** another feature ([zxcvbn0](https://github.com/googleapis/google-cloud-go/commit/zxcvbn098765))\n\n### Bug Fixes\n\n* **secretmanager:** correct typo in documentation ([123456a](https://github.com/googleapis/google-cloud-go/commit/123456abcdef))\n\n",
 			wantVersion:         "1.16.0",
-			wantSnippetVersion:  "\"version\": \"1.16.0\"",
+			wantSnippetVersion:  `"version": "1.16.0"`,
 		},
 		{
 			name:                "release not triggered",
@@ -151,11 +151,11 @@ func TestInit(t *testing.T) {
 			requestJSON: `{ "libraries": [ { "id": "secretmanager", "version": "1.16.0", "release_triggered": true, "apis": [{"path": "google/cloud/secretmanager/v1"}], "changes": [{"type": "feat", "subject": "add new GetSecret API"}] } ] }`,
 			initialRepoContent: map[string]string{
 				"secretmanager/CHANGES.md": "# Changes\n\n## [1.16.0](https://github.com/googleapis/google-cloud-go/releases/tag/secretmanager%2Fv1.16.0)\n- Already there.",
-				"internal/generated/snippets/secretmanager/apiv1/snippet_metadata.google.cloud.secretmanager.v1.json": `{\"version\": \"1.15.0\"}`,
+				"internal/generated/snippets/secretmanager/apiv1/snippet_metadata.google.cloud.secretmanager.v1.json": `{"version": "1.15.0"}`,
 			},
 			changelogAlreadyUpToDate: true,
 			wantVersion:              "1.16.0",
-			wantSnippetVersion:       `\"version\": \"1.16.0\"`,
+			wantSnippetVersion:       `"version": "1.16.0"`,
 		},
 		{
 			name:        "malformed json",

--- a/internal/librariangen/release/release_test.go
+++ b/internal/librariangen/release/release_test.go
@@ -137,7 +137,7 @@ func TestInit(t *testing.T) {
 				"secretmanager/internal/version.go": `package internal; const Version = "1.15.0"`,
 				"internal/generated/snippets/secretmanager/apiv1/snippet_metadata.google.cloud.secretmanager.v1.json": `{"version": "1.15.0"}`,
 			},
-			wantChangelogSubstr: "## [1.16.0](https://github.com/googleapis/google-cloud-go/releases/tag/secretmanager%2Fv1.16.0) (2025-09-11)\n\n### Features\n\n* **secretmanager:** add new GetSecret API ([abcdef1](https://github.com/googleapis/google-cloud-go/commit/abcdef123456))\n* **secretmanager:** another feature ([zxcvbn0](https://github.com/googleapis/google-cloud-go/commit/zxcvbn098765))\n\n### Bug Fixes\n\n* **secretmanager:** correct typo in documentation ([123456a](https://github.com/googleapis/google-cloud-go/commit/123456abcdef))\n\n",
+			wantChangelogSubstr: "## [1.16.0](https://github.com/googleapis/google-cloud-go/releases/tag/secretmanager%2Fv1.16.0) (2025-09-11)\n\n### Features\n\n* add new GetSecret API ([abcdef1](https://github.com/googleapis/google-cloud-go/commit/abcdef123456))\n* another feature ([zxcvbn0](https://github.com/googleapis/google-cloud-go/commit/zxcvbn098765))\n\n### Bug Fixes\n\n* correct typo in documentation ([123456a](https://github.com/googleapis/google-cloud-go/commit/123456abcdef))\n\n",
 			wantVersion:         "1.16.0",
 			wantSnippetVersion:  `"version": "1.16.0"`,
 		},

--- a/internal/librariangen/release/release_test.go
+++ b/internal/librariangen/release/release_test.go
@@ -126,8 +126,9 @@ func TestInit(t *testing.T) {
 					"id": "secretmanager", "version": "1.16.0", "release_triggered": true,
 					"apis": [{"path": "google/cloud/secretmanager/v1"}],
 					"changes": [
-						{"type": "feat", "subject": "add new GetSecret API"},
-						{"type": "fix", "subject": "correct typo in documentation"}
+						{"type": "feat", "subject": "another feature", "source_commit_hash": "zxcvbn098765"},
+						{"type": "fix", "subject": "correct typo in documentation", "source_commit_hash": "123456abcdef"},
+						{"type": "feat", "subject": "add new GetSecret API", "source_commit_hash": "abcdef123456"}
 					]
 				}]
 			}`,
@@ -136,12 +137,9 @@ func TestInit(t *testing.T) {
 				"secretmanager/internal/version.go": `package internal; const Version = "1.15.0"`,
 				"internal/generated/snippets/secretmanager/apiv1/snippet_metadata.google.cloud.secretmanager.v1.json": `{"version": "1.15.0"}`,
 			},
-			// This wantChangelogSubstr expectation intentionally includes two newline literals.
-			wantChangelogSubstr: `## [1.16.0](https://github.com/googleapis/google-cloud-go/releases/tag/secretmanager%2Fv1.16.0) (2025-09-11)
-
-`,
-			wantVersion:        "1.16.0",
-			wantSnippetVersion: `"version": "1.16.0"`,
+			wantChangelogSubstr: "## [1.16.0](https://github.com/googleapis/google-cloud-go/releases/tag/secretmanager%2Fv1.16.0) (2025-09-11)\n\n### Features\n\n* **secretmanager:** add new GetSecret API ([abcdef1](https://github.com/googleapis/google-cloud-go/commit/abcdef123456))\n* **secretmanager:** another feature ([zxcvbn0](https://github.com/googleapis/google-cloud-go/commit/zxcvbn098765))\n\n### Bug Fixes\n\n* **secretmanager:** correct typo in documentation ([123456a](https://github.com/googleapis/google-cloud-go/commit/123456abcdef))\n\n",
+			wantVersion:         "1.16.0",
+			wantSnippetVersion:  "\"version\": \"1.16.0\"",
 		},
 		{
 			name:                "release not triggered",
@@ -153,11 +151,11 @@ func TestInit(t *testing.T) {
 			requestJSON: `{ "libraries": [ { "id": "secretmanager", "version": "1.16.0", "release_triggered": true, "apis": [{"path": "google/cloud/secretmanager/v1"}], "changes": [{"type": "feat", "subject": "add new GetSecret API"}] } ] }`,
 			initialRepoContent: map[string]string{
 				"secretmanager/CHANGES.md": "# Changes\n\n## [1.16.0](https://github.com/googleapis/google-cloud-go/releases/tag/secretmanager%2Fv1.16.0)\n- Already there.",
-				"internal/generated/snippets/secretmanager/apiv1/snippet_metadata.google.cloud.secretmanager.v1.json": `{"version": "1.15.0"}`,
+				"internal/generated/snippets/secretmanager/apiv1/snippet_metadata.google.cloud.secretmanager.v1.json": `{\"version\": \"1.15.0\"}`,
 			},
 			changelogAlreadyUpToDate: true,
 			wantVersion:              "1.16.0",
-			wantSnippetVersion:       `"version": "1.16.0"`,
+			wantSnippetVersion:       `\"version\": \"1.16.0\"`,
 		},
 		{
 			name:        "malformed json",


### PR DESCRIPTION
fixes: googleapis/librarian#2105

New output:

```
## [1.16.0](https://github.com/googleapis/google-cloud-go/releases/tag/secretmanager%2Fv1.16.0) (2025-09-11)

### Features

* add new GetSecret API ([abcdef1](https://github.com/googleapis/google-cloud-go/commit/abcdef123456))
* another feature ([zxcvbn0](https://github.com/googleapis/google-cloud-go/commit/zxcvbn098765))

### Bug Fixes

* correct typo in documentation ([123456a](https://github.com/googleapis/google-cloud-go/commit/123456abcdef))
```