### PR TITLE
feat(internal/librariangen): make repo-config.yaml optional

### DIFF
--- a/internal/librariangen/config/repoconfig.go
+++ b/internal/librariangen/config/repoconfig.go
@@ -73,10 +73,11 @@ type APIConfig struct {
 
 // LoadRepoConfig loads the repository configuration with module-specific overrides,
 // from a file derived from the .librarian directory (specified as librarianDir).
+// The absence of the file is not an error; it's equivalent to an empty file being present.
 func LoadRepoConfig(librarianDir string) (*RepoConfig, error) {
 	var config RepoConfig
 	b, err := os.ReadFile(filepath.Join(librarianDir, GeneratorInputDir, RepoConfigFile))
-	if err != nil {
+	if err != nil && !os.IsNotExist(err) {
 		return nil, err
 	}
 	if err := yaml.Unmarshal(b, &config); err != nil {

--- a/internal/librariangen/config/repoconfig_test.go
+++ b/internal/librariangen/config/repoconfig_test.go
@@ -86,15 +86,19 @@ modules:
 		t.Fatalf("LoadRepoConfig() failed: %v", err)
 	}
 	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("Transform() mismatch (-want +got):\n%s", diff)
+		t.Errorf("LoadRepoConfig() mismatch (-want +got):\n%s", diff)
 	}
 }
 
 func TestLoadRepoConfig_NotFound(t *testing.T) {
 	tempDir := t.TempDir()
-	_, err := LoadRepoConfig(tempDir)
-	if err == nil {
-		t.Error("LoadRepoConfig() succeeded, want error")
+	got, err := LoadRepoConfig(tempDir)
+	if err != nil {
+		t.Fatalf("LoadRepoConfig() failed: %v", err)
+	}
+	want := &RepoConfig{}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("LoadRepoConfig() mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -133,7 +137,7 @@ func TestGetModuleConfig(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			got := config.GetModuleConfig(test.moduleName)
 			if diff := cmp.Diff(test.want, got); diff != "" {
-				t.Errorf("Transform() mismatch (-want +got):\n%s", diff)
+				t.Errorf("GetModuleConfig() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
If it's missing, that's now equivalent to being empty.

Fixes https://github.com/googleapis/librarian/issues/2480