### PR TITLE
fix(internal/librariangen): handle multi-versioned modules

### DIFF
--- a/internal/librariangen/generate/generator_test.go
+++ b/internal/librariangen/generate/generator_test.go
@@ -399,6 +399,7 @@ func TestConfig_Validate(t *testing.T) {
 func TestApplyModuleVersion(t *testing.T) {
 	tests := []struct {
 		name        string
+		libraryID   string
 		moduleName  string
 		modulePath  string
 		setupFiles  []string
@@ -408,6 +409,7 @@ func TestApplyModuleVersion(t *testing.T) {
 	}{
 		{
 			name:        "v1",
+			libraryID:   "functions",
 			moduleName:  "functions",
 			modulePath:  "cloud.google.com/go/functions",
 			setupFiles:  []string{"functions/apiv1/client.go", "internal/generated/snippets/functions/apiv1/snippets.go"},
@@ -415,6 +417,7 @@ func TestApplyModuleVersion(t *testing.T) {
 		},
 		{
 			name:        "v2",
+			libraryID:   "functions",
 			moduleName:  "functions",
 			modulePath:  "cloud.google.com/go/functions/v2",
 			setupFiles:  []string{"functions/v2/apiv1/client.go", "internal/generated/snippets/functions/v2/apiv1/snippets.go"},
@@ -422,7 +425,17 @@ func TestApplyModuleVersion(t *testing.T) {
 			wantAbsent:  []string{"functions/v2/apiv1/client.go", "internal/generated/snippets/functions/v2/apiv1/snippets.go"},
 		},
 		{
+			name:        "v2 in subdirectory",
+			libraryID:   "functions/v2",
+			moduleName:  "functions",
+			modulePath:  "cloud.google.com/go/functions/v2",
+			setupFiles:  []string{"functions/v2/apiv1/client.go", "internal/generated/snippets/functions/v2/apiv1/snippets.go"},
+			wantPresent: []string{"functions/v2/apiv1/client.go", "internal/generated/snippets/functions/v2/apiv1/snippets.go"},
+			wantAbsent:  []string{"functions/apiv1/client.go", "internal/generated/snippets/functions/apiv1/snippets.go"},
+		},
+		{
 			name:       "unexpected module path format",
+			libraryID:  "bogus",
 			moduleName: "bogus",
 			modulePath: "cloud.google.com/go/bogus/v1/v2",
 			wantErr:    true,
@@ -448,7 +461,7 @@ func TestApplyModuleVersion(t *testing.T) {
 				}
 			}
 
-			if err := applyModuleVersion(tmpDir, tt.modulePath); (err != nil) != tt.wantErr {
+			if err := applyModuleVersion(tmpDir, tt.libraryID, tt.modulePath); (err != nil) != tt.wantErr {
 				t.Errorf("applyModuleVersion() error = %v, wantErr %v", err, tt.wantErr)
 			}
 


### PR DESCRIPTION
If a library ID includes the version (e.g. "pubsub/v2") then we assume that's the module root, and we don't move generated code into just "pubsub".

Related to https://github.com/googleapis/librarian/issues/2305

(Once we've figured out how to handle all these situations, we definitely need to document "how to create a new major version" etc.)