### PR TITLE
feat(bigquery): transition format options

### DIFF
--- a/bigquery/iterator.go
+++ b/bigquery/iterator.go
@@ -25,6 +25,10 @@ import (
 	"google.golang.org/api/iterator"
 )
 
+const (
+	defaultTimestampWireFormat string = "INT64"
+)
+
 // Construct a RowIterator.
 func newRowIterator(ctx context.Context, src *rowSource, pf pageFetcher) *RowIterator {
 	it := &RowIterator{
@@ -290,7 +294,7 @@ func fetchTableResultPage(ctx context.Context, src *rowSource, schema Schema, st
 		}()
 	}
 	call := src.t.c.bqs.Tabledata.List(src.t.ProjectID, src.t.DatasetID, src.t.TableID)
-	call = call.FormatOptionsTimestampOutputFormat("INT64")
+	call = call.FormatOptionsTimestampOutputFormat(defaultTimestampWireFormat)
 	setClientHeader(call.Header())
 	if pageToken != "" {
 		call.PageToken(pageToken)
@@ -328,7 +332,7 @@ func fetchJobResultPage(ctx context.Context, src *rowSource, schema Schema, star
 	// reduce data transferred by leveraging api projections
 	projectedFields := []googleapi.Field{"rows", "pageToken", "totalRows"}
 	call := src.j.c.bqs.Jobs.GetQueryResults(src.j.projectID, src.j.jobID).Location(src.j.location).Context(ctx)
-	call = call.FormatOptionsTimestampOutputFormat("INT64")
+	call = call.FormatOptionsTimestampOutputFormat(defaultTimestampWireFormat)
 	if schema == nil {
 		// only project schema if we weren't supplied one.
 		projectedFields = append(projectedFields, "schema")

--- a/bigquery/job.go
+++ b/bigquery/job.go
@@ -353,7 +353,7 @@ func (j *Job) read(ctx context.Context, waitForQuery func(context.Context, strin
 func (j *Job) waitForQuery(ctx context.Context, projectID string) (Schema, uint64, error) {
 	// Use GetQueryResults only to wait for completion, not to read results.
 	call := j.c.bqs.Jobs.GetQueryResults(projectID, j.jobID).Location(j.location).Context(ctx).MaxResults(0)
-	call = call.FormatOptionsTimestampOutputFormat("INT64")
+	call = call.FormatOptionsTimestampOutputFormat(defaultTimestampWireFormat)
 	setClientHeader(call.Header())
 	backoff := gax.Backoff{
 		Initial:    50 * time.Millisecond,

--- a/bigquery/query.go
+++ b/bigquery/query.go
@@ -500,7 +500,7 @@ func (q *Query) probeFastPath() (*bq.QueryRequest, error) {
 		MaxSlots:           int64(q.MaxSlots),
 		Labels:             q.Labels,
 		FormatOptions: &bq.DataFormatOptions{
-			TimestampOutputFormat: "INT64",
+			TimestampOutputFormat: defaultTimestampWireFormat,
 		},
 	}
 	if q.QueryConfig.DisableQueryCache {

--- a/bigquery/query_test.go
+++ b/bigquery/query_test.go
@@ -470,7 +470,7 @@ func TestProbeFastPath(t *testing.T) {
 				Query:        "foo",
 				UseLegacySql: &pfalse,
 				FormatOptions: &bq.DataFormatOptions{
-					TimestampOutputFormat: "INT64",
+					TimestampOutputFormat: defaultTimestampWireFormat,
 				},
 			},
 		},
@@ -509,7 +509,7 @@ func TestProbeFastPath(t *testing.T) {
 				},
 				UseQueryCache: &pfalse,
 				FormatOptions: &bq.DataFormatOptions{
-					TimestampOutputFormat: "INT64",
+					TimestampOutputFormat: defaultTimestampWireFormat,
 				},
 				Reservation: "reservation/1",
 				MaxSlots:    222,


### PR DESCRIPTION
This PR is minimal, and updates all callsites that use the older UseInt64Timestamp boolean for controlling output to instead use the newer TimestampOutputFormat option and specify it using INT64.

Followup PRs will update this to use the new ISO string for output.

Towards internal b/447623020