### PR TITLE
test(bigquery): decouple legacy sql view testing from public dataset

### DIFF
--- a/bigquery/table_integration_test.go
+++ b/bigquery/table_integration_test.go
@@ -617,7 +617,7 @@ func TestIntegration_TableUseLegacySQL(t *testing.T) {
 		if err := view.Create(ctx, tm); err != nil {
 			t.Errorf("view creation for %q failed with legacy %t", view.FullyQualifiedName(), isLegacy)
 		}
-		view.Delete(ctx)
+		_ = view.Delete(ctx)
 	}
 }
 


### PR DESCRIPTION
Fixes: https://github.com/googleapis/google-cloud-go/issues/13474