### PR TITLE
chore(spanner): add gorm data type names for PG types

### DIFF
--- a/spanner/value.go
+++ b/spanner/value.go
@@ -1051,6 +1051,11 @@ func (n *PGNumeric) UnmarshalJSON(payload []byte) error {
 	return nil
 }
 
+// GormDataType is used by gorm to determine the default data type for fields with this type.
+func (n PGNumeric) GormDataType() string {
+	return "numeric"
+}
+
 // NullProtoMessage represents a Cloud Spanner PROTO that may be NULL.
 // To write a NULL value using NullProtoMessage set ProtoMessageVal to typed nil and set Valid to true.
 type NullProtoMessage struct {
@@ -1283,6 +1288,11 @@ func (n *PGJsonB) UnmarshalJSON(payload []byte) error {
 	n.Value = v
 	n.Valid = true
 	return nil
+}
+
+// GormDataType is used by gorm to determine the default data type for fields with this type.
+func (n PGJsonB) GormDataType() string {
+	return "jsonb"
 }
 
 func nulljson(valid bool, v interface{}) ([]byte, error) {


### PR DESCRIPTION
Add gorm data type names for PostgreSQL-specific types. This prevents gorm from interpreting these structs as models, and automatically creates columns with the correct data type when used as a field in a model.

Needed for https://github.com/googleapis/go-gorm-spanner/pull/199