### PR TITLE
perf(all): optimize string builder operations

### DIFF
--- a/internal/aliasgen/aliasgen.go
+++ b/internal/aliasgen/aliasgen.go
@@ -409,7 +409,8 @@ func (ti *typeInfo) FullType(pkg string) string {
 	if ti.pkg != pkg {
 		p = ti.pkg + "."
 	}
-	fmt.Fprintf(&sb, "%s%s", p, ti.typeName)
+	sb.WriteString(p)
+	sb.WriteString(ti.typeName)
 	return sb.String()
 }
 

--- a/internal/aliasgen/aliasgen.go
+++ b/internal/aliasgen/aliasgen.go
@@ -409,7 +409,7 @@ func (ti *typeInfo) FullType(pkg string) string {
 	if ti.pkg != pkg {
 		p = ti.pkg + "."
 	}
-	sb.WriteString(fmt.Sprintf("%s%s", p, ti.typeName))
+	fmt.Fprintf(&sb, "%s%s", p, ti.typeName)
 	return sb.String()
 }
 
@@ -423,17 +423,17 @@ func formatComment(doc, pkg string) string {
 		if (len(str) + lineLen + 1) < softLineBreak {
 			lineLen = lineLen + len(str) + 1
 		} else if lineLen == 0 {
-			sb.WriteString(fmt.Sprintf("// %s\n", str))
+			fmt.Fprintf(&sb, "// %s\n", str)
 			ssi = i + 1
 		} else {
-			sb.WriteString(fmt.Sprintf("// %s\n", strings.Join(ss[ssi:i], " ")))
+			fmt.Fprintf(&sb, "// %s\n", strings.Join(ss[ssi:i], " "))
 			ssi = i
 			lineLen = len(str)
 		}
 	}
 	if ssi != len(ss) {
-		sb.WriteString(fmt.Sprintf("// %s\n", strings.Join(ss[ssi:], " ")))
+		fmt.Fprintf(&sb, "// %s\n", strings.Join(ss[ssi:], " "))
 	}
-	sb.WriteString(fmt.Sprintf("//\n// Deprecated: Please use types in: %s\n", pkg))
+	fmt.Fprintf(&sb, "//\n// Deprecated: Please use types in: %s\n", pkg)
 	return sb.String()
 }

--- a/internal/aliasgen/aliasgen.go
+++ b/internal/aliasgen/aliasgen.go
@@ -424,7 +424,9 @@ func formatComment(doc, pkg string) string {
 		if (len(str) + lineLen + 1) < softLineBreak {
 			lineLen = lineLen + len(str) + 1
 		} else if lineLen == 0 {
-			fmt.Fprintf(&sb, "// %s\n", str)
+			sb.WriteString("// ")
+			sb.WriteString(str)
+			sb.WriteByte('\n')
 			ssi = i + 1
 		} else {
 			fmt.Fprintf(&sb, "// %s\n", strings.Join(ss[ssi:i], " "))

--- a/internal/carver/cmd/carver/main.go
+++ b/internal/carver/cmd/carver/main.go
@@ -490,13 +490,12 @@ func parseMetadata(r io.Reader) (map[string]string, error) {
 	if err := json.Unmarshal(b, &m); err != nil {
 		return nil, err
 	}
-	m2 := map[string]string{}
+	m2 := make(map[string]string, len(m))
 	for k, v := range m {
-		k2 := k
-if b, _, exists := strings.Cut(k2, "/apiv"); exists && b != "" {
-			k2 = b
+		if i := strings.Index(k, "/apiv"); i > 0 {
+			k = k[:i]
 		}
-		m2[k2] = v.Description
+		m2[k] = v.Description
 	}
 	return m2, nil
 }

--- a/internal/carver/cmd/carver/main.go
+++ b/internal/carver/cmd/carver/main.go
@@ -382,7 +382,9 @@ func gitCommit(dir string, tags []string, dryRun bool) error {
 		var sb strings.Builder
 		sb.WriteString("chore: carve out sub-modules\n\nThis commit will be tagged:\n")
 		for _, tag := range tags {
-			fmt.Fprintf(&sb, "\t- %s\n", tag)
+			sb.WriteString("\t- ")
+			sb.WriteString(tag)
+			sb.WriteByte('\n')
 		}
 		cmd = exec.Command("git", "commit", "-m", sb.String())
 		cmd.Dir = dir

--- a/internal/carver/cmd/carver/main.go
+++ b/internal/carver/cmd/carver/main.go
@@ -382,7 +382,7 @@ func gitCommit(dir string, tags []string, dryRun bool) error {
 		var sb strings.Builder
 		sb.WriteString("chore: carve out sub-modules\n\nThis commit will be tagged:\n")
 		for _, tag := range tags {
-			sb.WriteString(fmt.Sprintf("\t- %s\n", tag))
+			fmt.Fprintf(&sb, "\t- %s\n", tag)
 		}
 		cmd = exec.Command("git", "commit", "-m", sb.String())
 		cmd.Dir = dir
@@ -491,8 +491,8 @@ func parseMetadata(r io.Reader) (map[string]string, error) {
 	m2 := map[string]string{}
 	for k, v := range m {
 		k2 := k
-		if i := strings.Index(k2, "/apiv"); i > 0 {
-			k2 = k2[:i]
+		if b, _, exists := strings.Cut(k2, "/apiv"); exists {
+			k2 = b
 		}
 		m2[k2] = v.Description
 	}

--- a/internal/carver/cmd/carver/main.go
+++ b/internal/carver/cmd/carver/main.go
@@ -491,7 +491,7 @@ func parseMetadata(r io.Reader) (map[string]string, error) {
 	m2 := map[string]string{}
 	for k, v := range m {
 		k2 := k
-		if b, _, exists := strings.Cut(k2, "/apiv"); exists {
+if b, _, exists := strings.Cut(k2, "/apiv"); exists && b != "" {
 			k2 = b
 		}
 		m2[k2] = v.Description

--- a/internal/gapicgen/git/git.go
+++ b/internal/gapicgen/git/git.go
@@ -62,7 +62,7 @@ func truncateAndFormatChanges(changes []*ChangeInfo, onlyGapicChanges, truncate 
 		if truncate && len(title) > maxTruncatedTitleLen {
 			title = fmt.Sprintf("%v...", title[:maxTruncatedTitleLen])
 		}
-		sb.WriteString(fmt.Sprintf("%s\n", title))
+		fmt.Fprintf(&sb, "%s\n", title)
 
 		// Format the commit body to conventional commit footer standards.
 		splitBody := strings.Split(c.Body, "\n")
@@ -78,11 +78,11 @@ func truncateAndFormatChanges(changes []*ChangeInfo, onlyGapicChanges, truncate 
 			}
 		}
 
-		sb.WriteString(fmt.Sprintf("%s\n", body))
+		fmt.Fprintf(&sb, "%s\n", body)
 		if len(c.AffectedProtos) > 0 {
 			sb.WriteString("  Affected protos:\n")
 			for _, proto := range c.AffectedProtos {
-				sb.WriteString(fmt.Sprintf("  - %s\n", proto))
+				fmt.Fprintf(&sb, "  - %s\n", proto)
 			}
 		}
 		sb.WriteString("\n")

--- a/internal/gapicgen/git/git.go
+++ b/internal/gapicgen/git/git.go
@@ -79,11 +79,14 @@ func truncateAndFormatChanges(changes []*ChangeInfo, onlyGapicChanges, truncate 
 			}
 		}
 
-		fmt.Fprintf(&sb, "%s\n", body)
+		sb.WriteString(body)
+		sb.WriteByte('\n')
 		if len(c.AffectedProtos) > 0 {
 			sb.WriteString("  Affected protos:\n")
 			for _, proto := range c.AffectedProtos {
-				fmt.Fprintf(&sb, "  - %s\n", proto)
+				sb.WriteString("  - ")
+				sb.WriteString(proto)
+				sb.WriteByte('\n')
 			}
 		}
 		sb.WriteString("\n")

--- a/internal/gapicgen/git/git.go
+++ b/internal/gapicgen/git/git.go
@@ -62,7 +62,8 @@ func truncateAndFormatChanges(changes []*ChangeInfo, onlyGapicChanges, truncate 
 		if truncate && len(title) > maxTruncatedTitleLen {
 			title = fmt.Sprintf("%v...", title[:maxTruncatedTitleLen])
 		}
-		fmt.Fprintf(&sb, "%s\n", title)
+		sb.WriteString(title)
+		sb.WriteByte('\n')
 
 		// Format the commit body to conventional commit footer standards.
 		splitBody := strings.Split(c.Body, "\n")


### PR DESCRIPTION
 without creating a copy with fmt.Sprintf, writing directly to buffer