### PR TITLE
fix(compute/metadata): racy test and uninitialized subClient

### DIFF
--- a/compute/metadata/metadata.go
+++ b/compute/metadata/metadata.go
@@ -392,7 +392,7 @@ func NewClient(c *http.Client) *Client {
 		return defaultClient
 	}
 	// Return a new client with a no-op logger for backward compatibility.
-	return &Client{hc: c, logger: slog.New(noOpHandler{})}
+	return &Client{hc: c, subClient: c, logger: slog.New(noOpHandler{})}
 }
 
 // NewWithOptions returns a Client that is configured with the provided Options.

--- a/compute/metadata/metadata_test.go
+++ b/compute/metadata/metadata_test.go
@@ -354,6 +354,9 @@ func TestNewClient(t *testing.T) {
 				if got.hc != tt.wantHC {
 					t.Errorf("NewClient().hc = %p, want %p", got.hc, tt.wantHC)
 				}
+				if got.subClient != tt.wantHC {
+					t.Errorf("NewClient().hc = %p, want %p", got.hc, tt.wantHC)
+				}
 			}
 		})
 	}
@@ -424,6 +427,9 @@ func TestNewWithOptions(t *testing.T) {
 				if got.hc != tt.wantHC {
 					t.Errorf("NewWithOptions().hc = %p, want %p", got.hc, tt.wantHC)
 				}
+				if got.subClient != tt.wantHC {
+					t.Errorf("NewWithOptions().hc = %p, want %p", got.hc, tt.wantHC)
+				}
 			}
 			if tt.hasCustomLogger {
 				if got.logger != customLogger {
@@ -481,7 +487,7 @@ func TestSubscribeUsesSubscribeClient(t *testing.T) {
 		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	c.SubscribeWithContext(ctx, "some/path", func(ctx context.Context, v string, ok bool) error {
@@ -494,7 +500,7 @@ func TestSubscribeUsesSubscribeClient(t *testing.T) {
 		if !used {
 			t.Error("Subscribe did not use the subscribe client")
 		}
-	case <-ctx.Done():
+	case <-time.After(5 * time.Second):
 		// This can happen if the request from the client is never sent.
 		t.Fatal("Test timed out")
 	}


### PR DESCRIPTION
Fixes: #12888