### PR TITLE
chore: remove api-logging-go-reviewers from blunderbuss.yml

### DIFF
--- a/.github/blunderbuss.yml
+++ b/.github/blunderbuss.yml
@@ -22,11 +22,6 @@ assign_issues_by:
   to:
   - rahul2393
 - labels:
-  - 'api: logging'
-  - 'api: clouderrorreporting'
-  to:
-  - googleapis/api-logging-go-reviewers
-- labels:
   - 'api: cloudprofiler'
   to:
   - googleapis/api-profiler


### PR DESCRIPTION
I'm cleaning up the GitHub teams. In Cloud SDK, the responsibility of the logging libraries have moved to the language teams. I believe it's the same for the Go's logging library. I went ahead with deleting the googleapis/api-logging-go-reviewers team (Kevin was the only member).