### PR TITLE
chore(.github): Update apidiff for Librarian

### DIFF
--- a/.github/workflows/apidiff.yml
+++ b/.github/workflows/apidiff.yml
@@ -79,14 +79,13 @@ jobs:
         name: ${{ steps.baseline.outputs.pkg }}
         path: ${{ matrix.changed }}
     - name: Compare regenerated code to baseline
-      # Only ignore Go interface additions when the PR is from OwlBot as it is
-      # likely a new method added to the gRPC client stub interface, which is
-      # non-breaking.
+      # Only ignore Go interface additions when the PR is from Librarian (e.g., librarian-20251016T095208Z)
+      # as it is likely a new method added to the gRPC client stub interface, which is non-breaking.
       env:
         PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
       run: |
         cd ${{ matrix.changed }} && apidiff -m -incompatible ${{ steps.baseline.outputs.pkg }} . > diff.txt
-        if [[ "$PR_HEAD_REF" == owl-bot-copy ]]; then
+        if [[ "$PR_HEAD_REF" == librarian-* ]]; then
           sed -i '/: added/d' ./diff.txt
         fi
         cat diff.txt && ! [ -s diff.txt ]


### PR DESCRIPTION
Fix false positive apidiff failures such as in #13156.

```
Run cd maps && apidiff -m -incompatible maps_pkg.main . > diff.txt
- ./routeoptimization/apiv1/routeoptimizationpb.RouteOptimizationClient.OptimizeToursLongRunning: added
- ./routeoptimization/apiv1/routeoptimizationpb.RouteOptimizationClient.OptimizeToursUri: added
- ./routeoptimization/apiv1/routeoptimizationpb.RouteOptimizationServer.OptimizeToursLongRunning: added
- ./routeoptimization/apiv1/routeoptimizationpb.RouteOptimizationServer.OptimizeToursUri: added
Error: Process completed with exit code 1.
```