### PR TITLE
chore: bump changed modules

### DIFF
--- a/cloudtasks/CHANGES.md
+++ b/cloudtasks/CHANGES.md
@@ -247,3 +247,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out cloudtasks as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/rapidmigrationassessment/CHANGES.md
+++ b/rapidmigrationassessment/CHANGES.md
@@ -177,3 +177,4 @@
 * **rapidmigrationassessment:** Add API summary ([ebae64d](https://github.com/googleapis/google-cloud-go/commit/ebae64d53397ec5dfe851f098754eaa1f5df7cb1))
 
 ## Changes
+

--- a/recaptchaenterprise/CHANGES.md
+++ b/recaptchaenterprise/CHANGES.md
@@ -423,3 +423,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out recaptchaenterprise as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/recommendationengine/CHANGES.md
+++ b/recommendationengine/CHANGES.md
@@ -206,3 +206,4 @@
 
 This is the first tag to carve out recommendationengine as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/recommender/CHANGES.md
+++ b/recommender/CHANGES.md
@@ -228,3 +228,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out recommender as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/redis/CHANGES.md
+++ b/redis/CHANGES.md
@@ -307,3 +307,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out redis as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/resourcemanager/CHANGES.md
+++ b/resourcemanager/CHANGES.md
@@ -227,3 +227,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out resourcemanager as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/retail/CHANGES.md
+++ b/retail/CHANGES.md
@@ -371,3 +371,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out retail as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/scheduler/CHANGES.md
+++ b/scheduler/CHANGES.md
@@ -234,3 +234,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out scheduler as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/securesourcemanager/CHANGES.md
+++ b/securesourcemanager/CHANGES.md
@@ -164,3 +164,4 @@
 * **securesourcemanager:** New clients ([#8738](https://github.com/googleapis/google-cloud-go/issues/8738)) ([b02ab73](https://github.com/googleapis/google-cloud-go/commit/b02ab733edd1a74f74b244298524f72d84046c0c))
 
 ## Changes
+

--- a/security/CHANGES.md
+++ b/security/CHANGES.md
@@ -303,3 +303,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out security as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/securitycenter/CHANGES.md
+++ b/securitycenter/CHANGES.md
@@ -450,3 +450,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out securitycenter as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/securitycentermanagement/CHANGES.md
+++ b/securitycentermanagement/CHANGES.md
@@ -177,3 +177,4 @@
 * **securitycentermanagement:** Security Center Management API ([#9068](https://github.com/googleapis/google-cloud-go/issues/9068)) ([5132d0f](https://github.com/googleapis/google-cloud-go/commit/5132d0fea3a5ac902a2c9eee865241ed4509a5f4))
 
 ## Changes
+

--- a/securityposture/CHANGES.md
+++ b/securityposture/CHANGES.md
@@ -107,3 +107,4 @@
 * **securityposture:** New clients ([#9289](https://github.com/googleapis/google-cloud-go/issues/9289)) ([4a756bc](https://github.com/googleapis/google-cloud-go/commit/4a756bca314daa87101bfad16d2b8b2c352f0a4c))
 
 ## Changes
+

--- a/servicedirectory/CHANGES.md
+++ b/servicedirectory/CHANGES.md
@@ -235,3 +235,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out servicedirectory as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/servicehealth/CHANGES.md
+++ b/servicehealth/CHANGES.md
@@ -147,3 +147,4 @@
 * **servicehealth:** New clients ([#9245](https://github.com/googleapis/google-cloud-go/issues/9245)) ([2868a43](https://github.com/googleapis/google-cloud-go/commit/2868a43805e87ec51bfb816ecb3289c4c0e6bc09))
 
 ## Changes
+

--- a/shell/CHANGES.md
+++ b/shell/CHANGES.md
@@ -198,3 +198,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out shell as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/storagebatchoperations/CHANGES.md
+++ b/storagebatchoperations/CHANGES.md
@@ -13,3 +13,4 @@
 * **storagebatchoperations:** Minor fixes to the reference documentation ([f2b31a3](https://github.com/googleapis/google-cloud-go/commit/f2b31a31eb97db32ca7f19d5bb4f4c9cba73a806))
 
 ## Changes
+

--- a/storageinsights/CHANGES.md
+++ b/storageinsights/CHANGES.md
@@ -178,3 +178,4 @@
 * **storageinsights:** Start generating apiv1 ([#7862](https://github.com/googleapis/google-cloud-go/issues/7862)) ([07a5ac1](https://github.com/googleapis/google-cloud-go/commit/07a5ac1965154b471d5a45e0c566803ea9edb15f))
 
 ## Changes
+

--- a/support/CHANGES.md
+++ b/support/CHANGES.md
@@ -195,3 +195,4 @@
 * **support:** Start generating apiv2 ([#7879](https://github.com/googleapis/google-cloud-go/issues/7879)) ([e882c64](https://github.com/googleapis/google-cloud-go/commit/e882c647e58564bc6e4265d1424df22ab0eb0e2b))
 
 ## Changes
+

--- a/talent/CHANGES.md
+++ b/talent/CHANGES.md
@@ -302,3 +302,4 @@
 
 This is the first tag to carve out talent as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/telcoautomation/CHANGES.md
+++ b/telcoautomation/CHANGES.md
@@ -133,3 +133,4 @@
 * **telcoautomation:** Add telcoautomation API description ([#9019](https://github.com/googleapis/google-cloud-go/issues/9019)) ([03f9190](https://github.com/googleapis/google-cloud-go/commit/03f9190c36f69458e332d4f1b2e5edfd095899ad))
 
 ## Changes
+

--- a/tpu/CHANGES.md
+++ b/tpu/CHANGES.md
@@ -205,3 +205,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out tpu as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/video/CHANGES.md
+++ b/video/CHANGES.md
@@ -383,3 +383,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out video as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/videointelligence/CHANGES.md
+++ b/videointelligence/CHANGES.md
@@ -226,3 +226,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out videointelligence as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/visionai/CHANGES.md
+++ b/visionai/CHANGES.md
@@ -138,3 +138,4 @@
 * **visionai:** New clients ([#9333](https://github.com/googleapis/google-cloud-go/issues/9333)) ([4315cdf](https://github.com/googleapis/google-cloud-go/commit/4315cdf6bfdcd9ed6e9137254451eabbc5cb420b))
 
 ## Changes
+

--- a/vmmigration/CHANGES.md
+++ b/vmmigration/CHANGES.md
@@ -249,3 +249,4 @@
 ## v0.1.0
 
 - feat(vmmigration): start generating clients
+

--- a/vmwareengine/CHANGES.md
+++ b/vmwareengine/CHANGES.md
@@ -198,3 +198,4 @@
 * **vmwareengine:** Start generating apiv1 ([#7093](https://github.com/googleapis/google-cloud-go/issues/7093)) ([9cb00af](https://github.com/googleapis/google-cloud-go/commit/9cb00af1ad8ea1dcfd5b4a73cac75218460f9f6d))
 
 ## Changes
+

--- a/vpcaccess/CHANGES.md
+++ b/vpcaccess/CHANGES.md
@@ -198,3 +198,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out vpcaccess as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/webrisk/CHANGES.md
+++ b/webrisk/CHANGES.md
@@ -227,3 +227,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out webrisk as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/websecurityscanner/CHANGES.md
+++ b/websecurityscanner/CHANGES.md
@@ -198,3 +198,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out websecurityscanner as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/workflows/CHANGES.md
+++ b/workflows/CHANGES.md
@@ -269,3 +269,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out workflows as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/workstations/CHANGES.md
+++ b/workstations/CHANGES.md
@@ -186,3 +186,4 @@
 * **workstations:** Start generating apiv1beta ([#7599](https://github.com/googleapis/google-cloud-go/issues/7599)) ([e3d6afe](https://github.com/googleapis/google-cloud-go/commit/e3d6afe79ddc4579b54934b4884891f35cc3d1a3))
 
 ## Changes
+


### PR DESCRIPTION
BEGIN_NESTED_COMMIT
fix(cloudtasks): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(rapidmigrationassessment): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(recaptchaenterprise): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(recommendationengine): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(recommender): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(redis): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(resourcemanager): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(retail): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(scheduler): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(securesourcemanager): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(security): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(securitycenter): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(securitycentermanagement): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(securityposture): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(servicedirectory): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(servicehealth): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(shell): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(storagebatchoperations): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(storageinsights): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(support): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(talent): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(telcoautomation): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(tpu): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(video): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(videointelligence): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(visionai): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(vmmigration): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(vmwareengine): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(vpcaccess): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(webrisk): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(websecurityscanner): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(workflows): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(workstations): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT