### PR TITLE
fix(bigtable): fix project id sent in otel

### DIFF
--- a/bigtable/otel_metrics.go
+++ b/bigtable/otel_metrics.go
@@ -59,7 +59,7 @@ type bigtableClientMonitoredResource struct {
 
 func (bmr *bigtableClientMonitoredResource) exporter() (metric.Exporter, error) {
 	exporter, err := mexporter.New(
-		mexporter.WithProjectID(bmr.clientProject),
+		mexporter.WithProjectID(bmr.project),
 		mexporter.WithMetricDescriptorTypeFormatter(metricFormatter),
 		mexporter.WithCreateServiceTimeSeries(),
 		mexporter.WithMonitoredResourceDescription(bigtableClientMonitoredResourceName, []string{"project_id", "instance", "app_profile", "client_project", "cloud_platform", "host_id", "host_name", "client_name", "uuid", "region"}),


### PR DESCRIPTION
Project ID sent to Google Monitoring was different than the project ID sent in the labels, which was causing an error:

```
rpc error: code = InvalidArgument desc = Field resource.labels.project_id had an invalid value of "*": if present, must be the project number or ID in the request name (projects/*).
```

This happened when you run your app on a project but connect to Bigtable from a different project. The project in the monitoring request name would be the project that you are running on, and the project in the labels would be the Bigtable project, causing the mismatch.