### PR TITLE
chore: librarian release pull request: 20251215T160018Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -668,7 +668,7 @@ libraries:
       - internal/generated/snippets/assuredworkloads/
     tag_format: '{id}/v{version}'
   - id: auth
-    version: 0.17.0
+    version: 0.18.0
     last_generated_commit: 31b413bc4feb03f6849c718048c2b9998561b5fa
     apis: []
     source_roots:

--- a/auth/CHANGES.md
+++ b/auth/CHANGES.md
@@ -1,5 +1,13 @@
 # Changes
 
+## [0.18.0](https://github.com/googleapis/google-cloud-go/releases/tag/auth%2Fv0.18.0) (2025-12-15)
+
+### Features
+
+* Support scopes field from impersonated credential json (#13308) ([e3f62e1](https://github.com/googleapis/google-cloud-go/commit/e3f62e102840127a0058f5cced4c9738f2bf45f2))
+* add support for parsing EC private key (#13317) ([ea6bc62](https://github.com/googleapis/google-cloud-go/commit/ea6bc62ffe2cc0a6d607d698a181b37fa46c340d))
+* deprecate unsafe credentials JSON loading options (#13397) ([0dd2a3b](https://github.com/googleapis/google-cloud-go/commit/0dd2a3bdece9a85ee7216a737559fa9f5a869545))
+
 ## [0.17.0](https://github.com/googleapis/google-cloud-go/releases/tag/auth%2Fv0.17.0) (2025-10-02)
 
 ### Features

--- a/auth/internal/version.go
+++ b/auth/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "0.17.0"
+const Version = "0.18.0"


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.7.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go@sha256:718167d5c23ed389b41f617b3a00ac839bdd938a6bd2d48ae0c2f1fa51ab1c3d
<details><summary>auth: 0.18.0</summary>

## [0.18.0](https://github.com/googleapis/google-cloud-go/compare/auth/v0.17.0...auth/v0.18.0) (2025-12-15)

### Features

* deprecate unsafe credentials JSON loading options (#13397) ([0dd2a3bd](https://github.com/googleapis/google-cloud-go/commit/0dd2a3bd))

* Support scopes field from impersonated credential json (#13308) ([e3f62e10](https://github.com/googleapis/google-cloud-go/commit/e3f62e10))

* add support for parsing EC private key (#13317) ([ea6bc62f](https://github.com/googleapis/google-cloud-go/commit/ea6bc62f))

</details>