### PR TITLE
chore: bump modules pre librarian migration

### DIFF
--- a/accessapproval/CHANGES.md
+++ b/accessapproval/CHANGES.md
@@ -220,3 +220,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out accessapproval as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/certificatemanager/CHANGES.md
+++ b/certificatemanager/CHANGES.md
@@ -315,3 +315,4 @@
 
 * **certificatemanager:** release 0.1.0 ([#5743](https://github.com/googleapis/google-cloud-go/issues/5743)) ([24a817a](https://github.com/googleapis/google-cloud-go/commit/24a817a2a75dde10bcbecf2ced8f399cb05dc011))
 * ****certificatemanager**:** release v0.1.0 ([#5758](https://github.com/googleapis/google-cloud-go/issues/5758)) ([809f4ba](https://github.com/googleapis/google-cloud-go/commit/809f4ba385e2e9ed61df8ecbb6df7b371dc10641))
+

--- a/dataqna/CHANGES.md
+++ b/dataqna/CHANGES.md
@@ -201,3 +201,4 @@
 
 This is the first tag to carve out dataqna as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/grafeas/CHANGES.md
+++ b/grafeas/CHANGES.md
@@ -138,3 +138,4 @@
 
 This is the first tag to carve out grafeas as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/kms/CHANGES.md
+++ b/kms/CHANGES.md
@@ -398,3 +398,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out kms as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/servicecontrol/CHANGES.md
+++ b/servicecontrol/CHANGES.md
@@ -251,3 +251,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out servicecontrol as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/servicemanagement/CHANGES.md
+++ b/servicemanagement/CHANGES.md
@@ -226,3 +226,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out servicemanagement as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/serviceusage/CHANGES.md
+++ b/serviceusage/CHANGES.md
@@ -205,3 +205,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out serviceusage as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+


### PR DESCRIPTION
BEGIN_NESTED_COMMIT
fix(accessapproval):  include gapic_metadata.json in Go GAPIC assembly rule
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(certificatemanager): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(dataqna):  include gapic_metadata.json in Go GAPIC assembly rule
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(grafeas): upgrade to Go 1.24
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(kms): conditionally enable AllowHardBoundTokens
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(servicecontrol): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(servicemanagement): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix(serviceusage): upgrade gRPC service registration func

An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.
END_NESTED_COMMIT