### PR TITLE
chore(firestore): [PQ] update copyright year

### DIFF
--- a/firestore/pipeline.go
+++ b/firestore/pipeline.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/firestore/pipeline_aggregate.go
+++ b/firestore/pipeline_aggregate.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/firestore/pipeline_constant.go
+++ b/firestore/pipeline_constant.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/firestore/pipeline_expression.go
+++ b/firestore/pipeline_expression.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/firestore/pipeline_field.go
+++ b/firestore/pipeline_field.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/firestore/pipeline_filter_condition.go
+++ b/firestore/pipeline_filter_condition.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/firestore/pipeline_function.go
+++ b/firestore/pipeline_function.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/firestore/pipeline_integration_test.go
+++ b/firestore/pipeline_integration_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/firestore/pipeline_result.go
+++ b/firestore/pipeline_result.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/firestore/pipeline_result_test.go
+++ b/firestore/pipeline_result_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/firestore/pipeline_source.go
+++ b/firestore/pipeline_source.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/firestore/pipeline_source_test.go
+++ b/firestore/pipeline_source_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/firestore/pipeline_stage.go
+++ b/firestore/pipeline_stage.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/firestore/pipeline_stage_test.go
+++ b/firestore/pipeline_stage_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/firestore/pipeline_test.go
+++ b/firestore/pipeline_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/firestore/pipeline_utils.go
+++ b/firestore/pipeline_utils.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
header-check fails on https://github.com/googleapis/google-cloud-go/pull/12347 with error

firestore/pipeline.go should have a copyright year of 2026
firestore/pipeline_aggregate.go should have a copyright year of 2026
firestore/pipeline_constant.go should have a copyright year of 2026
firestore/pipeline_expression.go should have a copyright year of 2026
firestore/pipeline_field.go should have a copyright year of 2026
firestore/pipeline_filter_condition.go should have a copyright year of 2026
firestore/pipeline_function.go should have a copyright year of 2026
firestore/pipeline_integration_test.go should have a copyright year of 2026
firestore/pipeline_result.go should have a copyright year of 2026
firestore/pipeline_result_test.go should have a copyright year of 2026
firestore/pipeline_source.go should have a copyright year of 2026
firestore/pipeline_source_test.go should have a copyright year of 2026
firestore/pipeline_stage.go should have a copyright year of 2026
firestore/pipeline_stage_test.go should have a copyright year of 2026
firestore/pipeline_test.go should have a copyright year of 2026
firestore/pipeline_utils.go should have a copyright year of 2026

Fixing it in this PR