### PR TITLE
test(spanner): mark DML test as parallel

### DIFF
--- a/spanner/integration_test.go
+++ b/spanner/integration_test.go
@@ -4745,8 +4745,7 @@ func TestIntegration_CommitTimestamp(t *testing.T) {
 }
 
 func TestIntegration_DML(t *testing.T) {
-	//t.Parallel()
-	fmt.Printf("Starting the test")
+	t.Parallel()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()


### PR DESCRIPTION
Mark the DML test as parallel and remove the unnecessary test logging.