### PR TITLE
fix(librariangen): don't run tests from librariangen

### DIFF
--- a/internal/librariangen/build/builder.go
+++ b/internal/librariangen/build/builder.go
@@ -67,9 +67,7 @@ func Build(ctx context.Context, cfg *Config) error {
 	if err := goBuild(ctx, moduleDir, buildReq.ID); err != nil {
 		return fmt.Errorf("librariangen: failed to run 'go build': %w", err)
 	}
-	if err := goTest(ctx, moduleDir, buildReq.ID); err != nil {
-		return fmt.Errorf("librariangen: failed to run 'go test': %w", err)
-	}
+	// TODO(https://github.com/googleapis/google-cloud-go/issues/13335): run unit tests
 	return nil
 }
 
@@ -77,13 +75,6 @@ func Build(ctx context.Context, cfg *Config) error {
 func goBuild(ctx context.Context, dir, module string) error {
 	slog.Info("librariangen: building", "module", module)
 	args := []string{"go", "build", "./..."}
-	return execvRun(ctx, args, dir)
-}
-
-// goTest builds all the code under the specified directory
-func goTest(ctx context.Context, dir, module string) error {
-	slog.Info("librariangen: testing", "module", module)
-	args := []string{"go", "test", "./...", "-short"}
 	return execvRun(ctx, args, dir)
 }
 

--- a/internal/librariangen/build/builder_test.go
+++ b/internal/librariangen/build/builder_test.go
@@ -46,7 +46,7 @@ func TestBuild(t *testing.T) {
 				e.writeRequestFile(t, singleAPIRequest)
 			},
 			wantErr:        false,
-			wantExecvCount: 2,
+			wantExecvCount: 1,
 		},
 		{
 			name:    "missing request file",
@@ -60,15 +60,6 @@ func TestBuild(t *testing.T) {
 			buildErr:       errors.New("build failed"),
 			wantErr:        true,
 			wantExecvCount: 1,
-		},
-		{
-			name: "go test fails",
-			setup: func(e *testEnv, t *testing.T) {
-				e.writeRequestFile(t, singleAPIRequest)
-			},
-			testErr:        errors.New("test failed"),
-			wantErr:        true,
-			wantExecvCount: 2,
 		},
 	}
 
@@ -91,8 +82,6 @@ func TestBuild(t *testing.T) {
 				switch {
 				case slices.Equal(args, []string{"go", "build", "./..."}):
 					return tt.buildErr
-				case slices.Equal(args, []string{"go", "test", "./...", "-short"}):
-					return tt.testErr
 				default:
 					t.Errorf("execv called with unexpected args %v", args)
 					return nil


### PR DESCRIPTION
This will fix automated generation problems for now. There are at least two issues:

- https://github.com/googleapis/librarian/issues/2821 is about go test failing when downloading dependencies. It's possible that running "go mod download" before "go test" fixes that, but it would be good to know more.
- https://github.com/googleapis/google-cloud-go/issues/13335 is about our tests run with `-short` not being as unit-testy as we might want.

Note that we still build the production code, which should protect us against generators creating odd code - and the tests will still run on GitHub PRs as normal.