### PR TITLE
chore(.librarian): add global allowlist files for configure

### DIFF
--- a/.librarian/config.yaml
+++ b/.librarian/config.yaml
@@ -17,6 +17,11 @@
 #  - path: "CHANGES.md"
 #    permissions: "read-write"
 
+global_files_allowlist:
+ # Paths (currently just one) that need to modified during configure
+ - path: "internal/generated/snippets/go.mod"
+   permissions: "read-write"
+
 # All libraries with handwritten code (core, hybrid and handwritten)
 # libraries have "release_blocked: true" so that releases are
 # explicitly initiated


### PR DESCRIPTION
The comment is deliberately *within* the global_files_allowlist as I expect us to have different (logical) sections within the allowlist, each with its own comment.