### PR TITLE
test(spanner): increase context timeout to allow one executeSql to be executed

### DIFF
--- a/spanner/transaction_test.go
+++ b/spanner/transaction_test.go
@@ -2191,7 +2191,7 @@ func TestReadWriteTransactionUsesNewContextForRollback(t *testing.T) {
 	})
 	defer teardown()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancel()
 
 	_, err := client.ReadWriteTransaction(ctx, func(ctx context.Context, transaction *ReadWriteTransaction) error {


### PR DESCRIPTION
Fixes: https://github.com/googleapis/google-cloud-go/issues/12904