### PR TITLE
fix: don't update global object's readhandle in MRD

### DIFF
--- a/storage/grpc_reader_multi_range.go
+++ b/storage/grpc_reader_multi_range.go
@@ -566,9 +566,6 @@ func (m *multiRangeDownloaderManager) processSessionResult(result mrdSessionResu
 	resp := result.decoder.msg
 	if handle := resp.GetReadHandle().GetHandle(); len(handle) > 0 {
 		m.lastReadHandle = handle
-		if m.params.handle != nil {
-			*m.params.handle = handle
-		}
 	}
 
 	m.attrsOnce.Do(func() {


### PR DESCRIPTION
This change will make sure global object's read handle is not updated. This will avoid missing metadata errors in new MRDs for the same object.