### PR TITLE
feat(stategen): populate release_exclude_paths for snippets

### DIFF
--- a/internal/stategen/main.go
+++ b/internal/stategen/main.go
@@ -124,10 +124,6 @@ func addModule(repoRoot string, ppc *postProcessorConfig, state *LibrarianState,
 		LastGeneratedCommit: googleapisCommit,
 		SourceRoots: []string{
 			moduleName,
-			"internal/generated/snippets/" + moduleName,
-		},
-		RemoveRegex: []string{
-			"^internal/generated/snippets/" + moduleName + "/",
 		},
 		TagFormat: "{id}/v{version}",
 	}
@@ -139,6 +135,15 @@ func addModule(repoRoot string, ppc *postProcessorConfig, state *LibrarianState,
 	library.Version = version
 
 	addAPIProtoPaths(ppc, moduleName, library)
+
+	if len(library.APIs) > 0 {
+		library.SourceRoots = append(library.SourceRoots, "internal/generated/snippets/"+moduleName)
+		library.RemoveRegex = append(library.RemoveRegex, "^internal/generated/snippets/"+moduleName+"/")
+		// Probably irrelevant after the first release, but changes within the snippets aren't release-relevant;
+		// for the first release after onboarding, we will see an OwlBot commit updating snippet metadata with the
+		// final release-please-based commit, and we don't want to use that.
+		library.ReleaseExcludePaths = append(library.ReleaseExcludePaths, "internal/generated/snippets/"+moduleName+"/")
+	}
 
 	if err := addGeneratedCodeRemovals(repoRoot, moduleRoot, library); err != nil {
 		return err


### PR DESCRIPTION
This should simplify the first release after migration.

Additionally, we only conditionally mention snippets at all, which simplifies handwritten/core migration.

Fixes https://github.com/googleapis/librarian/issues/2335