### PR TITLE
chore(storage): add initial framework for PCU core logic

### DIFF
--- a/storage/pcu.go
+++ b/storage/pcu.go
@@ -304,7 +304,6 @@ func (s *pcuState) uploadPart(task uploadTask) (*ObjectHandle, *ObjectAttrs, err
 	pw.ChunkSize = 0 // Force single-shot upload for parts.
 	// Clear fields not applicable to parts or that are set by compose.
 	pw.ObjectAttrs.CRC32C = 0
-	pw.SendCRC32C = false
 	pw.ObjectAttrs.MD5 = nil
 	setPartMetadata(pw, s, task)
 
@@ -331,7 +330,7 @@ func setPartMetadata(pw *Writer, s *pcuState, task uploadTask) {
 	}
 	pw.ObjectAttrs.Metadata = md
 	pw.ObjectAttrs.Metadata[pcuPartNumberMetadataKey] = partNumberStr
-	pw.ObjectAttrs.Metadata[pcuFinalObjectMetadataKey] = pw.o.object
+	pw.ObjectAttrs.Metadata[pcuFinalObjectMetadataKey] = s.w.o.object
 	if s.config.metadataDecorator != nil {
 		s.config.metadataDecorator.Decorate(&pw.ObjectAttrs)
 	}

--- a/storage/pcu_test.go
+++ b/storage/pcu_test.go
@@ -523,10 +523,9 @@ func TestSetPartMetadata(t *testing.T) {
 				ObjectAttrs: ObjectAttrs{
 					Metadata: tc.initialMetadata,
 				},
+				o: &ObjectHandle{bucket: "my-bucket", object: tc.finalObjectName},
 			}
-			partWriter := &Writer{
-				o: &ObjectHandle{object: tc.finalObjectName},
-			}
+			partWriter := &Writer{}
 			state := &pcuState{
 				w: sourceWriter,
 				config: &parallelUploadConfig{


### PR DESCRIPTION
This initial implementation includes:
- The `pcuState` struct and configuration for managing the upload process.
- The `initPCU` function to initialize the worker pool and buffers.
- The core `worker` logic to process upload tasks from a channel.
- The `uploadPart` function, which uploads a single data part to a temporary GCS object.