### PR TITLE
feat(bigtable): Enable ALTS hard bound token in Bigtable w/ direct access

### DIFF
--- a/bigtable/bigtable.go
+++ b/bigtable/bigtable.go
@@ -143,7 +143,10 @@ func NewClientWithConfig(ctx context.Context, project, instance string, config C
 
 	enableDirectAccess, _ := strconv.ParseBool(os.Getenv("CBT_ENABLE_DIRECTPATH"))
 	if enableDirectAccess {
-		o = append(o, internaloption.EnableDirectPath(true), internaloption.EnableDirectPathXds(), internaloption.AllowHardBoundTokens("ALTS"))
+		o = append(o, internaloption.EnableDirectPath(true), internaloption.EnableDirectPathXds())
+		if disableBoundToken, _ := strconv.ParseBool(os.Getenv("CBT_DISABLE_DIRECTPATH_BOUND_TOKEN")); !disableBoundToken {
+			o = append(o, internaloption.AllowHardBoundTokens("ALTS"))
+		}
 	}
 
 	// Allow non-default service account in DirectPath.


### PR DESCRIPTION
The same thing has been introduced to Cloud Spanner and GCS.