### PR TITLE
testing(bigquery): remove header check enforcement for secondary APIs

### DIFF
--- a/bigquery/integration_test.go
+++ b/bigquery/integration_test.go
@@ -206,9 +206,6 @@ func initIntegrationTest() func() {
 			// We can't check universally because option.WithHTTPClient is
 			// incompatible with gRPC options.
 			bqOpts = append(bqOpts, grpcHeadersChecker.CallOptions()...)
-			sOpts = append(sOpts, grpcHeadersChecker.CallOptions()...)
-			ptmOpts = append(ptmOpts, grpcHeadersChecker.CallOptions()...)
-			connOpts = append(connOpts, grpcHeadersChecker.CallOptions()...)
 		}
 		var err error
 		client, err = NewClient(ctx, projID, bqOpts...)


### PR DESCRIPTION
Changes to underlying structure of the dial pattern have complicated testing slightly.  This PR removes header check enforcement from the secondary APIs BQ integration testing uses, as they're not really evaluating the client under test.

Fixes: https://github.com/googleapis/google-cloud-go/issues/13373