### PR TITLE
feat(storage): Takeover idempotence.

### DIFF
--- a/storage/writer.go
+++ b/storage/writer.go
@@ -272,6 +272,8 @@ func (w *Writer) openWriter() (err error) {
 	}
 
 	isIdempotent := w.o.conds != nil && (w.o.conds.GenerationMatch >= 0 || w.o.conds.DoesNotExist)
+	// Append operations that takeover a specific generation are idempotent.
+	isIdempotent = isIdempotent || w.Append && w.o.gen > 0
 	opts := makeStorageOpts(isIdempotent, w.o.retry, w.o.userProject)
 	params := &openWriterParams{
 		ctx:                  w.ctx,


### PR DESCRIPTION
Takeovers at a specific object generation are safe to retry.