### PR TITLE
chore: bump changed modules

### DIFF
--- a/eventarc/CHANGES.md
+++ b/eventarc/CHANGES.md
@@ -273,3 +273,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out eventarc as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/filestore/CHANGES.md
+++ b/filestore/CHANGES.md
@@ -208,3 +208,4 @@
 ## v0.1.0
 
 - feat(filestore): start generating clients
+

--- a/financialservices/CHANGES.md
+++ b/financialservices/CHANGES.md
@@ -30,3 +30,4 @@
 * **financialservices:** New client(s) ([#11781](https://github.com/googleapis/google-cloud-go/issues/11781)) ([674860f](https://github.com/googleapis/google-cloud-go/commit/674860fdbc0322d75ea3d4aff68ac4fc8220cc08))
 
 ## Changes
+

--- a/functions/CHANGES.md
+++ b/functions/CHANGES.md
@@ -323,3 +323,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out functions as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/geminidataanalytics/CHANGES.md
+++ b/geminidataanalytics/CHANGES.md
@@ -36,3 +36,4 @@
 * **geminidataanalytics:** New client ([#12729](https://github.com/googleapis/google-cloud-go/issues/12729)) ([1bc6c98](https://github.com/googleapis/google-cloud-go/commit/1bc6c98c371418b05cbe13a95a601e08d1c97014))
 
 ## Changes
+

--- a/gkebackup/CHANGES.md
+++ b/gkebackup/CHANGES.md
@@ -257,3 +257,4 @@
 ### Features
 
 * **gkebackup:** start generating apiv1 ([#6031](https://github.com/googleapis/google-cloud-go/issues/6031)) ([4816e84](https://github.com/googleapis/google-cloud-go/commit/4816e84076d62c0952eec0a7de80a230dc9074fe))
+

--- a/gkeconnect/CHANGES.md
+++ b/gkeconnect/CHANGES.md
@@ -216,3 +216,4 @@
 
 This is the first tag to carve out gkeconnect as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/gkemulticloud/CHANGES.md
+++ b/gkemulticloud/CHANGES.md
@@ -224,3 +224,4 @@
 ### Features
 
 * **gkemulticloud:** start generating apiv1 ([#6036](https://github.com/googleapis/google-cloud-go/issues/6036)) ([dc2b168](https://github.com/googleapis/google-cloud-go/commit/dc2b168162ba358435c7191f9d02edaea17d19bb))
+

--- a/gsuiteaddons/CHANGES.md
+++ b/gsuiteaddons/CHANGES.md
@@ -198,3 +198,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out gsuiteaddons as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/iap/CHANGES.md
+++ b/iap/CHANGES.md
@@ -282,3 +282,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out iap as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/identitytoolkit/CHANGES.md
+++ b/identitytoolkit/CHANGES.md
@@ -79,3 +79,4 @@
 * **identitytoolkit:** Enable new auth lib ([b95805f](https://github.com/googleapis/google-cloud-go/commit/b95805f4c87d3e8d10ea23bd7a2d68d7a4157568))
 
 ## Changes
+

--- a/ids/CHANGES.md
+++ b/ids/CHANGES.md
@@ -199,3 +199,4 @@
 ## v0.1.0
 
 - feat(ids): start generating clients
+

--- a/iot/CHANGES.md
+++ b/iot/CHANGES.md
@@ -198,3 +198,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out iot as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/licensemanager/CHANGES.md
+++ b/licensemanager/CHANGES.md
@@ -8,3 +8,4 @@
 * **licensemanager:** New clients ([#12624](https://github.com/googleapis/google-cloud-go/issues/12624)) ([11cf83b](https://github.com/googleapis/google-cloud-go/commit/11cf83bce20d9c93a01b978dd30e493aec39269b))
 
 ## Changes
+

--- a/lifesciences/CHANGES.md
+++ b/lifesciences/CHANGES.md
@@ -206,3 +206,4 @@
 
 This is the first tag to carve out lifesciences as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/locationfinder/CHANGES.md
+++ b/locationfinder/CHANGES.md
@@ -8,3 +8,4 @@
 * **locationfinder:** New client(s) ([#12905](https://github.com/googleapis/google-cloud-go/issues/12905)) ([a66428b](https://github.com/googleapis/google-cloud-go/commit/a66428bea9c054f362bb125d4471fc0a04391660))
 
 ## Changes
+

--- a/lustre/CHANGES.md
+++ b/lustre/CHANGES.md
@@ -32,3 +32,4 @@
 * **lustre:** New client(s) ([#12026](https://github.com/googleapis/google-cloud-go/issues/12026)) ([7d2236e](https://github.com/googleapis/google-cloud-go/commit/7d2236e1d93adc644a2c6c2ccbc1530f79b72674))
 
 ## Changes
+

--- a/maintenance/CHANGES.md
+++ b/maintenance/CHANGES.md
@@ -15,3 +15,4 @@
 * **maintenance:** New client(s) ([#12483](https://github.com/googleapis/google-cloud-go/issues/12483)) ([4ca647f](https://github.com/googleapis/google-cloud-go/commit/4ca647fc08fb218a7fd0ea82c5f6f5c17e78510a))
 
 ## Changes
+

--- a/managedidentities/CHANGES.md
+++ b/managedidentities/CHANGES.md
@@ -198,3 +198,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out managedidentities as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/managedkafka/CHANGES.md
+++ b/managedkafka/CHANGES.md
@@ -169,3 +169,4 @@
 * **managedkafka:** New clients ([#10274](https://github.com/googleapis/google-cloud-go/issues/10274)) ([3caccb5](https://github.com/googleapis/google-cloud-go/commit/3caccb556c889104fb77a6353774a8779a9ea24e))
 
 ## Changes
+

--- a/mediatranslation/CHANGES.md
+++ b/mediatranslation/CHANGES.md
@@ -194,3 +194,4 @@
 
 This is the first tag to carve out mediatranslation as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/memcache/CHANGES.md
+++ b/memcache/CHANGES.md
@@ -219,3 +219,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out memcache as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/memorystore/CHANGES.md
+++ b/memorystore/CHANGES.md
@@ -111,3 +111,4 @@
 * **memorystore:** New clients ([#11310](https://github.com/googleapis/google-cloud-go/issues/11310)) ([1946e3d](https://github.com/googleapis/google-cloud-go/commit/1946e3de6c3afb7ed51ac641bddcbe027916df46))
 
 ## Changes
+

--- a/metastore/CHANGES.md
+++ b/metastore/CHANGES.md
@@ -263,3 +263,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out metastore as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/migrationcenter/CHANGES.md
+++ b/migrationcenter/CHANGES.md
@@ -148,3 +148,4 @@
 * **migrationcenter:** Migration Center API ([fa91b47](https://github.com/googleapis/google-cloud-go/commit/fa91b478a55d6347f5c4fd29f2490316b2f31072))
 
 ## Changes
+

--- a/modelarmor/CHANGES.md
+++ b/modelarmor/CHANGES.md
@@ -80,3 +80,4 @@
 * **modelarmor:** New client(s) ([#11868](https://github.com/googleapis/google-cloud-go/issues/11868)) ([4b7209d](https://github.com/googleapis/google-cloud-go/commit/4b7209d54459d10741f4dd57bb9c1ae07450d719))
 
 ## Changes
+

--- a/netapp/CHANGES.md
+++ b/netapp/CHANGES.md
@@ -303,3 +303,4 @@
 * **netapp:** Start generating apiv1 ([#8353](https://github.com/googleapis/google-cloud-go/issues/8353)) ([f609b3c](https://github.com/googleapis/google-cloud-go/commit/f609b3cf831fb89c45386f81d0047560120cb3f4))
 
 ## Changes
+

--- a/networkconnectivity/CHANGES.md
+++ b/networkconnectivity/CHANGES.md
@@ -302,3 +302,4 @@
 
 This is the first tag to carve out networkconnectivity as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/networkmanagement/CHANGES.md
+++ b/networkmanagement/CHANGES.md
@@ -319,3 +319,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out networkmanagement as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/networksecurity/CHANGES.md
+++ b/networksecurity/CHANGES.md
@@ -207,3 +207,4 @@
 ## v0.1.0
 
 - feat(networksecurity): start generating clients
+

--- a/networkservices/CHANGES.md
+++ b/networkservices/CHANGES.md
@@ -171,3 +171,4 @@
 * **networkservices:** New client(s) ([#10314](https://github.com/googleapis/google-cloud-go/issues/10314)) ([ee4df98](https://github.com/googleapis/google-cloud-go/commit/ee4df98e7ff89c005ee345120fb53c85086a2461))
 
 ## Changes
+

--- a/notebooks/CHANGES.md
+++ b/notebooks/CHANGES.md
@@ -266,3 +266,4 @@
 
 This is the first tag to carve out notebooks as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/optimization/CHANGES.md
+++ b/optimization/CHANGES.md
@@ -232,3 +232,4 @@
 ## v0.1.0
 
 - feat(optimization): start generating clients
+

--- a/oracledatabase/CHANGES.md
+++ b/oracledatabase/CHANGES.md
@@ -86,3 +86,4 @@
 * **oracledatabase:** New clients ([#10975](https://github.com/googleapis/google-cloud-go/issues/10975)) ([5d39a54](https://github.com/googleapis/google-cloud-go/commit/5d39a54f645b118f6de80a14f942595e2c4dc6f9))
 
 ## Changes
+

--- a/orchestration/CHANGES.md
+++ b/orchestration/CHANGES.md
@@ -261,3 +261,4 @@
 ## v0.1.0
 
 - feat(orchestration): start generating clients
+

--- a/orgpolicy/CHANGES.md
+++ b/orgpolicy/CHANGES.md
@@ -252,3 +252,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out orgpolicy as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/osconfig/CHANGES.md
+++ b/osconfig/CHANGES.md
@@ -289,3 +289,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out osconfig as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/oslogin/CHANGES.md
+++ b/oslogin/CHANGES.md
@@ -247,3 +247,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out oslogin as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/parallelstore/CHANGES.md
+++ b/parallelstore/CHANGES.md
@@ -255,3 +255,4 @@
 * **parallelstore:** New client(s) ([#9434](https://github.com/googleapis/google-cloud-go/issues/9434)) ([3410b19](https://github.com/googleapis/google-cloud-go/commit/3410b190796edbf73f439494abcbeb204ed5e395))
 
 ## Changes
+

--- a/parametermanager/CHANGES.md
+++ b/parametermanager/CHANGES.md
@@ -37,3 +37,4 @@
 * **parametermanager:** New client(s) ([#11502](https://github.com/googleapis/google-cloud-go/issues/11502)) ([30de20d](https://github.com/googleapis/google-cloud-go/commit/30de20d9e3430acb7b557d77e316f2a87ec8ad0c))
 
 ## Changes
+

--- a/phishingprotection/CHANGES.md
+++ b/phishingprotection/CHANGES.md
@@ -194,3 +194,4 @@
 
 This is the first tag to carve out phishingprotection as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/policysimulator/CHANGES.md
+++ b/policysimulator/CHANGES.md
@@ -149,3 +149,4 @@
 * **policysimulator:** Start generating apiv1 ([#8340](https://github.com/googleapis/google-cloud-go/issues/8340)) ([a41e5ec](https://github.com/googleapis/google-cloud-go/commit/a41e5eca56246e83670d5c0d043d7ab78db47042))
 
 ## Changes
+

--- a/policytroubleshooter/CHANGES.md
+++ b/policytroubleshooter/CHANGES.md
@@ -221,3 +221,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out policytroubleshooter as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/privatecatalog/CHANGES.md
+++ b/privatecatalog/CHANGES.md
@@ -208,3 +208,4 @@
 
 This is the first tag to carve out privatecatalog as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/privilegedaccessmanager/CHANGES.md
+++ b/privilegedaccessmanager/CHANGES.md
@@ -70,3 +70,4 @@
 * **privilegedaccessmanager:** Update dependencies ([257c40b](https://github.com/googleapis/google-cloud-go/commit/257c40bd6d7e59730017cf32bda8823d7a232758))
 
 ## Changes
+


### PR DESCRIPTION
BEGIN_NESTED_COMMIT
fix(eventarc): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(filestore): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(financialservices): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(functions): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(geminidataanalytics): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(gkebackup): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(gkeconnect): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(gkemulticloud): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(gsuiteaddons): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(iap): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(identitytoolkit): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(ids): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(iot): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(licensemanager): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(lifesciences): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(locationfinder): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(lustre): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(maintenance): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(managedidentities): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(managedkafka): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(mediatranslation): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(memcache): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(memorystore): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(metastore): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(migrationcenter): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(modelarmor): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(netapp): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(networkconnectivity): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(networkmanagement): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(networksecurity): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(networkservices): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(notebooks): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(optimization): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(oracledatabase): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(orchestration): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(orgpolicy): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(osconfig): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(oslogin): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(parallelstore): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(parametermanager): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(phishingprotection): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(policysimulator): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(policytroubleshooter): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(privatecatalog): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(privilegedaccessmanager): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT