### PR TITLE
fix(auth): correctly parse executable command with quoted arguments

### DIFF
--- a/auth/credentials/internal/externalaccount/executable_provider.go
+++ b/auth/credentials/internal/externalaccount/executable_provider.go
@@ -24,10 +24,10 @@ import (
 	"os"
 	"os/exec"
 	"regexp"
-	"strings"
 	"time"
 
 	"cloud.google.com/go/auth/internal"
+	"github.com/mattn/go-shellwords"
 )
 
 const (
@@ -77,7 +77,13 @@ func (r runtimeEnvironment) now() time.Time {
 }
 
 func (r runtimeEnvironment) run(ctx context.Context, command string, env []string) ([]byte, error) {
-	splitCommand := strings.Fields(command)
+	splitCommand, err := shellwords.Parse(command)
+	if err != nil {
+		return nil, err
+	}
+	if len(splitCommand) == 0 {
+		return nil, errors.New("credentials: executable command is empty")
+	}
 	cmd := exec.CommandContext(ctx, splitCommand[0], splitCommand[1:]...)
 	cmd.Env = env
 

--- a/auth/credentials/internal/externalaccount/executable_provider_test.go
+++ b/auth/credentials/internal/externalaccount/executable_provider_test.go
@@ -26,7 +26,56 @@ import (
 	"cloud.google.com/go/auth/internal"
 	"cloud.google.com/go/auth/internal/credsfile"
 	"github.com/google/go-cmp/cmp"
+	"github.com/mattn/go-shellwords"
 )
+
+func TestShellwordsParse(t *testing.T) {
+	tests := []struct {
+		name    string
+		command string
+		want    []string
+		wantErr bool
+	}{
+		{
+			name:    "simple command",
+			command: "a b c",
+			want:    []string{"a", "b", "c"},
+		},
+		{
+			name:    "quoted argument",
+			command: `a "b c"`,
+			want:    []string{"a", "b c"},
+		},
+		{
+			name:    "quoted executable",
+			command: `"a b" c`,
+			want:    []string{"a b", "c"},
+		},
+		{
+			name:    "quoted executable and argument",
+			command: `"a b" "c d"`,
+			want:    []string{"a b", "c d"},
+		},
+		{
+			name:    "single quotes",
+			command: `'a b' 'c d'`,
+			want:    []string{"a b", "c d"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := shellwords.Parse(tt.command)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Parse() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !cmp.Equal(got, tt.want) {
+				t.Errorf("Parse() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
 
 var executablesAllowed = map[string]string{
 	allowExecutablesEnvVar: "1",

--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.6 // indirect
+	github.com/mattn/go-shellwords v1.0.12 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/spiffe/go-spiffe/v2 v2.5.0 // indirect
 	github.com/zeebo/errs v1.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -65,6 +65,8 @@ github.com/googleapis/enterprise-certificate-proxy v0.3.6 h1:GW/XbdyBFQ8Qe+YAmFU
 github.com/googleapis/enterprise-certificate-proxy v0.3.6/go.mod h1:MkHOF77EYAE7qfSuSS9PU6g4Nt4e11cnsDUowfwewLA=
 github.com/googleapis/gax-go/v2 v2.15.0 h1:SyjDc1mGgZU5LncH8gimWo9lW1DtIfPibOG81vgd/bo=
 github.com/googleapis/gax-go/v2 v2.15.0/go.mod h1:zVVkkxAQHa1RQpg9z2AUCMnKhi0Qld9rcmyfL1OZhoc=
+github.com/mattn/go-shellwords v1.0.12 h1:M2zGm7EW6UQJvDeQxo4T51eKPurbeFbe8WtebGE2xrk=
+github.com/mattn/go-shellwords v1.0.12/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
 github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 h1:GFCKgmp0tecUJ0sJuv4pzYCqS9+RGSn52M3FUwPs+uo=
 github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10/go.mod h1:t/avpk3KcrXxUnYOhZhMXJlSEyie6gQbtLq5NM3loB8=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=


### PR DESCRIPTION
The executable command for pluggable auth was being parsed with `strings.Fields`, which does not handle quoted arguments containing spaces correctly. This caused errors when the executable path or its arguments contained spaces.

This change replaces `strings.Fields` with `shellwords.Parse` from the `github.com/mattn/go-shellwords` library. This library correctly parses shell command strings, respecting quotes.

This change adds a new dependency on `github.com/mattn/go-shellwords`.

This was reported in b/238143555