### PR TITLE
fix: allow a single approval for automated prs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,6 @@
 # Default owner for all directories not owned by others
 
-*                       @googleapis/cloud-sdk-librarian-team # Librarian team access for merging Librarian PRs
-*                       @googleapis/cloud-sdk-go-eng
+*                       @googleapis/cloud-sdk-librarian-team @googleapis/cloud-sdk-go-eng # Librarian team access for merging Librarian PRs
 
 /ai/                    @googleapis/go-vertexai @googleapis/cloud-sdk-go-eng
 /aiplatform/            @googleapis/go-vertexai @googleapis/cloud-sdk-go-eng @googleapis/cloud-sdk-librarian-team


### PR DESCRIPTION
Currently, generate and release PRs require both an approval from someone on the golang team and from the librarian team to approve a PR. This PR fixes that issue.

See https://chat.google.com/room/AAQAYjxNRS8/23-YKMWfr78/OmPRBJT061c?cls=10