### PR TITLE
refactor(bigquery/v2): job polling logic

### DIFF
--- a/bigquery/v2/internal/job/handler.go
+++ b/bigquery/v2/internal/job/handler.go
@@ -1,0 +1,254 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package job
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"cloud.google.com/go/bigquery/v2/apiv2/bigquerypb"
+	"github.com/googleapis/gax-go/v2"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+)
+
+// Handler is responsible for managing the lifecycle of a BigQuery job.
+// It provides mechanisms for starting, waiting for, and checking the status of a job.
+type Handler struct {
+	create CreateFunc
+	wait   WaitFunc
+
+	jobRef *bigquerypb.JobReference
+
+	// context for background pooling
+	ctx      context.Context
+	mu       sync.RWMutex
+	complete bool
+	ready    chan struct{}
+	err      error
+}
+
+// CreateFunc is a function that start/insert a new job in BigQuery. Usually jobs.insert or jobs.query.
+type CreateFunc = func(ctx context.Context, opts []gax.CallOption) (protoreflect.Message, error)
+
+// WaitFunc is a function that check if a job is complete. Usually jobs.getQueryResults or jobs.get.
+type WaitFunc = func(ctx context.Context, opts []gax.CallOption) (protoreflect.Message, error)
+
+// NewHandler creates a new job handler.
+func NewHandler(ctx context.Context, create CreateFunc, wait WaitFunc, jobRef *bigquerypb.JobReference) *Handler {
+	jh := &Handler{
+		ctx:    ctx,
+		ready:  make(chan struct{}),
+		create: create,
+		wait:   wait,
+		jobRef: jobRef,
+	}
+
+	return jh
+}
+
+// Start begins the job creation and background polling process.
+func (jh *Handler) Start(opts []gax.CallOption) {
+	go jh.start(opts)
+}
+
+// start initiates the job creation and polling process.
+func (jh *Handler) start(opts []gax.CallOption) {
+	if jh.create != nil {
+		res, err := jh.create(jh.ctx, opts)
+		if err != nil {
+			jh.markDone(err)
+			return
+		}
+		jh.consumeResponse(res)
+	}
+	jh.waitInBackground(opts)
+}
+
+// Wait blocks until the query has completed. The provided context can be used to
+// cancel the wait. If the query completes successfully, Wait returns nil.
+// Otherwise, it returns the error that caused the query to fail.
+//
+// Wait is a convenience wrapper around Done and Err.
+func (jh *Handler) Wait(ctx context.Context) error {
+	select {
+	case <-jh.Done():
+		return jh.Err()
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// Done returns a channel that is closed when the job has completed.
+// It can be used in a select statement to perform non-blocking waits.
+//
+// Example:
+//
+//	select {
+//	case <-jh.Done():
+//		if err := jh.Err(); err != nil {
+//			// Handle error.
+//		}
+//		// Job is complete.
+//	 case <-time.After(30*time.Second):
+//		    // Timeout logic
+//	default:
+//		// Job is still running.
+//	}
+func (jh *Handler) Done(opts ...gax.CallOption) <-chan struct{} {
+	return jh.ready
+}
+
+// Err returns the final error state of the job. It is only valid to call Err
+// after the channel returned by Done has been closed. If the job completed
+// successfully, Err returns nil.
+func (jh *Handler) Err() error {
+	jh.mu.RLock()
+	defer jh.mu.RUnlock()
+	if jh.ctx.Err() != nil {
+		return jh.ctx.Err()
+	}
+	return jh.err
+}
+
+// waitInBackground polls the job status with exponential backoff until the job is complete.
+func (jh *Handler) waitInBackground(opts []gax.CallOption) {
+	backoff := gax.Backoff{
+		Initial:    50 * time.Millisecond,
+		Multiplier: 1.3,
+		Max:        60 * time.Second,
+	}
+	for !jh.complete {
+		m, err := jh.wait(jh.ctx, opts)
+		if err != nil {
+			jh.markDone(err)
+			return
+		}
+		jh.consumeResponse(m)
+		select {
+		case <-time.After(backoff.Pause()):
+		case <-jh.ctx.Done():
+			jh.markDone(jh.ctx.Err())
+			return
+		}
+	}
+	jh.markDone(nil)
+}
+
+// markDone marks the job as complete and records the final error state.
+func (jh *Handler) markDone(err error) {
+	jh.mu.Lock()
+	defer jh.mu.Unlock()
+
+	// Check if already done to prevent panic on closing closed channel.
+	select {
+	case <-jh.ready:
+		// Already closed
+		return
+	default:
+		// Not closed yet
+		jh.err = err
+		close(jh.ready)
+	}
+}
+
+// consumeResponse processes a response from the API, updating the job's state.
+func (jh *Handler) consumeResponse(m protoreflect.Message) {
+	jh.mu.Lock()
+	defer jh.mu.Unlock()
+
+	status := getJobStatus(m)
+	if status != nil {
+		jh.complete = status.GetState() == "DONE"
+	}
+
+	jobComplete := getJobComplete(m)
+	if jobComplete != nil {
+		jh.complete = jobComplete.GetValue()
+	}
+
+	jobRef := getJobReference(m)
+	if jobRef != nil {
+		jh.jobRef = jobRef
+	}
+}
+
+// getJobStatus extracts the job status from a protobuf message.
+func getJobStatus(m protoreflect.Message) *bigquerypb.JobStatus {
+	statusField := m.Descriptor().Fields().ByName("status")
+	if statusField == nil {
+		return nil
+	}
+	statusSrc := m.Get(statusField)
+
+	if statusSrc.IsValid() {
+		status := &bigquerypb.JobStatus{}
+		proto.Merge(status, statusSrc.Message().Interface())
+		return status
+	}
+
+	return nil
+}
+
+// getJobComplete extracts the job completion status from a protobuf message.
+func getJobComplete(m protoreflect.Message) *wrapperspb.BoolValue {
+	jobCompleteField := m.Descriptor().Fields().ByName("job_complete")
+	if jobCompleteField == nil {
+		return nil
+	}
+	jobCompleteSrc := m.Get(jobCompleteField)
+
+	if jobCompleteSrc.IsValid() {
+		jobComplete := &wrapperspb.BoolValue{}
+		proto.Merge(jobComplete, jobCompleteSrc.Message().Interface())
+		return jobComplete
+	}
+
+	return nil
+}
+
+// getJobReference extracts the job reference from a protobuf message.
+func getJobReference(m protoreflect.Message) *bigquerypb.JobReference {
+	jobRefField := m.Descriptor().Fields().ByName("job_reference")
+	if jobRefField == nil {
+		return nil
+	}
+	jobRefSrc := m.Get(jobRefField)
+
+	if jobRefSrc.IsValid() {
+		jobRef := &bigquerypb.JobReference{}
+		proto.Merge(jobRef, jobRefSrc.Message().Interface())
+		return jobRef
+	}
+
+	return nil
+}
+
+// JobReference returns a reference to the job.
+// This will be nil until the job has been successfully submitted.
+func (jh *Handler) JobReference() *bigquerypb.JobReference {
+	jh.mu.RLock()
+	defer jh.mu.RUnlock()
+	return jh.jobRef
+}
+
+// Complete returns true if the job has finished execution.
+func (jh *Handler) Complete() bool {
+	jh.mu.RLock()
+	defer jh.mu.RUnlock()
+	return jh.complete
+}

--- a/bigquery/v2/query/query.go
+++ b/bigquery/v2/query/query.go
@@ -16,30 +16,27 @@ package query
 
 import (
 	"context"
+	"fmt"
 	"sync"
-	"time"
 
 	"cloud.google.com/go/bigquery/v2/apiv2/bigquerypb"
+	internaljob "cloud.google.com/go/bigquery/v2/internal/job"
 	"github.com/googleapis/gax-go/v2"
+	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 // Query represents a handle to a query job. Its methods can be used to wait for
 // the job to complete and to iterate over the results.
 type Query struct {
-	h *Helper
+	h     *Helper
+	inner *internaljob.Handler
 
-	projectID string
-	jobID     string
-	location  string
-	queryID   string
+	queryID string
 
 	// context for background pooling
-	ctx      context.Context
-	mu       sync.RWMutex
-	complete bool
-	ready    chan struct{}
-	err      error
+	ctx context.Context
+	mu  sync.RWMutex
 
 	cachedTotalRows uint64
 }
@@ -47,24 +44,23 @@ type Query struct {
 // Create Query handler using jobs.query request and start background pooling job
 func newQueryJobFromQueryRequest(ctx context.Context, h *Helper, req *bigquerypb.PostQueryRequest, opts ...gax.CallOption) *Query {
 	q := &Query{
-		h:     h,
-		ctx:   ctx,
-		ready: make(chan struct{}),
+		h:   h,
+		ctx: ctx,
 	}
-	go q.runQuery(req, opts)
+	q.inner = internaljob.NewHandler(ctx, q.runQueryFunc(req), q.waitFunc, nil)
+	q.inner.Start(opts)
 
 	return q
 }
 
 // Create Query handler using jobs.insert request and start background pooling job
-func newQueryJobFromJob(ctx context.Context, h *Helper, projectID string, job *bigquerypb.Job, opts ...gax.CallOption) *Query {
+func newQueryJobFromJob(ctx context.Context, h *Helper, projectID string, j *bigquerypb.Job, opts ...gax.CallOption) *Query {
 	q := &Query{
-		h:         h,
-		ctx:       ctx,
-		ready:     make(chan struct{}),
-		projectID: projectID,
+		h:   h,
+		ctx: ctx,
 	}
-	go q.insertQuery(job, opts)
+	q.inner = internaljob.NewHandler(ctx, q.insertQueryFunc(j, projectID, opts), q.waitFunc, nil)
+	q.inner.Start(opts)
 
 	return q
 }
@@ -72,15 +68,11 @@ func newQueryJobFromJob(ctx context.Context, h *Helper, projectID string, job *b
 // Create Query handler from JobReference response and start background pooling job
 func newQueryJobFromJobReference(ctx context.Context, h *Helper, jobRef *bigquerypb.JobReference, opts ...gax.CallOption) *Query {
 	q := &Query{
-		h:     h,
-		ctx:   ctx,
-		ready: make(chan struct{}),
+		h:   h,
+		ctx: ctx,
 	}
-	q.consumeQueryResponse(&bigquerypb.GetQueryResultsResponse{
-		JobReference: jobRef,
-	})
-
-	go q.waitForQueryBackground(opts)
+	q.inner = internaljob.NewHandler(ctx, nil, q.waitFunc, jobRef)
+	q.inner.Start(opts)
 
 	return q
 }
@@ -97,12 +89,7 @@ func (q *Query) Read(ctx context.Context, opts ...ReadOption) (*RowIterator, err
 //
 // Wait is a convenience wrapper around Done and Err.
 func (q *Query) Wait(ctx context.Context) error {
-	select {
-	case <-q.Done():
-		return q.Err()
-	case <-ctx.Done():
-		return ctx.Err()
-	}
+	return q.inner.Wait(ctx)
 }
 
 // Done returns a channel that is closed when the query has completed.
@@ -122,133 +109,80 @@ func (q *Query) Wait(ctx context.Context) error {
 //			// Query is still running.
 //		}
 func (q *Query) Done(opts ...gax.CallOption) <-chan struct{} {
-	return q.ready
+	return q.inner.Done()
 }
 
 // Err returns the final error state of the query. It is only valid to call Err
 // after the channel returned by Done has been closed. If the query completed
 // successfully, Err returns nil.
 func (q *Query) Err() error {
-	q.mu.RLock()
-	defer q.mu.RUnlock()
-	err := q.ctx.Err()
-	if err != nil {
-		return err
-	}
-	return q.err
+	return q.inner.Err()
 }
 
-func (q *Query) insertQuery(job *bigquerypb.Job, opts []gax.CallOption) {
-	res, err := q.h.c.InsertJob(q.ctx, &bigquerypb.InsertJobRequest{
-		ProjectId: q.projectID,
-		Job:       job,
-	}, opts...)
+func (q *Query) insertQueryFunc(job *bigquerypb.Job, projectID string, opts []gax.CallOption) internaljob.CreateFunc {
+	return func(ctx context.Context, opts []gax.CallOption) (protoreflect.Message, error) {
+		res, err := q.h.c.InsertJob(q.ctx, &bigquerypb.InsertJobRequest{
+			ProjectId: projectID,
+			Job:       job,
+		}, opts...)
 
-	if err != nil {
-		q.markDone(err)
-		return
-	}
-
-	q.consumeQueryResponse(&bigquerypb.GetQueryResultsResponse{
-		JobReference: res.GetJobReference(),
-	})
-
-	go q.waitForQueryBackground(opts)
-}
-
-func (q *Query) runQuery(req *bigquerypb.PostQueryRequest, opts []gax.CallOption) {
-	res, err := q.h.c.Query(q.ctx, req, opts...)
-	if err != nil {
-		q.markDone(err)
-		return
-	}
-	q.queryID = res.GetQueryId()
-
-	q.consumeQueryResponse(res)
-
-	go q.waitForQueryBackground(opts)
-}
-
-func (q *Query) waitForQueryBackground(opts []gax.CallOption) {
-	backoff := gax.Backoff{
-		Initial:    50 * time.Millisecond,
-		Multiplier: 1.3,
-		Max:        60 * time.Second,
-	}
-	for !q.complete {
-		err := q.waitForQuery(q.ctx, opts)
 		if err != nil {
-			q.markDone(err)
-			return
+			return nil, err
 		}
-		select {
-		case <-time.After(backoff.Pause()):
-		case <-q.ctx.Done():
-			q.markDone(q.ctx.Err())
-			return
-		}
-	}
-	q.markDone(nil)
-}
 
-func (q *Query) markDone(err error) {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-
-	// Check if already done to prevent panic on closing closed channel.
-	select {
-	case <-q.ready:
-		// Already closed
-		return
-	default:
-		// Not closed yet
-		q.err = err
-		close(q.ready)
+		return res.ProtoReflect(), nil
 	}
 }
 
-func (q *Query) waitForQuery(ctx context.Context, opts []gax.CallOption) error {
+func (q *Query) runQueryFunc(req *bigquerypb.PostQueryRequest) internaljob.CreateFunc {
+	return func(ctx context.Context, opts []gax.CallOption) (protoreflect.Message, error) {
+		res, err := q.h.c.Query(q.ctx, req, opts...)
+		if err != nil {
+			return nil, err
+		}
+		q.queryID = res.GetQueryId()
+
+		q.consumeQueryResponse(res)
+		return res.ProtoReflect(), nil
+	}
+}
+
+func (q *Query) waitFunc(ctx context.Context, opts []gax.CallOption) (protoreflect.Message, error) {
+	jobRef := q.inner.JobReference()
+	if jobRef == nil {
+		return nil, fmt.Errorf("bigquery: job reference is missing, can't wait for query to complete")
+	}
+	location := ""
+	if jobRef.GetLocation() != nil {
+		location = jobRef.GetLocation().GetValue()
+	}
 	res, err := q.h.c.GetQueryResults(ctx, &bigquerypb.GetQueryResultsRequest{
-		ProjectId:  q.projectID,
-		JobId:      q.jobID,
-		Location:   q.location,
+		ProjectId:  jobRef.GetProjectId(),
+		JobId:      jobRef.GetJobId(),
+		Location:   location,
 		MaxResults: wrapperspb.UInt32(0),
 		FormatOptions: &bigquerypb.DataFormatOptions{
 			UseInt64Timestamp: true,
 		},
 	}, opts...)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	q.consumeQueryResponse(res)
-	return nil
+
+	return res.ProtoReflect(), nil
 }
 
 // Common fields from jobs.query and jobs.getQueryResults
 // Needs to be updated as new fields are consumed
 type queryResponse interface {
-	GetJobComplete() *wrapperspb.BoolValue
-	GetJobReference() *bigquerypb.JobReference
 	GetTotalRows() *wrapperspb.UInt64Value
 }
 
 func (q *Query) consumeQueryResponse(res queryResponse) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
-
-	if res.GetJobComplete() != nil {
-		q.complete = res.GetJobComplete().GetValue()
-	}
-
-	jobRef := res.GetJobReference()
-	if jobRef != nil {
-		q.projectID = jobRef.GetProjectId()
-		q.jobID = jobRef.GetJobId()
-		if jobRef.GetLocation() != nil {
-			q.location = jobRef.GetLocation().GetValue()
-		}
-	}
 
 	if res.GetTotalRows() != nil {
 		q.cachedTotalRows = res.GetTotalRows().GetValue()
@@ -269,16 +203,7 @@ func (q *Query) QueryID() string {
 // JobReference returns a reference to the query job.
 // This will be nil until the query job has been successfully submitted.
 func (q *Query) JobReference() *bigquerypb.JobReference {
-	q.mu.RLock()
-	defer q.mu.RUnlock()
-	if q.jobID == "" {
-		return nil
-	}
-	return &bigquerypb.JobReference{
-		ProjectId: q.projectID,
-		JobId:     q.jobID,
-		Location:  wrapperspb.String(q.location),
-	}
+	return q.inner.JobReference()
 }
 
 // Schema returns the schema of the query results.
@@ -289,7 +214,5 @@ func (q *Query) Schema() *bigquerypb.TableSchema {
 
 // Complete returns true if the query job has finished execution.
 func (q *Query) Complete() bool {
-	q.mu.RLock()
-	defer q.mu.RUnlock()
-	return q.complete
+	return q.inner.Complete()
 }


### PR DESCRIPTION
Split job polling logic, so later we can have a generic job vs query package to help execute and wait for jobs.

Towards https://github.com/googleapis/google-cloud-go/issues/12877