### PR TITLE
fix(compute/metadata): set subClient for UseDefaultClient case

### DIFF
--- a/compute/metadata/metadata.go
+++ b/compute/metadata/metadata.go
@@ -409,7 +409,7 @@ func NewWithOptions(opts *Options) *Client {
 		if logger == nil {
 			logger = slog.New(noOpHandler{})
 		}
-		return &Client{hc: defaultClient.hc, logger: logger}
+		return &Client{hc: defaultClient.hc, subClient: defaultClient.subClient, logger: logger}
 	}
 
 	// Handle isolated client creation.

--- a/compute/metadata/metadata_test.go
+++ b/compute/metadata/metadata_test.go
@@ -458,6 +458,16 @@ func TestNewWithOptions(t *testing.T) {
 	}
 }
 
+func TestNewWithOptions_UseDefaultClient(t *testing.T) {
+	client := NewWithOptions(&Options{UseDefaultClient: true})
+	if client.hc != defaultClient.hc {
+		t.Errorf("NewWithOptions(UseDefaultClient: true).hc = %p, want %p", client.hc, defaultClient.hc)
+	}
+	if client.subClient != defaultClient.subClient {
+		t.Errorf("NewWithOptions(UseDefaultClient: true).subClient = %p, want %p", client.subClient, defaultClient.subClient)
+	}
+}
+
 func TestSubscribeUsesSubscribeClient(t *testing.T) {
 	subscribeClientUsed := make(chan bool, 1)
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Caught in an internal review. Verified all constructors have been updated now.