### PR TITLE
test(bigtable/internal): Add missing arg in NewBigtableChannelPool test

### DIFF
--- a/bigtable/internal/transport/connpool_test.go
+++ b/bigtable/internal/transport/connpool_test.go
@@ -1420,7 +1420,7 @@ func TestRemoveConnections(t *testing.T) {
 
 	t.Run("MixedDrainingState", func(t *testing.T) {
 		poolSize := 5
-		pool, err := NewBigtableChannelPool(ctx, poolSize, btopt.RoundRobin, dialFunc, time.Now(), poolOpts()...)
+		pool, err := NewBigtableChannelPool(ctx, poolSize, btopt.RoundRobin, dialFunc, time.Unix(0, 0), poolOpts()...)
 		if err != nil {
 			t.Fatalf("Failed to create pool: %v", err)
 		}


### PR DESCRIPTION
Fixes: #13552


