### PR TITLE
feat(compute/metadata): retry on HTTP 429

### DIFF
--- a/compute/metadata/retry.go
+++ b/compute/metadata/retry.go
@@ -95,6 +95,9 @@ func shouldRetry(status int, err error) bool {
 	if 500 <= status && status <= 599 {
 		return true
 	}
+	if status == http.StatusTooManyRequests {
+		return true
+	}
 	if err == io.ErrUnexpectedEOF {
 		return true
 	}

--- a/compute/metadata/retry_test.go
+++ b/compute/metadata/retry_test.go
@@ -60,6 +60,12 @@ func TestMetadataRetryer(t *testing.T) {
 			wantShouldRetry: false,
 		},
 		{
+			name:            "retry on 429",
+			code:            429,
+			wantDelay:       100,
+			wantShouldRetry: true,
+		},
+		{
 			name:            "retry on io.ErrUnexpectedEOF",
 			code:            400,
 			err:             io.ErrUnexpectedEOF,


### PR DESCRIPTION
Per https://cloud.google.com/compute/docs/troubleshooting/troubleshoot-metadata-server#rate-limited-endpoints the metadata package should allow retry on HTTP 429 to address ratelimit pushback.  This PR augments the retry predicate to include HTTP 429 as retryable status.

internal: b/445054278

fixes: https://github.com/googleapis/google-cloud-go/issues/12929