### PR TITLE
feat: Add grpc.xds.resource_type label to xDS client metrics

### DIFF
--- a/spanner/metrics.go
+++ b/spanner/metrics.go
@@ -68,6 +68,7 @@ const (
 	metricLabelKeyDirectPathUsed        = "directpath_used"
 	metricLabelKeyGRPCLBPickResult      = "grpc.lb.pick_result"
 	metricLabelKeyGRPCLBDataPlaneTarget = "grpc.lb.rls.data_plane_target"
+	metricLabelKeyGRPCXDSResourceType   = "grpc.xds.resource_type"
 
 	// Metric names
 	metricNameOperationLatencies        = "operation_latencies"

--- a/spanner/metrics_monitoring_exporter.go
+++ b/spanner/metrics_monitoring_exporter.go
@@ -66,6 +66,7 @@ var (
 	allowedMetricLabels = map[string]bool{
 		metricLabelKeyGRPCLBPickResult:      true,
 		metricLabelKeyGRPCLBDataPlaneTarget: true,
+		metricLabelKeyGRPCXDSResourceType:   true,
 		metricLabelKeyClientUID:             true,
 		metricLabelKeyClientName:            true,
 		metricLabelKeyDatabase:              true,


### PR DESCRIPTION
This is a quick fix to add  the missing grpc.xds.resource_type label in xds_client metrics (b/451687047).