### PR TITLE
chore: update Librarian container to a272fe1ca4fb

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,4 +1,4 @@
-image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go:latest
+image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go@sha256:a272fe1ca4fba0c579426dd16fdbb0cac7795fae318292696aa59f801598d431
 libraries:
   - id: accessapproval
     version: 1.8.8
@@ -3673,7 +3673,7 @@ libraries:
     last_generated_commit: a32b926f35bf473f7ba31383e5247175beccd576
     apis:
       - path: google/pubsub/v1
-        service_config: ""
+        service_config: pubsub_v1.yaml
     source_roots:
       - pubsub/v2
       - internal/generated/snippets/pubsub/v2
@@ -3991,7 +3991,7 @@ libraries:
       - internal/testutil
       - internal/tracecontext
       - internal/version
-    tag_format: 'v{version}'
+    tag_format: v{version}
   - id: run
     version: 1.12.1
     last_generated_commit: a32b926f35bf473f7ba31383e5247175beccd576


### PR DESCRIPTION
Running "librarian update-image" specifying this image directly only gave expected changes which are effectively "post-migration changes haven't been merged yet". (They are all in current generation PRs.) Those changes (outside state.yaml) have not been included in this PR, as they'll happen naturally as part of generation.