### PR TITLE
chore: librarian release pull request: 20251002T165528Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -198,7 +198,7 @@ libraries:
       - internal/generated/snippets/apihub/
     tag_format: '{id}/v{version}'
   - id: auth
-    version: 0.16.5
+    version: 0.17.0
     last_generated_commit: 31b413bc4feb03f6849c718048c2b9998561b5fa
     apis: []
     source_roots:

--- a/auth/CHANGES.md
+++ b/auth/CHANGES.md
@@ -1,3 +1,10 @@
+## [0.17.0](https://github.com/googleapis/google-cloud-go/releases/tag/auth%2Fv0.17.0) (2025-10-02)
+
+### Features
+
+* Add trust boundary support for service accounts and impersonation (HTTP/gRPC) (#11870) ([5c2b665](https://github.com/googleapis/google-cloud-go/commit/5c2b665f392e6dd90192f107188720aa1357e7da))
+* add trust boundary support for external accounts (#12864) ([a67a146](https://github.com/googleapis/google-cloud-go/commit/a67a146a6a88a6f1ba10c409dfce8015ecd60a64))
+
 # Changelog
 
 ## [0.16.5](https://github.com/googleapis/google-cloud-go/compare/auth/v0.16.4...auth/v0.16.5) (2025-08-14)

--- a/auth/internal/version.go
+++ b/auth/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "0.16.5"
+const Version = "0.17.0"


### PR DESCRIPTION
Librarian Version: v0.3.1-0.20251002142634-d067bb5fdc6e
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go:latest
<details><summary>auth: 0.17.0</summary>

## [0.17.0](https://github.com/googleapis/google-cloud-go/compare/auth/v0.16.5...auth/v0.17.0) (2025-10-02)

### Features

* add trust boundary support for external accounts (#12864) ([a67a146](https://github.com/googleapis/google-cloud-go/commit/a67a146))

* Add trust boundary support for service accounts and impersonation (HTTP/gRPC) (#11870) ([5c2b665](https://github.com/googleapis/google-cloud-go/commit/5c2b665))

</details>