### PR TITLE
test(internal/postprocessor): remove bad expectations from config test

### DIFF
--- a/internal/postprocessor/config_test.go
+++ b/internal/postprocessor/config_test.go
@@ -25,20 +25,6 @@ func TestLoadConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	li := p.config.GoogleapisToImportPath["google/cloud/alloydb/connectors/v1"]
-	if got, want := li.ImportPath, "cloud.google.com/go/alloydb/connectors/apiv1"; got != want {
-		t.Errorf("got %v, want %v", got, want)
-	}
-	if got, want := li.ServiceConfig, "connectors_v1.yaml"; got != want {
-		t.Errorf("got %v, want %v", got, want)
-	}
-	if got, want := li.RelPath, "/alloydb/connectors/apiv1"; got != want {
-		t.Errorf("got %v, want %v", got, want)
-	}
-	if got, want := li.ReleaseLevel, "preview"; got != want {
-		t.Errorf("got %v, want %v", got, want)
-	}
-
 	wantSkipPath := "bigquery/v2"
 	found := false
 	for _, p := range p.config.SkipModuleScanPaths {


### PR DESCRIPTION
This test made assertions about specific API configs present in the config file, and those assertions are now invalid now that librarian migrations have started removing configs from the postprocessor.

This test removes those bad expectations

fixes: https://github.com/googleapis/google-cloud-go/issues/13034