### PR TITLE
chore(.github): restore deep-remove-regex entries

### DIFF
--- a/.github/.OwlBot.yaml
+++ b/.github/.OwlBot.yaml
@@ -577,13 +577,23 @@ deep-preserve-regex:
   - /compute/apiv1/smoke_test.go
 
 deep-copy-regex:
+  - source: /google/cloud/accessapproval/v1/cloud.google.com/go
+    dest: /
+  - source: /google/identity/accesscontextmanager/v1/cloud.google.com/go
+    dest: /
+  - source: /google/ai/generativelanguage/v1/cloud.google.com/go
+    dest: /
   - source: /google/ai/generativelanguage/v1alpha/cloud.google.com/go
     dest: /
   - source: /google/ai/generativelanguage/v1beta/cloud.google.com/go
     dest: /
   - source: /google/ai/generativelanguage/v1beta2/cloud.google.com/go
     dest: /
+  - source: /google/cloud/aiplatform/v1/cloud.google.com/go
+    dest: /
   - source: /google/cloud/aiplatform/v1beta1/cloud.google.com/go
+    dest: /
+  - source: /google/cloud/advisorynotifications/v1/cloud.google.com/go
     dest: /
   - source: /google/analytics/admin/v1alpha/cloud.google.com/go
     dest: /
@@ -592,13 +602,23 @@ deep-copy-regex:
     dest: /bigtable/admin/apiv2/adminpb
   - source: /google/bigtable/v2/cloud.google.com/go/bigtable/apiv2/bigtablepb
     dest: /bigtable/apiv2/bigtablepb
+  - source: /google/devtools/artifactregistry/v1/cloud.google.com/go
+    dest: /
   - source: /google/devtools/artifactregistry/v1beta2/cloud.google.com/go
     dest: /
+  - source: /google/cloud/bigquery/analyticshub/v1/cloud.google.com/go
+    dest: /
+  - source: /google/cloud/bigquery/biglake/v1/cloud.google.com/go
+    dest: /
   - source: /google/cloud/bigquery/biglake/v1alpha1/cloud.google.com/go
+    dest: /
+  - source: /google/cloud/bigquery/connection/v1/cloud.google.com/go
     dest: /
   - source: /google/cloud/bigquery/connection/v1beta1/cloud.google.com/go
     dest: /
   - source: /google/cloud/bigquery/dataexchange/v1beta1/cloud.google.com/go
+    dest: /
+  - source: /google/cloud/bigquery/datapolicies/v1/cloud.google.com/go
     dest: /
   - source: /google/cloud/bigquery/datapolicies/v1beta1/cloud.google.com/go
     dest: /
@@ -606,9 +626,15 @@ deep-copy-regex:
     dest: /
   - source: /google/cloud/bigquery/datapolicies/v2beta1/cloud.google.com/go
     dest: /
+  - source: /google/cloud/bigquery/datatransfer/v1/cloud.google.com/go
+    dest: /
   - source: /google/cloud/bigquery/migration/v2/cloud.google.com/go
     dest: /
   - source: /google/cloud/bigquery/migration/v2alpha/cloud.google.com/go
+    dest: /
+  - source: /google/cloud/bigquery/reservation/v1/cloud.google.com/go
+    dest: /
+  - source: /google/cloud/bigquery/storage/v1/cloud.google.com/go
     dest: /
   - source: /google/cloud/bigquery/storage/v1alpha/cloud.google.com/go
     dest: /
@@ -620,28 +646,66 @@ deep-copy-regex:
     dest: /
   - source: /google/cloud/bigquery/v2/cloud.google.com/go
     dest: /
+  - source: /google/cloud/certificatemanager/v1/cloud.google.com/go
+    dest: /
+  - source: /google/devtools/cloudbuild/v1/cloud.google.com/go
+    dest: /
   - source: /google/devtools/cloudbuild/v2/cloud.google.com/go
     dest: /
   - source: /google/devtools/cloudprofiler/v2/cloud.google.com/go
     dest: /
+  - source: /google/cloud/commerce/consumer/procurement/v1/cloud.google.com/go
+    dest: /
+  - source: /google/cloud/compute/v1/cloud.google.com/go
+    dest: /
   - source: /google/cloud/compute/v1beta/cloud.google.com/go
+    dest: /
+  - source: /google/cloud/config/v1/cloud.google.com/go
+    dest: /
+  - source: /google/cloud/configdelivery/v1/cloud.google.com/go
     dest: /
   - source: /google/cloud/configdelivery/v1beta/cloud.google.com/go
     dest: /
+  - source: /google/cloud/contactcenterinsights/v1/cloud.google.com/go
+    dest: /
+  - source: /google/container/v1/cloud.google.com/go
+    dest: /
   - source: /google/devtools/containeranalysis/v1beta1/cloud.google.com/go
+    dest: /
+  - source: /google/cloud/datacatalog/v1/cloud.google.com/go
     dest: /
   - source: /google/cloud/datacatalog/v1beta1/cloud.google.com/go
     dest: /
+  - source: /google/cloud/datacatalog/lineage/v1/cloud.google.com/go
+    dest: /
   - source: /google/dataflow/v1beta3/cloud.google.com/go
+    dest: /
+  - source: /google/cloud/dataform/v1/cloud.google.com/go
     dest: /
   - source: /google/cloud/dataform/v1beta1/cloud.google.com/go
     dest: /
+  - source: /google/cloud/datafusion/v1/cloud.google.com/go
+    dest: /
   - source: /google/cloud/datalabeling/v1beta1/cloud.google.com/go
+    dest: /
+  - source: /google/cloud/dataplex/v1/cloud.google.com/go
     dest: /
   - source: /google/cloud/dataqna/v1alpha/cloud.google.com/go
     dest: /
+  - source: /google/datastore/admin/v1/cloud.google.com/go
+    dest: /
   # Just copy the datastore protos for now
+  - source: /google/datastore/v1/cloud.google.com/go/datastore/apiv1/datastorepb
+    dest: /datastore/apiv1/datastorepb
+  - source: /google/cloud/datastream/v1/cloud.google.com/go
+    dest: /
   - source: /google/cloud/datastream/v1alpha1/cloud.google.com/go
+    dest: /
+  - source: /google/cloud/deploy/v1/cloud.google.com/go
+    dest: /
+  - source: /google/cloud/developerconnect/v1/cloud.google.com/go
+    dest: /
+  - source: /google/cloud/devicestreaming/v1/cloud.google.com/go
     dest: /
   - source: /google/cloud/dialogflow/v2/cloud.google.com/go
     dest: /
@@ -651,25 +715,55 @@ deep-copy-regex:
     dest: /
   - source: /google/cloud/dialogflow/cx/v3beta1/cloud.google.com/go
     dest: /
+  - source: /google/cloud/discoveryengine/v1/cloud.google.com/go
+    dest: /
   - source: /google/cloud/discoveryengine/v1beta/cloud.google.com/go
     dest: /
   - source: /google/cloud/discoveryengine/v1alpha/cloud.google.com/go
+    dest: /
+  - source: /google/cloud/documentai/v1/cloud.google.com/go
     dest: /
   - source: /google/cloud/documentai/v1beta3/cloud.google.com/go
     dest: /
   - source: /google/cloud/domains/v1beta1/cloud.google.com/go
     dest: /
+  - source: /google/cloud/edgecontainer/v1/cloud.google.com/go
+    dest: /
+  - source: /google/cloud/edgenetwork/v1/cloud.google.com/go
+    dest: /
   # - source: /google/devtools/clouderrorreporting/v1beta1/cloud.google.com/go
   #   dest: /
+  - source: /google/cloud/essentialcontacts/v1/cloud.google.com/go
+    dest: /
+  - source: /google/cloud/filestore/v1/cloud.google.com/go
+    dest: /
+  - source: /google/cloud/financialservices/v1/cloud.google.com/go
+    dest: /
+  - source: /google/firestore/v1/cloud.google.com/go
+    dest: /
+  - source: /google/firestore/admin/v1/cloud.google.com/go
+    dest: /
+  - source: /google/cloud/functions/v1/cloud.google.com/go
+    dest: /
   - source: /google/cloud/functions/v2/cloud.google.com/go
     dest: /
   - source: /google/cloud/functions/v2beta/cloud.google.com/go
     dest: /
   - source: /google/cloud/geminidataanalytics/v1beta/cloud.google.com/go
     dest: /
+  - source: /google/cloud/gkebackup/v1/cloud.google.com/go
+    dest: /
   - source: /google/cloud/gkeconnect/gateway/v1beta1/cloud.google.com/go
     dest: /
+  - source: /google/cloud/gkeconnect/gateway/v1/cloud.google.com/go
+    dest: /
   - source: /google/cloud/gkehub/v1beta1/cloud.google.com/go
+    dest: /
+  - source: /google/cloud/gkemulticloud/v1/cloud.google.com/go
+    dest: /
+  - source: /google/cloud/gsuiteaddons/v1/cloud.google.com/go
+    dest: /
+  - source: /google/iam/v1/cloud.google.com/go
     dest: /
   - source: /google/iam/v2/cloud.google.com/go
     dest: /
@@ -677,69 +771,159 @@ deep-copy-regex:
     dest: /
   - source: /google/iam/v3beta/cloud.google.com/go
     dest: /
+  - source: /google/iam/credentials/v1/cloud.google.com/go
+    dest: /
+  - source: /google/cloud/iap/v1/cloud.google.com/go
+    dest: /
   - source: /google/cloud/identitytoolkit/v2/cloud.google.com/go
+    dest: /
+  - source: /google/cloud/ids/v1/cloud.google.com/go
+    dest: /
+  - source: /google/cloud/iot/v1/cloud.google.com/go
+    dest: /
+  - source: /google/cloud/kms/v1/cloud.google.com/go
+    dest: /
+  - source: /google/cloud/kms/inventory/v1/cloud.google.com/go
+    dest: /
+  - source: /google/cloud/language/v1/cloud.google.com/go
     dest: /
   - source: /google/cloud/language/v1beta2/cloud.google.com/go
     dest: /
   - source: /google/cloud/language/v2/cloud.google.com/go
     dest: /
+  - source: /google/cloud/licensemanager/v1/cloud.google.com/go
+    dest: /
   - source: /google/cloud/lifesciences/v2beta/cloud.google.com/go
+    dest: /
+  - source: /google/cloud/locationfinder/v1/cloud.google.com/go
     dest: /
   - source: /google/logging/v2/cloud.google.com/go
     dest: /
+  - source: /google/cloud/lustre/v1/cloud.google.com/go
+    dest: /
   - source: /google/cloud/maintenance/api/v1beta/cloud.google.com/go
+    dest: /
+  - source: /google/cloud/managedidentities/v1/cloud.google.com/go
+    dest: /
+  - source: /google/cloud/managedkafka/v1/cloud.google.com/go
+    dest: /
+  - source: /google/cloud/managedkafka/schemaregistry/v1/cloud.google.com/go
     dest: /
   - source: /google/cloud/mediatranslation/v1beta1/cloud.google.com/go
     dest: /
+  - source: /google/cloud/memcache/v1/cloud.google.com/go
+    dest: /
   - source: /google/cloud/memcache/v1beta2/cloud.google.com/go
     dest: /
+  - source: /google/cloud/memorystore/v1/cloud.google.com/go
+    dest: /
   - source: /google/cloud/memorystore/v1beta/cloud.google.com/go
+    dest: /
+  - source: /google/cloud/metastore/v1/cloud.google.com/go
     dest: /
   - source: /google/cloud/metastore/v1alpha/cloud.google.com/go
     dest: /
   - source: /google/cloud/metastore/v1beta/cloud.google.com/go
     dest: /
+  - source: /google/cloud/migrationcenter/v1/cloud.google.com/go
+    dest: /
+  - source: /google/cloud/modelarmor/v1/cloud.google.com/go
+    dest: /
   - source: /google/cloud/modelarmor/v1beta/cloud.google.com/go
     dest: /
   - source: /google/monitoring/v3/cloud.google.com/go
     dest: /
+  - source: /google/monitoring/dashboard/v1/cloud.google.com/go
+    dest: /
+  - source: /google/monitoring/metricsscope/v1/cloud.google.com/go
+    dest: /
+  - source: /google/cloud/netapp/v1/cloud.google.com/go
+    dest: /
+  - source: /google/cloud/networkconnectivity/v1/cloud.google.com/go
+    dest: /
   - source: /google/cloud/networkconnectivity/v1alpha1/cloud.google.com/go
     dest: /
+  - source: /google/cloud/networkmanagement/v1/cloud.google.com/go
+    dest: /
   - source: /google/cloud/networksecurity/v1beta1/cloud.google.com/go
+    dest: /
+  - source: /google/cloud/networkservices/v1/cloud.google.com/go
+    dest: /
+  - source: /google/cloud/notebooks/v1/cloud.google.com/go
     dest: /
   - source: /google/cloud/notebooks/v1beta1/cloud.google.com/go
     dest: /
   - source: /google/cloud/notebooks/v2/cloud.google.com/go
     dest: /
+  - source: /google/cloud/optimization/v1/cloud.google.com/go
+    dest: /
+  - source: /google/cloud/oracledatabase/v1/cloud.google.com/go
+    dest: /
+  - source: /google/cloud/orchestration/airflow/service/v1/cloud.google.com/go
+    dest: /
+  - source: /google/cloud/orgpolicy/v1/cloud.google.com/go
+    dest: /
   - source: /google/cloud/orgpolicy/v2/cloud.google.com/go
     dest: /
+  - source: /google/cloud/osconfig/agentendpoint/v1/cloud.google.com/go
+    dest: /
   - source: /google/cloud/osconfig/agentendpoint/v1beta/cloud.google.com/go
+    dest: /
+  - source: /google/cloud/osconfig/v1/cloud.google.com/go
     dest: /
   - source: /google/cloud/osconfig/v1alpha/cloud.google.com/go
     dest: /
   - source: /google/cloud/osconfig/v1beta/cloud.google.com/go
     dest: /
+  - source: /google/cloud/oslogin/v1/cloud.google.com/go
+    dest: /
   - source: /google/cloud/oslogin/v1beta/cloud.google.com/go
     dest: /
   - source: /google/cloud/oslogin/common/cloud.google.com/go
     dest: /
+  - source: /google/cloud/parallelstore/v1/cloud.google.com/go
+    dest: /
   - source: /google/cloud/parallelstore/v1beta/cloud.google.com/go
+    dest: /
+  - source: /google/cloud/parametermanager/v1/cloud.google.com/go
     dest: /
   - source: /google/cloud/phishingprotection/v1beta1/cloud.google.com/go
     dest: /
+  - source: /google/cloud/policysimulator/v1/cloud.google.com/go
+    dest: /
   - source: /google/cloud/policytroubleshooter/iam/v3/cloud.google.com/go
+    dest: /
+  - source: /google/cloud/policytroubleshooter/v1/cloud.google.com/go
     dest: /
   - source: /google/cloud/privatecatalog/v1beta1/cloud.google.com/go
     dest: /
+  - source: /google/cloud/privilegedaccessmanager/v1/cloud.google.com/go
+    dest: /
+  - source: /google/pubsub/v1/cloud.google.com/go
+    dest: /
+  - source: /google/cloud/pubsublite/v1/cloud.google.com/go
+    dest: /
+  - source: /google/cloud/rapidmigrationassessment/v1/cloud.google.com/go
+    dest: /
+  - source: /google/cloud/recaptchaenterprise/v1/cloud.google.com/go/recaptchaenterprise/v2/apiv1
+    dest: /recaptchaenterprise/apiv1
+  - source: /google/cloud/recaptchaenterprise/v1/cloud.google.com/go/internal/generated/snippets/recaptchaenterprise/v2/apiv1
+    dest: /internal/generated/snippets/recaptchaenterprise/apiv1
   - source: /google/cloud/recaptchaenterprise/v1beta1/cloud.google.com/go/recaptchaenterprise/v2/apiv1beta1
     dest: /recaptchaenterprise/apiv1beta1
   - source: /google/cloud/recaptchaenterprise/v1beta1/cloud.google.com/go/internal/generated/snippets/recaptchaenterprise/v2/apiv1beta1
     dest: /internal/generated/snippets/recaptchaenterprise/apiv1beta1
   - source: /google/cloud/recommendationengine/v1beta1/cloud.google.com/go
     dest: /
+  - source: /google/cloud/recommender/v1/cloud.google.com/go
+    dest: /
   - source: /google/cloud/recommender/v1beta1/cloud.google.com/go
     dest: /
+  - source: /google/cloud/redis/v1/cloud.google.com/go
+    dest: /
   - source: /google/cloud/redis/v1beta1/cloud.google.com/go
+    dest: /
+  - source: /google/cloud/redis/cluster/v1/cloud.google.com/go
     dest: /
   - source: /google/cloud/resourcemanager/v2/cloud.google.com/go
     dest: /
@@ -753,11 +937,23 @@ deep-copy-regex:
     dest: /
   - source: /google/cloud/run/v2/cloud.google.com/go
     dest: /
+  - source: /google/cloud/scheduler/v1/cloud.google.com/go
+    dest: /
   - source: /google/cloud/scheduler/v1beta1/cloud.google.com/go
+    dest: /
+  - source: /google/cloud/secretmanager/v1/cloud.google.com/go
     dest: /
   - source: /google/cloud/secretmanager/v1beta2/cloud.google.com/go
     dest: /
+  - source: /google/cloud/securesourcemanager/v1/cloud.google.com/go
+    dest: /
+  - source: /google/cloud/security/privateca/v1/cloud.google.com/go
+    dest: /
   - source: /google/cloud/security/publicca/v1beta1/cloud.google.com/go
+    dest: /
+  - source: /google/cloud/security/publicca/v1/cloud.google.com/go
+    dest: /
+  - source: /google/cloud/securitycenter/v1/cloud.google.com/go
     dest: /
   - source: /google/cloud/securitycenter/v1beta1/cloud.google.com/go
     dest: /
@@ -767,37 +963,91 @@ deep-copy-regex:
     dest: /
   - source: /google/cloud/securitycenter/settings/v1beta1/cloud.google.com/go
     dest: /
+  - source: /google/cloud/securitycentermanagement/v1/cloud.google.com/go
+    dest: /
+  - source: /google/cloud/securityposture/v1/cloud.google.com/go
+    dest: /
+  - source: /google/api/servicecontrol/v1/cloud.google.com/go
+    dest: /
+  - source: /google/cloud/servicedirectory/v1/cloud.google.com/go
+    dest: /
   - source: /google/cloud/servicedirectory/v1beta1/cloud.google.com/go
+    dest: /
+  - source: /google/cloud/servicehealth/v1/cloud.google.com/go
+    dest: /
+  - source: /google/api/servicemanagement/v1/cloud.google.com/go
+    dest: /
+  - source: /google/api/serviceusage/v1/cloud.google.com/go
+    dest: /
+  - source: /google/cloud/shell/v1/cloud.google.com/go
+    dest: /
+  - source: /google/shopping/css/v1/cloud.google.com/go
+    dest: /
+  - source: /google/shopping/merchant/accounts/v1/cloud.google.com/go
     dest: /
   - source: /google/shopping/merchant/accounts/v1beta/cloud.google.com/go
     dest: /
+  - source: /google/shopping/merchant/conversions/v1/cloud.google.com/go
+    dest: /
   - source: /google/shopping/merchant/conversions/v1beta/cloud.google.com/go
+    dest: /
+  - source: /google/shopping/merchant/datasources/v1/cloud.google.com/go
     dest: /
   - source: /google/shopping/merchant/datasources/v1beta/cloud.google.com/go
     dest: /
+  - source: /google/shopping/merchant/notifications/v1/cloud.google.com/go
+    dest: /
   - source: /google/shopping/merchant/notifications/v1beta/cloud.google.com/go
     dest: /
+  - source: /google/shopping/merchant/ordertracking/v1/cloud.google.com/go
+    dest: /
   - source: /google/shopping/merchant/ordertracking/v1beta/cloud.google.com/go
+    dest: /
+  - source: /google/shopping/merchant/products/v1/cloud.google.com/go
     dest: /
   - source: /google/shopping/merchant/products/v1beta/cloud.google.com/go
     dest: /
   - source: /google/shopping/merchant/productstudio/v1alpha/cloud.google.com/go
     dest: /
+  - source: /google/shopping/merchant/promotions/v1/cloud.google.com/go
+    dest: /
   - source: /google/shopping/merchant/promotions/v1beta/cloud.google.com/go
+    dest: /
+  - source: /google/shopping/merchant/quota/v1/cloud.google.com/go
     dest: /
   - source: /google/shopping/merchant/quota/v1beta/cloud.google.com/go
     dest: /
+  - source: /google/shopping/merchant/inventories/v1/cloud.google.com/go
+    dest: /
   - source: /google/shopping/merchant/inventories/v1beta/cloud.google.com/go
+    dest: /
+  - source: /google/shopping/merchant/issueresolution/v1/cloud.google.com/go
     dest: /
   - source: /google/shopping/merchant/issueresolution/v1beta/cloud.google.com/go
     dest: /
+  - source: /google/shopping/merchant/lfp/v1/cloud.google.com/go
+    dest: /
   - source: /google/shopping/merchant/lfp/v1beta/cloud.google.com/go
+    dest: /
+  - source: /google/shopping/merchant/reports/v1/cloud.google.com/go
     dest: /
   - source: /google/shopping/merchant/reports/v1beta/cloud.google.com/go
     dest: /
   - source: /google/shopping/merchant/reviews/v1beta/cloud.google.com/go
     dest: /
   - source: /google/shopping/type/cloud.google.com/go
+    dest: /
+  - source: /google/spanner/adapter/v1/cloud.google.com/go
+    dest: /
+  - source: /google/spanner/admin/database/v1/cloud.google.com/go
+    dest: /
+  - source: /google/spanner/admin/instance/v1/cloud.google.com/go
+    dest: /
+  - source: /google/spanner/v1/cloud.google.com/go
+    dest: /
+  - source: /google/spanner/executor/v1/cloud.google.com/go
+    dest: /
+  - source: /google/cloud/speech/v1/cloud.google.com/go
     dest: /
   - source: /google/cloud/speech/v1p1beta1/cloud.google.com/go
     dest: /
@@ -807,6 +1057,14 @@ deep-copy-regex:
     dest: /
   - source: /google/storage/v2/cloud.google.com/go/storage/internal/apiv2
     dest: /storage/internal/apiv2
+  - source: /google/cloud/storagebatchoperations/v1/cloud.google.com/go
+    dest: /
+  - source: /google/cloud/storageinsights/v1/cloud.google.com/go
+    dest: /
+  - source: /google/storagetransfer/v1/cloud.google.com/go
+    dest: /
+  - source: /google/streetview/publish/v1/cloud.google.com/go
+    dest: /
   - source: /google/cloud/support/v2/cloud.google.com/go
     dest: /
   - source: /google/cloud/support/v2beta/cloud.google.com/go
@@ -815,23 +1073,61 @@ deep-copy-regex:
     dest: /
   - source: /google/cloud/talent/v4beta1/cloud.google.com/go
     dest: /
+  - source: /google/cloud/telcoautomation/v1/cloud.google.com/go
+    dest: /
+  - source: /google/cloud/texttospeech/v1/cloud.google.com/go
+    dest: /
+  - source: /google/cloud/tpu/v1/cloud.google.com/go
+    dest: /
+  - source: /google/devtools/cloudtrace/v1/cloud.google.com/go
+    dest: /
   - source: /google/devtools/cloudtrace/v2/cloud.google.com/go
     dest: /
   - source: /google/cloud/translate/v3/cloud.google.com/go
+    dest: /
+  - source: /google/cloud/video/livestream/v1/cloud.google.com/go
+    dest: /
+  - source: /google/cloud/video/stitcher/v1/cloud.google.com/go
+    dest: /
+  - source: /google/cloud/video/transcoder/v1/cloud.google.com/go
+    dest: /
+  - source: /google/cloud/videointelligence/v1/cloud.google.com/go
     dest: /
   - source: /google/cloud/videointelligence/v1beta2/cloud.google.com/go
     dest: /
   - source: /google/cloud/videointelligence/v1p3beta1/cloud.google.com/go
     dest: /
+  - source: /google/cloud/vision/v1/cloud.google.com/go/vision/v2/apiv1
+    dest: /vision/apiv1
+  - source: /google/cloud/vision/v1/cloud.google.com/go/internal/generated/snippets/vision/v2/apiv1
+    dest: /internal/generated/snippets/vision/apiv1
   - source: /google/cloud/vision/v1p1beta1/cloud.google.com/go/vision/v2/apiv1p1beta1
     dest: /vision/apiv1p1beta1
   - source: /google/cloud/vision/v1p1beta1/cloud.google.com/go/internal/generated/snippets/vision/v2/apiv1p1beta1
     dest: /internal/generated/snippets/vision/apiv1p1beta1
+  - source: /google/cloud/visionai/v1/cloud.google.com/go
+    dest: /
+  - source: /google/cloud/vmmigration/v1/cloud.google.com/go
+    dest: /
+  - source: /google/cloud/vmwareengine/v1/cloud.google.com/go
+    dest: /
+  - source: /google/cloud/vpcaccess/v1/cloud.google.com/go
+    dest: /
+  - source: /google/cloud/webrisk/v1/cloud.google.com/go
+    dest: /
   - source: /google/cloud/webrisk/v1beta1/cloud.google.com/go
+    dest: /
+  - source: /google/cloud/websecurityscanner/v1/cloud.google.com/go
+    dest: /
+  - source: /google/cloud/workflows/v1/cloud.google.com/go
     dest: /
   - source: /google/cloud/workflows/v1beta/cloud.google.com/go
     dest: /
+  - source: /google/cloud/workflows/executions/v1/cloud.google.com/go
+    dest: /
   - source: /google/cloud/workflows/executions/v1beta/cloud.google.com/go
+    dest: /
+  - source: /google/cloud/workstations/v1/cloud.google.com/go
     dest: /
   - source: /google/cloud/workstations/v1beta/cloud.google.com/go
     dest: /


### PR DESCRIPTION
Restore deep-remove-regex incorrectly removed by Librarian migration PR #13046

refs: #13046