### PR TITLE
chore(.github): update postprocessor sha for OwlBot

### DIFF
--- a/.github/.OwlBot.lock.yaml
+++ b/.github/.OwlBot.lock.yaml
@@ -13,4 +13,4 @@
 # limitations under the License.
 docker:
   image: gcr.io/cloud-devrel-public-resources/owlbot-go:infrastructure-public-image-latest
-  digest: sha256:2ac759056f75d1e67b3b4b40ccbfeabe5ee30739e13c455e1a05fc0b10b6afff
+  digest: sha256:fc0a16b67b4fde2b1d22b6febbe95a82bc549198ac1b7c4f6b045e78f43349de


### PR DESCRIPTION
postprocessor image update removes regeneration of .repo-metadata-full.json due to Librarian onboarding removing many modules