### PR TITLE
fix(librariangen): use os.MkdirAll to make output dir

### DIFF
--- a/internal/librariangen/configure/configure.go
+++ b/internal/librariangen/configure/configure.go
@@ -196,7 +196,7 @@ func configureLibrary(ctx context.Context, cfg *Config, library *request.Library
 	var moduleConfig = repoConfig.GetModuleConfig(library.ID)
 
 	moduleRoot := filepath.Join(cfg.OutputDir, library.ID)
-	if err := os.Mkdir(moduleRoot, 0755); err != nil {
+	if err := os.MkdirAll(moduleRoot, 0755); err != nil {
 		return nil, err
 	}
 	// Only a single API path can be added on each configure call, so we can tell


### PR DESCRIPTION
When running librarian with a library that has a slash in it, you cannot make an appropriate output directory, since the parent directory isn't created. Using `os.Mkdirall` should fix this issue.