### PR TITLE
chore: librarian release pull request: 20260114T061057Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -5750,7 +5750,7 @@ libraries:
       - internal/generated/snippets/speech/
     tag_format: '{id}/v{version}'
   - id: storage
-    version: 1.59.0
+    version: 1.59.1
     last_generated_commit: effe5c4fa816021e724ca856d5640f2e55b14a8b
     apis:
       - path: google/storage/control/v2

--- a/internal/generated/snippets/storage/control/apiv2/snippet_metadata.google.storage.control.v2.json
+++ b/internal/generated/snippets/storage/control/apiv2/snippet_metadata.google.storage.control.v2.json
@@ -1,7 +1,7 @@
 {
   "clientLibrary": {
     "name": "cloud.google.com/go/storage/control/apiv2",
-    "version": "1.59.0",
+    "version": "1.59.1",
     "language": "GO",
     "apis": [
       {

--- a/storage/CHANGES.md
+++ b/storage/CHANGES.md
@@ -1,6 +1,14 @@
 # Changes
 
 
+## [1.59.1](https://github.com/googleapis/google-cloud-go/releases/tag/storage%2Fv1.59.1) (2026-01-14)
+
+### Bug Fixes
+
+* close attrsReady channel when metadata is missing (#13574) ([712f562](https://github.com/googleapis/google-cloud-go/commit/712f56272ac5a219bac1b20894e4825f3682c920))
+* don't update global object's readhandle in MRD (#13575) ([bc92500](https://github.com/googleapis/google-cloud-go/commit/bc925001a2f5b186c231c2885f9162713bb4b1bf))
+* remove mandatory attrs response in MRD (#13585) ([6752a49](https://github.com/googleapis/google-cloud-go/commit/6752a496e756c214faf345c302b58ed7593c6017))
+
 ## [1.59.0](https://github.com/googleapis/google-cloud-go/releases/tag/storage%2Fv1.59.0) (2026-01-09)
 
 ### Features

--- a/storage/internal/version.go
+++ b/storage/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "1.59.0"
+const Version = "1.59.1"


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.7.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go@sha256:718167d5c23ed389b41f617b3a00ac839bdd938a6bd2d48ae0c2f1fa51ab1c3d
<details><summary>storage: 1.59.1</summary>

## [1.59.1](https://github.com/googleapis/google-cloud-go/compare/storage/v1.59.0...storage/v1.59.1) (2026-01-14)

### Bug Fixes

* remove mandatory attrs response in MRD (#13585) ([6752a496](https://github.com/googleapis/google-cloud-go/commit/6752a496))

* close attrsReady channel when metadata is missing (#13574) ([712f5627](https://github.com/googleapis/google-cloud-go/commit/712f5627))

* don&#39;t update global object&#39;s readhandle in MRD (#13575) ([bc925001](https://github.com/googleapis/google-cloud-go/commit/bc925001))

</details>