### PR TITLE
test(datastore): fix flaky tests

### DIFF
--- a/datastore/integration_test.go
+++ b/datastore/integration_test.go
@@ -481,7 +481,7 @@ func TestIntegration_RunWithReadTime(t *testing.T) {
 	testutil.Retry(t, 5, time.Duration(10*time.Second), func(r *testutil.R) {
 		got := RT{}
 		time.Sleep(readTimeConsistencyBuffer)
-		tm := ReadTime(time.Now())
+		tm := ReadTime(time.Now().Truncate(time.Microsecond))
 
 		runCtx, cancel := context.WithTimeout(context.Background(), time.Second*20)
 		runClient := newTestClient(runCtx, t)


### PR DESCRIPTION
Fixes #12808
Fixes panic in `TestIntegration_IgnoreFieldMismatch` by using a unique Kind for test isolation and adding bounds checks for slice access.

Fixes #12809
Wrap the `client.Get` call in `TestIntegration_TopLevelKeyLoaded` with `testutil.Retry` to handle the "no such entity" error caused by eventual consistency in the test environment. This ensures the test robustly waits for the entity to be retrievable after `Put`.

Fixes #12956
Fixes `TestIntegration_RunWithReadTime` which was failing with `context deadline exceeded`. The fix involves isolating the retry attempts with their own context and client to avoid inheriting the expiring parent context, and adding a small buffer to the ReadTime timestamp.


After fix:
```go
$ go test -v -timeout 45m -run '^(TestIntegration_IgnoreFieldMismatch|TestIntegration_TopLevelKeyLoaded|TestIntegration_RunWithReadTime)$' -count 20
2026/01/12 20:58:10 Setting up tests to run on databaseID: ""
=== RUN   TestIntegration_IgnoreFieldMismatch
=== RUN   TestIntegration_IgnoreFieldMismatch/Without_IgnoreFieldMismatch_option
=== RUN   TestIntegration_IgnoreFieldMismatch/With_IgnoreFieldMismatch_option
--- PASS: TestIntegration_IgnoreFieldMismatch (2.12s)
    --- PASS: TestIntegration_IgnoreFieldMismatch/Without_IgnoreFieldMismatch_option (1.09s)
    --- PASS: TestIntegration_IgnoreFieldMismatch/With_IgnoreFieldMismatch_option (0.56s)
=== RUN   TestIntegration_RunWithReadTime
--- PASS: TestIntegration_RunWithReadTime (0.80s)
=== RUN   TestIntegration_TopLevelKeyLoaded
--- PASS: TestIntegration_TopLevelKeyLoaded (0.42s)
=== RUN   TestIntegration_IgnoreFieldMismatch
=== RUN   TestIntegration_IgnoreFieldMismatch/Without_IgnoreFieldMismatch_option
=== RUN   TestIntegration_IgnoreFieldMismatch/With_IgnoreFieldMismatch_option
--- PASS: TestIntegration_IgnoreFieldMismatch (2.60s)
    --- PASS: TestIntegration_IgnoreFieldMismatch/Without_IgnoreFieldMismatch_option (1.22s)
    --- PASS: TestIntegration_IgnoreFieldMismatch/With_IgnoreFieldMismatch_option (1.00s)
=== RUN   TestIntegration_RunWithReadTime
--- PASS: TestIntegration_RunWithReadTime (11.24s)
=== RUN   TestIntegration_TopLevelKeyLoaded
--- PASS: TestIntegration_TopLevelKeyLoaded (0.36s)
=== RUN   TestIntegration_IgnoreFieldMismatch
=== RUN   TestIntegration_IgnoreFieldMismatch/Without_IgnoreFieldMismatch_option
=== RUN   TestIntegration_IgnoreFieldMismatch/With_IgnoreFieldMismatch_option
--- PASS: TestIntegration_IgnoreFieldMismatch (2.37s)
    --- PASS: TestIntegration_IgnoreFieldMismatch/Without_IgnoreFieldMismatch_option (1.10s)
    --- PASS: TestIntegration_IgnoreFieldMismatch/With_IgnoreFieldMismatch_option (1.10s)
=== RUN   TestIntegration_RunWithReadTime
--- PASS: TestIntegration_RunWithReadTime (11.11s)
=== RUN   TestIntegration_TopLevelKeyLoaded
--- PASS: TestIntegration_TopLevelKeyLoaded (0.38s)
=== RUN   TestIntegration_IgnoreFieldMismatch
=== RUN   TestIntegration_IgnoreFieldMismatch/Without_IgnoreFieldMismatch_option
=== RUN   TestIntegration_IgnoreFieldMismatch/With_IgnoreFieldMismatch_option
--- PASS: TestIntegration_IgnoreFieldMismatch (2.18s)
    --- PASS: TestIntegration_IgnoreFieldMismatch/Without_IgnoreFieldMismatch_option (1.00s)
    --- PASS: TestIntegration_IgnoreFieldMismatch/With_IgnoreFieldMismatch_option (0.99s)
=== RUN   TestIntegration_RunWithReadTime
--- PASS: TestIntegration_RunWithReadTime (11.19s)
=== RUN   TestIntegration_TopLevelKeyLoaded
--- PASS: TestIntegration_TopLevelKeyLoaded (0.43s)
=== RUN   TestIntegration_IgnoreFieldMismatch
=== RUN   TestIntegration_IgnoreFieldMismatch/Without_IgnoreFieldMismatch_option
=== RUN   TestIntegration_IgnoreFieldMismatch/With_IgnoreFieldMismatch_option
--- PASS: TestIntegration_IgnoreFieldMismatch (2.27s)
    --- PASS: TestIntegration_IgnoreFieldMismatch/Without_IgnoreFieldMismatch_option (1.03s)
    --- PASS: TestIntegration_IgnoreFieldMismatch/With_IgnoreFieldMismatch_option (1.04s)
=== RUN   TestIntegration_RunWithReadTime
--- PASS: TestIntegration_RunWithReadTime (11.11s)
=== RUN   TestIntegration_TopLevelKeyLoaded
--- PASS: TestIntegration_TopLevelKeyLoaded (0.35s)
=== RUN   TestIntegration_IgnoreFieldMismatch
=== RUN   TestIntegration_IgnoreFieldMismatch/Without_IgnoreFieldMismatch_option
=== RUN   TestIntegration_IgnoreFieldMismatch/With_IgnoreFieldMismatch_option
--- PASS: TestIntegration_IgnoreFieldMismatch (2.29s)
    --- PASS: TestIntegration_IgnoreFieldMismatch/Without_IgnoreFieldMismatch_option (1.03s)
    --- PASS: TestIntegration_IgnoreFieldMismatch/With_IgnoreFieldMismatch_option (1.07s)
=== RUN   TestIntegration_RunWithReadTime
--- PASS: TestIntegration_RunWithReadTime (11.05s)
=== RUN   TestIntegration_TopLevelKeyLoaded
--- PASS: TestIntegration_TopLevelKeyLoaded (0.36s)
=== RUN   TestIntegration_IgnoreFieldMismatch
=== RUN   TestIntegration_IgnoreFieldMismatch/Without_IgnoreFieldMismatch_option
=== RUN   TestIntegration_IgnoreFieldMismatch/With_IgnoreFieldMismatch_option
--- PASS: TestIntegration_IgnoreFieldMismatch (2.66s)
    --- PASS: TestIntegration_IgnoreFieldMismatch/Without_IgnoreFieldMismatch_option (1.24s)
    --- PASS: TestIntegration_IgnoreFieldMismatch/With_IgnoreFieldMismatch_option (1.16s)
=== RUN   TestIntegration_RunWithReadTime
--- PASS: TestIntegration_RunWithReadTime (11.16s)
=== RUN   TestIntegration_TopLevelKeyLoaded
--- PASS: TestIntegration_TopLevelKeyLoaded (0.24s)
=== RUN   TestIntegration_IgnoreFieldMismatch
=== RUN   TestIntegration_IgnoreFieldMismatch/Without_IgnoreFieldMismatch_option
=== RUN   TestIntegration_IgnoreFieldMismatch/With_IgnoreFieldMismatch_option
--- PASS: TestIntegration_IgnoreFieldMismatch (2.24s)
    --- PASS: TestIntegration_IgnoreFieldMismatch/Without_IgnoreFieldMismatch_option (1.00s)
    --- PASS: TestIntegration_IgnoreFieldMismatch/With_IgnoreFieldMismatch_option (1.01s)
=== RUN   TestIntegration_RunWithReadTime
--- PASS: TestIntegration_RunWithReadTime (11.05s)
=== RUN   TestIntegration_TopLevelKeyLoaded
--- PASS: TestIntegration_TopLevelKeyLoaded (0.34s)
=== RUN   TestIntegration_IgnoreFieldMismatch
=== RUN   TestIntegration_IgnoreFieldMismatch/Without_IgnoreFieldMismatch_option
=== RUN   TestIntegration_IgnoreFieldMismatch/With_IgnoreFieldMismatch_option
--- PASS: TestIntegration_IgnoreFieldMismatch (2.35s)
    --- PASS: TestIntegration_IgnoreFieldMismatch/Without_IgnoreFieldMismatch_option (1.02s)
    --- PASS: TestIntegration_IgnoreFieldMismatch/With_IgnoreFieldMismatch_option (1.15s)
=== RUN   TestIntegration_RunWithReadTime
--- PASS: TestIntegration_RunWithReadTime (11.12s)
=== RUN   TestIntegration_TopLevelKeyLoaded
--- PASS: TestIntegration_TopLevelKeyLoaded (0.62s)
=== RUN   TestIntegration_IgnoreFieldMismatch
=== RUN   TestIntegration_IgnoreFieldMismatch/Without_IgnoreFieldMismatch_option
=== RUN   TestIntegration_IgnoreFieldMismatch/With_IgnoreFieldMismatch_option
--- PASS: TestIntegration_IgnoreFieldMismatch (2.60s)
    --- PASS: TestIntegration_IgnoreFieldMismatch/Without_IgnoreFieldMismatch_option (1.15s)
    --- PASS: TestIntegration_IgnoreFieldMismatch/With_IgnoreFieldMismatch_option (1.23s)
=== RUN   TestIntegration_RunWithReadTime
--- PASS: TestIntegration_RunWithReadTime (11.39s)
=== RUN   TestIntegration_TopLevelKeyLoaded
--- PASS: TestIntegration_TopLevelKeyLoaded (0.36s)
=== RUN   TestIntegration_IgnoreFieldMismatch
=== RUN   TestIntegration_IgnoreFieldMismatch/Without_IgnoreFieldMismatch_option
=== RUN   TestIntegration_IgnoreFieldMismatch/With_IgnoreFieldMismatch_option
--- PASS: TestIntegration_IgnoreFieldMismatch (2.34s)
    --- PASS: TestIntegration_IgnoreFieldMismatch/Without_IgnoreFieldMismatch_option (1.01s)
    --- PASS: TestIntegration_IgnoreFieldMismatch/With_IgnoreFieldMismatch_option (1.14s)
=== RUN   TestIntegration_RunWithReadTime
--- PASS: TestIntegration_RunWithReadTime (11.24s)
=== RUN   TestIntegration_TopLevelKeyLoaded
--- PASS: TestIntegration_TopLevelKeyLoaded (0.42s)
=== RUN   TestIntegration_IgnoreFieldMismatch
=== RUN   TestIntegration_IgnoreFieldMismatch/Without_IgnoreFieldMismatch_option
=== RUN   TestIntegration_IgnoreFieldMismatch/With_IgnoreFieldMismatch_option
--- PASS: TestIntegration_IgnoreFieldMismatch (2.32s)
    --- PASS: TestIntegration_IgnoreFieldMismatch/Without_IgnoreFieldMismatch_option (1.11s)
    --- PASS: TestIntegration_IgnoreFieldMismatch/With_IgnoreFieldMismatch_option (1.02s)
=== RUN   TestIntegration_RunWithReadTime
--- PASS: TestIntegration_RunWithReadTime (11.19s)
=== RUN   TestIntegration_TopLevelKeyLoaded
--- PASS: TestIntegration_TopLevelKeyLoaded (0.59s)
=== RUN   TestIntegration_IgnoreFieldMismatch
=== RUN   TestIntegration_IgnoreFieldMismatch/Without_IgnoreFieldMismatch_option
=== RUN   TestIntegration_IgnoreFieldMismatch/With_IgnoreFieldMismatch_option
--- PASS: TestIntegration_IgnoreFieldMismatch (2.80s)
    --- PASS: TestIntegration_IgnoreFieldMismatch/Without_IgnoreFieldMismatch_option (1.20s)
    --- PASS: TestIntegration_IgnoreFieldMismatch/With_IgnoreFieldMismatch_option (1.18s)
=== RUN   TestIntegration_RunWithReadTime
--- PASS: TestIntegration_RunWithReadTime (0.95s)
=== RUN   TestIntegration_TopLevelKeyLoaded
--- PASS: TestIntegration_TopLevelKeyLoaded (0.60s)
=== RUN   TestIntegration_IgnoreFieldMismatch
=== RUN   TestIntegration_IgnoreFieldMismatch/Without_IgnoreFieldMismatch_option
=== RUN   TestIntegration_IgnoreFieldMismatch/With_IgnoreFieldMismatch_option
--- PASS: TestIntegration_IgnoreFieldMismatch (2.67s)
    --- PASS: TestIntegration_IgnoreFieldMismatch/Without_IgnoreFieldMismatch_option (1.15s)
    --- PASS: TestIntegration_IgnoreFieldMismatch/With_IgnoreFieldMismatch_option (1.11s)
=== RUN   TestIntegration_RunWithReadTime
--- PASS: TestIntegration_RunWithReadTime (11.25s)
=== RUN   TestIntegration_TopLevelKeyLoaded
--- PASS: TestIntegration_TopLevelKeyLoaded (0.40s)
=== RUN   TestIntegration_IgnoreFieldMismatch
=== RUN   TestIntegration_IgnoreFieldMismatch/Without_IgnoreFieldMismatch_option
=== RUN   TestIntegration_IgnoreFieldMismatch/With_IgnoreFieldMismatch_option
--- PASS: TestIntegration_IgnoreFieldMismatch (2.63s)
    --- PASS: TestIntegration_IgnoreFieldMismatch/Without_IgnoreFieldMismatch_option (1.16s)
    --- PASS: TestIntegration_IgnoreFieldMismatch/With_IgnoreFieldMismatch_option (1.11s)
=== RUN   TestIntegration_RunWithReadTime
--- PASS: TestIntegration_RunWithReadTime (11.32s)
=== RUN   TestIntegration_TopLevelKeyLoaded
--- PASS: TestIntegration_TopLevelKeyLoaded (0.37s)
=== RUN   TestIntegration_IgnoreFieldMismatch
=== RUN   TestIntegration_IgnoreFieldMismatch/Without_IgnoreFieldMismatch_option
=== RUN   TestIntegration_IgnoreFieldMismatch/With_IgnoreFieldMismatch_option
--- PASS: TestIntegration_IgnoreFieldMismatch (2.49s)
    --- PASS: TestIntegration_IgnoreFieldMismatch/Without_IgnoreFieldMismatch_option (1.18s)
    --- PASS: TestIntegration_IgnoreFieldMismatch/With_IgnoreFieldMismatch_option (0.96s)
=== RUN   TestIntegration_RunWithReadTime
--- PASS: TestIntegration_RunWithReadTime (11.25s)
=== RUN   TestIntegration_TopLevelKeyLoaded
--- PASS: TestIntegration_TopLevelKeyLoaded (0.53s)
=== RUN   TestIntegration_IgnoreFieldMismatch
=== RUN   TestIntegration_IgnoreFieldMismatch/Without_IgnoreFieldMismatch_option
=== RUN   TestIntegration_IgnoreFieldMismatch/With_IgnoreFieldMismatch_option
--- PASS: TestIntegration_IgnoreFieldMismatch (2.68s)
    --- PASS: TestIntegration_IgnoreFieldMismatch/Without_IgnoreFieldMismatch_option (1.26s)
    --- PASS: TestIntegration_IgnoreFieldMismatch/With_IgnoreFieldMismatch_option (1.07s)
=== RUN   TestIntegration_RunWithReadTime
--- PASS: TestIntegration_RunWithReadTime (11.45s)
=== RUN   TestIntegration_TopLevelKeyLoaded
--- PASS: TestIntegration_TopLevelKeyLoaded (0.61s)
=== RUN   TestIntegration_IgnoreFieldMismatch
=== RUN   TestIntegration_IgnoreFieldMismatch/Without_IgnoreFieldMismatch_option
=== RUN   TestIntegration_IgnoreFieldMismatch/With_IgnoreFieldMismatch_option
--- PASS: TestIntegration_IgnoreFieldMismatch (2.53s)
    --- PASS: TestIntegration_IgnoreFieldMismatch/Without_IgnoreFieldMismatch_option (1.01s)
    --- PASS: TestIntegration_IgnoreFieldMismatch/With_IgnoreFieldMismatch_option (1.15s)
=== RUN   TestIntegration_RunWithReadTime
--- PASS: TestIntegration_RunWithReadTime (11.24s)
=== RUN   TestIntegration_TopLevelKeyLoaded
--- PASS: TestIntegration_TopLevelKeyLoaded (0.54s)
=== RUN   TestIntegration_IgnoreFieldMismatch
=== RUN   TestIntegration_IgnoreFieldMismatch/Without_IgnoreFieldMismatch_option
=== RUN   TestIntegration_IgnoreFieldMismatch/With_IgnoreFieldMismatch_option
--- PASS: TestIntegration_IgnoreFieldMismatch (2.40s)
    --- PASS: TestIntegration_IgnoreFieldMismatch/Without_IgnoreFieldMismatch_option (1.12s)
    --- PASS: TestIntegration_IgnoreFieldMismatch/With_IgnoreFieldMismatch_option (1.11s)
=== RUN   TestIntegration_RunWithReadTime
--- PASS: TestIntegration_RunWithReadTime (11.22s)
=== RUN   TestIntegration_TopLevelKeyLoaded
--- PASS: TestIntegration_TopLevelKeyLoaded (0.55s)
=== RUN   TestIntegration_IgnoreFieldMismatch
=== RUN   TestIntegration_IgnoreFieldMismatch/Without_IgnoreFieldMismatch_option
=== RUN   TestIntegration_IgnoreFieldMismatch/With_IgnoreFieldMismatch_option
--- PASS: TestIntegration_IgnoreFieldMismatch (2.53s)
    --- PASS: TestIntegration_IgnoreFieldMismatch/Without_IgnoreFieldMismatch_option (1.09s)
    --- PASS: TestIntegration_IgnoreFieldMismatch/With_IgnoreFieldMismatch_option (1.09s)
=== RUN   TestIntegration_RunWithReadTime
--- PASS: TestIntegration_RunWithReadTime (11.24s)
=== RUN   TestIntegration_TopLevelKeyLoaded
--- PASS: TestIntegration_TopLevelKeyLoaded (0.40s)
PASS
ok      cloud.google.com/go/datastore   261.590s
$ 
```