### PR TITLE
test(storage): fix write emulator test

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -167,6 +167,7 @@ github.com/go-fonts/stix v0.1.0 h1:UlZlgrvvmT/58o573ot7NFw0vZasZ5I6bcIft/oMdgg=
 github.com/go-fonts/stix v0.2.2/go.mod h1:SUxggC9dxd/Q+rb5PkJuvfvTbOPtNc2Qaua00fIp9iU=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1 h1:QbL/5oDUmRBzO9/Z7Seo6zf912W/a6Sr4Eu0G/3Jho0=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20231223183121-56fa3ac82ce7/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
+github.com/go-jose/go-jose/v4 v4.1.2 h1:TK/7NqRQZfgAh+Td8AlsrvtPoUyiHh0LqVvokh+1vHI=
 github.com/go-jose/go-jose/v4 v4.1.2/go.mod h1:22cg9HWM1pOlnRiY+9cQYJ9XHmya1bYW8OeDM6Ku6Oo=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -2931,13 +2931,15 @@ func TestWriterChunkTransferTimeoutEmulated(t *testing.T) {
 						t.Fatalf("opening reading: %v", err)
 					}
 					wantLen := len(buffer)
-					got := make([]byte, wantLen)
-					n, err := r.Read(got)
-					if n != wantLen {
-						t.Fatalf("expected to read %d bytes, but got %d", wantLen, n)
+					got, err := io.ReadAll(r)
+					if err != nil {
+						t.Fatalf("reading bytes: %v", err)
 					}
-					if diff := cmp.Diff(got, buffer); diff != "" {
-						t.Fatalf("checking written content: got(-),want(+):\n%s", diff)
+					if len(got) != wantLen {
+						t.Fatalf("expected to read %d bytes, but got %d", wantLen, len(got))
+					}
+					if !bytes.Equal(got, buffer) {
+						t.Errorf("checking content: bytes did not match")
 					}
 				} else {
 					// Deadlines may come through as a context.DeadlineExceeded (HTTP) or status.DeadlineExceeded (gRPC)


### PR DESCRIPTION
This started breaking with the new testbench release and I'm not totally sure how it was passing before. Fix the way that bytes are read and checked in the test.