### PR TITLE
chore: bump changed modules

### DIFF
--- a/bigquery/CHANGES.md
+++ b/bigquery/CHANGES.md
@@ -1127,3 +1127,4 @@ cloud.google.com/go.
 
 This is the first tag to carve out bigquery as its own module. See:
 https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository.
+

--- a/bigquery/v2/CHANGES.md
+++ b/bigquery/v2/CHANGES.md
@@ -1,2 +1,3 @@
 # Changes
 
+

--- a/datastore/CHANGES.md
+++ b/datastore/CHANGES.md
@@ -260,3 +260,4 @@
 
 This is the first tag to carve out datastore as its own module. See:
 https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository.
+

--- a/firestore/CHANGES.md
+++ b/firestore/CHANGES.md
@@ -286,3 +286,4 @@
 
 This is the first tag to carve out firestore as its own module. See:
 https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository.
+

--- a/pubsub/v2/CHANGES.md
+++ b/pubsub/v2/CHANGES.md
@@ -50,3 +50,4 @@
 * **pubsub/v2:** Update v2 package docs with migration guide ([#12564](https://github.com/googleapis/google-cloud-go/issues/12564)) ([5ef6068](https://github.com/googleapis/google-cloud-go/commit/5ef606838a84f1c56225fc4e33f4ee394eb34725))
 
 ## Changes
+

--- a/spanner/CHANGES.md
+++ b/spanner/CHANGES.md
@@ -1544,3 +1544,4 @@
 
 This is the first tag to carve out spanner as its own module. See:
 https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository.
+

--- a/storage/CHANGES.md
+++ b/storage/CHANGES.md
@@ -912,3 +912,4 @@
 
 This is the first tag to carve out storage as its own module. See:
 https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository.
+


### PR DESCRIPTION
BEGIN_NESTED_COMMIT
fix(bigquery): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(bigquery/v2): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(datastore): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(firestore): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(pubsub/v2): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(spanner): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(storage): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT