### PR TITLE
chore: bump changed modules

### DIFF
--- a/cloudprofiler/CHANGES.md
+++ b/cloudprofiler/CHANGES.md
@@ -115,3 +115,4 @@
 * **cloudprofiler:** New clients ([#9016](https://github.com/googleapis/google-cloud-go/issues/9016)) ([8fefcce](https://github.com/googleapis/google-cloud-go/commit/8fefcce1bdd86afb07a4c8bcfc3d3d00f61a9100))
 
 ## Changes
+

--- a/containeranalysis/CHANGES.md
+++ b/containeranalysis/CHANGES.md
@@ -241,3 +241,4 @@
 
 This is the first tag to carve out containeranalysis as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/shopping/CHANGES.md
+++ b/shopping/CHANGES.md
@@ -626,3 +626,4 @@
 * **shopping:** New clients ([#8699](https://github.com/googleapis/google-cloud-go/issues/8699)) ([0e43b40](https://github.com/googleapis/google-cloud-go/commit/0e43b40184bacac8d355ea2cfd00ebe58bd9e30b))
 
 ## Changes
+

--- a/storagetransfer/CHANGES.md
+++ b/storagetransfer/CHANGES.md
@@ -247,3 +247,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out storagetransfer as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/streetview/CHANGES.md
+++ b/streetview/CHANGES.md
@@ -86,3 +86,4 @@
 * **streetview:** New client(s) ([#10075](https://github.com/googleapis/google-cloud-go/issues/10075)) ([e82cc5f](https://github.com/googleapis/google-cloud-go/commit/e82cc5f8667a4b0d9f47fe7f935d0a553c010e93))
 
 ## Changes
+

--- a/trace/CHANGES.md
+++ b/trace/CHANGES.md
@@ -245,3 +245,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out trace as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+


### PR DESCRIPTION
BEGIN_NESTED_COMMIT
fix(cloudprofiler): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(containeranalysis): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(shopping): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(storagetransfer): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(streetview): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(trace): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT