### PR TITLE
chore: update actions

### DIFF
--- a/.github/workflows/third_party_check.yml
+++ b/.github/workflows/third_party_check.yml
@@ -48,4 +48,4 @@ jobs:
     - uses: actions/checkout@v4
     - run: |
         cd internal/actions
-        go run ./internal/actions/cmd/thirdpartycheck -q -mod ${{ matrix.mods }}/go.mod
+        go run ./internal/actions/cmd/thirdpartycheck -q --dir=${{ github.workspace }} -mod ${{ matrix.mods }}/go.mod


### PR DESCRIPTION
This PR is a followup to the workspace removal in PR13476

Actions must be run from their module root now, not the workspace root.