### PR TITLE
test(internal/postprocessor): skip test that expects certain live config

### DIFF
--- a/internal/postprocessor/main_test.go
+++ b/internal/postprocessor/main_test.go
@@ -51,6 +51,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestProcessCommit(t *testing.T) {
+	t.Skip("test based on implicit config expectations")
 	tests := []struct {
 		name         string
 		title        string


### PR DESCRIPTION
Librarian migrations have broken another test.  Skip this one for the time being, as the expectation it will go away when migrations are complete.

Fixes: https://github.com/googleapis/google-cloud-go/issues/13055