### PR TITLE
docs: fix typo in README.md entries

### DIFF
--- a/apihub/README.md
+++ b/apihub/README.md
@@ -26,7 +26,7 @@ ends in `.../apivXXX`. The `XXX` could be something like `1` or `2` in the case
 of a stable service backend or may be like `1beta2` or `2beta` in the case of a
 more experimental service backend. Because of this fact, a given module can have
 multiple clients for different service backends. In these cases it is generally
-recommend to use clients with stable service backends, with import suffixes like
+recommended to use clients with stable service backends, with import suffixes like
 `apiv1`, unless you need to use features that are only present in a beta backend
 or there is not yet a stable backend available.
 

--- a/apphub/README.md
+++ b/apphub/README.md
@@ -26,7 +26,7 @@ ends in `.../apivXXX`. The `XXX` could be something like `1` or `2` in the case
 of a stable service backend or may be like `1beta2` or `2beta` in the case of a
 more experimental service backend. Because of this fact, a given module can have
 multiple clients for different service backends. In these cases it is generally
-recommend to use clients with stable service backends, with import suffixes like
+recommended to use clients with stable service backends, with import suffixes like
 `apiv1`, unless you need to use features that are only present in a beta backend
 or there is not yet a stable backend available.
 

--- a/apps/README.md
+++ b/apps/README.md
@@ -26,7 +26,7 @@ ends in `.../apivXXX`. The `XXX` could be something like `1` or `2` in the case
 of a stable service backend or may be like `1beta2` or `2beta` in the case of a
 more experimental service backend. Because of this fact, a given module can have
 multiple clients for different service backends. In these cases it is generally
-recommend to use clients with stable service backends, with import suffixes like
+recommended to use clients with stable service backends, with import suffixes like
 `apiv1`, unless you need to use features that are only present in a beta backend
 or there is not yet a stable backend available.
 

--- a/backupdr/README.md
+++ b/backupdr/README.md
@@ -26,7 +26,7 @@ ends in `.../apivXXX`. The `XXX` could be something like `1` or `2` in the case
 of a stable service backend or may be like `1beta2` or `2beta` in the case of a
 more experimental service backend. Because of this fact, a given module can have
 multiple clients for different service backends. In these cases it is generally
-recommend to use clients with stable service backends, with import suffixes like
+recommended to use clients with stable service backends, with import suffixes like
 `apiv1`, unless you need to use features that are only present in a beta backend
 or there is not yet a stable backend available.
 

--- a/capacityplanner/README.md
+++ b/capacityplanner/README.md
@@ -26,7 +26,7 @@ ends in `.../apivXXX`. The `XXX` could be something like `1` or `2` in the case
 of a stable service backend or may be like `1beta2` or `2beta` in the case of a
 more experimental service backend. Because of this fact, a given module can have
 multiple clients for different service backends. In these cases it is generally
-recommend to use clients with stable service backends, with import suffixes like
+recommended to use clients with stable service backends, with import suffixes like
 `apiv1`, unless you need to use features that are only present in a beta backend
 or there is not yet a stable backend available.
 

--- a/chat/README.md
+++ b/chat/README.md
@@ -26,7 +26,7 @@ ends in `.../apivXXX`. The `XXX` could be something like `1` or `2` in the case
 of a stable service backend or may be like `1beta2` or `2beta` in the case of a
 more experimental service backend. Because of this fact, a given module can have
 multiple clients for different service backends. In these cases it is generally
-recommend to use clients with stable service backends, with import suffixes like
+recommended to use clients with stable service backends, with import suffixes like
 `apiv1`, unless you need to use features that are only present in a beta backend
 or there is not yet a stable backend available.
 

--- a/chronicle/README.md
+++ b/chronicle/README.md
@@ -26,7 +26,7 @@ ends in `.../apivXXX`. The `XXX` could be something like `1` or `2` in the case
 of a stable service backend or may be like `1beta2` or `2beta` in the case of a
 more experimental service backend. Because of this fact, a given module can have
 multiple clients for different service backends. In these cases it is generally
-recommend to use clients with stable service backends, with import suffixes like
+recommended to use clients with stable service backends, with import suffixes like
 `apiv1`, unless you need to use features that are only present in a beta backend
 or there is not yet a stable backend available.
 

--- a/cloudcontrolspartner/README.md
+++ b/cloudcontrolspartner/README.md
@@ -26,7 +26,7 @@ ends in `.../apivXXX`. The `XXX` could be something like `1` or `2` in the case
 of a stable service backend or may be like `1beta2` or `2beta` in the case of a
 more experimental service backend. Because of this fact, a given module can have
 multiple clients for different service backends. In these cases it is generally
-recommend to use clients with stable service backends, with import suffixes like
+recommended to use clients with stable service backends, with import suffixes like
 `apiv1`, unless you need to use features that are only present in a beta backend
 or there is not yet a stable backend available.
 

--- a/cloudprofiler/README.md
+++ b/cloudprofiler/README.md
@@ -26,7 +26,7 @@ ends in `.../apivXXX`. The `XXX` could be something like `1` or `2` in the case
 of a stable service backend or may be like `1beta2` or `2beta` in the case of a
 more experimental service backend. Because of this fact, a given module can have
 multiple clients for different service backends. In these cases it is generally
-recommend to use clients with stable service backends, with import suffixes like
+recommended to use clients with stable service backends, with import suffixes like
 `apiv1`, unless you need to use features that are only present in a beta backend
 or there is not yet a stable backend available.
 

--- a/cloudquotas/README.md
+++ b/cloudquotas/README.md
@@ -26,7 +26,7 @@ ends in `.../apivXXX`. The `XXX` could be something like `1` or `2` in the case
 of a stable service backend or may be like `1beta2` or `2beta` in the case of a
 more experimental service backend. Because of this fact, a given module can have
 multiple clients for different service backends. In these cases it is generally
-recommend to use clients with stable service backends, with import suffixes like
+recommended to use clients with stable service backends, with import suffixes like
 `apiv1`, unless you need to use features that are only present in a beta backend
 or there is not yet a stable backend available.
 

--- a/configdelivery/README.md
+++ b/configdelivery/README.md
@@ -26,7 +26,7 @@ ends in `.../apivXXX`. The `XXX` could be something like `1` or `2` in the case
 of a stable service backend or may be like `1beta2` or `2beta` in the case of a
 more experimental service backend. Because of this fact, a given module can have
 multiple clients for different service backends. In these cases it is generally
-recommend to use clients with stable service backends, with import suffixes like
+recommended to use clients with stable service backends, with import suffixes like
 `apiv1`, unless you need to use features that are only present in a beta backend
 or there is not yet a stable backend available.
 

--- a/developerconnect/README.md
+++ b/developerconnect/README.md
@@ -26,7 +26,7 @@ ends in `.../apivXXX`. The `XXX` could be something like `1` or `2` in the case
 of a stable service backend or may be like `1beta2` or `2beta` in the case of a
 more experimental service backend. Because of this fact, a given module can have
 multiple clients for different service backends. In these cases it is generally
-recommend to use clients with stable service backends, with import suffixes like
+recommended to use clients with stable service backends, with import suffixes like
 `apiv1`, unless you need to use features that are only present in a beta backend
 or there is not yet a stable backend available.
 

--- a/devicestreaming/README.md
+++ b/devicestreaming/README.md
@@ -26,7 +26,7 @@ ends in `.../apivXXX`. The `XXX` could be something like `1` or `2` in the case
 of a stable service backend or may be like `1beta2` or `2beta` in the case of a
 more experimental service backend. Because of this fact, a given module can have
 multiple clients for different service backends. In these cases it is generally
-recommend to use clients with stable service backends, with import suffixes like
+recommended to use clients with stable service backends, with import suffixes like
 `apiv1`, unless you need to use features that are only present in a beta backend
 or there is not yet a stable backend available.
 

--- a/edgenetwork/README.md
+++ b/edgenetwork/README.md
@@ -26,7 +26,7 @@ ends in `.../apivXXX`. The `XXX` could be something like `1` or `2` in the case
 of a stable service backend or may be like `1beta2` or `2beta` in the case of a
 more experimental service backend. Because of this fact, a given module can have
 multiple clients for different service backends. In these cases it is generally
-recommend to use clients with stable service backends, with import suffixes like
+recommended to use clients with stable service backends, with import suffixes like
 `apiv1`, unless you need to use features that are only present in a beta backend
 or there is not yet a stable backend available.
 

--- a/financialservices/README.md
+++ b/financialservices/README.md
@@ -26,7 +26,7 @@ ends in `.../apivXXX`. The `XXX` could be something like `1` or `2` in the case
 of a stable service backend or may be like `1beta2` or `2beta` in the case of a
 more experimental service backend. Because of this fact, a given module can have
 multiple clients for different service backends. In these cases it is generally
-recommend to use clients with stable service backends, with import suffixes like
+recommended to use clients with stable service backends, with import suffixes like
 `apiv1`, unless you need to use features that are only present in a beta backend
 or there is not yet a stable backend available.
 

--- a/geminidataanalytics/README.md
+++ b/geminidataanalytics/README.md
@@ -26,7 +26,7 @@ ends in `.../apivXXX`. The `XXX` could be something like `1` or `2` in the case
 of a stable service backend or may be like `1beta2` or `2beta` in the case of a
 more experimental service backend. Because of this fact, a given module can have
 multiple clients for different service backends. In these cases it is generally
-recommend to use clients with stable service backends, with import suffixes like
+recommended to use clients with stable service backends, with import suffixes like
 `apiv1`, unless you need to use features that are only present in a beta backend
 or there is not yet a stable backend available.
 

--- a/gkerecommender/README.md
+++ b/gkerecommender/README.md
@@ -26,7 +26,7 @@ ends in `.../apivXXX`. The `XXX` could be something like `1` or `2` in the case
 of a stable service backend or may be like `1beta2` or `2beta` in the case of a
 more experimental service backend. Because of this fact, a given module can have
 multiple clients for different service backends. In these cases it is generally
-recommend to use clients with stable service backends, with import suffixes like
+recommended to use clients with stable service backends, with import suffixes like
 `apiv1`, unless you need to use features that are only present in a beta backend
 or there is not yet a stable backend available.
 

--- a/hypercomputecluster/README.md
+++ b/hypercomputecluster/README.md
@@ -26,7 +26,7 @@ ends in `.../apivXXX`. The `XXX` could be something like `1` or `2` in the case
 of a stable service backend or may be like `1beta2` or `2beta` in the case of a
 more experimental service backend. Because of this fact, a given module can have
 multiple clients for different service backends. In these cases it is generally
-recommend to use clients with stable service backends, with import suffixes like
+recommended to use clients with stable service backends, with import suffixes like
 `apiv1`, unless you need to use features that are only present in a beta backend
 or there is not yet a stable backend available.
 

--- a/identitytoolkit/README.md
+++ b/identitytoolkit/README.md
@@ -26,7 +26,7 @@ ends in `.../apivXXX`. The `XXX` could be something like `1` or `2` in the case
 of a stable service backend or may be like `1beta2` or `2beta` in the case of a
 more experimental service backend. Because of this fact, a given module can have
 multiple clients for different service backends. In these cases it is generally
-recommend to use clients with stable service backends, with import suffixes like
+recommended to use clients with stable service backends, with import suffixes like
 `apiv1`, unless you need to use features that are only present in a beta backend
 or there is not yet a stable backend available.
 

--- a/internal/librariangen/configure/_README.md.txt
+++ b/internal/librariangen/configure/_README.md.txt
@@ -26,7 +26,7 @@ ends in `.../apivXXX`. The `XXX` could be something like `1` or `2` in the case
 of a stable service backend or may be like `1beta2` or `2beta` in the case of a
 more experimental service backend. Because of this fact, a given module can have
 multiple clients for different service backends. In these cases it is generally
-recommend to use clients with stable service backends, with import suffixes like
+recommended to use clients with stable service backends, with import suffixes like
 `apiv1`, unless you need to use features that are only present in a beta backend
 or there is not yet a stable backend available.
 

--- a/licensemanager/README.md
+++ b/licensemanager/README.md
@@ -26,7 +26,7 @@ ends in `.../apivXXX`. The `XXX` could be something like `1` or `2` in the case
 of a stable service backend or may be like `1beta2` or `2beta` in the case of a
 more experimental service backend. Because of this fact, a given module can have
 multiple clients for different service backends. In these cases it is generally
-recommend to use clients with stable service backends, with import suffixes like
+recommended to use clients with stable service backends, with import suffixes like
 `apiv1`, unless you need to use features that are only present in a beta backend
 or there is not yet a stable backend available.
 

--- a/locationfinder/README.md
+++ b/locationfinder/README.md
@@ -26,7 +26,7 @@ ends in `.../apivXXX`. The `XXX` could be something like `1` or `2` in the case
 of a stable service backend or may be like `1beta2` or `2beta` in the case of a
 more experimental service backend. Because of this fact, a given module can have
 multiple clients for different service backends. In these cases it is generally
-recommend to use clients with stable service backends, with import suffixes like
+recommended to use clients with stable service backends, with import suffixes like
 `apiv1`, unless you need to use features that are only present in a beta backend
 or there is not yet a stable backend available.
 

--- a/lustre/README.md
+++ b/lustre/README.md
@@ -26,7 +26,7 @@ ends in `.../apivXXX`. The `XXX` could be something like `1` or `2` in the case
 of a stable service backend or may be like `1beta2` or `2beta` in the case of a
 more experimental service backend. Because of this fact, a given module can have
 multiple clients for different service backends. In these cases it is generally
-recommend to use clients with stable service backends, with import suffixes like
+recommended to use clients with stable service backends, with import suffixes like
 `apiv1`, unless you need to use features that are only present in a beta backend
 or there is not yet a stable backend available.
 

--- a/maintenance/README.md
+++ b/maintenance/README.md
@@ -26,7 +26,7 @@ ends in `.../apivXXX`. The `XXX` could be something like `1` or `2` in the case
 of a stable service backend or may be like `1beta2` or `2beta` in the case of a
 more experimental service backend. Because of this fact, a given module can have
 multiple clients for different service backends. In these cases it is generally
-recommend to use clients with stable service backends, with import suffixes like
+recommended to use clients with stable service backends, with import suffixes like
 `apiv1`, unless you need to use features that are only present in a beta backend
 or there is not yet a stable backend available.
 

--- a/managedkafka/README.md
+++ b/managedkafka/README.md
@@ -26,7 +26,7 @@ ends in `.../apivXXX`. The `XXX` could be something like `1` or `2` in the case
 of a stable service backend or may be like `1beta2` or `2beta` in the case of a
 more experimental service backend. Because of this fact, a given module can have
 multiple clients for different service backends. In these cases it is generally
-recommend to use clients with stable service backends, with import suffixes like
+recommended to use clients with stable service backends, with import suffixes like
 `apiv1`, unless you need to use features that are only present in a beta backend
 or there is not yet a stable backend available.
 

--- a/memorystore/README.md
+++ b/memorystore/README.md
@@ -26,7 +26,7 @@ ends in `.../apivXXX`. The `XXX` could be something like `1` or `2` in the case
 of a stable service backend or may be like `1beta2` or `2beta` in the case of a
 more experimental service backend. Because of this fact, a given module can have
 multiple clients for different service backends. In these cases it is generally
-recommend to use clients with stable service backends, with import suffixes like
+recommended to use clients with stable service backends, with import suffixes like
 `apiv1`, unless you need to use features that are only present in a beta backend
 or there is not yet a stable backend available.
 

--- a/modelarmor/README.md
+++ b/modelarmor/README.md
@@ -26,7 +26,7 @@ ends in `.../apivXXX`. The `XXX` could be something like `1` or `2` in the case
 of a stable service backend or may be like `1beta2` or `2beta` in the case of a
 more experimental service backend. Because of this fact, a given module can have
 multiple clients for different service backends. In these cases it is generally
-recommend to use clients with stable service backends, with import suffixes like
+recommended to use clients with stable service backends, with import suffixes like
 `apiv1`, unless you need to use features that are only present in a beta backend
 or there is not yet a stable backend available.
 

--- a/networkservices/README.md
+++ b/networkservices/README.md
@@ -26,7 +26,7 @@ ends in `.../apivXXX`. The `XXX` could be something like `1` or `2` in the case
 of a stable service backend or may be like `1beta2` or `2beta` in the case of a
 more experimental service backend. Because of this fact, a given module can have
 multiple clients for different service backends. In these cases it is generally
-recommend to use clients with stable service backends, with import suffixes like
+recommended to use clients with stable service backends, with import suffixes like
 `apiv1`, unless you need to use features that are only present in a beta backend
 or there is not yet a stable backend available.
 

--- a/oracledatabase/README.md
+++ b/oracledatabase/README.md
@@ -26,7 +26,7 @@ ends in `.../apivXXX`. The `XXX` could be something like `1` or `2` in the case
 of a stable service backend or may be like `1beta2` or `2beta` in the case of a
 more experimental service backend. Because of this fact, a given module can have
 multiple clients for different service backends. In these cases it is generally
-recommend to use clients with stable service backends, with import suffixes like
+recommended to use clients with stable service backends, with import suffixes like
 `apiv1`, unless you need to use features that are only present in a beta backend
 or there is not yet a stable backend available.
 

--- a/parallelstore/README.md
+++ b/parallelstore/README.md
@@ -26,7 +26,7 @@ ends in `.../apivXXX`. The `XXX` could be something like `1` or `2` in the case
 of a stable service backend or may be like `1beta2` or `2beta` in the case of a
 more experimental service backend. Because of this fact, a given module can have
 multiple clients for different service backends. In these cases it is generally
-recommend to use clients with stable service backends, with import suffixes like
+recommended to use clients with stable service backends, with import suffixes like
 `apiv1`, unless you need to use features that are only present in a beta backend
 or there is not yet a stable backend available.
 

--- a/parametermanager/README.md
+++ b/parametermanager/README.md
@@ -26,7 +26,7 @@ ends in `.../apivXXX`. The `XXX` could be something like `1` or `2` in the case
 of a stable service backend or may be like `1beta2` or `2beta` in the case of a
 more experimental service backend. Because of this fact, a given module can have
 multiple clients for different service backends. In these cases it is generally
-recommend to use clients with stable service backends, with import suffixes like
+recommended to use clients with stable service backends, with import suffixes like
 `apiv1`, unless you need to use features that are only present in a beta backend
 or there is not yet a stable backend available.
 

--- a/privilegedaccessmanager/README.md
+++ b/privilegedaccessmanager/README.md
@@ -26,7 +26,7 @@ ends in `.../apivXXX`. The `XXX` could be something like `1` or `2` in the case
 of a stable service backend or may be like `1beta2` or `2beta` in the case of a
 more experimental service backend. Because of this fact, a given module can have
 multiple clients for different service backends. In these cases it is generally
-recommend to use clients with stable service backends, with import suffixes like
+recommended to use clients with stable service backends, with import suffixes like
 `apiv1`, unless you need to use features that are only present in a beta backend
 or there is not yet a stable backend available.
 

--- a/saasplatform/README.md
+++ b/saasplatform/README.md
@@ -26,7 +26,7 @@ ends in `.../apivXXX`. The `XXX` could be something like `1` or `2` in the case
 of a stable service backend or may be like `1beta2` or `2beta` in the case of a
 more experimental service backend. Because of this fact, a given module can have
 multiple clients for different service backends. In these cases it is generally
-recommend to use clients with stable service backends, with import suffixes like
+recommended to use clients with stable service backends, with import suffixes like
 `apiv1`, unless you need to use features that are only present in a beta backend
 or there is not yet a stable backend available.
 

--- a/securesourcemanager/README.md
+++ b/securesourcemanager/README.md
@@ -26,7 +26,7 @@ ends in `.../apivXXX`. The `XXX` could be something like `1` or `2` in the case
 of a stable service backend or may be like `1beta2` or `2beta` in the case of a
 more experimental service backend. Because of this fact, a given module can have
 multiple clients for different service backends. In these cases it is generally
-recommend to use clients with stable service backends, with import suffixes like
+recommended to use clients with stable service backends, with import suffixes like
 `apiv1`, unless you need to use features that are only present in a beta backend
 or there is not yet a stable backend available.
 

--- a/securitycentermanagement/README.md
+++ b/securitycentermanagement/README.md
@@ -26,7 +26,7 @@ ends in `.../apivXXX`. The `XXX` could be something like `1` or `2` in the case
 of a stable service backend or may be like `1beta2` or `2beta` in the case of a
 more experimental service backend. Because of this fact, a given module can have
 multiple clients for different service backends. In these cases it is generally
-recommend to use clients with stable service backends, with import suffixes like
+recommended to use clients with stable service backends, with import suffixes like
 `apiv1`, unless you need to use features that are only present in a beta backend
 or there is not yet a stable backend available.
 

--- a/securityposture/README.md
+++ b/securityposture/README.md
@@ -26,7 +26,7 @@ ends in `.../apivXXX`. The `XXX` could be something like `1` or `2` in the case
 of a stable service backend or may be like `1beta2` or `2beta` in the case of a
 more experimental service backend. Because of this fact, a given module can have
 multiple clients for different service backends. In these cases it is generally
-recommend to use clients with stable service backends, with import suffixes like
+recommended to use clients with stable service backends, with import suffixes like
 `apiv1`, unless you need to use features that are only present in a beta backend
 or there is not yet a stable backend available.
 

--- a/servicehealth/README.md
+++ b/servicehealth/README.md
@@ -26,7 +26,7 @@ ends in `.../apivXXX`. The `XXX` could be something like `1` or `2` in the case
 of a stable service backend or may be like `1beta2` or `2beta` in the case of a
 more experimental service backend. Because of this fact, a given module can have
 multiple clients for different service backends. In these cases it is generally
-recommend to use clients with stable service backends, with import suffixes like
+recommended to use clients with stable service backends, with import suffixes like
 `apiv1`, unless you need to use features that are only present in a beta backend
 or there is not yet a stable backend available.
 

--- a/shopping/README.md
+++ b/shopping/README.md
@@ -26,7 +26,7 @@ ends in `.../apivXXX`. The `XXX` could be something like `1` or `2` in the case
 of a stable service backend or may be like `1beta2` or `2beta` in the case of a
 more experimental service backend. Because of this fact, a given module can have
 multiple clients for different service backends. In these cases it is generally
-recommend to use clients with stable service backends, with import suffixes like
+recommended to use clients with stable service backends, with import suffixes like
 `apiv1`, unless you need to use features that are only present in a beta backend
 or there is not yet a stable backend available.
 

--- a/storagebatchoperations/README.md
+++ b/storagebatchoperations/README.md
@@ -26,7 +26,7 @@ ends in `.../apivXXX`. The `XXX` could be something like `1` or `2` in the case
 of a stable service backend or may be like `1beta2` or `2beta` in the case of a
 more experimental service backend. Because of this fact, a given module can have
 multiple clients for different service backends. In these cases it is generally
-recommend to use clients with stable service backends, with import suffixes like
+recommended to use clients with stable service backends, with import suffixes like
 `apiv1`, unless you need to use features that are only present in a beta backend
 or there is not yet a stable backend available.
 

--- a/streetview/README.md
+++ b/streetview/README.md
@@ -26,7 +26,7 @@ ends in `.../apivXXX`. The `XXX` could be something like `1` or `2` in the case
 of a stable service backend or may be like `1beta2` or `2beta` in the case of a
 more experimental service backend. Because of this fact, a given module can have
 multiple clients for different service backends. In these cases it is generally
-recommend to use clients with stable service backends, with import suffixes like
+recommended to use clients with stable service backends, with import suffixes like
 `apiv1`, unless you need to use features that are only present in a beta backend
 or there is not yet a stable backend available.
 

--- a/telcoautomation/README.md
+++ b/telcoautomation/README.md
@@ -26,7 +26,7 @@ ends in `.../apivXXX`. The `XXX` could be something like `1` or `2` in the case
 of a stable service backend or may be like `1beta2` or `2beta` in the case of a
 more experimental service backend. Because of this fact, a given module can have
 multiple clients for different service backends. In these cases it is generally
-recommend to use clients with stable service backends, with import suffixes like
+recommended to use clients with stable service backends, with import suffixes like
 `apiv1`, unless you need to use features that are only present in a beta backend
 or there is not yet a stable backend available.
 

--- a/vectorsearch/README.md
+++ b/vectorsearch/README.md
@@ -26,7 +26,7 @@ ends in `.../apivXXX`. The `XXX` could be something like `1` or `2` in the case
 of a stable service backend or may be like `1beta2` or `2beta` in the case of a
 more experimental service backend. Because of this fact, a given module can have
 multiple clients for different service backends. In these cases it is generally
-recommend to use clients with stable service backends, with import suffixes like
+recommended to use clients with stable service backends, with import suffixes like
 `apiv1`, unless you need to use features that are only present in a beta backend
 or there is not yet a stable backend available.
 

--- a/visionai/README.md
+++ b/visionai/README.md
@@ -26,7 +26,7 @@ ends in `.../apivXXX`. The `XXX` could be something like `1` or `2` in the case
 of a stable service backend or may be like `1beta2` or `2beta` in the case of a
 more experimental service backend. Because of this fact, a given module can have
 multiple clients for different service backends. In these cases it is generally
-recommend to use clients with stable service backends, with import suffixes like
+recommended to use clients with stable service backends, with import suffixes like
 `apiv1`, unless you need to use features that are only present in a beta backend
 or there is not yet a stable backend available.
 


### PR DESCRIPTION
This PR does two things:
* fixes a typo in the README template used by librariangen (internal/librariangen/configure/_README.md.txt)
* fixes the typo in the generated README files.