### PR TITLE
chore(.librarian): exclude .repo-metadata-full.json from root-module releases

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -4128,6 +4128,7 @@ libraries:
     preserve_regex: []
     remove_regex: []
     release_exclude_paths:
+      - internal/.repo-metadata-full.json
       - internal/actions
       - internal/aliasfix
       - internal/aliasgen


### PR DESCRIPTION
We want to get rid of this file eventually, using separate repo metadata files, but for the moment, the combined file shouldn't be deemed relevant to releases.