### PR TITLE
feat(internal/librariangen): support for "whole repo" libraries

### DIFF
--- a/internal/librariangen/release/release.go
+++ b/internal/librariangen/release/release.go
@@ -123,7 +123,8 @@ func updateChangelog(cfg *Config, lib *request.Library, t time.Time) error {
 	var newEntry bytes.Buffer
 
 	var tag string
-	if wholeRepoLibrary(lib) {
+	// This is normally, but not *always*, because it's whole-repo library
+	if lib.TagFormat == "v{version}" {
 		tag = "v" + lib.Version
 	} else {
 		tag = fmt.Sprintf("%s/v%s", lib.ID, lib.Version)

--- a/internal/librariangen/release/release.go
+++ b/internal/librariangen/release/release.go
@@ -237,6 +237,24 @@ func writeErrorResponse(dir string, err error) error {
 	return err
 }
 
+// wholeRepoLibrary returns whether or not the given library is
+// intended to represent the whole repository. This is indicated by
+// a value in Library.SourcePaths of ".". In reality, this will mean
+// it's the only entry in SourcePaths - but that isn't validated.
+//
+// This is expected to be used for repos such as gapic-generator-go,
+// but does *not* apply to gax-go as the "root" for that repo is
+// the v1 code; the v2 code is under a "v2" directory so we just
+// use a library ID of "v2".
+//
+// The vast majority of modules in google-cloud-go have a single
+// source path for the production code, and another for the
+// generated snippets.
+//
+// The "main" module of google-cloud-go might be expected to use "."
+// as a source path, but that would end up getting changes from *all*
+// nested modules (which will expand over time). That module is likely
+// to have a snowflake-like configuration.
 func wholeRepoLibrary(lib *request.Library) bool {
 	return slices.Contains(lib.SourcePaths, ".")
 }

--- a/internal/librariangen/release/release_test.go
+++ b/internal/librariangen/release/release_test.go
@@ -131,7 +131,8 @@ func TestInit(t *testing.T) {
 						{"type": "feat", "subject": "another feature", "source_commit_hash": "zxcvbn098765"},
 						{"type": "fix", "subject": "correct typo in documentation", "source_commit_hash": "123456abcdef"},
 						{"type": "feat", "subject": "add new GetSecret API", "source_commit_hash": "abcdef123456"}
-					]
+					],
+					"tag_format": "{id}/v{version}"
 				}]
 			}`,
 			initialRepoContent: map[string]string{
@@ -151,7 +152,7 @@ func TestInit(t *testing.T) {
 		},
 		{
 			name:        "changelog already up-to-date",
-			requestJSON: `{ "libraries": [ { "id": "secretmanager", "version": "1.16.0", "release_triggered": true, "apis": [{"path": "google/cloud/secretmanager/v1"}], "changes": [{"type": "feat", "subject": "add new GetSecret API"}] } ] }`,
+			requestJSON: `{ "libraries": [ { "id": "secretmanager", "version": "1.16.0", "release_triggered": true, "apis": [{"path": "google/cloud/secretmanager/v1"}], "changes": [{"type": "feat", "subject": "add new GetSecret API"}] } ], "tag_format": "{id}/v{version}" }`,
 			initialRepoContent: map[string]string{
 				"secretmanager/CHANGES.md": "# Changes\n\n## [1.16.0](https://github.com/googleapis/google-cloud-go/releases/tag/secretmanager%2Fv1.16.0)\n- Already there.",
 				"internal/generated/snippets/secretmanager/apiv1/snippet_metadata.google.cloud.secretmanager.v1.json": `{"version": "1.15.0"}`,
@@ -171,7 +172,8 @@ func TestInit(t *testing.T) {
 						{"type": "feat", "subject": "another feature", "source_commit_hash": "zxcvbn098765"},
 						{"type": "fix", "subject": "correct typo in documentation", "source_commit_hash": "123456abcdef"},
 						{"type": "feat", "subject": "add new GetSecret API", "source_commit_hash": "abcdef123456"}
-					]
+					],
+					"tag_format": "v{version}"
 				}]
 			}`,
 			moduleRootPath: ".",

--- a/internal/librariangen/release/release_test.go
+++ b/internal/librariangen/release/release_test.go
@@ -112,6 +112,7 @@ func TestInit(t *testing.T) {
 		name                     string
 		requestJSON              string
 		initialRepoContent       map[string]string
+		moduleRootPath           string
 		wantChangelogSubstr      string
 		wantVersion              string
 		wantSnippetVersion       string
@@ -124,6 +125,7 @@ func TestInit(t *testing.T) {
 			requestJSON: `{ 
 				"libraries": [{ 
 					"id": "secretmanager", "version": "1.16.0", "release_triggered": true,
+					"source_roots": ["secretmanager"],
 					"apis": [{"path": "google/cloud/secretmanager/v1"}],
 					"changes": [
 						{"type": "feat", "subject": "another feature", "source_commit_hash": "zxcvbn098765"},
@@ -137,6 +139,7 @@ func TestInit(t *testing.T) {
 				"secretmanager/internal/version.go": `package internal; const Version = "1.15.0"`,
 				"internal/generated/snippets/secretmanager/apiv1/snippet_metadata.google.cloud.secretmanager.v1.json": `{"version": "1.15.0"}`,
 			},
+			moduleRootPath:      "secretmanager",
 			wantChangelogSubstr: "## [1.16.0](https://github.com/googleapis/google-cloud-go/releases/tag/secretmanager%2Fv1.16.0) (2025-09-11)\n\n### Features\n\n* add new GetSecret API ([abcdef1](https://github.com/googleapis/google-cloud-go/commit/abcdef123456))\n* another feature ([zxcvbn0](https://github.com/googleapis/google-cloud-go/commit/zxcvbn098765))\n\n### Bug Fixes\n\n* correct typo in documentation ([123456a](https://github.com/googleapis/google-cloud-go/commit/123456abcdef))\n\n",
 			wantVersion:         "1.16.0",
 			wantSnippetVersion:  `"version": "1.16.0"`,
@@ -153,9 +156,31 @@ func TestInit(t *testing.T) {
 				"secretmanager/CHANGES.md": "# Changes\n\n## [1.16.0](https://github.com/googleapis/google-cloud-go/releases/tag/secretmanager%2Fv1.16.0)\n- Already there.",
 				"internal/generated/snippets/secretmanager/apiv1/snippet_metadata.google.cloud.secretmanager.v1.json": `{"version": "1.15.0"}`,
 			},
+			moduleRootPath:           "secretmanager",
 			changelogAlreadyUpToDate: true,
 			wantVersion:              "1.16.0",
 			wantSnippetVersion:       `"version": "1.16.0"`,
+		},
+		{
+			name: "whole repo library",
+			requestJSON: `{
+				"libraries": [{
+					"id": "wholerepo", "version": "1.16.0", "release_triggered": true,
+					"source_roots": ["."],
+					"changes": [
+						{"type": "feat", "subject": "another feature", "source_commit_hash": "zxcvbn098765"},
+						{"type": "fix", "subject": "correct typo in documentation", "source_commit_hash": "123456abcdef"},
+						{"type": "feat", "subject": "add new GetSecret API", "source_commit_hash": "abcdef123456"}
+					]
+				}]
+			}`,
+			moduleRootPath: ".",
+			initialRepoContent: map[string]string{
+				"CHANGES.md":          "# Changes\n\n## [1.15.0]\n- Old stuff.",
+				"internal/version.go": `package internal; const Version = "1.15.0"`,
+			},
+			wantChangelogSubstr: "## [1.16.0](https://github.com/googleapis/google-cloud-go/releases/tag/v1.16.0) (2025-09-11)\n\n### Features\n\n* add new GetSecret API ([abcdef1](https://github.com/googleapis/google-cloud-go/commit/abcdef123456))\n* another feature ([zxcvbn0](https://github.com/googleapis/google-cloud-go/commit/zxcvbn098765))\n\n### Bug Fixes\n\n* correct typo in documentation ([123456a](https://github.com/googleapis/google-cloud-go/commit/123456abcdef))\n\n",
+			wantVersion:         "1.16.0",
 		},
 		{
 			name:        "malformed json",
@@ -191,12 +216,12 @@ func TestInit(t *testing.T) {
 			}
 
 			if tt.changelogAlreadyUpToDate {
-				_, err := os.Stat(filepath.Join(outputDir, "secretmanager/CHANGES.md"))
+				_, err := os.Stat(filepath.Join(outputDir, tt.moduleRootPath, "CHANGES.md"))
 				if !os.IsNotExist(err) {
 					t.Errorf("new changelog should not be created when already up-to-date")
 				}
 			} else {
-				changelog, err := os.ReadFile(filepath.Join(outputDir, "secretmanager/CHANGES.md"))
+				changelog, err := os.ReadFile(filepath.Join(outputDir, tt.moduleRootPath, "CHANGES.md"))
 				if err != nil {
 					t.Fatalf("failed to read changelog: %v", err)
 				}
@@ -205,14 +230,16 @@ func TestInit(t *testing.T) {
 				}
 			}
 
-			assertVersion(t, filepath.Join(outputDir, "secretmanager/internal/version.go"), tt.wantVersion)
+			assertVersion(t, filepath.Join(outputDir, tt.moduleRootPath, "internal/version.go"), tt.wantVersion)
 
-			snippet, err := os.ReadFile(filepath.Join(outputDir, "internal/generated/snippets/secretmanager/apiv1/snippet_metadata.google.cloud.secretmanager.v1.json"))
-			if err != nil {
-				t.Fatalf("failed to read snippet: %v", err)
-			}
-			if !strings.Contains(string(snippet), tt.wantSnippetVersion) {
-				t.Errorf("snippet content = %q, want contains %q", string(snippet), tt.wantSnippetVersion)
+			if tt.wantSnippetVersion != "" {
+				snippet, err := os.ReadFile(filepath.Join(outputDir, "internal/generated/snippets/secretmanager/apiv1/snippet_metadata.google.cloud.secretmanager.v1.json"))
+				if err != nil {
+					t.Fatalf("failed to read snippet: %v", err)
+				}
+				if !strings.Contains(string(snippet), tt.wantSnippetVersion) {
+					t.Errorf("snippet content = %q, want contains %q", string(snippet), tt.wantSnippetVersion)
+				}
 			}
 		})
 	}

--- a/internal/librariangen/request/request.go
+++ b/internal/librariangen/request/request.go
@@ -36,6 +36,11 @@ type Library struct {
 	RemoveRegex []string `json:"remove_regex,omitempty"`
 	// Changes are the changes being released (in a release request)
 	Changes []*Change `json:"changes,omitempty"`
+	// Specifying a tag format allows librarian to honor this format when creating
+	// a tag for the release of the library. The replacement values of {id} and {version}
+	// permitted to reference the values configured in the library. If not specified
+	// the assumed format is {id}-{version}. e.g., {id}/v{version}.
+	TagFormat string `yaml:"tag_format,omitempty" json:"tag_format,omitempty"`
 	// ReleaseTriggered indicates whether this library is being released (in a release request)
 	ReleaseTriggered bool `json:"release_triggered,omitempty"`
 }


### PR DESCRIPTION
If a library has "." configured as a source path, expect to find CHANGES.md in the root directory, and version.go under the root internal directory. (In every other case, we use the library ID as a "relative root directory" for the module.)