### PR TITLE
chore: refactor CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -27,7 +27,7 @@
 # We mark the librarian state file as unowned to avoid gatekeeping librarian operations on 
 # a single owner.  This allows multiple teams to interact with librarian operations that cause
 # changes to librarian state.
-/.library/state.yaml
+/.librarian/state.yaml
 
 # Owned by all
 go.work


### PR DESCRIPTION
This PR makes a couple of minor changes to the CODEOWNERS structure
* widens @googleapis/cloud-sdk-librarian-team access to match @googleapis/cloud-sdk-go-eng
* removes the release-please manifest entry
* makes library statefile unowned to reduce friction for librarian operations

Related: internal b/460809672