### PR TITLE
testing(bigquery): fix TestIntegration_InsertAndRead

### DIFF
--- a/bigquery/integration_test.go
+++ b/bigquery/integration_test.go
@@ -1105,7 +1105,7 @@ func TestIntegration_InsertAndRead(t *testing.T) {
 	if job1.LastStatus() == nil {
 		t.Error("no LastStatus")
 	}
-	job2, err := client.JobFromID(ctx, job1.ID())
+	job2, err := client.JobFromIDLocation(ctx, job1.ID(), job1.Location())
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
The switch to an explicit region made our default choice insufficient for reading job metadata.

Fixes: https://github.com/googleapis/google-cloud-go/issues/13467