### PR TITLE
feat(client): Enable routing cookie and attempt headers for enhanced retries

### DIFF
--- a/bigtable/internal/testproxy/known_failures.txt
+++ b/bigtable/internal/testproxy/known_failures.txt
@@ -1,6 +1,1 @@
-TestMutateRows_Retry_WithRoutingCookie\|
-TestReadRow_Retry_WithRoutingCookie\|
-TestReadRows_Retry_WithRoutingCookie\|
-TestReadRows_Retry_WithRoutingCookie_MultipleErrorResponses\|
-TestReadRows_Retry_WithRetryInfo_MultipleErrorResponse\|
-TestSampleRowKeys_Retry_WithRoutingCookie
+TestReadRows_Retry_WithRetryInfo_MultipleErrorResponse


### PR DESCRIPTION
Implements client-side logic to support the Cloud Bigtable routing cookie protocol (see go/cbt-support-routing-cookie). This feature enhances server-initiated retries and improves resilience.

Specific modifications:

*   **Feature Flag:** The client now signals support for this feature by setting `RoutingCookie: true` in the `bigtable-features` header.
*   **Cookie Propagation:** Any headers prefixed with `x-goog-cbt-cookie-` received in response metadata are collected and sent back on subsequent requests for the same operation.
*   **Attempt Header:**
    *   The `x-goog-cbt-attempt` header is added to each outgoing RPC attempt.
    *   This integer value starts at 0 and is incremented before each call.
    *   Crucially, the counter is reset to 0 if the client receives *any* metadata (headers or trailers) from the server, indicating the request reached the backend. This helps differentiate between network issues and server-side retries.
*   **Internal Tracking:** The `opTracer` in `metrics.go` now stores the current cookies and the `routingAttempt` number.

These changes enable more sophisticated load balancing and retry strategies, by giving the service and routing layers visibility into the client's retry state and a mechanism to influence client behavior.


Fixes: #12658