### PR TITLE
feat: add delete_generation_output_paths to repo-config.yaml

### DIFF
--- a/internal/librariangen/config/repoconfig.go
+++ b/internal/librariangen/config/repoconfig.go
@@ -48,6 +48,11 @@ type ModuleConfig struct {
 	ModulePathVersion string `yaml:"module_path_version"`
 	// APIs is the list of APIs within this module (that need overrides).
 	APIs []*APIConfig `yaml:"apis"`
+	// DeleteGenerationOutputPaths specifies paths (files or directories) to
+	// be deleted from the output directory at the end of generation. This is for files
+	// which it is difficult to prevent from being generated, but which shouldn't appear
+	// in the repo.
+	DeleteGenerationOutputPaths []string `yaml:"delete_generation_output_paths"`
 }
 
 // APIConfig provides per-API configuration to override defaults,


### PR DESCRIPTION
This is used as an emergency escape hatch when generation creates files we don't want. The only known usage at the moment is for storage, where files are generated under
internal/generated/snippets/storage/internal and we don't want them.

Fixes https://github.com/googleapis/librarian/issues/2620