### PR TITLE
fix(compute/metadata): use separate client for subscribe methods 

### DIFF
--- a/compute/metadata/metadata_test.go
+++ b/compute/metadata/metadata_test.go
@@ -17,9 +17,11 @@ package metadata
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"strings"
 	"sync"
@@ -105,7 +107,7 @@ func TestOnGCE_CancelTryHarder(t *testing.T) {
 	}
 
 	// Should have returned around 500ms, but account for some scheduling budget
-	if time.Now().Sub(start) > 510*time.Millisecond {
+	if time.Since(start) > 510*time.Millisecond {
 		t.Error("OnGCE() did not return within deadline")
 	}
 }
@@ -448,4 +450,63 @@ func TestNewWithOptions(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSubscribeUsesSubscribeClient(t *testing.T) {
+	subscribeClientUsed := make(chan bool, 1)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Test-Header") == "subscribe" {
+			subscribeClientUsed <- true
+		} else {
+			subscribeClientUsed <- false
+		}
+		w.Header().Set("Etag", "etag-1")
+		fmt.Fprint(w, "initial-value")
+	}))
+	defer ts.Close()
+
+	t.Setenv(metadataHostEnv, strings.TrimPrefix(ts.URL, "http://"))
+
+	subTransport := &headerTransport{
+		header: "X-Test-Header",
+		value:  "subscribe",
+		base:   http.DefaultTransport,
+	}
+	subClient := &http.Client{Transport: subTransport}
+	hc := newDefaultHTTPClient(true)
+
+	c := &Client{
+		hc:        hc,
+		subClient: subClient,
+		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	c.SubscribeWithContext(ctx, "some/path", func(ctx context.Context, v string, ok bool) error {
+		cancel()
+		return nil
+	})
+
+	select {
+	case used := <-subscribeClientUsed:
+		if !used {
+			t.Error("Subscribe did not use the subscribe client")
+		}
+	case <-ctx.Done():
+		// This can happen if the request from the client is never sent.
+		t.Fatal("Test timed out")
+	}
+}
+
+type headerTransport struct {
+	header string
+	value  string
+	base   http.RoundTripper
+}
+
+func (t *headerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.Header.Set(t.header, t.value)
+	return t.base.RoundTrip(req)
 }


### PR DESCRIPTION
By default the Client in this package now uses a slightly different client for subscription methods. Subscription clients should not set the idle timeout because they could go long periods of time without the connection being used again. If the users specifies a client it will be used for both types of calls.

Also fixed a bug where Subscribe methods were not honoring context errors.

Internal Bug: 427030684