### PR TITLE
chore: bump changed modules

### DIFF
--- a/clouddms/CHANGES.md
+++ b/clouddms/CHANGES.md
@@ -206,3 +206,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out clouddms as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/commerce/CHANGES.md
+++ b/commerce/CHANGES.md
@@ -168,3 +168,4 @@
 * **commerce:** Start generating apiv1 ([#8322](https://github.com/googleapis/google-cloud-go/issues/8322)) ([db4f48b](https://github.com/googleapis/google-cloud-go/commit/db4f48bc9d5366f524f1fce82f2fea8094ea8c1e))
 
 ## Changes
+

--- a/confidentialcomputing/CHANGES.md
+++ b/confidentialcomputing/CHANGES.md
@@ -240,3 +240,4 @@
 ### Features
 
 * **confidentialcomputing:** Start generating apiv1alpha1 ([#7846](https://github.com/googleapis/google-cloud-go/issues/7846)) ([d0a5d6e](https://github.com/googleapis/google-cloud-go/commit/d0a5d6eda292a7c87ec6d1a4147b037970242641))
+

--- a/config/CHANGES.md
+++ b/config/CHANGES.md
@@ -218,3 +218,4 @@
 * **config:** New clients ([#8493](https://github.com/googleapis/google-cloud-go/issues/8493)) ([9874485](https://github.com/googleapis/google-cloud-go/commit/9874485f0ac1f47139c903bfee4f57c64c3149d4))
 
 ## Changes
+

--- a/configdelivery/CHANGES.md
+++ b/configdelivery/CHANGES.md
@@ -13,3 +13,4 @@
 * **configdelivery:** Mark Variant's resources field as input only ([9d29fa9](https://github.com/googleapis/google-cloud-go/commit/9d29fa96abaac05868fa4ed1bc986244e9f561d8))
 
 ## Changes
+

--- a/contactcenterinsights/CHANGES.md
+++ b/contactcenterinsights/CHANGES.md
@@ -332,3 +332,4 @@
 ## v0.1.0
 
 - feat(contactcenterinsights): start generating clients
+

--- a/datacatalog/CHANGES.md
+++ b/datacatalog/CHANGES.md
@@ -473,3 +473,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out datacatalog as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/dataform/CHANGES.md
+++ b/dataform/CHANGES.md
@@ -239,3 +239,4 @@
 
 * **dataform:** remove unused filter field from alpha2 version of API before release ([8a1ad06](https://github.com/googleapis/google-cloud-go/commit/8a1ad06572a65afa91a0a77a85b849e766876671))
 * **dataform:** start generating apiv1alpha2 ([#6299](https://github.com/googleapis/google-cloud-go/issues/6299)) ([1c434c6](https://github.com/googleapis/google-cloud-go/commit/1c434c6657b9bd8529760681c95aef9373c66120))
+

--- a/datafusion/CHANGES.md
+++ b/datafusion/CHANGES.md
@@ -198,3 +198,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out datafusion as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/datalabeling/CHANGES.md
+++ b/datalabeling/CHANGES.md
@@ -201,3 +201,4 @@
 
 This is the first tag to carve out datalabeling as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/dataplex/CHANGES.md
+++ b/dataplex/CHANGES.md
@@ -620,3 +620,4 @@
 ## v0.1.0
 
 - feat(dataplex): start generating clients
+

--- a/dataproc/CHANGES.md
+++ b/dataproc/CHANGES.md
@@ -346,3 +346,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out dataproc as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/datastream/CHANGES.md
+++ b/datastream/CHANGES.md
@@ -377,3 +377,4 @@
 
 This is the first tag to carve out datastream as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/deploy/CHANGES.md
+++ b/deploy/CHANGES.md
@@ -432,3 +432,4 @@
 ## v0.1.0
 
 - feat(deploy): start generating clients
+

--- a/developerconnect/CHANGES.md
+++ b/developerconnect/CHANGES.md
@@ -124,3 +124,4 @@
 * **developerconnect:** Enable new auth lib ([b95805f](https://github.com/googleapis/google-cloud-go/commit/b95805f4c87d3e8d10ea23bd7a2d68d7a4157568))
 
 ## Changes
+

--- a/devicestreaming/CHANGES.md
+++ b/devicestreaming/CHANGES.md
@@ -8,3 +8,4 @@
 * **devicestreaming:** New clients ([#11994](https://github.com/googleapis/google-cloud-go/issues/11994)) ([7e70f60](https://github.com/googleapis/google-cloud-go/commit/7e70f607b1860f5b13ec5b5a823df3043b4dc014))
 
 ## Changes
+

--- a/dialogflow/CHANGES.md
+++ b/dialogflow/CHANGES.md
@@ -954,3 +954,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out dialogflow as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/discoveryengine/CHANGES.md
+++ b/discoveryengine/CHANGES.md
@@ -538,3 +538,4 @@
 * **discoveryengine:** Start generating apiv1beta ([#7427](https://github.com/googleapis/google-cloud-go/issues/7427)) ([0d289a0](https://github.com/googleapis/google-cloud-go/commit/0d289a07106226b4398935357ab0f30a3a30340d))
 
 ## Changes
+

--- a/documentai/CHANGES.md
+++ b/documentai/CHANGES.md
@@ -624,3 +624,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out documentai as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/domains/CHANGES.md
+++ b/domains/CHANGES.md
@@ -201,3 +201,4 @@
 
 This is the first tag to carve out domains as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/edgecontainer/CHANGES.md
+++ b/edgecontainer/CHANGES.md
@@ -200,3 +200,4 @@
 * **edgecontainer:** Start generating apiv1 ([#6694](https://github.com/googleapis/google-cloud-go/issues/6694)) ([6bc9b69](https://github.com/googleapis/google-cloud-go/commit/6bc9b69ca4dd910a9801f07bbc2b8abfdabe8628))
 
 ## Changes
+

--- a/edgenetwork/CHANGES.md
+++ b/edgenetwork/CHANGES.md
@@ -140,3 +140,4 @@
 * **edgenetwork:** New client(s) ([#8996](https://github.com/googleapis/google-cloud-go/issues/8996)) ([8e63c70](https://github.com/googleapis/google-cloud-go/commit/8e63c70b423e8c10ecd617ccf81fa0662f8f91b5))
 
 ## Changes
+

--- a/essentialcontacts/CHANGES.md
+++ b/essentialcontacts/CHANGES.md
@@ -203,3 +203,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out essentialcontacts as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+


### PR DESCRIPTION
BEGIN_NESTED_COMMIT
fix(clouddms): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(commerce): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(confidentialcomputing): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(config): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(configdelivery): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(contactcenterinsights): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(datacatalog): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(dataform): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(datafusion): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(datalabeling): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(dataplex): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(dataproc): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(datastream): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(deploy): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(developerconnect): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(devicestreaming): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(dialogflow): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(discoveryengine): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(documentai): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(domains): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(edgecontainer): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(edgenetwork): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(essentialcontacts): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT