### PR TITLE
fix(compute): upgrade gRPC service registration func

### DIFF
--- a/compute/CHANGES.md
+++ b/compute/CHANGES.md
@@ -568,3 +568,4 @@ Compute metadata has been moved to its own module.
 
 This is the first tag to carve out compute as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+


### PR DESCRIPTION
An update to Go gRPC Protobuf generation will change service registration function signatures to use an interface instead of a concrete type in generated .pb.go service files. This change should affect very few client library users. See release notes advisories in https://togithub.com/googleapis/google-cloud-go/pull/11025.