### PR TITLE
fix(spanner): use fresh context for rollback

### DIFF
--- a/spanner/transaction.go
+++ b/spanner/transaction.go
@@ -2025,7 +2025,9 @@ func (t *ReadWriteTransaction) runInTransaction(ctx context.Context, f func(cont
 		// up here. Context errors (deadline exceeded / canceled) during
 		// commits are also not rolled back.
 		if !errDuringCommit {
-			t.rollback(ctx)
+			// Use a fresh context without a timeout for the rollback to prevent
+			// the rollback from being cancelled / skipped.
+			t.rollback(context.Background())
 		}
 		return resp, err
 	}

--- a/spanner/transaction_test.go
+++ b/spanner/transaction_test.go
@@ -2179,6 +2179,49 @@ func TestLastStatement_StmtBasedTx_BatchUpdate(t *testing.T) {
 	}
 }
 
+func TestReadWriteTransactionUsesNewContextForRollback(t *testing.T) {
+	t.Parallel()
+
+	server, client, teardown := setupMockedTestServerWithConfig(t, ClientConfig{
+		DisableNativeMetrics: true,
+		SessionPoolConfig: SessionPoolConfig{
+			MinOpened: 10,
+			MaxOpened: 10,
+		},
+	})
+	defer teardown()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Millisecond)
+	defer cancel()
+
+	_, err := client.ReadWriteTransaction(ctx, func(ctx context.Context, transaction *ReadWriteTransaction) error {
+		// Execute a statement that actually starts the transaction and returns a transaction ID.
+		if _, err := transaction.Update(ctx, NewStatement(UpdateBarSetFoo)); err != nil {
+			return err
+		}
+		// Make the next statement slow. This should now fail with a DEADLINE_EXCEEDED error.
+		server.TestSpanner.PutExecutionTime(MethodExecuteSql, SimulatedExecutionTime{MinimumExecutionTime: 100 * time.Millisecond})
+		if _, err := transaction.Update(ctx, NewStatement(UpdateBarSetFoo)); err != nil {
+			return err
+		}
+		return nil
+	})
+	if g, w := ErrCode(err), codes.DeadlineExceeded; g != w {
+		t.Fatalf("error code mismatch\n Got: %v\nWant: %v", g, w)
+	}
+
+	requests := drainRequestsFromServer(server.TestSpanner)
+	executeRequests := requestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
+	if g, w := len(executeRequests), 2; g != w {
+		t.Fatalf("execute count mismatch\n Got: %v\nWant: %v", g, w)
+	}
+	// Make sure a Rollback request is actually sent to Spanner to release the locks of the transaction.
+	rollbackRequests := requestsOfType(requests, reflect.TypeOf(&sppb.RollbackRequest{}))
+	if g, w := len(rollbackRequests), 1; g != w {
+		t.Fatalf("rollback count mismatch\n Got: %v\nWant: %v", g, w)
+	}
+}
+
 // shouldHaveReceived asserts that exactly expectedRequests were present in
 // the server's ReceivedRequests channel. It only looks at type, not contents.
 //


### PR DESCRIPTION
Use a fresh context without a timeout for the Rollback call when a transaction has failed. This prevents the Rollback from being skipped or cancelled if the original context's deadline has been exceeded. This again would lead to the locks that had been taken by the transaction to remain in place until Spanner releases these after 10 seconds.