### PR TITLE
fix(internal/stategen): be more conservative about removing OwlBot lines

### DIFF
--- a/.github/.OwlBot.yaml
+++ b/.github/.OwlBot.yaml
@@ -94,11 +94,6 @@ deep-remove-regex:
   - /gkehub/apiv1beta1/
   - /gkemulticloud/apiv1/
   - /gsuiteaddons/apiv1/
-  - /iam/apiv1/
-  - /iam/apiv2/
-  - /iam/apiv3/
-  - /iam/apiv3beta/
-  - /iam/credentials/apiv1/
   - /iap/apiv1/
   - /identitytoolkit/apiv2/
   - /ids/apiv1/
@@ -192,11 +187,6 @@ deep-remove-regex:
   - /internal/generated/snippets/gkehub/apiv1beta1/
   - /internal/generated/snippets/gkemulticloud/apiv1/
   - /internal/generated/snippets/gsuiteaddons/apiv1/
-  - /internal/generated/snippets/iam/apiv1/
-  - /internal/generated/snippets/iam/apiv2/
-  - /internal/generated/snippets/iam/apiv3/
-  - /internal/generated/snippets/iam/apiv3beta/
-  - /internal/generated/snippets/iam/credentials/apiv1/
   - /internal/generated/snippets/iap/apiv1/
   - /internal/generated/snippets/identitytoolkit/apiv2/
   - /internal/generated/snippets/ids/apiv1/
@@ -762,16 +752,6 @@ deep-copy-regex:
   - source: /google/cloud/gkemulticloud/v1/cloud.google.com/go
     dest: /
   - source: /google/cloud/gsuiteaddons/v1/cloud.google.com/go
-    dest: /
-  - source: /google/iam/v1/cloud.google.com/go
-    dest: /
-  - source: /google/iam/v2/cloud.google.com/go
-    dest: /
-  - source: /google/iam/v3/cloud.google.com/go
-    dest: /
-  - source: /google/iam/v3beta/cloud.google.com/go
-    dest: /
-  - source: /google/iam/credentials/v1/cloud.google.com/go
     dest: /
   - source: /google/cloud/iap/v1/cloud.google.com/go
     dest: /

--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1047,6 +1047,83 @@ libraries:
     release_exclude_paths:
       - internal/generated/snippets/eventarc/
     tag_format: '{id}/v{version}'
+  - id: iam
+    version: 1.5.3
+    last_generated_commit: 6821943108fe3284f483defc9b60774a3752de2b
+    apis:
+      - path: google/iam/credentials/v1
+        service_config: iamcredentials_v1.yaml
+      - path: google/iam/v1
+        service_config: iam_meta_api.yaml
+      - path: google/iam/v2
+        service_config: iam_v2.yaml
+      - path: google/iam/v3
+        service_config: iam_v3.yaml
+      - path: google/iam/v3beta
+        service_config: iam_v3beta.yaml
+    source_roots:
+      - iam
+      - internal/generated/snippets/iam
+    preserve_regex: []
+    remove_regex:
+      - ^internal/generated/snippets/iam/
+      - ^iam/admin/apiv1/[^/]*_client\.go$
+      - ^iam/admin/apiv1/[^/]*_client_example_go123_test\.go$
+      - ^iam/admin/apiv1/[^/]*_client_example_test\.go$
+      - ^iam/admin/apiv1/auxiliary\.go$
+      - ^iam/admin/apiv1/auxiliary_go123\.go$
+      - ^iam/admin/apiv1/doc\.go$
+      - ^iam/admin/apiv1/gapic_metadata\.json$
+      - ^iam/admin/apiv1/helpers\.go$
+      - ^iam/admin/apiv1/adminpb/.*$
+      - ^iam/apiv1/[^/]*_client\.go$
+      - ^iam/apiv1/[^/]*_client_example_go123_test\.go$
+      - ^iam/apiv1/[^/]*_client_example_test\.go$
+      - ^iam/apiv1/auxiliary\.go$
+      - ^iam/apiv1/auxiliary_go123\.go$
+      - ^iam/apiv1/doc\.go$
+      - ^iam/apiv1/gapic_metadata\.json$
+      - ^iam/apiv1/helpers\.go$
+      - ^iam/apiv1/iampb/.*$
+      - ^iam/apiv2/[^/]*_client\.go$
+      - ^iam/apiv2/[^/]*_client_example_go123_test\.go$
+      - ^iam/apiv2/[^/]*_client_example_test\.go$
+      - ^iam/apiv2/auxiliary\.go$
+      - ^iam/apiv2/auxiliary_go123\.go$
+      - ^iam/apiv2/doc\.go$
+      - ^iam/apiv2/gapic_metadata\.json$
+      - ^iam/apiv2/helpers\.go$
+      - ^iam/apiv2/iampb/.*$
+      - ^iam/apiv3/[^/]*_client\.go$
+      - ^iam/apiv3/[^/]*_client_example_go123_test\.go$
+      - ^iam/apiv3/[^/]*_client_example_test\.go$
+      - ^iam/apiv3/auxiliary\.go$
+      - ^iam/apiv3/auxiliary_go123\.go$
+      - ^iam/apiv3/doc\.go$
+      - ^iam/apiv3/gapic_metadata\.json$
+      - ^iam/apiv3/helpers\.go$
+      - ^iam/apiv3/iampb/.*$
+      - ^iam/apiv3beta/[^/]*_client\.go$
+      - ^iam/apiv3beta/[^/]*_client_example_go123_test\.go$
+      - ^iam/apiv3beta/[^/]*_client_example_test\.go$
+      - ^iam/apiv3beta/auxiliary\.go$
+      - ^iam/apiv3beta/auxiliary_go123\.go$
+      - ^iam/apiv3beta/doc\.go$
+      - ^iam/apiv3beta/gapic_metadata\.json$
+      - ^iam/apiv3beta/helpers\.go$
+      - ^iam/apiv3beta/iampb/.*$
+      - ^iam/credentials/apiv1/[^/]*_client\.go$
+      - ^iam/credentials/apiv1/[^/]*_client_example_go123_test\.go$
+      - ^iam/credentials/apiv1/[^/]*_client_example_test\.go$
+      - ^iam/credentials/apiv1/auxiliary\.go$
+      - ^iam/credentials/apiv1/auxiliary_go123\.go$
+      - ^iam/credentials/apiv1/doc\.go$
+      - ^iam/credentials/apiv1/gapic_metadata\.json$
+      - ^iam/credentials/apiv1/helpers\.go$
+      - ^iam/credentials/apiv1/credentialspb/.*$
+    release_exclude_paths:
+      - internal/generated/snippets/iam/
+    tag_format: '{id}/v{version}'
   - id: longrunning
     version: 0.6.7
     last_generated_commit: 7b2b58ff4fb3eee3c0923af35fdee90134fabe3b

--- a/.release-please-manifest-submodules.json
+++ b/.release-please-manifest-submodules.json
@@ -44,7 +44,6 @@
     "gkemulticloud": "1.5.4",
     "grafeas": "0.3.16",
     "gsuiteaddons": "1.7.8",
-    "iam": "1.5.3",
     "iap": "1.11.3",
     "identitytoolkit": "0.2.6",
     "ids": "1.5.7",

--- a/internal/stategen/cleanup.go
+++ b/internal/stategen/cleanup.go
@@ -246,13 +246,25 @@ func cleanupOwlBotYaml(repoRoot, moduleName string) error {
 		return fmt.Errorf("loading postprocessor config: %w", err)
 	}
 	importPrefix := "cloud.google.com/go/" + moduleName + "/"
-	// These are designed to match lines conservatively. The leading
-	// space before the module name prevents spurious matches such as
-	// "- /policytroubleshooter/iam/apiv3/" for a module of "iam".
-	// Likewise the "/snippets/" prefix effectively roots the snippet
-	// matches for this module - so
-	// " - /internal/generated/snippets/policytroubleshooter/iam/apiv3/"
-	// shouldn't be removed for module "iam".
+	// These are designed to match lines conservatively against the root
+	// of the repo and the root of the generated snippets. For example,
+	// when removing deep-remove-regex entries for the module "iam"
+	// want to remove all of:
+	//
+	// - /iam/apiv1/
+	// - /iam/apiv2/
+	// - /iam/apiv3/
+	// - /iam/apiv3beta/
+	// - /iam/credentials/apiv1/
+	// - /internal/generated/snippets/iam/apiv1/
+	// - /internal/generated/snippets/iam/apiv2/
+	// - /internal/generated/snippets/iam/apiv3/
+	// - /internal/generated/snippets/iam/apiv3beta/
+	// - /internal/generated/snippets/iam/credentials/apiv1
+	//
+	// ... but we *don't* want to remove:
+	// - /policytroubleshooter/iam/apiv3/
+	// - /internal/generated/snippets/policytroubleshooter/iam/apiv3/
 	modulePathFragment := " /" + moduleName + "/"
 	snippetsPathFragment := "/snippets/" + moduleName + "/"
 

--- a/release-please-config-yoshi-submodules.json
+++ b/release-please-config-yoshi-submodules.json
@@ -138,9 +138,6 @@
         "gsuiteaddons": {
             "component": "gsuiteaddons"
         },
-        "iam": {
-            "component": "iam"
-        },
         "iap": {
             "component": "iap"
         },


### PR DESCRIPTION
Previously, migrating module "iam" would remove all lines containing "/iam/" - even if they weren't in the iam module.