### PR TITLE
chore(all): update snippet metadata by running librarian update-image

### DIFF
--- a/internal/generated/snippets/bigquery/analyticshub/apiv1/snippet_metadata.google.cloud.bigquery.analyticshub.v1.json
+++ b/internal/generated/snippets/bigquery/analyticshub/apiv1/snippet_metadata.google.cloud.bigquery.analyticshub.v1.json
@@ -1,7 +1,7 @@
 {
   "clientLibrary": {
     "name": "cloud.google.com/go/bigquery/analyticshub/apiv1",
-    "version": "1.71.0",
+    "version": "1.72.0",
     "language": "GO",
     "apis": [
       {

--- a/internal/generated/snippets/bigquery/biglake/apiv1/snippet_metadata.google.cloud.bigquery.biglake.v1.json
+++ b/internal/generated/snippets/bigquery/biglake/apiv1/snippet_metadata.google.cloud.bigquery.biglake.v1.json
@@ -1,7 +1,7 @@
 {
   "clientLibrary": {
     "name": "cloud.google.com/go/bigquery/biglake/apiv1",
-    "version": "1.71.0",
+    "version": "1.72.0",
     "language": "GO",
     "apis": [
       {

--- a/internal/generated/snippets/bigquery/biglake/apiv1alpha1/snippet_metadata.google.cloud.bigquery.biglake.v1alpha1.json
+++ b/internal/generated/snippets/bigquery/biglake/apiv1alpha1/snippet_metadata.google.cloud.bigquery.biglake.v1alpha1.json
@@ -1,7 +1,7 @@
 {
   "clientLibrary": {
     "name": "cloud.google.com/go/bigquery/biglake/apiv1alpha1",
-    "version": "1.71.0",
+    "version": "1.72.0",
     "language": "GO",
     "apis": [
       {

--- a/internal/generated/snippets/bigquery/connection/apiv1/snippet_metadata.google.cloud.bigquery.connection.v1.json
+++ b/internal/generated/snippets/bigquery/connection/apiv1/snippet_metadata.google.cloud.bigquery.connection.v1.json
@@ -1,7 +1,7 @@
 {
   "clientLibrary": {
     "name": "cloud.google.com/go/bigquery/connection/apiv1",
-    "version": "1.71.0",
+    "version": "1.72.0",
     "language": "GO",
     "apis": [
       {

--- a/internal/generated/snippets/bigquery/connection/apiv1beta1/snippet_metadata.google.cloud.bigquery.connection.v1beta1.json
+++ b/internal/generated/snippets/bigquery/connection/apiv1beta1/snippet_metadata.google.cloud.bigquery.connection.v1beta1.json
@@ -1,7 +1,7 @@
 {
   "clientLibrary": {
     "name": "cloud.google.com/go/bigquery/connection/apiv1beta1",
-    "version": "1.71.0",
+    "version": "1.72.0",
     "language": "GO",
     "apis": [
       {

--- a/internal/generated/snippets/bigquery/dataexchange/apiv1beta1/snippet_metadata.google.cloud.bigquery.dataexchange.v1beta1.json
+++ b/internal/generated/snippets/bigquery/dataexchange/apiv1beta1/snippet_metadata.google.cloud.bigquery.dataexchange.v1beta1.json
@@ -1,7 +1,7 @@
 {
   "clientLibrary": {
     "name": "cloud.google.com/go/bigquery/dataexchange/apiv1beta1",
-    "version": "1.71.0",
+    "version": "1.72.0",
     "language": "GO",
     "apis": [
       {

--- a/internal/generated/snippets/bigquery/datapolicies/apiv1/snippet_metadata.google.cloud.bigquery.datapolicies.v1.json
+++ b/internal/generated/snippets/bigquery/datapolicies/apiv1/snippet_metadata.google.cloud.bigquery.datapolicies.v1.json
@@ -1,7 +1,7 @@
 {
   "clientLibrary": {
     "name": "cloud.google.com/go/bigquery/datapolicies/apiv1",
-    "version": "1.71.0",
+    "version": "1.72.0",
     "language": "GO",
     "apis": [
       {

--- a/internal/generated/snippets/bigquery/datapolicies/apiv1beta1/snippet_metadata.google.cloud.bigquery.datapolicies.v1beta1.json
+++ b/internal/generated/snippets/bigquery/datapolicies/apiv1beta1/snippet_metadata.google.cloud.bigquery.datapolicies.v1beta1.json
@@ -1,7 +1,7 @@
 {
   "clientLibrary": {
     "name": "cloud.google.com/go/bigquery/datapolicies/apiv1beta1",
-    "version": "1.71.0",
+    "version": "1.72.0",
     "language": "GO",
     "apis": [
       {

--- a/internal/generated/snippets/bigquery/datapolicies/apiv2/snippet_metadata.google.cloud.bigquery.datapolicies.v2.json
+++ b/internal/generated/snippets/bigquery/datapolicies/apiv2/snippet_metadata.google.cloud.bigquery.datapolicies.v2.json
@@ -1,7 +1,7 @@
 {
   "clientLibrary": {
     "name": "cloud.google.com/go/bigquery/datapolicies/apiv2",
-    "version": "1.71.0",
+    "version": "1.72.0",
     "language": "GO",
     "apis": [
       {

--- a/internal/generated/snippets/bigquery/datapolicies/apiv2beta1/snippet_metadata.google.cloud.bigquery.datapolicies.v2beta1.json
+++ b/internal/generated/snippets/bigquery/datapolicies/apiv2beta1/snippet_metadata.google.cloud.bigquery.datapolicies.v2beta1.json
@@ -1,7 +1,7 @@
 {
   "clientLibrary": {
     "name": "cloud.google.com/go/bigquery/datapolicies/apiv2beta1",
-    "version": "1.71.0",
+    "version": "1.72.0",
     "language": "GO",
     "apis": [
       {

--- a/internal/generated/snippets/bigquery/datatransfer/apiv1/snippet_metadata.google.cloud.bigquery.datatransfer.v1.json
+++ b/internal/generated/snippets/bigquery/datatransfer/apiv1/snippet_metadata.google.cloud.bigquery.datatransfer.v1.json
@@ -1,7 +1,7 @@
 {
   "clientLibrary": {
     "name": "cloud.google.com/go/bigquery/datatransfer/apiv1",
-    "version": "1.71.0",
+    "version": "1.72.0",
     "language": "GO",
     "apis": [
       {

--- a/internal/generated/snippets/bigquery/migration/apiv2/snippet_metadata.google.cloud.bigquery.migration.v2.json
+++ b/internal/generated/snippets/bigquery/migration/apiv2/snippet_metadata.google.cloud.bigquery.migration.v2.json
@@ -1,7 +1,7 @@
 {
   "clientLibrary": {
     "name": "cloud.google.com/go/bigquery/migration/apiv2",
-    "version": "1.71.0",
+    "version": "1.72.0",
     "language": "GO",
     "apis": [
       {

--- a/internal/generated/snippets/bigquery/migration/apiv2alpha/snippet_metadata.google.cloud.bigquery.migration.v2alpha.json
+++ b/internal/generated/snippets/bigquery/migration/apiv2alpha/snippet_metadata.google.cloud.bigquery.migration.v2alpha.json
@@ -1,7 +1,7 @@
 {
   "clientLibrary": {
     "name": "cloud.google.com/go/bigquery/migration/apiv2alpha",
-    "version": "1.71.0",
+    "version": "1.72.0",
     "language": "GO",
     "apis": [
       {

--- a/internal/generated/snippets/bigquery/reservation/apiv1/snippet_metadata.google.cloud.bigquery.reservation.v1.json
+++ b/internal/generated/snippets/bigquery/reservation/apiv1/snippet_metadata.google.cloud.bigquery.reservation.v1.json
@@ -1,7 +1,7 @@
 {
   "clientLibrary": {
     "name": "cloud.google.com/go/bigquery/reservation/apiv1",
-    "version": "1.71.0",
+    "version": "1.72.0",
     "language": "GO",
     "apis": [
       {

--- a/internal/generated/snippets/bigquery/storage/apiv1/snippet_metadata.google.cloud.bigquery.storage.v1.json
+++ b/internal/generated/snippets/bigquery/storage/apiv1/snippet_metadata.google.cloud.bigquery.storage.v1.json
@@ -1,7 +1,7 @@
 {
   "clientLibrary": {
     "name": "cloud.google.com/go/bigquery/storage/apiv1",
-    "version": "1.71.0",
+    "version": "1.72.0",
     "language": "GO",
     "apis": [
       {

--- a/internal/generated/snippets/bigquery/storage/apiv1alpha/snippet_metadata.google.cloud.bigquery.storage.v1alpha.json
+++ b/internal/generated/snippets/bigquery/storage/apiv1alpha/snippet_metadata.google.cloud.bigquery.storage.v1alpha.json
@@ -1,7 +1,7 @@
 {
   "clientLibrary": {
     "name": "cloud.google.com/go/bigquery/storage/apiv1alpha",
-    "version": "1.71.0",
+    "version": "1.72.0",
     "language": "GO",
     "apis": [
       {

--- a/internal/generated/snippets/bigquery/storage/apiv1beta/snippet_metadata.google.cloud.bigquery.storage.v1beta.json
+++ b/internal/generated/snippets/bigquery/storage/apiv1beta/snippet_metadata.google.cloud.bigquery.storage.v1beta.json
@@ -1,7 +1,7 @@
 {
   "clientLibrary": {
     "name": "cloud.google.com/go/bigquery/storage/apiv1beta",
-    "version": "1.71.0",
+    "version": "1.72.0",
     "language": "GO",
     "apis": [
       {

--- a/internal/generated/snippets/bigquery/storage/apiv1beta1/snippet_metadata.google.cloud.bigquery.storage.v1beta1.json
+++ b/internal/generated/snippets/bigquery/storage/apiv1beta1/snippet_metadata.google.cloud.bigquery.storage.v1beta1.json
@@ -1,7 +1,7 @@
 {
   "clientLibrary": {
     "name": "cloud.google.com/go/bigquery/storage/apiv1beta1",
-    "version": "1.71.0",
+    "version": "1.72.0",
     "language": "GO",
     "apis": [
       {

--- a/internal/generated/snippets/bigquery/storage/apiv1beta2/snippet_metadata.google.cloud.bigquery.storage.v1beta2.json
+++ b/internal/generated/snippets/bigquery/storage/apiv1beta2/snippet_metadata.google.cloud.bigquery.storage.v1beta2.json
@@ -1,7 +1,7 @@
 {
   "clientLibrary": {
     "name": "cloud.google.com/go/bigquery/storage/apiv1beta2",
-    "version": "1.71.0",
+    "version": "1.72.0",
     "language": "GO",
     "apis": [
       {

--- a/internal/generated/snippets/bigquery/v2/apiv2/snippet_metadata.google.cloud.bigquery.v2.json
+++ b/internal/generated/snippets/bigquery/v2/apiv2/snippet_metadata.google.cloud.bigquery.v2.json
@@ -1,7 +1,7 @@
 {
   "clientLibrary": {
     "name": "cloud.google.com/go/bigquery/v2/apiv2",
-    "version": "1.71.0",
+    "version": "$VERSION",
     "language": "GO",
     "apis": [
       {

--- a/internal/generated/snippets/logging/apiv2/snippet_metadata.google.logging.v2.json
+++ b/internal/generated/snippets/logging/apiv2/snippet_metadata.google.logging.v2.json
@@ -1,7 +1,7 @@
 {
   "clientLibrary": {
     "name": "cloud.google.com/go/logging/apiv2",
-    "version": "1.13.0",
+    "version": "1.13.1",
     "language": "GO",
     "apis": [
       {

--- a/internal/generated/snippets/storage/control/apiv2/snippet_metadata.google.storage.control.v2.json
+++ b/internal/generated/snippets/storage/control/apiv2/snippet_metadata.google.storage.control.v2.json
@@ -1,7 +1,7 @@
 {
   "clientLibrary": {
     "name": "cloud.google.com/go/storage/control/apiv2",
-    "version": "1.57.0",
+    "version": "1.57.1",
     "language": "GO",
     "apis": [
       {


### PR DESCRIPTION
This just regenerates all APIs at the API specification they were all at. The changes here are correct: they reflect the actual version that was most recently released. These changes would previously have come from OwlBot in the run after the release-please PR; from now on the metadata will be updated as part of the Librarian release PR.