### PR TITLE
chore: switch presubmit to use gotestsum

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -36,7 +36,6 @@ import (
 	"github.com/googleapis/gax-go/v2/internallog"
 )
 
-
 const (
 	// Parameter keys for AuthCodeURL method to support PKCE.
 	codeChallengeKey       = "code_challenge"

--- a/bigquery/bigquery.go
+++ b/bigquery/bigquery.go
@@ -35,7 +35,6 @@ import (
 	"google.golang.org/api/option"
 )
 
-
 const (
 	// Scope is the Oauth2 scope for the service.
 	// For relevant BigQuery scopes, see:


### PR DESCRIPTION
This PR migrates presubmit tests to run using gotestsum, and stops the use of go-junit-report to parse logs.

related: b/473558736