### PR TITLE
chore: create a release

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,7 +1,7 @@
 image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go:latest
 libraries:
   - id: alloydb
-    version: 1.18.0
+    version: 1.19.0
     last_generated_commit: 7b2b58ff4fb3eee3c0923af35fdee90134fabe3b
     apis:
       - path: google/cloud/alloydb/v1

--- a/alloydb/CHANGES.md
+++ b/alloydb/CHANGES.md
@@ -3,6 +3,25 @@
 
 
 
+## [1.19.0](https://github.com/googleapis/google-cloud-go/releases/tag/alloydb%2Fv1.19.0) (2025-10-09)
+
+### Features
+
+* add CRUD APIs on Databases ([2a37bd3](https://github.com/googleapis/google-cloud-go/commit/2a37bd3a8dbfebe64d46f3214b84b80cd69ae4e0))
+* add PG 17 as a Database version ([2a37bd3](https://github.com/googleapis/google-cloud-go/commit/2a37bd3a8dbfebe64d46f3214b84b80cd69ae4e0))
+* add additional fields to Database object to specify the collation type, character type, if it is a template database, and the template to use for the database ([2a37bd3](https://github.com/googleapis/google-cloud-go/commit/2a37bd3a8dbfebe64d46f3214b84b80cd69ae4e0))
+* add configuration for Managed Connection Pool ([2a37bd3](https://github.com/googleapis/google-cloud-go/commit/2a37bd3a8dbfebe64d46f3214b84b80cd69ae4e0))
+* add field to ExecuteSQL request to just validate the sql statement ([2a37bd3](https://github.com/googleapis/google-cloud-go/commit/2a37bd3a8dbfebe64d46f3214b84b80cd69ae4e0))
+* update `Database.charset` to be immutable ([2a37bd3](https://github.com/googleapis/google-cloud-go/commit/2a37bd3a8dbfebe64d46f3214b84b80cd69ae4e0))
+
+### Bug Fixes
+
+* An existing enum `PoolMode` is removed from the `ConnectionPoolConfig` ([2a37bd3](https://github.com/googleapis/google-cloud-go/commit/2a37bd3a8dbfebe64d46f3214b84b80cd69ae4e0))
+
+### Documentation
+
+* specify that the STOPPED state is not used for clusters anymore ([2a37bd3](https://github.com/googleapis/google-cloud-go/commit/2a37bd3a8dbfebe64d46f3214b84b80cd69ae4e0))
+
 ## [1.18.0](https://github.com/googleapis/google-cloud-go/compare/alloydb/v1.17.0...alloydb/v1.18.0) (2025-06-25)
 
 

--- a/alloydb/internal/version.go
+++ b/alloydb/internal/version.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "1.18.0"
+const Version = "1.19.0"

--- a/internal/generated/snippets/alloydb/apiv1/snippet_metadata.google.cloud.alloydb.v1.json
+++ b/internal/generated/snippets/alloydb/apiv1/snippet_metadata.google.cloud.alloydb.v1.json
@@ -1,7 +1,7 @@
 {
   "clientLibrary": {
     "name": "cloud.google.com/go/alloydb/apiv1",
-    "version": "1.18.0",
+    "version": "1.19.0",
     "language": "GO",
     "apis": [
       {

--- a/internal/generated/snippets/alloydb/apiv1alpha/snippet_metadata.google.cloud.alloydb.v1alpha.json
+++ b/internal/generated/snippets/alloydb/apiv1alpha/snippet_metadata.google.cloud.alloydb.v1alpha.json
@@ -1,7 +1,7 @@
 {
   "clientLibrary": {
     "name": "cloud.google.com/go/alloydb/apiv1alpha",
-    "version": "1.18.0",
+    "version": "1.19.0",
     "language": "GO",
     "apis": [
       {

--- a/internal/generated/snippets/alloydb/apiv1beta/snippet_metadata.google.cloud.alloydb.v1beta.json
+++ b/internal/generated/snippets/alloydb/apiv1beta/snippet_metadata.google.cloud.alloydb.v1beta.json
@@ -1,7 +1,7 @@
 {
   "clientLibrary": {
     "name": "cloud.google.com/go/alloydb/apiv1beta",
-    "version": "1.18.0",
+    "version": "1.19.0",
     "language": "GO",
     "apis": [
       {


### PR DESCRIPTION
Librarian Version: not available
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go:latest
<details><summary>alloydb: 1.19.0</summary>

## [1.19.0](https://github.com/googleapis/google-cloud-go/compare/alloydb/v1.18.0...alloydb/v1.19.0) (2025-10-09)

### Features

* add CRUD APIs on Databases (PiperOrigin-RevId: 811874519) ([2a37bd3](https://github.com/googleapis/google-cloud-go/commit/2a37bd3))

* add PG 17 as a Database version (PiperOrigin-RevId: 811874519) ([2a37bd3](https://github.com/googleapis/google-cloud-go/commit/2a37bd3))

* add configuration for Managed Connection Pool (PiperOrigin-RevId: 811874519) ([2a37bd3](https://github.com/googleapis/google-cloud-go/commit/2a37bd3))

* update `Database.charset` to be immutable (PiperOrigin-RevId: 811874519) ([2a37bd3](https://github.com/googleapis/google-cloud-go/commit/2a37bd3))

* add additional fields to Database object to specify the collation type, character type, if it is a template database, and the template to use for the database (PiperOrigin-RevId: 811874519) ([2a37bd3](https://github.com/googleapis/google-cloud-go/commit/2a37bd3))

* add field to ExecuteSQL request to just validate the sql statement (PiperOrigin-RevId: 811874519) ([2a37bd3](https://github.com/googleapis/google-cloud-go/commit/2a37bd3))

### Bug Fixes

* An existing enum `PoolMode` is removed from the `ConnectionPoolConfig` (PiperOrigin-RevId: 811874519) ([2a37bd3](https://github.com/googleapis/google-cloud-go/commit/2a37bd3))

### Documentation

* specify that the STOPPED state is not used for clusters anymore (PiperOrigin-RevId: 811874519) ([2a37bd3](https://github.com/googleapis/google-cloud-go/commit/2a37bd3))

</details>
