### PR TITLE
chore: enable auto-generation for packages with minimal customization

### DIFF
--- a/.librarian/config.yaml
+++ b/.librarian/config.yaml
@@ -32,15 +32,7 @@ libraries:
     release_blocked: true
   - id: "datastore"
     release_blocked: true
-  - id: "errorreporting"
-    release_blocked: true
   - id: "firestore"
-    release_blocked: true
-  - id: "logging"
-    release_blocked: true
-  - id: "longrunning"
-    release_blocked: true
-  - id: "profiler"
     release_blocked: true
   - id: "pubsub"
     release_blocked: true


### PR DESCRIPTION
This PR enables librarian autogeneration for modules that are largely mature and don't see ongoing handwritten investments.

The candidate modules affected with their last manual change dates, based on a quick view of commit history and/or reviewing CHANGES.md

* errorreporting - Oct 2020
* logging - June 2024
* longrunning - Feb 2023
* profiler - Oct 2023