### PR TITLE
test(storage): add and improve tests for MultiRangeDownloader

### DIFF
--- a/storage/integration_test.go
+++ b/storage/integration_test.go
@@ -90,8 +90,8 @@ const (
 	testUniverseLocation   = "TEST_UNIVERSE_LOCATION"
 	testUniverseCreds      = "TEST_UNIVERSE_DOMAIN_CREDENTIAL"
 	// Location and Zone for zonal buckets tests
-	testZonalLocation = "us-central1"
-	testZonalZone     = "us-central1-a"
+	testZonalLocation = "us-west4"
+	testZonalZone     = "us-west4-a"
 )
 
 var (

--- a/storage/integration_test.go
+++ b/storage/integration_test.go
@@ -41,6 +41,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -65,7 +66,6 @@ import (
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"golang.org/x/oauth2/google"
-	"golang.org/x/sync/errgroup"
 	"google.golang.org/api/googleapi"
 	"google.golang.org/api/iterator"
 	itesting "google.golang.org/api/iterator/testing"
@@ -529,11 +529,11 @@ func TestIntegration_MRDCallbackReturnsDataLength(t *testing.T) {
 // TestIntegration_ReadSameFileConcurrentlyUsingMultiRangeDownloader tests for potential deadlocks
 // or race conditions when multiple goroutines call Add() concurrently on the same MRD multiple times.
 func TestIntegration_ReadSameFileConcurrentlyUsingMultiRangeDownloader(t *testing.T) {
-	t.Skip("flaky - https://github.com/googleapis/google-cloud-go/issues/12655")
 	multiTransportTest(skipAllButZonal(context.Background(), "Bidi Read API test"), t, func(t *testing.T, ctx context.Context, bucket string, _ string, client *Client) {
-		content := make([]byte, 5<<20)
+		// Use a 10MB object to allow for many non-overlapping range requests.
+		content := make([]byte, 10<<20)
 		rand.New(rand.NewSource(0)).Read(content)
-		objName := "MultiRangeDownloader"
+		objName := "MultiRangeDownloaderConcurrentReads"
 
 		// Upload test data.
 		obj := client.Bucket(bucket).Object(objName)
@@ -550,63 +550,59 @@ func TestIntegration_ReadSameFileConcurrentlyUsingMultiRangeDownloader(t *testin
 			t.Fatalf("NewMultiRangeDownloader: %v", err)
 		}
 
-		// Create a top-level errgroup for each goroutine
-		eG, ctx := errgroup.WithContext(ctx)
-		goRoutineCount := 10
+		// Use 50 goroutines with 10 adds each (500 total).
+		// This exceeds the internal session reqC buffer of 100, stressing the manager's event loop.
+		goRoutineCount := 50
 		perGoRoutineAddCount := 10
-		res := make([]multiRangeDownloaderOutput, goRoutineCount*perGoRoutineAddCount)
 
-		// Create multiple go routines to read concurrently.
+		type rangeRes struct {
+			buf    bytes.Buffer
+			offset int64
+			limit  int64
+			err    error
+		}
+		results := make([]*rangeRes, goRoutineCount*perGoRoutineAddCount)
+
+		var wg sync.WaitGroup
+		wg.Add(len(results))
+
 		for i := 0; i < goRoutineCount; i++ {
-			groupID := i
-			eG.Go(func() error {
-
-				// Subgroup for tasks within this goroutine
-				subGroup, _ := errgroup.WithContext(ctx)
-
+			go func(gID int) {
 				for j := 0; j < perGoRoutineAddCount; j++ {
-					taskID := perGoRoutineAddCount*groupID + j
-					subGroup.Go(func() error {
-						// Use a channel to receive the callback results
-						done := make(chan error, 1)
+					taskID := gID*perGoRoutineAddCount + j
+					// Randomize offset/limit slightly to ensure varied request patterns.
+					offset := int64((taskID * 2048) % (len(content) - 4096))
+					limit := int64(1024 + rand.Intn(2048))
 
-						reader.Add(&res[taskID].buf, 0, int64(len(content)), func(x, y int64, err error) {
-							res[taskID].offset = x
-							res[taskID].limit = y
-							res[taskID].err = err
-							// Send each callback result to subGroup.
-							done <- err
-						})
-						return <-done
+					r := &rangeRes{offset: offset, limit: limit}
+					results[taskID] = r
+
+					reader.Add(&r.buf, offset, limit, func(o, l int64, err error) {
+						r.err = err
+						wg.Done()
 					})
 				}
-				// Wait for all tasks in current sub-group to complete to send result to main error group.
-				return subGroup.Wait()
-			})
+			}(i)
 		}
 
-		// Wait for all top-level goroutines to complete
-		if err := eG.Wait(); err != nil {
-			t.Errorf("Possible deadlock or race condition detected during concurrent Add calls: %v\n", err)
-		}
-
+		// Wait for all range-specific callbacks to complete.
+		wg.Wait()
+		// Ensure the MRD has reached a stable state before closing.
 		reader.Wait()
+
 		if err = reader.Close(); err != nil {
-			t.Fatalf("Error while closing reader %v", err)
+			t.Fatalf("Error while closing reader: %v", err)
 		}
-		for id, k := range res {
-			if k.err != nil {
-				t.Fatalf("reading range %v: %v", id, k.err)
+
+		for id, res := range results {
+			if res.err != nil {
+				t.Errorf("Range %d (offset %d) failed: %v", id, res.offset, res.err)
+				continue
 			}
-			if got, want := k.offset, 0; got != int64(want) {
-				t.Errorf("range id %v: got callback offset %v, want %v", id, got, want)
-			}
-			if got, want := k.limit, len(content); got != int64(want) {
-				t.Errorf("range id %v: got callback limit %v, want %v", id, got, want)
-			}
-			if !bytes.Equal(k.buf.Bytes(), content) {
-				t.Errorf("content mismatch in read range %v: got %v bytes, want %v bytes",
-					id, len(k.buf.Bytes()), len(content))
+			want := content[res.offset : res.offset+res.limit]
+			if !bytes.Equal(res.buf.Bytes(), want) {
+				t.Errorf("Data mismatch in range %d: got %d bytes, want %d bytes",
+					id, res.buf.Len(), len(want))
 			}
 		}
 	})

--- a/storage/integration_test.go
+++ b/storage/integration_test.go
@@ -90,8 +90,8 @@ const (
 	testUniverseLocation   = "TEST_UNIVERSE_LOCATION"
 	testUniverseCreds      = "TEST_UNIVERSE_DOMAIN_CREDENTIAL"
 	// Location and Zone for zonal buckets tests
-	testZonalLocation = "us-west4"
-	testZonalZone     = "us-west4-a"
+	testZonalLocation = "us-central1"
+	testZonalZone     = "us-central1-a"
 )
 
 var (
@@ -666,8 +666,8 @@ func TestIntegration_MRDWithNonRetriableError(t *testing.T) {
 				t.Errorf("read range %v to %v want err: nil, got: %v", k.offset, k.limit, k.err)
 			}
 		}
-		if err = reader.Close(); err != nil {
-			t.Fatalf("Error while closing reader %v", err)
+		if err = reader.Close(); err == nil {
+			t.Fatalf("Expected error while closing reader, got nil")
 		}
 	})
 }

--- a/storage/retry_conformance_test.go
+++ b/storage/retry_conformance_test.go
@@ -37,6 +37,8 @@ import (
 	"github.com/googleapis/gax-go/v2"
 	"github.com/googleapis/gax-go/v2/callctx"
 	"google.golang.org/api/iterator"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 const (
@@ -316,6 +318,133 @@ var methods = map[string][]retryFunc{
 				return err
 			}
 			return nil
+		},
+		func(ctx context.Context, c *Client, fs *resources, _ bool) error {
+			_, ok := c.tc.(*grpcStorageClient)
+			if !ok {
+				// Do a regular get to consume instructions.
+				_, err := c.Bucket(fs.bucket.Name).Object(fs.object.Name).Attrs(ctx)
+				return err
+			}
+
+			// Download the test object using the MultiRangeDownloader.
+			mrd, err := c.Bucket(fs.bucket.Name).Object(fs.object.Name).NewMultiRangeDownloader(ctx)
+			if err != nil {
+				return err
+			}
+
+			// Verify recovery for multiple concurrent requests on a single stream.
+			buf1, buf2, buf3 := new(bytes.Buffer), new(bytes.Buffer), new(bytes.Buffer)
+			var err1, err2, err3 error
+
+			mrd.Add(buf1, 0, 3, func(x, y int64, err error) {
+				err1 = err
+			})
+			mrd.Add(buf2, 3, 3, func(x, y int64, err error) {
+				err2 = err
+			})
+			mrd.Add(buf3, 6, 3, func(x, y int64, err error) {
+				err3 = err
+			})
+
+			mrd.Wait()
+
+			if err1 != nil || err2 != nil || err3 != nil {
+				return fmt.Errorf("multi-range retry failed: err1=%v, err2=%v, err3=%v", err1, err2, err3)
+			}
+
+			combined := append(buf1.Bytes(), append(buf2.Bytes(), buf3.Bytes()...)...)
+			if !bytes.Equal(combined, randomBytesToWrite) {
+				return fmt.Errorf("data mismatch after multi-range retry")
+			}
+
+			if err := mrd.Close(); err != nil {
+				return err
+			}
+			return nil
+		},
+		func(ctx context.Context, c *Client, fs *resources, _ bool) error {
+			_, ok := c.tc.(*grpcStorageClient)
+			if !ok {
+				// Do a regular get to consume instructions.
+				_, err := c.Bucket(fs.bucket.Name).Object(fs.object.Name).Attrs(ctx)
+				return err
+			}
+
+			// Download the test object using the MultiRangeDownloader.
+			mrd, err := c.Bucket(fs.bucket.Name).Object(fs.object.Name).NewMultiRangeDownloader(ctx)
+			if err != nil {
+				return err
+			}
+
+			bufValid := new(bytes.Buffer)
+			var errValid, errInvalid error
+
+			// Valid Range (first 3 bytes)
+			mrd.Add(bufValid, 0, 3, func(x, y int64, err error) { errValid = err })
+
+			// Invalid Range (well beyond the 6-byte object size)
+			mrd.Add(io.Discard, 1000, 10, func(x, y int64, err error) { errInvalid = err })
+
+			mrd.Wait()
+
+			// Valid range must succeed
+			if errValid != nil {
+				return fmt.Errorf("valid range failed unexpectedly: %v", errValid)
+			}
+			if !bytes.Equal(bufValid.Bytes(), randomBytesToWrite[:3]) {
+				return fmt.Errorf("valid range data mismatch")
+			}
+
+			// Invalid range must report OutOfRange
+			if status.Code(errInvalid) != codes.OutOfRange {
+				return fmt.Errorf("invalid range did not return OutOfRange; got: %v", errInvalid)
+			}
+
+			return mrd.Close()
+		},
+		func(ctx context.Context, c *Client, fs *resources, _ bool) error {
+			_, ok := c.tc.(*grpcStorageClient)
+			if !ok {
+				_, err := c.Bucket(fs.bucket.Name).Object(fs.object.Name).Attrs(ctx)
+				return err
+			}
+
+			// Upload 3MiB of data. This provides enough data to ensure retries happen mid-stream.
+			objName := objectIDs.New()
+			if err := uploadTestObject(fs.bucket.Name, objName, randomBytes3MiB); err != nil {
+				return fmt.Errorf("failed to upload 3MiB object: %v", err)
+			}
+
+			obj := c.Bucket(fs.bucket.Name).Object(objName)
+			mrd, err := obj.NewMultiRangeDownloader(ctx)
+			if err != nil {
+				return err
+			}
+
+			buf := new(bytes.Buffer)
+			var errRes error
+
+			// Request the full 3MiB range.
+			// The emulator's fault injection (e.g., reset-connection) will trigger mid-download.
+			mrd.Add(buf, 0, 3*MiB, func(x, y int64, err error) {
+				errRes = err
+			})
+
+			mrd.Wait()
+
+			if errRes != nil {
+				return fmt.Errorf("resumption test failed: %v", errRes)
+			}
+
+			if int64(buf.Len()) != 3*MiB {
+				return fmt.Errorf("resumption data length mismatch: got %d, want %d", buf.Len(), 3*MiB)
+			}
+			if !bytes.Equal(buf.Bytes(), randomBytes3MiB) {
+				return fmt.Errorf("resumption data mismatch: content does not match randomBytes3MiB")
+			}
+
+			return mrd.Close()
 		},
 	},
 	"storage.objects.download": {

--- a/storage/retry_conformance_test.go
+++ b/storage/retry_conformance_test.go
@@ -337,13 +337,13 @@ var methods = map[string][]retryFunc{
 			buf1, buf2, buf3 := new(bytes.Buffer), new(bytes.Buffer), new(bytes.Buffer)
 			var err1, err2, err3 error
 
-			mrd.Add(buf1, 0, 3, func(x, y int64, err error) {
+			mrd.Add(buf1, 0, 2, func(x, y int64, err error) {
 				err1 = err
 			})
-			mrd.Add(buf2, 3, 3, func(x, y int64, err error) {
+			mrd.Add(buf2, 2, 2, func(x, y int64, err error) {
 				err2 = err
 			})
-			mrd.Add(buf3, 6, 3, func(x, y int64, err error) {
+			mrd.Add(buf3, 4, 2, func(x, y int64, err error) {
 				err3 = err
 			})
 
@@ -382,9 +382,6 @@ var methods = map[string][]retryFunc{
 
 			// Valid Range (first 3 bytes)
 			mrd.Add(bufValid, 0, 3, func(x, y int64, err error) { errValid = err })
-
-			// Invalid Range (well beyond the 6-byte object size)
-			mrd.Add(io.Discard, 1000, 10, func(x, y int64, err error) { errInvalid = err })
 
 			mrd.Wait()
 

--- a/storage/retry_conformance_test.go
+++ b/storage/retry_conformance_test.go
@@ -383,11 +383,15 @@ var methods = map[string][]retryFunc{
 			mrd.Add(io.Discard, 1000, 10, func(x, y int64, err error) { errInvalid = err })
 
 			mrd.Wait()
-			err = mrd.Close()
 
-			// Invalid range and close error must report OutOfRange
-			if status.Code(errInvalid) != codes.OutOfRange || status.Code(err) != codes.OutOfRange {
+			// Invalid range error must report OutOfRange.
+			if status.Code(errInvalid) != codes.OutOfRange {
 				return fmt.Errorf("invalid range did not return OutOfRange; got: %v", errInvalid)
+			}
+			// Close error must also report OutOfRange.
+			err = mrd.Close()
+			if status.Code(err) != codes.OutOfRange {
+				return fmt.Errorf("Close did not return OutOfRange; got: %v", err)
 			}
 			return nil
 		},


### PR DESCRIPTION

- The previously skipped `TestIntegration_ReadSameFileConcurrentlyUsingMultiRangeDownloader` test has been unskipped and refactored. It now uses `sync.WaitGroup` for managing concurrency, increases the test object size to 10MB, and randomizes offset/limit values for `Add` calls to better simulate varied request patterns and stress the internal event loop.
- **New MultiRangeDownloader Retry Conformance Tests**: Three new conformance tests have been added for the `MultiRangeDownloader`. These tests verify retry behavior for multiple concurrent requests on a single stream, ensure correct error handling for invalid download ranges (returning `codes.OutOfRange`), and confirm mid-stream resumption capabilities for large object downloads.
