### PR TITLE
chore: use a consistent heading for all changelogs

### DIFF
--- a/advisorynotifications/CHANGES.md
+++ b/advisorynotifications/CHANGES.md
@@ -1,4 +1,4 @@
-# Changelog
+# Changes
 
 
 ## [1.5.6](https://github.com/googleapis/google-cloud-go/compare/advisorynotifications/v1.5.5...advisorynotifications/v1.5.6) (2025-06-04)

--- a/ai/CHANGES.md
+++ b/ai/CHANGES.md
@@ -1,4 +1,4 @@
-# Changelog
+# Changes
 
 
 ## [0.13.0](https://github.com/googleapis/google-cloud-go/compare/ai/v0.12.1...ai/v0.13.0) (2025-09-04)

--- a/alloydb/CHANGES.md
+++ b/alloydb/CHANGES.md
@@ -1,4 +1,4 @@
-# Changelog
+# Changes
 
 
 

--- a/apigeeregistry/CHANGES.md
+++ b/apigeeregistry/CHANGES.md
@@ -1,4 +1,4 @@
-# Changelog
+# Changes
 
 ## [0.9.6](https://github.com/googleapis/google-cloud-go/compare/apigeeregistry/v0.9.5...apigeeregistry/v0.9.6) (2025-04-15)
 

--- a/apihub/CHANGES.md
+++ b/apihub/CHANGES.md
@@ -1,4 +1,4 @@
-# Changelog
+# Changes
 
 ## [0.2.0](https://github.com/googleapis/google-cloud-go/compare/apihub/v0.1.5...apihub/v0.2.0) (2025-09-11)
 

--- a/apikeys/CHANGES.md
+++ b/apikeys/CHANGES.md
@@ -1,4 +1,4 @@
-# Changelog
+# Changes
 
 
 ## [1.2.7](https://github.com/googleapis/google-cloud-go/compare/apikeys/v1.2.6...apikeys/v1.2.7) (2025-06-04)

--- a/apphub/CHANGES.md
+++ b/apphub/CHANGES.md
@@ -1,4 +1,4 @@
-# Changelog
+# Changes
 
 ## [0.3.1](https://github.com/googleapis/google-cloud-go/compare/apphub/v0.3.0...apphub/v0.3.1) (2025-04-15)
 

--- a/apps/CHANGES.md
+++ b/apps/CHANGES.md
@@ -1,4 +1,4 @@
-# Changelog
+# Changes
 
 ## [0.8.0](https://github.com/googleapis/google-cloud-go/compare/apps/v0.7.4...apps/v0.8.0) (2025-07-09)
 

--- a/auth/CHANGES.md
+++ b/auth/CHANGES.md
@@ -1,11 +1,11 @@
+# Changes
+
 ## [0.17.0](https://github.com/googleapis/google-cloud-go/releases/tag/auth%2Fv0.17.0) (2025-10-02)
 
 ### Features
 
 * Add trust boundary support for service accounts and impersonation (HTTP/gRPC) (#11870) ([5c2b665](https://github.com/googleapis/google-cloud-go/commit/5c2b665f392e6dd90192f107188720aa1357e7da))
 * add trust boundary support for external accounts (#12864) ([a67a146](https://github.com/googleapis/google-cloud-go/commit/a67a146a6a88a6f1ba10c409dfce8015ecd60a64))
-
-# Changelog
 
 ## [0.16.5](https://github.com/googleapis/google-cloud-go/compare/auth/v0.16.4...auth/v0.16.5) (2025-08-14)
 

--- a/auth/oauth2adapt/CHANGES.md
+++ b/auth/oauth2adapt/CHANGES.md
@@ -1,4 +1,4 @@
-# Changelog
+# Changes
 
 ## [0.2.8](https://github.com/googleapis/google-cloud-go/compare/auth/oauth2adapt/v0.2.7...auth/oauth2adapt/v0.2.8) (2025-03-17)
 

--- a/backupdr/CHANGES.md
+++ b/backupdr/CHANGES.md
@@ -1,4 +1,4 @@
-# Changelog
+# Changes
 
 
 

--- a/baremetalsolution/CHANGES.md
+++ b/baremetalsolution/CHANGES.md
@@ -1,4 +1,4 @@
-# Changelog
+# Changes
 
 
 ## [1.3.6](https://github.com/googleapis/google-cloud-go/compare/baremetalsolution/v1.3.5...baremetalsolution/v1.3.6) (2025-04-15)

--- a/batch/CHANGES.md
+++ b/batch/CHANGES.md
@@ -1,4 +1,4 @@
-# Changelog
+# Changes
 
 
 ## [1.12.2](https://github.com/googleapis/google-cloud-go/compare/batch/v1.12.1...batch/v1.12.2) (2025-04-15)

--- a/beyondcorp/CHANGES.md
+++ b/beyondcorp/CHANGES.md
@@ -1,4 +1,4 @@
-# Changelog
+# Changes
 
 
 ## [1.1.6](https://github.com/googleapis/google-cloud-go/compare/beyondcorp/v1.1.5...beyondcorp/v1.1.6) (2025-04-15)

--- a/bigquery/v2/CHANGES.md
+++ b/bigquery/v2/CHANGES.md
@@ -1,2 +1,2 @@
-# Changelog
+# Changes
 

--- a/capacityplanner/CHANGES.md
+++ b/capacityplanner/CHANGES.md
@@ -1,4 +1,4 @@
-# Changelog
+# Changes
 
 ## 0.1.0 (2025-09-11)
 

--- a/chat/CHANGES.md
+++ b/chat/CHANGES.md
@@ -1,4 +1,4 @@
-# Changelog
+# Changes
 
 ## [0.15.1](https://github.com/googleapis/google-cloud-go/compare/chat/v0.15.0...chat/v0.15.1) (2025-09-04)
 

--- a/chronicle/CHANGES.md
+++ b/chronicle/CHANGES.md
@@ -1,4 +1,4 @@
-# Changelog
+# Changes
 
 ## [0.1.1](https://github.com/googleapis/google-cloud-go/compare/chronicle/v0.1.0...chronicle/v0.1.1) (2025-05-21)
 

--- a/cloudcontrolspartner/CHANGES.md
+++ b/cloudcontrolspartner/CHANGES.md
@@ -1,4 +1,4 @@
-# Changelog
+# Changes
 
 
 

--- a/cloudprofiler/CHANGES.md
+++ b/cloudprofiler/CHANGES.md
@@ -1,4 +1,4 @@
-# Changelog
+# Changes
 
 
 ## [0.4.5](https://github.com/googleapis/google-cloud-go/compare/cloudprofiler/v0.4.4...cloudprofiler/v0.4.5) (2025-04-15)

--- a/cloudquotas/CHANGES.md
+++ b/cloudquotas/CHANGES.md
@@ -1,4 +1,4 @@
-# Changelog
+# Changes
 
 
 

--- a/commerce/CHANGES.md
+++ b/commerce/CHANGES.md
@@ -1,4 +1,4 @@
-# Changelog
+# Changes
 
 
 ## [1.2.6](https://github.com/googleapis/google-cloud-go/compare/commerce/v1.2.5...commerce/v1.2.6) (2025-09-16)

--- a/confidentialcomputing/CHANGES.md
+++ b/confidentialcomputing/CHANGES.md
@@ -1,4 +1,4 @@
-# Changelog
+# Changes
 
 
 ## [1.10.1](https://github.com/googleapis/google-cloud-go/compare/confidentialcomputing/v1.10.0...confidentialcomputing/v1.10.1) (2025-09-16)

--- a/config/CHANGES.md
+++ b/config/CHANGES.md
@@ -1,4 +1,4 @@
-# Changelog
+# Changes
 
 
 ## [1.5.1](https://github.com/googleapis/google-cloud-go/compare/config/v1.5.0...config/v1.5.1) (2025-09-16)

--- a/configdelivery/CHANGES.md
+++ b/configdelivery/CHANGES.md
@@ -1,4 +1,4 @@
-# Changelog
+# Changes
 
 ## [0.1.1](https://github.com/googleapis/google-cloud-go/compare/configdelivery/v0.1.0...configdelivery/v0.1.1) (2025-09-16)
 

--- a/dataform/CHANGES.md
+++ b/dataform/CHANGES.md
@@ -1,4 +1,4 @@
-# Changelog
+# Changes
 
 ## [0.12.1](https://github.com/googleapis/google-cloud-go/compare/dataform/v0.12.0...dataform/v0.12.1) (2025-09-16)
 

--- a/developerconnect/CHANGES.md
+++ b/developerconnect/CHANGES.md
@@ -1,4 +1,4 @@
-# Changelog
+# Changes
 
 ## [0.4.1](https://github.com/googleapis/google-cloud-go/compare/developerconnect/v0.4.0...developerconnect/v0.4.1) (2025-09-16)
 

--- a/devicestreaming/CHANGES.md
+++ b/devicestreaming/CHANGES.md
@@ -1,4 +1,4 @@
-# Changelog
+# Changes
 
 ## [0.1.1](https://github.com/googleapis/google-cloud-go/compare/devicestreaming/v0.1.0...devicestreaming/v0.1.1) (2025-09-16)
 

--- a/discoveryengine/CHANGES.md
+++ b/discoveryengine/CHANGES.md
@@ -1,4 +1,4 @@
-# Changelog
+# Changes
 
 
 

--- a/edgecontainer/CHANGES.md
+++ b/edgecontainer/CHANGES.md
@@ -1,4 +1,4 @@
-# Changelog
+# Changes
 
 
 ## [1.4.4](https://github.com/googleapis/google-cloud-go/compare/edgecontainer/v1.4.3...edgecontainer/v1.4.4) (2025-09-16)

--- a/edgenetwork/CHANGES.md
+++ b/edgenetwork/CHANGES.md
@@ -1,4 +1,4 @@
-# Changelog
+# Changes
 
 
 

--- a/financialservices/CHANGES.md
+++ b/financialservices/CHANGES.md
@@ -1,4 +1,4 @@
-# Changelog
+# Changes
 
 ## [0.1.4](https://github.com/googleapis/google-cloud-go/compare/financialservices/v0.1.3...financialservices/v0.1.4) (2025-09-18)
 

--- a/geminidataanalytics/CHANGES.md
+++ b/geminidataanalytics/CHANGES.md
@@ -1,4 +1,4 @@
-# Changelog
+# Changes
 
 ## [0.2.1](https://github.com/googleapis/google-cloud-go/compare/geminidataanalytics/v0.2.0...geminidataanalytics/v0.2.1) (2025-09-18)
 

--- a/gkebackup/CHANGES.md
+++ b/gkebackup/CHANGES.md
@@ -1,4 +1,4 @@
-# Changelog
+# Changes
 
 
 

--- a/gkemulticloud/CHANGES.md
+++ b/gkemulticloud/CHANGES.md
@@ -1,4 +1,4 @@
-# Changelog
+# Changes
 
 
 ## [1.5.4](https://github.com/googleapis/google-cloud-go/compare/gkemulticloud/v1.5.3...gkemulticloud/v1.5.4) (2025-09-18)

--- a/identitytoolkit/CHANGES.md
+++ b/identitytoolkit/CHANGES.md
@@ -1,4 +1,4 @@
-# Changelog
+# Changes
 
 ## [0.2.6](https://github.com/googleapis/google-cloud-go/compare/identitytoolkit/v0.2.5...identitytoolkit/v0.2.6) (2025-09-18)
 

--- a/licensemanager/CHANGES.md
+++ b/licensemanager/CHANGES.md
@@ -1,4 +1,4 @@
-# Changelog
+# Changes
 
 ## [0.1.1](https://github.com/googleapis/google-cloud-go/compare/licensemanager/v0.1.0...licensemanager/v0.1.1) (2025-09-18)
 

--- a/locationfinder/CHANGES.md
+++ b/locationfinder/CHANGES.md
@@ -1,4 +1,4 @@
-# Changelog
+# Changes
 
 ## [0.1.1](https://github.com/googleapis/google-cloud-go/compare/locationfinder/v0.1.0...locationfinder/v0.1.1) (2025-09-18)
 

--- a/lustre/CHANGES.md
+++ b/lustre/CHANGES.md
@@ -1,4 +1,4 @@
-# Changelog
+# Changes
 
 ## [0.2.1](https://github.com/googleapis/google-cloud-go/compare/lustre/v0.2.0...lustre/v0.2.1) (2025-09-18)
 

--- a/maintenance/CHANGES.md
+++ b/maintenance/CHANGES.md
@@ -1,4 +1,4 @@
-# Changelog
+# Changes
 
 ## [0.1.2](https://github.com/googleapis/google-cloud-go/compare/maintenance/v0.1.1...maintenance/v0.1.2) (2025-09-18)
 

--- a/managedkafka/CHANGES.md
+++ b/managedkafka/CHANGES.md
@@ -1,4 +1,4 @@
-# Changelog
+# Changes
 
 ## [0.8.1](https://github.com/googleapis/google-cloud-go/compare/managedkafka/v0.8.0...managedkafka/v0.8.1) (2025-09-18)
 

--- a/memorystore/CHANGES.md
+++ b/memorystore/CHANGES.md
@@ -1,4 +1,4 @@
-# Changelog
+# Changes
 
 
 ## [0.3.1](https://github.com/googleapis/google-cloud-go/compare/memorystore/v0.3.0...memorystore/v0.3.1) (2025-09-18)

--- a/migrationcenter/CHANGES.md
+++ b/migrationcenter/CHANGES.md
@@ -1,4 +1,4 @@
-# Changelog
+# Changes
 
 
 ## [1.1.6](https://github.com/googleapis/google-cloud-go/compare/migrationcenter/v1.1.5...migrationcenter/v1.1.6) (2025-09-18)

--- a/modelarmor/CHANGES.md
+++ b/modelarmor/CHANGES.md
@@ -1,4 +1,4 @@
-# Changelog
+# Changes
 
 ## [0.6.1](https://github.com/googleapis/google-cloud-go/compare/modelarmor/v0.6.0...modelarmor/v0.6.1) (2025-09-18)
 

--- a/netapp/CHANGES.md
+++ b/netapp/CHANGES.md
@@ -1,4 +1,4 @@
-# Changelog
+# Changes
 
 
 ## [1.10.1](https://github.com/googleapis/google-cloud-go/compare/netapp/v1.10.0...netapp/v1.10.1) (2025-09-18)

--- a/networkservices/CHANGES.md
+++ b/networkservices/CHANGES.md
@@ -1,4 +1,4 @@
-# Changelog
+# Changes
 
 ## [0.5.1](https://github.com/googleapis/google-cloud-go/compare/networkservices/v0.5.0...networkservices/v0.5.1) (2025-09-18)
 

--- a/oracledatabase/CHANGES.md
+++ b/oracledatabase/CHANGES.md
@@ -1,4 +1,4 @@
-# Changelog
+# Changes
 
 ## [0.5.1](https://github.com/googleapis/google-cloud-go/compare/oracledatabase/v0.5.0...oracledatabase/v0.5.1) (2025-09-18)
 

--- a/parallelstore/CHANGES.md
+++ b/parallelstore/CHANGES.md
@@ -1,4 +1,4 @@
-# Changelog
+# Changes
 
 
 ## [0.11.4](https://github.com/googleapis/google-cloud-go/compare/parallelstore/v0.11.3...parallelstore/v0.11.4) (2025-09-18)

--- a/parametermanager/CHANGES.md
+++ b/parametermanager/CHANGES.md
@@ -1,4 +1,4 @@
-# Changelog
+# Changes
 
 ## [0.3.1](https://github.com/googleapis/google-cloud-go/compare/parametermanager/v0.3.0...parametermanager/v0.3.1) (2025-09-18)
 

--- a/policysimulator/CHANGES.md
+++ b/policysimulator/CHANGES.md
@@ -1,4 +1,4 @@
-# Changelog
+# Changes
 
 ## [0.4.1](https://github.com/googleapis/google-cloud-go/compare/policysimulator/v0.4.0...policysimulator/v0.4.1) (2025-09-18)
 

--- a/privilegedaccessmanager/CHANGES.md
+++ b/privilegedaccessmanager/CHANGES.md
@@ -1,4 +1,4 @@
-# Changelog
+# Changes
 
 ## [0.3.1](https://github.com/googleapis/google-cloud-go/compare/privilegedaccessmanager/v0.3.0...privilegedaccessmanager/v0.3.1) (2025-09-18)
 

--- a/pubsub/v2/CHANGES.md
+++ b/pubsub/v2/CHANGES.md
@@ -1,4 +1,4 @@
-# Changelog
+# Changes
 
 ## [2.1.0](https://github.com/googleapis/google-cloud-go/compare/pubsub/v2/v2.0.1...pubsub/v2/v2.1.0) (2025-09-25)
 

--- a/rapidmigrationassessment/CHANGES.md
+++ b/rapidmigrationassessment/CHANGES.md
@@ -1,4 +1,4 @@
-# Changelog
+# Changes
 
 
 ## [1.1.8](https://github.com/googleapis/google-cloud-go/compare/rapidmigrationassessment/v1.1.7...rapidmigrationassessment/v1.1.8) (2025-09-22)

--- a/run/CHANGES.md
+++ b/run/CHANGES.md
@@ -1,4 +1,4 @@
-# Changelog
+# Changes
 
 
 ## [1.12.0](https://github.com/googleapis/google-cloud-go/compare/run/v1.11.0...run/v1.12.0) (2025-08-12)

--- a/securesourcemanager/CHANGES.md
+++ b/securesourcemanager/CHANGES.md
@@ -1,4 +1,4 @@
-# Changelog
+# Changes
 
 
 

--- a/securitycentermanagement/CHANGES.md
+++ b/securitycentermanagement/CHANGES.md
@@ -1,4 +1,4 @@
-# Changelog
+# Changes
 
 
 

--- a/securityposture/CHANGES.md
+++ b/securityposture/CHANGES.md
@@ -1,4 +1,4 @@
-# Changelog
+# Changes
 
 ## [0.2.6](https://github.com/googleapis/google-cloud-go/compare/securityposture/v0.2.5...securityposture/v0.2.6) (2025-09-22)
 

--- a/servicehealth/CHANGES.md
+++ b/servicehealth/CHANGES.md
@@ -1,4 +1,4 @@
-# Changelog
+# Changes
 
 
 ## [1.2.4](https://github.com/googleapis/google-cloud-go/compare/servicehealth/v1.2.3...servicehealth/v1.2.4) (2025-09-22)

--- a/shopping/CHANGES.md
+++ b/shopping/CHANGES.md
@@ -1,4 +1,4 @@
-# Changelog
+# Changes
 
 
 ## [1.1.1](https://github.com/googleapis/google-cloud-go/compare/shopping/v1.1.0...shopping/v1.1.1) (2025-09-30)

--- a/spanner/benchmarks/CHANGES.md
+++ b/spanner/benchmarks/CHANGES.md
@@ -1,4 +1,4 @@
-# Changelog
+# Changes
 
 ## 0.1.0 (2025-04-15)
 

--- a/storagebatchoperations/CHANGES.md
+++ b/storagebatchoperations/CHANGES.md
@@ -1,4 +1,4 @@
-# Changelog
+# Changes
 
 ## [0.1.1](https://github.com/googleapis/google-cloud-go/compare/storagebatchoperations/v0.1.0...storagebatchoperations/v0.1.1) (2025-09-22)
 

--- a/storageinsights/CHANGES.md
+++ b/storageinsights/CHANGES.md
@@ -1,4 +1,4 @@
-# Changelog
+# Changes
 
 
 ## [1.2.1](https://github.com/googleapis/google-cloud-go/compare/storageinsights/v1.2.0...storageinsights/v1.2.1) (2025-09-22)

--- a/streetview/CHANGES.md
+++ b/streetview/CHANGES.md
@@ -1,4 +1,4 @@
-# Changelog
+# Changes
 
 ## [0.2.5](https://github.com/googleapis/google-cloud-go/compare/streetview/v0.2.4...streetview/v0.2.5) (2025-04-15)
 

--- a/support/CHANGES.md
+++ b/support/CHANGES.md
@@ -1,4 +1,4 @@
-# Changelog
+# Changes
 
 
 ## [1.4.1](https://github.com/googleapis/google-cloud-go/compare/support/v1.4.0...support/v1.4.1) (2025-09-22)

--- a/telcoautomation/CHANGES.md
+++ b/telcoautomation/CHANGES.md
@@ -1,4 +1,4 @@
-# Changelog
+# Changes
 
 
 

--- a/vertexai/CHANGES.md
+++ b/vertexai/CHANGES.md
@@ -1,4 +1,4 @@
-# Changelog
+# Changes
 
 ## [0.15.0](https://github.com/googleapis/google-cloud-go/compare/vertexai/v0.14.0...vertexai/v0.15.0) (2025-06-25)
 

--- a/visionai/CHANGES.md
+++ b/visionai/CHANGES.md
@@ -1,4 +1,4 @@
-# Changelog
+# Changes
 
 ## [0.4.6](https://github.com/googleapis/google-cloud-go/compare/visionai/v0.4.5...visionai/v0.4.6) (2025-09-22)
 

--- a/vmwareengine/CHANGES.md
+++ b/vmwareengine/CHANGES.md
@@ -1,4 +1,4 @@
-# Changelog
+# Changes
 
 
 ## [1.3.6](https://github.com/googleapis/google-cloud-go/compare/vmwareengine/v1.3.5...vmwareengine/v1.3.6) (2025-09-22)

--- a/workstations/CHANGES.md
+++ b/workstations/CHANGES.md
@@ -1,4 +1,4 @@
-# Changelog
+# Changes
 
 
 


### PR DESCRIPTION
This will avoid Librarian release putting changes in the wrong place

Fixes https://github.com/googleapis/librarian/issues/2476