### PR TITLE
fix(pubsub/v2): avoid Receive hang on context cancellation

### DIFF
--- a/pubsub/v2/subscriber.go
+++ b/pubsub/v2/subscriber.go
@@ -320,7 +320,7 @@ func (s *Subscriber) Receive(ctx context.Context, f func(context.Context, *Messa
 				msgChan := make(chan []*Message)
 				errChan := make(chan error)
 				go func() {
-					// Make message pulling dependent on iterator for context cancellation
+					// Make message pulling dependent on iterator for context cancellation.
 					// If the context is cancelled while pulling messages, stop reading from stream early.
 					select {
 					case <-ctx.Done():


### PR DESCRIPTION
Related to https://github.com/googleapis/google-cloud-go/issues/13113

## Cause of the Issue

In v2.0, when the context was canceled, [all messages were Nacked](https://github.com/googleapis/google-cloud-go/blob/494c545e468b5e1b2aa371811c07b4208ab4a87f/pubsub/v2/subscriber.go#L305-L312).

However, starting from v2.1, when the context is canceled, even if a message has already been received via [iter.receive()](https://github.com/landcelita/google-cloud-go/blob/0135d9305581444e1ddcdd8f4fe63e4c588b575f/pubsub/v2/subscriber.go#L323)
, the implementation [returns without calling Nack()](https://github.com/landcelita/google-cloud-go/blob/0135d9305581444e1ddcdd8f4fe63e4c588b575f/pubsub/v2/subscriber.go#L340).

As a result, since v2.1, [iterator.done()](https://github.com/landcelita/google-cloud-go/blob/14c3887819c7bfdf3de661ec807fa82b6bb3183e/pubsub/v2/iterator.go#L219) may not be executed for some keys, which causes the condition [len(it.keepAliveDeadlines) == 0](https://github.com/landcelita/google-cloud-go/blob/14c3887819c7bfdf3de661ec807fa82b6bb3183e/pubsub/v2/iterator.go#L201) to never be satisfied.

Consequently, the program remains blocked at the section where [it.wg.Wait()](https://github.com/landcelita/google-cloud-go/blob/14c3887819c7bfdf3de661ec807fa82b6bb3183e/pubsub/v2/iterator.go#L183) is called, which in turn causes [Receive’s group.Wait()](https://github.com/landcelita/google-cloud-go/blob/76ddb3498f2c986b156abaeaf7efeab1c9490725/pubsub/subscription.go#L1533) to remain blocked as well, resulting in a hang.

## Summary of the Fix

Modified the behavior so that no further messages are received once the context is canceled.