### PR TITLE
chore: update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,25 +1,25 @@
 # Default owner for all directories not owned by others
-*                       @googleapis/yoshi-go-admins
+*                       @googleapis/cloud-sdk-go-eng
 
-/ai/                    @googleapis/go-vertexai @googleapis/yoshi-go-admins
-/aiplatform/            @googleapis/go-vertexai @googleapis/yoshi-go-admins
-/bigtable/              @googleapis/cloud-native-db-dpes @googleapis/api-bigtable-partners @googleapis/api-bigtable @googleapis/yoshi-go-admins
-/bigtable/cmd/cbt       @igorbernstein2 @googleapis/cloud-native-db-dpes @googleapis/api-bigtable-partners @googleapis/api-bigtable @googleapis/yoshi-go-admins
-/bigtable/cmd/emulator  @igorbernstein2 @googleapis/cloud-native-db-dpes @googleapis/api-bigtable-partners @googleapis/api-bigtable @googleapis/yoshi-go-admins
-/bigtable/bttest        @igorbernstein2 @googleapis/cloud-native-db-dpes @googleapis/api-bigtable-partners @googleapis/api-bigtable @googleapis/yoshi-go-admins
-/bigquery/              @googleapis/api-bigquery @googleapis/yoshi-go-admins
-/datastore/             @googleapis/cloud-native-db-dpes @googleapis/api-firestore-partners @googleapis/yoshi-go-admins
-/firestore/             @googleapis/cloud-native-db-dpes @googleapis/api-firestore-partners @googleapis/yoshi-go-admins
-/pubsub/                @googleapis/api-pubsub @googleapis/yoshi-go-admins @shollyman @googleapis/cloud-native-db-dpes
-/pubsublite/            @googleapis/api-pubsub @googleapis/yoshi-go-admins
-/spanner/               @googleapis/spanner-client-libraries-go @googleapis/yoshi-go-admins
-/storage/               @googleapis/gcs-sdk-team @googleapis/yoshi-go-admins
-/httpreplay/            @googleapis/gcs-sdk-team @googleapis/yoshi-go-admins
-/errorreporting/        @googleapis/api-logging @googleapis/api-logging-partners @googleapis/yoshi-go-admins
-/logging/               @googleapis/api-logging @googleapis/api-logging-partners @googleapis/yoshi-go-admins
-/profiler/              @googleapis/api-profiler @googleapis/yoshi-go-admins
-/vertexai/              @googleapis/go-vertexai @googleapis/yoshi-go-admins
-/internal/protoveneer/  @googleapis/yoshi-go-admins @jba
+/ai/                    @googleapis/go-vertexai @googleapis/cloud-sdk-go-eng
+/aiplatform/            @googleapis/go-vertexai @googleapis/cloud-sdk-go-eng
+/bigtable/              @googleapis/cloud-native-db-dpes @googleapis/api-bigtable-partners @googleapis/api-bigtable @googleapis/cloud-sdk-go-eng
+/bigtable/cmd/cbt       @igorbernstein2 @googleapis/cloud-native-db-dpes @googleapis/api-bigtable-partners @googleapis/api-bigtable @googleapis/cloud-sdk-go-eng
+/bigtable/cmd/emulator  @igorbernstein2 @googleapis/cloud-native-db-dpes @googleapis/api-bigtable-partners @googleapis/api-bigtable @googleapis/cloud-sdk-go-eng
+/bigtable/bttest        @igorbernstein2 @googleapis/cloud-native-db-dpes @googleapis/api-bigtable-partners @googleapis/api-bigtable @googleapis/cloud-sdk-go-eng
+/bigquery/              @googleapis/api-bigquery @googleapis/cloud-sdk-go-eng
+/datastore/             @googleapis/cloud-native-db-dpes @googleapis/api-firestore-partners @googleapis/cloud-sdk-go-eng
+/firestore/             @googleapis/cloud-native-db-dpes @googleapis/api-firestore-partners @googleapis/cloud-sdk-go-eng
+/pubsub/                @googleapis/api-pubsub @googleapis/cloud-sdk-go-eng @googleapis/cloud-native-db-dpes
+/pubsublite/            @googleapis/api-pubsub @googleapis/cloud-sdk-go-eng
+/spanner/               @googleapis/spanner-client-libraries-go @googleapis/cloud-sdk-go-eng
+/storage/               @googleapis/gcs-sdk-team @googleapis/cloud-sdk-go-eng
+/httpreplay/            @googleapis/gcs-sdk-team @googleapis/cloud-sdk-go-eng
+/errorreporting/        @googleapis/api-logging @googleapis/api-logging-partners @googleapis/cloud-sdk-go-eng
+/logging/               @googleapis/api-logging @googleapis/api-logging-partners @googleapis/cloud-sdk-go-eng
+/profiler/              @googleapis/api-profiler @googleapis/cloud-sdk-go-eng
+/vertexai/              @googleapis/go-vertexai @googleapis/cloud-sdk-go-eng
+/internal/protoveneer/  @googleapis/cloud-sdk-go-eng @jba
 
 # individual release versions manifest is unowned (to avoid notifying every team)
 .release-please-manifest-individual.json


### PR DESCRIPTION
This PR migrates away from the yoshi admin group and to the new cloud-sdk-go-eng.  Same folks under the hood, just a different way of expressing the group.

It also removes shollyman as an explicit owner from pubsub as the entry is now redundant.