### PR TITLE
chore: bump changed modules

### DIFF
--- a/iam/CHANGES.md
+++ b/iam/CHANGES.md
@@ -288,3 +288,4 @@
 
 This is the first tag to carve out iam as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/monitoring/CHANGES.md
+++ b/monitoring/CHANGES.md
@@ -337,3 +337,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out monitoring as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+


### PR DESCRIPTION
BEGIN_NESTED_COMMIT
fix(iam): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(monitoring): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT