### PR TITLE
fix(firestore): Initialize readSettings in queries to prevent panic

### DIFF
--- a/firestore/collgroupref.go
+++ b/firestore/collgroupref.go
@@ -43,6 +43,7 @@ func newCollectionGroupRef(c *Client, dbPath, collectionID string) *CollectionGr
 			path:           dbPath,
 			parentPath:     dbPath + "/documents",
 			allDescendants: true,
+			readSettings:   &readSettings{},
 		},
 	}
 }

--- a/firestore/collref.go
+++ b/firestore/collref.go
@@ -56,6 +56,7 @@ type CollectionRef struct {
 }
 
 func newTopLevelCollRef(c *Client, dbPath, id string) *CollectionRef {
+	readSettings := &readSettings{}
 	return &CollectionRef{
 		c:          c,
 		ID:         id,
@@ -67,13 +68,15 @@ func newTopLevelCollRef(c *Client, dbPath, id string) *CollectionRef {
 			collectionID: id,
 			path:         dbPath + "/documents/" + id,
 			parentPath:   dbPath + "/documents",
+			readSettings: readSettings,
 		},
-		readSettings: &readSettings{},
+		readSettings: readSettings,
 	}
 }
 
 func newCollRefWithParent(c *Client, parent *DocumentRef, id string) *CollectionRef {
 	selfPath := parent.shortPath + "/" + id
+	readSettings := &readSettings{}
 	return &CollectionRef{
 		c:          c,
 		Parent:     parent,
@@ -86,8 +89,9 @@ func newCollRefWithParent(c *Client, parent *DocumentRef, id string) *Collection
 			collectionID: id,
 			path:         parent.Path + "/" + id,
 			parentPath:   parent.Path,
+			readSettings: readSettings,
 		},
-		readSettings: &readSettings{},
+		readSettings: readSettings,
 	}
 }
 

--- a/firestore/query.go
+++ b/firestore/query.go
@@ -1548,6 +1548,9 @@ func (*btreeDocumentIterator) getExplainMetrics() (*ExplainMetrics, error) {
 // WithReadOptions specifies constraints for accessing documents from the database,
 // e.g. at what time snapshot to read the documents.
 func (q *Query) WithReadOptions(opts ...ReadOption) *Query {
+	if q.readSettings == nil {
+		q.readSettings = &readSettings{}
+	}
 	for _, ro := range opts {
 		ro.apply(q.readSettings)
 	}


### PR DESCRIPTION
This commit fixes a panic and incorrect behavior that occurs when using WithReadOptions in firestore queries.

The readSettings field in the Query struct was not always initialized, leading to a nil pointer dereference when WithReadOptions was called. This affected CollectionGroupRef and CollectionRef in three distinct scenarios as reported in the issue.

This commit addresses the issue by implementing the following changes:

- **Initialized readSettings in CollectionGroupRef**: The newCollectionGroupRef function in collgroupref.go now initializes the readSettings field on the embedded Query object, preventing panics when WithReadOptions is used on a collection group query.
- **Shared readSettings in CollectionRef**: The newTopLevelCollRef and newCollRefWithParent functions in collref.go now create a single readSettings instance that is shared between the CollectionRef and its embedded Query object. This ensures that read options set on a CollectionRef are correctly propagated to its queries.
- **Added nil check for robustness**: A nil check has been added to the WithReadOptions method in query.go. This makes the method more robust by initializing readSettings if it hasn't been already, preventing potential panics from manually constructed Query objects.

These changes ensure that readSettings is always initialized before use, providing consistent and panic-free behavior for WithReadOptions across all query types.

Fixes #12448 