### PR TITLE
feat(auth): Implement updated design for regional access boundary

### DIFF
--- a/auth/credentials/detect.go
+++ b/auth/credentials/detect.go
@@ -27,7 +27,7 @@ import (
 	"cloud.google.com/go/auth"
 	"cloud.google.com/go/auth/internal"
 	"cloud.google.com/go/auth/internal/credsfile"
-	"cloud.google.com/go/auth/internal/trustboundary"
+	"cloud.google.com/go/auth/internal/regionalaccessboundary"
 	"cloud.google.com/go/compute/metadata"
 	"github.com/googleapis/gax-go/v2/internallog"
 )
@@ -142,7 +142,7 @@ func DetectDefault(opts *DetectOptions) (*auth.Credentials, error) {
 	if err := opts.validate(); err != nil {
 		return nil, err
 	}
-	trustBoundaryEnabled, err := trustboundary.IsEnabled()
+	trustBoundaryEnabled, err := regionalaccessboundary.IsEnabled()
 	if err != nil {
 		return nil, err
 	}
@@ -176,11 +176,11 @@ func DetectDefault(opts *DetectOptions) (*auth.Credentials, error) {
 
 		tp := computeTokenProvider(opts, metadataClient)
 		if trustBoundaryEnabled {
-			gceConfigProvider := trustboundary.NewGCEConfigProvider(gceUniverseDomainProvider)
+			gceConfigProvider := regionalaccessboundary.NewGCEConfigProvider(gceUniverseDomainProvider)
 			var err error
-			tp, err = trustboundary.NewProvider(opts.client(), gceConfigProvider, opts.logger(), tp)
+			tp, err = regionalaccessboundary.NewProvider(opts.client(), gceConfigProvider, opts.logger(), tp)
 			if err != nil {
-				return nil, fmt.Errorf("credentials: failed to initialize GCE trust boundary provider: %w", err)
+				return nil, fmt.Errorf("credentials: failed to initialize GCE Regional Access Boundary provider: %w", err)
 			}
 
 		}

--- a/auth/credentials/detect.go
+++ b/auth/credentials/detect.go
@@ -142,7 +142,7 @@ func DetectDefault(opts *DetectOptions) (*auth.Credentials, error) {
 	if err := opts.validate(); err != nil {
 		return nil, err
 	}
-	trustBoundaryEnabled, err := regionalaccessboundary.IsEnabled()
+	regionalAccessBoundaryEnabled, err := regionalaccessboundary.IsEnabled()
 	if err != nil {
 		return nil, err
 	}
@@ -175,7 +175,7 @@ func DetectDefault(opts *DetectOptions) (*auth.Credentials, error) {
 		}
 
 		tp := computeTokenProvider(opts, metadataClient)
-		if trustBoundaryEnabled {
+		if regionalAccessBoundaryEnabled {
 			gceConfigProvider := regionalaccessboundary.NewGCEConfigProvider(gceUniverseDomainProvider)
 			var err error
 			tp, err = regionalaccessboundary.NewProvider(opts.client(), gceConfigProvider, opts.logger(), tp)

--- a/auth/credentials/filetypes.go
+++ b/auth/credentials/filetypes.go
@@ -25,7 +25,7 @@ import (
 	"cloud.google.com/go/auth/credentials/internal/impersonate"
 	internalauth "cloud.google.com/go/auth/internal"
 	"cloud.google.com/go/auth/internal/credsfile"
-	"cloud.google.com/go/auth/internal/trustboundary"
+	"cloud.google.com/go/auth/internal/regionalaccessboundary"
 )
 
 const cloudPlatformScope = "https://www.googleapis.com/auth/cloud-platform"
@@ -159,15 +159,15 @@ func handleServiceAccount(f *credsfile.ServiceAccountFile, opts *DetectOptions) 
 		return nil, err
 	}
 
-	trustBoundaryEnabled, err := trustboundary.IsEnabled()
+	regionalAccessBoundaryEnabled, err := regionalaccessboundary.IsEnabled()
 	if err != nil {
 		return nil, err
 	}
-	if !trustBoundaryEnabled {
+	if !regionalAccessBoundaryEnabled {
 		return tp, nil
 	}
-	saConfig := trustboundary.NewServiceAccountConfigProvider(opts2LO.Email, opts2LO.UniverseDomain)
-	return trustboundary.NewProvider(opts.client(), saConfig, opts.logger(), tp)
+	saConfig := regionalaccessboundary.NewServiceAccountConfigProvider(opts2LO.Email, opts2LO.UniverseDomain)
+	return regionalaccessboundary.NewProvider(opts.client(), saConfig, opts.logger(), tp)
 }
 
 func handleUserCredential(f *credsfile.UserCredentialsFile, opts *DetectOptions) (auth.TokenProvider, error) {
@@ -210,35 +210,35 @@ func handleExternalAccount(f *credsfile.ExternalAccountFile, opts *DetectOptions
 	if err != nil {
 		return nil, err
 	}
-	trustBoundaryEnabled, err := trustboundary.IsEnabled()
+	regionalAccessBoundaryEnabled, err := regionalaccessboundary.IsEnabled()
 	if err != nil {
 		return nil, err
 	}
-	if !trustBoundaryEnabled {
+	if !regionalAccessBoundaryEnabled {
 		return tp, nil
 	}
 
 	ud := resolveUniverseDomain(opts.UniverseDomain, f.UniverseDomain)
-	var configProvider trustboundary.ConfigProvider
+	var configProvider regionalaccessboundary.ConfigProvider
 
 	if f.ServiceAccountImpersonationURL == "" {
 		// No impersonation, this is a direct external account credential.
-		// The trust boundary is based on the workload/workforce pool.
+		// The Regional Access Boundary is based on the workload/workforce pool.
 		var err error
-		configProvider, err = trustboundary.NewExternalAccountConfigProvider(f.Audience, ud)
+		configProvider, err = regionalaccessboundary.NewExternalAccountConfigProvider(f.Audience, ud)
 		if err != nil {
 			return nil, err
 		}
 	} else {
-		// Impersonation is used. The trust boundary is based on the target service account.
+		// Impersonation is used. The Regional Access Boundary is based on the target service account.
 		targetSAEmail, err := impersonate.ExtractServiceAccountEmail(f.ServiceAccountImpersonationURL)
 		if err != nil {
-			return nil, fmt.Errorf("credentials: could not extract target service account email for trust boundary: %w", err)
+			return nil, fmt.Errorf("credentials: could not extract target service account email for Regional Access Boundary: %w", err)
 		}
-		configProvider = trustboundary.NewServiceAccountConfigProvider(targetSAEmail, ud)
+		configProvider = regionalaccessboundary.NewServiceAccountConfigProvider(targetSAEmail, ud)
 	}
 
-	return trustboundary.NewProvider(opts.client(), configProvider, opts.logger(), tp)
+	return regionalaccessboundary.NewProvider(opts.client(), configProvider, opts.logger(), tp)
 }
 
 func handleExternalAccountAuthorizedUser(f *credsfile.ExternalAccountAuthorizedUserFile, opts *DetectOptions) (auth.TokenProvider, error) {
@@ -257,20 +257,20 @@ func handleExternalAccountAuthorizedUser(f *credsfile.ExternalAccountAuthorizedU
 	if err != nil {
 		return nil, err
 	}
-	trustBoundaryEnabled, err := trustboundary.IsEnabled()
+	regionalAccessBoundaryEnabled, err := regionalaccessboundary.IsEnabled()
 	if err != nil {
 		return nil, err
 	}
-	if !trustBoundaryEnabled {
+	if !regionalAccessBoundaryEnabled {
 		return tp, nil
 	}
 
 	ud := resolveUniverseDomain(opts.UniverseDomain, f.UniverseDomain)
-	configProvider, err := trustboundary.NewExternalAccountConfigProvider(f.Audience, ud)
+	configProvider, err := regionalaccessboundary.NewExternalAccountConfigProvider(f.Audience, ud)
 	if err != nil {
 		return nil, err
 	}
-	return trustboundary.NewProvider(opts.client(), configProvider, opts.logger(), tp)
+	return regionalaccessboundary.NewProvider(opts.client(), configProvider, opts.logger(), tp)
 }
 
 func handleImpersonatedServiceAccount(f *credsfile.ImpersonatedServiceAccountFile, opts *DetectOptions) (auth.TokenProvider, error) {
@@ -306,19 +306,19 @@ func handleImpersonatedServiceAccount(f *credsfile.ImpersonatedServiceAccountFil
 	if err != nil {
 		return nil, err
 	}
-	trustBoundaryEnabled, err := trustboundary.IsEnabled()
+	regionalAccessBoundaryEnabled, err := regionalaccessboundary.IsEnabled()
 	if err != nil {
 		return nil, err
 	}
-	if !trustBoundaryEnabled {
+	if !regionalAccessBoundaryEnabled {
 		return tp, nil
 	}
 	targetSAEmail, err := impersonate.ExtractServiceAccountEmail(f.ServiceAccountImpersonationURL)
 	if err != nil {
-		return nil, fmt.Errorf("credentials: could not extract target service account email for trust boundary: %w", err)
+		return nil, fmt.Errorf("credentials: could not extract target service account email for Regional Access Boundary: %w", err)
 	}
-	targetSAConfig := trustboundary.NewServiceAccountConfigProvider(targetSAEmail, ud)
-	return trustboundary.NewProvider(opts.client(), targetSAConfig, opts.logger(), tp)
+	targetSAConfig := regionalaccessboundary.NewServiceAccountConfigProvider(targetSAEmail, ud)
+	return regionalaccessboundary.NewProvider(opts.client(), targetSAConfig, opts.logger(), tp)
 }
 func handleGDCHServiceAccount(f *credsfile.GDCHServiceAccountFile, opts *DetectOptions) (auth.TokenProvider, error) {
 	return gdch.NewTokenProvider(f, &gdch.Options{

--- a/auth/grpctransport/directpath.go
+++ b/auth/grpctransport/directpath.go
@@ -120,7 +120,7 @@ func configureDirectPath(grpcOpts []grpc.DialOption, opts *Options, endpoint str
 	})
 	if isDirectPathEnabled(endpoint, opts) && compute.OnComputeEngine() && isTokenProviderDirectPathCompatible(creds, opts) {
 		// Overwrite all of the previously specific DialOptions, DirectPath uses its own set of credentials and certificates.
-		defaultCredetialsOptions := grpcgoogle.DefaultCredentialsOptions{PerRPCCreds: &grpcCredentialsProvider{creds: creds}}
+		defaultCredetialsOptions := grpcgoogle.DefaultCredentialsOptions{PerRPCCreds: &grpcCredentialsProvider{creds: creds, endpoint: endpoint}}
 		if isDirectPathBoundTokenEnabled(opts.InternalOptions) && isTokenProviderComputeEngine(creds) {
 			optsClone := opts.resolveDetectOptions()
 			optsClone.TokenBindingType = credentials.ALTSHardBinding
@@ -128,7 +128,7 @@ func configureDirectPath(grpcOpts []grpc.DialOption, opts *Options, endpoint str
 			if err != nil {
 				return nil, "", err
 			}
-			defaultCredetialsOptions.ALTSPerRPCCreds = &grpcCredentialsProvider{creds: altsCreds}
+			defaultCredetialsOptions.ALTSPerRPCCreds = &grpcCredentialsProvider{creds: altsCreds, endpoint: endpoint}
 		}
 		grpcOpts = []grpc.DialOption{
 			grpc.WithCredentialsBundle(grpcgoogle.NewDefaultCredentialsWithOptions(defaultCredetialsOptions))}

--- a/auth/grpctransport/grpctransport.go
+++ b/auth/grpctransport/grpctransport.go
@@ -415,7 +415,11 @@ func (c *grpcCredentialsProvider) GetRequestMetadata(ctx context.Context, uri ..
 		}
 	}
 	metadata := make(map[string]string, len(c.metadata)+1)
-	headers.SetAuthMetadata(token, metadata)
+	var reqURL string
+	if len(uri) > 0 {
+		reqURL = uri[0]
+	}
+	headers.SetAuthMetadata(token, reqURL, metadata)
 	for k, v := range c.metadata {
 		metadata[k] = v
 	}

--- a/auth/grpctransport/grpctransport.go
+++ b/auth/grpctransport/grpctransport.go
@@ -417,7 +417,7 @@ func (c *grpcCredentialsProvider) GetRequestMetadata(ctx context.Context, uri ..
 		}
 	}
 	metadata := make(map[string]string, len(c.metadata)+1)
-	headers.SetAuthMetadata(token, c.endpoint, metadata)
+	headers.SetAuthMetadata(ctx, token, c.endpoint, metadata)
 	for k, v := range c.metadata {
 		metadata[k] = v
 	}

--- a/auth/grpctransport/grpctransport.go
+++ b/auth/grpctransport/grpctransport.go
@@ -326,6 +326,7 @@ func dial(ctx context.Context, secure bool, opts *Options) (*grpc.ClientConn, er
 				creds:                creds,
 				metadata:             metadata,
 				clientUniverseDomain: opts.UniverseDomain,
+				endpoint:             transportCreds.Endpoint,
 			}),
 		)
 		// Attempt Direct Path
@@ -373,6 +374,7 @@ type grpcCredentialsProvider struct {
 	// Additional metadata attached as headers.
 	metadata             map[string]string
 	clientUniverseDomain string
+	endpoint             string
 }
 
 // getClientUniverseDomain returns the default service domain for a given Cloud
@@ -415,11 +417,7 @@ func (c *grpcCredentialsProvider) GetRequestMetadata(ctx context.Context, uri ..
 		}
 	}
 	metadata := make(map[string]string, len(c.metadata)+1)
-	var reqURL string
-	if len(uri) > 0 {
-		reqURL = uri[0]
-	}
-	headers.SetAuthMetadata(token, reqURL, metadata)
+	headers.SetAuthMetadata(token, c.endpoint, metadata)
 	for k, v := range c.metadata {
 		metadata[k] = v
 	}

--- a/auth/grpctransport/grpctransport_test.go
+++ b/auth/grpctransport/grpctransport_test.go
@@ -350,6 +350,47 @@ func TestGrpcCredentialsProvider_TokenType(t *testing.T) {
 	}
 }
 
+type mockRABProvider struct {
+	gotCtx context.Context
+}
+
+func (m *mockRABProvider) GetHeaderValue(ctx context.Context, reqURL string, token *auth.Token) string {
+	m.gotCtx = ctx
+	return ""
+}
+
+func TestGrpcCredentialsProvider_GetRequestMetadata_Context(t *testing.T) {
+	type testKeyType struct{}
+	var testKey testKeyType
+	testCtx := context.WithValue(context.Background(), testKey, "testVal")
+
+	rabProvider := &mockRABProvider{}
+	cp := grpcCredentialsProvider{
+		creds: &auth.Credentials{
+			TokenProvider: &staticTP{
+				tok: &auth.Token{
+					Value: "token",
+					Metadata: map[string]interface{}{
+						"regionalaccessboundary.ProviderKey": rabProvider,
+					},
+				},
+			},
+		},
+	}
+
+	_, err := cp.GetRequestMetadata(testCtx, "")
+	if err != nil {
+		t.Fatalf("cp.GetRequestMetadata() unexpected error: %v", err)
+	}
+
+	if rabProvider.gotCtx == nil {
+		t.Fatal("GetRequestMetadata did not pass context to RAB provider")
+	}
+	if v := rabProvider.gotCtx.Value(testKey); v != "testVal" {
+		t.Errorf("GetRequestMetadata did not pass context to RAB provider, got value %v", v)
+	}
+}
+
 func TestNewClient_DetectedServiceAccount(t *testing.T) {
 	testQuota := "testquota"
 	wantHeader := "bar"

--- a/auth/internal/internal.go
+++ b/auth/internal/internal.go
@@ -48,8 +48,8 @@ const (
 	// Universe domain is the default service domain for a given Cloud universe.
 	DefaultUniverseDomain = "googleapis.com"
 
-	// TrustBoundaryDataKey is the key used to store trust boundary data in a token's metadata.
-	TrustBoundaryDataKey = "google.auth.trust_boundary_data"
+	// RegionalAccessBoundaryDataKey is the key used to store regional access boundary data in a token's metadata.
+	RegionalAccessBoundaryDataKey = "google.auth.regional_access_boundary_data"
 )
 
 type clonableTransport interface {
@@ -228,24 +228,24 @@ func FormatIAMServiceAccountResource(name string) string {
 	return fmt.Sprintf("projects/-/serviceAccounts/%s", name)
 }
 
-// TrustBoundaryData represents the trust boundary data associated with a token.
+// RegionalAccessBoundaryData represents the regional access boundary data associated with a token.
 // It contains information about the regions or environments where the token is valid.
-type TrustBoundaryData struct {
+type RegionalAccessBoundaryData struct {
 	// Locations is the list of locations that the token is allowed to be used in.
 	Locations []string
 	// EncodedLocations represents the locations in an encoded format.
 	EncodedLocations string
 }
 
-// NewTrustBoundaryData returns a new TrustBoundaryData with the specified locations and encoded locations.
-func NewTrustBoundaryData(locations []string, encodedLocations string) *TrustBoundaryData {
+// NewRegionalAccessBoundaryData returns a new RegionalAccessBoundaryData with the specified locations and encoded locations.
+func NewRegionalAccessBoundaryData(locations []string, encodedLocations string) *RegionalAccessBoundaryData {
 	// Ensure consistency by treating a nil slice as an empty slice.
 	if locations == nil {
 		locations = []string{}
 	}
 	locationsCopy := make([]string, len(locations))
 	copy(locationsCopy, locations)
-	return &TrustBoundaryData{
+	return &RegionalAccessBoundaryData{
 		Locations:        locationsCopy,
 		EncodedLocations: encodedLocations,
 	}
@@ -254,7 +254,7 @@ func NewTrustBoundaryData(locations []string, encodedLocations string) *TrustBou
 // TrustBoundaryHeader returns the value for the x-allowed-locations header and a bool
 // indicating if the header should be set. If EncodedLocations is empty, the header
 // should not be present. Otherwise, it should be present with the value of EncodedLocations.
-func (t TrustBoundaryData) TrustBoundaryHeader() (value string, present bool) {
+func (t RegionalAccessBoundaryData) RegionalAccessBoundaryHeader() (value string, present bool) {
 	if t.EncodedLocations == "" {
 		return "", false
 	}

--- a/auth/internal/internal.go
+++ b/auth/internal/internal.go
@@ -48,9 +48,6 @@ const (
 	// Universe domain is the default service domain for a given Cloud universe.
 	DefaultUniverseDomain = "googleapis.com"
 
-	// TrustBoundaryNoOp is a constant indicating no trust boundary is enforced.
-	TrustBoundaryNoOp = "0x0"
-
 	// TrustBoundaryDataKey is the key used to store trust boundary data in a token's metadata.
 	TrustBoundaryDataKey = "google.auth.trust_boundary_data"
 )
@@ -254,32 +251,12 @@ func NewTrustBoundaryData(locations []string, encodedLocations string) *TrustBou
 	}
 }
 
-// NewNoOpTrustBoundaryData returns a new TrustBoundaryData with no restrictions.
-func NewNoOpTrustBoundaryData() *TrustBoundaryData {
-	return &TrustBoundaryData{
-		Locations:        []string{},
-		EncodedLocations: TrustBoundaryNoOp,
-	}
-}
-
 // TrustBoundaryHeader returns the value for the x-allowed-locations header and a bool
-// indicating if the header should be set. The return values are structured to
-// handle three distinct states required by the backend:
-// 1. Header not set: (value="", present=false) -> data is empty.
-// 2. Header set to an empty string: (value="", present=true) -> data is a no-op.
-// 3. Header set to a value: (value="...", present=true) -> data has locations.
+// indicating if the header should be set. If EncodedLocations is empty, the header
+// should not be present. Otherwise, it should be present with the value of EncodedLocations.
 func (t TrustBoundaryData) TrustBoundaryHeader() (value string, present bool) {
 	if t.EncodedLocations == "" {
-		// If the data is empty, the header should not be present.
 		return "", false
 	}
-
-	// If data is not empty, the header should always be present.
-	present = true
-	value = ""
-	if t.EncodedLocations != TrustBoundaryNoOp {
-		value = t.EncodedLocations
-	}
-	// For a no-op, the backend requires an empty string.
-	return value, present
+	return t.EncodedLocations, true
 }

--- a/auth/internal/internal.go
+++ b/auth/internal/internal.go
@@ -251,7 +251,7 @@ func NewRegionalAccessBoundaryData(locations []string, encodedLocations string) 
 	}
 }
 
-// TrustBoundaryHeader returns the value for the x-allowed-locations header and a bool
+// RegionalAccessBoundaryHeader returns the value for the x-allowed-locations header and a bool
 // indicating if the header should be set. If EncodedLocations is empty, the header
 // should not be present. Otherwise, it should be present with the value of EncodedLocations.
 func (t RegionalAccessBoundaryData) RegionalAccessBoundaryHeader() (value string, present bool) {

--- a/auth/internal/internal_test.go
+++ b/auth/internal/internal_test.go
@@ -136,25 +136,18 @@ func TestNewTrustBoundaryData(t *testing.T) {
 			wantEncoded:      "0xABC123",
 		},
 		{
-			name:             "Empty locations, not no-op encoded",
+			name:             "Empty locations, with encoded locations",
 			locations:        []string{},
 			encodedLocations: "0xDEF456",
 			wantLocations:    []string{},
 			wantEncoded:      "0xDEF456",
 		},
 		{
-			name:             "Nil locations, not no-op encoded",
+			name:             "Nil locations, with encoded locations",
 			locations:        nil,
 			encodedLocations: "0xGHI789",
 			wantLocations:    []string{}, // Expect empty slice, not nil
 			wantEncoded:      "0xGHI789",
-		},
-		{
-			name:             "No-op encoded locations",
-			locations:        []string{"us-east1"},
-			encodedLocations: TrustBoundaryNoOp,
-			wantLocations:    []string{"us-east1"},
-			wantEncoded:      TrustBoundaryNoOp,
 		},
 		{
 			name:             "Empty string encoded locations",
@@ -181,18 +174,6 @@ func TestNewTrustBoundaryData(t *testing.T) {
 	}
 }
 
-func TestNewNoOpTrustBoundaryData(t *testing.T) {
-	data := NewNoOpTrustBoundaryData()
-
-	if data == nil {
-		t.Fatal("NewNoOpTrustBoundaryData() returned nil")
-	}
-
-	if got := data.EncodedLocations; got != TrustBoundaryNoOp {
-		t.Errorf("NewNoOpTrustBoundaryData().EncodedLocations = %q, want %q", got, TrustBoundaryNoOp)
-	}
-}
-
 func TestTrustBoundaryHeader(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -205,12 +186,6 @@ func TestTrustBoundaryHeader(t *testing.T) {
 			tbd:         TrustBoundaryData{},
 			wantValue:   "",
 			wantPresent: false,
-		},
-		{
-			name:        "no-op data",
-			tbd:         *NewNoOpTrustBoundaryData(),
-			wantValue:   "",
-			wantPresent: true,
 		},
 		{
 			name:        "regular data",

--- a/auth/internal/internal_test.go
+++ b/auth/internal/internal_test.go
@@ -120,7 +120,7 @@ func TestDefaultClient(t *testing.T) {
 	}
 }
 
-func TestNewTrustBoundaryData(t *testing.T) {
+func TestNewRegionalAccessBoundaryData(t *testing.T) {
 	tests := []struct {
 		name             string
 		locations        []string
@@ -160,48 +160,48 @@ func TestNewTrustBoundaryData(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			data := NewTrustBoundaryData(tt.locations, tt.encodedLocations)
+			data := NewRegionalAccessBoundaryData(tt.locations, tt.encodedLocations)
 
 			if got := data.EncodedLocations; got != tt.wantEncoded {
-				t.Errorf("NewTrustBoundaryData().EncodedLocations = %q, want %q", got, tt.wantEncoded)
+				t.Errorf("NewRegionalAccessBoundaryData().EncodedLocations = %q, want %q", got, tt.wantEncoded)
 			}
 
 			gotLocations := data.Locations
 			if !reflect.DeepEqual(gotLocations, tt.wantLocations) {
-				t.Errorf("NewTrustBoundaryData().Locations = %v, want %v", gotLocations, tt.wantLocations)
+				t.Errorf("NewRegionalAccessBoundaryData().Locations = %v, want %v", gotLocations, tt.wantLocations)
 			}
 		})
 	}
 }
 
-func TestTrustBoundaryHeader(t *testing.T) {
+func TestRegionalAccessBoundaryHeader(t *testing.T) {
 	tests := []struct {
 		name        string
-		tbd         TrustBoundaryData
+		tbd         RegionalAccessBoundaryData
 		wantValue   string
 		wantPresent bool
 	}{
 		{
 			name:        "empty data",
-			tbd:         TrustBoundaryData{},
+			tbd:         RegionalAccessBoundaryData{},
 			wantValue:   "",
 			wantPresent: false,
 		},
 		{
 			name:        "regular data",
-			tbd:         *NewTrustBoundaryData(nil, "some-encoded-locations"),
+			tbd:         *NewRegionalAccessBoundaryData(nil, "some-encoded-locations"),
 			wantValue:   "some-encoded-locations",
 			wantPresent: true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotValue, gotPresent := tt.tbd.TrustBoundaryHeader()
+			gotValue, gotPresent := tt.tbd.RegionalAccessBoundaryHeader()
 			if gotValue != tt.wantValue {
-				t.Errorf("TrustBoundaryHeader() gotValue = %v, want %v", gotValue, tt.wantValue)
+				t.Errorf("RegionalAccessBoundaryHeader() gotValue = %v, want %v", gotValue, tt.wantValue)
 			}
 			if gotPresent != tt.wantPresent {
-				t.Errorf("TrustBoundaryHeader() gotPresent = %v, want %v", gotPresent, tt.wantPresent)
+				t.Errorf("RegionalAccessBoundaryHeader() gotPresent = %v, want %v", gotPresent, tt.wantPresent)
 			}
 		})
 	}

--- a/auth/internal/regionalaccessboundary/external_accounts_config_providers.go
+++ b/auth/internal/regionalaccessboundary/external_accounts_config_providers.go
@@ -21,8 +21,8 @@ import (
 )
 
 const (
-	workloadAllowedLocationsEndpoint  = "https://iamcredentials.%s/v1/projects/%s/locations/global/workloadIdentityPools/%s/allowedLocations"
-	workforceAllowedLocationsEndpoint = "https://iamcredentials.%s/v1/locations/global/workforcePools/%s/allowedLocations"
+	workloadAllowedLocationsEndpoint  = "https://iamcredentials.googleapis.com/v1/projects/%s/locations/global/workloadIdentityPools/%s/allowedLocations"
+	workforceAllowedLocationsEndpoint = "https://iamcredentials.googleapis.com/v1/locations/global/workforcePools/%s/allowedLocations"
 )
 
 var (
@@ -78,7 +78,7 @@ type workforcePoolConfigProvider struct {
 }
 
 func (p *workforcePoolConfigProvider) GetRegionalAccessBoundaryEndpoint(ctx context.Context) (string, error) {
-	return fmt.Sprintf(workforceAllowedLocationsEndpoint, p.universeDomain, p.poolID), nil
+	return fmt.Sprintf(workforceAllowedLocationsEndpoint, p.poolID), nil
 }
 
 func (p *workforcePoolConfigProvider) GetUniverseDomain(ctx context.Context) (string, error) {
@@ -92,7 +92,7 @@ type workloadIdentityPoolConfigProvider struct {
 }
 
 func (p *workloadIdentityPoolConfigProvider) GetRegionalAccessBoundaryEndpoint(ctx context.Context) (string, error) {
-	return fmt.Sprintf(workloadAllowedLocationsEndpoint, p.universeDomain, p.projectNumber, p.poolID), nil
+	return fmt.Sprintf(workloadAllowedLocationsEndpoint, p.projectNumber, p.poolID), nil
 }
 
 func (p *workloadIdentityPoolConfigProvider) GetUniverseDomain(ctx context.Context) (string, error) {

--- a/auth/internal/regionalaccessboundary/external_accounts_config_providers.go
+++ b/auth/internal/regionalaccessboundary/external_accounts_config_providers.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package trustboundary
+package regionalaccessboundary
 
 import (
 	"context"
@@ -48,7 +48,7 @@ func NewExternalAccountConfigProvider(audience, inputUniverseDomain string) (Con
 			poolID = matches[2]
 			isWorkload = false
 		} else {
-			return nil, fmt.Errorf("trustboundary: unknown audience format: %q", audience)
+			return nil, fmt.Errorf("regionalaccessboundary: unknown audience format: %q", audience)
 		}
 	}
 
@@ -56,7 +56,7 @@ func NewExternalAccountConfigProvider(audience, inputUniverseDomain string) (Con
 	if effectiveUniverseDomain == "" {
 		effectiveUniverseDomain = audienceDomain
 	} else if audienceDomain != "" && effectiveUniverseDomain != audienceDomain {
-		return nil, fmt.Errorf("trustboundary: provided universe domain (%q) does not match domain in audience (%q)", inputUniverseDomain, audienceDomain)
+		return nil, fmt.Errorf("regionalaccessboundary: provided universe domain (%q) does not match domain in audience (%q)", inputUniverseDomain, audienceDomain)
 	}
 
 	if isWorkload {
@@ -77,7 +77,7 @@ type workforcePoolConfigProvider struct {
 	universeDomain string
 }
 
-func (p *workforcePoolConfigProvider) GetTrustBoundaryEndpoint(ctx context.Context) (string, error) {
+func (p *workforcePoolConfigProvider) GetRegionalAccessBoundaryEndpoint(ctx context.Context) (string, error) {
 	return fmt.Sprintf(workforceAllowedLocationsEndpoint, p.universeDomain, p.poolID), nil
 }
 
@@ -91,7 +91,7 @@ type workloadIdentityPoolConfigProvider struct {
 	universeDomain string
 }
 
-func (p *workloadIdentityPoolConfigProvider) GetTrustBoundaryEndpoint(ctx context.Context) (string, error) {
+func (p *workloadIdentityPoolConfigProvider) GetRegionalAccessBoundaryEndpoint(ctx context.Context) (string, error) {
 	return fmt.Sprintf(workloadAllowedLocationsEndpoint, p.universeDomain, p.projectNumber, p.poolID), nil
 }
 

--- a/auth/internal/regionalaccessboundary/external_accounts_config_providers.go
+++ b/auth/internal/regionalaccessboundary/external_accounts_config_providers.go
@@ -26,8 +26,8 @@ const (
 )
 
 var (
-	workforceAudiencePattern = regexp.MustCompile(`^//iam\.([^/]+)/locations/global/workforcePools/([^/]+)$`)
-	workloadAudiencePattern  = regexp.MustCompile(`^//iam\.([^/]+)/projects/([^/]+)/locations/global/workloadIdentityPools/([^/]+)$`)
+	workforceAudiencePattern = regexp.MustCompile(`^//iam\.([^/]+)/locations/([^/]+)/workforcePools/([^/]+)/providers/[^/]+$`)
+	workloadAudiencePattern  = regexp.MustCompile(`^//iam\.([^/]+)/projects/([^/]+)/locations/([^/]+)/workloadIdentityPools/([^/]+)/providers/[^/]+$`)
 )
 
 // NewExternalAccountConfigProvider creates a new ConfigProvider for external accounts.
@@ -36,16 +36,16 @@ func NewExternalAccountConfigProvider(audience, inputUniverseDomain string) (Con
 	var isWorkload bool
 
 	matches := workloadAudiencePattern.FindStringSubmatch(audience)
-	if len(matches) == 4 { // Expecting full match, domain, projectNumber, poolID
+	if len(matches) == 5 { // Expecting full match, domain, projectNumber, location, poolID
 		audienceDomain = matches[1]
 		projectNumber = matches[2]
-		poolID = matches[3]
+		poolID = matches[4]
 		isWorkload = true
 	} else {
 		matches = workforceAudiencePattern.FindStringSubmatch(audience)
-		if len(matches) == 3 { // Expecting full match, domain, poolID
+		if len(matches) == 4 { // Expecting full match, domain, location, poolID
 			audienceDomain = matches[1]
-			poolID = matches[2]
+			poolID = matches[3]
 			isWorkload = false
 		} else {
 			return nil, fmt.Errorf("regionalaccessboundary: unknown audience format: %q", audience)

--- a/auth/internal/regionalaccessboundary/external_accounts_config_providers.go
+++ b/auth/internal/regionalaccessboundary/external_accounts_config_providers.go
@@ -26,8 +26,8 @@ const (
 )
 
 var (
-	workforceAudiencePattern = regexp.MustCompile(`//iam\.([^/]+)/locations/global/workforcePools/([^/]+)`)
-	workloadAudiencePattern  = regexp.MustCompile(`//iam\.([^/]+)/projects/([^/]+)/locations/global/workloadIdentityPools/([^/]+)`)
+	workforceAudiencePattern = regexp.MustCompile(`^//iam\.([^/]+)/locations/global/workforcePools/([^/]+)$`)
+	workloadAudiencePattern  = regexp.MustCompile(`^//iam\.([^/]+)/projects/([^/]+)/locations/global/workloadIdentityPools/([^/]+)$`)
 )
 
 // NewExternalAccountConfigProvider creates a new ConfigProvider for external accounts.

--- a/auth/internal/regionalaccessboundary/external_accounts_config_providers_test.go
+++ b/auth/internal/regionalaccessboundary/external_accounts_config_providers_test.go
@@ -142,7 +142,7 @@ func TestWorkloadIdentityPoolConfigProvider(t *testing.T) {
 	})
 
 	t.Run("GetRegionalAccessBoundaryEndpoint", func(t *testing.T) {
-		want := "https://iamcredentials.example.com/v1/projects/12345/locations/global/workloadIdentityPools/my-pool/allowedLocations"
+		want := "https://iamcredentials.googleapis.com/v1/projects/12345/locations/global/workloadIdentityPools/my-pool/allowedLocations"
 		endpoint, err := p.GetRegionalAccessBoundaryEndpoint(ctx)
 		if err != nil {
 			t.Fatalf("GetRegionalAccessBoundaryEndpoint() unexpected error: %v", err)
@@ -171,7 +171,7 @@ func TestWorkforcePoolConfigProvider(t *testing.T) {
 	})
 
 	t.Run("GetRegionalAccessBoundaryEndpoint", func(t *testing.T) {
-		want := "https://iamcredentials.example.com/v1/locations/global/workforcePools/my-pool/allowedLocations"
+		want := "https://iamcredentials.googleapis.com/v1/locations/global/workforcePools/my-pool/allowedLocations"
 		endpoint, err := p.GetRegionalAccessBoundaryEndpoint(ctx)
 		if err != nil {
 			t.Fatalf("GetRegionalAccessBoundaryEndpoint() unexpected error: %v", err)

--- a/auth/internal/regionalaccessboundary/external_accounts_config_providers_test.go
+++ b/auth/internal/regionalaccessboundary/external_accounts_config_providers_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package trustboundary
+package regionalaccessboundary
 
 import (
 	"context"
@@ -141,14 +141,14 @@ func TestWorkloadIdentityPoolConfigProvider(t *testing.T) {
 		}
 	})
 
-	t.Run("GetTrustBoundaryEndpoint", func(t *testing.T) {
+	t.Run("GetRegionalAccessBoundaryEndpoint", func(t *testing.T) {
 		want := "https://iamcredentials.example.com/v1/projects/12345/locations/global/workloadIdentityPools/my-pool/allowedLocations"
-		endpoint, err := p.GetTrustBoundaryEndpoint(ctx)
+		endpoint, err := p.GetRegionalAccessBoundaryEndpoint(ctx)
 		if err != nil {
-			t.Fatalf("GetTrustBoundaryEndpoint() unexpected error: %v", err)
+			t.Fatalf("GetRegionalAccessBoundaryEndpoint() unexpected error: %v", err)
 		}
 		if endpoint != want {
-			t.Errorf("GetTrustBoundaryEndpoint() = %q, want %q", endpoint, want)
+			t.Errorf("GetRegionalAccessBoundaryEndpoint() = %q, want %q", endpoint, want)
 		}
 	})
 }
@@ -170,14 +170,14 @@ func TestWorkforcePoolConfigProvider(t *testing.T) {
 		}
 	})
 
-	t.Run("GetTrustBoundaryEndpoint", func(t *testing.T) {
+	t.Run("GetRegionalAccessBoundaryEndpoint", func(t *testing.T) {
 		want := "https://iamcredentials.example.com/v1/locations/global/workforcePools/my-pool/allowedLocations"
-		endpoint, err := p.GetTrustBoundaryEndpoint(ctx)
+		endpoint, err := p.GetRegionalAccessBoundaryEndpoint(ctx)
 		if err != nil {
-			t.Fatalf("GetTrustBoundaryEndpoint() unexpected error: %v", err)
+			t.Fatalf("GetRegionalAccessBoundaryEndpoint() unexpected error: %v", err)
 		}
 		if endpoint != want {
-			t.Errorf("GetTrustBoundaryEndpoint() = %q, want %q", endpoint, want)
+			t.Errorf("GetRegionalAccessBoundaryEndpoint() = %q, want %q", endpoint, want)
 		}
 	})
 }

--- a/auth/internal/regionalaccessboundary/external_accounts_config_providers_test.go
+++ b/auth/internal/regionalaccessboundary/external_accounts_config_providers_test.go
@@ -30,7 +30,7 @@ func TestNewExternalAccountConfigProvider(t *testing.T) {
 	}{
 		{
 			name:           "workload identity pool with matching explicit universe domain",
-			audience:       "//iam.googleapis.com/projects/12345/locations/global/workloadIdentityPools/my-pool",
+			audience:       "//iam.googleapis.com/projects/12345/locations/global/workloadIdentityPools/my-pool/providers/my-provider",
 			universeDomain: "googleapis.com",
 			wantProvider: &workloadIdentityPoolConfigProvider{
 				projectNumber:  "12345",
@@ -40,7 +40,7 @@ func TestNewExternalAccountConfigProvider(t *testing.T) {
 		},
 		{
 			name:           "workload identity pool with universe domain from audience",
-			audience:       "//iam.custom.com/projects/12345/locations/global/workloadIdentityPools/my-pool",
+			audience:       "//iam.custom.com/projects/12345/locations/global/workloadIdentityPools/my-pool/providers/my-provider",
 			universeDomain: "",
 			wantProvider: &workloadIdentityPoolConfigProvider{
 				projectNumber:  "12345",
@@ -50,13 +50,13 @@ func TestNewExternalAccountConfigProvider(t *testing.T) {
 		},
 		{
 			name:           "workload identity pool with non-matching universe domain",
-			audience:       "//iam.custom.com/projects/12345/locations/global/workloadIdentityPools/my-pool",
+			audience:       "//iam.custom.com/projects/12345/locations/global/workloadIdentityPools/my-pool/providers/my-provider",
 			universeDomain: "example.com",
 			wantErr:        "provided universe domain (\"example.com\") does not match domain in audience",
 		},
 		{
 			name:           "workforce pool with matching explicit universe domain",
-			audience:       "//iam.googleapis.com/locations/global/workforcePools/my-pool",
+			audience:       "//iam.googleapis.com/locations/global/workforcePools/my-pool/providers/my-provider",
 			universeDomain: "googleapis.com",
 			wantProvider: &workforcePoolConfigProvider{
 				poolID:         "my-pool",
@@ -65,7 +65,7 @@ func TestNewExternalAccountConfigProvider(t *testing.T) {
 		},
 		{
 			name:           "workforce pool with universe domain from audience",
-			audience:       "//iam.custom.com/locations/global/workforcePools/my-pool",
+			audience:       "//iam.custom.com/locations/global/workforcePools/my-pool/providers/my-provider",
 			universeDomain: "",
 			wantProvider: &workforcePoolConfigProvider{
 				poolID:         "my-pool",
@@ -74,7 +74,7 @@ func TestNewExternalAccountConfigProvider(t *testing.T) {
 		},
 		{
 			name:           "workforce pool with non-matching universe domain",
-			audience:       "//iam.custom.com/locations/global/workforcePools/my-pool",
+			audience:       "//iam.custom.com/locations/global/workforcePools/my-pool/providers/my-provider",
 			universeDomain: "example.com",
 			wantErr:        "provided universe domain (\"example.com\") does not match domain in audience",
 		},
@@ -86,13 +86,13 @@ func TestNewExternalAccountConfigProvider(t *testing.T) {
 		},
 		{
 			name:           "prefix partial match failure for workload identity pool",
-			audience:       "prefix-//iam.googleapis.com/projects/12345/locations/global/workloadIdentityPools/my-pool",
+			audience:       "prefix-//iam.googleapis.com/projects/12345/locations/global/workloadIdentityPools/my-pool/providers/my-provider",
 			universeDomain: "",
 			wantErr:        "unknown audience format",
 		},
 		{
 			name:           "suffix partial match failure for workload identity pool",
-			audience:       "//iam.googleapis.com/projects/12345/locations/global/workloadIdentityPools/my-pool/suffix",
+			audience:       "//iam.googleapis.com/projects/12345/locations/global/workloadIdentityPools/my-pool/providers/my-provider/suffix",
 			universeDomain: "",
 			wantErr:        "unknown audience format",
 		},

--- a/auth/internal/regionalaccessboundary/external_accounts_config_providers_test.go
+++ b/auth/internal/regionalaccessboundary/external_accounts_config_providers_test.go
@@ -84,6 +84,18 @@ func TestNewExternalAccountConfigProvider(t *testing.T) {
 			universeDomain: "",
 			wantErr:        "unknown audience format",
 		},
+		{
+			name:           "prefix partial match failure for workload identity pool",
+			audience:       "prefix-//iam.googleapis.com/projects/12345/locations/global/workloadIdentityPools/my-pool",
+			universeDomain: "",
+			wantErr:        "unknown audience format",
+		},
+		{
+			name:           "suffix partial match failure for workload identity pool",
+			audience:       "//iam.googleapis.com/projects/12345/locations/global/workloadIdentityPools/my-pool/suffix",
+			universeDomain: "",
+			wantErr:        "unknown audience format",
+		},
 	}
 
 	for _, tt := range tests {

--- a/auth/internal/regionalaccessboundary/regional_access_boundary.go
+++ b/auth/internal/regionalaccessboundary/regional_access_boundary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/auth/internal/regionalaccessboundary/regional_access_boundary.go
+++ b/auth/internal/regionalaccessboundary/regional_access_boundary.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package trustboundary
+package regionalaccessboundary
 
 import (
 	"context"
@@ -38,17 +38,17 @@ const (
 	serviceAccountAllowedLocationsEndpoint = "https://iamcredentials.%s/v1/projects/-/serviceAccounts/%s/allowedLocations"
 )
 
-// isEnabled wraps isTrustBoundaryEnabled with sync.OnceValues to ensure it's
+// isEnabled wraps isRegionalAccessBoundaryEnabled with sync.OnceValues to ensure it's
 // called only once.
-var isEnabled = sync.OnceValues(isTrustBoundaryEnabled)
+var isEnabled = sync.OnceValues(isRegionalAccessBoundaryEnabled)
 
-// IsEnabled returns if the trust boundary feature is enabled and an error if
+// IsEnabled returns if the Regional Access Boundary feature is enabled and an error if
 // the configuration is invalid. The underlying check is performed only once.
 func IsEnabled() (bool, error) {
 	return isEnabled()
 }
 
-// isTrustBoundaryEnabled checks if the trust boundary feature is enabled via
+// isRegionalAccessBoundaryEnabled checks if the Regional Access Boundary feature is enabled via
 // GOOGLE_AUTH_TRUST_BOUNDARY_ENABLED environment variable.
 //
 // If the environment variable is not set, it is considered false.
@@ -59,33 +59,40 @@ func IsEnabled() (bool, error) {
 //   - "false", "0" are considered false.
 //
 // Any other values will return an error.
-func isTrustBoundaryEnabled() (bool, error) {
-	const envVar = "GOOGLE_AUTH_TRUST_BOUNDARY_ENABLED"
-	val, ok := os.LookupEnv(envVar)
-	if !ok {
-		return false, nil
+func isRegionalAccessBoundaryEnabled() (bool, error) {
+	newEnvVar := "GOOGLE_AUTH_REGIONAL_ACCESS_BOUNDARY_ENABLE_EXPERIMENT"
+	oldEnvVar := "GOOGLE_AUTH_TRUST_BOUNDARY_ENABLED"
+
+	// Check new environment variable first.
+	if val, ok := os.LookupEnv(newEnvVar); ok {
+		val = strings.ToLower(val)
+		if val == "true" || val == "1" {
+			return true, nil
+		}
+		return false, nil // Ignore other values, default to false
 	}
-	val = strings.ToLower(val)
-	switch val {
-	case "true", "1":
-		return true, nil
-	case "false", "0":
-		return false, nil
-	default:
-		return false, fmt.Errorf(`invalid value for %s: %q. Must be one of "true", "false", "1", or "0"`, envVar, val)
+
+	// Fallback to old environment variable.
+	if val, ok := os.LookupEnv(oldEnvVar); ok {
+		val = strings.ToLower(val)
+		if val == "true" || val == "1" {
+			return true, nil
+		}
+		return false, nil // Ignore other values, default to false
 	}
+	return false, nil
 }
 
-// ConfigProvider provides specific configuration for trust boundary lookups.
+// ConfigProvider provides specific configuration for Regional Access Boundary lookups.
 type ConfigProvider interface {
-	// GetTrustBoundaryEndpoint returns the endpoint URL for the trust boundary lookup.
-	GetTrustBoundaryEndpoint(ctx context.Context) (url string, err error)
+	// GetRegionalAccessBoundaryEndpoint returns the endpoint URL for the Regional Access Boundary lookup.
+	GetRegionalAccessBoundaryEndpoint(ctx context.Context) (url string, err error)
 	// GetUniverseDomain returns the universe domain associated with the credential.
 	// It may return an error if the universe domain cannot be determined.
 	GetUniverseDomain(ctx context.Context) (string, error)
 }
 
-// AllowedLocationsResponse is the structure of the response from the Trust Boundary API.
+// AllowedLocationsResponse is the structure of the response from the Regional Access Boundary API.
 type AllowedLocationsResponse struct {
 	// Locations is the list of allowed locations.
 	Locations []string `json:"locations"`
@@ -93,29 +100,29 @@ type AllowedLocationsResponse struct {
 	EncodedLocations string `json:"encodedLocations"`
 }
 
-// fetchTrustBoundaryData fetches the trust boundary data from the API.
-func fetchTrustBoundaryData(ctx context.Context, client *http.Client, url string, token *auth.Token, logger *slog.Logger) (*internal.TrustBoundaryData, error) {
+// fetchRegionalAccessBoundaryData fetches the Regional Access Boundary data from the API.
+func fetchRegionalAccessBoundaryData(ctx context.Context, client *http.Client, url string, token *auth.Token, logger *slog.Logger) (*internal.RegionalAccessBoundaryData, error) {
 	if logger == nil {
 		logger = slog.New(slog.NewTextHandler(io.Discard, nil))
 	}
 	if client == nil {
-		return nil, errors.New("trustboundary: HTTP client is required")
+		return nil, errors.New("regionalaccessboundary: HTTP client is required")
 	}
 
 	if url == "" {
-		return nil, errors.New("trustboundary: URL cannot be empty")
+		return nil, errors.New("regionalaccessboundary: URL cannot be empty")
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
-		return nil, fmt.Errorf("trustboundary: failed to create trust boundary request: %w", err)
+		return nil, fmt.Errorf("regionalaccessboundary: failed to create Regional Access Boundary request: %w", err)
 	}
 
 	if token == nil || token.Value == "" {
-		return nil, errors.New("trustboundary: access token required for lookup API authentication")
+		return nil, errors.New("regionalaccessboundary: access token required for lookup API authentication")
 	}
 	headers.SetAuthHeader(token, req)
-	logger.DebugContext(ctx, "trust boundary request", "request", internallog.HTTPRequest(req, nil))
+	logger.DebugContext(ctx, "Regional Access Boundary request", "request", internallog.HTTPRequest(req, nil))
 
 	retryer := retry.New()
 	var response *http.Response
@@ -144,34 +151,34 @@ func fetchTrustBoundaryData(ctx context.Context, client *http.Client, url string
 	}
 
 	if err != nil {
-		return nil, fmt.Errorf("trustboundary: failed to fetch trust boundary: %w", err)
+		return nil, fmt.Errorf("regionalaccessboundary: failed to fetch Regional Access Boundary: %w", err)
 	}
 	defer response.Body.Close()
 
 	body, err := io.ReadAll(response.Body)
 	if err != nil {
-		return nil, fmt.Errorf("trustboundary: failed to read trust boundary response: %w", err)
+		return nil, fmt.Errorf("regionalaccessboundary: failed to read Regional Access Boundary response: %w", err)
 	}
 
-	logger.DebugContext(ctx, "trust boundary response", "response", internallog.HTTPResponse(response, body))
+	logger.DebugContext(ctx, "Regional Access Boundary response", "response", internallog.HTTPResponse(response, body))
 
 	if response.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("trustboundary: trust boundary request failed with status: %s, body: %s", response.Status, string(body))
+		return nil, fmt.Errorf("regionalaccessboundary: Regional Access Boundary request failed with status: %s, body: %s", response.Status, string(body))
 	}
 
 	apiResponse := AllowedLocationsResponse{}
 	if err := json.Unmarshal(body, &apiResponse); err != nil {
-		return nil, fmt.Errorf("trustboundary: failed to unmarshal trust boundary response: %w", err)
+		return nil, fmt.Errorf("regionalaccessboundary: failed to unmarshal Regional Access Boundary response: %w", err)
 	}
 
 	if apiResponse.EncodedLocations == "" {
-		return nil, errors.New("trustboundary: invalid API response: encodedLocations is empty")
+		return nil, errors.New("regionalaccessboundary: invalid API response: encodedLocations is empty")
 	}
 
-	return internal.NewTrustBoundaryData(apiResponse.Locations, apiResponse.EncodedLocations), nil
+	return internal.NewRegionalAccessBoundaryData(apiResponse.Locations, apiResponse.EncodedLocations), nil
 }
 
-// serviceAccountConfig holds configuration for SA trust boundary lookups.
+// serviceAccountConfig holds configuration for SA Regional Access Boundary lookups.
 // It implements the ConfigProvider interface.
 type serviceAccountConfig struct {
 	ServiceAccountEmail string
@@ -186,11 +193,11 @@ func NewServiceAccountConfigProvider(saEmail, universeDomain string) ConfigProvi
 	}
 }
 
-// GetTrustBoundaryEndpoint returns the formatted URL for fetching allowed locations
+// GetRegionalAccessBoundaryEndpoint returns the formatted URL for fetching allowed locations
 // for the configured service account and universe domain.
-func (sac *serviceAccountConfig) GetTrustBoundaryEndpoint(ctx context.Context) (url string, err error) {
+func (sac *serviceAccountConfig) GetRegionalAccessBoundaryEndpoint(ctx context.Context) (url string, err error) {
 	if sac.ServiceAccountEmail == "" {
-		return "", errors.New("trustboundary: service account email cannot be empty for config")
+		return "", errors.New("regionalaccessboundary: service account email cannot be empty for config")
 	}
 	ud := sac.UniverseDomain
 	if ud == "" {
@@ -208,27 +215,27 @@ func (sac *serviceAccountConfig) GetUniverseDomain(ctx context.Context) (string,
 	return sac.UniverseDomain, nil
 }
 
-// DataProvider fetches and caches trust boundary Data.
+// DataProvider fetches and caches Regional Access Boundary Data.
 // It implements the DataProvider interface and uses a ConfigProvider
 // to get type-specific details for the lookup.
 type DataProvider struct {
 	client         *http.Client
 	configProvider ConfigProvider
-	data           *internal.TrustBoundaryData
+	data           *internal.RegionalAccessBoundaryData
 	logger         *slog.Logger
 	base           auth.TokenProvider
 }
 
 // NewProvider wraps the provided base [auth.TokenProvider] to create a new
-// provider that injects tokens with trust boundary data. It uses the provided
+// provider that injects tokens with Regional Access Boundary data. It uses the provided
 // HTTP client and configProvider to fetch the data and attach it to the token's
 // metadata.
 func NewProvider(client *http.Client, configProvider ConfigProvider, logger *slog.Logger, base auth.TokenProvider) (*DataProvider, error) {
 	if client == nil {
-		return nil, errors.New("trustboundary: HTTP client cannot be nil for DataProvider")
+		return nil, errors.New("regionalaccessboundary: HTTP client cannot be nil for DataProvider")
 	}
 	if configProvider == nil {
-		return nil, errors.New("trustboundary: ConfigProvider cannot be nil for DataProvider")
+		return nil, errors.New("regionalaccessboundary: ConfigProvider cannot be nil for DataProvider")
 	}
 	p := &DataProvider{
 		client:         client,
@@ -248,28 +255,28 @@ func (p *DataProvider) Token(ctx context.Context) (*auth.Token, error) {
 		return nil, err
 	}
 
-	tbData, err := p.GetTrustBoundaryData(ctx, token)
+	tbData, err := p.GetRegionalAccessBoundaryData(ctx, token)
 	if err != nil {
-		return nil, fmt.Errorf("trustboundary: error fetching the trust boundary data: %w", err)
+		return nil, fmt.Errorf("regionalaccessboundary: error fetching the Regional Access Boundary data: %w", err)
 	}
 	if tbData != nil {
 		if token.Metadata == nil {
 			token.Metadata = make(map[string]interface{})
 		}
-		token.Metadata[internal.TrustBoundaryDataKey] = *tbData
+		token.Metadata[internal.RegionalAccessBoundaryDataKey] = *tbData
 	}
 	return token, nil
 }
 
-// GetTrustBoundaryData retrieves the trust boundary data.
+// GetRegionalAccessBoundaryData retrieves the Regional Access Boundary data.
 // It first checks the universe domain: if it's non-default, nil is returned.
 // It fetches new data from the endpoint provided by its ConfigProvider,
 // using the given accessToken for authentication. Results are cached.
 // If fetching fails, it returns previously cached data if available, otherwise the fetch error.
-func (p *DataProvider) GetTrustBoundaryData(ctx context.Context, token *auth.Token) (*internal.TrustBoundaryData, error) {
+func (p *DataProvider) GetRegionalAccessBoundaryData(ctx context.Context, token *auth.Token) (*internal.RegionalAccessBoundaryData, error) {
 	uniDomain, err := p.configProvider.GetUniverseDomain(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("trustboundary: error getting universe domain: %w", err)
+		return nil, fmt.Errorf("regionalaccessboundary: error getting universe domain: %w", err)
 	}
 	if uniDomain != "" && uniDomain != internal.DefaultUniverseDomain {
 		return nil, nil
@@ -279,13 +286,13 @@ func (p *DataProvider) GetTrustBoundaryData(ctx context.Context, token *auth.Tok
 	cachedData := p.data
 
 	// Get the endpoint
-	url, err := p.configProvider.GetTrustBoundaryEndpoint(ctx)
+	url, err := p.configProvider.GetRegionalAccessBoundaryEndpoint(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("trustboundary: error getting the lookup endpoint: %w", err)
+		return nil, fmt.Errorf("regionalaccessboundary: error getting the lookup endpoint: %w", err)
 	}
 
 	// Proceed to fetch new data.
-	newData, fetchErr := fetchTrustBoundaryData(ctx, p.client, url, token, p.logger)
+	newData, fetchErr := fetchRegionalAccessBoundaryData(ctx, p.client, url, token, p.logger)
 
 	if fetchErr != nil {
 		// Fetch failed. Fallback to cachedData if available.
@@ -293,7 +300,7 @@ func (p *DataProvider) GetTrustBoundaryData(ctx context.Context, token *auth.Tok
 			return cachedData, nil // Successful fallback
 		}
 		// No cache to fallback to.
-		return nil, fmt.Errorf("trustboundary: failed to fetch trust boundary data for endpoint %s and no cache available: %w", url, fetchErr)
+		return nil, fmt.Errorf("regionalaccessboundary: failed to fetch Regional Access Boundary data for endpoint %s and no cache available: %w", url, fetchErr)
 	}
 
 	// Fetch successful. Update cache.
@@ -323,7 +330,7 @@ type GCEConfigProvider struct {
 // which uses the provided gceUDP to interact with the GCE metadata server.
 func NewGCEConfigProvider(gceUDP *internal.ComputeUniverseDomainProvider) *GCEConfigProvider {
 	// The validity of gceUDP and its internal MetadataClient will be checked
-	// within the GetTrustBoundaryEndpoint and GetUniverseDomain methods.
+	// within the GetRegionalAccessBoundaryEndpoint and GetUniverseDomain methods.
 	return &GCEConfigProvider{
 		universeDomainProvider: gceUDP,
 	}
@@ -331,13 +338,13 @@ func NewGCEConfigProvider(gceUDP *internal.ComputeUniverseDomainProvider) *GCECo
 
 func (g *GCEConfigProvider) fetchSA(ctx context.Context) {
 	if g.universeDomainProvider == nil || g.universeDomainProvider.MetadataClient == nil {
-		g.saEmailErr = errors.New("trustboundary: GCEConfigProvider not properly initialized (missing ComputeUniverseDomainProvider or MetadataClient)")
+		g.saEmailErr = errors.New("regionalaccessboundary: GCEConfigProvider not properly initialized (missing ComputeUniverseDomainProvider or MetadataClient)")
 		return
 	}
 	mdClient := g.universeDomainProvider.MetadataClient
 	saEmail, err := mdClient.EmailWithContext(ctx, "default")
 	if err != nil {
-		g.saEmailErr = fmt.Errorf("trustboundary: GCE config: failed to get service account email: %w", err)
+		g.saEmailErr = fmt.Errorf("regionalaccessboundary: GCE config: failed to get service account email: %w", err)
 		return
 	}
 	g.saEmail = saEmail
@@ -345,12 +352,12 @@ func (g *GCEConfigProvider) fetchSA(ctx context.Context) {
 
 func (g *GCEConfigProvider) fetchUD(ctx context.Context) {
 	if g.universeDomainProvider == nil || g.universeDomainProvider.MetadataClient == nil {
-		g.udErr = errors.New("trustboundary: GCEConfigProvider not properly initialized (missing ComputeUniverseDomainProvider or MetadataClient)")
+		g.udErr = errors.New("regionalaccessboundary: GCEConfigProvider not properly initialized (missing ComputeUniverseDomainProvider or MetadataClient)")
 		return
 	}
 	ud, err := g.universeDomainProvider.GetProperty(ctx)
 	if err != nil {
-		g.udErr = fmt.Errorf("trustboundary: GCE config: failed to get universe domain: %w", err)
+		g.udErr = fmt.Errorf("regionalaccessboundary: GCE config: failed to get universe domain: %w", err)
 		return
 	}
 	if ud == "" {
@@ -359,9 +366,9 @@ func (g *GCEConfigProvider) fetchUD(ctx context.Context) {
 	g.ud = ud
 }
 
-// GetTrustBoundaryEndpoint constructs the trust boundary lookup URL for a GCE environment.
+// GetRegionalAccessBoundaryEndpoint constructs the Regional Access Boundary lookup URL for a GCE environment.
 // It uses cached metadata (service account email, universe domain) after the first call.
-func (g *GCEConfigProvider) GetTrustBoundaryEndpoint(ctx context.Context) (string, error) {
+func (g *GCEConfigProvider) GetRegionalAccessBoundaryEndpoint(ctx context.Context) (string, error) {
 	g.saOnce.Do(func() { g.fetchSA(ctx) })
 	if g.saEmailErr != nil {
 		return "", g.saEmailErr

--- a/auth/internal/regionalaccessboundary/regional_access_boundary.go
+++ b/auth/internal/regionalaccessboundary/regional_access_boundary.go
@@ -418,8 +418,8 @@ type GCEConfigProvider struct {
 	universeDomainProvider *internal.ComputeUniverseDomainProvider
 
 	// Caching for service account email
-	saMu       sync.Mutex
-	saEmail    string
+	saMu    sync.Mutex
+	saEmail string
 
 	// Caching for universe domain
 	udOnce sync.Once

--- a/auth/internal/regionalaccessboundary/regional_access_boundary.go
+++ b/auth/internal/regionalaccessboundary/regional_access_boundary.go
@@ -257,6 +257,9 @@ func (p *DataProvider) GetHeaderValue(ctx context.Context, reqURL string, access
 	}
 	if u, err := url.Parse(reqURL); err == nil {
 		host := u.Host
+		if host == "" && strings.HasPrefix(u.Path, "/") {
+			host = strings.TrimPrefix(u.Path, "/")
+		}
 		if h, _, err := net.SplitHostPort(host); err == nil {
 			host = h
 		}

--- a/auth/internal/regionalaccessboundary/regional_access_boundary.go
+++ b/auth/internal/regionalaccessboundary/regional_access_boundary.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"maps"
 	"math/rand"
 	"net"
 	"net/http"
@@ -237,18 +238,20 @@ func (p *DataProvider) Token(ctx context.Context) (*auth.Token, error) {
 		return nil, err
 	}
 
-	if token.Metadata == nil {
-		token.Metadata = make(map[string]interface{})
+	// Clone the token and its metadata to avoid mutating shared/cached state.
+	newToken := *token
+	newToken.Metadata = maps.Clone(token.Metadata)
+	if newToken.Metadata == nil {
+		newToken.Metadata = make(map[string]interface{})
 	}
+	newToken.Metadata[ProviderKey] = p
 
-	token.Metadata[ProviderKey] = p
-	return token, nil
+	return &newToken, nil
 }
 
 // GetHeaderValue immediately returns a valid header if it's cached, or kicks off a background fetch
 // if it is unpopulated or expired.
 func (p *DataProvider) GetHeaderValue(ctx context.Context, reqURL string, accessToken *auth.Token) string {
-	// Skip lookup for regional endpoints.
 	if !strings.Contains(reqURL, "://") {
 		reqURL = "https://" + reqURL
 	}
@@ -257,15 +260,25 @@ func (p *DataProvider) GetHeaderValue(ctx context.Context, reqURL string, access
 		if h, _, err := net.SplitHostPort(host); err == nil {
 			host = h
 		}
+		// Skip lookup for regional endpoints.
 		if host == "rep.googleapis.com" || strings.HasSuffix(host, ".rep.googleapis.com") ||
 			host == "rep.sandbox.googleapis.com" || strings.HasSuffix(host, ".rep.sandbox.googleapis.com") {
+			return ""
+		}
+		// Skip lookup for IAM and STS endpoints as they do not require RAB headers.
+		if host == "iam.googleapis.com" || host == "iamcredentials.googleapis.com" ||
+			host == "sts.googleapis.com" {
 			return ""
 		}
 	}
 
 	// Skip lookup for non-default universe domains.
 	uniDomain, err := p.configProvider.GetUniverseDomain(ctx)
-	if err == nil && uniDomain != "" && uniDomain != internal.DefaultUniverseDomain {
+	if err != nil {
+		p.logger.WarnContext(ctx, "regionalaccessboundary: error getting universe domain", "error", err)
+		return ""
+	}
+	if uniDomain != "" && uniDomain != internal.DefaultUniverseDomain {
 		return ""
 	}
 
@@ -319,7 +332,7 @@ func (p *DataProvider) fetchAsync(ctx context.Context, accessToken *auth.Token) 
 
 	url, err := p.configProvider.GetRegionalAccessBoundaryEndpoint(ctx)
 	if err != nil {
-		p.logger.ErrorContext(ctx, "regionalaccessboundary: error getting the lookup endpoint", "error", err)
+		p.logger.WarnContext(ctx, "regionalaccessboundary: error getting the lookup endpoint", "error", err)
 		p.handleFetchFailure(ctx)
 		return
 	}
@@ -327,7 +340,7 @@ func (p *DataProvider) fetchAsync(ctx context.Context, accessToken *auth.Token) 
 	newData, fetchErr := fetchRegionalAccessBoundaryData(ctx, p.client, url, accessToken, p.logger)
 
 	if fetchErr != nil {
-		p.logger.ErrorContext(ctx, "regionalaccessboundary: async fetch failed", "error", fetchErr)
+		p.logger.WarnContext(ctx, "regionalaccessboundary: async fetch failed", "error", fetchErr)
 		p.handleFetchFailure(ctx)
 		return
 	}
@@ -402,9 +415,8 @@ type GCEConfigProvider struct {
 	universeDomainProvider *internal.ComputeUniverseDomainProvider
 
 	// Caching for service account email
-	saOnce     sync.Once
+	saMu       sync.Mutex
 	saEmail    string
-	saEmailErr error
 
 	// Caching for universe domain
 	udOnce sync.Once
@@ -422,18 +434,16 @@ func NewGCEConfigProvider(gceUDP *internal.ComputeUniverseDomainProvider) *GCECo
 	}
 }
 
-func (g *GCEConfigProvider) fetchSA(ctx context.Context) {
+func (g *GCEConfigProvider) fetchSA(ctx context.Context) (string, error) {
 	if g.universeDomainProvider == nil || g.universeDomainProvider.MetadataClient == nil {
-		g.saEmailErr = errors.New("regionalaccessboundary: GCEConfigProvider not properly initialized (missing ComputeUniverseDomainProvider or MetadataClient)")
-		return
+		return "", errors.New("regionalaccessboundary: GCEConfigProvider not properly initialized (missing ComputeUniverseDomainProvider or MetadataClient)")
 	}
 	mdClient := g.universeDomainProvider.MetadataClient
 	saEmail, err := mdClient.EmailWithContext(ctx, "default")
 	if err != nil {
-		g.saEmailErr = fmt.Errorf("regionalaccessboundary: GCE config: failed to get service account email: %w", err)
-		return
+		return "", fmt.Errorf("regionalaccessboundary: GCE config: failed to get service account email: %w", err)
 	}
-	g.saEmail = saEmail
+	return saEmail, nil
 }
 
 func (g *GCEConfigProvider) fetchUD(ctx context.Context) {
@@ -455,11 +465,28 @@ func (g *GCEConfigProvider) fetchUD(ctx context.Context) {
 // GetRegionalAccessBoundaryEndpoint constructs the Regional Access Boundary lookup URL for a GCE environment.
 // It uses cached service account email after the first call.
 func (g *GCEConfigProvider) GetRegionalAccessBoundaryEndpoint(ctx context.Context) (string, error) {
-	g.saOnce.Do(func() { g.fetchSA(ctx) })
-	if g.saEmailErr != nil {
-		return "", g.saEmailErr
+	// Check if we already have a cached service account email.
+	g.saMu.Lock()
+	if g.saEmail != "" {
+		email := g.saEmail
+		g.saMu.Unlock()
+		return fmt.Sprintf(serviceAccountAllowedLocationsEndpoint, email), nil
 	}
-	return fmt.Sprintf(serviceAccountAllowedLocationsEndpoint, g.saEmail), nil
+	g.saMu.Unlock()
+
+	// Fetch the email from the metadata server. We do not hold the lock
+	// during this I/O operation to avoid blocking other goroutines.
+	email, err := g.fetchSA(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	// Cache the successful result.
+	g.saMu.Lock()
+	g.saEmail = email
+	g.saMu.Unlock()
+
+	return fmt.Sprintf(serviceAccountAllowedLocationsEndpoint, email), nil
 }
 
 // GetUniverseDomain retrieves the universe domain from the GCE metadata server.

--- a/auth/internal/regionalaccessboundary/regional_access_boundary.go
+++ b/auth/internal/regionalaccessboundary/regional_access_boundary.go
@@ -232,7 +232,7 @@ func (p *DataProvider) Token(ctx context.Context) (*auth.Token, error) {
 	return token, nil
 }
 
-// It immediately returns a valid header if it's cached, or kicks off a background fetch
+// GetHeaderValue immediately returns a valid header if it's cached, or kicks off a background fetch
 // if it is unpopulated or expired.
 func (p *DataProvider) GetHeaderValue(ctx context.Context, reqURL string, accessToken *auth.Token) string {
 	// Skip lookup for regional endpoints.
@@ -295,6 +295,7 @@ func (p *DataProvider) fetchAsync(ctx context.Context, accessToken *auth.Token) 
 	url, err := p.configProvider.GetRegionalAccessBoundaryEndpoint(ctx)
 	if err != nil {
 		p.logger.ErrorContext(ctx, "regionalaccessboundary: error getting the lookup endpoint", "error", err)
+		p.handleFetchFailure(ctx)
 		return
 	}
 
@@ -423,15 +424,11 @@ func (g *GCEConfigProvider) fetchUD(ctx context.Context) {
 }
 
 // GetRegionalAccessBoundaryEndpoint constructs the Regional Access Boundary lookup URL for a GCE environment.
-// It uses cached metadata (service account email, universe domain) after the first call.
+// It uses cached service account email after the first call.
 func (g *GCEConfigProvider) GetRegionalAccessBoundaryEndpoint(ctx context.Context) (string, error) {
 	g.saOnce.Do(func() { g.fetchSA(ctx) })
 	if g.saEmailErr != nil {
 		return "", g.saEmailErr
-	}
-	g.udOnce.Do(func() { g.fetchUD(ctx) })
-	if g.udErr != nil {
-		return "", g.udErr
 	}
 	return fmt.Sprintf(serviceAccountAllowedLocationsEndpoint, g.saEmail), nil
 }

--- a/auth/internal/regionalaccessboundary/regional_access_boundary.go
+++ b/auth/internal/regionalaccessboundary/regional_access_boundary.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"math/rand"
 	"net"
 	"net/http"
 	"net/url"
@@ -349,9 +350,11 @@ func (p *DataProvider) handleFetchFailure(ctx context.Context) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	p.cooldownExpiry = time.Now().Add(p.cooldownDuration)
+	// Add random bounded jitter (between half of the base and the full base) to prevent thundering herds
+	jitter := p.cooldownDuration/2 + time.Duration(rand.Int63n(int64(p.cooldownDuration/2)))
+	p.cooldownExpiry = time.Now().Add(jitter)
 
-	// Exponential backoff for cooldown, up to cacheTTL max (6 hours)
+	// Exponential backoff for the NEXT attempt, up to cacheTTL max (6 hours)
 	nextCooldown := p.cooldownDuration * 2
 	if nextCooldown > cacheTTL {
 		nextCooldown = cacheTTL

--- a/auth/internal/regionalaccessboundary/regional_access_boundary.go
+++ b/auth/internal/regionalaccessboundary/regional_access_boundary.go
@@ -39,7 +39,7 @@ const ProviderKey = "regionalaccessboundary.ProviderKey"
 const (
 	// serviceAccountAllowedLocationsEndpoint is the URL for fetching allowed locations for a given service account email.
 	serviceAccountAllowedLocationsEndpoint = "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/%s/allowedLocations"
-	
+
 	// cacheTTL is the duration cached RAB data remains valid before hard expiry.
 	cacheTTL = 6 * time.Hour
 	// cacheSoftExpiry is the threshold before hard expiry where a background refresh is triggered.
@@ -128,7 +128,7 @@ func fetchRegionalAccessBoundaryData(ctx context.Context, client *http.Client, u
 			statusCode = response.StatusCode
 		}
 		pause, shouldRetry := retryer.Retry(statusCode, err)
-		
+
 		// Enforce a maximum 1 minute retry window for specific server errors.
 		if shouldRetry && (statusCode == 500 || statusCode == 502 || statusCode == 503 || statusCode == 504) {
 			if time.Since(startTime)+pause > 1*time.Minute {
@@ -255,7 +255,7 @@ func (p *DataProvider) GetHeaderValue(ctx context.Context, reqURL string, access
 	now := time.Now()
 	if data != nil && now.Before(dataExpiry) {
 		val, _ := data.RegionalAccessBoundaryHeader()
-		
+
 		// Soft Expiry: if the cached data is within the soft expiration window,
 		// initiate a non-blocking background refresh to proactively fetch new data
 		// while continuing to serve the current valid cache block.
@@ -267,7 +267,7 @@ func (p *DataProvider) GetHeaderValue(ctx context.Context, reqURL string, access
 			}
 			p.mu.Unlock()
 		}
-		
+
 		return val
 	}
 

--- a/auth/internal/regionalaccessboundary/regional_access_boundary.go
+++ b/auth/internal/regionalaccessboundary/regional_access_boundary.go
@@ -21,7 +21,9 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"sync"
@@ -246,8 +248,18 @@ func (p *DataProvider) Token(ctx context.Context) (*auth.Token, error) {
 // if it is unpopulated or expired.
 func (p *DataProvider) GetHeaderValue(ctx context.Context, reqURL string, accessToken *auth.Token) string {
 	// Skip lookup for regional endpoints.
-	if strings.Contains(reqURL, "rep.googleapis.com") || strings.Contains(reqURL, "rep.sandbox.googleapis.com") {
-		return ""
+	if !strings.Contains(reqURL, "://") {
+		reqURL = "https://" + reqURL
+	}
+	if u, err := url.Parse(reqURL); err == nil {
+		host := u.Host
+		if h, _, err := net.SplitHostPort(host); err == nil {
+			host = h
+		}
+		if host == "rep.googleapis.com" || strings.HasSuffix(host, ".rep.googleapis.com") ||
+			host == "rep.sandbox.googleapis.com" || strings.HasSuffix(host, ".rep.sandbox.googleapis.com") {
+			return ""
+		}
 	}
 
 	// Skip lookup for non-default universe domains.

--- a/auth/internal/regionalaccessboundary/regional_access_boundary.go
+++ b/auth/internal/regionalaccessboundary/regional_access_boundary.go
@@ -48,6 +48,16 @@ const (
 	baseCooldownDuration = 15 * time.Minute
 )
 
+var (
+	// retryOptions configures the retry behavior for Regional Access Boundary lookups.
+	retryOptions = &retry.Options{
+		Initial:     1 * time.Second,
+		Max:         60 * time.Second,
+		Multiplier:  2.0,
+		MaxAttempts: 6,
+	}
+)
+
 // isEnabled wraps isRegionalAccessBoundaryEnabled with sync.OnceValues to ensure it's
 // called only once.
 var isEnabled = sync.OnceValues(isRegionalAccessBoundaryEnabled)
@@ -117,7 +127,7 @@ func fetchRegionalAccessBoundaryData(ctx context.Context, client *http.Client, u
 	req.Header.Set("Authorization", typ+" "+token.Value)
 	logger.DebugContext(ctx, "Regional Access Boundary request", "request", internallog.HTTPRequest(req, nil))
 
-	retryer := retry.New()
+	retryer := retry.NewWithOptions(retryOptions)
 	startTime := time.Now()
 	var response *http.Response
 	for {
@@ -285,6 +295,8 @@ func (p *DataProvider) GetHeaderValue(ctx context.Context, reqURL string, access
 	return ""
 }
 
+// fetchAsync performs the background lookup for Regional Access Boundary data.
+// It updates the provider's state based on the result (success or failure).
 func (p *DataProvider) fetchAsync(ctx context.Context, accessToken *auth.Token) {
 	defer func() {
 		p.mu.Lock()
@@ -310,6 +322,7 @@ func (p *DataProvider) fetchAsync(ctx context.Context, accessToken *auth.Token) 
 	p.handleFetchSuccess(newData)
 }
 
+// handleFetchSuccess updates the cache with new data and clears any existing cooldown.
 func (p *DataProvider) handleFetchSuccess(newData *internal.RegionalAccessBoundaryData) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -319,6 +332,7 @@ func (p *DataProvider) handleFetchSuccess(newData *internal.RegionalAccessBounda
 	p.cooldownDuration = baseCooldownDuration
 }
 
+// handleFetchFailure triggers the cooldown period using exponential backoff.
 func (p *DataProvider) handleFetchFailure(ctx context.Context) {
 	p.mu.Lock()
 	defer p.mu.Unlock()

--- a/auth/internal/regionalaccessboundary/regional_access_boundary.go
+++ b/auth/internal/regionalaccessboundary/regional_access_boundary.go
@@ -39,6 +39,13 @@ const ProviderKey = "regionalaccessboundary.ProviderKey"
 const (
 	// serviceAccountAllowedLocationsEndpoint is the URL for fetching allowed locations for a given service account email.
 	serviceAccountAllowedLocationsEndpoint = "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/%s/allowedLocations"
+	
+	// cacheTTL is the duration cached RAB data remains valid before hard expiry.
+	cacheTTL = 6 * time.Hour
+	// cacheSoftExpiry is the threshold before hard expiry where a background refresh is triggered.
+	cacheSoftExpiry = 1 * time.Hour
+	// baseCooldownDuration is the initial delay after a failed background fetch.
+	baseCooldownDuration = 15 * time.Minute
 )
 
 // isEnabled wraps isRegionalAccessBoundaryEnabled with sync.OnceValues to ensure it's
@@ -51,39 +58,18 @@ func IsEnabled() (bool, error) {
 	return isEnabled()
 }
 
-// isRegionalAccessBoundaryEnabled checks if the Regional Access Boundary feature is enabled via
-// GOOGLE_AUTH_TRUST_BOUNDARY_ENABLED environment variable.
+// isRegionalAccessBoundaryEnabled checks if the Regional Access Boundary feature
+// is enabled via the GOOGLE_AUTH_TRUST_BOUNDARY_ENABLED environment variable.
 //
-// If the environment variable is not set, it is considered false.
+// If the environment variable is not set or empty, it is considered false.
 //
 // The environment variable is interpreted as a boolean with the following
 // (case-insensitive) rules:
 //   - "true", "1" are considered true.
-//   - "false", "0" are considered false.
-//
-// Any other values will return an error.
+//   - All other values (including "false", "0", or invalid strings) are considered false.
 func isRegionalAccessBoundaryEnabled() (bool, error) {
-	newEnvVar := "GOOGLE_AUTH_REGIONAL_ACCESS_BOUNDARY_ENABLE_EXPERIMENT"
-	oldEnvVar := "GOOGLE_AUTH_TRUST_BOUNDARY_ENABLED"
-
-	// Check new environment variable first.
-	if val, ok := os.LookupEnv(newEnvVar); ok {
-		val = strings.ToLower(val)
-		if val == "true" || val == "1" {
-			return true, nil
-		}
-		return false, nil // Ignore other values, default to false
-	}
-
-	// Fallback to old environment variable.
-	if val, ok := os.LookupEnv(oldEnvVar); ok {
-		val = strings.ToLower(val)
-		if val == "true" || val == "1" {
-			return true, nil
-		}
-		return false, nil // Ignore other values, default to false
-	}
-	return false, nil
+	val := strings.ToLower(os.Getenv("GOOGLE_AUTH_TRUST_BOUNDARY_ENABLED"))
+	return val == "true" || val == "1", nil
 }
 
 // ConfigProvider provides specific configuration for Regional Access Boundary lookups.
@@ -132,6 +118,7 @@ func fetchRegionalAccessBoundaryData(ctx context.Context, client *http.Client, u
 	logger.DebugContext(ctx, "Regional Access Boundary request", "request", internallog.HTTPRequest(req, nil))
 
 	retryer := retry.New()
+	startTime := time.Now()
 	var response *http.Response
 	for {
 		response, err = client.Do(req)
@@ -141,6 +128,13 @@ func fetchRegionalAccessBoundaryData(ctx context.Context, client *http.Client, u
 			statusCode = response.StatusCode
 		}
 		pause, shouldRetry := retryer.Retry(statusCode, err)
+		
+		// Enforce a maximum 1 minute retry window for specific server errors.
+		if shouldRetry && (statusCode == 500 || statusCode == 502 || statusCode == 503 || statusCode == 504) {
+			if time.Since(startTime)+pause > 1*time.Minute {
+				shouldRetry = false
+			}
+		}
 
 		if !shouldRetry {
 			break
@@ -261,6 +255,19 @@ func (p *DataProvider) GetHeaderValue(ctx context.Context, reqURL string, access
 	now := time.Now()
 	if data != nil && now.Before(dataExpiry) {
 		val, _ := data.RegionalAccessBoundaryHeader()
+		
+		// Soft Expiry: if the cached data is within the soft expiration window,
+		// initiate a non-blocking background refresh to proactively fetch new data
+		// while continuing to serve the current valid cache block.
+		if now.After(dataExpiry.Add(-cacheSoftExpiry)) {
+			p.mu.Lock()
+			if !p.isFetching && now.After(p.cooldownExpiry) {
+				p.isFetching = true
+				go p.fetchAsync(context.Background(), accessToken)
+			}
+			p.mu.Unlock()
+		}
+		
 		return val
 	}
 
@@ -306,9 +313,9 @@ func (p *DataProvider) handleFetchSuccess(newData *internal.RegionalAccessBounda
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.data = newData
-	p.dataExpiry = time.Now().Add(6 * time.Hour) // 6 hour TTL
-	p.cooldownExpiry = time.Time{}               // reset cooldown
-	p.cooldownDuration = 15 * time.Minute        // reset cooldown multiplier
+	p.dataExpiry = time.Now().Add(cacheTTL)
+	p.cooldownExpiry = time.Time{}
+	p.cooldownDuration = baseCooldownDuration
 }
 
 func (p *DataProvider) handleFetchFailure(ctx context.Context) {
@@ -317,11 +324,10 @@ func (p *DataProvider) handleFetchFailure(ctx context.Context) {
 
 	p.cooldownExpiry = time.Now().Add(p.cooldownDuration)
 
-	// Exponential backoff for cooldown, up to 6 hours max
+	// Exponential backoff for cooldown, up to cacheTTL max (6 hours)
 	nextCooldown := p.cooldownDuration * 2
-	maxCooldown := 6 * time.Hour
-	if nextCooldown > maxCooldown {
-		nextCooldown = maxCooldown
+	if nextCooldown > cacheTTL {
+		nextCooldown = cacheTTL
 	}
 	p.cooldownDuration = nextCooldown
 }

--- a/auth/internal/regionalaccessboundary/regional_access_boundary_test.go
+++ b/auth/internal/regionalaccessboundary/regional_access_boundary_test.go
@@ -580,6 +580,51 @@ func TestGCEConfigProvider_CachesResults(t *testing.T) {
 	}
 }
 
+func TestGCEConfigProvider_TransientFailure(t *testing.T) {
+	var failMDS bool = true
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if failMDS {
+			http.Error(w, "metadata server down", http.StatusInternalServerError)
+			return
+		}
+		switch r.URL.Path {
+		case "/computeMetadata/v1/instance/service-accounts/default/email":
+			w.Write([]byte("test-sa@example.com"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	parsedURL, _ := url.Parse(server.URL)
+	t.Setenv("GCE_METADATA_HOST", parsedURL.Host)
+	mdClient := metadata.NewClient(server.Client())
+	udp := &internal.ComputeUniverseDomainProvider{MetadataClient: mdClient}
+	provider := NewGCEConfigProvider(udp)
+
+	ctx := context.Background()
+
+	// First call should fail (MDS down)
+	_, err := provider.GetRegionalAccessBoundaryEndpoint(ctx)
+	if err == nil {
+		t.Fatal("GetRegionalAccessBoundaryEndpoint() expected error on first call, got nil")
+	}
+
+	// Enable success for the next call
+	failMDS = false
+
+	// Second call should succeed (MDS up)
+	endpoint, err := provider.GetRegionalAccessBoundaryEndpoint(ctx)
+	if err != nil {
+		t.Fatalf("GetRegionalAccessBoundaryEndpoint() unexpected error on second call: %v", err)
+	}
+
+	want := fmt.Sprintf(serviceAccountAllowedLocationsEndpoint, "test-sa@example.com")
+	if endpoint != want {
+		t.Errorf("GetRegionalAccessBoundaryEndpoint() = %q, want %q", endpoint, want)
+	}
+}
+
 type mockConfigProvider struct {
 	mu                  sync.Mutex
 	endpointCallCount   int
@@ -628,7 +673,12 @@ func (m *mockTokenProvider) Token(ctx context.Context) (*auth.Token, error) {
 
 func TestDataProvider_Token(t *testing.T) {
 	ctx := context.Background()
-	baseToken := &auth.Token{Value: "base-token"}
+	baseToken := &auth.Token{
+		Value: "base-token",
+		Metadata: map[string]interface{}{
+			"pre-existing-key": "pre-existing-value",
+		},
+	}
 	baseProvider := &mockTokenProvider{TokenToReturn: baseToken}
 
 	provider, err := NewProvider(http.DefaultClient, &mockConfigProvider{}, nil, baseProvider)
@@ -647,6 +697,22 @@ func TestDataProvider_Token(t *testing.T) {
 
 	if p, ok := token.Metadata[ProviderKey]; !ok || p != provider {
 		t.Errorf("provider.Token() metadata missing ProviderKey or incorrect provider reference")
+	}
+
+	// Assert that the original token metadata was not mutated.
+	if _, ok := baseToken.Metadata[ProviderKey]; ok {
+		t.Errorf("provider.Token() mutated the base token's metadata")
+	}
+
+	// Assert that existing metadata entries are preserved.
+	if v, ok := token.Metadata["pre-existing-key"]; !ok || v != "pre-existing-value" {
+		t.Errorf("provider.Token() did not preserve existing metadata entries")
+	}
+
+	// Assert that the returned metadata map is not the same map instance as baseToken.Metadata.
+	token.Metadata["test_mutation"] = true
+	if _, ok := baseToken.Metadata["test_mutation"]; ok {
+		t.Errorf("provider.Token() returned a metadata map that shares state with the base token")
 	}
 }
 

--- a/auth/internal/regionalaccessboundary/regional_access_boundary_test.go
+++ b/auth/internal/regionalaccessboundary/regional_access_boundary_test.go
@@ -633,12 +633,19 @@ type mockConfigProvider struct {
 	endpointErrToReturn error
 	universeToReturn    string
 	universeErrToReturn error
+	endpointCallCh      chan struct{}
 }
 
 func (m *mockConfigProvider) GetRegionalAccessBoundaryEndpoint(ctx context.Context) (string, error) {
 	m.mu.Lock()
 	m.endpointCallCount++
 	m.mu.Unlock()
+	if m.endpointCallCh != nil {
+		select {
+		case m.endpointCallCh <- struct{}{}:
+		default:
+		}
+	}
 	return m.endpointToReturn, m.endpointErrToReturn
 }
 
@@ -734,28 +741,69 @@ func TestDataProvider_GetHeaderValue(t *testing.T) {
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
 				token := &auth.Token{Value: "base"}
-				mockConfig := &mockConfigProvider{universeToReturn: internal.DefaultUniverseDomain}
+				mockConfig := &mockConfigProvider{
+					universeToReturn: internal.DefaultUniverseDomain,
+					endpointCallCh:   make(chan struct{}, 1),
+				}
 				provider, _ := NewProvider(http.DefaultClient, mockConfig, nil, &mockTokenProvider{TokenToReturn: token})
 
 				_ = provider.GetHeaderValue(ctx, tt.reqURL, token)
 
 				if tt.wantCall {
-					deadline := time.Now().Add(1 * time.Second)
-					var gotCall bool
-					for time.Now().Before(deadline) {
-						if mockConfig.GetEndpointCallCount() > 0 {
-							gotCall = true
-							break
-						}
-						time.Sleep(10 * time.Millisecond)
-					}
-					if !gotCall {
+					select {
+					case <-mockConfig.endpointCallCh:
+						// Success
+					case <-time.After(1 * time.Second):
 						t.Errorf("GetHeaderValue(%q) did not initiate fetch (want fetch)", tt.reqURL)
 					}
 				} else {
-					time.Sleep(50 * time.Millisecond)
-					if mockConfig.GetEndpointCallCount() > 0 {
+					select {
+					case <-mockConfig.endpointCallCh:
 						t.Errorf("GetHeaderValue(%q) initiated fetch unexpectedly", tt.reqURL)
+					case <-time.After(50 * time.Millisecond):
+						// Success
+					}
+				}
+			})
+		}
+	})
+
+	t.Run("Resolver scheme skip", func(t *testing.T) {
+		tests := []struct {
+			name     string
+			reqURL   string
+			wantCall bool
+		}{
+			{"DNS Resolver Scheme IAM", "dns:///iam.googleapis.com", false},
+			{"DNS Resolver Scheme STS", "dns:///sts.googleapis.com", false},
+			{"DNS Resolver Scheme Regional", "dns:///us-central1.rep.googleapis.com", false},
+			{"DNS Resolver Scheme Global", "dns:///pubsub.googleapis.com", true},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				token := &auth.Token{Value: "base"}
+				mockConfig := &mockConfigProvider{
+					universeToReturn: internal.DefaultUniverseDomain,
+					endpointCallCh:   make(chan struct{}, 1),
+				}
+				provider, _ := NewProvider(http.DefaultClient, mockConfig, nil, &mockTokenProvider{TokenToReturn: token})
+
+				_ = provider.GetHeaderValue(ctx, tt.reqURL, token)
+
+				if tt.wantCall {
+					select {
+					case <-mockConfig.endpointCallCh:
+						// Success
+					case <-time.After(1 * time.Second):
+						t.Errorf("GetHeaderValue(%q) did not initiate fetch (want fetch)", tt.reqURL)
+					}
+				} else {
+					select {
+					case <-mockConfig.endpointCallCh:
+						t.Errorf("GetHeaderValue(%q) initiated fetch unexpectedly", tt.reqURL)
+					case <-time.After(50 * time.Millisecond):
+						// Success
 					}
 				}
 			})

--- a/auth/internal/regionalaccessboundary/regional_access_boundary_test.go
+++ b/auth/internal/regionalaccessboundary/regional_access_boundary_test.go
@@ -641,11 +641,45 @@ func TestDataProvider_GetHeaderValue(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("Regional endpoint skip", func(t *testing.T) {
-		token := &auth.Token{Value: "base"}
-		provider, _ := NewProvider(http.DefaultClient, &mockConfigProvider{}, nil, &mockTokenProvider{TokenToReturn: token})
-		val := provider.GetHeaderValue(ctx, "https://us-central1.rep.googleapis.com/v1/...", token)
-		if val != "" {
-			t.Errorf("Expected empty header for regional endpoint, got %q", val)
+		tests := []struct {
+			name     string
+			reqURL   string
+			wantCall bool
+		}{
+			{"Standard Regional URL", "https://us-central1.rep.googleapis.com/v1/...", false},
+			{"Regional Host Only", "us-central1.rep.googleapis.com", false},
+			{"Regional with Port", "us-central1.rep.googleapis.com:443", false},
+			{"Injected Query Param", "https://pubsub.googleapis.com/v1/...?tracking=rep.googleapis.com", true},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				token := &auth.Token{Value: "base"}
+				mockConfig := &mockConfigProvider{universeToReturn: internal.DefaultUniverseDomain}
+				provider, _ := NewProvider(http.DefaultClient, mockConfig, nil, &mockTokenProvider{TokenToReturn: token})
+
+				_ = provider.GetHeaderValue(ctx, tt.reqURL, token)
+
+				if tt.wantCall {
+					deadline := time.Now().Add(1 * time.Second)
+					var gotCall bool
+					for time.Now().Before(deadline) {
+						if mockConfig.endpointCallCount > 0 {
+							gotCall = true
+							break
+						}
+						time.Sleep(10 * time.Millisecond)
+					}
+					if !gotCall {
+						t.Errorf("GetHeaderValue(%q) did not initiate fetch (want fetch)", tt.reqURL)
+					}
+				} else {
+					time.Sleep(50 * time.Millisecond)
+					if mockConfig.endpointCallCount > 0 {
+						t.Errorf("GetHeaderValue(%q) initiated fetch unexpectedly", tt.reqURL)
+					}
+				}
+			})
 		}
 	})
 

--- a/auth/internal/regionalaccessboundary/regional_access_boundary_test.go
+++ b/auth/internal/regionalaccessboundary/regional_access_boundary_test.go
@@ -581,6 +581,7 @@ func TestGCEConfigProvider_CachesResults(t *testing.T) {
 }
 
 type mockConfigProvider struct {
+	mu                  sync.Mutex
 	endpointCallCount   int
 	universeCallCount   int
 	endpointToReturn    string
@@ -590,18 +591,30 @@ type mockConfigProvider struct {
 }
 
 func (m *mockConfigProvider) GetRegionalAccessBoundaryEndpoint(ctx context.Context) (string, error) {
+	m.mu.Lock()
 	m.endpointCallCount++
+	m.mu.Unlock()
 	return m.endpointToReturn, m.endpointErrToReturn
 }
 
 func (m *mockConfigProvider) GetUniverseDomain(ctx context.Context) (string, error) {
+	m.mu.Lock()
 	m.universeCallCount++
+	m.mu.Unlock()
 	return m.universeToReturn, m.universeErrToReturn
 }
 
 func (m *mockConfigProvider) Reset() {
+	m.mu.Lock()
 	m.endpointCallCount = 0
 	m.universeCallCount = 0
+	m.mu.Unlock()
+}
+
+func (m *mockConfigProvider) GetEndpointCallCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.endpointCallCount
 }
 
 type mockTokenProvider struct {
@@ -664,7 +677,7 @@ func TestDataProvider_GetHeaderValue(t *testing.T) {
 					deadline := time.Now().Add(1 * time.Second)
 					var gotCall bool
 					for time.Now().Before(deadline) {
-						if mockConfig.endpointCallCount > 0 {
+						if mockConfig.GetEndpointCallCount() > 0 {
 							gotCall = true
 							break
 						}
@@ -675,7 +688,7 @@ func TestDataProvider_GetHeaderValue(t *testing.T) {
 					}
 				} else {
 					time.Sleep(50 * time.Millisecond)
-					if mockConfig.endpointCallCount > 0 {
+					if mockConfig.GetEndpointCallCount() > 0 {
 						t.Errorf("GetHeaderValue(%q) initiated fetch unexpectedly", tt.reqURL)
 					}
 				}

--- a/auth/internal/regionalaccessboundary/regional_access_boundary_test.go
+++ b/auth/internal/regionalaccessboundary/regional_access_boundary_test.go
@@ -29,8 +29,19 @@ import (
 
 	"cloud.google.com/go/auth"
 	"cloud.google.com/go/auth/internal"
+	"cloud.google.com/go/auth/internal/retry"
 	"cloud.google.com/go/compute/metadata"
 )
+
+func init() {
+	// Override retry options for testing to avoid long waits.
+	retryOptions = &retry.Options{
+		Initial:     1 * time.Millisecond,
+		Max:         5 * time.Millisecond,
+		Multiplier:  2.0,
+		MaxAttempts: 6,
+	}
+}
 
 func TestFetchRegionalAccessBoundaryData(t *testing.T) {
 	type serverResponse struct {

--- a/auth/internal/regionalaccessboundary/regional_access_boundary_test.go
+++ b/auth/internal/regionalaccessboundary/regional_access_boundary_test.go
@@ -16,6 +16,7 @@ package regionalaccessboundary
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -425,8 +426,8 @@ func TestGCEConfigProvider(t *testing.T) {
 					http.NotFound(w, r)
 				}
 			},
-			wantErrEndpoint: "regionalaccessboundary: GCE config: failed to get universe domain",
-			wantErrUD:       "regionalaccessboundary: GCE config: failed to get universe domain",
+			expectedEndpoint: defaultExpectedEndpoint,
+			wantErrUD:        "regionalaccessboundary: GCE config: failed to get universe domain",
 		},
 		{
 			name:                    "Nil ComputeUniverseDomainProvider",
@@ -679,6 +680,41 @@ func TestDataProvider_GetHeaderValue(t *testing.T) {
 			t.Errorf("Second call did not return cached header within timeout")
 		} else if val2 != "0xABC" {
 			t.Errorf("Second call returned %q, expected %q", val2, "0xABC")
+		}
+	})
+
+	t.Run("Endpoint_fetch_failure_sets_cooldown", func(t *testing.T) {
+		configProvider := &mockConfigProvider{
+			endpointErrToReturn: errors.New("endpoint error"),
+		}
+		provider, err := NewProvider(http.DefaultClient, configProvider, nil, nil)
+		if err != nil {
+			t.Fatalf("NewProvider() unexpected error: %v", err)
+		}
+
+		// First call should trigger async fetch (which fails).
+		val := provider.GetHeaderValue(context.Background(), "https://example.com", nil)
+		if val != "" {
+			t.Errorf("First call expected empty string, got %q", val)
+		}
+
+		// Wait for the async fetch to complete and set cooldown.
+		// Since there is no direct channel to signal completion, we poll the cooldown status.
+		deadline := time.Now().Add(1 * time.Second)
+		cooldownSet := false
+		for time.Now().Before(deadline) {
+			provider.mu.Lock()
+			if !provider.cooldownExpiry.IsZero() {
+				cooldownSet = true
+				provider.mu.Unlock()
+				break
+			}
+			provider.mu.Unlock()
+			time.Sleep(10 * time.Millisecond)
+		}
+
+		if !cooldownSet {
+			t.Errorf("Cooldown expiry was not set after endpoint failure")
 		}
 	})
 }

--- a/auth/internal/regionalaccessboundary/regional_access_boundary_test.go
+++ b/auth/internal/regionalaccessboundary/regional_access_boundary_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -221,12 +221,12 @@ func TestIsRegionalAccessBoundaryEnabled(t *testing.T) {
 	oldEnvVar := "GOOGLE_AUTH_TRUST_BOUNDARY_ENABLED"
 
 	tests := []struct {
-		name              string
-		newEnvVal         string
-		oldEnvVal         string
-		setNewEnv         bool
-		setOldEnv         bool
-		want              bool
+		name      string
+		newEnvVal string
+		oldEnvVal string
+		setNewEnv bool
+		setOldEnv bool
+		want      bool
 	}{
 		{
 			name:      "new env unset, old env unset",
@@ -486,7 +486,7 @@ func TestGCEConfigProvider(t *testing.T) {
 				}
 			},
 			wantErrEndpoint: "regionalaccessboundary: GCE config: failed to get universe domain",
-			wantErrUD: "regionalaccessboundary: GCE config: failed to get universe domain",
+			wantErrUD:       "regionalaccessboundary: GCE config: failed to get universe domain",
 		},
 		{
 			name:                    "Nil ComputeUniverseDomainProvider",
@@ -718,14 +718,14 @@ func TestDataProvider_GetHeaderValue(t *testing.T) {
 
 		token := &auth.Token{Value: "base"}
 		provider, _ := NewProvider(server.Client(), mockConfig, nil, &mockTokenProvider{TokenToReturn: token})
-		
+
 		val := provider.GetHeaderValue(ctx, "https://example.com/v1", token)
 		if val != "" {
 			t.Errorf("First call should return empty while fetching async")
 		}
 
 		wg.Wait() // Wait for server to receive request
-		
+
 		// Wait an extra beat for HandleFetchSuccess to write the cache locally in the goroutine
 		time.Sleep(50 * time.Millisecond)
 

--- a/auth/internal/regionalaccessboundary/regional_access_boundary_test.go
+++ b/auth/internal/regionalaccessboundary/regional_access_boundary_test.go
@@ -20,7 +20,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"os"
 	"reflect"
 	"strings"
 	"sync"
@@ -217,108 +216,52 @@ func TestFetchRegionalAccessBoundaryData(t *testing.T) {
 }
 
 func TestIsRegionalAccessBoundaryEnabled(t *testing.T) {
-	newEnvVar := "GOOGLE_AUTH_REGIONAL_ACCESS_BOUNDARY_ENABLE_EXPERIMENT"
-	oldEnvVar := "GOOGLE_AUTH_TRUST_BOUNDARY_ENABLED"
+	envVar := "GOOGLE_AUTH_TRUST_BOUNDARY_ENABLED"
 
 	tests := []struct {
-		name      string
-		newEnvVal string
-		oldEnvVal string
-		setNewEnv bool
-		setOldEnv bool
-		want      bool
+		name   string
+		envVal string
+		want   bool
 	}{
 		{
-			name:      "new env unset, old env unset",
-			setNewEnv: false,
-			setOldEnv: false,
-			want:      false,
+			name:   "env empty/unset",
+			envVal: "",
+			want:   false,
 		},
 		{
-			name:      "new env empty, old env unset",
-			newEnvVal: "",
-			setNewEnv: true,
-			setOldEnv: false,
-			want:      false,
+			name:   "env true",
+			envVal: "true",
+			want:   true,
 		},
 		{
-			name:      "new env true, old env unset",
-			newEnvVal: "true",
-			setNewEnv: true,
-			setOldEnv: false,
-			want:      true,
+			name:   "env 1",
+			envVal: "1",
+			want:   true,
 		},
 		{
-			name:      "new env 1, old env unset",
-			newEnvVal: "1",
-			setNewEnv: true,
-			setOldEnv: false,
-			want:      true,
+			name:   "env false",
+			envVal: "false",
+			want:   false,
 		},
 		{
-			name:      "new env false, old env unset",
-			newEnvVal: "false",
-			setNewEnv: true,
-			setOldEnv: false,
-			want:      false,
+			name:   "env 0",
+			envVal: "0",
+			want:   false,
 		},
 		{
-			name:      "new env 0, old env unset",
-			newEnvVal: "0",
-			setNewEnv: true,
-			setOldEnv: false,
-			want:      false,
+			name:   "env invalid",
+			envVal: "invalid",
+			want:   false,
 		},
 		{
-			name:      "new env invalid, old env unset",
-			newEnvVal: "invalid",
-			setNewEnv: true,
-			setOldEnv: false,
-			want:      false,
-		},
-		{
-			name:      "new env unset, old env true",
-			setNewEnv: false,
-			oldEnvVal: "true",
-			setOldEnv: true,
-			want:      true,
-		},
-		{
-			name:      "new env unset, old env invalid",
-			setNewEnv: false,
-			oldEnvVal: "invalid",
-			setOldEnv: true,
-			want:      false,
-		},
-		{
-			name:      "new env true, old env false (new takes precedence)",
-			newEnvVal: "true",
-			setNewEnv: true,
-			oldEnvVal: "false",
-			setOldEnv: true,
-			want:      true,
-		},
-		{
-			name:      "new env false, old env true (new takes precedence)",
-			newEnvVal: "false",
-			setNewEnv: true,
-			oldEnvVal: "true",
-			setOldEnv: true,
-			want:      false,
+			name:   "env uppercase TRUE",
+			envVal: "TRUE",
+			want:   true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.setNewEnv {
-				t.Setenv(newEnvVar, tt.newEnvVal)
-			} else {
-				os.Unsetenv(newEnvVar)
-			}
-			if tt.setOldEnv {
-				t.Setenv(oldEnvVar, tt.oldEnvVal)
-			} else {
-				os.Unsetenv(oldEnvVar)
-			}
+			t.Setenv(envVar, tt.envVal)
 
 			got, err := isRegionalAccessBoundaryEnabled()
 			if err != nil {
@@ -421,9 +364,6 @@ func TestGCEConfigProvider(t *testing.T) {
 	defaultTestEmail := "test-sa@example.iam.gserviceaccount.com"
 	defaultTestUD := "example.com"
 	defaultExpectedEndpoint := fmt.Sprintf(serviceAccountAllowedLocationsEndpoint, defaultTestEmail)
-
-	originalGCEHost := os.Getenv("GCE_METADATA_HOST")
-	defer os.Setenv("GCE_METADATA_HOST", originalGCEHost)
 
 	tests := []struct {
 		name                    string
@@ -554,14 +494,14 @@ func TestGCEConfigProvider(t *testing.T) {
 				if err != nil {
 					t.Fatalf("Failed to parse server URL: %v", err)
 				}
-				os.Setenv("GCE_METADATA_HOST", parsedURL.Host)
+				t.Setenv("GCE_METADATA_HOST", parsedURL.Host)
 				mdClient := metadata.NewClient(server.Client())
 				udp := &internal.ComputeUniverseDomainProvider{
 					MetadataClient: mdClient,
 				}
 				provider = NewGCEConfigProvider(udp)
 			} else {
-				os.Unsetenv("GCE_METADATA_HOST")
+				t.Setenv("GCE_METADATA_HOST", "")
 				provider = NewGCEConfigProvider(tt.gceUDP)
 			}
 
@@ -595,8 +535,6 @@ func TestGCEConfigProvider(t *testing.T) {
 }
 
 func TestGCEConfigProvider_CachesResults(t *testing.T) {
-	originalGCEHost := os.Getenv("GCE_METADATA_HOST")
-	defer os.Setenv("GCE_METADATA_HOST", originalGCEHost)
 
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -613,7 +551,7 @@ func TestGCEConfigProvider_CachesResults(t *testing.T) {
 	defer server.Close()
 
 	parsedURL, _ := url.Parse(server.URL)
-	os.Setenv("GCE_METADATA_HOST", parsedURL.Host)
+	t.Setenv("GCE_METADATA_HOST", parsedURL.Host)
 	mdClient := metadata.NewClient(server.Client())
 	udp := &internal.ComputeUniverseDomainProvider{MetadataClient: mdClient}
 	provider := NewGCEConfigProvider(udp)
@@ -726,12 +664,19 @@ func TestDataProvider_GetHeaderValue(t *testing.T) {
 
 		wg.Wait() // Wait for server to receive request
 
-		// Wait an extra beat for HandleFetchSuccess to write the cache locally in the goroutine
-		time.Sleep(50 * time.Millisecond)
+		// Wait for background fetch to complete and populate cache.
+		var val2 string
+		deadline := time.Now().Add(1 * time.Second)
+		for time.Now().Before(deadline) {
+			val2 = provider.GetHeaderValue(ctx, "https://example.com/v1", token)
+			if val2 != "" {
+				break
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
 
-		val2 := provider.GetHeaderValue(ctx, "https://example.com/v1", token)
 		if val2 == "" {
-			t.Errorf("Second call did not return cached header")
+			t.Errorf("Second call did not return cached header within timeout")
 		} else if val2 != "0xABC" {
 			t.Errorf("Second call returned %q, expected %q", val2, "0xABC")
 		}

--- a/auth/internal/regionalaccessboundary/regional_access_boundary_test.go
+++ b/auth/internal/regionalaccessboundary/regional_access_boundary_test.go
@@ -16,7 +16,6 @@ package regionalaccessboundary
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -24,7 +23,9 @@ import (
 	"os"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"cloud.google.com/go/auth"
 	"cloud.google.com/go/auth/internal"
@@ -355,7 +356,7 @@ func TestServiceAccountConfig(t *testing.T) {
 				name:    "Valid SA Email",
 				ud:      "example.com",
 				saEmail: "test-sa@example.iam.gserviceaccount.com",
-				wantURL: fmt.Sprintf(serviceAccountAllowedLocationsEndpoint, "example.com", "test-sa@example.iam.gserviceaccount.com"),
+				wantURL: fmt.Sprintf(serviceAccountAllowedLocationsEndpoint, "test-sa@example.iam.gserviceaccount.com"),
 			},
 			{
 				name:    "Empty SA Email",
@@ -366,7 +367,7 @@ func TestServiceAccountConfig(t *testing.T) {
 				name:    "Empty UD defaults to googleapis.com",
 				ud:      "",
 				saEmail: "test-sa@example.iam.gserviceaccount.com",
-				wantURL: fmt.Sprintf(serviceAccountAllowedLocationsEndpoint, internal.DefaultUniverseDomain, "test-sa@example.iam.gserviceaccount.com"),
+				wantURL: fmt.Sprintf(serviceAccountAllowedLocationsEndpoint, "test-sa@example.iam.gserviceaccount.com"),
 			},
 		}
 		for _, tt := range tests {
@@ -419,7 +420,7 @@ func TestServiceAccountConfig(t *testing.T) {
 func TestGCEConfigProvider(t *testing.T) {
 	defaultTestEmail := "test-sa@example.iam.gserviceaccount.com"
 	defaultTestUD := "example.com"
-	defaultExpectedEndpoint := fmt.Sprintf(serviceAccountAllowedLocationsEndpoint, defaultTestUD, defaultTestEmail)
+	defaultExpectedEndpoint := fmt.Sprintf(serviceAccountAllowedLocationsEndpoint, defaultTestEmail)
 
 	originalGCEHost := os.Getenv("GCE_METADATA_HOST")
 	defer os.Setenv("GCE_METADATA_HOST", originalGCEHost)
@@ -535,7 +536,7 @@ func TestGCEConfigProvider(t *testing.T) {
 					}
 				}
 			},
-			expectedEndpoint: fmt.Sprintf(serviceAccountAllowedLocationsEndpoint, internal.DefaultUniverseDomain, defaultTestEmail),
+			expectedEndpoint: fmt.Sprintf(serviceAccountAllowedLocationsEndpoint, defaultTestEmail),
 			expectedUD:       internal.DefaultUniverseDomain,
 		},
 	}
@@ -664,241 +665,75 @@ func (m *mockTokenProvider) Token(ctx context.Context) (*auth.Token, error) {
 
 func TestDataProvider_Token(t *testing.T) {
 	ctx := context.Background()
+	baseToken := &auth.Token{Value: "base-token"}
+	baseProvider := &mockTokenProvider{TokenToReturn: baseToken}
 
-	type serverResponse struct {
-		status int
-		body   string
+	provider, err := NewProvider(http.DefaultClient, &mockConfigProvider{}, nil, baseProvider)
+	if err != nil {
+		t.Fatalf("NewProvider() failed: %v", err)
 	}
 
-	tests := []struct {
-		name                  string
-		mockConfig            *mockConfigProvider
-		serverResponse        *serverResponse // for fetchRegionalAccessBoundaryData
-		baseProvider          *mockTokenProvider
-		wantDataOnToken       *internal.RegionalAccessBoundaryData
-		wantErr               string
-		wantUniverseCallCount int
-		wantEndpointCallCount int
-		// secondRun allows testing caching behavior by running the same hook again
-		// with a different server/mock configuration.
-		secondRun *struct {
-			serverResponse        *serverResponse
-			wantDataOnToken       *internal.RegionalAccessBoundaryData
-			wantErr               string
-			wantUniverseCallCount int
-			wantEndpointCallCount int
+	token, err := provider.Token(ctx)
+	if err != nil {
+		t.Fatalf("provider.Token() unexpected error: %v", err)
+	}
+
+	if token.Value != baseToken.Value {
+		t.Errorf("provider.Token() value = %q, want %q", token.Value, baseToken.Value)
+	}
+
+	if p, ok := token.Metadata[ProviderKey]; !ok || p != provider {
+		t.Errorf("provider.Token() metadata missing ProviderKey or incorrect provider reference")
+	}
+}
+
+func TestDataProvider_GetHeaderValue(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("Regional endpoint skip", func(t *testing.T) {
+		token := &auth.Token{Value: "base"}
+		provider, _ := NewProvider(http.DefaultClient, &mockConfigProvider{}, nil, &mockTokenProvider{TokenToReturn: token})
+		val := provider.GetHeaderValue(ctx, "https://us-central1.rep.googleapis.com/v1/...", token)
+		if val != "" {
+			t.Errorf("Expected empty header for regional endpoint, got %q", val)
 		}
-	}{
-		{
-			name: "Non-default universe domain returns nil",
-			mockConfig: &mockConfigProvider{
-				universeToReturn: "example.com",
-			},
-			baseProvider: &mockTokenProvider{
-				TokenToReturn: &auth.Token{Value: "base-token"},
-			},
-			wantDataOnToken:       nil,
-			wantUniverseCallCount: 1,
-			wantEndpointCallCount: 0,
-		},
-		{
-			name: "Default universe, no cache, successful fetch",
-			mockConfig: &mockConfigProvider{
-				universeToReturn: internal.DefaultUniverseDomain,
-			},
-			baseProvider: &mockTokenProvider{
-				TokenToReturn: &auth.Token{Value: "base-token"},
-			},
-			serverResponse: &serverResponse{
-				status: http.StatusOK,
-				body:   `{"locations": ["us-east1"], "encodedLocations": "0xABC"}`,
-			},
-			wantDataOnToken:       internal.NewRegionalAccessBoundaryData([]string{"us-east1"}, "0xABC"),
-			wantUniverseCallCount: 1,
-			wantEndpointCallCount: 1,
-		},
-		{
-			name: "Default universe, fetch fails, no cache, returns error",
-			mockConfig: &mockConfigProvider{
-				universeToReturn: internal.DefaultUniverseDomain,
-			},
-			baseProvider: &mockTokenProvider{
-				TokenToReturn: &auth.Token{Value: "base-token"},
-			},
-			serverResponse: &serverResponse{
-				status: http.StatusInternalServerError,
-				body:   "server error",
-			},
-			wantDataOnToken:       &internal.RegionalAccessBoundaryData{},
-			wantErr:               "and no cache available",
-			wantUniverseCallCount: 1,
-			wantEndpointCallCount: 1,
-		},
-		{
-			name: "Error from GetUniverseDomain",
-			mockConfig: &mockConfigProvider{
-				universeErrToReturn: errors.New("universe domain error"),
-			},
-			baseProvider: &mockTokenProvider{
-				TokenToReturn: &auth.Token{Value: "base-token"},
-			},
-			wantDataOnToken:       &internal.RegionalAccessBoundaryData{},
-			wantErr:               "error getting universe domain",
-			wantUniverseCallCount: 1,
-			wantEndpointCallCount: 0,
-		},
-		{
-			name: "Error from GetRegionalAccessBoundaryEndpoint",
-			mockConfig: &mockConfigProvider{
-				universeToReturn:    internal.DefaultUniverseDomain,
-				endpointErrToReturn: errors.New("endpoint error"),
-			},
-			baseProvider: &mockTokenProvider{
-				TokenToReturn: &auth.Token{Value: "base-token"},
-			},
-			wantDataOnToken:       &internal.RegionalAccessBoundaryData{},
-			wantErr:               "error getting the lookup endpoint",
-			wantUniverseCallCount: 1,
-			wantEndpointCallCount: 1,
-		},
-		{
-			name: "Cache fallback on second call",
-			mockConfig: &mockConfigProvider{
-				universeToReturn: internal.DefaultUniverseDomain,
-			},
-			baseProvider: &mockTokenProvider{
-				TokenToReturn: &auth.Token{Value: "base-token"},
-			},
-			serverResponse: &serverResponse{ // First call is successful
-				status: http.StatusOK,
-				body:   `{"locations": ["us-east1"], "encodedLocations": "0xABC"}`,
-			},
-			wantDataOnToken:       internal.NewRegionalAccessBoundaryData([]string{"us-east1"}, "0xABC"),
-			wantUniverseCallCount: 1,
-			wantEndpointCallCount: 1,
-			secondRun: &struct {
-				serverResponse        *serverResponse
-				wantDataOnToken       *internal.RegionalAccessBoundaryData
-				wantErr               string
-				wantUniverseCallCount int
-				wantEndpointCallCount int
-			}{
-				serverResponse: &serverResponse{ // Second call fails
-					status: http.StatusInternalServerError,
-					body:   "server error",
-				},
-				wantDataOnToken: internal.NewRegionalAccessBoundaryData([]string{"us-east1"}, "0xABC"), // Should get cached data
-				wantErr:         "",                                                           // No error due to fallback
-				// It tries to fetch again, but falls back to cache.
-				wantUniverseCallCount: 1,
-				wantEndpointCallCount: 1,
-			},
-		},
-	}
+	})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			tt.mockConfig.Reset()
-			var server *httptest.Server
-			client := http.DefaultClient
+	t.Run("Async fetch success", func(t *testing.T) {
+		var wg sync.WaitGroup
+		wg.Add(1)
 
-			if tt.serverResponse != nil { // Indicates a fetch is expected
-				server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					w.Header().Set("Content-Type", "application/json")
-					w.WriteHeader(tt.serverResponse.status)
-					fmt.Fprintln(w, tt.serverResponse.body)
-				}))
-				defer server.Close()
-				tt.mockConfig.endpointToReturn = server.URL
-				client = server.Client() // Use the test server's client
-			}
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			defer wg.Done()
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprintln(w, `{"locations": ["us-east1"], "encodedLocations": "0xABC"}`)
+		}))
+		defer server.Close()
 
-			provider, err := NewProvider(client, tt.mockConfig, nil, tt.baseProvider)
-			if err != nil {
-				t.Fatalf("NewProvider() failed: %v", err)
-			}
+		mockConfig := &mockConfigProvider{
+			universeToReturn: internal.DefaultUniverseDomain,
+			endpointToReturn: server.URL,
+		}
 
-			// First run
-			token, err := provider.Token(ctx)
+		token := &auth.Token{Value: "base"}
+		provider, _ := NewProvider(server.Client(), mockConfig, nil, &mockTokenProvider{TokenToReturn: token})
+		
+		val := provider.GetHeaderValue(ctx, "https://example.com/v1", token)
+		if val != "" {
+			t.Errorf("First call should return empty while fetching async")
+		}
 
-			if tt.wantErr != "" {
-				if err == nil {
-					t.Fatalf("provider.Token() error = nil, want %q", tt.wantErr)
-				}
-				if !strings.Contains(err.Error(), tt.wantErr) {
-					t.Errorf("provider.Token() error = %q, want %q", err.Error(), tt.wantErr)
-				}
-			} else if err != nil {
-				t.Fatalf("provider.Token() unexpected error: %v", err)
-			} else {
-				if token.Value != tt.baseProvider.TokenToReturn.Value {
-					t.Errorf("provider.Token() value = %q, want %q", token.Value, tt.baseProvider.TokenToReturn.Value)
-				}
-				var gotData internal.RegionalAccessBoundaryData
-				data, ok := token.Metadata[internal.RegionalAccessBoundaryDataKey]
-				if tt.wantDataOnToken == nil {
-					if ok {
-						t.Errorf("provider.Token() data on token = %+v, want nil", data)
-					}
-				} else {
-					if ok {
-						gotData, _ = data.(internal.RegionalAccessBoundaryData)
-					}
-					if !reflect.DeepEqual(gotData, *tt.wantDataOnToken) {
-						t.Errorf("provider.Token() data on token = %+v, want %+v", gotData, *tt.wantDataOnToken)
-					}
-				}
-			}
+		wg.Wait() // Wait for server to receive request
+		
+		// Wait an extra beat for HandleFetchSuccess to write the cache locally in the goroutine
+		time.Sleep(50 * time.Millisecond)
 
-			if tt.mockConfig.universeCallCount != tt.wantUniverseCallCount {
-				t.Errorf("GetUniverseDomain call count = %d, want %d", tt.mockConfig.universeCallCount, tt.wantUniverseCallCount)
-			}
-			if tt.mockConfig.endpointCallCount != tt.wantEndpointCallCount {
-				t.Errorf("GetRegionalAccessBoundaryEndpoint call count = %d, want %d", tt.mockConfig.endpointCallCount, tt.wantEndpointCallCount)
-			}
-
-			// Second run, if configured
-			if tt.secondRun != nil {
-				// Reset server if needed
-				if tt.secondRun.serverResponse != nil {
-					server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-						w.Header().Set("Content-Type", "application/json")
-						w.WriteHeader(tt.secondRun.serverResponse.status)
-						fmt.Fprintln(w, tt.secondRun.serverResponse.body)
-					})
-				}
-
-				// Reset mock call counts for the second run
-				tt.mockConfig.Reset()
-
-				secondToken, err := provider.Token(ctx)
-
-				if tt.secondRun.wantErr != "" {
-					if err == nil {
-						t.Fatalf("provider.Token() second run error = nil, want %q", tt.secondRun.wantErr)
-					}
-					if !strings.Contains(err.Error(), tt.secondRun.wantErr) {
-						t.Errorf("provider.Token() second run error = %q, want %q", err.Error(), tt.secondRun.wantErr)
-					}
-				} else if err != nil {
-					t.Fatalf("provider.Token() second run unexpected error: %v", err)
-				} else {
-					var gotData internal.RegionalAccessBoundaryData
-					if data, ok := secondToken.Metadata[internal.RegionalAccessBoundaryDataKey]; ok {
-						gotData, _ = data.(internal.RegionalAccessBoundaryData)
-					}
-					if !reflect.DeepEqual(gotData, *tt.secondRun.wantDataOnToken) {
-						t.Errorf("provider.Token() second run data on token = %+v, want %+v", gotData, *tt.secondRun.wantDataOnToken)
-					}
-				}
-
-				if tt.mockConfig.universeCallCount != tt.secondRun.wantUniverseCallCount {
-					t.Errorf("second run GetUniverseDomain call count = %d, want %d", tt.mockConfig.universeCallCount, tt.secondRun.wantUniverseCallCount)
-				}
-				if tt.mockConfig.endpointCallCount != tt.secondRun.wantEndpointCallCount {
-					t.Errorf("second run GetRegionalAccessBoundaryEndpoint call count = %d, want %d", tt.mockConfig.endpointCallCount, tt.secondRun.wantEndpointCallCount)
-				}
-			}
-		})
-	}
+		val2 := provider.GetHeaderValue(ctx, "https://example.com/v1", token)
+		if val2 == "" {
+			t.Errorf("Second call did not return cached header")
+		} else if val2 != "0xABC" {
+			t.Errorf("Second call returned %q, expected %q", val2, "0xABC")
+		}
+	})
 }

--- a/auth/internal/retry/retry.go
+++ b/auth/internal/retry/retry.go
@@ -22,10 +22,6 @@ import (
 	"time"
 )
 
-const (
-	maxRetryAttempts = 5
-)
-
 var (
 	syscallRetryable = func(error) bool { return false }
 )
@@ -61,21 +57,69 @@ func Sleep(ctx context.Context, d time.Duration) error {
 
 // New returns a new Retryer with the default backoff strategy.
 func New() *Retryer {
-	return &Retryer{bo: &defaultBackoff{
-		cur: 100 * time.Millisecond,
-		max: 30 * time.Second,
-		mul: 2,
-	}}
+	return NewWithOptions(&Options{
+		Initial:     100 * time.Millisecond,
+		Max:         30 * time.Second,
+		Multiplier:  2,
+		MaxAttempts: 5,
+	})
+}
+
+// Options defines the configuration for the Retryer.
+type Options struct {
+	// Initial is the initial backoff duration.
+	Initial time.Duration
+	// Max is the maximum backoff duration for a single retry attempt.
+	// It does not limit the total time of all retries.
+	Max time.Duration
+	// Multiplier is the factor by which the backoff duration is multiplied after each attempt.
+	Multiplier float64
+	// MaxAttempts is the maximum number of attempts before giving up.
+	MaxAttempts int
+}
+
+// NewWithOptions returns a new Retryer with the specified backoff strategy.
+// If any option is not set (zero value), it defaults to the values used in New().
+func NewWithOptions(opts *Options) *Retryer {
+	initial := opts.Initial
+	if initial <= 0 {
+		initial = 100 * time.Millisecond
+	}
+
+	max := opts.Max
+	if max <= 0 {
+		max = 30 * time.Second
+	}
+
+	multiplier := opts.Multiplier
+	if multiplier < 1.0 {
+		multiplier = 2.0
+	}
+
+	maxAttempts := opts.MaxAttempts
+	if maxAttempts <= 0 {
+		maxAttempts = 5
+	}
+
+	return &Retryer{
+		bo: &defaultBackoff{
+			cur: initial,
+			max: max,
+			mul: multiplier,
+		},
+		maxAttempts: maxAttempts,
+	}
 }
 
 type backoff interface {
 	Pause() time.Duration
 }
 
-// Retryer is a retryer for HTTP requests.
+// Retryer handles retry logic for HTTP requests using a configurable backoff strategy.
 type Retryer struct {
-	bo       backoff
-	attempts int
+	bo          backoff
+	attempts    int
+	maxAttempts int
 }
 
 // Retry determines if a request should be retried.
@@ -87,7 +131,7 @@ func (r *Retryer) Retry(status int, err error) (time.Duration, bool) {
 	if !retryOk {
 		return 0, false
 	}
-	if r.attempts == maxRetryAttempts {
+	if r.attempts == r.maxAttempts {
 		return 0, false
 	}
 	r.attempts++

--- a/auth/internal/retry/retry_linux.go
+++ b/auth/internal/retry/retry_linux.go
@@ -1,0 +1,31 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+// +build linux
+
+package retry
+
+import (
+	"errors"
+	"syscall"
+)
+
+func init() {
+	// Initialize syscallRetryable to return true on transient socket-level
+	// errors. These errors are specific to Linux.
+	syscallRetryable = func(err error) bool {
+		return errors.Is(err, syscall.ECONNRESET) || errors.Is(err, syscall.ECONNREFUSED)
+	}
+}

--- a/auth/internal/retry/retry_linux_test.go
+++ b/auth/internal/retry/retry_linux_test.go
@@ -1,0 +1,36 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+// +build linux
+
+package retry
+
+import (
+	"syscall"
+	"testing"
+)
+
+func TestShouldRetryLinux(t *testing.T) {
+	t.Run("retry on syscall.ECONNRESET", func(t *testing.T) {
+		if !shouldRetry(0, syscall.ECONNRESET) {
+			t.Fatal("shouldRetry(0, syscall.ECONNRESET) = false, want true")
+		}
+	})
+	t.Run("retry on syscall.ECONNREFUSED", func(t *testing.T) {
+		if !shouldRetry(0, syscall.ECONNREFUSED) {
+			t.Fatal("shouldRetry(0, syscall.ECONNREFUSED) = false, want true")
+		}
+	})
+}

--- a/auth/internal/retry/retry_test.go
+++ b/auth/internal/retry/retry_test.go
@@ -104,7 +104,7 @@ func TestShouldRetry(t *testing.T) {
 func TestRetryer_Retry(t *testing.T) {
 	t.Run("stops after max attempts", func(t *testing.T) {
 		r := New()
-		for i := 0; i < maxRetryAttempts; i++ {
+		for i := 0; i < r.maxAttempts; i++ {
 			if _, ok := r.Retry(500, nil); !ok {
 				t.Errorf("Retry() should have returned true on attempt %d", i)
 			}
@@ -151,4 +151,63 @@ func TestDefaultBackoff_Pause(t *testing.T) {
 	if b.cur > 1*time.Second {
 		t.Errorf("b.cur got %v, want <= 1s", b.cur)
 	}
+}
+
+func TestNewWithOptions(t *testing.T) {
+	t.Run("Full options", func(t *testing.T) {
+		opts := &Options{
+			Initial:     200 * time.Millisecond,
+			Max:         500 * time.Millisecond,
+			Multiplier:  1.5,
+			MaxAttempts: 3,
+		}
+		r := NewWithOptions(opts)
+
+		if r.maxAttempts != 3 {
+			t.Errorf("maxAttempts = %d, want 3", r.maxAttempts)
+		}
+
+		b, ok := r.bo.(*defaultBackoff)
+		if !ok {
+			t.Fatalf("backoff is not defaultBackoff")
+		}
+		if b.cur != 200*time.Millisecond {
+			t.Errorf("Initial = %v, want 200ms", b.cur)
+		}
+		if b.max != 500*time.Millisecond {
+			t.Errorf("Max = %v, want 500ms", b.max)
+		}
+		if b.mul != 1.5 {
+			t.Errorf("Multiplier = %v, want 1.5", b.mul)
+		}
+	})
+
+	t.Run("Partial options (defaults)", func(t *testing.T) {
+		// Provide only partial options, zeros should become defaults.
+		opts := &Options{
+			Initial: 0,   // Should default to 100ms
+			Max:     0,   // Should default to 30s
+			// Multiplier 0 -> Should default to 2.0
+			// MaxAttempts 0 -> Should default to 5
+		}
+		r := NewWithOptions(opts)
+
+		if r.maxAttempts != 5 {
+			t.Errorf("maxAttempts = %d, want 5 (default)", r.maxAttempts)
+		}
+
+		b, ok := r.bo.(*defaultBackoff)
+		if !ok {
+			t.Fatalf("backoff is not defaultBackoff")
+		}
+		if b.cur != 100*time.Millisecond {
+			t.Errorf("Initial = %v, want 100ms (default)", b.cur)
+		}
+		if b.max != 30*time.Second {
+			t.Errorf("Max = %v, want 30s (default)", b.max)
+		}
+		if b.mul != 2.0 {
+			t.Errorf("Multiplier = %v, want 2.0 (default)", b.mul)
+		}
+	})
 }

--- a/auth/internal/retry/retry_test.go
+++ b/auth/internal/retry/retry_test.go
@@ -185,8 +185,8 @@ func TestNewWithOptions(t *testing.T) {
 	t.Run("Partial options (defaults)", func(t *testing.T) {
 		// Provide only partial options, zeros should become defaults.
 		opts := &Options{
-			Initial: 0,   // Should default to 100ms
-			Max:     0,   // Should default to 30s
+			Initial: 0, // Should default to 100ms
+			Max:     0, // Should default to 30s
 			// Multiplier 0 -> Should default to 2.0
 			// MaxAttempts 0 -> Should default to 5
 		}

--- a/auth/internal/transport/headers/headers.go
+++ b/auth/internal/transport/headers/headers.go
@@ -21,8 +21,8 @@ import (
 	"cloud.google.com/go/auth/internal"
 )
 
-// SetAuthHeader uses the provided token to set the Authorization and trust
-// boundary headers on a request. If the token.Type is empty, the type is
+// SetAuthHeader uses the provided token to set the Authorization and regional
+// access boundary headers on a request. If the token.Type is empty, the type is
 // assumed to be Bearer.
 func SetAuthHeader(token *auth.Token, req *http.Request) {
 	typ := token.Type
@@ -31,13 +31,13 @@ func SetAuthHeader(token *auth.Token, req *http.Request) {
 	}
 	req.Header.Set("Authorization", typ+" "+token.Value)
 
-	if headerVal, setHeader := getTrustBoundaryHeader(token); setHeader {
+	if headerVal, setHeader := getRegionalAccessBoundaryHeader(token); setHeader {
 		req.Header.Set("x-allowed-locations", headerVal)
 	}
 }
 
-// SetAuthMetadata uses the provided token to set the Authorization and trust
-// boundary metadata. If the token.Type is empty, the type is assumed to be
+// SetAuthMetadata uses the provided token to set the Authorization and regional
+// access boundary metadata. If the token.Type is empty, the type is assumed to be
 // Bearer.
 func SetAuthMetadata(token *auth.Token, m map[string]string) {
 	typ := token.Type
@@ -46,15 +46,15 @@ func SetAuthMetadata(token *auth.Token, m map[string]string) {
 	}
 	m["authorization"] = typ + " " + token.Value
 
-	if headerVal, setHeader := getTrustBoundaryHeader(token); setHeader {
+	if headerVal, setHeader := getRegionalAccessBoundaryHeader(token); setHeader {
 		m["x-allowed-locations"] = headerVal
 	}
 }
 
-func getTrustBoundaryHeader(token *auth.Token) (val string, present bool) {
-	if data, ok := token.Metadata[internal.TrustBoundaryDataKey]; ok {
-		if tbd, ok := data.(internal.TrustBoundaryData); ok {
-			return tbd.TrustBoundaryHeader()
+func getRegionalAccessBoundaryHeader(token *auth.Token) (val string, present bool) {
+	if data, ok := token.Metadata[internal.RegionalAccessBoundaryDataKey]; ok {
+		if tbd, ok := data.(internal.RegionalAccessBoundaryData); ok {
+			return tbd.RegionalAccessBoundaryHeader()
 		}
 	}
 	return "", false

--- a/auth/internal/transport/headers/headers.go
+++ b/auth/internal/transport/headers/headers.go
@@ -47,7 +47,7 @@ func SetAuthHeader(token *auth.Token, req *http.Request) {
 // SetAuthMetadata uses the provided token to set the Authorization and regional
 // access boundary metadata. If the token.Type is empty, the type is assumed to be
 // Bearer.
-func SetAuthMetadata(token *auth.Token, reqURL string, m map[string]string) {
+func SetAuthMetadata(ctx context.Context, token *auth.Token, reqURL string, m map[string]string) {
 	typ := token.Type
 	if typ == "" {
 		typ = internal.TokenTypeBearer
@@ -55,7 +55,7 @@ func SetAuthMetadata(token *auth.Token, reqURL string, m map[string]string) {
 	m["authorization"] = typ + " " + token.Value
 
 	if provider, ok := token.Metadata[regionalaccessboundary.ProviderKey].(regionalAccessBoundaryProvider); ok {
-		if headerVal := provider.GetHeaderValue(context.Background(), reqURL, token); headerVal != "" {
+		if headerVal := provider.GetHeaderValue(ctx, reqURL, token); headerVal != "" {
 			m["x-allowed-locations"] = headerVal
 		}
 	}

--- a/auth/internal/transport/headers/headers_test.go
+++ b/auth/internal/transport/headers/headers_test.go
@@ -27,7 +27,7 @@ func TestSetAuth(t *testing.T) {
 	tests := []struct {
 		name            string
 		baseToken       *auth.Token
-		tbd             *internal.TrustBoundaryData
+		tbd             *internal.RegionalAccessBoundaryData
 		wantAuthHeader  string
 		wantTBHeader    bool
 		wantTBHeaderVal string
@@ -46,7 +46,7 @@ func TestSetAuth(t *testing.T) {
 				Value: "token_val",
 				Type:  "Bearer",
 			},
-			tbd:            &internal.TrustBoundaryData{},
+			tbd:            &internal.RegionalAccessBoundaryData{},
 			wantAuthHeader: "Bearer token_val",
 			wantTBHeader:   false,
 			wantGRPCMeta:   map[string]string{"authorization": "Bearer token_val"},
@@ -57,7 +57,7 @@ func TestSetAuth(t *testing.T) {
 				Value: "token_val",
 				Type:  "Bearer",
 			},
-			tbd:             internal.NewTrustBoundaryData(nil, "some_value"),
+			tbd:             internal.NewRegionalAccessBoundaryData(nil, "some_value"),
 			wantAuthHeader:  "Bearer token_val",
 			wantTBHeader:    true,
 			wantTBHeaderVal: "some_value",
@@ -71,7 +71,7 @@ func TestSetAuth(t *testing.T) {
 				Type:  tt.baseToken.Type,
 			}
 			if tt.tbd != nil {
-				token.Metadata = map[string]interface{}{internal.TrustBoundaryDataKey: *tt.tbd}
+				token.Metadata = map[string]interface{}{internal.RegionalAccessBoundaryDataKey: *tt.tbd}
 			}
 			// Test HTTP
 			req := httptest.NewRequest("GET", "/", nil)

--- a/auth/internal/transport/headers/headers_test.go
+++ b/auth/internal/transport/headers/headers_test.go
@@ -52,18 +52,6 @@ func TestSetAuth(t *testing.T) {
 			wantGRPCMeta:   map[string]string{"authorization": "Bearer token_val"},
 		},
 		{
-			name: "auth with no-op tbd",
-			baseToken: &auth.Token{
-				Value: "token_val",
-				Type:  "Bearer",
-			},
-			tbd:             internal.NewNoOpTrustBoundaryData(),
-			wantAuthHeader:  "Bearer token_val",
-			wantTBHeader:    true,
-			wantTBHeaderVal: "",
-			wantGRPCMeta:    map[string]string{"authorization": "Bearer token_val", "x-allowed-locations": ""},
-		},
-		{
 			name: "auth with tbd",
 			baseToken: &auth.Token{
 				Value: "token_val",

--- a/auth/internal/transport/headers/headers_test.go
+++ b/auth/internal/transport/headers/headers_test.go
@@ -25,10 +25,12 @@ import (
 )
 
 type mockProvider struct {
-	val string
+	val    string
+	gotCtx context.Context
 }
 
 func (m *mockProvider) GetHeaderValue(ctx context.Context, reqURL string, token *auth.Token) string {
+	m.gotCtx = ctx
 	return m.val
 }
 
@@ -94,9 +96,17 @@ func TestSetAuth(t *testing.T) {
 
 			// Test gRPC
 			gotMeta := make(map[string]string)
-			SetAuthMetadata(token, "https://example.com/v1", gotMeta)
+			type testKeyType struct{}
+			var testKey testKeyType
+			testCtx := context.WithValue(context.Background(), testKey, "testVal")
+			SetAuthMetadata(testCtx, token, "https://example.com/v1", gotMeta)
 			if diff := cmp.Diff(tt.wantGRPCMeta, gotMeta); diff != "" {
 				t.Errorf("gRPC metadata mismatch (-want +got):\n%s", diff)
+			}
+			if tt.provider != nil {
+				if v := tt.provider.gotCtx.Value(testKey); v != "testVal" {
+					t.Errorf("SetAuthMetadata did not pass context to provider, got value %v", v)
+				}
 			}
 		})
 	}

--- a/auth/internal/transport/headers/headers_test.go
+++ b/auth/internal/transport/headers/headers_test.go
@@ -15,53 +15,62 @@
 package headers
 
 import (
+	"context"
 	"net/http/httptest"
 	"testing"
 
 	"cloud.google.com/go/auth"
-	"cloud.google.com/go/auth/internal"
+	"cloud.google.com/go/auth/internal/regionalaccessboundary"
 	"github.com/google/go-cmp/cmp"
 )
 
+type mockProvider struct {
+	val string
+}
+
+func (m *mockProvider) GetHeaderValue(ctx context.Context, reqURL string, token *auth.Token) string {
+	return m.val
+}
+
 func TestSetAuth(t *testing.T) {
 	tests := []struct {
-		name            string
-		baseToken       *auth.Token
-		tbd             *internal.RegionalAccessBoundaryData
-		wantAuthHeader  string
-		wantTBHeader    bool
-		wantTBHeaderVal string
-		wantGRPCMeta    map[string]string
+		name             string
+		baseToken        *auth.Token
+		provider         *mockProvider
+		wantAuthHeader   string
+		wantRABHeader    bool
+		wantRABHeaderVal string
+		wantGRPCMeta     map[string]string
 	}{
 		{
 			name:           "auth only",
 			baseToken:      &auth.Token{Value: "token_val", Type: "Bearer"},
 			wantAuthHeader: "Bearer token_val",
-			wantTBHeader:   false,
+			wantRABHeader:  false,
 			wantGRPCMeta:   map[string]string{"authorization": "Bearer token_val"},
 		},
 		{
-			name: "auth with empty tbd",
+			name: "auth with empty rab",
 			baseToken: &auth.Token{
 				Value: "token_val",
 				Type:  "Bearer",
 			},
-			tbd:            &internal.RegionalAccessBoundaryData{},
+			provider:       &mockProvider{val: ""},
 			wantAuthHeader: "Bearer token_val",
-			wantTBHeader:   false,
+			wantRABHeader:  false,
 			wantGRPCMeta:   map[string]string{"authorization": "Bearer token_val"},
 		},
 		{
-			name: "auth with tbd",
+			name: "auth with rab",
 			baseToken: &auth.Token{
 				Value: "token_val",
 				Type:  "Bearer",
 			},
-			tbd:             internal.NewRegionalAccessBoundaryData(nil, "some_value"),
-			wantAuthHeader:  "Bearer token_val",
-			wantTBHeader:    true,
-			wantTBHeaderVal: "some_value",
-			wantGRPCMeta:    map[string]string{"authorization": "Bearer token_val", "x-allowed-locations": "some_value"},
+			provider:         &mockProvider{val: "some_value"},
+			wantAuthHeader:   "Bearer token_val",
+			wantRABHeader:    true,
+			wantRABHeaderVal: "some_value",
+			wantGRPCMeta:     map[string]string{"authorization": "Bearer token_val", "x-allowed-locations": "some_value"},
 		},
 	}
 	for _, tt := range tests {
@@ -70,22 +79,22 @@ func TestSetAuth(t *testing.T) {
 				Value: tt.baseToken.Value,
 				Type:  tt.baseToken.Type,
 			}
-			if tt.tbd != nil {
-				token.Metadata = map[string]interface{}{internal.RegionalAccessBoundaryDataKey: *tt.tbd}
+			if tt.provider != nil {
+				token.Metadata = map[string]interface{}{regionalaccessboundary.ProviderKey: tt.provider}
 			}
 			// Test HTTP
-			req := httptest.NewRequest("GET", "/", nil)
+			req := httptest.NewRequest("GET", "https://example.com/v1", nil)
 			SetAuthHeader(token, req)
 			if got := req.Header.Get("Authorization"); got != tt.wantAuthHeader {
 				t.Errorf("Authorization header: got %q, want %q", got, tt.wantAuthHeader)
 			}
-			if got, ok := req.Header["X-Allowed-Locations"]; ok != tt.wantTBHeader || (ok && got[0] != tt.wantTBHeaderVal) {
-				t.Errorf("X-Allowed-Locations header: got %q, want %q (present: %v)", got, tt.wantTBHeaderVal, tt.wantTBHeader)
+			if got, ok := req.Header["X-Allowed-Locations"]; ok != tt.wantRABHeader || (ok && got[0] != tt.wantRABHeaderVal) {
+				t.Errorf("X-Allowed-Locations header: got %q, want %q (present: %v)", got, tt.wantRABHeaderVal, tt.wantRABHeader)
 			}
 
 			// Test gRPC
 			gotMeta := make(map[string]string)
-			SetAuthMetadata(token, gotMeta)
+			SetAuthMetadata(token, "https://example.com/v1", gotMeta)
 			if diff := cmp.Diff(tt.wantGRPCMeta, gotMeta); diff != "" {
 				t.Errorf("gRPC metadata mismatch (-want +got):\n%s", diff)
 			}

--- a/auth/internal/trustboundary/trust_boundary.go
+++ b/auth/internal/trustboundary/trust_boundary.go
@@ -262,29 +262,21 @@ func (p *DataProvider) Token(ctx context.Context) (*auth.Token, error) {
 }
 
 // GetTrustBoundaryData retrieves the trust boundary data.
-// It first checks the universe domain: if it's non-default, a NoOp is returned.
-// Otherwise, it checks a local cache. If the data is not cached as NoOp,
-// it fetches new data from the endpoint provided by its ConfigProvider,
+// It first checks the universe domain: if it's non-default, nil is returned.
+// It fetches new data from the endpoint provided by its ConfigProvider,
 // using the given accessToken for authentication. Results are cached.
 // If fetching fails, it returns previously cached data if available, otherwise the fetch error.
 func (p *DataProvider) GetTrustBoundaryData(ctx context.Context, token *auth.Token) (*internal.TrustBoundaryData, error) {
-	// Check the universe domain.
 	uniDomain, err := p.configProvider.GetUniverseDomain(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("trustboundary: error getting universe domain: %w", err)
 	}
 	if uniDomain != "" && uniDomain != internal.DefaultUniverseDomain {
-		if p.data == nil || p.data.EncodedLocations != internal.TrustBoundaryNoOp {
-			p.data = internal.NewNoOpTrustBoundaryData()
-		}
-		return p.data, nil
+		return nil, nil
 	}
 
-	// Check cache for a no-op result from a previous API call.
+	// Check cache for results from a previous API call.
 	cachedData := p.data
-	if cachedData != nil && cachedData.EncodedLocations == internal.TrustBoundaryNoOp {
-		return cachedData, nil
-	}
 
 	// Get the endpoint
 	url, err := p.configProvider.GetTrustBoundaryEndpoint(ctx)


### PR DESCRIPTION
Bring RAB (formerly known as trust boundaries) up to date with the design changes:
- Decouple RAB fetching from token refresh and use api calls as a trigger to fetch RAB.
- Make fetching async, non blocking, and fail open
- remove no-op signal
- Implement a 6 hour TTL with a soft expiry and proactive refresh