### PR TITLE
fix(internal/librariangen): use TagFormat as the CLI does

### DIFF
--- a/internal/librariangen/release/release.go
+++ b/internal/librariangen/release/release.go
@@ -122,14 +122,7 @@ func updateChangelog(cfg *Config, lib *request.Library, t time.Time) error {
 
 	var newEntry bytes.Buffer
 
-	var tag string
-	// This is normally, but not *always*, because it's whole-repo library
-	if lib.TagFormat == "v{version}" {
-		tag = "v" + lib.Version
-	} else {
-		tag = fmt.Sprintf("%s/v%s", lib.ID, lib.Version)
-	}
-
+	tag := strings.NewReplacer("{id}", lib.ID, "{version}", lib.Version).Replace(lib.TagFormat)
 	encodedTag := strings.ReplaceAll(tag, "/", "%2F")
 	releaseURL := "https://github.com/googleapis/google-cloud-go/releases/tag/" + encodedTag
 	date := t.Format("2006-01-02")

--- a/internal/librariangen/release/release_test.go
+++ b/internal/librariangen/release/release_test.go
@@ -185,6 +185,26 @@ func TestInit(t *testing.T) {
 			wantVersion:         "1.16.0",
 		},
 		{
+			name: "custom tag format",
+			requestJSON: `{
+				"libraries": [{
+					"id": "xyz", "version": "1.16.0", "release_triggered": true,
+					"source_roots": ["xyz"],
+					"changes": [
+						{"type": "feat", "subject": "another feature", "source_commit_hash": "zxcvbn098765"}
+					],
+					"tag_format": "custom-{id}-v{version}"
+				}]
+			}`,
+			moduleRootPath: "xyz",
+			initialRepoContent: map[string]string{
+				"xyz/CHANGES.md":          "# Changes\n\n## [1.15.0]\n- Old stuff.",
+				"xyz/internal/version.go": `package internal; const Version = "1.15.0"`,
+			},
+			wantChangelogSubstr: "## [1.16.0](https://github.com/googleapis/google-cloud-go/releases/tag/custom-xyz-v1.16.0) (2025-09-11)\n\n### Features\n\n* another feature ([zxcvbn0](https://github.com/googleapis/google-cloud-go/commit/zxcvbn098765))\n\n",
+			wantVersion:         "1.16.0",
+		},
+		{
 			name:        "malformed json",
 			requestJSON: `{"libraries": [}`,
 			wantErr:     true,


### PR DESCRIPTION
(This will be needed for a library with an ID of "pubsub/v2", so that we don't mangle the release notes.)

Fixes https://github.com/googleapis/librarian/issues/2466