### PR TITLE
fix(logging): upgrade gRPC service registration func

### DIFF
--- a/logging/CHANGES.md
+++ b/logging/CHANGES.md
@@ -216,3 +216,4 @@
 
 This is the first tag to carve out logging as its own module. See:
 https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository.
+


### PR DESCRIPTION
An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.