### PR TITLE
fix(storage): Handle redirect on takeover.

### DIFF
--- a/storage/grpc_writer.go
+++ b/storage/grpc_writer.go
@@ -1229,7 +1229,8 @@ func (s *gRPCAppendTakeoverBidiWriteBufferSender) connect(ctx context.Context, c
 
 		resp, err := stream.Recv()
 		if err != nil {
-			s.streamErr = err
+			// A Recv() error may be a redirect.
+			s.streamErr = s.maybeHandleRedirectionError(err)
 			close(cs.completions)
 			return
 		}


### PR DESCRIPTION
The initial takeover response wasn't being checked for a redirect.

PR #13239 addressed successful responses. This addresses error responses.

See #12785, b/459905219