### PR TITLE
fix(bigtable): retry unexpected EOF errors

### DIFF
--- a/bigtable/bigtable.go
+++ b/bigtable/bigtable.go
@@ -64,6 +64,11 @@ var (
 		"Received Rst stream",
 		"RST_STREAM closed stream",
 		"Received RST_STREAM",
+
+		// https://github.com/googleapis/google-cloud-go/issues/10207#issuecomment-2604859656
+		// https://github.com/googleapis/google-cloud-go/issues/10909
+		// https://github.com/googleapis/google-cloud-go/pull/11276
+		"unexpected EOF",
 	}
 	defaultBackoff = gax.Backoff{
 		Initial:    100 * time.Millisecond,


### PR DESCRIPTION
This has been previously discussed at https://github.com/googleapis/google-cloud-go/pull/11276.
I am resubmitting the change again, since we still see the UnexpectedEOF and we are running with this patch in production to retry it.

Apparently there is a flaky test that shows the same issue as well: https://github.com/googleapis/google-cloud-go/issues/10909

There are more cases that use the comparison of the error message now, and the grpc-go has [some places](https://github.com/grpc/grpc-go/blob/ae62635cb0e21ae37e7ae5f0f18aaac5e8139834/rpc_util.go#L1033) that return a gRPC status error with the error message of the io.UnexpectedEOF.
So I kept the handling by error message text instead of comparing directly to io.UnexpectedEOF.