### PR TITLE
chore: Update Dataproc's readme to get v2

### DIFF
--- a/dataproc/README.md
+++ b/dataproc/README.md
@@ -7,7 +7,7 @@ Go Client Library for Cloud Dataproc API.
 ## Install
 
 ```bash
-go get cloud.google.com/go/dataproc
+go get cloud.google.com/go/dataproc/v2
 ```
 
 ## Stability


### PR DESCRIPTION
chore: Update Dataproc's readme to `go get` the current, non-deprecated, version of the library, `cloud.google.com/go/dataproc/v2`.

Fixes #12981