### PR TITLE
feat(bigquery/v2): query request builder function

### DIFF
--- a/bigquery/v2/query/builder.go
+++ b/bigquery/v2/query/builder.go
@@ -1,0 +1,42 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package query
+
+import (
+	"cloud.google.com/go/bigquery/v2/apiv2/bigquerypb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+)
+
+// FromSQL creates a query configuration from a SQL string.
+func (h *Helper) FromSQL(sql string) *bigquerypb.PostQueryRequest {
+	req := fromSQL(h.projectID, sql)
+	return req
+}
+
+// fromSQL creates a query configuration from a SQL string.
+// Internal now to see if we are gonna allow more optiosn to customize
+// base request template.
+func fromSQL(projectID, sql string) *bigquerypb.PostQueryRequest {
+	return &bigquerypb.PostQueryRequest{
+		QueryRequest: &bigquerypb.QueryRequest{
+			Query:        sql,
+			UseLegacySql: wrapperspb.Bool(false),
+			FormatOptions: &bigquerypb.DataFormatOptions{
+				UseInt64Timestamp: true,
+			},
+		},
+		ProjectId: projectID,
+	}
+}

--- a/bigquery/v2/query/doc.go
+++ b/bigquery/v2/query/doc.go
@@ -34,11 +34,8 @@
 //		// TODO: Handle error.
 //	}
 //
-//	q, err := helper.StartQuery(ctx, &bigquerypb.PostQueryRequest{
-//		QueryRequest: &bigquerypb.QueryRequest{
-//			Query: "SELECT 123 as foo",
-//		},
-//	})
+//	req := helper.FromSQL("SELECT 1 as foo")
+//	q, err := helper.StartQuery(ctx, req)
 //	if err != nil {
 //		// TODO: Handle error.
 //	}


### PR DESCRIPTION
Add helper function to build `PostQueryRequest` object to be used with `StartQuery`.

Towards #12877 