### PR TITLE
chore: update librarian image

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,4 +1,4 @@
-image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go@sha256:718167d5c23ed389b41f617b3a00ac839bdd938a6bd2d48ae0c2f1fa51ab1c3d
+image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go@sha256:d2dee66d7c8c1d673fac26280164ea24015b79491b7f9d6ba369e6a98ab3420c
 libraries:
   - id: accessapproval
     version: 1.8.8

--- a/accessapproval/apiv1/access_approval_client.go
+++ b/accessapproval/apiv1/access_approval_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/accessapproval/apiv1/access_approval_client_example_go123_test.go
+++ b/accessapproval/apiv1/access_approval_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/accessapproval/apiv1/access_approval_client_example_test.go
+++ b/accessapproval/apiv1/access_approval_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/accessapproval/apiv1/auxiliary.go
+++ b/accessapproval/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/accessapproval/apiv1/auxiliary_go123.go
+++ b/accessapproval/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/accessapproval/apiv1/doc.go
+++ b/accessapproval/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/accessapproval/apiv1/helpers.go
+++ b/accessapproval/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/accesscontextmanager/apiv1/access_context_manager_client.go
+++ b/accesscontextmanager/apiv1/access_context_manager_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/accesscontextmanager/apiv1/access_context_manager_client_example_go123_test.go
+++ b/accesscontextmanager/apiv1/access_context_manager_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/accesscontextmanager/apiv1/access_context_manager_client_example_test.go
+++ b/accesscontextmanager/apiv1/access_context_manager_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/accesscontextmanager/apiv1/auxiliary.go
+++ b/accesscontextmanager/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/accesscontextmanager/apiv1/auxiliary_go123.go
+++ b/accesscontextmanager/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/accesscontextmanager/apiv1/doc.go
+++ b/accesscontextmanager/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/accesscontextmanager/apiv1/helpers.go
+++ b/accesscontextmanager/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/advisorynotifications/apiv1/advisory_notifications_client.go
+++ b/advisorynotifications/apiv1/advisory_notifications_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/advisorynotifications/apiv1/advisory_notifications_client_example_go123_test.go
+++ b/advisorynotifications/apiv1/advisory_notifications_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/advisorynotifications/apiv1/advisory_notifications_client_example_test.go
+++ b/advisorynotifications/apiv1/advisory_notifications_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/advisorynotifications/apiv1/auxiliary.go
+++ b/advisorynotifications/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/advisorynotifications/apiv1/auxiliary_go123.go
+++ b/advisorynotifications/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/advisorynotifications/apiv1/doc.go
+++ b/advisorynotifications/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/advisorynotifications/apiv1/helpers.go
+++ b/advisorynotifications/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1/auxiliary.go
+++ b/ai/generativelanguage/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1/auxiliary_go123.go
+++ b/ai/generativelanguage/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1/doc.go
+++ b/ai/generativelanguage/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1/generative_client.go
+++ b/ai/generativelanguage/apiv1/generative_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1/generative_client_example_go123_test.go
+++ b/ai/generativelanguage/apiv1/generative_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1/generative_client_example_test.go
+++ b/ai/generativelanguage/apiv1/generative_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1/helpers.go
+++ b/ai/generativelanguage/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1/model_client.go
+++ b/ai/generativelanguage/apiv1/model_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1/model_client_example_go123_test.go
+++ b/ai/generativelanguage/apiv1/model_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1/model_client_example_test.go
+++ b/ai/generativelanguage/apiv1/model_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1alpha/auxiliary.go
+++ b/ai/generativelanguage/apiv1alpha/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1alpha/auxiliary_go123.go
+++ b/ai/generativelanguage/apiv1alpha/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1alpha/cache_client.go
+++ b/ai/generativelanguage/apiv1alpha/cache_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1alpha/cache_client_example_go123_test.go
+++ b/ai/generativelanguage/apiv1alpha/cache_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1alpha/cache_client_example_test.go
+++ b/ai/generativelanguage/apiv1alpha/cache_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1alpha/discuss_client.go
+++ b/ai/generativelanguage/apiv1alpha/discuss_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1alpha/discuss_client_example_go123_test.go
+++ b/ai/generativelanguage/apiv1alpha/discuss_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1alpha/discuss_client_example_test.go
+++ b/ai/generativelanguage/apiv1alpha/discuss_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1alpha/doc.go
+++ b/ai/generativelanguage/apiv1alpha/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1alpha/file_client.go
+++ b/ai/generativelanguage/apiv1alpha/file_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1alpha/file_client_example_go123_test.go
+++ b/ai/generativelanguage/apiv1alpha/file_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1alpha/file_client_example_test.go
+++ b/ai/generativelanguage/apiv1alpha/file_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1alpha/generative_client.go
+++ b/ai/generativelanguage/apiv1alpha/generative_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1alpha/generative_client_example_go123_test.go
+++ b/ai/generativelanguage/apiv1alpha/generative_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1alpha/generative_client_example_test.go
+++ b/ai/generativelanguage/apiv1alpha/generative_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1alpha/helpers.go
+++ b/ai/generativelanguage/apiv1alpha/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1alpha/model_client.go
+++ b/ai/generativelanguage/apiv1alpha/model_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1alpha/model_client_example_go123_test.go
+++ b/ai/generativelanguage/apiv1alpha/model_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1alpha/model_client_example_test.go
+++ b/ai/generativelanguage/apiv1alpha/model_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1alpha/permission_client.go
+++ b/ai/generativelanguage/apiv1alpha/permission_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1alpha/permission_client_example_go123_test.go
+++ b/ai/generativelanguage/apiv1alpha/permission_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1alpha/permission_client_example_test.go
+++ b/ai/generativelanguage/apiv1alpha/permission_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1alpha/prediction_client.go
+++ b/ai/generativelanguage/apiv1alpha/prediction_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1alpha/prediction_client_example_go123_test.go
+++ b/ai/generativelanguage/apiv1alpha/prediction_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1alpha/prediction_client_example_test.go
+++ b/ai/generativelanguage/apiv1alpha/prediction_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1alpha/retriever_client.go
+++ b/ai/generativelanguage/apiv1alpha/retriever_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1alpha/retriever_client_example_go123_test.go
+++ b/ai/generativelanguage/apiv1alpha/retriever_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1alpha/retriever_client_example_test.go
+++ b/ai/generativelanguage/apiv1alpha/retriever_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1alpha/text_client.go
+++ b/ai/generativelanguage/apiv1alpha/text_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1alpha/text_client_example_go123_test.go
+++ b/ai/generativelanguage/apiv1alpha/text_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1alpha/text_client_example_test.go
+++ b/ai/generativelanguage/apiv1alpha/text_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1beta/auxiliary.go
+++ b/ai/generativelanguage/apiv1beta/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1beta/auxiliary_go123.go
+++ b/ai/generativelanguage/apiv1beta/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1beta/cache_client.go
+++ b/ai/generativelanguage/apiv1beta/cache_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1beta/cache_client_example_go123_test.go
+++ b/ai/generativelanguage/apiv1beta/cache_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1beta/cache_client_example_test.go
+++ b/ai/generativelanguage/apiv1beta/cache_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1beta/discuss_client.go
+++ b/ai/generativelanguage/apiv1beta/discuss_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1beta/discuss_client_example_go123_test.go
+++ b/ai/generativelanguage/apiv1beta/discuss_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1beta/discuss_client_example_test.go
+++ b/ai/generativelanguage/apiv1beta/discuss_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1beta/doc.go
+++ b/ai/generativelanguage/apiv1beta/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1beta/file_client.go
+++ b/ai/generativelanguage/apiv1beta/file_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1beta/file_client_example_go123_test.go
+++ b/ai/generativelanguage/apiv1beta/file_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1beta/file_client_example_test.go
+++ b/ai/generativelanguage/apiv1beta/file_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1beta/generative_client.go
+++ b/ai/generativelanguage/apiv1beta/generative_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1beta/generative_client_example_go123_test.go
+++ b/ai/generativelanguage/apiv1beta/generative_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1beta/generative_client_example_test.go
+++ b/ai/generativelanguage/apiv1beta/generative_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1beta/helpers.go
+++ b/ai/generativelanguage/apiv1beta/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1beta/model_client.go
+++ b/ai/generativelanguage/apiv1beta/model_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1beta/model_client_example_go123_test.go
+++ b/ai/generativelanguage/apiv1beta/model_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1beta/model_client_example_test.go
+++ b/ai/generativelanguage/apiv1beta/model_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1beta/permission_client.go
+++ b/ai/generativelanguage/apiv1beta/permission_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1beta/permission_client_example_go123_test.go
+++ b/ai/generativelanguage/apiv1beta/permission_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1beta/permission_client_example_test.go
+++ b/ai/generativelanguage/apiv1beta/permission_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1beta/prediction_client.go
+++ b/ai/generativelanguage/apiv1beta/prediction_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1beta/prediction_client_example_go123_test.go
+++ b/ai/generativelanguage/apiv1beta/prediction_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1beta/prediction_client_example_test.go
+++ b/ai/generativelanguage/apiv1beta/prediction_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1beta/retriever_client.go
+++ b/ai/generativelanguage/apiv1beta/retriever_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1beta/retriever_client_example_go123_test.go
+++ b/ai/generativelanguage/apiv1beta/retriever_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1beta/retriever_client_example_test.go
+++ b/ai/generativelanguage/apiv1beta/retriever_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1beta/text_client.go
+++ b/ai/generativelanguage/apiv1beta/text_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1beta/text_client_example_go123_test.go
+++ b/ai/generativelanguage/apiv1beta/text_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1beta/text_client_example_test.go
+++ b/ai/generativelanguage/apiv1beta/text_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1beta2/auxiliary.go
+++ b/ai/generativelanguage/apiv1beta2/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1beta2/auxiliary_go123.go
+++ b/ai/generativelanguage/apiv1beta2/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1beta2/discuss_client.go
+++ b/ai/generativelanguage/apiv1beta2/discuss_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1beta2/discuss_client_example_go123_test.go
+++ b/ai/generativelanguage/apiv1beta2/discuss_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1beta2/discuss_client_example_test.go
+++ b/ai/generativelanguage/apiv1beta2/discuss_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1beta2/doc.go
+++ b/ai/generativelanguage/apiv1beta2/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1beta2/helpers.go
+++ b/ai/generativelanguage/apiv1beta2/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1beta2/model_client.go
+++ b/ai/generativelanguage/apiv1beta2/model_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1beta2/model_client_example_go123_test.go
+++ b/ai/generativelanguage/apiv1beta2/model_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1beta2/model_client_example_test.go
+++ b/ai/generativelanguage/apiv1beta2/model_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1beta2/text_client.go
+++ b/ai/generativelanguage/apiv1beta2/text_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1beta2/text_client_example_go123_test.go
+++ b/ai/generativelanguage/apiv1beta2/text_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ai/generativelanguage/apiv1beta2/text_client_example_test.go
+++ b/ai/generativelanguage/apiv1beta2/text_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/analytics/admin/apiv1alpha/analytics_admin_client.go
+++ b/analytics/admin/apiv1alpha/analytics_admin_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/analytics/admin/apiv1alpha/analytics_admin_client_example_go123_test.go
+++ b/analytics/admin/apiv1alpha/analytics_admin_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/analytics/admin/apiv1alpha/analytics_admin_client_example_test.go
+++ b/analytics/admin/apiv1alpha/analytics_admin_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/analytics/admin/apiv1alpha/auxiliary.go
+++ b/analytics/admin/apiv1alpha/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/analytics/admin/apiv1alpha/auxiliary_go123.go
+++ b/analytics/admin/apiv1alpha/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/analytics/admin/apiv1alpha/doc.go
+++ b/analytics/admin/apiv1alpha/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/analytics/admin/apiv1alpha/helpers.go
+++ b/analytics/admin/apiv1alpha/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apigateway/apiv1/api_gateway_client.go
+++ b/apigateway/apiv1/api_gateway_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apigateway/apiv1/api_gateway_client_example_go123_test.go
+++ b/apigateway/apiv1/api_gateway_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apigateway/apiv1/api_gateway_client_example_test.go
+++ b/apigateway/apiv1/api_gateway_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apigateway/apiv1/auxiliary.go
+++ b/apigateway/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apigateway/apiv1/auxiliary_go123.go
+++ b/apigateway/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apigateway/apiv1/doc.go
+++ b/apigateway/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apigateway/apiv1/helpers.go
+++ b/apigateway/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apigeeconnect/apiv1/auxiliary.go
+++ b/apigeeconnect/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apigeeconnect/apiv1/auxiliary_go123.go
+++ b/apigeeconnect/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apigeeconnect/apiv1/connection_client.go
+++ b/apigeeconnect/apiv1/connection_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apigeeconnect/apiv1/connection_client_example_go123_test.go
+++ b/apigeeconnect/apiv1/connection_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apigeeconnect/apiv1/connection_client_example_test.go
+++ b/apigeeconnect/apiv1/connection_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apigeeconnect/apiv1/doc.go
+++ b/apigeeconnect/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apigeeconnect/apiv1/helpers.go
+++ b/apigeeconnect/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apigeeconnect/apiv1/tether_client.go
+++ b/apigeeconnect/apiv1/tether_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apigeeconnect/apiv1/tether_client_example_go123_test.go
+++ b/apigeeconnect/apiv1/tether_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apigeeconnect/apiv1/tether_client_example_test.go
+++ b/apigeeconnect/apiv1/tether_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apigeeregistry/apiv1/auxiliary.go
+++ b/apigeeregistry/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apigeeregistry/apiv1/auxiliary_go123.go
+++ b/apigeeregistry/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apigeeregistry/apiv1/doc.go
+++ b/apigeeregistry/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apigeeregistry/apiv1/helpers.go
+++ b/apigeeregistry/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apigeeregistry/apiv1/provisioning_client.go
+++ b/apigeeregistry/apiv1/provisioning_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apigeeregistry/apiv1/provisioning_client_example_go123_test.go
+++ b/apigeeregistry/apiv1/provisioning_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apigeeregistry/apiv1/provisioning_client_example_test.go
+++ b/apigeeregistry/apiv1/provisioning_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apigeeregistry/apiv1/registry_client.go
+++ b/apigeeregistry/apiv1/registry_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apigeeregistry/apiv1/registry_client_example_go123_test.go
+++ b/apigeeregistry/apiv1/registry_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apigeeregistry/apiv1/registry_client_example_test.go
+++ b/apigeeregistry/apiv1/registry_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apihub/apiv1/api_hub_client.go
+++ b/apihub/apiv1/api_hub_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apihub/apiv1/api_hub_client_example_go123_test.go
+++ b/apihub/apiv1/api_hub_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apihub/apiv1/api_hub_client_example_test.go
+++ b/apihub/apiv1/api_hub_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apihub/apiv1/api_hub_collect_client.go
+++ b/apihub/apiv1/api_hub_collect_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apihub/apiv1/api_hub_collect_client_example_go123_test.go
+++ b/apihub/apiv1/api_hub_collect_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apihub/apiv1/api_hub_collect_client_example_test.go
+++ b/apihub/apiv1/api_hub_collect_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apihub/apiv1/api_hub_curate_client.go
+++ b/apihub/apiv1/api_hub_curate_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apihub/apiv1/api_hub_curate_client_example_go123_test.go
+++ b/apihub/apiv1/api_hub_curate_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apihub/apiv1/api_hub_curate_client_example_test.go
+++ b/apihub/apiv1/api_hub_curate_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apihub/apiv1/api_hub_dependencies_client.go
+++ b/apihub/apiv1/api_hub_dependencies_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apihub/apiv1/api_hub_dependencies_client_example_go123_test.go
+++ b/apihub/apiv1/api_hub_dependencies_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apihub/apiv1/api_hub_dependencies_client_example_test.go
+++ b/apihub/apiv1/api_hub_dependencies_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apihub/apiv1/api_hub_discovery_client.go
+++ b/apihub/apiv1/api_hub_discovery_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apihub/apiv1/api_hub_discovery_client_example_go123_test.go
+++ b/apihub/apiv1/api_hub_discovery_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apihub/apiv1/api_hub_discovery_client_example_test.go
+++ b/apihub/apiv1/api_hub_discovery_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apihub/apiv1/api_hub_plugin_client.go
+++ b/apihub/apiv1/api_hub_plugin_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apihub/apiv1/api_hub_plugin_client_example_go123_test.go
+++ b/apihub/apiv1/api_hub_plugin_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apihub/apiv1/api_hub_plugin_client_example_test.go
+++ b/apihub/apiv1/api_hub_plugin_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apihub/apiv1/auxiliary.go
+++ b/apihub/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apihub/apiv1/auxiliary_go123.go
+++ b/apihub/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apihub/apiv1/doc.go
+++ b/apihub/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apihub/apiv1/helpers.go
+++ b/apihub/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apihub/apiv1/host_project_registration_client.go
+++ b/apihub/apiv1/host_project_registration_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apihub/apiv1/host_project_registration_client_example_go123_test.go
+++ b/apihub/apiv1/host_project_registration_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apihub/apiv1/host_project_registration_client_example_test.go
+++ b/apihub/apiv1/host_project_registration_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apihub/apiv1/linting_client.go
+++ b/apihub/apiv1/linting_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apihub/apiv1/linting_client_example_go123_test.go
+++ b/apihub/apiv1/linting_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apihub/apiv1/linting_client_example_test.go
+++ b/apihub/apiv1/linting_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apihub/apiv1/provisioning_client.go
+++ b/apihub/apiv1/provisioning_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apihub/apiv1/provisioning_client_example_go123_test.go
+++ b/apihub/apiv1/provisioning_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apihub/apiv1/provisioning_client_example_test.go
+++ b/apihub/apiv1/provisioning_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apihub/apiv1/runtime_project_attachment_client.go
+++ b/apihub/apiv1/runtime_project_attachment_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apihub/apiv1/runtime_project_attachment_client_example_go123_test.go
+++ b/apihub/apiv1/runtime_project_attachment_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apihub/apiv1/runtime_project_attachment_client_example_test.go
+++ b/apihub/apiv1/runtime_project_attachment_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apikeys/apiv2/api_keys_client.go
+++ b/apikeys/apiv2/api_keys_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apikeys/apiv2/api_keys_client_example_go123_test.go
+++ b/apikeys/apiv2/api_keys_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apikeys/apiv2/api_keys_client_example_test.go
+++ b/apikeys/apiv2/api_keys_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apikeys/apiv2/auxiliary.go
+++ b/apikeys/apiv2/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apikeys/apiv2/auxiliary_go123.go
+++ b/apikeys/apiv2/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apikeys/apiv2/doc.go
+++ b/apikeys/apiv2/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apikeys/apiv2/helpers.go
+++ b/apikeys/apiv2/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apiregistry/apiv1beta/auxiliary.go
+++ b/apiregistry/apiv1beta/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apiregistry/apiv1beta/auxiliary_go123.go
+++ b/apiregistry/apiv1beta/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apiregistry/apiv1beta/cloud_api_registry_client.go
+++ b/apiregistry/apiv1beta/cloud_api_registry_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apiregistry/apiv1beta/cloud_api_registry_client_example_go123_test.go
+++ b/apiregistry/apiv1beta/cloud_api_registry_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apiregistry/apiv1beta/cloud_api_registry_client_example_test.go
+++ b/apiregistry/apiv1beta/cloud_api_registry_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apiregistry/apiv1beta/doc.go
+++ b/apiregistry/apiv1beta/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apiregistry/apiv1beta/helpers.go
+++ b/apiregistry/apiv1beta/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/appengine/apiv1/applications_client.go
+++ b/appengine/apiv1/applications_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/appengine/apiv1/applications_client_example_go123_test.go
+++ b/appengine/apiv1/applications_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/appengine/apiv1/applications_client_example_test.go
+++ b/appengine/apiv1/applications_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/appengine/apiv1/authorized_certificates_client.go
+++ b/appengine/apiv1/authorized_certificates_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/appengine/apiv1/authorized_certificates_client_example_go123_test.go
+++ b/appengine/apiv1/authorized_certificates_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/appengine/apiv1/authorized_certificates_client_example_test.go
+++ b/appengine/apiv1/authorized_certificates_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/appengine/apiv1/authorized_domains_client.go
+++ b/appengine/apiv1/authorized_domains_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/appengine/apiv1/authorized_domains_client_example_go123_test.go
+++ b/appengine/apiv1/authorized_domains_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/appengine/apiv1/authorized_domains_client_example_test.go
+++ b/appengine/apiv1/authorized_domains_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/appengine/apiv1/auxiliary.go
+++ b/appengine/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/appengine/apiv1/auxiliary_go123.go
+++ b/appengine/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/appengine/apiv1/doc.go
+++ b/appengine/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/appengine/apiv1/domain_mappings_client.go
+++ b/appengine/apiv1/domain_mappings_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/appengine/apiv1/domain_mappings_client_example_go123_test.go
+++ b/appengine/apiv1/domain_mappings_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/appengine/apiv1/domain_mappings_client_example_test.go
+++ b/appengine/apiv1/domain_mappings_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/appengine/apiv1/firewall_client.go
+++ b/appengine/apiv1/firewall_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/appengine/apiv1/firewall_client_example_go123_test.go
+++ b/appengine/apiv1/firewall_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/appengine/apiv1/firewall_client_example_test.go
+++ b/appengine/apiv1/firewall_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/appengine/apiv1/helpers.go
+++ b/appengine/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/appengine/apiv1/instances_client.go
+++ b/appengine/apiv1/instances_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/appengine/apiv1/instances_client_example_go123_test.go
+++ b/appengine/apiv1/instances_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/appengine/apiv1/instances_client_example_test.go
+++ b/appengine/apiv1/instances_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/appengine/apiv1/services_client.go
+++ b/appengine/apiv1/services_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/appengine/apiv1/services_client_example_go123_test.go
+++ b/appengine/apiv1/services_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/appengine/apiv1/services_client_example_test.go
+++ b/appengine/apiv1/services_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/appengine/apiv1/versions_client.go
+++ b/appengine/apiv1/versions_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/appengine/apiv1/versions_client_example_go123_test.go
+++ b/appengine/apiv1/versions_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/appengine/apiv1/versions_client_example_test.go
+++ b/appengine/apiv1/versions_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apphub/apiv1/app_hub_client.go
+++ b/apphub/apiv1/app_hub_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apphub/apiv1/app_hub_client_example_go123_test.go
+++ b/apphub/apiv1/app_hub_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apphub/apiv1/app_hub_client_example_test.go
+++ b/apphub/apiv1/app_hub_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apphub/apiv1/auxiliary.go
+++ b/apphub/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apphub/apiv1/auxiliary_go123.go
+++ b/apphub/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apphub/apiv1/doc.go
+++ b/apphub/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apphub/apiv1/helpers.go
+++ b/apphub/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apps/events/subscriptions/apiv1/auxiliary.go
+++ b/apps/events/subscriptions/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apps/events/subscriptions/apiv1/auxiliary_go123.go
+++ b/apps/events/subscriptions/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apps/events/subscriptions/apiv1/doc.go
+++ b/apps/events/subscriptions/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apps/events/subscriptions/apiv1/helpers.go
+++ b/apps/events/subscriptions/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apps/events/subscriptions/apiv1/subscriptions_client.go
+++ b/apps/events/subscriptions/apiv1/subscriptions_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apps/events/subscriptions/apiv1/subscriptions_client_example_go123_test.go
+++ b/apps/events/subscriptions/apiv1/subscriptions_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apps/events/subscriptions/apiv1/subscriptions_client_example_test.go
+++ b/apps/events/subscriptions/apiv1/subscriptions_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apps/events/subscriptions/apiv1beta/auxiliary.go
+++ b/apps/events/subscriptions/apiv1beta/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apps/events/subscriptions/apiv1beta/auxiliary_go123.go
+++ b/apps/events/subscriptions/apiv1beta/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apps/events/subscriptions/apiv1beta/doc.go
+++ b/apps/events/subscriptions/apiv1beta/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apps/events/subscriptions/apiv1beta/helpers.go
+++ b/apps/events/subscriptions/apiv1beta/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apps/events/subscriptions/apiv1beta/subscriptions_client.go
+++ b/apps/events/subscriptions/apiv1beta/subscriptions_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apps/events/subscriptions/apiv1beta/subscriptions_client_example_go123_test.go
+++ b/apps/events/subscriptions/apiv1beta/subscriptions_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apps/events/subscriptions/apiv1beta/subscriptions_client_example_test.go
+++ b/apps/events/subscriptions/apiv1beta/subscriptions_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apps/meet/apiv2/auxiliary.go
+++ b/apps/meet/apiv2/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apps/meet/apiv2/auxiliary_go123.go
+++ b/apps/meet/apiv2/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apps/meet/apiv2/conference_records_client.go
+++ b/apps/meet/apiv2/conference_records_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apps/meet/apiv2/conference_records_client_example_go123_test.go
+++ b/apps/meet/apiv2/conference_records_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apps/meet/apiv2/conference_records_client_example_test.go
+++ b/apps/meet/apiv2/conference_records_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apps/meet/apiv2/doc.go
+++ b/apps/meet/apiv2/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apps/meet/apiv2/helpers.go
+++ b/apps/meet/apiv2/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apps/meet/apiv2/spaces_client.go
+++ b/apps/meet/apiv2/spaces_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apps/meet/apiv2/spaces_client_example_go123_test.go
+++ b/apps/meet/apiv2/spaces_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apps/meet/apiv2/spaces_client_example_test.go
+++ b/apps/meet/apiv2/spaces_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apps/meet/apiv2beta/auxiliary.go
+++ b/apps/meet/apiv2beta/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apps/meet/apiv2beta/auxiliary_go123.go
+++ b/apps/meet/apiv2beta/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apps/meet/apiv2beta/conference_records_client.go
+++ b/apps/meet/apiv2beta/conference_records_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apps/meet/apiv2beta/conference_records_client_example_go123_test.go
+++ b/apps/meet/apiv2beta/conference_records_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apps/meet/apiv2beta/conference_records_client_example_test.go
+++ b/apps/meet/apiv2beta/conference_records_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apps/meet/apiv2beta/doc.go
+++ b/apps/meet/apiv2beta/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apps/meet/apiv2beta/helpers.go
+++ b/apps/meet/apiv2beta/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apps/meet/apiv2beta/spaces_client.go
+++ b/apps/meet/apiv2beta/spaces_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apps/meet/apiv2beta/spaces_client_example_go123_test.go
+++ b/apps/meet/apiv2beta/spaces_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apps/meet/apiv2beta/spaces_client_example_test.go
+++ b/apps/meet/apiv2beta/spaces_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/area120/tables/apiv1alpha1/auxiliary.go
+++ b/area120/tables/apiv1alpha1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/area120/tables/apiv1alpha1/auxiliary_go123.go
+++ b/area120/tables/apiv1alpha1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/area120/tables/apiv1alpha1/doc.go
+++ b/area120/tables/apiv1alpha1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/area120/tables/apiv1alpha1/helpers.go
+++ b/area120/tables/apiv1alpha1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/area120/tables/apiv1alpha1/tables_client.go
+++ b/area120/tables/apiv1alpha1/tables_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/area120/tables/apiv1alpha1/tables_client_example_go123_test.go
+++ b/area120/tables/apiv1alpha1/tables_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/area120/tables/apiv1alpha1/tables_client_example_test.go
+++ b/area120/tables/apiv1alpha1/tables_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/artifactregistry/apiv1/artifact_registry_client.go
+++ b/artifactregistry/apiv1/artifact_registry_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/artifactregistry/apiv1/artifact_registry_client_example_go123_test.go
+++ b/artifactregistry/apiv1/artifact_registry_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/artifactregistry/apiv1/artifact_registry_client_example_test.go
+++ b/artifactregistry/apiv1/artifact_registry_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/artifactregistry/apiv1/auxiliary.go
+++ b/artifactregistry/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/artifactregistry/apiv1/auxiliary_go123.go
+++ b/artifactregistry/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/artifactregistry/apiv1/doc.go
+++ b/artifactregistry/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/artifactregistry/apiv1/helpers.go
+++ b/artifactregistry/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/artifactregistry/apiv1beta2/artifact_registry_client.go
+++ b/artifactregistry/apiv1beta2/artifact_registry_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/artifactregistry/apiv1beta2/artifact_registry_client_example_go123_test.go
+++ b/artifactregistry/apiv1beta2/artifact_registry_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/artifactregistry/apiv1beta2/artifact_registry_client_example_test.go
+++ b/artifactregistry/apiv1beta2/artifact_registry_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/artifactregistry/apiv1beta2/auxiliary.go
+++ b/artifactregistry/apiv1beta2/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/artifactregistry/apiv1beta2/auxiliary_go123.go
+++ b/artifactregistry/apiv1beta2/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/artifactregistry/apiv1beta2/doc.go
+++ b/artifactregistry/apiv1beta2/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/artifactregistry/apiv1beta2/helpers.go
+++ b/artifactregistry/apiv1beta2/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/asset/apiv1/asset_client.go
+++ b/asset/apiv1/asset_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/asset/apiv1/asset_client_example_go123_test.go
+++ b/asset/apiv1/asset_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/asset/apiv1/asset_client_example_test.go
+++ b/asset/apiv1/asset_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/asset/apiv1/auxiliary.go
+++ b/asset/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/asset/apiv1/auxiliary_go123.go
+++ b/asset/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/asset/apiv1/doc.go
+++ b/asset/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/asset/apiv1/helpers.go
+++ b/asset/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/asset/apiv1p2beta1/asset_client.go
+++ b/asset/apiv1p2beta1/asset_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/asset/apiv1p2beta1/asset_client_example_go123_test.go
+++ b/asset/apiv1p2beta1/asset_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/asset/apiv1p2beta1/asset_client_example_test.go
+++ b/asset/apiv1p2beta1/asset_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/asset/apiv1p2beta1/auxiliary.go
+++ b/asset/apiv1p2beta1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/asset/apiv1p2beta1/auxiliary_go123.go
+++ b/asset/apiv1p2beta1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/asset/apiv1p2beta1/doc.go
+++ b/asset/apiv1p2beta1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/asset/apiv1p2beta1/helpers.go
+++ b/asset/apiv1p2beta1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/asset/apiv1p5beta1/asset_client.go
+++ b/asset/apiv1p5beta1/asset_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/asset/apiv1p5beta1/asset_client_example_go123_test.go
+++ b/asset/apiv1p5beta1/asset_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/asset/apiv1p5beta1/asset_client_example_test.go
+++ b/asset/apiv1p5beta1/asset_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/asset/apiv1p5beta1/auxiliary.go
+++ b/asset/apiv1p5beta1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/asset/apiv1p5beta1/auxiliary_go123.go
+++ b/asset/apiv1p5beta1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/asset/apiv1p5beta1/doc.go
+++ b/asset/apiv1p5beta1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/asset/apiv1p5beta1/helpers.go
+++ b/asset/apiv1p5beta1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/assuredworkloads/apiv1/assured_workloads_client.go
+++ b/assuredworkloads/apiv1/assured_workloads_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/assuredworkloads/apiv1/assured_workloads_client_example_go123_test.go
+++ b/assuredworkloads/apiv1/assured_workloads_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/assuredworkloads/apiv1/assured_workloads_client_example_test.go
+++ b/assuredworkloads/apiv1/assured_workloads_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/assuredworkloads/apiv1/auxiliary.go
+++ b/assuredworkloads/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/assuredworkloads/apiv1/auxiliary_go123.go
+++ b/assuredworkloads/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/assuredworkloads/apiv1/doc.go
+++ b/assuredworkloads/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/assuredworkloads/apiv1/helpers.go
+++ b/assuredworkloads/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/assuredworkloads/apiv1beta1/assured_workloads_client.go
+++ b/assuredworkloads/apiv1beta1/assured_workloads_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/assuredworkloads/apiv1beta1/assured_workloads_client_example_go123_test.go
+++ b/assuredworkloads/apiv1beta1/assured_workloads_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/assuredworkloads/apiv1beta1/assured_workloads_client_example_test.go
+++ b/assuredworkloads/apiv1beta1/assured_workloads_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/assuredworkloads/apiv1beta1/auxiliary.go
+++ b/assuredworkloads/apiv1beta1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/assuredworkloads/apiv1beta1/auxiliary_go123.go
+++ b/assuredworkloads/apiv1beta1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/assuredworkloads/apiv1beta1/doc.go
+++ b/assuredworkloads/apiv1beta1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/assuredworkloads/apiv1beta1/helpers.go
+++ b/assuredworkloads/apiv1beta1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/automl/apiv1/auto_ml_client.go
+++ b/automl/apiv1/auto_ml_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/automl/apiv1/auto_ml_client_example_go123_test.go
+++ b/automl/apiv1/auto_ml_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/automl/apiv1/auto_ml_client_example_test.go
+++ b/automl/apiv1/auto_ml_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/automl/apiv1/auxiliary.go
+++ b/automl/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/automl/apiv1/auxiliary_go123.go
+++ b/automl/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/automl/apiv1/doc.go
+++ b/automl/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/automl/apiv1/helpers.go
+++ b/automl/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/automl/apiv1/prediction_client.go
+++ b/automl/apiv1/prediction_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/automl/apiv1/prediction_client_example_go123_test.go
+++ b/automl/apiv1/prediction_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/automl/apiv1/prediction_client_example_test.go
+++ b/automl/apiv1/prediction_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/automl/apiv1beta1/auto_ml_client.go
+++ b/automl/apiv1beta1/auto_ml_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/automl/apiv1beta1/auto_ml_client_example_go123_test.go
+++ b/automl/apiv1beta1/auto_ml_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/automl/apiv1beta1/auto_ml_client_example_test.go
+++ b/automl/apiv1beta1/auto_ml_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/automl/apiv1beta1/auxiliary.go
+++ b/automl/apiv1beta1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/automl/apiv1beta1/auxiliary_go123.go
+++ b/automl/apiv1beta1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/automl/apiv1beta1/doc.go
+++ b/automl/apiv1beta1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/automl/apiv1beta1/helpers.go
+++ b/automl/apiv1beta1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/automl/apiv1beta1/prediction_client.go
+++ b/automl/apiv1beta1/prediction_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/automl/apiv1beta1/prediction_client_example_go123_test.go
+++ b/automl/apiv1beta1/prediction_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/automl/apiv1beta1/prediction_client_example_test.go
+++ b/automl/apiv1beta1/prediction_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baremetalsolution/apiv2/auxiliary.go
+++ b/baremetalsolution/apiv2/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baremetalsolution/apiv2/auxiliary_go123.go
+++ b/baremetalsolution/apiv2/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baremetalsolution/apiv2/bare_metal_solution_client.go
+++ b/baremetalsolution/apiv2/bare_metal_solution_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baremetalsolution/apiv2/bare_metal_solution_client_example_go123_test.go
+++ b/baremetalsolution/apiv2/bare_metal_solution_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baremetalsolution/apiv2/bare_metal_solution_client_example_test.go
+++ b/baremetalsolution/apiv2/bare_metal_solution_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baremetalsolution/apiv2/doc.go
+++ b/baremetalsolution/apiv2/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baremetalsolution/apiv2/helpers.go
+++ b/baremetalsolution/apiv2/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/batch/apiv1/auxiliary.go
+++ b/batch/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/batch/apiv1/auxiliary_go123.go
+++ b/batch/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/batch/apiv1/batch_client.go
+++ b/batch/apiv1/batch_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/batch/apiv1/batch_client_example_go123_test.go
+++ b/batch/apiv1/batch_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/batch/apiv1/batch_client_example_test.go
+++ b/batch/apiv1/batch_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/batch/apiv1/doc.go
+++ b/batch/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/batch/apiv1/helpers.go
+++ b/batch/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/beyondcorp/appconnections/apiv1/app_connections_client.go
+++ b/beyondcorp/appconnections/apiv1/app_connections_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/beyondcorp/appconnections/apiv1/app_connections_client_example_go123_test.go
+++ b/beyondcorp/appconnections/apiv1/app_connections_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/beyondcorp/appconnections/apiv1/app_connections_client_example_test.go
+++ b/beyondcorp/appconnections/apiv1/app_connections_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/beyondcorp/appconnections/apiv1/auxiliary.go
+++ b/beyondcorp/appconnections/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/beyondcorp/appconnections/apiv1/auxiliary_go123.go
+++ b/beyondcorp/appconnections/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/beyondcorp/appconnections/apiv1/doc.go
+++ b/beyondcorp/appconnections/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/beyondcorp/appconnections/apiv1/helpers.go
+++ b/beyondcorp/appconnections/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/beyondcorp/appconnectors/apiv1/app_connectors_client.go
+++ b/beyondcorp/appconnectors/apiv1/app_connectors_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/beyondcorp/appconnectors/apiv1/app_connectors_client_example_go123_test.go
+++ b/beyondcorp/appconnectors/apiv1/app_connectors_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/beyondcorp/appconnectors/apiv1/app_connectors_client_example_test.go
+++ b/beyondcorp/appconnectors/apiv1/app_connectors_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/beyondcorp/appconnectors/apiv1/auxiliary.go
+++ b/beyondcorp/appconnectors/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/beyondcorp/appconnectors/apiv1/auxiliary_go123.go
+++ b/beyondcorp/appconnectors/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/beyondcorp/appconnectors/apiv1/doc.go
+++ b/beyondcorp/appconnectors/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/beyondcorp/appconnectors/apiv1/helpers.go
+++ b/beyondcorp/appconnectors/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/beyondcorp/appgateways/apiv1/app_gateways_client.go
+++ b/beyondcorp/appgateways/apiv1/app_gateways_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/beyondcorp/appgateways/apiv1/app_gateways_client_example_go123_test.go
+++ b/beyondcorp/appgateways/apiv1/app_gateways_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/beyondcorp/appgateways/apiv1/app_gateways_client_example_test.go
+++ b/beyondcorp/appgateways/apiv1/app_gateways_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/beyondcorp/appgateways/apiv1/auxiliary.go
+++ b/beyondcorp/appgateways/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/beyondcorp/appgateways/apiv1/auxiliary_go123.go
+++ b/beyondcorp/appgateways/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/beyondcorp/appgateways/apiv1/doc.go
+++ b/beyondcorp/appgateways/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/beyondcorp/appgateways/apiv1/helpers.go
+++ b/beyondcorp/appgateways/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/beyondcorp/clientconnectorservices/apiv1/auxiliary.go
+++ b/beyondcorp/clientconnectorservices/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/beyondcorp/clientconnectorservices/apiv1/auxiliary_go123.go
+++ b/beyondcorp/clientconnectorservices/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/beyondcorp/clientconnectorservices/apiv1/client_connector_services_client.go
+++ b/beyondcorp/clientconnectorservices/apiv1/client_connector_services_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/beyondcorp/clientconnectorservices/apiv1/client_connector_services_client_example_go123_test.go
+++ b/beyondcorp/clientconnectorservices/apiv1/client_connector_services_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/beyondcorp/clientconnectorservices/apiv1/client_connector_services_client_example_test.go
+++ b/beyondcorp/clientconnectorservices/apiv1/client_connector_services_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/beyondcorp/clientconnectorservices/apiv1/doc.go
+++ b/beyondcorp/clientconnectorservices/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/beyondcorp/clientconnectorservices/apiv1/helpers.go
+++ b/beyondcorp/clientconnectorservices/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/beyondcorp/clientgateways/apiv1/auxiliary.go
+++ b/beyondcorp/clientgateways/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/beyondcorp/clientgateways/apiv1/auxiliary_go123.go
+++ b/beyondcorp/clientgateways/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/beyondcorp/clientgateways/apiv1/client_gateways_client.go
+++ b/beyondcorp/clientgateways/apiv1/client_gateways_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/beyondcorp/clientgateways/apiv1/client_gateways_client_example_go123_test.go
+++ b/beyondcorp/clientgateways/apiv1/client_gateways_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/beyondcorp/clientgateways/apiv1/client_gateways_client_example_test.go
+++ b/beyondcorp/clientgateways/apiv1/client_gateways_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/beyondcorp/clientgateways/apiv1/doc.go
+++ b/beyondcorp/clientgateways/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/beyondcorp/clientgateways/apiv1/helpers.go
+++ b/beyondcorp/clientgateways/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/analyticshub/apiv1/analytics_hub_client.go
+++ b/bigquery/analyticshub/apiv1/analytics_hub_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/analyticshub/apiv1/analytics_hub_client_example_go123_test.go
+++ b/bigquery/analyticshub/apiv1/analytics_hub_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/analyticshub/apiv1/analytics_hub_client_example_test.go
+++ b/bigquery/analyticshub/apiv1/analytics_hub_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/analyticshub/apiv1/auxiliary.go
+++ b/bigquery/analyticshub/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/analyticshub/apiv1/auxiliary_go123.go
+++ b/bigquery/analyticshub/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/analyticshub/apiv1/doc.go
+++ b/bigquery/analyticshub/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/analyticshub/apiv1/helpers.go
+++ b/bigquery/analyticshub/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/biglake/apiv1/auxiliary.go
+++ b/bigquery/biglake/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/biglake/apiv1/auxiliary_go123.go
+++ b/bigquery/biglake/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/biglake/apiv1/doc.go
+++ b/bigquery/biglake/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/biglake/apiv1/helpers.go
+++ b/bigquery/biglake/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/biglake/apiv1/metastore_client.go
+++ b/bigquery/biglake/apiv1/metastore_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/biglake/apiv1/metastore_client_example_go123_test.go
+++ b/bigquery/biglake/apiv1/metastore_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/biglake/apiv1/metastore_client_example_test.go
+++ b/bigquery/biglake/apiv1/metastore_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/biglake/apiv1alpha1/auxiliary.go
+++ b/bigquery/biglake/apiv1alpha1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/biglake/apiv1alpha1/auxiliary_go123.go
+++ b/bigquery/biglake/apiv1alpha1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/biglake/apiv1alpha1/doc.go
+++ b/bigquery/biglake/apiv1alpha1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/biglake/apiv1alpha1/helpers.go
+++ b/bigquery/biglake/apiv1alpha1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/biglake/apiv1alpha1/metastore_client.go
+++ b/bigquery/biglake/apiv1alpha1/metastore_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/biglake/apiv1alpha1/metastore_client_example_go123_test.go
+++ b/bigquery/biglake/apiv1alpha1/metastore_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/biglake/apiv1alpha1/metastore_client_example_test.go
+++ b/bigquery/biglake/apiv1alpha1/metastore_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/connection/apiv1/auxiliary.go
+++ b/bigquery/connection/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/connection/apiv1/auxiliary_go123.go
+++ b/bigquery/connection/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/connection/apiv1/connection_client.go
+++ b/bigquery/connection/apiv1/connection_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/connection/apiv1/connection_client_example_go123_test.go
+++ b/bigquery/connection/apiv1/connection_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/connection/apiv1/connection_client_example_test.go
+++ b/bigquery/connection/apiv1/connection_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/connection/apiv1/doc.go
+++ b/bigquery/connection/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/connection/apiv1/helpers.go
+++ b/bigquery/connection/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/connection/apiv1beta1/auxiliary.go
+++ b/bigquery/connection/apiv1beta1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/connection/apiv1beta1/auxiliary_go123.go
+++ b/bigquery/connection/apiv1beta1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/connection/apiv1beta1/connection_client.go
+++ b/bigquery/connection/apiv1beta1/connection_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/connection/apiv1beta1/connection_client_example_go123_test.go
+++ b/bigquery/connection/apiv1beta1/connection_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/connection/apiv1beta1/connection_client_example_test.go
+++ b/bigquery/connection/apiv1beta1/connection_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/connection/apiv1beta1/doc.go
+++ b/bigquery/connection/apiv1beta1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/connection/apiv1beta1/helpers.go
+++ b/bigquery/connection/apiv1beta1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/dataexchange/apiv1beta1/analytics_hub_client.go
+++ b/bigquery/dataexchange/apiv1beta1/analytics_hub_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/dataexchange/apiv1beta1/analytics_hub_client_example_go123_test.go
+++ b/bigquery/dataexchange/apiv1beta1/analytics_hub_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/dataexchange/apiv1beta1/analytics_hub_client_example_test.go
+++ b/bigquery/dataexchange/apiv1beta1/analytics_hub_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/dataexchange/apiv1beta1/auxiliary.go
+++ b/bigquery/dataexchange/apiv1beta1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/dataexchange/apiv1beta1/auxiliary_go123.go
+++ b/bigquery/dataexchange/apiv1beta1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/dataexchange/apiv1beta1/doc.go
+++ b/bigquery/dataexchange/apiv1beta1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/dataexchange/apiv1beta1/helpers.go
+++ b/bigquery/dataexchange/apiv1beta1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/datapolicies/apiv1/auxiliary.go
+++ b/bigquery/datapolicies/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/datapolicies/apiv1/auxiliary_go123.go
+++ b/bigquery/datapolicies/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/datapolicies/apiv1/data_policy_client.go
+++ b/bigquery/datapolicies/apiv1/data_policy_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/datapolicies/apiv1/data_policy_client_example_go123_test.go
+++ b/bigquery/datapolicies/apiv1/data_policy_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/datapolicies/apiv1/data_policy_client_example_test.go
+++ b/bigquery/datapolicies/apiv1/data_policy_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/datapolicies/apiv1/doc.go
+++ b/bigquery/datapolicies/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/datapolicies/apiv1/helpers.go
+++ b/bigquery/datapolicies/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/datapolicies/apiv1beta1/auxiliary.go
+++ b/bigquery/datapolicies/apiv1beta1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/datapolicies/apiv1beta1/auxiliary_go123.go
+++ b/bigquery/datapolicies/apiv1beta1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/datapolicies/apiv1beta1/data_policy_client.go
+++ b/bigquery/datapolicies/apiv1beta1/data_policy_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/datapolicies/apiv1beta1/data_policy_client_example_go123_test.go
+++ b/bigquery/datapolicies/apiv1beta1/data_policy_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/datapolicies/apiv1beta1/data_policy_client_example_test.go
+++ b/bigquery/datapolicies/apiv1beta1/data_policy_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/datapolicies/apiv1beta1/doc.go
+++ b/bigquery/datapolicies/apiv1beta1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/datapolicies/apiv1beta1/helpers.go
+++ b/bigquery/datapolicies/apiv1beta1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/datapolicies/apiv2/auxiliary.go
+++ b/bigquery/datapolicies/apiv2/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/datapolicies/apiv2/auxiliary_go123.go
+++ b/bigquery/datapolicies/apiv2/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/datapolicies/apiv2/data_policy_client.go
+++ b/bigquery/datapolicies/apiv2/data_policy_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/datapolicies/apiv2/data_policy_client_example_go123_test.go
+++ b/bigquery/datapolicies/apiv2/data_policy_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/datapolicies/apiv2/data_policy_client_example_test.go
+++ b/bigquery/datapolicies/apiv2/data_policy_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/datapolicies/apiv2/doc.go
+++ b/bigquery/datapolicies/apiv2/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/datapolicies/apiv2/helpers.go
+++ b/bigquery/datapolicies/apiv2/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/datapolicies/apiv2beta1/auxiliary.go
+++ b/bigquery/datapolicies/apiv2beta1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/datapolicies/apiv2beta1/auxiliary_go123.go
+++ b/bigquery/datapolicies/apiv2beta1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/datapolicies/apiv2beta1/data_policy_client.go
+++ b/bigquery/datapolicies/apiv2beta1/data_policy_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/datapolicies/apiv2beta1/data_policy_client_example_go123_test.go
+++ b/bigquery/datapolicies/apiv2beta1/data_policy_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/datapolicies/apiv2beta1/data_policy_client_example_test.go
+++ b/bigquery/datapolicies/apiv2beta1/data_policy_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/datapolicies/apiv2beta1/doc.go
+++ b/bigquery/datapolicies/apiv2beta1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/datapolicies/apiv2beta1/helpers.go
+++ b/bigquery/datapolicies/apiv2beta1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/datatransfer/apiv1/auxiliary.go
+++ b/bigquery/datatransfer/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/datatransfer/apiv1/auxiliary_go123.go
+++ b/bigquery/datatransfer/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/datatransfer/apiv1/data_transfer_client.go
+++ b/bigquery/datatransfer/apiv1/data_transfer_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/datatransfer/apiv1/data_transfer_client_example_go123_test.go
+++ b/bigquery/datatransfer/apiv1/data_transfer_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/datatransfer/apiv1/data_transfer_client_example_test.go
+++ b/bigquery/datatransfer/apiv1/data_transfer_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/datatransfer/apiv1/doc.go
+++ b/bigquery/datatransfer/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/datatransfer/apiv1/helpers.go
+++ b/bigquery/datatransfer/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/migration/apiv2/auxiliary.go
+++ b/bigquery/migration/apiv2/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/migration/apiv2/auxiliary_go123.go
+++ b/bigquery/migration/apiv2/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/migration/apiv2/doc.go
+++ b/bigquery/migration/apiv2/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/migration/apiv2/helpers.go
+++ b/bigquery/migration/apiv2/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/migration/apiv2/migration_client.go
+++ b/bigquery/migration/apiv2/migration_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/migration/apiv2/migration_client_example_go123_test.go
+++ b/bigquery/migration/apiv2/migration_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/migration/apiv2/migration_client_example_test.go
+++ b/bigquery/migration/apiv2/migration_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/migration/apiv2alpha/auxiliary.go
+++ b/bigquery/migration/apiv2alpha/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/migration/apiv2alpha/auxiliary_go123.go
+++ b/bigquery/migration/apiv2alpha/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/migration/apiv2alpha/doc.go
+++ b/bigquery/migration/apiv2alpha/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/migration/apiv2alpha/helpers.go
+++ b/bigquery/migration/apiv2alpha/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/migration/apiv2alpha/migration_client.go
+++ b/bigquery/migration/apiv2alpha/migration_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/migration/apiv2alpha/migration_client_example_go123_test.go
+++ b/bigquery/migration/apiv2alpha/migration_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/migration/apiv2alpha/migration_client_example_test.go
+++ b/bigquery/migration/apiv2alpha/migration_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/migration/apiv2alpha/sql_translation_client.go
+++ b/bigquery/migration/apiv2alpha/sql_translation_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/migration/apiv2alpha/sql_translation_client_example_go123_test.go
+++ b/bigquery/migration/apiv2alpha/sql_translation_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/migration/apiv2alpha/sql_translation_client_example_test.go
+++ b/bigquery/migration/apiv2alpha/sql_translation_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/reservation/apiv1/auxiliary.go
+++ b/bigquery/reservation/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/reservation/apiv1/auxiliary_go123.go
+++ b/bigquery/reservation/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/reservation/apiv1/doc.go
+++ b/bigquery/reservation/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/reservation/apiv1/helpers.go
+++ b/bigquery/reservation/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/reservation/apiv1/reservation_client.go
+++ b/bigquery/reservation/apiv1/reservation_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/reservation/apiv1/reservation_client_example_go123_test.go
+++ b/bigquery/reservation/apiv1/reservation_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/reservation/apiv1/reservation_client_example_test.go
+++ b/bigquery/reservation/apiv1/reservation_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/storage/apiv1/auxiliary.go
+++ b/bigquery/storage/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/storage/apiv1/auxiliary_go123.go
+++ b/bigquery/storage/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/storage/apiv1/big_query_read_client.go
+++ b/bigquery/storage/apiv1/big_query_read_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/storage/apiv1/big_query_read_client_example_go123_test.go
+++ b/bigquery/storage/apiv1/big_query_read_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/storage/apiv1/big_query_read_client_example_test.go
+++ b/bigquery/storage/apiv1/big_query_read_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/storage/apiv1/big_query_write_client.go
+++ b/bigquery/storage/apiv1/big_query_write_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/storage/apiv1/big_query_write_client_example_go123_test.go
+++ b/bigquery/storage/apiv1/big_query_write_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/storage/apiv1/big_query_write_client_example_test.go
+++ b/bigquery/storage/apiv1/big_query_write_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/storage/apiv1/doc.go
+++ b/bigquery/storage/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/storage/apiv1/helpers.go
+++ b/bigquery/storage/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/storage/apiv1alpha/auxiliary.go
+++ b/bigquery/storage/apiv1alpha/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/storage/apiv1alpha/auxiliary_go123.go
+++ b/bigquery/storage/apiv1alpha/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/storage/apiv1alpha/doc.go
+++ b/bigquery/storage/apiv1alpha/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/storage/apiv1alpha/helpers.go
+++ b/bigquery/storage/apiv1alpha/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/storage/apiv1alpha/metastore_partition_client.go
+++ b/bigquery/storage/apiv1alpha/metastore_partition_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/storage/apiv1alpha/metastore_partition_client_example_go123_test.go
+++ b/bigquery/storage/apiv1alpha/metastore_partition_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/storage/apiv1alpha/metastore_partition_client_example_test.go
+++ b/bigquery/storage/apiv1alpha/metastore_partition_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/storage/apiv1beta/auxiliary.go
+++ b/bigquery/storage/apiv1beta/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/storage/apiv1beta/auxiliary_go123.go
+++ b/bigquery/storage/apiv1beta/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/storage/apiv1beta/doc.go
+++ b/bigquery/storage/apiv1beta/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/storage/apiv1beta/helpers.go
+++ b/bigquery/storage/apiv1beta/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/storage/apiv1beta/metastore_partition_client.go
+++ b/bigquery/storage/apiv1beta/metastore_partition_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/storage/apiv1beta/metastore_partition_client_example_go123_test.go
+++ b/bigquery/storage/apiv1beta/metastore_partition_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/storage/apiv1beta/metastore_partition_client_example_test.go
+++ b/bigquery/storage/apiv1beta/metastore_partition_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/storage/apiv1beta1/auxiliary.go
+++ b/bigquery/storage/apiv1beta1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/storage/apiv1beta1/auxiliary_go123.go
+++ b/bigquery/storage/apiv1beta1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/storage/apiv1beta1/big_query_storage_client.go
+++ b/bigquery/storage/apiv1beta1/big_query_storage_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/storage/apiv1beta1/big_query_storage_client_example_go123_test.go
+++ b/bigquery/storage/apiv1beta1/big_query_storage_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/storage/apiv1beta1/big_query_storage_client_example_test.go
+++ b/bigquery/storage/apiv1beta1/big_query_storage_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/storage/apiv1beta1/doc.go
+++ b/bigquery/storage/apiv1beta1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/storage/apiv1beta1/helpers.go
+++ b/bigquery/storage/apiv1beta1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/storage/apiv1beta2/auxiliary.go
+++ b/bigquery/storage/apiv1beta2/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/storage/apiv1beta2/auxiliary_go123.go
+++ b/bigquery/storage/apiv1beta2/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/storage/apiv1beta2/big_query_read_client.go
+++ b/bigquery/storage/apiv1beta2/big_query_read_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/storage/apiv1beta2/big_query_read_client_example_go123_test.go
+++ b/bigquery/storage/apiv1beta2/big_query_read_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/storage/apiv1beta2/big_query_read_client_example_test.go
+++ b/bigquery/storage/apiv1beta2/big_query_read_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/storage/apiv1beta2/big_query_write_client.go
+++ b/bigquery/storage/apiv1beta2/big_query_write_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/storage/apiv1beta2/big_query_write_client_example_go123_test.go
+++ b/bigquery/storage/apiv1beta2/big_query_write_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/storage/apiv1beta2/big_query_write_client_example_test.go
+++ b/bigquery/storage/apiv1beta2/big_query_write_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/storage/apiv1beta2/doc.go
+++ b/bigquery/storage/apiv1beta2/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/storage/apiv1beta2/helpers.go
+++ b/bigquery/storage/apiv1beta2/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/v2/apiv2/auxiliary.go
+++ b/bigquery/v2/apiv2/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/v2/apiv2/auxiliary_go123.go
+++ b/bigquery/v2/apiv2/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/v2/apiv2/dataset_client.go
+++ b/bigquery/v2/apiv2/dataset_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/v2/apiv2/dataset_client_example_go123_test.go
+++ b/bigquery/v2/apiv2/dataset_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/v2/apiv2/dataset_client_example_test.go
+++ b/bigquery/v2/apiv2/dataset_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/v2/apiv2/doc.go
+++ b/bigquery/v2/apiv2/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/v2/apiv2/helpers.go
+++ b/bigquery/v2/apiv2/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/v2/apiv2/job_client.go
+++ b/bigquery/v2/apiv2/job_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/v2/apiv2/job_client_example_go123_test.go
+++ b/bigquery/v2/apiv2/job_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/v2/apiv2/job_client_example_test.go
+++ b/bigquery/v2/apiv2/job_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/v2/apiv2/model_client.go
+++ b/bigquery/v2/apiv2/model_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/v2/apiv2/model_client_example_go123_test.go
+++ b/bigquery/v2/apiv2/model_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/v2/apiv2/model_client_example_test.go
+++ b/bigquery/v2/apiv2/model_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/v2/apiv2/project_client.go
+++ b/bigquery/v2/apiv2/project_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/v2/apiv2/project_client_example_go123_test.go
+++ b/bigquery/v2/apiv2/project_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/v2/apiv2/project_client_example_test.go
+++ b/bigquery/v2/apiv2/project_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/v2/apiv2/routine_client.go
+++ b/bigquery/v2/apiv2/routine_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/v2/apiv2/routine_client_example_go123_test.go
+++ b/bigquery/v2/apiv2/routine_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/v2/apiv2/routine_client_example_test.go
+++ b/bigquery/v2/apiv2/routine_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/v2/apiv2/row_access_policy_client.go
+++ b/bigquery/v2/apiv2/row_access_policy_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/v2/apiv2/row_access_policy_client_example_go123_test.go
+++ b/bigquery/v2/apiv2/row_access_policy_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/v2/apiv2/row_access_policy_client_example_test.go
+++ b/bigquery/v2/apiv2/row_access_policy_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/v2/apiv2/table_client.go
+++ b/bigquery/v2/apiv2/table_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/v2/apiv2/table_client_example_go123_test.go
+++ b/bigquery/v2/apiv2/table_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigquery/v2/apiv2/table_client_example_test.go
+++ b/bigquery/v2/apiv2/table_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/billing/apiv1/auxiliary.go
+++ b/billing/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/billing/apiv1/auxiliary_go123.go
+++ b/billing/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/billing/apiv1/cloud_billing_client.go
+++ b/billing/apiv1/cloud_billing_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/billing/apiv1/cloud_billing_client_example_go123_test.go
+++ b/billing/apiv1/cloud_billing_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/billing/apiv1/cloud_billing_client_example_test.go
+++ b/billing/apiv1/cloud_billing_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/billing/apiv1/cloud_catalog_client.go
+++ b/billing/apiv1/cloud_catalog_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/billing/apiv1/cloud_catalog_client_example_go123_test.go
+++ b/billing/apiv1/cloud_catalog_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/billing/apiv1/cloud_catalog_client_example_test.go
+++ b/billing/apiv1/cloud_catalog_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/billing/apiv1/doc.go
+++ b/billing/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/billing/apiv1/helpers.go
+++ b/billing/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/billing/budgets/apiv1/auxiliary.go
+++ b/billing/budgets/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/billing/budgets/apiv1/auxiliary_go123.go
+++ b/billing/budgets/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/billing/budgets/apiv1/budget_client.go
+++ b/billing/budgets/apiv1/budget_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/billing/budgets/apiv1/budget_client_example_go123_test.go
+++ b/billing/budgets/apiv1/budget_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/billing/budgets/apiv1/budget_client_example_test.go
+++ b/billing/budgets/apiv1/budget_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/billing/budgets/apiv1/doc.go
+++ b/billing/budgets/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/billing/budgets/apiv1/helpers.go
+++ b/billing/budgets/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/billing/budgets/apiv1beta1/auxiliary.go
+++ b/billing/budgets/apiv1beta1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/billing/budgets/apiv1beta1/auxiliary_go123.go
+++ b/billing/budgets/apiv1beta1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/billing/budgets/apiv1beta1/budget_client.go
+++ b/billing/budgets/apiv1beta1/budget_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/billing/budgets/apiv1beta1/budget_client_example_go123_test.go
+++ b/billing/budgets/apiv1beta1/budget_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/billing/budgets/apiv1beta1/budget_client_example_test.go
+++ b/billing/budgets/apiv1beta1/budget_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/billing/budgets/apiv1beta1/doc.go
+++ b/billing/budgets/apiv1beta1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/billing/budgets/apiv1beta1/helpers.go
+++ b/billing/budgets/apiv1beta1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/binaryauthorization/apiv1/auxiliary.go
+++ b/binaryauthorization/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/binaryauthorization/apiv1/auxiliary_go123.go
+++ b/binaryauthorization/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/binaryauthorization/apiv1/binauthz_management_client.go
+++ b/binaryauthorization/apiv1/binauthz_management_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/binaryauthorization/apiv1/binauthz_management_client_example_go123_test.go
+++ b/binaryauthorization/apiv1/binauthz_management_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/binaryauthorization/apiv1/binauthz_management_client_example_test.go
+++ b/binaryauthorization/apiv1/binauthz_management_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/binaryauthorization/apiv1/doc.go
+++ b/binaryauthorization/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/binaryauthorization/apiv1/helpers.go
+++ b/binaryauthorization/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/binaryauthorization/apiv1/system_policy_client.go
+++ b/binaryauthorization/apiv1/system_policy_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/binaryauthorization/apiv1/system_policy_client_example_go123_test.go
+++ b/binaryauthorization/apiv1/system_policy_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/binaryauthorization/apiv1/system_policy_client_example_test.go
+++ b/binaryauthorization/apiv1/system_policy_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/binaryauthorization/apiv1/validation_helper_client.go
+++ b/binaryauthorization/apiv1/validation_helper_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/binaryauthorization/apiv1/validation_helper_client_example_go123_test.go
+++ b/binaryauthorization/apiv1/validation_helper_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/binaryauthorization/apiv1/validation_helper_client_example_test.go
+++ b/binaryauthorization/apiv1/validation_helper_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/binaryauthorization/apiv1beta1/auxiliary.go
+++ b/binaryauthorization/apiv1beta1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/binaryauthorization/apiv1beta1/auxiliary_go123.go
+++ b/binaryauthorization/apiv1beta1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/binaryauthorization/apiv1beta1/binauthz_management_service_v1_beta1_client.go
+++ b/binaryauthorization/apiv1beta1/binauthz_management_service_v1_beta1_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/binaryauthorization/apiv1beta1/binauthz_management_service_v1_beta1_client_example_go123_test.go
+++ b/binaryauthorization/apiv1beta1/binauthz_management_service_v1_beta1_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/binaryauthorization/apiv1beta1/binauthz_management_service_v1_beta1_client_example_test.go
+++ b/binaryauthorization/apiv1beta1/binauthz_management_service_v1_beta1_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/binaryauthorization/apiv1beta1/doc.go
+++ b/binaryauthorization/apiv1beta1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/binaryauthorization/apiv1beta1/helpers.go
+++ b/binaryauthorization/apiv1beta1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/binaryauthorization/apiv1beta1/system_policy_v1_beta1_client.go
+++ b/binaryauthorization/apiv1beta1/system_policy_v1_beta1_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/binaryauthorization/apiv1beta1/system_policy_v1_beta1_client_example_go123_test.go
+++ b/binaryauthorization/apiv1beta1/system_policy_v1_beta1_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/binaryauthorization/apiv1beta1/system_policy_v1_beta1_client_example_test.go
+++ b/binaryauthorization/apiv1beta1/system_policy_v1_beta1_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/capacityplanner/apiv1beta/auxiliary.go
+++ b/capacityplanner/apiv1beta/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/capacityplanner/apiv1beta/auxiliary_go123.go
+++ b/capacityplanner/apiv1beta/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/capacityplanner/apiv1beta/doc.go
+++ b/capacityplanner/apiv1beta/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/capacityplanner/apiv1beta/helpers.go
+++ b/capacityplanner/apiv1beta/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/capacityplanner/apiv1beta/usage_client.go
+++ b/capacityplanner/apiv1beta/usage_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/capacityplanner/apiv1beta/usage_client_example_go123_test.go
+++ b/capacityplanner/apiv1beta/usage_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/capacityplanner/apiv1beta/usage_client_example_test.go
+++ b/capacityplanner/apiv1beta/usage_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/certificatemanager/apiv1/auxiliary.go
+++ b/certificatemanager/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/certificatemanager/apiv1/auxiliary_go123.go
+++ b/certificatemanager/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/certificatemanager/apiv1/certificate_manager_client.go
+++ b/certificatemanager/apiv1/certificate_manager_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/certificatemanager/apiv1/certificate_manager_client_example_go123_test.go
+++ b/certificatemanager/apiv1/certificate_manager_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/certificatemanager/apiv1/certificate_manager_client_example_test.go
+++ b/certificatemanager/apiv1/certificate_manager_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/certificatemanager/apiv1/doc.go
+++ b/certificatemanager/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/certificatemanager/apiv1/helpers.go
+++ b/certificatemanager/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/channel/apiv1/auxiliary.go
+++ b/channel/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/channel/apiv1/auxiliary_go123.go
+++ b/channel/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/channel/apiv1/cloud_channel_client.go
+++ b/channel/apiv1/cloud_channel_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/channel/apiv1/cloud_channel_client_example_go123_test.go
+++ b/channel/apiv1/cloud_channel_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/channel/apiv1/cloud_channel_client_example_test.go
+++ b/channel/apiv1/cloud_channel_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/channel/apiv1/cloud_channel_reports_client.go
+++ b/channel/apiv1/cloud_channel_reports_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/channel/apiv1/cloud_channel_reports_client_example_go123_test.go
+++ b/channel/apiv1/cloud_channel_reports_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/channel/apiv1/cloud_channel_reports_client_example_test.go
+++ b/channel/apiv1/cloud_channel_reports_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/channel/apiv1/doc.go
+++ b/channel/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/channel/apiv1/helpers.go
+++ b/channel/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/chat/apiv1/auxiliary.go
+++ b/chat/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/chat/apiv1/auxiliary_go123.go
+++ b/chat/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/chat/apiv1/chat_client.go
+++ b/chat/apiv1/chat_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/chat/apiv1/chat_client_example_go123_test.go
+++ b/chat/apiv1/chat_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/chat/apiv1/chat_client_example_test.go
+++ b/chat/apiv1/chat_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/chat/apiv1/doc.go
+++ b/chat/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/chat/apiv1/helpers.go
+++ b/chat/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/chronicle/apiv1/auxiliary.go
+++ b/chronicle/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/chronicle/apiv1/auxiliary_go123.go
+++ b/chronicle/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/chronicle/apiv1/data_access_control_client.go
+++ b/chronicle/apiv1/data_access_control_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/chronicle/apiv1/data_access_control_client_example_go123_test.go
+++ b/chronicle/apiv1/data_access_control_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/chronicle/apiv1/data_access_control_client_example_test.go
+++ b/chronicle/apiv1/data_access_control_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/chronicle/apiv1/doc.go
+++ b/chronicle/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/chronicle/apiv1/entity_client.go
+++ b/chronicle/apiv1/entity_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/chronicle/apiv1/entity_client_example_go123_test.go
+++ b/chronicle/apiv1/entity_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/chronicle/apiv1/entity_client_example_test.go
+++ b/chronicle/apiv1/entity_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/chronicle/apiv1/helpers.go
+++ b/chronicle/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/chronicle/apiv1/instance_client.go
+++ b/chronicle/apiv1/instance_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/chronicle/apiv1/instance_client_example_go123_test.go
+++ b/chronicle/apiv1/instance_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/chronicle/apiv1/instance_client_example_test.go
+++ b/chronicle/apiv1/instance_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/chronicle/apiv1/reference_list_client.go
+++ b/chronicle/apiv1/reference_list_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/chronicle/apiv1/reference_list_client_example_go123_test.go
+++ b/chronicle/apiv1/reference_list_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/chronicle/apiv1/reference_list_client_example_test.go
+++ b/chronicle/apiv1/reference_list_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/chronicle/apiv1/rule_client.go
+++ b/chronicle/apiv1/rule_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/chronicle/apiv1/rule_client_example_go123_test.go
+++ b/chronicle/apiv1/rule_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/chronicle/apiv1/rule_client_example_test.go
+++ b/chronicle/apiv1/rule_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudbuild/apiv1/v2/auxiliary.go
+++ b/cloudbuild/apiv1/v2/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudbuild/apiv1/v2/auxiliary_go123.go
+++ b/cloudbuild/apiv1/v2/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudbuild/apiv1/v2/cloud_build_client.go
+++ b/cloudbuild/apiv1/v2/cloud_build_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudbuild/apiv1/v2/cloud_build_client_example_go123_test.go
+++ b/cloudbuild/apiv1/v2/cloud_build_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudbuild/apiv1/v2/cloud_build_client_example_test.go
+++ b/cloudbuild/apiv1/v2/cloud_build_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudbuild/apiv1/v2/doc.go
+++ b/cloudbuild/apiv1/v2/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudbuild/apiv1/v2/helpers.go
+++ b/cloudbuild/apiv1/v2/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudbuild/apiv2/auxiliary.go
+++ b/cloudbuild/apiv2/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudbuild/apiv2/auxiliary_go123.go
+++ b/cloudbuild/apiv2/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudbuild/apiv2/doc.go
+++ b/cloudbuild/apiv2/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudbuild/apiv2/helpers.go
+++ b/cloudbuild/apiv2/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudbuild/apiv2/repository_manager_client.go
+++ b/cloudbuild/apiv2/repository_manager_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudbuild/apiv2/repository_manager_client_example_go123_test.go
+++ b/cloudbuild/apiv2/repository_manager_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudbuild/apiv2/repository_manager_client_example_test.go
+++ b/cloudbuild/apiv2/repository_manager_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudcontrolspartner/apiv1/auxiliary.go
+++ b/cloudcontrolspartner/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudcontrolspartner/apiv1/auxiliary_go123.go
+++ b/cloudcontrolspartner/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudcontrolspartner/apiv1/cloud_controls_partner_core_client.go
+++ b/cloudcontrolspartner/apiv1/cloud_controls_partner_core_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudcontrolspartner/apiv1/cloud_controls_partner_core_client_example_go123_test.go
+++ b/cloudcontrolspartner/apiv1/cloud_controls_partner_core_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudcontrolspartner/apiv1/cloud_controls_partner_core_client_example_test.go
+++ b/cloudcontrolspartner/apiv1/cloud_controls_partner_core_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudcontrolspartner/apiv1/cloud_controls_partner_monitoring_client.go
+++ b/cloudcontrolspartner/apiv1/cloud_controls_partner_monitoring_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudcontrolspartner/apiv1/cloud_controls_partner_monitoring_client_example_go123_test.go
+++ b/cloudcontrolspartner/apiv1/cloud_controls_partner_monitoring_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudcontrolspartner/apiv1/cloud_controls_partner_monitoring_client_example_test.go
+++ b/cloudcontrolspartner/apiv1/cloud_controls_partner_monitoring_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudcontrolspartner/apiv1/doc.go
+++ b/cloudcontrolspartner/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudcontrolspartner/apiv1/helpers.go
+++ b/cloudcontrolspartner/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudcontrolspartner/apiv1beta/auxiliary.go
+++ b/cloudcontrolspartner/apiv1beta/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudcontrolspartner/apiv1beta/auxiliary_go123.go
+++ b/cloudcontrolspartner/apiv1beta/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudcontrolspartner/apiv1beta/cloud_controls_partner_core_client.go
+++ b/cloudcontrolspartner/apiv1beta/cloud_controls_partner_core_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudcontrolspartner/apiv1beta/cloud_controls_partner_core_client_example_go123_test.go
+++ b/cloudcontrolspartner/apiv1beta/cloud_controls_partner_core_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudcontrolspartner/apiv1beta/cloud_controls_partner_core_client_example_test.go
+++ b/cloudcontrolspartner/apiv1beta/cloud_controls_partner_core_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudcontrolspartner/apiv1beta/cloud_controls_partner_monitoring_client.go
+++ b/cloudcontrolspartner/apiv1beta/cloud_controls_partner_monitoring_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudcontrolspartner/apiv1beta/cloud_controls_partner_monitoring_client_example_go123_test.go
+++ b/cloudcontrolspartner/apiv1beta/cloud_controls_partner_monitoring_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudcontrolspartner/apiv1beta/cloud_controls_partner_monitoring_client_example_test.go
+++ b/cloudcontrolspartner/apiv1beta/cloud_controls_partner_monitoring_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudcontrolspartner/apiv1beta/doc.go
+++ b/cloudcontrolspartner/apiv1beta/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudcontrolspartner/apiv1beta/helpers.go
+++ b/cloudcontrolspartner/apiv1beta/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/clouddms/apiv1/auxiliary.go
+++ b/clouddms/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/clouddms/apiv1/auxiliary_go123.go
+++ b/clouddms/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/clouddms/apiv1/data_migration_client.go
+++ b/clouddms/apiv1/data_migration_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/clouddms/apiv1/data_migration_client_example_go123_test.go
+++ b/clouddms/apiv1/data_migration_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/clouddms/apiv1/data_migration_client_example_test.go
+++ b/clouddms/apiv1/data_migration_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/clouddms/apiv1/doc.go
+++ b/clouddms/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/clouddms/apiv1/helpers.go
+++ b/clouddms/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudprofiler/apiv2/auxiliary.go
+++ b/cloudprofiler/apiv2/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudprofiler/apiv2/auxiliary_go123.go
+++ b/cloudprofiler/apiv2/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudprofiler/apiv2/doc.go
+++ b/cloudprofiler/apiv2/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudprofiler/apiv2/export_client.go
+++ b/cloudprofiler/apiv2/export_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudprofiler/apiv2/export_client_example_go123_test.go
+++ b/cloudprofiler/apiv2/export_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudprofiler/apiv2/export_client_example_test.go
+++ b/cloudprofiler/apiv2/export_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudprofiler/apiv2/helpers.go
+++ b/cloudprofiler/apiv2/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudprofiler/apiv2/profiler_client.go
+++ b/cloudprofiler/apiv2/profiler_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudprofiler/apiv2/profiler_client_example_go123_test.go
+++ b/cloudprofiler/apiv2/profiler_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudprofiler/apiv2/profiler_client_example_test.go
+++ b/cloudprofiler/apiv2/profiler_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudquotas/apiv1/auxiliary.go
+++ b/cloudquotas/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudquotas/apiv1/auxiliary_go123.go
+++ b/cloudquotas/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudquotas/apiv1/cloud_quotas_client.go
+++ b/cloudquotas/apiv1/cloud_quotas_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudquotas/apiv1/cloud_quotas_client_example_go123_test.go
+++ b/cloudquotas/apiv1/cloud_quotas_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudquotas/apiv1/cloud_quotas_client_example_test.go
+++ b/cloudquotas/apiv1/cloud_quotas_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudquotas/apiv1/doc.go
+++ b/cloudquotas/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudquotas/apiv1/helpers.go
+++ b/cloudquotas/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudquotas/apiv1beta/auxiliary.go
+++ b/cloudquotas/apiv1beta/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudquotas/apiv1beta/auxiliary_go123.go
+++ b/cloudquotas/apiv1beta/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudquotas/apiv1beta/cloud_quotas_client.go
+++ b/cloudquotas/apiv1beta/cloud_quotas_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudquotas/apiv1beta/cloud_quotas_client_example_go123_test.go
+++ b/cloudquotas/apiv1beta/cloud_quotas_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudquotas/apiv1beta/cloud_quotas_client_example_test.go
+++ b/cloudquotas/apiv1beta/cloud_quotas_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudquotas/apiv1beta/doc.go
+++ b/cloudquotas/apiv1beta/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudquotas/apiv1beta/helpers.go
+++ b/cloudquotas/apiv1beta/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudquotas/apiv1beta/quota_adjuster_settings_manager_client.go
+++ b/cloudquotas/apiv1beta/quota_adjuster_settings_manager_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudquotas/apiv1beta/quota_adjuster_settings_manager_client_example_go123_test.go
+++ b/cloudquotas/apiv1beta/quota_adjuster_settings_manager_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudquotas/apiv1beta/quota_adjuster_settings_manager_client_example_test.go
+++ b/cloudquotas/apiv1beta/quota_adjuster_settings_manager_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudtasks/apiv2/auxiliary.go
+++ b/cloudtasks/apiv2/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudtasks/apiv2/auxiliary_go123.go
+++ b/cloudtasks/apiv2/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudtasks/apiv2/cloud_tasks_client.go
+++ b/cloudtasks/apiv2/cloud_tasks_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudtasks/apiv2/cloud_tasks_client_example_go123_test.go
+++ b/cloudtasks/apiv2/cloud_tasks_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudtasks/apiv2/cloud_tasks_client_example_test.go
+++ b/cloudtasks/apiv2/cloud_tasks_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudtasks/apiv2/doc.go
+++ b/cloudtasks/apiv2/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudtasks/apiv2/helpers.go
+++ b/cloudtasks/apiv2/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudtasks/apiv2beta2/auxiliary.go
+++ b/cloudtasks/apiv2beta2/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudtasks/apiv2beta2/auxiliary_go123.go
+++ b/cloudtasks/apiv2beta2/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudtasks/apiv2beta2/cloud_tasks_client.go
+++ b/cloudtasks/apiv2beta2/cloud_tasks_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudtasks/apiv2beta2/cloud_tasks_client_example_go123_test.go
+++ b/cloudtasks/apiv2beta2/cloud_tasks_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudtasks/apiv2beta2/cloud_tasks_client_example_test.go
+++ b/cloudtasks/apiv2beta2/cloud_tasks_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudtasks/apiv2beta2/doc.go
+++ b/cloudtasks/apiv2beta2/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudtasks/apiv2beta2/helpers.go
+++ b/cloudtasks/apiv2beta2/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudtasks/apiv2beta3/auxiliary.go
+++ b/cloudtasks/apiv2beta3/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudtasks/apiv2beta3/auxiliary_go123.go
+++ b/cloudtasks/apiv2beta3/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudtasks/apiv2beta3/cloud_tasks_client.go
+++ b/cloudtasks/apiv2beta3/cloud_tasks_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudtasks/apiv2beta3/cloud_tasks_client_example_go123_test.go
+++ b/cloudtasks/apiv2beta3/cloud_tasks_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudtasks/apiv2beta3/cloud_tasks_client_example_test.go
+++ b/cloudtasks/apiv2beta3/cloud_tasks_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudtasks/apiv2beta3/doc.go
+++ b/cloudtasks/apiv2beta3/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudtasks/apiv2beta3/helpers.go
+++ b/cloudtasks/apiv2beta3/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/commerce/consumer/procurement/apiv1/auxiliary.go
+++ b/commerce/consumer/procurement/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/commerce/consumer/procurement/apiv1/auxiliary_go123.go
+++ b/commerce/consumer/procurement/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/commerce/consumer/procurement/apiv1/consumer_procurement_client.go
+++ b/commerce/consumer/procurement/apiv1/consumer_procurement_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/commerce/consumer/procurement/apiv1/consumer_procurement_client_example_go123_test.go
+++ b/commerce/consumer/procurement/apiv1/consumer_procurement_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/commerce/consumer/procurement/apiv1/consumer_procurement_client_example_test.go
+++ b/commerce/consumer/procurement/apiv1/consumer_procurement_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/commerce/consumer/procurement/apiv1/doc.go
+++ b/commerce/consumer/procurement/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/commerce/consumer/procurement/apiv1/helpers.go
+++ b/commerce/consumer/procurement/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/commerce/consumer/procurement/apiv1/license_management_client.go
+++ b/commerce/consumer/procurement/apiv1/license_management_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/commerce/consumer/procurement/apiv1/license_management_client_example_go123_test.go
+++ b/commerce/consumer/procurement/apiv1/license_management_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/commerce/consumer/procurement/apiv1/license_management_client_example_test.go
+++ b/commerce/consumer/procurement/apiv1/license_management_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/confidentialcomputing/apiv1/auxiliary.go
+++ b/confidentialcomputing/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/confidentialcomputing/apiv1/auxiliary_go123.go
+++ b/confidentialcomputing/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/confidentialcomputing/apiv1/confidential_computing_client.go
+++ b/confidentialcomputing/apiv1/confidential_computing_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/confidentialcomputing/apiv1/confidential_computing_client_example_go123_test.go
+++ b/confidentialcomputing/apiv1/confidential_computing_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/confidentialcomputing/apiv1/confidential_computing_client_example_test.go
+++ b/confidentialcomputing/apiv1/confidential_computing_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/confidentialcomputing/apiv1/doc.go
+++ b/confidentialcomputing/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/confidentialcomputing/apiv1/helpers.go
+++ b/confidentialcomputing/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/confidentialcomputing/apiv1alpha1/auxiliary.go
+++ b/confidentialcomputing/apiv1alpha1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/confidentialcomputing/apiv1alpha1/auxiliary_go123.go
+++ b/confidentialcomputing/apiv1alpha1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/confidentialcomputing/apiv1alpha1/confidential_computing_client.go
+++ b/confidentialcomputing/apiv1alpha1/confidential_computing_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/confidentialcomputing/apiv1alpha1/confidential_computing_client_example_go123_test.go
+++ b/confidentialcomputing/apiv1alpha1/confidential_computing_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/confidentialcomputing/apiv1alpha1/confidential_computing_client_example_test.go
+++ b/confidentialcomputing/apiv1alpha1/confidential_computing_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/confidentialcomputing/apiv1alpha1/doc.go
+++ b/confidentialcomputing/apiv1alpha1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/confidentialcomputing/apiv1alpha1/helpers.go
+++ b/confidentialcomputing/apiv1alpha1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/configdelivery/apiv1/auxiliary.go
+++ b/configdelivery/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/configdelivery/apiv1/auxiliary_go123.go
+++ b/configdelivery/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/configdelivery/apiv1/config_delivery_client.go
+++ b/configdelivery/apiv1/config_delivery_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/configdelivery/apiv1/config_delivery_client_example_go123_test.go
+++ b/configdelivery/apiv1/config_delivery_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/configdelivery/apiv1/config_delivery_client_example_test.go
+++ b/configdelivery/apiv1/config_delivery_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/configdelivery/apiv1/doc.go
+++ b/configdelivery/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/configdelivery/apiv1/helpers.go
+++ b/configdelivery/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/configdelivery/apiv1beta/auxiliary.go
+++ b/configdelivery/apiv1beta/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/configdelivery/apiv1beta/auxiliary_go123.go
+++ b/configdelivery/apiv1beta/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/configdelivery/apiv1beta/config_delivery_client.go
+++ b/configdelivery/apiv1beta/config_delivery_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/configdelivery/apiv1beta/config_delivery_client_example_go123_test.go
+++ b/configdelivery/apiv1beta/config_delivery_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/configdelivery/apiv1beta/config_delivery_client_example_test.go
+++ b/configdelivery/apiv1beta/config_delivery_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/configdelivery/apiv1beta/doc.go
+++ b/configdelivery/apiv1beta/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/configdelivery/apiv1beta/helpers.go
+++ b/configdelivery/apiv1beta/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/contactcenterinsights/apiv1/auxiliary.go
+++ b/contactcenterinsights/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/contactcenterinsights/apiv1/auxiliary_go123.go
+++ b/contactcenterinsights/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/contactcenterinsights/apiv1/contact_center_insights_client.go
+++ b/contactcenterinsights/apiv1/contact_center_insights_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/contactcenterinsights/apiv1/contact_center_insights_client_example_go123_test.go
+++ b/contactcenterinsights/apiv1/contact_center_insights_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/contactcenterinsights/apiv1/contact_center_insights_client_example_test.go
+++ b/contactcenterinsights/apiv1/contact_center_insights_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/contactcenterinsights/apiv1/doc.go
+++ b/contactcenterinsights/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/contactcenterinsights/apiv1/helpers.go
+++ b/contactcenterinsights/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/container/apiv1/auxiliary.go
+++ b/container/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/container/apiv1/auxiliary_go123.go
+++ b/container/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/container/apiv1/cluster_manager_client.go
+++ b/container/apiv1/cluster_manager_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/container/apiv1/cluster_manager_client_example_go123_test.go
+++ b/container/apiv1/cluster_manager_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/container/apiv1/cluster_manager_client_example_test.go
+++ b/container/apiv1/cluster_manager_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/container/apiv1/doc.go
+++ b/container/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/container/apiv1/helpers.go
+++ b/container/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/containeranalysis/apiv1beta1/auxiliary.go
+++ b/containeranalysis/apiv1beta1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/containeranalysis/apiv1beta1/auxiliary_go123.go
+++ b/containeranalysis/apiv1beta1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/containeranalysis/apiv1beta1/container_analysis_v1_beta1_client.go
+++ b/containeranalysis/apiv1beta1/container_analysis_v1_beta1_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/containeranalysis/apiv1beta1/container_analysis_v1_beta1_client_example_go123_test.go
+++ b/containeranalysis/apiv1beta1/container_analysis_v1_beta1_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/containeranalysis/apiv1beta1/container_analysis_v1_beta1_client_example_test.go
+++ b/containeranalysis/apiv1beta1/container_analysis_v1_beta1_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/containeranalysis/apiv1beta1/doc.go
+++ b/containeranalysis/apiv1beta1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/containeranalysis/apiv1beta1/grafeas_v1_beta1_client.go
+++ b/containeranalysis/apiv1beta1/grafeas_v1_beta1_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/containeranalysis/apiv1beta1/grafeas_v1_beta1_client_example_go123_test.go
+++ b/containeranalysis/apiv1beta1/grafeas_v1_beta1_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/containeranalysis/apiv1beta1/grafeas_v1_beta1_client_example_test.go
+++ b/containeranalysis/apiv1beta1/grafeas_v1_beta1_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/containeranalysis/apiv1beta1/helpers.go
+++ b/containeranalysis/apiv1beta1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/datacatalog/apiv1/auxiliary.go
+++ b/datacatalog/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/datacatalog/apiv1/auxiliary_go123.go
+++ b/datacatalog/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/datacatalog/apiv1/data_catalog_client.go
+++ b/datacatalog/apiv1/data_catalog_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/datacatalog/apiv1/data_catalog_client_example_go123_test.go
+++ b/datacatalog/apiv1/data_catalog_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/datacatalog/apiv1/data_catalog_client_example_test.go
+++ b/datacatalog/apiv1/data_catalog_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/datacatalog/apiv1/doc.go
+++ b/datacatalog/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/datacatalog/apiv1/helpers.go
+++ b/datacatalog/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/datacatalog/apiv1/policy_tag_manager_client.go
+++ b/datacatalog/apiv1/policy_tag_manager_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/datacatalog/apiv1/policy_tag_manager_client_example_go123_test.go
+++ b/datacatalog/apiv1/policy_tag_manager_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/datacatalog/apiv1/policy_tag_manager_client_example_test.go
+++ b/datacatalog/apiv1/policy_tag_manager_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/datacatalog/apiv1/policy_tag_manager_serialization_client.go
+++ b/datacatalog/apiv1/policy_tag_manager_serialization_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/datacatalog/apiv1/policy_tag_manager_serialization_client_example_go123_test.go
+++ b/datacatalog/apiv1/policy_tag_manager_serialization_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/datacatalog/apiv1/policy_tag_manager_serialization_client_example_test.go
+++ b/datacatalog/apiv1/policy_tag_manager_serialization_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/datacatalog/apiv1beta1/auxiliary.go
+++ b/datacatalog/apiv1beta1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/datacatalog/apiv1beta1/auxiliary_go123.go
+++ b/datacatalog/apiv1beta1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/datacatalog/apiv1beta1/data_catalog_client.go
+++ b/datacatalog/apiv1beta1/data_catalog_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/datacatalog/apiv1beta1/data_catalog_client_example_go123_test.go
+++ b/datacatalog/apiv1beta1/data_catalog_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/datacatalog/apiv1beta1/data_catalog_client_example_test.go
+++ b/datacatalog/apiv1beta1/data_catalog_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/datacatalog/apiv1beta1/doc.go
+++ b/datacatalog/apiv1beta1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/datacatalog/apiv1beta1/helpers.go
+++ b/datacatalog/apiv1beta1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/datacatalog/apiv1beta1/policy_tag_manager_client.go
+++ b/datacatalog/apiv1beta1/policy_tag_manager_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/datacatalog/apiv1beta1/policy_tag_manager_client_example_go123_test.go
+++ b/datacatalog/apiv1beta1/policy_tag_manager_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/datacatalog/apiv1beta1/policy_tag_manager_client_example_test.go
+++ b/datacatalog/apiv1beta1/policy_tag_manager_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/datacatalog/apiv1beta1/policy_tag_manager_serialization_client.go
+++ b/datacatalog/apiv1beta1/policy_tag_manager_serialization_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/datacatalog/apiv1beta1/policy_tag_manager_serialization_client_example_go123_test.go
+++ b/datacatalog/apiv1beta1/policy_tag_manager_serialization_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/datacatalog/apiv1beta1/policy_tag_manager_serialization_client_example_test.go
+++ b/datacatalog/apiv1beta1/policy_tag_manager_serialization_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/datacatalog/lineage/apiv1/auxiliary.go
+++ b/datacatalog/lineage/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/datacatalog/lineage/apiv1/auxiliary_go123.go
+++ b/datacatalog/lineage/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/datacatalog/lineage/apiv1/doc.go
+++ b/datacatalog/lineage/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/datacatalog/lineage/apiv1/helpers.go
+++ b/datacatalog/lineage/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/datacatalog/lineage/apiv1/lineage_client.go
+++ b/datacatalog/lineage/apiv1/lineage_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/datacatalog/lineage/apiv1/lineage_client_example_go123_test.go
+++ b/datacatalog/lineage/apiv1/lineage_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/datacatalog/lineage/apiv1/lineage_client_example_test.go
+++ b/datacatalog/lineage/apiv1/lineage_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataflow/apiv1beta3/auxiliary.go
+++ b/dataflow/apiv1beta3/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataflow/apiv1beta3/auxiliary_go123.go
+++ b/dataflow/apiv1beta3/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataflow/apiv1beta3/doc.go
+++ b/dataflow/apiv1beta3/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataflow/apiv1beta3/flex_templates_client.go
+++ b/dataflow/apiv1beta3/flex_templates_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataflow/apiv1beta3/flex_templates_client_example_go123_test.go
+++ b/dataflow/apiv1beta3/flex_templates_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataflow/apiv1beta3/flex_templates_client_example_test.go
+++ b/dataflow/apiv1beta3/flex_templates_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataflow/apiv1beta3/helpers.go
+++ b/dataflow/apiv1beta3/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataflow/apiv1beta3/jobs_v1_beta3_client.go
+++ b/dataflow/apiv1beta3/jobs_v1_beta3_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataflow/apiv1beta3/jobs_v1_beta3_client_example_go123_test.go
+++ b/dataflow/apiv1beta3/jobs_v1_beta3_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataflow/apiv1beta3/jobs_v1_beta3_client_example_test.go
+++ b/dataflow/apiv1beta3/jobs_v1_beta3_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataflow/apiv1beta3/messages_v1_beta3_client.go
+++ b/dataflow/apiv1beta3/messages_v1_beta3_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataflow/apiv1beta3/messages_v1_beta3_client_example_go123_test.go
+++ b/dataflow/apiv1beta3/messages_v1_beta3_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataflow/apiv1beta3/messages_v1_beta3_client_example_test.go
+++ b/dataflow/apiv1beta3/messages_v1_beta3_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataflow/apiv1beta3/metrics_v1_beta3_client.go
+++ b/dataflow/apiv1beta3/metrics_v1_beta3_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataflow/apiv1beta3/metrics_v1_beta3_client_example_go123_test.go
+++ b/dataflow/apiv1beta3/metrics_v1_beta3_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataflow/apiv1beta3/metrics_v1_beta3_client_example_test.go
+++ b/dataflow/apiv1beta3/metrics_v1_beta3_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataflow/apiv1beta3/snapshots_v1_beta3_client.go
+++ b/dataflow/apiv1beta3/snapshots_v1_beta3_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataflow/apiv1beta3/snapshots_v1_beta3_client_example_go123_test.go
+++ b/dataflow/apiv1beta3/snapshots_v1_beta3_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataflow/apiv1beta3/snapshots_v1_beta3_client_example_test.go
+++ b/dataflow/apiv1beta3/snapshots_v1_beta3_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataflow/apiv1beta3/templates_client.go
+++ b/dataflow/apiv1beta3/templates_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataflow/apiv1beta3/templates_client_example_go123_test.go
+++ b/dataflow/apiv1beta3/templates_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataflow/apiv1beta3/templates_client_example_test.go
+++ b/dataflow/apiv1beta3/templates_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataform/apiv1/auxiliary.go
+++ b/dataform/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataform/apiv1/auxiliary_go123.go
+++ b/dataform/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataform/apiv1/dataform_client.go
+++ b/dataform/apiv1/dataform_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataform/apiv1/dataform_client_example_go123_test.go
+++ b/dataform/apiv1/dataform_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataform/apiv1/dataform_client_example_test.go
+++ b/dataform/apiv1/dataform_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataform/apiv1/doc.go
+++ b/dataform/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataform/apiv1/helpers.go
+++ b/dataform/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataform/apiv1beta1/auxiliary.go
+++ b/dataform/apiv1beta1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataform/apiv1beta1/auxiliary_go123.go
+++ b/dataform/apiv1beta1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataform/apiv1beta1/dataform_client.go
+++ b/dataform/apiv1beta1/dataform_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataform/apiv1beta1/dataform_client_example_go123_test.go
+++ b/dataform/apiv1beta1/dataform_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataform/apiv1beta1/dataform_client_example_test.go
+++ b/dataform/apiv1beta1/dataform_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataform/apiv1beta1/doc.go
+++ b/dataform/apiv1beta1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataform/apiv1beta1/helpers.go
+++ b/dataform/apiv1beta1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/datafusion/apiv1/auxiliary.go
+++ b/datafusion/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/datafusion/apiv1/auxiliary_go123.go
+++ b/datafusion/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/datafusion/apiv1/data_fusion_client.go
+++ b/datafusion/apiv1/data_fusion_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/datafusion/apiv1/data_fusion_client_example_go123_test.go
+++ b/datafusion/apiv1/data_fusion_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/datafusion/apiv1/data_fusion_client_example_test.go
+++ b/datafusion/apiv1/data_fusion_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/datafusion/apiv1/doc.go
+++ b/datafusion/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/datafusion/apiv1/helpers.go
+++ b/datafusion/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/datalabeling/apiv1beta1/auxiliary.go
+++ b/datalabeling/apiv1beta1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/datalabeling/apiv1beta1/auxiliary_go123.go
+++ b/datalabeling/apiv1beta1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/datalabeling/apiv1beta1/data_labeling_client.go
+++ b/datalabeling/apiv1beta1/data_labeling_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/datalabeling/apiv1beta1/data_labeling_client_example_go123_test.go
+++ b/datalabeling/apiv1beta1/data_labeling_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/datalabeling/apiv1beta1/data_labeling_client_example_test.go
+++ b/datalabeling/apiv1beta1/data_labeling_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/datalabeling/apiv1beta1/doc.go
+++ b/datalabeling/apiv1beta1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/datalabeling/apiv1beta1/helpers.go
+++ b/datalabeling/apiv1beta1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataplex/apiv1/auxiliary.go
+++ b/dataplex/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataplex/apiv1/auxiliary_go123.go
+++ b/dataplex/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataplex/apiv1/business_glossary_client.go
+++ b/dataplex/apiv1/business_glossary_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataplex/apiv1/business_glossary_client_example_go123_test.go
+++ b/dataplex/apiv1/business_glossary_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataplex/apiv1/business_glossary_client_example_test.go
+++ b/dataplex/apiv1/business_glossary_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataplex/apiv1/catalog_client.go
+++ b/dataplex/apiv1/catalog_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataplex/apiv1/catalog_client_example_go123_test.go
+++ b/dataplex/apiv1/catalog_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataplex/apiv1/catalog_client_example_test.go
+++ b/dataplex/apiv1/catalog_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataplex/apiv1/cmek_client.go
+++ b/dataplex/apiv1/cmek_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataplex/apiv1/cmek_client_example_go123_test.go
+++ b/dataplex/apiv1/cmek_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataplex/apiv1/cmek_client_example_test.go
+++ b/dataplex/apiv1/cmek_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataplex/apiv1/content_client.go
+++ b/dataplex/apiv1/content_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataplex/apiv1/content_client_example_go123_test.go
+++ b/dataplex/apiv1/content_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataplex/apiv1/content_client_example_test.go
+++ b/dataplex/apiv1/content_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataplex/apiv1/data_scan_client.go
+++ b/dataplex/apiv1/data_scan_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataplex/apiv1/data_scan_client_example_go123_test.go
+++ b/dataplex/apiv1/data_scan_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataplex/apiv1/data_scan_client_example_test.go
+++ b/dataplex/apiv1/data_scan_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataplex/apiv1/data_taxonomy_client.go
+++ b/dataplex/apiv1/data_taxonomy_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataplex/apiv1/data_taxonomy_client_example_go123_test.go
+++ b/dataplex/apiv1/data_taxonomy_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataplex/apiv1/data_taxonomy_client_example_test.go
+++ b/dataplex/apiv1/data_taxonomy_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataplex/apiv1/dataplex_client.go
+++ b/dataplex/apiv1/dataplex_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataplex/apiv1/dataplex_client_example_go123_test.go
+++ b/dataplex/apiv1/dataplex_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataplex/apiv1/dataplex_client_example_test.go
+++ b/dataplex/apiv1/dataplex_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataplex/apiv1/doc.go
+++ b/dataplex/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataplex/apiv1/helpers.go
+++ b/dataplex/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataplex/apiv1/metadata_client.go
+++ b/dataplex/apiv1/metadata_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataplex/apiv1/metadata_client_example_go123_test.go
+++ b/dataplex/apiv1/metadata_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataplex/apiv1/metadata_client_example_test.go
+++ b/dataplex/apiv1/metadata_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataproc/apiv1/autoscaling_policy_client.go
+++ b/dataproc/apiv1/autoscaling_policy_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataproc/apiv1/autoscaling_policy_client_example_go123_test.go
+++ b/dataproc/apiv1/autoscaling_policy_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataproc/apiv1/autoscaling_policy_client_example_test.go
+++ b/dataproc/apiv1/autoscaling_policy_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataproc/apiv1/auxiliary.go
+++ b/dataproc/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataproc/apiv1/auxiliary_go123.go
+++ b/dataproc/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataproc/apiv1/batch_controller_client.go
+++ b/dataproc/apiv1/batch_controller_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataproc/apiv1/batch_controller_client_example_go123_test.go
+++ b/dataproc/apiv1/batch_controller_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataproc/apiv1/batch_controller_client_example_test.go
+++ b/dataproc/apiv1/batch_controller_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataproc/apiv1/cluster_controller_client.go
+++ b/dataproc/apiv1/cluster_controller_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataproc/apiv1/cluster_controller_client_example_go123_test.go
+++ b/dataproc/apiv1/cluster_controller_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataproc/apiv1/cluster_controller_client_example_test.go
+++ b/dataproc/apiv1/cluster_controller_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataproc/apiv1/doc.go
+++ b/dataproc/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataproc/apiv1/helpers.go
+++ b/dataproc/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataproc/apiv1/job_controller_client.go
+++ b/dataproc/apiv1/job_controller_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataproc/apiv1/job_controller_client_example_go123_test.go
+++ b/dataproc/apiv1/job_controller_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataproc/apiv1/job_controller_client_example_test.go
+++ b/dataproc/apiv1/job_controller_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataproc/apiv1/node_group_controller_client.go
+++ b/dataproc/apiv1/node_group_controller_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataproc/apiv1/node_group_controller_client_example_go123_test.go
+++ b/dataproc/apiv1/node_group_controller_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataproc/apiv1/node_group_controller_client_example_test.go
+++ b/dataproc/apiv1/node_group_controller_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataproc/apiv1/session_controller_client.go
+++ b/dataproc/apiv1/session_controller_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataproc/apiv1/session_controller_client_example_go123_test.go
+++ b/dataproc/apiv1/session_controller_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataproc/apiv1/session_controller_client_example_test.go
+++ b/dataproc/apiv1/session_controller_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataproc/apiv1/session_template_controller_client.go
+++ b/dataproc/apiv1/session_template_controller_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataproc/apiv1/session_template_controller_client_example_go123_test.go
+++ b/dataproc/apiv1/session_template_controller_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataproc/apiv1/session_template_controller_client_example_test.go
+++ b/dataproc/apiv1/session_template_controller_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataproc/apiv1/workflow_template_client.go
+++ b/dataproc/apiv1/workflow_template_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataproc/apiv1/workflow_template_client_example_go123_test.go
+++ b/dataproc/apiv1/workflow_template_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataproc/apiv1/workflow_template_client_example_test.go
+++ b/dataproc/apiv1/workflow_template_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataqna/apiv1alpha/auto_suggestion_client.go
+++ b/dataqna/apiv1alpha/auto_suggestion_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataqna/apiv1alpha/auto_suggestion_client_example_go123_test.go
+++ b/dataqna/apiv1alpha/auto_suggestion_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataqna/apiv1alpha/auto_suggestion_client_example_test.go
+++ b/dataqna/apiv1alpha/auto_suggestion_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataqna/apiv1alpha/auxiliary.go
+++ b/dataqna/apiv1alpha/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataqna/apiv1alpha/auxiliary_go123.go
+++ b/dataqna/apiv1alpha/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataqna/apiv1alpha/doc.go
+++ b/dataqna/apiv1alpha/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataqna/apiv1alpha/helpers.go
+++ b/dataqna/apiv1alpha/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataqna/apiv1alpha/question_client.go
+++ b/dataqna/apiv1alpha/question_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataqna/apiv1alpha/question_client_example_go123_test.go
+++ b/dataqna/apiv1alpha/question_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dataqna/apiv1alpha/question_client_example_test.go
+++ b/dataqna/apiv1alpha/question_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/datastore/admin/apiv1/auxiliary.go
+++ b/datastore/admin/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/datastore/admin/apiv1/auxiliary_go123.go
+++ b/datastore/admin/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/datastore/admin/apiv1/datastore_admin_client.go
+++ b/datastore/admin/apiv1/datastore_admin_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/datastore/admin/apiv1/datastore_admin_client_example_go123_test.go
+++ b/datastore/admin/apiv1/datastore_admin_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/datastore/admin/apiv1/datastore_admin_client_example_test.go
+++ b/datastore/admin/apiv1/datastore_admin_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/datastore/admin/apiv1/doc.go
+++ b/datastore/admin/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/datastore/admin/apiv1/helpers.go
+++ b/datastore/admin/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/datastream/apiv1/auxiliary.go
+++ b/datastream/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/datastream/apiv1/auxiliary_go123.go
+++ b/datastream/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/datastream/apiv1/datastream_client.go
+++ b/datastream/apiv1/datastream_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/datastream/apiv1/datastream_client_example_go123_test.go
+++ b/datastream/apiv1/datastream_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/datastream/apiv1/datastream_client_example_test.go
+++ b/datastream/apiv1/datastream_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/datastream/apiv1/doc.go
+++ b/datastream/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/datastream/apiv1/helpers.go
+++ b/datastream/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/datastream/apiv1alpha1/auxiliary.go
+++ b/datastream/apiv1alpha1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/datastream/apiv1alpha1/auxiliary_go123.go
+++ b/datastream/apiv1alpha1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/datastream/apiv1alpha1/datastream_client.go
+++ b/datastream/apiv1alpha1/datastream_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/datastream/apiv1alpha1/datastream_client_example_go123_test.go
+++ b/datastream/apiv1alpha1/datastream_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/datastream/apiv1alpha1/datastream_client_example_test.go
+++ b/datastream/apiv1alpha1/datastream_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/datastream/apiv1alpha1/doc.go
+++ b/datastream/apiv1alpha1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/datastream/apiv1alpha1/helpers.go
+++ b/datastream/apiv1alpha1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/deploy/apiv1/auxiliary.go
+++ b/deploy/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/deploy/apiv1/auxiliary_go123.go
+++ b/deploy/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/deploy/apiv1/cloud_deploy_client.go
+++ b/deploy/apiv1/cloud_deploy_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/deploy/apiv1/cloud_deploy_client_example_go123_test.go
+++ b/deploy/apiv1/cloud_deploy_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/deploy/apiv1/cloud_deploy_client_example_test.go
+++ b/deploy/apiv1/cloud_deploy_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/deploy/apiv1/doc.go
+++ b/deploy/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/deploy/apiv1/helpers.go
+++ b/deploy/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/developerconnect/apiv1/auxiliary.go
+++ b/developerconnect/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/developerconnect/apiv1/auxiliary_go123.go
+++ b/developerconnect/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/developerconnect/apiv1/developer_connect_client.go
+++ b/developerconnect/apiv1/developer_connect_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/developerconnect/apiv1/developer_connect_client_example_go123_test.go
+++ b/developerconnect/apiv1/developer_connect_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/developerconnect/apiv1/developer_connect_client_example_test.go
+++ b/developerconnect/apiv1/developer_connect_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/developerconnect/apiv1/doc.go
+++ b/developerconnect/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/developerconnect/apiv1/helpers.go
+++ b/developerconnect/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/developerconnect/apiv1/insights_config_client.go
+++ b/developerconnect/apiv1/insights_config_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/developerconnect/apiv1/insights_config_client_example_go123_test.go
+++ b/developerconnect/apiv1/insights_config_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/developerconnect/apiv1/insights_config_client_example_test.go
+++ b/developerconnect/apiv1/insights_config_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/devicestreaming/apiv1/auxiliary.go
+++ b/devicestreaming/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/devicestreaming/apiv1/auxiliary_go123.go
+++ b/devicestreaming/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/devicestreaming/apiv1/direct_access_client.go
+++ b/devicestreaming/apiv1/direct_access_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/devicestreaming/apiv1/direct_access_client_example_go123_test.go
+++ b/devicestreaming/apiv1/direct_access_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/devicestreaming/apiv1/direct_access_client_example_test.go
+++ b/devicestreaming/apiv1/direct_access_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/devicestreaming/apiv1/doc.go
+++ b/devicestreaming/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/devicestreaming/apiv1/helpers.go
+++ b/devicestreaming/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2/agents_client.go
+++ b/dialogflow/apiv2/agents_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2/agents_client_example_go123_test.go
+++ b/dialogflow/apiv2/agents_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2/agents_client_example_test.go
+++ b/dialogflow/apiv2/agents_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2/answer_records_client.go
+++ b/dialogflow/apiv2/answer_records_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2/answer_records_client_example_go123_test.go
+++ b/dialogflow/apiv2/answer_records_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2/answer_records_client_example_test.go
+++ b/dialogflow/apiv2/answer_records_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2/auxiliary.go
+++ b/dialogflow/apiv2/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2/auxiliary_go123.go
+++ b/dialogflow/apiv2/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2/contexts_client.go
+++ b/dialogflow/apiv2/contexts_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2/contexts_client_example_go123_test.go
+++ b/dialogflow/apiv2/contexts_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2/contexts_client_example_test.go
+++ b/dialogflow/apiv2/contexts_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2/conversation_datasets_client.go
+++ b/dialogflow/apiv2/conversation_datasets_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2/conversation_datasets_client_example_go123_test.go
+++ b/dialogflow/apiv2/conversation_datasets_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2/conversation_datasets_client_example_test.go
+++ b/dialogflow/apiv2/conversation_datasets_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2/conversation_models_client.go
+++ b/dialogflow/apiv2/conversation_models_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2/conversation_models_client_example_go123_test.go
+++ b/dialogflow/apiv2/conversation_models_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2/conversation_models_client_example_test.go
+++ b/dialogflow/apiv2/conversation_models_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2/conversation_profiles_client.go
+++ b/dialogflow/apiv2/conversation_profiles_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2/conversation_profiles_client_example_go123_test.go
+++ b/dialogflow/apiv2/conversation_profiles_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2/conversation_profiles_client_example_test.go
+++ b/dialogflow/apiv2/conversation_profiles_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2/conversations_client.go
+++ b/dialogflow/apiv2/conversations_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2/conversations_client_example_go123_test.go
+++ b/dialogflow/apiv2/conversations_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2/conversations_client_example_test.go
+++ b/dialogflow/apiv2/conversations_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2/doc.go
+++ b/dialogflow/apiv2/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2/documents_client.go
+++ b/dialogflow/apiv2/documents_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2/documents_client_example_go123_test.go
+++ b/dialogflow/apiv2/documents_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2/documents_client_example_test.go
+++ b/dialogflow/apiv2/documents_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2/encryption_spec_client.go
+++ b/dialogflow/apiv2/encryption_spec_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2/encryption_spec_client_example_go123_test.go
+++ b/dialogflow/apiv2/encryption_spec_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2/encryption_spec_client_example_test.go
+++ b/dialogflow/apiv2/encryption_spec_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2/entity_types_client.go
+++ b/dialogflow/apiv2/entity_types_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2/entity_types_client_example_go123_test.go
+++ b/dialogflow/apiv2/entity_types_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2/entity_types_client_example_test.go
+++ b/dialogflow/apiv2/entity_types_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2/environments_client.go
+++ b/dialogflow/apiv2/environments_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2/environments_client_example_go123_test.go
+++ b/dialogflow/apiv2/environments_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2/environments_client_example_test.go
+++ b/dialogflow/apiv2/environments_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2/fulfillments_client.go
+++ b/dialogflow/apiv2/fulfillments_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2/fulfillments_client_example_go123_test.go
+++ b/dialogflow/apiv2/fulfillments_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2/fulfillments_client_example_test.go
+++ b/dialogflow/apiv2/fulfillments_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2/generator_evaluations_client.go
+++ b/dialogflow/apiv2/generator_evaluations_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2/generator_evaluations_client_example_go123_test.go
+++ b/dialogflow/apiv2/generator_evaluations_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2/generator_evaluations_client_example_test.go
+++ b/dialogflow/apiv2/generator_evaluations_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2/generators_client.go
+++ b/dialogflow/apiv2/generators_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2/generators_client_example_go123_test.go
+++ b/dialogflow/apiv2/generators_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2/generators_client_example_test.go
+++ b/dialogflow/apiv2/generators_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2/helpers.go
+++ b/dialogflow/apiv2/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2/intents_client.go
+++ b/dialogflow/apiv2/intents_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2/intents_client_example_go123_test.go
+++ b/dialogflow/apiv2/intents_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2/intents_client_example_test.go
+++ b/dialogflow/apiv2/intents_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2/knowledge_bases_client.go
+++ b/dialogflow/apiv2/knowledge_bases_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2/knowledge_bases_client_example_go123_test.go
+++ b/dialogflow/apiv2/knowledge_bases_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2/knowledge_bases_client_example_test.go
+++ b/dialogflow/apiv2/knowledge_bases_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2/participants_client.go
+++ b/dialogflow/apiv2/participants_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2/participants_client_example_go123_test.go
+++ b/dialogflow/apiv2/participants_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2/participants_client_example_test.go
+++ b/dialogflow/apiv2/participants_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2/session_entity_types_client.go
+++ b/dialogflow/apiv2/session_entity_types_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2/session_entity_types_client_example_go123_test.go
+++ b/dialogflow/apiv2/session_entity_types_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2/session_entity_types_client_example_test.go
+++ b/dialogflow/apiv2/session_entity_types_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2/sessions_client.go
+++ b/dialogflow/apiv2/sessions_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2/sessions_client_example_go123_test.go
+++ b/dialogflow/apiv2/sessions_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2/sessions_client_example_test.go
+++ b/dialogflow/apiv2/sessions_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2/sip_trunks_client.go
+++ b/dialogflow/apiv2/sip_trunks_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2/sip_trunks_client_example_go123_test.go
+++ b/dialogflow/apiv2/sip_trunks_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2/sip_trunks_client_example_test.go
+++ b/dialogflow/apiv2/sip_trunks_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2/tools_client.go
+++ b/dialogflow/apiv2/tools_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2/tools_client_example_go123_test.go
+++ b/dialogflow/apiv2/tools_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2/tools_client_example_test.go
+++ b/dialogflow/apiv2/tools_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2/versions_client.go
+++ b/dialogflow/apiv2/versions_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2/versions_client_example_go123_test.go
+++ b/dialogflow/apiv2/versions_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2/versions_client_example_test.go
+++ b/dialogflow/apiv2/versions_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2beta1/agents_client.go
+++ b/dialogflow/apiv2beta1/agents_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2beta1/agents_client_example_go123_test.go
+++ b/dialogflow/apiv2beta1/agents_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2beta1/agents_client_example_test.go
+++ b/dialogflow/apiv2beta1/agents_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2beta1/answer_records_client.go
+++ b/dialogflow/apiv2beta1/answer_records_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2beta1/answer_records_client_example_go123_test.go
+++ b/dialogflow/apiv2beta1/answer_records_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2beta1/answer_records_client_example_test.go
+++ b/dialogflow/apiv2beta1/answer_records_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2beta1/auxiliary.go
+++ b/dialogflow/apiv2beta1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2beta1/auxiliary_go123.go
+++ b/dialogflow/apiv2beta1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2beta1/contexts_client.go
+++ b/dialogflow/apiv2beta1/contexts_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2beta1/contexts_client_example_go123_test.go
+++ b/dialogflow/apiv2beta1/contexts_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2beta1/contexts_client_example_test.go
+++ b/dialogflow/apiv2beta1/contexts_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2beta1/conversation_profiles_client.go
+++ b/dialogflow/apiv2beta1/conversation_profiles_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2beta1/conversation_profiles_client_example_go123_test.go
+++ b/dialogflow/apiv2beta1/conversation_profiles_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2beta1/conversation_profiles_client_example_test.go
+++ b/dialogflow/apiv2beta1/conversation_profiles_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2beta1/conversations_client.go
+++ b/dialogflow/apiv2beta1/conversations_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2beta1/conversations_client_example_go123_test.go
+++ b/dialogflow/apiv2beta1/conversations_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2beta1/conversations_client_example_test.go
+++ b/dialogflow/apiv2beta1/conversations_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2beta1/doc.go
+++ b/dialogflow/apiv2beta1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2beta1/documents_client.go
+++ b/dialogflow/apiv2beta1/documents_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2beta1/documents_client_example_go123_test.go
+++ b/dialogflow/apiv2beta1/documents_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2beta1/documents_client_example_test.go
+++ b/dialogflow/apiv2beta1/documents_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2beta1/encryption_spec_client.go
+++ b/dialogflow/apiv2beta1/encryption_spec_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2beta1/encryption_spec_client_example_go123_test.go
+++ b/dialogflow/apiv2beta1/encryption_spec_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2beta1/encryption_spec_client_example_test.go
+++ b/dialogflow/apiv2beta1/encryption_spec_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2beta1/entity_types_client.go
+++ b/dialogflow/apiv2beta1/entity_types_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2beta1/entity_types_client_example_go123_test.go
+++ b/dialogflow/apiv2beta1/entity_types_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2beta1/entity_types_client_example_test.go
+++ b/dialogflow/apiv2beta1/entity_types_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2beta1/environments_client.go
+++ b/dialogflow/apiv2beta1/environments_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2beta1/environments_client_example_go123_test.go
+++ b/dialogflow/apiv2beta1/environments_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2beta1/environments_client_example_test.go
+++ b/dialogflow/apiv2beta1/environments_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2beta1/fulfillments_client.go
+++ b/dialogflow/apiv2beta1/fulfillments_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2beta1/fulfillments_client_example_go123_test.go
+++ b/dialogflow/apiv2beta1/fulfillments_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2beta1/fulfillments_client_example_test.go
+++ b/dialogflow/apiv2beta1/fulfillments_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2beta1/generator_evaluations_client.go
+++ b/dialogflow/apiv2beta1/generator_evaluations_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2beta1/generator_evaluations_client_example_go123_test.go
+++ b/dialogflow/apiv2beta1/generator_evaluations_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2beta1/generator_evaluations_client_example_test.go
+++ b/dialogflow/apiv2beta1/generator_evaluations_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2beta1/generators_client.go
+++ b/dialogflow/apiv2beta1/generators_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2beta1/generators_client_example_go123_test.go
+++ b/dialogflow/apiv2beta1/generators_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2beta1/generators_client_example_test.go
+++ b/dialogflow/apiv2beta1/generators_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2beta1/helpers.go
+++ b/dialogflow/apiv2beta1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2beta1/intents_client.go
+++ b/dialogflow/apiv2beta1/intents_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2beta1/intents_client_example_go123_test.go
+++ b/dialogflow/apiv2beta1/intents_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2beta1/intents_client_example_test.go
+++ b/dialogflow/apiv2beta1/intents_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2beta1/knowledge_bases_client.go
+++ b/dialogflow/apiv2beta1/knowledge_bases_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2beta1/knowledge_bases_client_example_go123_test.go
+++ b/dialogflow/apiv2beta1/knowledge_bases_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2beta1/knowledge_bases_client_example_test.go
+++ b/dialogflow/apiv2beta1/knowledge_bases_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2beta1/participants_client.go
+++ b/dialogflow/apiv2beta1/participants_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2beta1/participants_client_example_go123_test.go
+++ b/dialogflow/apiv2beta1/participants_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2beta1/participants_client_example_test.go
+++ b/dialogflow/apiv2beta1/participants_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2beta1/phone_numbers_client.go
+++ b/dialogflow/apiv2beta1/phone_numbers_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2beta1/phone_numbers_client_example_go123_test.go
+++ b/dialogflow/apiv2beta1/phone_numbers_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2beta1/phone_numbers_client_example_test.go
+++ b/dialogflow/apiv2beta1/phone_numbers_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2beta1/session_entity_types_client.go
+++ b/dialogflow/apiv2beta1/session_entity_types_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2beta1/session_entity_types_client_example_go123_test.go
+++ b/dialogflow/apiv2beta1/session_entity_types_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2beta1/session_entity_types_client_example_test.go
+++ b/dialogflow/apiv2beta1/session_entity_types_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2beta1/sessions_client.go
+++ b/dialogflow/apiv2beta1/sessions_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2beta1/sessions_client_example_go123_test.go
+++ b/dialogflow/apiv2beta1/sessions_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2beta1/sessions_client_example_test.go
+++ b/dialogflow/apiv2beta1/sessions_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2beta1/sip_trunks_client.go
+++ b/dialogflow/apiv2beta1/sip_trunks_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2beta1/sip_trunks_client_example_go123_test.go
+++ b/dialogflow/apiv2beta1/sip_trunks_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2beta1/sip_trunks_client_example_test.go
+++ b/dialogflow/apiv2beta1/sip_trunks_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2beta1/tools_client.go
+++ b/dialogflow/apiv2beta1/tools_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2beta1/tools_client_example_go123_test.go
+++ b/dialogflow/apiv2beta1/tools_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2beta1/tools_client_example_test.go
+++ b/dialogflow/apiv2beta1/tools_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2beta1/versions_client.go
+++ b/dialogflow/apiv2beta1/versions_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2beta1/versions_client_example_go123_test.go
+++ b/dialogflow/apiv2beta1/versions_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/apiv2beta1/versions_client_example_test.go
+++ b/dialogflow/apiv2beta1/versions_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3/agents_client.go
+++ b/dialogflow/cx/apiv3/agents_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3/agents_client_example_go123_test.go
+++ b/dialogflow/cx/apiv3/agents_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3/agents_client_example_test.go
+++ b/dialogflow/cx/apiv3/agents_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3/auxiliary.go
+++ b/dialogflow/cx/apiv3/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3/auxiliary_go123.go
+++ b/dialogflow/cx/apiv3/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3/changelogs_client.go
+++ b/dialogflow/cx/apiv3/changelogs_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3/changelogs_client_example_go123_test.go
+++ b/dialogflow/cx/apiv3/changelogs_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3/changelogs_client_example_test.go
+++ b/dialogflow/cx/apiv3/changelogs_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3/deployments_client.go
+++ b/dialogflow/cx/apiv3/deployments_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3/deployments_client_example_go123_test.go
+++ b/dialogflow/cx/apiv3/deployments_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3/deployments_client_example_test.go
+++ b/dialogflow/cx/apiv3/deployments_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3/doc.go
+++ b/dialogflow/cx/apiv3/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3/entity_types_client.go
+++ b/dialogflow/cx/apiv3/entity_types_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3/entity_types_client_example_go123_test.go
+++ b/dialogflow/cx/apiv3/entity_types_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3/entity_types_client_example_test.go
+++ b/dialogflow/cx/apiv3/entity_types_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3/environments_client.go
+++ b/dialogflow/cx/apiv3/environments_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3/environments_client_example_go123_test.go
+++ b/dialogflow/cx/apiv3/environments_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3/environments_client_example_test.go
+++ b/dialogflow/cx/apiv3/environments_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3/experiments_client.go
+++ b/dialogflow/cx/apiv3/experiments_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3/experiments_client_example_go123_test.go
+++ b/dialogflow/cx/apiv3/experiments_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3/experiments_client_example_test.go
+++ b/dialogflow/cx/apiv3/experiments_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3/flows_client.go
+++ b/dialogflow/cx/apiv3/flows_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3/flows_client_example_go123_test.go
+++ b/dialogflow/cx/apiv3/flows_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3/flows_client_example_test.go
+++ b/dialogflow/cx/apiv3/flows_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3/generators_client.go
+++ b/dialogflow/cx/apiv3/generators_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3/generators_client_example_go123_test.go
+++ b/dialogflow/cx/apiv3/generators_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3/generators_client_example_test.go
+++ b/dialogflow/cx/apiv3/generators_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3/helpers.go
+++ b/dialogflow/cx/apiv3/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3/intents_client.go
+++ b/dialogflow/cx/apiv3/intents_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3/intents_client_example_go123_test.go
+++ b/dialogflow/cx/apiv3/intents_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3/intents_client_example_test.go
+++ b/dialogflow/cx/apiv3/intents_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3/pages_client.go
+++ b/dialogflow/cx/apiv3/pages_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3/pages_client_example_go123_test.go
+++ b/dialogflow/cx/apiv3/pages_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3/pages_client_example_test.go
+++ b/dialogflow/cx/apiv3/pages_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3/security_settings_client.go
+++ b/dialogflow/cx/apiv3/security_settings_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3/security_settings_client_example_go123_test.go
+++ b/dialogflow/cx/apiv3/security_settings_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3/security_settings_client_example_test.go
+++ b/dialogflow/cx/apiv3/security_settings_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3/session_entity_types_client.go
+++ b/dialogflow/cx/apiv3/session_entity_types_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3/session_entity_types_client_example_go123_test.go
+++ b/dialogflow/cx/apiv3/session_entity_types_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3/session_entity_types_client_example_test.go
+++ b/dialogflow/cx/apiv3/session_entity_types_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3/sessions_client.go
+++ b/dialogflow/cx/apiv3/sessions_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3/sessions_client_example_go123_test.go
+++ b/dialogflow/cx/apiv3/sessions_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3/sessions_client_example_test.go
+++ b/dialogflow/cx/apiv3/sessions_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3/test_cases_client.go
+++ b/dialogflow/cx/apiv3/test_cases_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3/test_cases_client_example_go123_test.go
+++ b/dialogflow/cx/apiv3/test_cases_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3/test_cases_client_example_test.go
+++ b/dialogflow/cx/apiv3/test_cases_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3/transition_route_groups_client.go
+++ b/dialogflow/cx/apiv3/transition_route_groups_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3/transition_route_groups_client_example_go123_test.go
+++ b/dialogflow/cx/apiv3/transition_route_groups_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3/transition_route_groups_client_example_test.go
+++ b/dialogflow/cx/apiv3/transition_route_groups_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3/versions_client.go
+++ b/dialogflow/cx/apiv3/versions_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3/versions_client_example_go123_test.go
+++ b/dialogflow/cx/apiv3/versions_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3/versions_client_example_test.go
+++ b/dialogflow/cx/apiv3/versions_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3/webhooks_client.go
+++ b/dialogflow/cx/apiv3/webhooks_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3/webhooks_client_example_go123_test.go
+++ b/dialogflow/cx/apiv3/webhooks_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3/webhooks_client_example_test.go
+++ b/dialogflow/cx/apiv3/webhooks_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3beta1/agents_client.go
+++ b/dialogflow/cx/apiv3beta1/agents_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3beta1/agents_client_example_go123_test.go
+++ b/dialogflow/cx/apiv3beta1/agents_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3beta1/agents_client_example_test.go
+++ b/dialogflow/cx/apiv3beta1/agents_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3beta1/auxiliary.go
+++ b/dialogflow/cx/apiv3beta1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3beta1/auxiliary_go123.go
+++ b/dialogflow/cx/apiv3beta1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3beta1/changelogs_client.go
+++ b/dialogflow/cx/apiv3beta1/changelogs_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3beta1/changelogs_client_example_go123_test.go
+++ b/dialogflow/cx/apiv3beta1/changelogs_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3beta1/changelogs_client_example_test.go
+++ b/dialogflow/cx/apiv3beta1/changelogs_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3beta1/conversation_history_client.go
+++ b/dialogflow/cx/apiv3beta1/conversation_history_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3beta1/conversation_history_client_example_go123_test.go
+++ b/dialogflow/cx/apiv3beta1/conversation_history_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3beta1/conversation_history_client_example_test.go
+++ b/dialogflow/cx/apiv3beta1/conversation_history_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3beta1/deployments_client.go
+++ b/dialogflow/cx/apiv3beta1/deployments_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3beta1/deployments_client_example_go123_test.go
+++ b/dialogflow/cx/apiv3beta1/deployments_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3beta1/deployments_client_example_test.go
+++ b/dialogflow/cx/apiv3beta1/deployments_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3beta1/doc.go
+++ b/dialogflow/cx/apiv3beta1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3beta1/entity_types_client.go
+++ b/dialogflow/cx/apiv3beta1/entity_types_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3beta1/entity_types_client_example_go123_test.go
+++ b/dialogflow/cx/apiv3beta1/entity_types_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3beta1/entity_types_client_example_test.go
+++ b/dialogflow/cx/apiv3beta1/entity_types_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3beta1/environments_client.go
+++ b/dialogflow/cx/apiv3beta1/environments_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3beta1/environments_client_example_go123_test.go
+++ b/dialogflow/cx/apiv3beta1/environments_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3beta1/environments_client_example_test.go
+++ b/dialogflow/cx/apiv3beta1/environments_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3beta1/examples_client.go
+++ b/dialogflow/cx/apiv3beta1/examples_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3beta1/examples_client_example_go123_test.go
+++ b/dialogflow/cx/apiv3beta1/examples_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3beta1/examples_client_example_test.go
+++ b/dialogflow/cx/apiv3beta1/examples_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3beta1/experiments_client.go
+++ b/dialogflow/cx/apiv3beta1/experiments_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3beta1/experiments_client_example_go123_test.go
+++ b/dialogflow/cx/apiv3beta1/experiments_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3beta1/experiments_client_example_test.go
+++ b/dialogflow/cx/apiv3beta1/experiments_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3beta1/flows_client.go
+++ b/dialogflow/cx/apiv3beta1/flows_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3beta1/flows_client_example_go123_test.go
+++ b/dialogflow/cx/apiv3beta1/flows_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3beta1/flows_client_example_test.go
+++ b/dialogflow/cx/apiv3beta1/flows_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3beta1/generators_client.go
+++ b/dialogflow/cx/apiv3beta1/generators_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3beta1/generators_client_example_go123_test.go
+++ b/dialogflow/cx/apiv3beta1/generators_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3beta1/generators_client_example_test.go
+++ b/dialogflow/cx/apiv3beta1/generators_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3beta1/helpers.go
+++ b/dialogflow/cx/apiv3beta1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3beta1/intents_client.go
+++ b/dialogflow/cx/apiv3beta1/intents_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3beta1/intents_client_example_go123_test.go
+++ b/dialogflow/cx/apiv3beta1/intents_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3beta1/intents_client_example_test.go
+++ b/dialogflow/cx/apiv3beta1/intents_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3beta1/pages_client.go
+++ b/dialogflow/cx/apiv3beta1/pages_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3beta1/pages_client_example_go123_test.go
+++ b/dialogflow/cx/apiv3beta1/pages_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3beta1/pages_client_example_test.go
+++ b/dialogflow/cx/apiv3beta1/pages_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3beta1/playbooks_client.go
+++ b/dialogflow/cx/apiv3beta1/playbooks_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3beta1/playbooks_client_example_go123_test.go
+++ b/dialogflow/cx/apiv3beta1/playbooks_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3beta1/playbooks_client_example_test.go
+++ b/dialogflow/cx/apiv3beta1/playbooks_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3beta1/security_settings_client.go
+++ b/dialogflow/cx/apiv3beta1/security_settings_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3beta1/security_settings_client_example_go123_test.go
+++ b/dialogflow/cx/apiv3beta1/security_settings_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3beta1/security_settings_client_example_test.go
+++ b/dialogflow/cx/apiv3beta1/security_settings_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3beta1/session_entity_types_client.go
+++ b/dialogflow/cx/apiv3beta1/session_entity_types_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3beta1/session_entity_types_client_example_go123_test.go
+++ b/dialogflow/cx/apiv3beta1/session_entity_types_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3beta1/session_entity_types_client_example_test.go
+++ b/dialogflow/cx/apiv3beta1/session_entity_types_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3beta1/sessions_client.go
+++ b/dialogflow/cx/apiv3beta1/sessions_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3beta1/sessions_client_example_go123_test.go
+++ b/dialogflow/cx/apiv3beta1/sessions_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3beta1/sessions_client_example_test.go
+++ b/dialogflow/cx/apiv3beta1/sessions_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3beta1/test_cases_client.go
+++ b/dialogflow/cx/apiv3beta1/test_cases_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3beta1/test_cases_client_example_go123_test.go
+++ b/dialogflow/cx/apiv3beta1/test_cases_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3beta1/test_cases_client_example_test.go
+++ b/dialogflow/cx/apiv3beta1/test_cases_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3beta1/tools_client.go
+++ b/dialogflow/cx/apiv3beta1/tools_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3beta1/tools_client_example_go123_test.go
+++ b/dialogflow/cx/apiv3beta1/tools_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3beta1/tools_client_example_test.go
+++ b/dialogflow/cx/apiv3beta1/tools_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3beta1/transition_route_groups_client.go
+++ b/dialogflow/cx/apiv3beta1/transition_route_groups_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3beta1/transition_route_groups_client_example_go123_test.go
+++ b/dialogflow/cx/apiv3beta1/transition_route_groups_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3beta1/transition_route_groups_client_example_test.go
+++ b/dialogflow/cx/apiv3beta1/transition_route_groups_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3beta1/versions_client.go
+++ b/dialogflow/cx/apiv3beta1/versions_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3beta1/versions_client_example_go123_test.go
+++ b/dialogflow/cx/apiv3beta1/versions_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3beta1/versions_client_example_test.go
+++ b/dialogflow/cx/apiv3beta1/versions_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3beta1/webhooks_client.go
+++ b/dialogflow/cx/apiv3beta1/webhooks_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3beta1/webhooks_client_example_go123_test.go
+++ b/dialogflow/cx/apiv3beta1/webhooks_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dialogflow/cx/apiv3beta1/webhooks_client_example_test.go
+++ b/dialogflow/cx/apiv3beta1/webhooks_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1/assistant_client.go
+++ b/discoveryengine/apiv1/assistant_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1/assistant_client_example_go123_test.go
+++ b/discoveryengine/apiv1/assistant_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1/assistant_client_example_test.go
+++ b/discoveryengine/apiv1/assistant_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1/auxiliary.go
+++ b/discoveryengine/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1/auxiliary_go123.go
+++ b/discoveryengine/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1/cmek_config_client.go
+++ b/discoveryengine/apiv1/cmek_config_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1/cmek_config_client_example_go123_test.go
+++ b/discoveryengine/apiv1/cmek_config_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1/cmek_config_client_example_test.go
+++ b/discoveryengine/apiv1/cmek_config_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1/completion_client.go
+++ b/discoveryengine/apiv1/completion_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1/completion_client_example_go123_test.go
+++ b/discoveryengine/apiv1/completion_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1/completion_client_example_test.go
+++ b/discoveryengine/apiv1/completion_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1/control_client.go
+++ b/discoveryengine/apiv1/control_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1/control_client_example_go123_test.go
+++ b/discoveryengine/apiv1/control_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1/control_client_example_test.go
+++ b/discoveryengine/apiv1/control_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1/conversational_search_client.go
+++ b/discoveryengine/apiv1/conversational_search_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1/conversational_search_client_example_go123_test.go
+++ b/discoveryengine/apiv1/conversational_search_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1/conversational_search_client_example_test.go
+++ b/discoveryengine/apiv1/conversational_search_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1/data_store_client.go
+++ b/discoveryengine/apiv1/data_store_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1/data_store_client_example_go123_test.go
+++ b/discoveryengine/apiv1/data_store_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1/data_store_client_example_test.go
+++ b/discoveryengine/apiv1/data_store_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1/doc.go
+++ b/discoveryengine/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1/document_client.go
+++ b/discoveryengine/apiv1/document_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1/document_client_example_go123_test.go
+++ b/discoveryengine/apiv1/document_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1/document_client_example_test.go
+++ b/discoveryengine/apiv1/document_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1/engine_client.go
+++ b/discoveryengine/apiv1/engine_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1/engine_client_example_go123_test.go
+++ b/discoveryengine/apiv1/engine_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1/engine_client_example_test.go
+++ b/discoveryengine/apiv1/engine_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1/grounded_generation_client.go
+++ b/discoveryengine/apiv1/grounded_generation_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1/grounded_generation_client_example_go123_test.go
+++ b/discoveryengine/apiv1/grounded_generation_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1/grounded_generation_client_example_test.go
+++ b/discoveryengine/apiv1/grounded_generation_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1/helpers.go
+++ b/discoveryengine/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1/identity_mapping_store_client.go
+++ b/discoveryengine/apiv1/identity_mapping_store_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1/identity_mapping_store_client_example_go123_test.go
+++ b/discoveryengine/apiv1/identity_mapping_store_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1/identity_mapping_store_client_example_test.go
+++ b/discoveryengine/apiv1/identity_mapping_store_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1/project_client.go
+++ b/discoveryengine/apiv1/project_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1/project_client_example_go123_test.go
+++ b/discoveryengine/apiv1/project_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1/project_client_example_test.go
+++ b/discoveryengine/apiv1/project_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1/rank_client.go
+++ b/discoveryengine/apiv1/rank_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1/rank_client_example_go123_test.go
+++ b/discoveryengine/apiv1/rank_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1/rank_client_example_test.go
+++ b/discoveryengine/apiv1/rank_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1/recommendation_client.go
+++ b/discoveryengine/apiv1/recommendation_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1/recommendation_client_example_go123_test.go
+++ b/discoveryengine/apiv1/recommendation_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1/recommendation_client_example_test.go
+++ b/discoveryengine/apiv1/recommendation_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1/schema_client.go
+++ b/discoveryengine/apiv1/schema_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1/schema_client_example_go123_test.go
+++ b/discoveryengine/apiv1/schema_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1/schema_client_example_test.go
+++ b/discoveryengine/apiv1/schema_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1/search_client.go
+++ b/discoveryengine/apiv1/search_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1/search_client_example_go123_test.go
+++ b/discoveryengine/apiv1/search_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1/search_client_example_test.go
+++ b/discoveryengine/apiv1/search_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1/search_tuning_client.go
+++ b/discoveryengine/apiv1/search_tuning_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1/search_tuning_client_example_go123_test.go
+++ b/discoveryengine/apiv1/search_tuning_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1/search_tuning_client_example_test.go
+++ b/discoveryengine/apiv1/search_tuning_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1/serving_config_client.go
+++ b/discoveryengine/apiv1/serving_config_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1/serving_config_client_example_go123_test.go
+++ b/discoveryengine/apiv1/serving_config_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1/serving_config_client_example_test.go
+++ b/discoveryengine/apiv1/serving_config_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1/session_client.go
+++ b/discoveryengine/apiv1/session_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1/session_client_example_go123_test.go
+++ b/discoveryengine/apiv1/session_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1/session_client_example_test.go
+++ b/discoveryengine/apiv1/session_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1/site_search_engine_client.go
+++ b/discoveryengine/apiv1/site_search_engine_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1/site_search_engine_client_example_go123_test.go
+++ b/discoveryengine/apiv1/site_search_engine_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1/site_search_engine_client_example_test.go
+++ b/discoveryengine/apiv1/site_search_engine_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1/user_event_client.go
+++ b/discoveryengine/apiv1/user_event_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1/user_event_client_example_go123_test.go
+++ b/discoveryengine/apiv1/user_event_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1/user_event_client_example_test.go
+++ b/discoveryengine/apiv1/user_event_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1/user_license_client.go
+++ b/discoveryengine/apiv1/user_license_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1/user_license_client_example_go123_test.go
+++ b/discoveryengine/apiv1/user_license_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1/user_license_client_example_test.go
+++ b/discoveryengine/apiv1/user_license_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1alpha/acl_config_client.go
+++ b/discoveryengine/apiv1alpha/acl_config_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1alpha/acl_config_client_example_go123_test.go
+++ b/discoveryengine/apiv1alpha/acl_config_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1alpha/acl_config_client_example_test.go
+++ b/discoveryengine/apiv1alpha/acl_config_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1alpha/auxiliary.go
+++ b/discoveryengine/apiv1alpha/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1alpha/auxiliary_go123.go
+++ b/discoveryengine/apiv1alpha/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1alpha/chunk_client.go
+++ b/discoveryengine/apiv1alpha/chunk_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1alpha/chunk_client_example_go123_test.go
+++ b/discoveryengine/apiv1alpha/chunk_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1alpha/chunk_client_example_test.go
+++ b/discoveryengine/apiv1alpha/chunk_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1alpha/completion_client.go
+++ b/discoveryengine/apiv1alpha/completion_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1alpha/completion_client_example_go123_test.go
+++ b/discoveryengine/apiv1alpha/completion_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1alpha/completion_client_example_test.go
+++ b/discoveryengine/apiv1alpha/completion_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1alpha/control_client.go
+++ b/discoveryengine/apiv1alpha/control_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1alpha/control_client_example_go123_test.go
+++ b/discoveryengine/apiv1alpha/control_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1alpha/control_client_example_test.go
+++ b/discoveryengine/apiv1alpha/control_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1alpha/conversational_search_client.go
+++ b/discoveryengine/apiv1alpha/conversational_search_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1alpha/conversational_search_client_example_go123_test.go
+++ b/discoveryengine/apiv1alpha/conversational_search_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1alpha/conversational_search_client_example_test.go
+++ b/discoveryengine/apiv1alpha/conversational_search_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1alpha/data_store_client.go
+++ b/discoveryengine/apiv1alpha/data_store_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1alpha/data_store_client_example_go123_test.go
+++ b/discoveryengine/apiv1alpha/data_store_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1alpha/data_store_client_example_test.go
+++ b/discoveryengine/apiv1alpha/data_store_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1alpha/doc.go
+++ b/discoveryengine/apiv1alpha/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1alpha/document_client.go
+++ b/discoveryengine/apiv1alpha/document_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1alpha/document_client_example_go123_test.go
+++ b/discoveryengine/apiv1alpha/document_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1alpha/document_client_example_test.go
+++ b/discoveryengine/apiv1alpha/document_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1alpha/engine_client.go
+++ b/discoveryengine/apiv1alpha/engine_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1alpha/engine_client_example_go123_test.go
+++ b/discoveryengine/apiv1alpha/engine_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1alpha/engine_client_example_test.go
+++ b/discoveryengine/apiv1alpha/engine_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1alpha/estimate_billing_client.go
+++ b/discoveryengine/apiv1alpha/estimate_billing_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1alpha/estimate_billing_client_example_go123_test.go
+++ b/discoveryengine/apiv1alpha/estimate_billing_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1alpha/estimate_billing_client_example_test.go
+++ b/discoveryengine/apiv1alpha/estimate_billing_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1alpha/evaluation_client.go
+++ b/discoveryengine/apiv1alpha/evaluation_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1alpha/evaluation_client_example_go123_test.go
+++ b/discoveryengine/apiv1alpha/evaluation_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1alpha/evaluation_client_example_test.go
+++ b/discoveryengine/apiv1alpha/evaluation_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1alpha/grounded_generation_client.go
+++ b/discoveryengine/apiv1alpha/grounded_generation_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1alpha/grounded_generation_client_example_go123_test.go
+++ b/discoveryengine/apiv1alpha/grounded_generation_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1alpha/grounded_generation_client_example_test.go
+++ b/discoveryengine/apiv1alpha/grounded_generation_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1alpha/helpers.go
+++ b/discoveryengine/apiv1alpha/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1alpha/project_client.go
+++ b/discoveryengine/apiv1alpha/project_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1alpha/project_client_example_go123_test.go
+++ b/discoveryengine/apiv1alpha/project_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1alpha/project_client_example_test.go
+++ b/discoveryengine/apiv1alpha/project_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1alpha/rank_client.go
+++ b/discoveryengine/apiv1alpha/rank_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1alpha/rank_client_example_go123_test.go
+++ b/discoveryengine/apiv1alpha/rank_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1alpha/rank_client_example_test.go
+++ b/discoveryengine/apiv1alpha/rank_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1alpha/recommendation_client.go
+++ b/discoveryengine/apiv1alpha/recommendation_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1alpha/recommendation_client_example_go123_test.go
+++ b/discoveryengine/apiv1alpha/recommendation_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1alpha/recommendation_client_example_test.go
+++ b/discoveryengine/apiv1alpha/recommendation_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1alpha/sample_query_client.go
+++ b/discoveryengine/apiv1alpha/sample_query_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1alpha/sample_query_client_example_go123_test.go
+++ b/discoveryengine/apiv1alpha/sample_query_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1alpha/sample_query_client_example_test.go
+++ b/discoveryengine/apiv1alpha/sample_query_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1alpha/sample_query_set_client.go
+++ b/discoveryengine/apiv1alpha/sample_query_set_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1alpha/sample_query_set_client_example_go123_test.go
+++ b/discoveryengine/apiv1alpha/sample_query_set_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1alpha/sample_query_set_client_example_test.go
+++ b/discoveryengine/apiv1alpha/sample_query_set_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1alpha/schema_client.go
+++ b/discoveryengine/apiv1alpha/schema_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1alpha/schema_client_example_go123_test.go
+++ b/discoveryengine/apiv1alpha/schema_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1alpha/schema_client_example_test.go
+++ b/discoveryengine/apiv1alpha/schema_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1alpha/search_client.go
+++ b/discoveryengine/apiv1alpha/search_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1alpha/search_client_example_go123_test.go
+++ b/discoveryengine/apiv1alpha/search_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1alpha/search_client_example_test.go
+++ b/discoveryengine/apiv1alpha/search_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1alpha/search_tuning_client.go
+++ b/discoveryengine/apiv1alpha/search_tuning_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1alpha/search_tuning_client_example_go123_test.go
+++ b/discoveryengine/apiv1alpha/search_tuning_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1alpha/search_tuning_client_example_test.go
+++ b/discoveryengine/apiv1alpha/search_tuning_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1alpha/serving_config_client.go
+++ b/discoveryengine/apiv1alpha/serving_config_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1alpha/serving_config_client_example_go123_test.go
+++ b/discoveryengine/apiv1alpha/serving_config_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1alpha/serving_config_client_example_test.go
+++ b/discoveryengine/apiv1alpha/serving_config_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1alpha/session_client.go
+++ b/discoveryengine/apiv1alpha/session_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1alpha/session_client_example_go123_test.go
+++ b/discoveryengine/apiv1alpha/session_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1alpha/session_client_example_test.go
+++ b/discoveryengine/apiv1alpha/session_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1alpha/site_search_engine_client.go
+++ b/discoveryengine/apiv1alpha/site_search_engine_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1alpha/site_search_engine_client_example_go123_test.go
+++ b/discoveryengine/apiv1alpha/site_search_engine_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1alpha/site_search_engine_client_example_test.go
+++ b/discoveryengine/apiv1alpha/site_search_engine_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1alpha/user_event_client.go
+++ b/discoveryengine/apiv1alpha/user_event_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1alpha/user_event_client_example_go123_test.go
+++ b/discoveryengine/apiv1alpha/user_event_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1alpha/user_event_client_example_test.go
+++ b/discoveryengine/apiv1alpha/user_event_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1beta/auxiliary.go
+++ b/discoveryengine/apiv1beta/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1beta/auxiliary_go123.go
+++ b/discoveryengine/apiv1beta/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1beta/completion_client.go
+++ b/discoveryengine/apiv1beta/completion_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1beta/completion_client_example_go123_test.go
+++ b/discoveryengine/apiv1beta/completion_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1beta/completion_client_example_test.go
+++ b/discoveryengine/apiv1beta/completion_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1beta/control_client.go
+++ b/discoveryengine/apiv1beta/control_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1beta/control_client_example_go123_test.go
+++ b/discoveryengine/apiv1beta/control_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1beta/control_client_example_test.go
+++ b/discoveryengine/apiv1beta/control_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1beta/conversational_search_client.go
+++ b/discoveryengine/apiv1beta/conversational_search_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1beta/conversational_search_client_example_go123_test.go
+++ b/discoveryengine/apiv1beta/conversational_search_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1beta/conversational_search_client_example_test.go
+++ b/discoveryengine/apiv1beta/conversational_search_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1beta/data_store_client.go
+++ b/discoveryengine/apiv1beta/data_store_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1beta/data_store_client_example_go123_test.go
+++ b/discoveryengine/apiv1beta/data_store_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1beta/data_store_client_example_test.go
+++ b/discoveryengine/apiv1beta/data_store_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1beta/doc.go
+++ b/discoveryengine/apiv1beta/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1beta/document_client.go
+++ b/discoveryengine/apiv1beta/document_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1beta/document_client_example_go123_test.go
+++ b/discoveryengine/apiv1beta/document_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1beta/document_client_example_test.go
+++ b/discoveryengine/apiv1beta/document_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1beta/engine_client.go
+++ b/discoveryengine/apiv1beta/engine_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1beta/engine_client_example_go123_test.go
+++ b/discoveryengine/apiv1beta/engine_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1beta/engine_client_example_test.go
+++ b/discoveryengine/apiv1beta/engine_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1beta/evaluation_client.go
+++ b/discoveryengine/apiv1beta/evaluation_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1beta/evaluation_client_example_go123_test.go
+++ b/discoveryengine/apiv1beta/evaluation_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1beta/evaluation_client_example_test.go
+++ b/discoveryengine/apiv1beta/evaluation_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1beta/grounded_generation_client.go
+++ b/discoveryengine/apiv1beta/grounded_generation_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1beta/grounded_generation_client_example_go123_test.go
+++ b/discoveryengine/apiv1beta/grounded_generation_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1beta/grounded_generation_client_example_test.go
+++ b/discoveryengine/apiv1beta/grounded_generation_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1beta/helpers.go
+++ b/discoveryengine/apiv1beta/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1beta/project_client.go
+++ b/discoveryengine/apiv1beta/project_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1beta/project_client_example_go123_test.go
+++ b/discoveryengine/apiv1beta/project_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1beta/project_client_example_test.go
+++ b/discoveryengine/apiv1beta/project_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1beta/rank_client.go
+++ b/discoveryengine/apiv1beta/rank_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1beta/rank_client_example_go123_test.go
+++ b/discoveryengine/apiv1beta/rank_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1beta/rank_client_example_test.go
+++ b/discoveryengine/apiv1beta/rank_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1beta/recommendation_client.go
+++ b/discoveryengine/apiv1beta/recommendation_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1beta/recommendation_client_example_go123_test.go
+++ b/discoveryengine/apiv1beta/recommendation_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1beta/recommendation_client_example_test.go
+++ b/discoveryengine/apiv1beta/recommendation_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1beta/sample_query_client.go
+++ b/discoveryengine/apiv1beta/sample_query_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1beta/sample_query_client_example_go123_test.go
+++ b/discoveryengine/apiv1beta/sample_query_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1beta/sample_query_client_example_test.go
+++ b/discoveryengine/apiv1beta/sample_query_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1beta/sample_query_set_client.go
+++ b/discoveryengine/apiv1beta/sample_query_set_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1beta/sample_query_set_client_example_go123_test.go
+++ b/discoveryengine/apiv1beta/sample_query_set_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1beta/sample_query_set_client_example_test.go
+++ b/discoveryengine/apiv1beta/sample_query_set_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1beta/schema_client.go
+++ b/discoveryengine/apiv1beta/schema_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1beta/schema_client_example_go123_test.go
+++ b/discoveryengine/apiv1beta/schema_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1beta/schema_client_example_test.go
+++ b/discoveryengine/apiv1beta/schema_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1beta/search_client.go
+++ b/discoveryengine/apiv1beta/search_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1beta/search_client_example_go123_test.go
+++ b/discoveryengine/apiv1beta/search_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1beta/search_client_example_test.go
+++ b/discoveryengine/apiv1beta/search_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1beta/search_tuning_client.go
+++ b/discoveryengine/apiv1beta/search_tuning_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1beta/search_tuning_client_example_go123_test.go
+++ b/discoveryengine/apiv1beta/search_tuning_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1beta/search_tuning_client_example_test.go
+++ b/discoveryengine/apiv1beta/search_tuning_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1beta/serving_config_client.go
+++ b/discoveryengine/apiv1beta/serving_config_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1beta/serving_config_client_example_go123_test.go
+++ b/discoveryengine/apiv1beta/serving_config_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1beta/serving_config_client_example_test.go
+++ b/discoveryengine/apiv1beta/serving_config_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1beta/session_client.go
+++ b/discoveryengine/apiv1beta/session_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1beta/session_client_example_go123_test.go
+++ b/discoveryengine/apiv1beta/session_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1beta/session_client_example_test.go
+++ b/discoveryengine/apiv1beta/session_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1beta/site_search_engine_client.go
+++ b/discoveryengine/apiv1beta/site_search_engine_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1beta/site_search_engine_client_example_go123_test.go
+++ b/discoveryengine/apiv1beta/site_search_engine_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1beta/site_search_engine_client_example_test.go
+++ b/discoveryengine/apiv1beta/site_search_engine_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1beta/user_event_client.go
+++ b/discoveryengine/apiv1beta/user_event_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1beta/user_event_client_example_go123_test.go
+++ b/discoveryengine/apiv1beta/user_event_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discoveryengine/apiv1beta/user_event_client_example_test.go
+++ b/discoveryengine/apiv1beta/user_event_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dlp/apiv2/auxiliary.go
+++ b/dlp/apiv2/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dlp/apiv2/auxiliary_go123.go
+++ b/dlp/apiv2/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dlp/apiv2/dlp_client.go
+++ b/dlp/apiv2/dlp_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dlp/apiv2/dlp_client_example_go123_test.go
+++ b/dlp/apiv2/dlp_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dlp/apiv2/dlp_client_example_test.go
+++ b/dlp/apiv2/dlp_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dlp/apiv2/doc.go
+++ b/dlp/apiv2/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dlp/apiv2/helpers.go
+++ b/dlp/apiv2/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/documentai/apiv1/auxiliary.go
+++ b/documentai/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/documentai/apiv1/auxiliary_go123.go
+++ b/documentai/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/documentai/apiv1/doc.go
+++ b/documentai/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/documentai/apiv1/document_processor_client.go
+++ b/documentai/apiv1/document_processor_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/documentai/apiv1/document_processor_client_example_go123_test.go
+++ b/documentai/apiv1/document_processor_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/documentai/apiv1/document_processor_client_example_test.go
+++ b/documentai/apiv1/document_processor_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/documentai/apiv1/helpers.go
+++ b/documentai/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/documentai/apiv1beta3/auxiliary.go
+++ b/documentai/apiv1beta3/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/documentai/apiv1beta3/auxiliary_go123.go
+++ b/documentai/apiv1beta3/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/documentai/apiv1beta3/doc.go
+++ b/documentai/apiv1beta3/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/documentai/apiv1beta3/document_client.go
+++ b/documentai/apiv1beta3/document_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/documentai/apiv1beta3/document_client_example_go123_test.go
+++ b/documentai/apiv1beta3/document_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/documentai/apiv1beta3/document_client_example_test.go
+++ b/documentai/apiv1beta3/document_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/documentai/apiv1beta3/document_processor_client.go
+++ b/documentai/apiv1beta3/document_processor_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/documentai/apiv1beta3/document_processor_client_example_go123_test.go
+++ b/documentai/apiv1beta3/document_processor_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/documentai/apiv1beta3/document_processor_client_example_test.go
+++ b/documentai/apiv1beta3/document_processor_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/documentai/apiv1beta3/helpers.go
+++ b/documentai/apiv1beta3/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/domains/apiv1beta1/auxiliary.go
+++ b/domains/apiv1beta1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/domains/apiv1beta1/auxiliary_go123.go
+++ b/domains/apiv1beta1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/domains/apiv1beta1/doc.go
+++ b/domains/apiv1beta1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/domains/apiv1beta1/domains_client.go
+++ b/domains/apiv1beta1/domains_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/domains/apiv1beta1/domains_client_example_go123_test.go
+++ b/domains/apiv1beta1/domains_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/domains/apiv1beta1/domains_client_example_test.go
+++ b/domains/apiv1beta1/domains_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/domains/apiv1beta1/helpers.go
+++ b/domains/apiv1beta1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/edgecontainer/apiv1/auxiliary.go
+++ b/edgecontainer/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/edgecontainer/apiv1/auxiliary_go123.go
+++ b/edgecontainer/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/edgecontainer/apiv1/doc.go
+++ b/edgecontainer/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/edgecontainer/apiv1/edge_container_client.go
+++ b/edgecontainer/apiv1/edge_container_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/edgecontainer/apiv1/edge_container_client_example_go123_test.go
+++ b/edgecontainer/apiv1/edge_container_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/edgecontainer/apiv1/edge_container_client_example_test.go
+++ b/edgecontainer/apiv1/edge_container_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/edgecontainer/apiv1/helpers.go
+++ b/edgecontainer/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/edgenetwork/apiv1/auxiliary.go
+++ b/edgenetwork/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/edgenetwork/apiv1/auxiliary_go123.go
+++ b/edgenetwork/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/edgenetwork/apiv1/doc.go
+++ b/edgenetwork/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/edgenetwork/apiv1/edge_network_client.go
+++ b/edgenetwork/apiv1/edge_network_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/edgenetwork/apiv1/edge_network_client_example_go123_test.go
+++ b/edgenetwork/apiv1/edge_network_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/edgenetwork/apiv1/edge_network_client_example_test.go
+++ b/edgenetwork/apiv1/edge_network_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/edgenetwork/apiv1/helpers.go
+++ b/edgenetwork/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/errorreporting/apiv1beta1/auxiliary.go
+++ b/errorreporting/apiv1beta1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/errorreporting/apiv1beta1/auxiliary_go123.go
+++ b/errorreporting/apiv1beta1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/errorreporting/apiv1beta1/doc.go
+++ b/errorreporting/apiv1beta1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/errorreporting/apiv1beta1/error_group_client.go
+++ b/errorreporting/apiv1beta1/error_group_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/errorreporting/apiv1beta1/error_group_client_example_go123_test.go
+++ b/errorreporting/apiv1beta1/error_group_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/errorreporting/apiv1beta1/error_group_client_example_test.go
+++ b/errorreporting/apiv1beta1/error_group_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/errorreporting/apiv1beta1/error_stats_client.go
+++ b/errorreporting/apiv1beta1/error_stats_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/errorreporting/apiv1beta1/error_stats_client_example_go123_test.go
+++ b/errorreporting/apiv1beta1/error_stats_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/errorreporting/apiv1beta1/error_stats_client_example_test.go
+++ b/errorreporting/apiv1beta1/error_stats_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/errorreporting/apiv1beta1/helpers.go
+++ b/errorreporting/apiv1beta1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/errorreporting/apiv1beta1/report_errors_client.go
+++ b/errorreporting/apiv1beta1/report_errors_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/errorreporting/apiv1beta1/report_errors_client_example_go123_test.go
+++ b/errorreporting/apiv1beta1/report_errors_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/errorreporting/apiv1beta1/report_errors_client_example_test.go
+++ b/errorreporting/apiv1beta1/report_errors_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/essentialcontacts/apiv1/auxiliary.go
+++ b/essentialcontacts/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/essentialcontacts/apiv1/auxiliary_go123.go
+++ b/essentialcontacts/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/essentialcontacts/apiv1/doc.go
+++ b/essentialcontacts/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/essentialcontacts/apiv1/essential_contacts_client.go
+++ b/essentialcontacts/apiv1/essential_contacts_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/essentialcontacts/apiv1/essential_contacts_client_example_go123_test.go
+++ b/essentialcontacts/apiv1/essential_contacts_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/essentialcontacts/apiv1/essential_contacts_client_example_test.go
+++ b/essentialcontacts/apiv1/essential_contacts_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/essentialcontacts/apiv1/helpers.go
+++ b/essentialcontacts/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/eventarc/apiv1/auxiliary.go
+++ b/eventarc/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/eventarc/apiv1/auxiliary_go123.go
+++ b/eventarc/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/eventarc/apiv1/doc.go
+++ b/eventarc/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/eventarc/apiv1/eventarc_client.go
+++ b/eventarc/apiv1/eventarc_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/eventarc/apiv1/eventarc_client_example_go123_test.go
+++ b/eventarc/apiv1/eventarc_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/eventarc/apiv1/eventarc_client_example_test.go
+++ b/eventarc/apiv1/eventarc_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/eventarc/apiv1/helpers.go
+++ b/eventarc/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/eventarc/publishing/apiv1/auxiliary.go
+++ b/eventarc/publishing/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/eventarc/publishing/apiv1/auxiliary_go123.go
+++ b/eventarc/publishing/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/eventarc/publishing/apiv1/doc.go
+++ b/eventarc/publishing/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/eventarc/publishing/apiv1/helpers.go
+++ b/eventarc/publishing/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/eventarc/publishing/apiv1/publisher_client.go
+++ b/eventarc/publishing/apiv1/publisher_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/eventarc/publishing/apiv1/publisher_client_example_go123_test.go
+++ b/eventarc/publishing/apiv1/publisher_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/eventarc/publishing/apiv1/publisher_client_example_test.go
+++ b/eventarc/publishing/apiv1/publisher_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/filestore/apiv1/auxiliary.go
+++ b/filestore/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/filestore/apiv1/auxiliary_go123.go
+++ b/filestore/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/filestore/apiv1/cloud_filestore_manager_client.go
+++ b/filestore/apiv1/cloud_filestore_manager_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/filestore/apiv1/cloud_filestore_manager_client_example_go123_test.go
+++ b/filestore/apiv1/cloud_filestore_manager_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/filestore/apiv1/cloud_filestore_manager_client_example_test.go
+++ b/filestore/apiv1/cloud_filestore_manager_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/filestore/apiv1/doc.go
+++ b/filestore/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/filestore/apiv1/helpers.go
+++ b/filestore/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/financialservices/apiv1/aml_client.go
+++ b/financialservices/apiv1/aml_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/financialservices/apiv1/aml_client_example_go123_test.go
+++ b/financialservices/apiv1/aml_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/financialservices/apiv1/aml_client_example_test.go
+++ b/financialservices/apiv1/aml_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/financialservices/apiv1/auxiliary.go
+++ b/financialservices/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/financialservices/apiv1/auxiliary_go123.go
+++ b/financialservices/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/financialservices/apiv1/doc.go
+++ b/financialservices/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/financialservices/apiv1/helpers.go
+++ b/financialservices/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/firestore/apiv1/admin/auxiliary.go
+++ b/firestore/apiv1/admin/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/firestore/apiv1/admin/auxiliary_go123.go
+++ b/firestore/apiv1/admin/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/firestore/apiv1/admin/doc.go
+++ b/firestore/apiv1/admin/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/firestore/apiv1/admin/firestore_admin_client.go
+++ b/firestore/apiv1/admin/firestore_admin_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -1650,8 +1650,13 @@ func (c *firestoreAdminGRPCClient) CloneDatabase(ctx context.Context, req *admin
 	if reg := regexp.MustCompile("projects/[^/]+/databases/(?P<database_id>[^/]+)(?:/.*)?"); reg.MatchString(req.GetPitrSnapshot().GetDatabase()) && len(url.QueryEscape(reg.FindStringSubmatch(req.GetPitrSnapshot().GetDatabase())[1])) > 0 {
 		routingHeadersMap["database_id"] = url.QueryEscape(reg.FindStringSubmatch(req.GetPitrSnapshot().GetDatabase())[1])
 	}
-	for headerName, headerValue := range routingHeadersMap {
-		routingHeaders = fmt.Sprintf("%s%s=%s&", routingHeaders, headerName, headerValue)
+	if headerValue, ok := routingHeadersMap["project_id"]; ok {
+		routingHeaders = fmt.Sprintf("%s%s=%s&", routingHeaders, "project_id", headerValue)
+		delete(routingHeadersMap, "project_id")
+	}
+	if headerValue, ok := routingHeadersMap["database_id"]; ok {
+		routingHeaders = fmt.Sprintf("%s%s=%s&", routingHeaders, "database_id", headerValue)
+		delete(routingHeadersMap, "database_id")
 	}
 	routingHeaders = strings.TrimSuffix(routingHeaders, "&")
 	hds := []string{"x-goog-request-params", routingHeaders}
@@ -3578,8 +3583,13 @@ func (c *firestoreAdminRESTClient) CloneDatabase(ctx context.Context, req *admin
 	if reg := regexp.MustCompile("projects/[^/]+/databases/(?P<database_id>[^/]+)(?:/.*)?"); reg.MatchString(req.GetPitrSnapshot().GetDatabase()) && len(url.QueryEscape(reg.FindStringSubmatch(req.GetPitrSnapshot().GetDatabase())[1])) > 0 {
 		routingHeadersMap["database_id"] = url.QueryEscape(reg.FindStringSubmatch(req.GetPitrSnapshot().GetDatabase())[1])
 	}
-	for headerName, headerValue := range routingHeadersMap {
-		routingHeaders = fmt.Sprintf("%s%s=%s&", routingHeaders, headerName, headerValue)
+	if headerValue, ok := routingHeadersMap["project_id"]; ok {
+		routingHeaders = fmt.Sprintf("%s%s=%s&", routingHeaders, "project_id", headerValue)
+		delete(routingHeadersMap, "project_id")
+	}
+	if headerValue, ok := routingHeadersMap["database_id"]; ok {
+		routingHeaders = fmt.Sprintf("%s%s=%s&", routingHeaders, "database_id", headerValue)
+		delete(routingHeadersMap, "database_id")
 	}
 	routingHeaders = strings.TrimSuffix(routingHeaders, "&")
 	hds := []string{"x-goog-request-params", routingHeaders}

--- a/firestore/apiv1/admin/firestore_admin_client_example_go123_test.go
+++ b/firestore/apiv1/admin/firestore_admin_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/firestore/apiv1/admin/firestore_admin_client_example_test.go
+++ b/firestore/apiv1/admin/firestore_admin_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/firestore/apiv1/admin/helpers.go
+++ b/firestore/apiv1/admin/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/firestore/apiv1/auxiliary.go
+++ b/firestore/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/firestore/apiv1/auxiliary_go123.go
+++ b/firestore/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/firestore/apiv1/doc.go
+++ b/firestore/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/firestore/apiv1/firestore_client.go
+++ b/firestore/apiv1/firestore_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -1121,8 +1121,13 @@ func (c *gRPCClient) ExecutePipeline(ctx context.Context, req *firestorepb.Execu
 	if reg := regexp.MustCompile("projects/[^/]+/databases/(?P<database_id>[^/]+)(?:/.*)?"); reg.MatchString(req.GetDatabase()) && len(url.QueryEscape(reg.FindStringSubmatch(req.GetDatabase())[1])) > 0 {
 		routingHeadersMap["database_id"] = url.QueryEscape(reg.FindStringSubmatch(req.GetDatabase())[1])
 	}
-	for headerName, headerValue := range routingHeadersMap {
-		routingHeaders = fmt.Sprintf("%s%s=%s&", routingHeaders, headerName, headerValue)
+	if headerValue, ok := routingHeadersMap["project_id"]; ok {
+		routingHeaders = fmt.Sprintf("%s%s=%s&", routingHeaders, "project_id", headerValue)
+		delete(routingHeadersMap, "project_id")
+	}
+	if headerValue, ok := routingHeadersMap["database_id"]; ok {
+		routingHeaders = fmt.Sprintf("%s%s=%s&", routingHeaders, "database_id", headerValue)
+		delete(routingHeadersMap, "database_id")
 	}
 	routingHeaders = strings.TrimSuffix(routingHeaders, "&")
 	hds := []string{"x-goog-request-params", routingHeaders}
@@ -2092,8 +2097,13 @@ func (c *restClient) ExecutePipeline(ctx context.Context, req *firestorepb.Execu
 	if reg := regexp.MustCompile("projects/[^/]+/databases/(?P<database_id>[^/]+)(?:/.*)?"); reg.MatchString(req.GetDatabase()) && len(url.QueryEscape(reg.FindStringSubmatch(req.GetDatabase())[1])) > 0 {
 		routingHeadersMap["database_id"] = url.QueryEscape(reg.FindStringSubmatch(req.GetDatabase())[1])
 	}
-	for headerName, headerValue := range routingHeadersMap {
-		routingHeaders = fmt.Sprintf("%s%s=%s&", routingHeaders, headerName, headerValue)
+	if headerValue, ok := routingHeadersMap["project_id"]; ok {
+		routingHeaders = fmt.Sprintf("%s%s=%s&", routingHeaders, "project_id", headerValue)
+		delete(routingHeadersMap, "project_id")
+	}
+	if headerValue, ok := routingHeadersMap["database_id"]; ok {
+		routingHeaders = fmt.Sprintf("%s%s=%s&", routingHeaders, "database_id", headerValue)
+		delete(routingHeadersMap, "database_id")
 	}
 	routingHeaders = strings.TrimSuffix(routingHeaders, "&")
 	hds := []string{"x-goog-request-params", routingHeaders}

--- a/firestore/apiv1/firestore_client_example_go123_test.go
+++ b/firestore/apiv1/firestore_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/firestore/apiv1/firestore_client_example_test.go
+++ b/firestore/apiv1/firestore_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/firestore/apiv1/helpers.go
+++ b/firestore/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/functions/apiv1/auxiliary.go
+++ b/functions/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/functions/apiv1/auxiliary_go123.go
+++ b/functions/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/functions/apiv1/cloud_functions_client.go
+++ b/functions/apiv1/cloud_functions_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/functions/apiv1/cloud_functions_client_example_go123_test.go
+++ b/functions/apiv1/cloud_functions_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/functions/apiv1/cloud_functions_client_example_test.go
+++ b/functions/apiv1/cloud_functions_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/functions/apiv1/doc.go
+++ b/functions/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/functions/apiv1/helpers.go
+++ b/functions/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/functions/apiv2/auxiliary.go
+++ b/functions/apiv2/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/functions/apiv2/auxiliary_go123.go
+++ b/functions/apiv2/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/functions/apiv2/doc.go
+++ b/functions/apiv2/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/functions/apiv2/function_client.go
+++ b/functions/apiv2/function_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/functions/apiv2/function_client_example_go123_test.go
+++ b/functions/apiv2/function_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/functions/apiv2/function_client_example_test.go
+++ b/functions/apiv2/function_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/functions/apiv2/helpers.go
+++ b/functions/apiv2/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/functions/apiv2beta/auxiliary.go
+++ b/functions/apiv2beta/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/functions/apiv2beta/auxiliary_go123.go
+++ b/functions/apiv2beta/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/functions/apiv2beta/doc.go
+++ b/functions/apiv2beta/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/functions/apiv2beta/function_client.go
+++ b/functions/apiv2beta/function_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/functions/apiv2beta/function_client_example_go123_test.go
+++ b/functions/apiv2beta/function_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/functions/apiv2beta/function_client_example_test.go
+++ b/functions/apiv2beta/function_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/functions/apiv2beta/helpers.go
+++ b/functions/apiv2beta/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/gkebackup/apiv1/auxiliary.go
+++ b/gkebackup/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/gkebackup/apiv1/auxiliary_go123.go
+++ b/gkebackup/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/gkebackup/apiv1/backup_forgke_client.go
+++ b/gkebackup/apiv1/backup_forgke_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/gkebackup/apiv1/backup_forgke_client_example_go123_test.go
+++ b/gkebackup/apiv1/backup_forgke_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/gkebackup/apiv1/backup_forgke_client_example_test.go
+++ b/gkebackup/apiv1/backup_forgke_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/gkebackup/apiv1/doc.go
+++ b/gkebackup/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/gkebackup/apiv1/helpers.go
+++ b/gkebackup/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/gkeconnect/gateway/apiv1/auxiliary.go
+++ b/gkeconnect/gateway/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/gkeconnect/gateway/apiv1/auxiliary_go123.go
+++ b/gkeconnect/gateway/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/gkeconnect/gateway/apiv1/doc.go
+++ b/gkeconnect/gateway/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/gkeconnect/gateway/apiv1/gateway_control_client.go
+++ b/gkeconnect/gateway/apiv1/gateway_control_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/gkeconnect/gateway/apiv1/gateway_control_client_example_go123_test.go
+++ b/gkeconnect/gateway/apiv1/gateway_control_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/gkeconnect/gateway/apiv1/gateway_control_client_example_test.go
+++ b/gkeconnect/gateway/apiv1/gateway_control_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/gkeconnect/gateway/apiv1/helpers.go
+++ b/gkeconnect/gateway/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/gkeconnect/gateway/apiv1beta1/auxiliary.go
+++ b/gkeconnect/gateway/apiv1beta1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/gkeconnect/gateway/apiv1beta1/auxiliary_go123.go
+++ b/gkeconnect/gateway/apiv1beta1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/gkeconnect/gateway/apiv1beta1/doc.go
+++ b/gkeconnect/gateway/apiv1beta1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/gkeconnect/gateway/apiv1beta1/gateway_control_client.go
+++ b/gkeconnect/gateway/apiv1beta1/gateway_control_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/gkeconnect/gateway/apiv1beta1/gateway_control_client_example_go123_test.go
+++ b/gkeconnect/gateway/apiv1beta1/gateway_control_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/gkeconnect/gateway/apiv1beta1/gateway_control_client_example_test.go
+++ b/gkeconnect/gateway/apiv1beta1/gateway_control_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/gkeconnect/gateway/apiv1beta1/helpers.go
+++ b/gkeconnect/gateway/apiv1beta1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/gkehub/apiv1beta1/auxiliary.go
+++ b/gkehub/apiv1beta1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/gkehub/apiv1beta1/auxiliary_go123.go
+++ b/gkehub/apiv1beta1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/gkehub/apiv1beta1/doc.go
+++ b/gkehub/apiv1beta1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/gkehub/apiv1beta1/gke_hub_membership_client.go
+++ b/gkehub/apiv1beta1/gke_hub_membership_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/gkehub/apiv1beta1/gke_hub_membership_client_example_go123_test.go
+++ b/gkehub/apiv1beta1/gke_hub_membership_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/gkehub/apiv1beta1/gke_hub_membership_client_example_test.go
+++ b/gkehub/apiv1beta1/gke_hub_membership_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/gkehub/apiv1beta1/helpers.go
+++ b/gkehub/apiv1beta1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/gkemulticloud/apiv1/attached_clusters_client.go
+++ b/gkemulticloud/apiv1/attached_clusters_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/gkemulticloud/apiv1/attached_clusters_client_example_go123_test.go
+++ b/gkemulticloud/apiv1/attached_clusters_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/gkemulticloud/apiv1/attached_clusters_client_example_test.go
+++ b/gkemulticloud/apiv1/attached_clusters_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/gkemulticloud/apiv1/auxiliary.go
+++ b/gkemulticloud/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/gkemulticloud/apiv1/auxiliary_go123.go
+++ b/gkemulticloud/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/gkemulticloud/apiv1/aws_clusters_client.go
+++ b/gkemulticloud/apiv1/aws_clusters_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/gkemulticloud/apiv1/aws_clusters_client_example_go123_test.go
+++ b/gkemulticloud/apiv1/aws_clusters_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/gkemulticloud/apiv1/aws_clusters_client_example_test.go
+++ b/gkemulticloud/apiv1/aws_clusters_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/gkemulticloud/apiv1/azure_clusters_client.go
+++ b/gkemulticloud/apiv1/azure_clusters_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/gkemulticloud/apiv1/azure_clusters_client_example_go123_test.go
+++ b/gkemulticloud/apiv1/azure_clusters_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/gkemulticloud/apiv1/azure_clusters_client_example_test.go
+++ b/gkemulticloud/apiv1/azure_clusters_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/gkemulticloud/apiv1/doc.go
+++ b/gkemulticloud/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/gkemulticloud/apiv1/helpers.go
+++ b/gkemulticloud/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/gkerecommender/apiv1/auxiliary.go
+++ b/gkerecommender/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/gkerecommender/apiv1/auxiliary_go123.go
+++ b/gkerecommender/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/gkerecommender/apiv1/doc.go
+++ b/gkerecommender/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/gkerecommender/apiv1/gke_inference_quickstart_client.go
+++ b/gkerecommender/apiv1/gke_inference_quickstart_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/gkerecommender/apiv1/gke_inference_quickstart_client_example_go123_test.go
+++ b/gkerecommender/apiv1/gke_inference_quickstart_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/gkerecommender/apiv1/gke_inference_quickstart_client_example_test.go
+++ b/gkerecommender/apiv1/gke_inference_quickstart_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/gkerecommender/apiv1/helpers.go
+++ b/gkerecommender/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/gsuiteaddons/apiv1/auxiliary.go
+++ b/gsuiteaddons/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/gsuiteaddons/apiv1/auxiliary_go123.go
+++ b/gsuiteaddons/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/gsuiteaddons/apiv1/doc.go
+++ b/gsuiteaddons/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/gsuiteaddons/apiv1/g_suite_add_ons_client.go
+++ b/gsuiteaddons/apiv1/g_suite_add_ons_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/gsuiteaddons/apiv1/g_suite_add_ons_client_example_go123_test.go
+++ b/gsuiteaddons/apiv1/g_suite_add_ons_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/gsuiteaddons/apiv1/g_suite_add_ons_client_example_test.go
+++ b/gsuiteaddons/apiv1/g_suite_add_ons_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/gsuiteaddons/apiv1/helpers.go
+++ b/gsuiteaddons/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/hypercomputecluster/apiv1beta/auxiliary.go
+++ b/hypercomputecluster/apiv1beta/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/hypercomputecluster/apiv1beta/auxiliary_go123.go
+++ b/hypercomputecluster/apiv1beta/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/hypercomputecluster/apiv1beta/doc.go
+++ b/hypercomputecluster/apiv1beta/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/hypercomputecluster/apiv1beta/helpers.go
+++ b/hypercomputecluster/apiv1beta/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/hypercomputecluster/apiv1beta/hypercompute_cluster_client.go
+++ b/hypercomputecluster/apiv1beta/hypercompute_cluster_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/hypercomputecluster/apiv1beta/hypercompute_cluster_client_example_go123_test.go
+++ b/hypercomputecluster/apiv1beta/hypercompute_cluster_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/hypercomputecluster/apiv1beta/hypercompute_cluster_client_example_test.go
+++ b/hypercomputecluster/apiv1beta/hypercompute_cluster_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iam/apiv1/auxiliary.go
+++ b/iam/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iam/apiv1/auxiliary_go123.go
+++ b/iam/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iam/apiv1/doc.go
+++ b/iam/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iam/apiv1/helpers.go
+++ b/iam/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iam/apiv1/iam_policy_client.go
+++ b/iam/apiv1/iam_policy_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iam/apiv1/iam_policy_client_example_go123_test.go
+++ b/iam/apiv1/iam_policy_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iam/apiv1/iam_policy_client_example_test.go
+++ b/iam/apiv1/iam_policy_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iam/apiv2/auxiliary.go
+++ b/iam/apiv2/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iam/apiv2/auxiliary_go123.go
+++ b/iam/apiv2/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iam/apiv2/doc.go
+++ b/iam/apiv2/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iam/apiv2/helpers.go
+++ b/iam/apiv2/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iam/apiv2/policies_client.go
+++ b/iam/apiv2/policies_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iam/apiv2/policies_client_example_go123_test.go
+++ b/iam/apiv2/policies_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iam/apiv2/policies_client_example_test.go
+++ b/iam/apiv2/policies_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iam/apiv3/auxiliary.go
+++ b/iam/apiv3/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iam/apiv3/auxiliary_go123.go
+++ b/iam/apiv3/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iam/apiv3/doc.go
+++ b/iam/apiv3/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iam/apiv3/helpers.go
+++ b/iam/apiv3/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iam/apiv3/policy_bindings_client.go
+++ b/iam/apiv3/policy_bindings_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iam/apiv3/policy_bindings_client_example_go123_test.go
+++ b/iam/apiv3/policy_bindings_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iam/apiv3/policy_bindings_client_example_test.go
+++ b/iam/apiv3/policy_bindings_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iam/apiv3/principal_access_boundary_policies_client.go
+++ b/iam/apiv3/principal_access_boundary_policies_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iam/apiv3/principal_access_boundary_policies_client_example_go123_test.go
+++ b/iam/apiv3/principal_access_boundary_policies_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iam/apiv3/principal_access_boundary_policies_client_example_test.go
+++ b/iam/apiv3/principal_access_boundary_policies_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iam/apiv3beta/auxiliary.go
+++ b/iam/apiv3beta/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iam/apiv3beta/auxiliary_go123.go
+++ b/iam/apiv3beta/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iam/apiv3beta/doc.go
+++ b/iam/apiv3beta/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iam/apiv3beta/helpers.go
+++ b/iam/apiv3beta/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iam/apiv3beta/policy_bindings_client.go
+++ b/iam/apiv3beta/policy_bindings_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iam/apiv3beta/policy_bindings_client_example_go123_test.go
+++ b/iam/apiv3beta/policy_bindings_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iam/apiv3beta/policy_bindings_client_example_test.go
+++ b/iam/apiv3beta/policy_bindings_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iam/apiv3beta/principal_access_boundary_policies_client.go
+++ b/iam/apiv3beta/principal_access_boundary_policies_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iam/apiv3beta/principal_access_boundary_policies_client_example_go123_test.go
+++ b/iam/apiv3beta/principal_access_boundary_policies_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iam/apiv3beta/principal_access_boundary_policies_client_example_test.go
+++ b/iam/apiv3beta/principal_access_boundary_policies_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iam/credentials/apiv1/auxiliary.go
+++ b/iam/credentials/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iam/credentials/apiv1/auxiliary_go123.go
+++ b/iam/credentials/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iam/credentials/apiv1/doc.go
+++ b/iam/credentials/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iam/credentials/apiv1/helpers.go
+++ b/iam/credentials/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iam/credentials/apiv1/iam_credentials_client.go
+++ b/iam/credentials/apiv1/iam_credentials_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iam/credentials/apiv1/iam_credentials_client_example_go123_test.go
+++ b/iam/credentials/apiv1/iam_credentials_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iam/credentials/apiv1/iam_credentials_client_example_test.go
+++ b/iam/credentials/apiv1/iam_credentials_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iap/apiv1/auxiliary.go
+++ b/iap/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iap/apiv1/auxiliary_go123.go
+++ b/iap/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iap/apiv1/doc.go
+++ b/iap/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iap/apiv1/helpers.go
+++ b/iap/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iap/apiv1/identity_aware_proxy_admin_client.go
+++ b/iap/apiv1/identity_aware_proxy_admin_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iap/apiv1/identity_aware_proxy_admin_client_example_go123_test.go
+++ b/iap/apiv1/identity_aware_proxy_admin_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iap/apiv1/identity_aware_proxy_admin_client_example_test.go
+++ b/iap/apiv1/identity_aware_proxy_admin_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iap/apiv1/identity_aware_proxyo_auth_client.go
+++ b/iap/apiv1/identity_aware_proxyo_auth_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iap/apiv1/identity_aware_proxyo_auth_client_example_go123_test.go
+++ b/iap/apiv1/identity_aware_proxyo_auth_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iap/apiv1/identity_aware_proxyo_auth_client_example_test.go
+++ b/iap/apiv1/identity_aware_proxyo_auth_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/identitytoolkit/apiv2/account_management_client.go
+++ b/identitytoolkit/apiv2/account_management_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/identitytoolkit/apiv2/account_management_client_example_go123_test.go
+++ b/identitytoolkit/apiv2/account_management_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/identitytoolkit/apiv2/account_management_client_example_test.go
+++ b/identitytoolkit/apiv2/account_management_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/identitytoolkit/apiv2/authentication_client.go
+++ b/identitytoolkit/apiv2/authentication_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/identitytoolkit/apiv2/authentication_client_example_go123_test.go
+++ b/identitytoolkit/apiv2/authentication_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/identitytoolkit/apiv2/authentication_client_example_test.go
+++ b/identitytoolkit/apiv2/authentication_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/identitytoolkit/apiv2/auxiliary.go
+++ b/identitytoolkit/apiv2/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/identitytoolkit/apiv2/auxiliary_go123.go
+++ b/identitytoolkit/apiv2/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/identitytoolkit/apiv2/doc.go
+++ b/identitytoolkit/apiv2/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/identitytoolkit/apiv2/helpers.go
+++ b/identitytoolkit/apiv2/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ids/apiv1/auxiliary.go
+++ b/ids/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ids/apiv1/auxiliary_go123.go
+++ b/ids/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ids/apiv1/doc.go
+++ b/ids/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ids/apiv1/helpers.go
+++ b/ids/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ids/apiv1/ids_client.go
+++ b/ids/apiv1/ids_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ids/apiv1/ids_client_example_go123_test.go
+++ b/ids/apiv1/ids_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ids/apiv1/ids_client_example_test.go
+++ b/ids/apiv1/ids_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/accessapproval/apiv1/Client/ApproveApprovalRequest/main.go
+++ b/internal/generated/snippets/accessapproval/apiv1/Client/ApproveApprovalRequest/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/accessapproval/apiv1/Client/DeleteAccessApprovalSettings/main.go
+++ b/internal/generated/snippets/accessapproval/apiv1/Client/DeleteAccessApprovalSettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/accessapproval/apiv1/Client/DismissApprovalRequest/main.go
+++ b/internal/generated/snippets/accessapproval/apiv1/Client/DismissApprovalRequest/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/accessapproval/apiv1/Client/GetAccessApprovalServiceAccount/main.go
+++ b/internal/generated/snippets/accessapproval/apiv1/Client/GetAccessApprovalServiceAccount/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/accessapproval/apiv1/Client/GetAccessApprovalSettings/main.go
+++ b/internal/generated/snippets/accessapproval/apiv1/Client/GetAccessApprovalSettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/accessapproval/apiv1/Client/GetApprovalRequest/main.go
+++ b/internal/generated/snippets/accessapproval/apiv1/Client/GetApprovalRequest/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/accessapproval/apiv1/Client/InvalidateApprovalRequest/main.go
+++ b/internal/generated/snippets/accessapproval/apiv1/Client/InvalidateApprovalRequest/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/accessapproval/apiv1/Client/ListApprovalRequests/main.go
+++ b/internal/generated/snippets/accessapproval/apiv1/Client/ListApprovalRequests/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/accessapproval/apiv1/Client/UpdateAccessApprovalSettings/main.go
+++ b/internal/generated/snippets/accessapproval/apiv1/Client/UpdateAccessApprovalSettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/accesscontextmanager/apiv1/Client/CommitServicePerimeters/main.go
+++ b/internal/generated/snippets/accesscontextmanager/apiv1/Client/CommitServicePerimeters/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/accesscontextmanager/apiv1/Client/CreateAccessLevel/main.go
+++ b/internal/generated/snippets/accesscontextmanager/apiv1/Client/CreateAccessLevel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/accesscontextmanager/apiv1/Client/CreateAccessPolicy/main.go
+++ b/internal/generated/snippets/accesscontextmanager/apiv1/Client/CreateAccessPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/accesscontextmanager/apiv1/Client/CreateGcpUserAccessBinding/main.go
+++ b/internal/generated/snippets/accesscontextmanager/apiv1/Client/CreateGcpUserAccessBinding/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/accesscontextmanager/apiv1/Client/CreateServicePerimeter/main.go
+++ b/internal/generated/snippets/accesscontextmanager/apiv1/Client/CreateServicePerimeter/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/accesscontextmanager/apiv1/Client/DeleteAccessLevel/main.go
+++ b/internal/generated/snippets/accesscontextmanager/apiv1/Client/DeleteAccessLevel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/accesscontextmanager/apiv1/Client/DeleteAccessPolicy/main.go
+++ b/internal/generated/snippets/accesscontextmanager/apiv1/Client/DeleteAccessPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/accesscontextmanager/apiv1/Client/DeleteGcpUserAccessBinding/main.go
+++ b/internal/generated/snippets/accesscontextmanager/apiv1/Client/DeleteGcpUserAccessBinding/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/accesscontextmanager/apiv1/Client/DeleteServicePerimeter/main.go
+++ b/internal/generated/snippets/accesscontextmanager/apiv1/Client/DeleteServicePerimeter/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/accesscontextmanager/apiv1/Client/GetAccessLevel/main.go
+++ b/internal/generated/snippets/accesscontextmanager/apiv1/Client/GetAccessLevel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/accesscontextmanager/apiv1/Client/GetAccessPolicy/main.go
+++ b/internal/generated/snippets/accesscontextmanager/apiv1/Client/GetAccessPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/accesscontextmanager/apiv1/Client/GetGcpUserAccessBinding/main.go
+++ b/internal/generated/snippets/accesscontextmanager/apiv1/Client/GetGcpUserAccessBinding/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/accesscontextmanager/apiv1/Client/GetIamPolicy/main.go
+++ b/internal/generated/snippets/accesscontextmanager/apiv1/Client/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/accesscontextmanager/apiv1/Client/GetOperation/main.go
+++ b/internal/generated/snippets/accesscontextmanager/apiv1/Client/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/accesscontextmanager/apiv1/Client/GetServicePerimeter/main.go
+++ b/internal/generated/snippets/accesscontextmanager/apiv1/Client/GetServicePerimeter/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/accesscontextmanager/apiv1/Client/ListAccessLevels/main.go
+++ b/internal/generated/snippets/accesscontextmanager/apiv1/Client/ListAccessLevels/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/accesscontextmanager/apiv1/Client/ListAccessPolicies/main.go
+++ b/internal/generated/snippets/accesscontextmanager/apiv1/Client/ListAccessPolicies/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/accesscontextmanager/apiv1/Client/ListGcpUserAccessBindings/main.go
+++ b/internal/generated/snippets/accesscontextmanager/apiv1/Client/ListGcpUserAccessBindings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/accesscontextmanager/apiv1/Client/ListServicePerimeters/main.go
+++ b/internal/generated/snippets/accesscontextmanager/apiv1/Client/ListServicePerimeters/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/accesscontextmanager/apiv1/Client/ReplaceAccessLevels/main.go
+++ b/internal/generated/snippets/accesscontextmanager/apiv1/Client/ReplaceAccessLevels/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/accesscontextmanager/apiv1/Client/ReplaceServicePerimeters/main.go
+++ b/internal/generated/snippets/accesscontextmanager/apiv1/Client/ReplaceServicePerimeters/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/accesscontextmanager/apiv1/Client/SetIamPolicy/main.go
+++ b/internal/generated/snippets/accesscontextmanager/apiv1/Client/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/accesscontextmanager/apiv1/Client/TestIamPermissions/main.go
+++ b/internal/generated/snippets/accesscontextmanager/apiv1/Client/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/accesscontextmanager/apiv1/Client/UpdateAccessLevel/main.go
+++ b/internal/generated/snippets/accesscontextmanager/apiv1/Client/UpdateAccessLevel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/accesscontextmanager/apiv1/Client/UpdateAccessPolicy/main.go
+++ b/internal/generated/snippets/accesscontextmanager/apiv1/Client/UpdateAccessPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/accesscontextmanager/apiv1/Client/UpdateGcpUserAccessBinding/main.go
+++ b/internal/generated/snippets/accesscontextmanager/apiv1/Client/UpdateGcpUserAccessBinding/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/accesscontextmanager/apiv1/Client/UpdateServicePerimeter/main.go
+++ b/internal/generated/snippets/accesscontextmanager/apiv1/Client/UpdateServicePerimeter/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/advisorynotifications/apiv1/Client/GetNotification/main.go
+++ b/internal/generated/snippets/advisorynotifications/apiv1/Client/GetNotification/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/advisorynotifications/apiv1/Client/GetSettings/main.go
+++ b/internal/generated/snippets/advisorynotifications/apiv1/Client/GetSettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/advisorynotifications/apiv1/Client/ListNotifications/main.go
+++ b/internal/generated/snippets/advisorynotifications/apiv1/Client/ListNotifications/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/advisorynotifications/apiv1/Client/UpdateSettings/main.go
+++ b/internal/generated/snippets/advisorynotifications/apiv1/Client/UpdateSettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1/GenerativeClient/BatchEmbedContents/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1/GenerativeClient/BatchEmbedContents/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1/GenerativeClient/CancelOperation/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1/GenerativeClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1/GenerativeClient/CountTokens/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1/GenerativeClient/CountTokens/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1/GenerativeClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1/GenerativeClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1/GenerativeClient/EmbedContent/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1/GenerativeClient/EmbedContent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1/GenerativeClient/GenerateContent/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1/GenerativeClient/GenerateContent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1/GenerativeClient/GetOperation/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1/GenerativeClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1/GenerativeClient/ListOperations/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1/GenerativeClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1/ModelClient/CancelOperation/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1/ModelClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1/ModelClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1/ModelClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1/ModelClient/GetModel/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1/ModelClient/GetModel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1/ModelClient/GetOperation/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1/ModelClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1/ModelClient/ListModels/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1/ModelClient/ListModels/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1/ModelClient/ListOperations/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1/ModelClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1alpha/CacheClient/CreateCachedContent/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1alpha/CacheClient/CreateCachedContent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1alpha/CacheClient/DeleteCachedContent/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1alpha/CacheClient/DeleteCachedContent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1alpha/CacheClient/GetCachedContent/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1alpha/CacheClient/GetCachedContent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1alpha/CacheClient/GetOperation/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1alpha/CacheClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1alpha/CacheClient/ListCachedContents/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1alpha/CacheClient/ListCachedContents/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1alpha/CacheClient/ListOperations/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1alpha/CacheClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1alpha/CacheClient/UpdateCachedContent/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1alpha/CacheClient/UpdateCachedContent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1alpha/DiscussClient/CountMessageTokens/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1alpha/DiscussClient/CountMessageTokens/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1alpha/DiscussClient/GenerateMessage/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1alpha/DiscussClient/GenerateMessage/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1alpha/DiscussClient/GetOperation/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1alpha/DiscussClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1alpha/DiscussClient/ListOperations/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1alpha/DiscussClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1alpha/FileClient/CreateFile/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1alpha/FileClient/CreateFile/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1alpha/FileClient/DeleteFile/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1alpha/FileClient/DeleteFile/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1alpha/FileClient/GetFile/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1alpha/FileClient/GetFile/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1alpha/FileClient/GetOperation/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1alpha/FileClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1alpha/FileClient/ListFiles/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1alpha/FileClient/ListFiles/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1alpha/FileClient/ListOperations/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1alpha/FileClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1alpha/GenerativeClient/BatchEmbedContents/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1alpha/GenerativeClient/BatchEmbedContents/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1alpha/GenerativeClient/BidiGenerateContent/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1alpha/GenerativeClient/BidiGenerateContent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1alpha/GenerativeClient/CountTokens/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1alpha/GenerativeClient/CountTokens/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1alpha/GenerativeClient/EmbedContent/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1alpha/GenerativeClient/EmbedContent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1alpha/GenerativeClient/GenerateAnswer/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1alpha/GenerativeClient/GenerateAnswer/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1alpha/GenerativeClient/GenerateContent/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1alpha/GenerativeClient/GenerateContent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1alpha/GenerativeClient/GetOperation/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1alpha/GenerativeClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1alpha/GenerativeClient/ListOperations/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1alpha/GenerativeClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1alpha/ModelClient/CreateTunedModel/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1alpha/ModelClient/CreateTunedModel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1alpha/ModelClient/DeleteTunedModel/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1alpha/ModelClient/DeleteTunedModel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1alpha/ModelClient/GetModel/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1alpha/ModelClient/GetModel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1alpha/ModelClient/GetOperation/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1alpha/ModelClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1alpha/ModelClient/GetTunedModel/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1alpha/ModelClient/GetTunedModel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1alpha/ModelClient/ListModels/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1alpha/ModelClient/ListModels/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1alpha/ModelClient/ListOperations/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1alpha/ModelClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1alpha/ModelClient/ListTunedModels/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1alpha/ModelClient/ListTunedModels/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1alpha/ModelClient/UpdateTunedModel/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1alpha/ModelClient/UpdateTunedModel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1alpha/PermissionClient/CreatePermission/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1alpha/PermissionClient/CreatePermission/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1alpha/PermissionClient/DeletePermission/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1alpha/PermissionClient/DeletePermission/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1alpha/PermissionClient/GetOperation/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1alpha/PermissionClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1alpha/PermissionClient/GetPermission/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1alpha/PermissionClient/GetPermission/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1alpha/PermissionClient/ListOperations/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1alpha/PermissionClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1alpha/PermissionClient/ListPermissions/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1alpha/PermissionClient/ListPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1alpha/PermissionClient/TransferOwnership/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1alpha/PermissionClient/TransferOwnership/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1alpha/PermissionClient/UpdatePermission/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1alpha/PermissionClient/UpdatePermission/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1alpha/PredictionClient/GetOperation/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1alpha/PredictionClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1alpha/PredictionClient/ListOperations/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1alpha/PredictionClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1alpha/PredictionClient/Predict/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1alpha/PredictionClient/Predict/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1alpha/RetrieverClient/BatchCreateChunks/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1alpha/RetrieverClient/BatchCreateChunks/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1alpha/RetrieverClient/BatchDeleteChunks/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1alpha/RetrieverClient/BatchDeleteChunks/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1alpha/RetrieverClient/BatchUpdateChunks/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1alpha/RetrieverClient/BatchUpdateChunks/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1alpha/RetrieverClient/CreateChunk/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1alpha/RetrieverClient/CreateChunk/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1alpha/RetrieverClient/CreateCorpus/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1alpha/RetrieverClient/CreateCorpus/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1alpha/RetrieverClient/CreateDocument/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1alpha/RetrieverClient/CreateDocument/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1alpha/RetrieverClient/DeleteChunk/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1alpha/RetrieverClient/DeleteChunk/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1alpha/RetrieverClient/DeleteCorpus/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1alpha/RetrieverClient/DeleteCorpus/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1alpha/RetrieverClient/DeleteDocument/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1alpha/RetrieverClient/DeleteDocument/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1alpha/RetrieverClient/GetChunk/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1alpha/RetrieverClient/GetChunk/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1alpha/RetrieverClient/GetCorpus/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1alpha/RetrieverClient/GetCorpus/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1alpha/RetrieverClient/GetDocument/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1alpha/RetrieverClient/GetDocument/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1alpha/RetrieverClient/GetOperation/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1alpha/RetrieverClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1alpha/RetrieverClient/ListChunks/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1alpha/RetrieverClient/ListChunks/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1alpha/RetrieverClient/ListCorpora/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1alpha/RetrieverClient/ListCorpora/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1alpha/RetrieverClient/ListDocuments/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1alpha/RetrieverClient/ListDocuments/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1alpha/RetrieverClient/ListOperations/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1alpha/RetrieverClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1alpha/RetrieverClient/QueryCorpus/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1alpha/RetrieverClient/QueryCorpus/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1alpha/RetrieverClient/QueryDocument/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1alpha/RetrieverClient/QueryDocument/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1alpha/RetrieverClient/UpdateChunk/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1alpha/RetrieverClient/UpdateChunk/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1alpha/RetrieverClient/UpdateCorpus/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1alpha/RetrieverClient/UpdateCorpus/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1alpha/RetrieverClient/UpdateDocument/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1alpha/RetrieverClient/UpdateDocument/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1alpha/TextClient/BatchEmbedText/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1alpha/TextClient/BatchEmbedText/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1alpha/TextClient/CountTextTokens/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1alpha/TextClient/CountTextTokens/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1alpha/TextClient/EmbedText/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1alpha/TextClient/EmbedText/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1alpha/TextClient/GenerateText/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1alpha/TextClient/GenerateText/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1alpha/TextClient/GetOperation/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1alpha/TextClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1alpha/TextClient/ListOperations/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1alpha/TextClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/CacheClient/CancelOperation/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/CacheClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/CacheClient/CreateCachedContent/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/CacheClient/CreateCachedContent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/CacheClient/DeleteCachedContent/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/CacheClient/DeleteCachedContent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/CacheClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/CacheClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/CacheClient/GetCachedContent/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/CacheClient/GetCachedContent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/CacheClient/GetOperation/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/CacheClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/CacheClient/ListCachedContents/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/CacheClient/ListCachedContents/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/CacheClient/ListOperations/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/CacheClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/CacheClient/UpdateCachedContent/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/CacheClient/UpdateCachedContent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/DiscussClient/CancelOperation/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/DiscussClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/DiscussClient/CountMessageTokens/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/DiscussClient/CountMessageTokens/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/DiscussClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/DiscussClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/DiscussClient/GenerateMessage/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/DiscussClient/GenerateMessage/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/DiscussClient/GetOperation/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/DiscussClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/DiscussClient/ListOperations/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/DiscussClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/FileClient/CancelOperation/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/FileClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/FileClient/CreateFile/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/FileClient/CreateFile/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/FileClient/DeleteFile/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/FileClient/DeleteFile/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/FileClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/FileClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/FileClient/DownloadFile/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/FileClient/DownloadFile/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/FileClient/GetFile/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/FileClient/GetFile/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/FileClient/GetOperation/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/FileClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/FileClient/ListFiles/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/FileClient/ListFiles/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/FileClient/ListOperations/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/FileClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/GenerativeClient/BatchEmbedContents/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/GenerativeClient/BatchEmbedContents/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/GenerativeClient/BidiGenerateContent/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/GenerativeClient/BidiGenerateContent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/GenerativeClient/CancelOperation/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/GenerativeClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/GenerativeClient/CountTokens/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/GenerativeClient/CountTokens/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/GenerativeClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/GenerativeClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/GenerativeClient/EmbedContent/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/GenerativeClient/EmbedContent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/GenerativeClient/GenerateAnswer/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/GenerativeClient/GenerateAnswer/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/GenerativeClient/GenerateContent/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/GenerativeClient/GenerateContent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/GenerativeClient/GetOperation/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/GenerativeClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/GenerativeClient/ListOperations/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/GenerativeClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/ModelClient/CancelOperation/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/ModelClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/ModelClient/CreateTunedModel/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/ModelClient/CreateTunedModel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/ModelClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/ModelClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/ModelClient/DeleteTunedModel/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/ModelClient/DeleteTunedModel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/ModelClient/GetModel/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/ModelClient/GetModel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/ModelClient/GetOperation/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/ModelClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/ModelClient/GetTunedModel/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/ModelClient/GetTunedModel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/ModelClient/ListModels/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/ModelClient/ListModels/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/ModelClient/ListOperations/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/ModelClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/ModelClient/ListTunedModels/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/ModelClient/ListTunedModels/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/ModelClient/UpdateTunedModel/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/ModelClient/UpdateTunedModel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/PermissionClient/CancelOperation/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/PermissionClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/PermissionClient/CreatePermission/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/PermissionClient/CreatePermission/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/PermissionClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/PermissionClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/PermissionClient/DeletePermission/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/PermissionClient/DeletePermission/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/PermissionClient/GetOperation/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/PermissionClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/PermissionClient/GetPermission/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/PermissionClient/GetPermission/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/PermissionClient/ListOperations/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/PermissionClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/PermissionClient/ListPermissions/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/PermissionClient/ListPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/PermissionClient/TransferOwnership/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/PermissionClient/TransferOwnership/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/PermissionClient/UpdatePermission/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/PermissionClient/UpdatePermission/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/PredictionClient/CancelOperation/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/PredictionClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/PredictionClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/PredictionClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/PredictionClient/GetOperation/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/PredictionClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/PredictionClient/ListOperations/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/PredictionClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/PredictionClient/Predict/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/PredictionClient/Predict/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/PredictionClient/PredictLongRunning/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/PredictionClient/PredictLongRunning/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/RetrieverClient/BatchCreateChunks/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/RetrieverClient/BatchCreateChunks/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/RetrieverClient/BatchDeleteChunks/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/RetrieverClient/BatchDeleteChunks/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/RetrieverClient/BatchUpdateChunks/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/RetrieverClient/BatchUpdateChunks/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/RetrieverClient/CancelOperation/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/RetrieverClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/RetrieverClient/CreateChunk/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/RetrieverClient/CreateChunk/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/RetrieverClient/CreateCorpus/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/RetrieverClient/CreateCorpus/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/RetrieverClient/CreateDocument/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/RetrieverClient/CreateDocument/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/RetrieverClient/DeleteChunk/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/RetrieverClient/DeleteChunk/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/RetrieverClient/DeleteCorpus/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/RetrieverClient/DeleteCorpus/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/RetrieverClient/DeleteDocument/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/RetrieverClient/DeleteDocument/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/RetrieverClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/RetrieverClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/RetrieverClient/GetChunk/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/RetrieverClient/GetChunk/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/RetrieverClient/GetCorpus/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/RetrieverClient/GetCorpus/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/RetrieverClient/GetDocument/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/RetrieverClient/GetDocument/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/RetrieverClient/GetOperation/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/RetrieverClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/RetrieverClient/ListChunks/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/RetrieverClient/ListChunks/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/RetrieverClient/ListCorpora/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/RetrieverClient/ListCorpora/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/RetrieverClient/ListDocuments/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/RetrieverClient/ListDocuments/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/RetrieverClient/ListOperations/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/RetrieverClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/RetrieverClient/QueryCorpus/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/RetrieverClient/QueryCorpus/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/RetrieverClient/QueryDocument/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/RetrieverClient/QueryDocument/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/RetrieverClient/UpdateChunk/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/RetrieverClient/UpdateChunk/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/RetrieverClient/UpdateCorpus/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/RetrieverClient/UpdateCorpus/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/RetrieverClient/UpdateDocument/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/RetrieverClient/UpdateDocument/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/TextClient/BatchEmbedText/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/TextClient/BatchEmbedText/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/TextClient/CancelOperation/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/TextClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/TextClient/CountTextTokens/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/TextClient/CountTextTokens/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/TextClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/TextClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/TextClient/EmbedText/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/TextClient/EmbedText/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/TextClient/GenerateText/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/TextClient/GenerateText/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/TextClient/GetOperation/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/TextClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/TextClient/ListOperations/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/TextClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta2/DiscussClient/CountMessageTokens/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta2/DiscussClient/CountMessageTokens/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta2/DiscussClient/GenerateMessage/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta2/DiscussClient/GenerateMessage/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta2/ModelClient/GetModel/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta2/ModelClient/GetModel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta2/ModelClient/ListModels/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta2/ModelClient/ListModels/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta2/TextClient/EmbedText/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta2/TextClient/EmbedText/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta2/TextClient/GenerateText/main.go
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta2/TextClient/GenerateText/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/AcknowledgeUserDataCollection/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/AcknowledgeUserDataCollection/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/ApproveDisplayVideo360AdvertiserLinkProposal/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/ApproveDisplayVideo360AdvertiserLinkProposal/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/ArchiveAudience/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/ArchiveAudience/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/ArchiveCustomDimension/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/ArchiveCustomDimension/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/ArchiveCustomMetric/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/ArchiveCustomMetric/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/BatchCreateAccessBindings/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/BatchCreateAccessBindings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/BatchDeleteAccessBindings/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/BatchDeleteAccessBindings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/BatchGetAccessBindings/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/BatchGetAccessBindings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/BatchUpdateAccessBindings/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/BatchUpdateAccessBindings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/CancelDisplayVideo360AdvertiserLinkProposal/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/CancelDisplayVideo360AdvertiserLinkProposal/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/CreateAccessBinding/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/CreateAccessBinding/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/CreateAdSenseLink/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/CreateAdSenseLink/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/CreateAudience/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/CreateAudience/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/CreateBigQueryLink/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/CreateBigQueryLink/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/CreateCalculatedMetric/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/CreateCalculatedMetric/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/CreateChannelGroup/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/CreateChannelGroup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/CreateConversionEvent/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/CreateConversionEvent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/CreateCustomDimension/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/CreateCustomDimension/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/CreateCustomMetric/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/CreateCustomMetric/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/CreateDataStream/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/CreateDataStream/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/CreateDisplayVideo360AdvertiserLink/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/CreateDisplayVideo360AdvertiserLink/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/CreateDisplayVideo360AdvertiserLinkProposal/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/CreateDisplayVideo360AdvertiserLinkProposal/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/CreateEventCreateRule/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/CreateEventCreateRule/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/CreateEventEditRule/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/CreateEventEditRule/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/CreateExpandedDataSet/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/CreateExpandedDataSet/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/CreateFirebaseLink/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/CreateFirebaseLink/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/CreateGoogleAdsLink/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/CreateGoogleAdsLink/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/CreateKeyEvent/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/CreateKeyEvent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/CreateMeasurementProtocolSecret/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/CreateMeasurementProtocolSecret/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/CreateProperty/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/CreateProperty/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/CreateReportingDataAnnotation/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/CreateReportingDataAnnotation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/CreateRollupProperty/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/CreateRollupProperty/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/CreateRollupPropertySourceLink/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/CreateRollupPropertySourceLink/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/CreateSKAdNetworkConversionValueSchema/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/CreateSKAdNetworkConversionValueSchema/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/CreateSearchAds360Link/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/CreateSearchAds360Link/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/CreateSubpropertyEventFilter/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/CreateSubpropertyEventFilter/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/DeleteAccessBinding/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/DeleteAccessBinding/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/DeleteAccount/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/DeleteAccount/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/DeleteAdSenseLink/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/DeleteAdSenseLink/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/DeleteBigQueryLink/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/DeleteBigQueryLink/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/DeleteCalculatedMetric/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/DeleteCalculatedMetric/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/DeleteChannelGroup/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/DeleteChannelGroup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/DeleteConversionEvent/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/DeleteConversionEvent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/DeleteDataStream/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/DeleteDataStream/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/DeleteDisplayVideo360AdvertiserLink/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/DeleteDisplayVideo360AdvertiserLink/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/DeleteDisplayVideo360AdvertiserLinkProposal/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/DeleteDisplayVideo360AdvertiserLinkProposal/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/DeleteEventCreateRule/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/DeleteEventCreateRule/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/DeleteEventEditRule/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/DeleteEventEditRule/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/DeleteExpandedDataSet/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/DeleteExpandedDataSet/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/DeleteFirebaseLink/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/DeleteFirebaseLink/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/DeleteGoogleAdsLink/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/DeleteGoogleAdsLink/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/DeleteKeyEvent/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/DeleteKeyEvent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/DeleteMeasurementProtocolSecret/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/DeleteMeasurementProtocolSecret/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/DeleteProperty/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/DeleteProperty/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/DeleteReportingDataAnnotation/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/DeleteReportingDataAnnotation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/DeleteRollupPropertySourceLink/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/DeleteRollupPropertySourceLink/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/DeleteSKAdNetworkConversionValueSchema/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/DeleteSKAdNetworkConversionValueSchema/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/DeleteSearchAds360Link/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/DeleteSearchAds360Link/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/DeleteSubpropertyEventFilter/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/DeleteSubpropertyEventFilter/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/GetAccessBinding/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/GetAccessBinding/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/GetAccount/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/GetAccount/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/GetAdSenseLink/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/GetAdSenseLink/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/GetAttributionSettings/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/GetAttributionSettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/GetAudience/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/GetAudience/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/GetBigQueryLink/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/GetBigQueryLink/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/GetCalculatedMetric/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/GetCalculatedMetric/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/GetChannelGroup/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/GetChannelGroup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/GetConversionEvent/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/GetConversionEvent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/GetCustomDimension/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/GetCustomDimension/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/GetCustomMetric/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/GetCustomMetric/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/GetDataRedactionSettings/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/GetDataRedactionSettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/GetDataRetentionSettings/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/GetDataRetentionSettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/GetDataSharingSettings/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/GetDataSharingSettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/GetDataStream/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/GetDataStream/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/GetDisplayVideo360AdvertiserLink/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/GetDisplayVideo360AdvertiserLink/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/GetDisplayVideo360AdvertiserLinkProposal/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/GetDisplayVideo360AdvertiserLinkProposal/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/GetEnhancedMeasurementSettings/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/GetEnhancedMeasurementSettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/GetEventCreateRule/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/GetEventCreateRule/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/GetEventEditRule/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/GetEventEditRule/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/GetExpandedDataSet/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/GetExpandedDataSet/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/GetGlobalSiteTag/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/GetGlobalSiteTag/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/GetGoogleSignalsSettings/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/GetGoogleSignalsSettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/GetKeyEvent/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/GetKeyEvent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/GetMeasurementProtocolSecret/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/GetMeasurementProtocolSecret/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/GetProperty/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/GetProperty/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/GetReportingDataAnnotation/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/GetReportingDataAnnotation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/GetReportingIdentitySettings/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/GetReportingIdentitySettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/GetRollupPropertySourceLink/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/GetRollupPropertySourceLink/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/GetSKAdNetworkConversionValueSchema/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/GetSKAdNetworkConversionValueSchema/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/GetSearchAds360Link/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/GetSearchAds360Link/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/GetSubpropertyEventFilter/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/GetSubpropertyEventFilter/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/GetSubpropertySyncConfig/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/GetSubpropertySyncConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/ListAccessBindings/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/ListAccessBindings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/ListAccountSummaries/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/ListAccountSummaries/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/ListAccounts/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/ListAccounts/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/ListAdSenseLinks/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/ListAdSenseLinks/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/ListAudiences/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/ListAudiences/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/ListBigQueryLinks/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/ListBigQueryLinks/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/ListCalculatedMetrics/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/ListCalculatedMetrics/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/ListChannelGroups/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/ListChannelGroups/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/ListConversionEvents/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/ListConversionEvents/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/ListCustomDimensions/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/ListCustomDimensions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/ListCustomMetrics/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/ListCustomMetrics/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/ListDataStreams/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/ListDataStreams/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/ListDisplayVideo360AdvertiserLinkProposals/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/ListDisplayVideo360AdvertiserLinkProposals/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/ListDisplayVideo360AdvertiserLinks/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/ListDisplayVideo360AdvertiserLinks/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/ListEventCreateRules/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/ListEventCreateRules/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/ListEventEditRules/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/ListEventEditRules/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/ListExpandedDataSets/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/ListExpandedDataSets/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/ListFirebaseLinks/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/ListFirebaseLinks/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/ListGoogleAdsLinks/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/ListGoogleAdsLinks/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/ListKeyEvents/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/ListKeyEvents/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/ListMeasurementProtocolSecrets/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/ListMeasurementProtocolSecrets/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/ListProperties/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/ListProperties/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/ListReportingDataAnnotations/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/ListReportingDataAnnotations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/ListRollupPropertySourceLinks/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/ListRollupPropertySourceLinks/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/ListSKAdNetworkConversionValueSchemas/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/ListSKAdNetworkConversionValueSchemas/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/ListSearchAds360Links/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/ListSearchAds360Links/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/ListSubpropertyEventFilters/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/ListSubpropertyEventFilters/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/ListSubpropertySyncConfigs/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/ListSubpropertySyncConfigs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/ProvisionAccountTicket/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/ProvisionAccountTicket/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/ProvisionSubproperty/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/ProvisionSubproperty/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/ReorderEventEditRules/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/ReorderEventEditRules/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/RunAccessReport/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/RunAccessReport/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/SearchChangeHistoryEvents/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/SearchChangeHistoryEvents/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/SubmitUserDeletion/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/SubmitUserDeletion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/UpdateAccessBinding/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/UpdateAccessBinding/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/UpdateAccount/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/UpdateAccount/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/UpdateAttributionSettings/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/UpdateAttributionSettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/UpdateAudience/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/UpdateAudience/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/UpdateBigQueryLink/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/UpdateBigQueryLink/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/UpdateCalculatedMetric/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/UpdateCalculatedMetric/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/UpdateChannelGroup/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/UpdateChannelGroup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/UpdateConversionEvent/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/UpdateConversionEvent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/UpdateCustomDimension/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/UpdateCustomDimension/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/UpdateCustomMetric/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/UpdateCustomMetric/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/UpdateDataRedactionSettings/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/UpdateDataRedactionSettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/UpdateDataRetentionSettings/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/UpdateDataRetentionSettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/UpdateDataStream/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/UpdateDataStream/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/UpdateDisplayVideo360AdvertiserLink/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/UpdateDisplayVideo360AdvertiserLink/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/UpdateEnhancedMeasurementSettings/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/UpdateEnhancedMeasurementSettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/UpdateEventCreateRule/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/UpdateEventCreateRule/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/UpdateEventEditRule/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/UpdateEventEditRule/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/UpdateExpandedDataSet/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/UpdateExpandedDataSet/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/UpdateGoogleAdsLink/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/UpdateGoogleAdsLink/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/UpdateGoogleSignalsSettings/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/UpdateGoogleSignalsSettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/UpdateKeyEvent/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/UpdateKeyEvent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/UpdateMeasurementProtocolSecret/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/UpdateMeasurementProtocolSecret/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/UpdateProperty/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/UpdateProperty/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/UpdateReportingDataAnnotation/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/UpdateReportingDataAnnotation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/UpdateSKAdNetworkConversionValueSchema/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/UpdateSKAdNetworkConversionValueSchema/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/UpdateSearchAds360Link/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/UpdateSearchAds360Link/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/UpdateSubpropertyEventFilter/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/UpdateSubpropertyEventFilter/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/UpdateSubpropertySyncConfig/main.go
+++ b/internal/generated/snippets/analytics/admin/apiv1alpha/AnalyticsAdminClient/UpdateSubpropertySyncConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apigateway/apiv1/Client/CreateApi/main.go
+++ b/internal/generated/snippets/apigateway/apiv1/Client/CreateApi/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apigateway/apiv1/Client/CreateApiConfig/main.go
+++ b/internal/generated/snippets/apigateway/apiv1/Client/CreateApiConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apigateway/apiv1/Client/CreateGateway/main.go
+++ b/internal/generated/snippets/apigateway/apiv1/Client/CreateGateway/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apigateway/apiv1/Client/DeleteApi/main.go
+++ b/internal/generated/snippets/apigateway/apiv1/Client/DeleteApi/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apigateway/apiv1/Client/DeleteApiConfig/main.go
+++ b/internal/generated/snippets/apigateway/apiv1/Client/DeleteApiConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apigateway/apiv1/Client/DeleteGateway/main.go
+++ b/internal/generated/snippets/apigateway/apiv1/Client/DeleteGateway/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apigateway/apiv1/Client/GetApi/main.go
+++ b/internal/generated/snippets/apigateway/apiv1/Client/GetApi/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apigateway/apiv1/Client/GetApiConfig/main.go
+++ b/internal/generated/snippets/apigateway/apiv1/Client/GetApiConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apigateway/apiv1/Client/GetGateway/main.go
+++ b/internal/generated/snippets/apigateway/apiv1/Client/GetGateway/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apigateway/apiv1/Client/ListApiConfigs/main.go
+++ b/internal/generated/snippets/apigateway/apiv1/Client/ListApiConfigs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apigateway/apiv1/Client/ListApis/main.go
+++ b/internal/generated/snippets/apigateway/apiv1/Client/ListApis/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apigateway/apiv1/Client/ListGateways/main.go
+++ b/internal/generated/snippets/apigateway/apiv1/Client/ListGateways/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apigateway/apiv1/Client/UpdateApi/main.go
+++ b/internal/generated/snippets/apigateway/apiv1/Client/UpdateApi/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apigateway/apiv1/Client/UpdateApiConfig/main.go
+++ b/internal/generated/snippets/apigateway/apiv1/Client/UpdateApiConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apigateway/apiv1/Client/UpdateGateway/main.go
+++ b/internal/generated/snippets/apigateway/apiv1/Client/UpdateGateway/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apigeeconnect/apiv1/ConnectionClient/ListConnections/main.go
+++ b/internal/generated/snippets/apigeeconnect/apiv1/ConnectionClient/ListConnections/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apigeeconnect/apiv1/TetherClient/Egress/main.go
+++ b/internal/generated/snippets/apigeeconnect/apiv1/TetherClient/Egress/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apigeeregistry/apiv1/ProvisioningClient/CancelOperation/main.go
+++ b/internal/generated/snippets/apigeeregistry/apiv1/ProvisioningClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apigeeregistry/apiv1/ProvisioningClient/CreateInstance/main.go
+++ b/internal/generated/snippets/apigeeregistry/apiv1/ProvisioningClient/CreateInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apigeeregistry/apiv1/ProvisioningClient/DeleteInstance/main.go
+++ b/internal/generated/snippets/apigeeregistry/apiv1/ProvisioningClient/DeleteInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apigeeregistry/apiv1/ProvisioningClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/apigeeregistry/apiv1/ProvisioningClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apigeeregistry/apiv1/ProvisioningClient/GetIamPolicy/main.go
+++ b/internal/generated/snippets/apigeeregistry/apiv1/ProvisioningClient/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apigeeregistry/apiv1/ProvisioningClient/GetInstance/main.go
+++ b/internal/generated/snippets/apigeeregistry/apiv1/ProvisioningClient/GetInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apigeeregistry/apiv1/ProvisioningClient/GetLocation/main.go
+++ b/internal/generated/snippets/apigeeregistry/apiv1/ProvisioningClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apigeeregistry/apiv1/ProvisioningClient/GetOperation/main.go
+++ b/internal/generated/snippets/apigeeregistry/apiv1/ProvisioningClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apigeeregistry/apiv1/ProvisioningClient/ListLocations/main.go
+++ b/internal/generated/snippets/apigeeregistry/apiv1/ProvisioningClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apigeeregistry/apiv1/ProvisioningClient/ListOperations/main.go
+++ b/internal/generated/snippets/apigeeregistry/apiv1/ProvisioningClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apigeeregistry/apiv1/ProvisioningClient/SetIamPolicy/main.go
+++ b/internal/generated/snippets/apigeeregistry/apiv1/ProvisioningClient/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apigeeregistry/apiv1/ProvisioningClient/TestIamPermissions/main.go
+++ b/internal/generated/snippets/apigeeregistry/apiv1/ProvisioningClient/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/CancelOperation/main.go
+++ b/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/CreateApi/main.go
+++ b/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/CreateApi/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/CreateApiDeployment/main.go
+++ b/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/CreateApiDeployment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/CreateApiSpec/main.go
+++ b/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/CreateApiSpec/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/CreateApiVersion/main.go
+++ b/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/CreateApiVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/CreateArtifact/main.go
+++ b/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/CreateArtifact/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/DeleteApi/main.go
+++ b/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/DeleteApi/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/DeleteApiDeployment/main.go
+++ b/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/DeleteApiDeployment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/DeleteApiDeploymentRevision/main.go
+++ b/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/DeleteApiDeploymentRevision/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/DeleteApiSpec/main.go
+++ b/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/DeleteApiSpec/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/DeleteApiSpecRevision/main.go
+++ b/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/DeleteApiSpecRevision/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/DeleteApiVersion/main.go
+++ b/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/DeleteApiVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/DeleteArtifact/main.go
+++ b/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/DeleteArtifact/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/GetApi/main.go
+++ b/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/GetApi/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/GetApiDeployment/main.go
+++ b/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/GetApiDeployment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/GetApiSpec/main.go
+++ b/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/GetApiSpec/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/GetApiSpecContents/main.go
+++ b/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/GetApiSpecContents/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/GetApiVersion/main.go
+++ b/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/GetApiVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/GetArtifact/main.go
+++ b/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/GetArtifact/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/GetArtifactContents/main.go
+++ b/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/GetArtifactContents/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/GetIamPolicy/main.go
+++ b/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/GetLocation/main.go
+++ b/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/GetOperation/main.go
+++ b/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/ListApiDeploymentRevisions/main.go
+++ b/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/ListApiDeploymentRevisions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/ListApiDeployments/main.go
+++ b/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/ListApiDeployments/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/ListApiSpecRevisions/main.go
+++ b/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/ListApiSpecRevisions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/ListApiSpecs/main.go
+++ b/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/ListApiSpecs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/ListApiVersions/main.go
+++ b/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/ListApiVersions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/ListApis/main.go
+++ b/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/ListApis/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/ListArtifacts/main.go
+++ b/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/ListArtifacts/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/ListLocations/main.go
+++ b/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/ListOperations/main.go
+++ b/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/ReplaceArtifact/main.go
+++ b/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/ReplaceArtifact/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/RollbackApiDeployment/main.go
+++ b/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/RollbackApiDeployment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/RollbackApiSpec/main.go
+++ b/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/RollbackApiSpec/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/SetIamPolicy/main.go
+++ b/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/TagApiDeploymentRevision/main.go
+++ b/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/TagApiDeploymentRevision/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/TagApiSpecRevision/main.go
+++ b/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/TagApiSpecRevision/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/TestIamPermissions/main.go
+++ b/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/UpdateApi/main.go
+++ b/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/UpdateApi/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/UpdateApiDeployment/main.go
+++ b/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/UpdateApiDeployment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/UpdateApiSpec/main.go
+++ b/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/UpdateApiSpec/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/UpdateApiVersion/main.go
+++ b/internal/generated/snippets/apigeeregistry/apiv1/RegistryClient/UpdateApiVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/ApiHubCollectClient/CancelOperation/main.go
+++ b/internal/generated/snippets/apihub/apiv1/ApiHubCollectClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/ApiHubCollectClient/CollectApiData/main.go
+++ b/internal/generated/snippets/apihub/apiv1/ApiHubCollectClient/CollectApiData/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/ApiHubCollectClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/apihub/apiv1/ApiHubCollectClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/ApiHubCollectClient/GetLocation/main.go
+++ b/internal/generated/snippets/apihub/apiv1/ApiHubCollectClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/ApiHubCollectClient/GetOperation/main.go
+++ b/internal/generated/snippets/apihub/apiv1/ApiHubCollectClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/ApiHubCollectClient/ListLocations/main.go
+++ b/internal/generated/snippets/apihub/apiv1/ApiHubCollectClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/ApiHubCollectClient/ListOperations/main.go
+++ b/internal/generated/snippets/apihub/apiv1/ApiHubCollectClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/ApiHubCurateClient/CancelOperation/main.go
+++ b/internal/generated/snippets/apihub/apiv1/ApiHubCurateClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/ApiHubCurateClient/CreateCuration/main.go
+++ b/internal/generated/snippets/apihub/apiv1/ApiHubCurateClient/CreateCuration/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/ApiHubCurateClient/DeleteCuration/main.go
+++ b/internal/generated/snippets/apihub/apiv1/ApiHubCurateClient/DeleteCuration/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/ApiHubCurateClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/apihub/apiv1/ApiHubCurateClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/ApiHubCurateClient/GetCuration/main.go
+++ b/internal/generated/snippets/apihub/apiv1/ApiHubCurateClient/GetCuration/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/ApiHubCurateClient/GetLocation/main.go
+++ b/internal/generated/snippets/apihub/apiv1/ApiHubCurateClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/ApiHubCurateClient/GetOperation/main.go
+++ b/internal/generated/snippets/apihub/apiv1/ApiHubCurateClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/ApiHubCurateClient/ListCurations/main.go
+++ b/internal/generated/snippets/apihub/apiv1/ApiHubCurateClient/ListCurations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/ApiHubCurateClient/ListLocations/main.go
+++ b/internal/generated/snippets/apihub/apiv1/ApiHubCurateClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/ApiHubCurateClient/ListOperations/main.go
+++ b/internal/generated/snippets/apihub/apiv1/ApiHubCurateClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/ApiHubCurateClient/UpdateCuration/main.go
+++ b/internal/generated/snippets/apihub/apiv1/ApiHubCurateClient/UpdateCuration/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/ApiHubDependenciesClient/CancelOperation/main.go
+++ b/internal/generated/snippets/apihub/apiv1/ApiHubDependenciesClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/ApiHubDependenciesClient/CreateDependency/main.go
+++ b/internal/generated/snippets/apihub/apiv1/ApiHubDependenciesClient/CreateDependency/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/ApiHubDependenciesClient/DeleteDependency/main.go
+++ b/internal/generated/snippets/apihub/apiv1/ApiHubDependenciesClient/DeleteDependency/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/ApiHubDependenciesClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/apihub/apiv1/ApiHubDependenciesClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/ApiHubDependenciesClient/GetDependency/main.go
+++ b/internal/generated/snippets/apihub/apiv1/ApiHubDependenciesClient/GetDependency/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/ApiHubDependenciesClient/GetLocation/main.go
+++ b/internal/generated/snippets/apihub/apiv1/ApiHubDependenciesClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/ApiHubDependenciesClient/GetOperation/main.go
+++ b/internal/generated/snippets/apihub/apiv1/ApiHubDependenciesClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/ApiHubDependenciesClient/ListDependencies/main.go
+++ b/internal/generated/snippets/apihub/apiv1/ApiHubDependenciesClient/ListDependencies/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/ApiHubDependenciesClient/ListLocations/main.go
+++ b/internal/generated/snippets/apihub/apiv1/ApiHubDependenciesClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/ApiHubDependenciesClient/ListOperations/main.go
+++ b/internal/generated/snippets/apihub/apiv1/ApiHubDependenciesClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/ApiHubDependenciesClient/UpdateDependency/main.go
+++ b/internal/generated/snippets/apihub/apiv1/ApiHubDependenciesClient/UpdateDependency/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/ApiHubDiscoveryClient/CancelOperation/main.go
+++ b/internal/generated/snippets/apihub/apiv1/ApiHubDiscoveryClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/ApiHubDiscoveryClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/apihub/apiv1/ApiHubDiscoveryClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/ApiHubDiscoveryClient/GetDiscoveredApiObservation/main.go
+++ b/internal/generated/snippets/apihub/apiv1/ApiHubDiscoveryClient/GetDiscoveredApiObservation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/ApiHubDiscoveryClient/GetDiscoveredApiOperation/main.go
+++ b/internal/generated/snippets/apihub/apiv1/ApiHubDiscoveryClient/GetDiscoveredApiOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/ApiHubDiscoveryClient/GetLocation/main.go
+++ b/internal/generated/snippets/apihub/apiv1/ApiHubDiscoveryClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/ApiHubDiscoveryClient/GetOperation/main.go
+++ b/internal/generated/snippets/apihub/apiv1/ApiHubDiscoveryClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/ApiHubDiscoveryClient/ListDiscoveredApiObservations/main.go
+++ b/internal/generated/snippets/apihub/apiv1/ApiHubDiscoveryClient/ListDiscoveredApiObservations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/ApiHubDiscoveryClient/ListDiscoveredApiOperations/main.go
+++ b/internal/generated/snippets/apihub/apiv1/ApiHubDiscoveryClient/ListDiscoveredApiOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/ApiHubDiscoveryClient/ListLocations/main.go
+++ b/internal/generated/snippets/apihub/apiv1/ApiHubDiscoveryClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/ApiHubDiscoveryClient/ListOperations/main.go
+++ b/internal/generated/snippets/apihub/apiv1/ApiHubDiscoveryClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/ApiHubPluginClient/CancelOperation/main.go
+++ b/internal/generated/snippets/apihub/apiv1/ApiHubPluginClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/ApiHubPluginClient/CreatePlugin/main.go
+++ b/internal/generated/snippets/apihub/apiv1/ApiHubPluginClient/CreatePlugin/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/ApiHubPluginClient/CreatePluginInstance/main.go
+++ b/internal/generated/snippets/apihub/apiv1/ApiHubPluginClient/CreatePluginInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/ApiHubPluginClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/apihub/apiv1/ApiHubPluginClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/ApiHubPluginClient/DeletePlugin/main.go
+++ b/internal/generated/snippets/apihub/apiv1/ApiHubPluginClient/DeletePlugin/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/ApiHubPluginClient/DeletePluginInstance/main.go
+++ b/internal/generated/snippets/apihub/apiv1/ApiHubPluginClient/DeletePluginInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/ApiHubPluginClient/DisablePlugin/main.go
+++ b/internal/generated/snippets/apihub/apiv1/ApiHubPluginClient/DisablePlugin/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/ApiHubPluginClient/DisablePluginInstanceAction/main.go
+++ b/internal/generated/snippets/apihub/apiv1/ApiHubPluginClient/DisablePluginInstanceAction/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/ApiHubPluginClient/EnablePlugin/main.go
+++ b/internal/generated/snippets/apihub/apiv1/ApiHubPluginClient/EnablePlugin/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/ApiHubPluginClient/EnablePluginInstanceAction/main.go
+++ b/internal/generated/snippets/apihub/apiv1/ApiHubPluginClient/EnablePluginInstanceAction/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/ApiHubPluginClient/ExecutePluginInstanceAction/main.go
+++ b/internal/generated/snippets/apihub/apiv1/ApiHubPluginClient/ExecutePluginInstanceAction/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/ApiHubPluginClient/GetLocation/main.go
+++ b/internal/generated/snippets/apihub/apiv1/ApiHubPluginClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/ApiHubPluginClient/GetOperation/main.go
+++ b/internal/generated/snippets/apihub/apiv1/ApiHubPluginClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/ApiHubPluginClient/GetPlugin/main.go
+++ b/internal/generated/snippets/apihub/apiv1/ApiHubPluginClient/GetPlugin/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/ApiHubPluginClient/GetPluginInstance/main.go
+++ b/internal/generated/snippets/apihub/apiv1/ApiHubPluginClient/GetPluginInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/ApiHubPluginClient/ListLocations/main.go
+++ b/internal/generated/snippets/apihub/apiv1/ApiHubPluginClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/ApiHubPluginClient/ListOperations/main.go
+++ b/internal/generated/snippets/apihub/apiv1/ApiHubPluginClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/ApiHubPluginClient/ListPluginInstances/main.go
+++ b/internal/generated/snippets/apihub/apiv1/ApiHubPluginClient/ListPluginInstances/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/ApiHubPluginClient/ListPlugins/main.go
+++ b/internal/generated/snippets/apihub/apiv1/ApiHubPluginClient/ListPlugins/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/ApiHubPluginClient/UpdatePluginInstance/main.go
+++ b/internal/generated/snippets/apihub/apiv1/ApiHubPluginClient/UpdatePluginInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/Client/CancelOperation/main.go
+++ b/internal/generated/snippets/apihub/apiv1/Client/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/Client/CreateApi/main.go
+++ b/internal/generated/snippets/apihub/apiv1/Client/CreateApi/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/Client/CreateApiOperation/main.go
+++ b/internal/generated/snippets/apihub/apiv1/Client/CreateApiOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/Client/CreateAttribute/main.go
+++ b/internal/generated/snippets/apihub/apiv1/Client/CreateAttribute/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/Client/CreateDeployment/main.go
+++ b/internal/generated/snippets/apihub/apiv1/Client/CreateDeployment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/Client/CreateExternalApi/main.go
+++ b/internal/generated/snippets/apihub/apiv1/Client/CreateExternalApi/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/Client/CreateSpec/main.go
+++ b/internal/generated/snippets/apihub/apiv1/Client/CreateSpec/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/Client/CreateVersion/main.go
+++ b/internal/generated/snippets/apihub/apiv1/Client/CreateVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/Client/DeleteApi/main.go
+++ b/internal/generated/snippets/apihub/apiv1/Client/DeleteApi/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/Client/DeleteApiOperation/main.go
+++ b/internal/generated/snippets/apihub/apiv1/Client/DeleteApiOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/Client/DeleteAttribute/main.go
+++ b/internal/generated/snippets/apihub/apiv1/Client/DeleteAttribute/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/Client/DeleteDeployment/main.go
+++ b/internal/generated/snippets/apihub/apiv1/Client/DeleteDeployment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/Client/DeleteExternalApi/main.go
+++ b/internal/generated/snippets/apihub/apiv1/Client/DeleteExternalApi/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/Client/DeleteOperation/main.go
+++ b/internal/generated/snippets/apihub/apiv1/Client/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/Client/DeleteSpec/main.go
+++ b/internal/generated/snippets/apihub/apiv1/Client/DeleteSpec/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/Client/DeleteVersion/main.go
+++ b/internal/generated/snippets/apihub/apiv1/Client/DeleteVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/Client/GetApi/main.go
+++ b/internal/generated/snippets/apihub/apiv1/Client/GetApi/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/Client/GetApiOperation/main.go
+++ b/internal/generated/snippets/apihub/apiv1/Client/GetApiOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/Client/GetAttribute/main.go
+++ b/internal/generated/snippets/apihub/apiv1/Client/GetAttribute/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/Client/GetDefinition/main.go
+++ b/internal/generated/snippets/apihub/apiv1/Client/GetDefinition/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/Client/GetDeployment/main.go
+++ b/internal/generated/snippets/apihub/apiv1/Client/GetDeployment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/Client/GetExternalApi/main.go
+++ b/internal/generated/snippets/apihub/apiv1/Client/GetExternalApi/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/Client/GetLocation/main.go
+++ b/internal/generated/snippets/apihub/apiv1/Client/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/Client/GetOperation/main.go
+++ b/internal/generated/snippets/apihub/apiv1/Client/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/Client/GetSpec/main.go
+++ b/internal/generated/snippets/apihub/apiv1/Client/GetSpec/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/Client/GetSpecContents/main.go
+++ b/internal/generated/snippets/apihub/apiv1/Client/GetSpecContents/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/Client/GetVersion/main.go
+++ b/internal/generated/snippets/apihub/apiv1/Client/GetVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/Client/ListApiOperations/main.go
+++ b/internal/generated/snippets/apihub/apiv1/Client/ListApiOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/Client/ListApis/main.go
+++ b/internal/generated/snippets/apihub/apiv1/Client/ListApis/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/Client/ListAttributes/main.go
+++ b/internal/generated/snippets/apihub/apiv1/Client/ListAttributes/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/Client/ListDeployments/main.go
+++ b/internal/generated/snippets/apihub/apiv1/Client/ListDeployments/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/Client/ListExternalApis/main.go
+++ b/internal/generated/snippets/apihub/apiv1/Client/ListExternalApis/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/Client/ListLocations/main.go
+++ b/internal/generated/snippets/apihub/apiv1/Client/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/Client/ListOperations/main.go
+++ b/internal/generated/snippets/apihub/apiv1/Client/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/Client/ListSpecs/main.go
+++ b/internal/generated/snippets/apihub/apiv1/Client/ListSpecs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/Client/ListVersions/main.go
+++ b/internal/generated/snippets/apihub/apiv1/Client/ListVersions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/Client/SearchResources/main.go
+++ b/internal/generated/snippets/apihub/apiv1/Client/SearchResources/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/Client/UpdateApi/main.go
+++ b/internal/generated/snippets/apihub/apiv1/Client/UpdateApi/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/Client/UpdateApiOperation/main.go
+++ b/internal/generated/snippets/apihub/apiv1/Client/UpdateApiOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/Client/UpdateAttribute/main.go
+++ b/internal/generated/snippets/apihub/apiv1/Client/UpdateAttribute/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/Client/UpdateDeployment/main.go
+++ b/internal/generated/snippets/apihub/apiv1/Client/UpdateDeployment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/Client/UpdateExternalApi/main.go
+++ b/internal/generated/snippets/apihub/apiv1/Client/UpdateExternalApi/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/Client/UpdateSpec/main.go
+++ b/internal/generated/snippets/apihub/apiv1/Client/UpdateSpec/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/Client/UpdateVersion/main.go
+++ b/internal/generated/snippets/apihub/apiv1/Client/UpdateVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/HostProjectRegistrationClient/CancelOperation/main.go
+++ b/internal/generated/snippets/apihub/apiv1/HostProjectRegistrationClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/HostProjectRegistrationClient/CreateHostProjectRegistration/main.go
+++ b/internal/generated/snippets/apihub/apiv1/HostProjectRegistrationClient/CreateHostProjectRegistration/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/HostProjectRegistrationClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/apihub/apiv1/HostProjectRegistrationClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/HostProjectRegistrationClient/GetHostProjectRegistration/main.go
+++ b/internal/generated/snippets/apihub/apiv1/HostProjectRegistrationClient/GetHostProjectRegistration/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/HostProjectRegistrationClient/GetLocation/main.go
+++ b/internal/generated/snippets/apihub/apiv1/HostProjectRegistrationClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/HostProjectRegistrationClient/GetOperation/main.go
+++ b/internal/generated/snippets/apihub/apiv1/HostProjectRegistrationClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/HostProjectRegistrationClient/ListHostProjectRegistrations/main.go
+++ b/internal/generated/snippets/apihub/apiv1/HostProjectRegistrationClient/ListHostProjectRegistrations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/HostProjectRegistrationClient/ListLocations/main.go
+++ b/internal/generated/snippets/apihub/apiv1/HostProjectRegistrationClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/HostProjectRegistrationClient/ListOperations/main.go
+++ b/internal/generated/snippets/apihub/apiv1/HostProjectRegistrationClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/LintingClient/CancelOperation/main.go
+++ b/internal/generated/snippets/apihub/apiv1/LintingClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/LintingClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/apihub/apiv1/LintingClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/LintingClient/GetLocation/main.go
+++ b/internal/generated/snippets/apihub/apiv1/LintingClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/LintingClient/GetOperation/main.go
+++ b/internal/generated/snippets/apihub/apiv1/LintingClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/LintingClient/GetStyleGuide/main.go
+++ b/internal/generated/snippets/apihub/apiv1/LintingClient/GetStyleGuide/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/LintingClient/GetStyleGuideContents/main.go
+++ b/internal/generated/snippets/apihub/apiv1/LintingClient/GetStyleGuideContents/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/LintingClient/LintSpec/main.go
+++ b/internal/generated/snippets/apihub/apiv1/LintingClient/LintSpec/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/LintingClient/ListLocations/main.go
+++ b/internal/generated/snippets/apihub/apiv1/LintingClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/LintingClient/ListOperations/main.go
+++ b/internal/generated/snippets/apihub/apiv1/LintingClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/LintingClient/UpdateStyleGuide/main.go
+++ b/internal/generated/snippets/apihub/apiv1/LintingClient/UpdateStyleGuide/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/ProvisioningClient/CancelOperation/main.go
+++ b/internal/generated/snippets/apihub/apiv1/ProvisioningClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/ProvisioningClient/CreateApiHubInstance/main.go
+++ b/internal/generated/snippets/apihub/apiv1/ProvisioningClient/CreateApiHubInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/ProvisioningClient/DeleteApiHubInstance/main.go
+++ b/internal/generated/snippets/apihub/apiv1/ProvisioningClient/DeleteApiHubInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/ProvisioningClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/apihub/apiv1/ProvisioningClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/ProvisioningClient/GetApiHubInstance/main.go
+++ b/internal/generated/snippets/apihub/apiv1/ProvisioningClient/GetApiHubInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/ProvisioningClient/GetLocation/main.go
+++ b/internal/generated/snippets/apihub/apiv1/ProvisioningClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/ProvisioningClient/GetOperation/main.go
+++ b/internal/generated/snippets/apihub/apiv1/ProvisioningClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/ProvisioningClient/ListLocations/main.go
+++ b/internal/generated/snippets/apihub/apiv1/ProvisioningClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/ProvisioningClient/ListOperations/main.go
+++ b/internal/generated/snippets/apihub/apiv1/ProvisioningClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/ProvisioningClient/LookupApiHubInstance/main.go
+++ b/internal/generated/snippets/apihub/apiv1/ProvisioningClient/LookupApiHubInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/RuntimeProjectAttachmentClient/CancelOperation/main.go
+++ b/internal/generated/snippets/apihub/apiv1/RuntimeProjectAttachmentClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/RuntimeProjectAttachmentClient/CreateRuntimeProjectAttachment/main.go
+++ b/internal/generated/snippets/apihub/apiv1/RuntimeProjectAttachmentClient/CreateRuntimeProjectAttachment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/RuntimeProjectAttachmentClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/apihub/apiv1/RuntimeProjectAttachmentClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/RuntimeProjectAttachmentClient/DeleteRuntimeProjectAttachment/main.go
+++ b/internal/generated/snippets/apihub/apiv1/RuntimeProjectAttachmentClient/DeleteRuntimeProjectAttachment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/RuntimeProjectAttachmentClient/GetLocation/main.go
+++ b/internal/generated/snippets/apihub/apiv1/RuntimeProjectAttachmentClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/RuntimeProjectAttachmentClient/GetOperation/main.go
+++ b/internal/generated/snippets/apihub/apiv1/RuntimeProjectAttachmentClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/RuntimeProjectAttachmentClient/GetRuntimeProjectAttachment/main.go
+++ b/internal/generated/snippets/apihub/apiv1/RuntimeProjectAttachmentClient/GetRuntimeProjectAttachment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/RuntimeProjectAttachmentClient/ListLocations/main.go
+++ b/internal/generated/snippets/apihub/apiv1/RuntimeProjectAttachmentClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/RuntimeProjectAttachmentClient/ListOperations/main.go
+++ b/internal/generated/snippets/apihub/apiv1/RuntimeProjectAttachmentClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/RuntimeProjectAttachmentClient/ListRuntimeProjectAttachments/main.go
+++ b/internal/generated/snippets/apihub/apiv1/RuntimeProjectAttachmentClient/ListRuntimeProjectAttachments/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apihub/apiv1/RuntimeProjectAttachmentClient/LookupRuntimeProjectAttachment/main.go
+++ b/internal/generated/snippets/apihub/apiv1/RuntimeProjectAttachmentClient/LookupRuntimeProjectAttachment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apikeys/apiv2/Client/CreateKey/main.go
+++ b/internal/generated/snippets/apikeys/apiv2/Client/CreateKey/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apikeys/apiv2/Client/DeleteKey/main.go
+++ b/internal/generated/snippets/apikeys/apiv2/Client/DeleteKey/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apikeys/apiv2/Client/GetKey/main.go
+++ b/internal/generated/snippets/apikeys/apiv2/Client/GetKey/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apikeys/apiv2/Client/GetKeyString/main.go
+++ b/internal/generated/snippets/apikeys/apiv2/Client/GetKeyString/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apikeys/apiv2/Client/GetOperation/main.go
+++ b/internal/generated/snippets/apikeys/apiv2/Client/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apikeys/apiv2/Client/ListKeys/main.go
+++ b/internal/generated/snippets/apikeys/apiv2/Client/ListKeys/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apikeys/apiv2/Client/LookupKey/main.go
+++ b/internal/generated/snippets/apikeys/apiv2/Client/LookupKey/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apikeys/apiv2/Client/UndeleteKey/main.go
+++ b/internal/generated/snippets/apikeys/apiv2/Client/UndeleteKey/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apikeys/apiv2/Client/UpdateKey/main.go
+++ b/internal/generated/snippets/apikeys/apiv2/Client/UpdateKey/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apiregistry/apiv1beta/CloudApiRegistryClient/GetLocation/main.go
+++ b/internal/generated/snippets/apiregistry/apiv1beta/CloudApiRegistryClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apiregistry/apiv1beta/CloudApiRegistryClient/GetMcpServer/main.go
+++ b/internal/generated/snippets/apiregistry/apiv1beta/CloudApiRegistryClient/GetMcpServer/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apiregistry/apiv1beta/CloudApiRegistryClient/GetMcpTool/main.go
+++ b/internal/generated/snippets/apiregistry/apiv1beta/CloudApiRegistryClient/GetMcpTool/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apiregistry/apiv1beta/CloudApiRegistryClient/ListLocations/main.go
+++ b/internal/generated/snippets/apiregistry/apiv1beta/CloudApiRegistryClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apiregistry/apiv1beta/CloudApiRegistryClient/ListMcpServers/main.go
+++ b/internal/generated/snippets/apiregistry/apiv1beta/CloudApiRegistryClient/ListMcpServers/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apiregistry/apiv1beta/CloudApiRegistryClient/ListMcpTools/main.go
+++ b/internal/generated/snippets/apiregistry/apiv1beta/CloudApiRegistryClient/ListMcpTools/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/appengine/apiv1/ApplicationsClient/CreateApplication/main.go
+++ b/internal/generated/snippets/appengine/apiv1/ApplicationsClient/CreateApplication/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/appengine/apiv1/ApplicationsClient/GetApplication/main.go
+++ b/internal/generated/snippets/appengine/apiv1/ApplicationsClient/GetApplication/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/appengine/apiv1/ApplicationsClient/RepairApplication/main.go
+++ b/internal/generated/snippets/appengine/apiv1/ApplicationsClient/RepairApplication/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/appengine/apiv1/ApplicationsClient/UpdateApplication/main.go
+++ b/internal/generated/snippets/appengine/apiv1/ApplicationsClient/UpdateApplication/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/appengine/apiv1/AuthorizedCertificatesClient/CreateAuthorizedCertificate/main.go
+++ b/internal/generated/snippets/appengine/apiv1/AuthorizedCertificatesClient/CreateAuthorizedCertificate/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/appengine/apiv1/AuthorizedCertificatesClient/DeleteAuthorizedCertificate/main.go
+++ b/internal/generated/snippets/appengine/apiv1/AuthorizedCertificatesClient/DeleteAuthorizedCertificate/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/appengine/apiv1/AuthorizedCertificatesClient/GetAuthorizedCertificate/main.go
+++ b/internal/generated/snippets/appengine/apiv1/AuthorizedCertificatesClient/GetAuthorizedCertificate/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/appengine/apiv1/AuthorizedCertificatesClient/ListAuthorizedCertificates/main.go
+++ b/internal/generated/snippets/appengine/apiv1/AuthorizedCertificatesClient/ListAuthorizedCertificates/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/appengine/apiv1/AuthorizedCertificatesClient/UpdateAuthorizedCertificate/main.go
+++ b/internal/generated/snippets/appengine/apiv1/AuthorizedCertificatesClient/UpdateAuthorizedCertificate/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/appengine/apiv1/AuthorizedDomainsClient/ListAuthorizedDomains/main.go
+++ b/internal/generated/snippets/appengine/apiv1/AuthorizedDomainsClient/ListAuthorizedDomains/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/appengine/apiv1/DomainMappingsClient/CreateDomainMapping/main.go
+++ b/internal/generated/snippets/appengine/apiv1/DomainMappingsClient/CreateDomainMapping/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/appengine/apiv1/DomainMappingsClient/DeleteDomainMapping/main.go
+++ b/internal/generated/snippets/appengine/apiv1/DomainMappingsClient/DeleteDomainMapping/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/appengine/apiv1/DomainMappingsClient/GetDomainMapping/main.go
+++ b/internal/generated/snippets/appengine/apiv1/DomainMappingsClient/GetDomainMapping/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/appengine/apiv1/DomainMappingsClient/ListDomainMappings/main.go
+++ b/internal/generated/snippets/appengine/apiv1/DomainMappingsClient/ListDomainMappings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/appengine/apiv1/DomainMappingsClient/UpdateDomainMapping/main.go
+++ b/internal/generated/snippets/appengine/apiv1/DomainMappingsClient/UpdateDomainMapping/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/appengine/apiv1/FirewallClient/BatchUpdateIngressRules/main.go
+++ b/internal/generated/snippets/appengine/apiv1/FirewallClient/BatchUpdateIngressRules/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/appengine/apiv1/FirewallClient/CreateIngressRule/main.go
+++ b/internal/generated/snippets/appengine/apiv1/FirewallClient/CreateIngressRule/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/appengine/apiv1/FirewallClient/DeleteIngressRule/main.go
+++ b/internal/generated/snippets/appengine/apiv1/FirewallClient/DeleteIngressRule/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/appengine/apiv1/FirewallClient/GetIngressRule/main.go
+++ b/internal/generated/snippets/appengine/apiv1/FirewallClient/GetIngressRule/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/appengine/apiv1/FirewallClient/ListIngressRules/main.go
+++ b/internal/generated/snippets/appengine/apiv1/FirewallClient/ListIngressRules/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/appengine/apiv1/FirewallClient/UpdateIngressRule/main.go
+++ b/internal/generated/snippets/appengine/apiv1/FirewallClient/UpdateIngressRule/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/appengine/apiv1/InstancesClient/DebugInstance/main.go
+++ b/internal/generated/snippets/appengine/apiv1/InstancesClient/DebugInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/appengine/apiv1/InstancesClient/DeleteInstance/main.go
+++ b/internal/generated/snippets/appengine/apiv1/InstancesClient/DeleteInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/appengine/apiv1/InstancesClient/GetInstance/main.go
+++ b/internal/generated/snippets/appengine/apiv1/InstancesClient/GetInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/appengine/apiv1/InstancesClient/ListInstances/main.go
+++ b/internal/generated/snippets/appengine/apiv1/InstancesClient/ListInstances/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/appengine/apiv1/ServicesClient/DeleteService/main.go
+++ b/internal/generated/snippets/appengine/apiv1/ServicesClient/DeleteService/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/appengine/apiv1/ServicesClient/GetService/main.go
+++ b/internal/generated/snippets/appengine/apiv1/ServicesClient/GetService/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/appengine/apiv1/ServicesClient/ListServices/main.go
+++ b/internal/generated/snippets/appengine/apiv1/ServicesClient/ListServices/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/appengine/apiv1/ServicesClient/UpdateService/main.go
+++ b/internal/generated/snippets/appengine/apiv1/ServicesClient/UpdateService/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/appengine/apiv1/VersionsClient/CreateVersion/main.go
+++ b/internal/generated/snippets/appengine/apiv1/VersionsClient/CreateVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/appengine/apiv1/VersionsClient/DeleteVersion/main.go
+++ b/internal/generated/snippets/appengine/apiv1/VersionsClient/DeleteVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/appengine/apiv1/VersionsClient/GetVersion/main.go
+++ b/internal/generated/snippets/appengine/apiv1/VersionsClient/GetVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/appengine/apiv1/VersionsClient/ListVersions/main.go
+++ b/internal/generated/snippets/appengine/apiv1/VersionsClient/ListVersions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/appengine/apiv1/VersionsClient/UpdateVersion/main.go
+++ b/internal/generated/snippets/appengine/apiv1/VersionsClient/UpdateVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apphub/apiv1/Client/CancelOperation/main.go
+++ b/internal/generated/snippets/apphub/apiv1/Client/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apphub/apiv1/Client/CreateApplication/main.go
+++ b/internal/generated/snippets/apphub/apiv1/Client/CreateApplication/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apphub/apiv1/Client/CreateService/main.go
+++ b/internal/generated/snippets/apphub/apiv1/Client/CreateService/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apphub/apiv1/Client/CreateServiceProjectAttachment/main.go
+++ b/internal/generated/snippets/apphub/apiv1/Client/CreateServiceProjectAttachment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apphub/apiv1/Client/CreateWorkload/main.go
+++ b/internal/generated/snippets/apphub/apiv1/Client/CreateWorkload/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apphub/apiv1/Client/DeleteApplication/main.go
+++ b/internal/generated/snippets/apphub/apiv1/Client/DeleteApplication/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apphub/apiv1/Client/DeleteOperation/main.go
+++ b/internal/generated/snippets/apphub/apiv1/Client/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apphub/apiv1/Client/DeleteService/main.go
+++ b/internal/generated/snippets/apphub/apiv1/Client/DeleteService/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apphub/apiv1/Client/DeleteServiceProjectAttachment/main.go
+++ b/internal/generated/snippets/apphub/apiv1/Client/DeleteServiceProjectAttachment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apphub/apiv1/Client/DeleteWorkload/main.go
+++ b/internal/generated/snippets/apphub/apiv1/Client/DeleteWorkload/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apphub/apiv1/Client/DetachServiceProjectAttachment/main.go
+++ b/internal/generated/snippets/apphub/apiv1/Client/DetachServiceProjectAttachment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apphub/apiv1/Client/GetApplication/main.go
+++ b/internal/generated/snippets/apphub/apiv1/Client/GetApplication/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apphub/apiv1/Client/GetDiscoveredService/main.go
+++ b/internal/generated/snippets/apphub/apiv1/Client/GetDiscoveredService/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apphub/apiv1/Client/GetDiscoveredWorkload/main.go
+++ b/internal/generated/snippets/apphub/apiv1/Client/GetDiscoveredWorkload/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apphub/apiv1/Client/GetIamPolicy/main.go
+++ b/internal/generated/snippets/apphub/apiv1/Client/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apphub/apiv1/Client/GetLocation/main.go
+++ b/internal/generated/snippets/apphub/apiv1/Client/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apphub/apiv1/Client/GetOperation/main.go
+++ b/internal/generated/snippets/apphub/apiv1/Client/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apphub/apiv1/Client/GetService/main.go
+++ b/internal/generated/snippets/apphub/apiv1/Client/GetService/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apphub/apiv1/Client/GetServiceProjectAttachment/main.go
+++ b/internal/generated/snippets/apphub/apiv1/Client/GetServiceProjectAttachment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apphub/apiv1/Client/GetWorkload/main.go
+++ b/internal/generated/snippets/apphub/apiv1/Client/GetWorkload/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apphub/apiv1/Client/ListApplications/main.go
+++ b/internal/generated/snippets/apphub/apiv1/Client/ListApplications/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apphub/apiv1/Client/ListDiscoveredServices/main.go
+++ b/internal/generated/snippets/apphub/apiv1/Client/ListDiscoveredServices/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apphub/apiv1/Client/ListDiscoveredWorkloads/main.go
+++ b/internal/generated/snippets/apphub/apiv1/Client/ListDiscoveredWorkloads/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apphub/apiv1/Client/ListLocations/main.go
+++ b/internal/generated/snippets/apphub/apiv1/Client/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apphub/apiv1/Client/ListOperations/main.go
+++ b/internal/generated/snippets/apphub/apiv1/Client/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apphub/apiv1/Client/ListServiceProjectAttachments/main.go
+++ b/internal/generated/snippets/apphub/apiv1/Client/ListServiceProjectAttachments/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apphub/apiv1/Client/ListServices/main.go
+++ b/internal/generated/snippets/apphub/apiv1/Client/ListServices/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apphub/apiv1/Client/ListWorkloads/main.go
+++ b/internal/generated/snippets/apphub/apiv1/Client/ListWorkloads/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apphub/apiv1/Client/LookupDiscoveredService/main.go
+++ b/internal/generated/snippets/apphub/apiv1/Client/LookupDiscoveredService/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apphub/apiv1/Client/LookupDiscoveredWorkload/main.go
+++ b/internal/generated/snippets/apphub/apiv1/Client/LookupDiscoveredWorkload/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apphub/apiv1/Client/LookupServiceProjectAttachment/main.go
+++ b/internal/generated/snippets/apphub/apiv1/Client/LookupServiceProjectAttachment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apphub/apiv1/Client/SetIamPolicy/main.go
+++ b/internal/generated/snippets/apphub/apiv1/Client/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apphub/apiv1/Client/TestIamPermissions/main.go
+++ b/internal/generated/snippets/apphub/apiv1/Client/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apphub/apiv1/Client/UpdateApplication/main.go
+++ b/internal/generated/snippets/apphub/apiv1/Client/UpdateApplication/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apphub/apiv1/Client/UpdateService/main.go
+++ b/internal/generated/snippets/apphub/apiv1/Client/UpdateService/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apphub/apiv1/Client/UpdateWorkload/main.go
+++ b/internal/generated/snippets/apphub/apiv1/Client/UpdateWorkload/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apps/events/subscriptions/apiv1/Client/CreateSubscription/main.go
+++ b/internal/generated/snippets/apps/events/subscriptions/apiv1/Client/CreateSubscription/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apps/events/subscriptions/apiv1/Client/DeleteSubscription/main.go
+++ b/internal/generated/snippets/apps/events/subscriptions/apiv1/Client/DeleteSubscription/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apps/events/subscriptions/apiv1/Client/GetOperation/main.go
+++ b/internal/generated/snippets/apps/events/subscriptions/apiv1/Client/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apps/events/subscriptions/apiv1/Client/GetSubscription/main.go
+++ b/internal/generated/snippets/apps/events/subscriptions/apiv1/Client/GetSubscription/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apps/events/subscriptions/apiv1/Client/ListSubscriptions/main.go
+++ b/internal/generated/snippets/apps/events/subscriptions/apiv1/Client/ListSubscriptions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apps/events/subscriptions/apiv1/Client/ReactivateSubscription/main.go
+++ b/internal/generated/snippets/apps/events/subscriptions/apiv1/Client/ReactivateSubscription/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apps/events/subscriptions/apiv1/Client/UpdateSubscription/main.go
+++ b/internal/generated/snippets/apps/events/subscriptions/apiv1/Client/UpdateSubscription/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apps/events/subscriptions/apiv1beta/Client/CreateSubscription/main.go
+++ b/internal/generated/snippets/apps/events/subscriptions/apiv1beta/Client/CreateSubscription/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apps/events/subscriptions/apiv1beta/Client/DeleteSubscription/main.go
+++ b/internal/generated/snippets/apps/events/subscriptions/apiv1beta/Client/DeleteSubscription/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apps/events/subscriptions/apiv1beta/Client/GetOperation/main.go
+++ b/internal/generated/snippets/apps/events/subscriptions/apiv1beta/Client/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apps/events/subscriptions/apiv1beta/Client/GetSubscription/main.go
+++ b/internal/generated/snippets/apps/events/subscriptions/apiv1beta/Client/GetSubscription/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apps/events/subscriptions/apiv1beta/Client/ListSubscriptions/main.go
+++ b/internal/generated/snippets/apps/events/subscriptions/apiv1beta/Client/ListSubscriptions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apps/events/subscriptions/apiv1beta/Client/ReactivateSubscription/main.go
+++ b/internal/generated/snippets/apps/events/subscriptions/apiv1beta/Client/ReactivateSubscription/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apps/events/subscriptions/apiv1beta/Client/UpdateSubscription/main.go
+++ b/internal/generated/snippets/apps/events/subscriptions/apiv1beta/Client/UpdateSubscription/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apps/meet/apiv2/ConferenceRecordsClient/GetConferenceRecord/main.go
+++ b/internal/generated/snippets/apps/meet/apiv2/ConferenceRecordsClient/GetConferenceRecord/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apps/meet/apiv2/ConferenceRecordsClient/GetParticipant/main.go
+++ b/internal/generated/snippets/apps/meet/apiv2/ConferenceRecordsClient/GetParticipant/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apps/meet/apiv2/ConferenceRecordsClient/GetParticipantSession/main.go
+++ b/internal/generated/snippets/apps/meet/apiv2/ConferenceRecordsClient/GetParticipantSession/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apps/meet/apiv2/ConferenceRecordsClient/GetRecording/main.go
+++ b/internal/generated/snippets/apps/meet/apiv2/ConferenceRecordsClient/GetRecording/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apps/meet/apiv2/ConferenceRecordsClient/GetTranscript/main.go
+++ b/internal/generated/snippets/apps/meet/apiv2/ConferenceRecordsClient/GetTranscript/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apps/meet/apiv2/ConferenceRecordsClient/GetTranscriptEntry/main.go
+++ b/internal/generated/snippets/apps/meet/apiv2/ConferenceRecordsClient/GetTranscriptEntry/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apps/meet/apiv2/ConferenceRecordsClient/ListConferenceRecords/main.go
+++ b/internal/generated/snippets/apps/meet/apiv2/ConferenceRecordsClient/ListConferenceRecords/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apps/meet/apiv2/ConferenceRecordsClient/ListParticipantSessions/main.go
+++ b/internal/generated/snippets/apps/meet/apiv2/ConferenceRecordsClient/ListParticipantSessions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apps/meet/apiv2/ConferenceRecordsClient/ListParticipants/main.go
+++ b/internal/generated/snippets/apps/meet/apiv2/ConferenceRecordsClient/ListParticipants/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apps/meet/apiv2/ConferenceRecordsClient/ListRecordings/main.go
+++ b/internal/generated/snippets/apps/meet/apiv2/ConferenceRecordsClient/ListRecordings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apps/meet/apiv2/ConferenceRecordsClient/ListTranscriptEntries/main.go
+++ b/internal/generated/snippets/apps/meet/apiv2/ConferenceRecordsClient/ListTranscriptEntries/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apps/meet/apiv2/ConferenceRecordsClient/ListTranscripts/main.go
+++ b/internal/generated/snippets/apps/meet/apiv2/ConferenceRecordsClient/ListTranscripts/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apps/meet/apiv2/SpacesClient/CreateSpace/main.go
+++ b/internal/generated/snippets/apps/meet/apiv2/SpacesClient/CreateSpace/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apps/meet/apiv2/SpacesClient/EndActiveConference/main.go
+++ b/internal/generated/snippets/apps/meet/apiv2/SpacesClient/EndActiveConference/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apps/meet/apiv2/SpacesClient/GetSpace/main.go
+++ b/internal/generated/snippets/apps/meet/apiv2/SpacesClient/GetSpace/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apps/meet/apiv2/SpacesClient/UpdateSpace/main.go
+++ b/internal/generated/snippets/apps/meet/apiv2/SpacesClient/UpdateSpace/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apps/meet/apiv2beta/ConferenceRecordsClient/GetConferenceRecord/main.go
+++ b/internal/generated/snippets/apps/meet/apiv2beta/ConferenceRecordsClient/GetConferenceRecord/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apps/meet/apiv2beta/ConferenceRecordsClient/GetParticipant/main.go
+++ b/internal/generated/snippets/apps/meet/apiv2beta/ConferenceRecordsClient/GetParticipant/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apps/meet/apiv2beta/ConferenceRecordsClient/GetParticipantSession/main.go
+++ b/internal/generated/snippets/apps/meet/apiv2beta/ConferenceRecordsClient/GetParticipantSession/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apps/meet/apiv2beta/ConferenceRecordsClient/GetRecording/main.go
+++ b/internal/generated/snippets/apps/meet/apiv2beta/ConferenceRecordsClient/GetRecording/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apps/meet/apiv2beta/ConferenceRecordsClient/GetTranscript/main.go
+++ b/internal/generated/snippets/apps/meet/apiv2beta/ConferenceRecordsClient/GetTranscript/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apps/meet/apiv2beta/ConferenceRecordsClient/GetTranscriptEntry/main.go
+++ b/internal/generated/snippets/apps/meet/apiv2beta/ConferenceRecordsClient/GetTranscriptEntry/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apps/meet/apiv2beta/ConferenceRecordsClient/ListConferenceRecords/main.go
+++ b/internal/generated/snippets/apps/meet/apiv2beta/ConferenceRecordsClient/ListConferenceRecords/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apps/meet/apiv2beta/ConferenceRecordsClient/ListParticipantSessions/main.go
+++ b/internal/generated/snippets/apps/meet/apiv2beta/ConferenceRecordsClient/ListParticipantSessions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apps/meet/apiv2beta/ConferenceRecordsClient/ListParticipants/main.go
+++ b/internal/generated/snippets/apps/meet/apiv2beta/ConferenceRecordsClient/ListParticipants/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apps/meet/apiv2beta/ConferenceRecordsClient/ListRecordings/main.go
+++ b/internal/generated/snippets/apps/meet/apiv2beta/ConferenceRecordsClient/ListRecordings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apps/meet/apiv2beta/ConferenceRecordsClient/ListTranscriptEntries/main.go
+++ b/internal/generated/snippets/apps/meet/apiv2beta/ConferenceRecordsClient/ListTranscriptEntries/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apps/meet/apiv2beta/ConferenceRecordsClient/ListTranscripts/main.go
+++ b/internal/generated/snippets/apps/meet/apiv2beta/ConferenceRecordsClient/ListTranscripts/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apps/meet/apiv2beta/SpacesClient/ConnectActiveConference/main.go
+++ b/internal/generated/snippets/apps/meet/apiv2beta/SpacesClient/ConnectActiveConference/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apps/meet/apiv2beta/SpacesClient/CreateMember/main.go
+++ b/internal/generated/snippets/apps/meet/apiv2beta/SpacesClient/CreateMember/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apps/meet/apiv2beta/SpacesClient/CreateSpace/main.go
+++ b/internal/generated/snippets/apps/meet/apiv2beta/SpacesClient/CreateSpace/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apps/meet/apiv2beta/SpacesClient/DeleteMember/main.go
+++ b/internal/generated/snippets/apps/meet/apiv2beta/SpacesClient/DeleteMember/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apps/meet/apiv2beta/SpacesClient/EndActiveConference/main.go
+++ b/internal/generated/snippets/apps/meet/apiv2beta/SpacesClient/EndActiveConference/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apps/meet/apiv2beta/SpacesClient/GetMember/main.go
+++ b/internal/generated/snippets/apps/meet/apiv2beta/SpacesClient/GetMember/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apps/meet/apiv2beta/SpacesClient/GetSpace/main.go
+++ b/internal/generated/snippets/apps/meet/apiv2beta/SpacesClient/GetSpace/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apps/meet/apiv2beta/SpacesClient/ListMembers/main.go
+++ b/internal/generated/snippets/apps/meet/apiv2beta/SpacesClient/ListMembers/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/apps/meet/apiv2beta/SpacesClient/UpdateSpace/main.go
+++ b/internal/generated/snippets/apps/meet/apiv2beta/SpacesClient/UpdateSpace/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/area120/tables/apiv1alpha1/Client/BatchCreateRows/main.go
+++ b/internal/generated/snippets/area120/tables/apiv1alpha1/Client/BatchCreateRows/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/area120/tables/apiv1alpha1/Client/BatchDeleteRows/main.go
+++ b/internal/generated/snippets/area120/tables/apiv1alpha1/Client/BatchDeleteRows/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/area120/tables/apiv1alpha1/Client/BatchUpdateRows/main.go
+++ b/internal/generated/snippets/area120/tables/apiv1alpha1/Client/BatchUpdateRows/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/area120/tables/apiv1alpha1/Client/CreateRow/main.go
+++ b/internal/generated/snippets/area120/tables/apiv1alpha1/Client/CreateRow/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/area120/tables/apiv1alpha1/Client/DeleteRow/main.go
+++ b/internal/generated/snippets/area120/tables/apiv1alpha1/Client/DeleteRow/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/area120/tables/apiv1alpha1/Client/GetRow/main.go
+++ b/internal/generated/snippets/area120/tables/apiv1alpha1/Client/GetRow/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/area120/tables/apiv1alpha1/Client/GetTable/main.go
+++ b/internal/generated/snippets/area120/tables/apiv1alpha1/Client/GetTable/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/area120/tables/apiv1alpha1/Client/GetWorkspace/main.go
+++ b/internal/generated/snippets/area120/tables/apiv1alpha1/Client/GetWorkspace/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/area120/tables/apiv1alpha1/Client/ListRows/main.go
+++ b/internal/generated/snippets/area120/tables/apiv1alpha1/Client/ListRows/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/area120/tables/apiv1alpha1/Client/ListTables/main.go
+++ b/internal/generated/snippets/area120/tables/apiv1alpha1/Client/ListTables/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/area120/tables/apiv1alpha1/Client/ListWorkspaces/main.go
+++ b/internal/generated/snippets/area120/tables/apiv1alpha1/Client/ListWorkspaces/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/area120/tables/apiv1alpha1/Client/UpdateRow/main.go
+++ b/internal/generated/snippets/area120/tables/apiv1alpha1/Client/UpdateRow/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1/Client/BatchDeleteVersions/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1/Client/BatchDeleteVersions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1/Client/CreateAttachment/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1/Client/CreateAttachment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1/Client/CreateRepository/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1/Client/CreateRepository/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1/Client/CreateRule/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1/Client/CreateRule/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1/Client/CreateTag/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1/Client/CreateTag/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1/Client/DeleteAttachment/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1/Client/DeleteAttachment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1/Client/DeleteFile/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1/Client/DeleteFile/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1/Client/DeletePackage/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1/Client/DeletePackage/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1/Client/DeleteRepository/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1/Client/DeleteRepository/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1/Client/DeleteRule/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1/Client/DeleteRule/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1/Client/DeleteTag/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1/Client/DeleteTag/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1/Client/DeleteVersion/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1/Client/DeleteVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1/Client/ExportArtifact/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1/Client/ExportArtifact/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1/Client/GetAttachment/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1/Client/GetAttachment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1/Client/GetDockerImage/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1/Client/GetDockerImage/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1/Client/GetFile/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1/Client/GetFile/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1/Client/GetIamPolicy/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1/Client/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1/Client/GetLocation/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1/Client/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1/Client/GetMavenArtifact/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1/Client/GetMavenArtifact/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1/Client/GetNpmPackage/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1/Client/GetNpmPackage/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1/Client/GetOperation/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1/Client/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1/Client/GetPackage/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1/Client/GetPackage/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1/Client/GetProjectSettings/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1/Client/GetProjectSettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1/Client/GetPythonPackage/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1/Client/GetPythonPackage/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1/Client/GetRepository/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1/Client/GetRepository/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1/Client/GetRule/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1/Client/GetRule/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1/Client/GetTag/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1/Client/GetTag/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1/Client/GetVPCSCConfig/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1/Client/GetVPCSCConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1/Client/GetVersion/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1/Client/GetVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1/Client/ImportAptArtifacts/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1/Client/ImportAptArtifacts/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1/Client/ImportYumArtifacts/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1/Client/ImportYumArtifacts/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1/Client/ListAttachments/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1/Client/ListAttachments/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1/Client/ListDockerImages/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1/Client/ListDockerImages/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1/Client/ListFiles/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1/Client/ListFiles/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1/Client/ListLocations/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1/Client/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1/Client/ListMavenArtifacts/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1/Client/ListMavenArtifacts/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1/Client/ListNpmPackages/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1/Client/ListNpmPackages/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1/Client/ListPackages/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1/Client/ListPackages/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1/Client/ListPythonPackages/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1/Client/ListPythonPackages/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1/Client/ListRepositories/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1/Client/ListRepositories/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1/Client/ListRules/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1/Client/ListRules/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1/Client/ListTags/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1/Client/ListTags/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1/Client/ListVersions/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1/Client/ListVersions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1/Client/SetIamPolicy/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1/Client/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1/Client/TestIamPermissions/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1/Client/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1/Client/UpdateFile/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1/Client/UpdateFile/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1/Client/UpdatePackage/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1/Client/UpdatePackage/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1/Client/UpdateProjectSettings/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1/Client/UpdateProjectSettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1/Client/UpdateRepository/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1/Client/UpdateRepository/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1/Client/UpdateRule/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1/Client/UpdateRule/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1/Client/UpdateTag/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1/Client/UpdateTag/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1/Client/UpdateVPCSCConfig/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1/Client/UpdateVPCSCConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1/Client/UpdateVersion/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1/Client/UpdateVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1beta2/Client/CreateRepository/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1beta2/Client/CreateRepository/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1beta2/Client/CreateTag/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1beta2/Client/CreateTag/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1beta2/Client/DeletePackage/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1beta2/Client/DeletePackage/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1beta2/Client/DeleteRepository/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1beta2/Client/DeleteRepository/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1beta2/Client/DeleteTag/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1beta2/Client/DeleteTag/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1beta2/Client/DeleteVersion/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1beta2/Client/DeleteVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1beta2/Client/GetFile/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1beta2/Client/GetFile/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1beta2/Client/GetIamPolicy/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1beta2/Client/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1beta2/Client/GetLocation/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1beta2/Client/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1beta2/Client/GetPackage/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1beta2/Client/GetPackage/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1beta2/Client/GetProjectSettings/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1beta2/Client/GetProjectSettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1beta2/Client/GetRepository/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1beta2/Client/GetRepository/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1beta2/Client/GetTag/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1beta2/Client/GetTag/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1beta2/Client/GetVersion/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1beta2/Client/GetVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1beta2/Client/ImportAptArtifacts/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1beta2/Client/ImportAptArtifacts/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1beta2/Client/ImportYumArtifacts/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1beta2/Client/ImportYumArtifacts/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1beta2/Client/ListFiles/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1beta2/Client/ListFiles/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1beta2/Client/ListLocations/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1beta2/Client/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1beta2/Client/ListPackages/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1beta2/Client/ListPackages/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1beta2/Client/ListRepositories/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1beta2/Client/ListRepositories/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1beta2/Client/ListTags/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1beta2/Client/ListTags/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1beta2/Client/ListVersions/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1beta2/Client/ListVersions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1beta2/Client/SetIamPolicy/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1beta2/Client/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1beta2/Client/TestIamPermissions/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1beta2/Client/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1beta2/Client/UpdateProjectSettings/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1beta2/Client/UpdateProjectSettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1beta2/Client/UpdateRepository/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1beta2/Client/UpdateRepository/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/artifactregistry/apiv1beta2/Client/UpdateTag/main.go
+++ b/internal/generated/snippets/artifactregistry/apiv1beta2/Client/UpdateTag/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/asset/apiv1/Client/AnalyzeIamPolicy/main.go
+++ b/internal/generated/snippets/asset/apiv1/Client/AnalyzeIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/asset/apiv1/Client/AnalyzeIamPolicyLongrunning/main.go
+++ b/internal/generated/snippets/asset/apiv1/Client/AnalyzeIamPolicyLongrunning/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/asset/apiv1/Client/AnalyzeMove/main.go
+++ b/internal/generated/snippets/asset/apiv1/Client/AnalyzeMove/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/asset/apiv1/Client/AnalyzeOrgPolicies/main.go
+++ b/internal/generated/snippets/asset/apiv1/Client/AnalyzeOrgPolicies/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/asset/apiv1/Client/AnalyzeOrgPolicyGovernedAssets/main.go
+++ b/internal/generated/snippets/asset/apiv1/Client/AnalyzeOrgPolicyGovernedAssets/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/asset/apiv1/Client/AnalyzeOrgPolicyGovernedContainers/main.go
+++ b/internal/generated/snippets/asset/apiv1/Client/AnalyzeOrgPolicyGovernedContainers/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/asset/apiv1/Client/BatchGetAssetsHistory/main.go
+++ b/internal/generated/snippets/asset/apiv1/Client/BatchGetAssetsHistory/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/asset/apiv1/Client/BatchGetEffectiveIamPolicies/main.go
+++ b/internal/generated/snippets/asset/apiv1/Client/BatchGetEffectiveIamPolicies/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/asset/apiv1/Client/CreateFeed/main.go
+++ b/internal/generated/snippets/asset/apiv1/Client/CreateFeed/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/asset/apiv1/Client/CreateSavedQuery/main.go
+++ b/internal/generated/snippets/asset/apiv1/Client/CreateSavedQuery/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/asset/apiv1/Client/DeleteFeed/main.go
+++ b/internal/generated/snippets/asset/apiv1/Client/DeleteFeed/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/asset/apiv1/Client/DeleteSavedQuery/main.go
+++ b/internal/generated/snippets/asset/apiv1/Client/DeleteSavedQuery/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/asset/apiv1/Client/ExportAssets/main.go
+++ b/internal/generated/snippets/asset/apiv1/Client/ExportAssets/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/asset/apiv1/Client/GetFeed/main.go
+++ b/internal/generated/snippets/asset/apiv1/Client/GetFeed/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/asset/apiv1/Client/GetOperation/main.go
+++ b/internal/generated/snippets/asset/apiv1/Client/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/asset/apiv1/Client/GetSavedQuery/main.go
+++ b/internal/generated/snippets/asset/apiv1/Client/GetSavedQuery/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/asset/apiv1/Client/ListAssets/main.go
+++ b/internal/generated/snippets/asset/apiv1/Client/ListAssets/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/asset/apiv1/Client/ListFeeds/main.go
+++ b/internal/generated/snippets/asset/apiv1/Client/ListFeeds/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/asset/apiv1/Client/ListSavedQueries/main.go
+++ b/internal/generated/snippets/asset/apiv1/Client/ListSavedQueries/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/asset/apiv1/Client/QueryAssets/main.go
+++ b/internal/generated/snippets/asset/apiv1/Client/QueryAssets/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/asset/apiv1/Client/SearchAllIamPolicies/main.go
+++ b/internal/generated/snippets/asset/apiv1/Client/SearchAllIamPolicies/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/asset/apiv1/Client/SearchAllResources/main.go
+++ b/internal/generated/snippets/asset/apiv1/Client/SearchAllResources/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/asset/apiv1/Client/UpdateFeed/main.go
+++ b/internal/generated/snippets/asset/apiv1/Client/UpdateFeed/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/asset/apiv1/Client/UpdateSavedQuery/main.go
+++ b/internal/generated/snippets/asset/apiv1/Client/UpdateSavedQuery/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/asset/apiv1p2beta1/Client/CreateFeed/main.go
+++ b/internal/generated/snippets/asset/apiv1p2beta1/Client/CreateFeed/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/asset/apiv1p2beta1/Client/DeleteFeed/main.go
+++ b/internal/generated/snippets/asset/apiv1p2beta1/Client/DeleteFeed/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/asset/apiv1p2beta1/Client/GetFeed/main.go
+++ b/internal/generated/snippets/asset/apiv1p2beta1/Client/GetFeed/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/asset/apiv1p2beta1/Client/GetOperation/main.go
+++ b/internal/generated/snippets/asset/apiv1p2beta1/Client/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/asset/apiv1p2beta1/Client/ListFeeds/main.go
+++ b/internal/generated/snippets/asset/apiv1p2beta1/Client/ListFeeds/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/asset/apiv1p2beta1/Client/UpdateFeed/main.go
+++ b/internal/generated/snippets/asset/apiv1p2beta1/Client/UpdateFeed/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/asset/apiv1p5beta1/Client/ListAssets/main.go
+++ b/internal/generated/snippets/asset/apiv1p5beta1/Client/ListAssets/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/assuredworkloads/apiv1/Client/AcknowledgeViolation/main.go
+++ b/internal/generated/snippets/assuredworkloads/apiv1/Client/AcknowledgeViolation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/assuredworkloads/apiv1/Client/CreateWorkload/main.go
+++ b/internal/generated/snippets/assuredworkloads/apiv1/Client/CreateWorkload/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/assuredworkloads/apiv1/Client/DeleteWorkload/main.go
+++ b/internal/generated/snippets/assuredworkloads/apiv1/Client/DeleteWorkload/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/assuredworkloads/apiv1/Client/GetOperation/main.go
+++ b/internal/generated/snippets/assuredworkloads/apiv1/Client/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/assuredworkloads/apiv1/Client/GetViolation/main.go
+++ b/internal/generated/snippets/assuredworkloads/apiv1/Client/GetViolation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/assuredworkloads/apiv1/Client/GetWorkload/main.go
+++ b/internal/generated/snippets/assuredworkloads/apiv1/Client/GetWorkload/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/assuredworkloads/apiv1/Client/ListOperations/main.go
+++ b/internal/generated/snippets/assuredworkloads/apiv1/Client/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/assuredworkloads/apiv1/Client/ListViolations/main.go
+++ b/internal/generated/snippets/assuredworkloads/apiv1/Client/ListViolations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/assuredworkloads/apiv1/Client/ListWorkloads/main.go
+++ b/internal/generated/snippets/assuredworkloads/apiv1/Client/ListWorkloads/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/assuredworkloads/apiv1/Client/RestrictAllowedResources/main.go
+++ b/internal/generated/snippets/assuredworkloads/apiv1/Client/RestrictAllowedResources/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/assuredworkloads/apiv1/Client/UpdateWorkload/main.go
+++ b/internal/generated/snippets/assuredworkloads/apiv1/Client/UpdateWorkload/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/assuredworkloads/apiv1beta1/Client/AnalyzeWorkloadMove/main.go
+++ b/internal/generated/snippets/assuredworkloads/apiv1beta1/Client/AnalyzeWorkloadMove/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/assuredworkloads/apiv1beta1/Client/CreateWorkload/main.go
+++ b/internal/generated/snippets/assuredworkloads/apiv1beta1/Client/CreateWorkload/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/assuredworkloads/apiv1beta1/Client/DeleteWorkload/main.go
+++ b/internal/generated/snippets/assuredworkloads/apiv1beta1/Client/DeleteWorkload/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/assuredworkloads/apiv1beta1/Client/GetOperation/main.go
+++ b/internal/generated/snippets/assuredworkloads/apiv1beta1/Client/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/assuredworkloads/apiv1beta1/Client/GetWorkload/main.go
+++ b/internal/generated/snippets/assuredworkloads/apiv1beta1/Client/GetWorkload/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/assuredworkloads/apiv1beta1/Client/ListOperations/main.go
+++ b/internal/generated/snippets/assuredworkloads/apiv1beta1/Client/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/assuredworkloads/apiv1beta1/Client/ListWorkloads/main.go
+++ b/internal/generated/snippets/assuredworkloads/apiv1beta1/Client/ListWorkloads/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/assuredworkloads/apiv1beta1/Client/RestrictAllowedResources/main.go
+++ b/internal/generated/snippets/assuredworkloads/apiv1beta1/Client/RestrictAllowedResources/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/assuredworkloads/apiv1beta1/Client/UpdateWorkload/main.go
+++ b/internal/generated/snippets/assuredworkloads/apiv1beta1/Client/UpdateWorkload/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/automl/apiv1/Client/CreateDataset/main.go
+++ b/internal/generated/snippets/automl/apiv1/Client/CreateDataset/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/automl/apiv1/Client/CreateModel/main.go
+++ b/internal/generated/snippets/automl/apiv1/Client/CreateModel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/automl/apiv1/Client/DeleteDataset/main.go
+++ b/internal/generated/snippets/automl/apiv1/Client/DeleteDataset/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/automl/apiv1/Client/DeleteModel/main.go
+++ b/internal/generated/snippets/automl/apiv1/Client/DeleteModel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/automl/apiv1/Client/DeployModel/main.go
+++ b/internal/generated/snippets/automl/apiv1/Client/DeployModel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/automl/apiv1/Client/ExportData/main.go
+++ b/internal/generated/snippets/automl/apiv1/Client/ExportData/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/automl/apiv1/Client/ExportModel/main.go
+++ b/internal/generated/snippets/automl/apiv1/Client/ExportModel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/automl/apiv1/Client/GetAnnotationSpec/main.go
+++ b/internal/generated/snippets/automl/apiv1/Client/GetAnnotationSpec/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/automl/apiv1/Client/GetDataset/main.go
+++ b/internal/generated/snippets/automl/apiv1/Client/GetDataset/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/automl/apiv1/Client/GetModel/main.go
+++ b/internal/generated/snippets/automl/apiv1/Client/GetModel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/automl/apiv1/Client/GetModelEvaluation/main.go
+++ b/internal/generated/snippets/automl/apiv1/Client/GetModelEvaluation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/automl/apiv1/Client/ImportData/main.go
+++ b/internal/generated/snippets/automl/apiv1/Client/ImportData/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/automl/apiv1/Client/ListDatasets/main.go
+++ b/internal/generated/snippets/automl/apiv1/Client/ListDatasets/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/automl/apiv1/Client/ListModelEvaluations/main.go
+++ b/internal/generated/snippets/automl/apiv1/Client/ListModelEvaluations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/automl/apiv1/Client/ListModels/main.go
+++ b/internal/generated/snippets/automl/apiv1/Client/ListModels/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/automl/apiv1/Client/UndeployModel/main.go
+++ b/internal/generated/snippets/automl/apiv1/Client/UndeployModel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/automl/apiv1/Client/UpdateDataset/main.go
+++ b/internal/generated/snippets/automl/apiv1/Client/UpdateDataset/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/automl/apiv1/Client/UpdateModel/main.go
+++ b/internal/generated/snippets/automl/apiv1/Client/UpdateModel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/automl/apiv1/PredictionClient/BatchPredict/main.go
+++ b/internal/generated/snippets/automl/apiv1/PredictionClient/BatchPredict/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/automl/apiv1/PredictionClient/Predict/main.go
+++ b/internal/generated/snippets/automl/apiv1/PredictionClient/Predict/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/automl/apiv1beta1/Client/CreateDataset/main.go
+++ b/internal/generated/snippets/automl/apiv1beta1/Client/CreateDataset/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/automl/apiv1beta1/Client/CreateModel/main.go
+++ b/internal/generated/snippets/automl/apiv1beta1/Client/CreateModel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/automl/apiv1beta1/Client/DeleteDataset/main.go
+++ b/internal/generated/snippets/automl/apiv1beta1/Client/DeleteDataset/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/automl/apiv1beta1/Client/DeleteModel/main.go
+++ b/internal/generated/snippets/automl/apiv1beta1/Client/DeleteModel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/automl/apiv1beta1/Client/DeployModel/main.go
+++ b/internal/generated/snippets/automl/apiv1beta1/Client/DeployModel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/automl/apiv1beta1/Client/ExportData/main.go
+++ b/internal/generated/snippets/automl/apiv1beta1/Client/ExportData/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/automl/apiv1beta1/Client/ExportEvaluatedExamples/main.go
+++ b/internal/generated/snippets/automl/apiv1beta1/Client/ExportEvaluatedExamples/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/automl/apiv1beta1/Client/ExportModel/main.go
+++ b/internal/generated/snippets/automl/apiv1beta1/Client/ExportModel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/automl/apiv1beta1/Client/GetAnnotationSpec/main.go
+++ b/internal/generated/snippets/automl/apiv1beta1/Client/GetAnnotationSpec/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/automl/apiv1beta1/Client/GetColumnSpec/main.go
+++ b/internal/generated/snippets/automl/apiv1beta1/Client/GetColumnSpec/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/automl/apiv1beta1/Client/GetDataset/main.go
+++ b/internal/generated/snippets/automl/apiv1beta1/Client/GetDataset/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/automl/apiv1beta1/Client/GetModel/main.go
+++ b/internal/generated/snippets/automl/apiv1beta1/Client/GetModel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/automl/apiv1beta1/Client/GetModelEvaluation/main.go
+++ b/internal/generated/snippets/automl/apiv1beta1/Client/GetModelEvaluation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/automl/apiv1beta1/Client/GetTableSpec/main.go
+++ b/internal/generated/snippets/automl/apiv1beta1/Client/GetTableSpec/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/automl/apiv1beta1/Client/ImportData/main.go
+++ b/internal/generated/snippets/automl/apiv1beta1/Client/ImportData/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/automl/apiv1beta1/Client/ListColumnSpecs/main.go
+++ b/internal/generated/snippets/automl/apiv1beta1/Client/ListColumnSpecs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/automl/apiv1beta1/Client/ListDatasets/main.go
+++ b/internal/generated/snippets/automl/apiv1beta1/Client/ListDatasets/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/automl/apiv1beta1/Client/ListModelEvaluations/main.go
+++ b/internal/generated/snippets/automl/apiv1beta1/Client/ListModelEvaluations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/automl/apiv1beta1/Client/ListModels/main.go
+++ b/internal/generated/snippets/automl/apiv1beta1/Client/ListModels/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/automl/apiv1beta1/Client/ListTableSpecs/main.go
+++ b/internal/generated/snippets/automl/apiv1beta1/Client/ListTableSpecs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/automl/apiv1beta1/Client/UndeployModel/main.go
+++ b/internal/generated/snippets/automl/apiv1beta1/Client/UndeployModel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/automl/apiv1beta1/Client/UpdateColumnSpec/main.go
+++ b/internal/generated/snippets/automl/apiv1beta1/Client/UpdateColumnSpec/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/automl/apiv1beta1/Client/UpdateDataset/main.go
+++ b/internal/generated/snippets/automl/apiv1beta1/Client/UpdateDataset/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/automl/apiv1beta1/Client/UpdateTableSpec/main.go
+++ b/internal/generated/snippets/automl/apiv1beta1/Client/UpdateTableSpec/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/automl/apiv1beta1/PredictionClient/BatchPredict/main.go
+++ b/internal/generated/snippets/automl/apiv1beta1/PredictionClient/BatchPredict/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/automl/apiv1beta1/PredictionClient/Predict/main.go
+++ b/internal/generated/snippets/automl/apiv1beta1/PredictionClient/Predict/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/baremetalsolution/apiv2/Client/CreateNfsShare/main.go
+++ b/internal/generated/snippets/baremetalsolution/apiv2/Client/CreateNfsShare/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/baremetalsolution/apiv2/Client/CreateProvisioningConfig/main.go
+++ b/internal/generated/snippets/baremetalsolution/apiv2/Client/CreateProvisioningConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/baremetalsolution/apiv2/Client/CreateSSHKey/main.go
+++ b/internal/generated/snippets/baremetalsolution/apiv2/Client/CreateSSHKey/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/baremetalsolution/apiv2/Client/CreateVolumeSnapshot/main.go
+++ b/internal/generated/snippets/baremetalsolution/apiv2/Client/CreateVolumeSnapshot/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/baremetalsolution/apiv2/Client/DeleteNfsShare/main.go
+++ b/internal/generated/snippets/baremetalsolution/apiv2/Client/DeleteNfsShare/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/baremetalsolution/apiv2/Client/DeleteSSHKey/main.go
+++ b/internal/generated/snippets/baremetalsolution/apiv2/Client/DeleteSSHKey/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/baremetalsolution/apiv2/Client/DeleteVolumeSnapshot/main.go
+++ b/internal/generated/snippets/baremetalsolution/apiv2/Client/DeleteVolumeSnapshot/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/baremetalsolution/apiv2/Client/DetachLun/main.go
+++ b/internal/generated/snippets/baremetalsolution/apiv2/Client/DetachLun/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/baremetalsolution/apiv2/Client/DisableInteractiveSerialConsole/main.go
+++ b/internal/generated/snippets/baremetalsolution/apiv2/Client/DisableInteractiveSerialConsole/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/baremetalsolution/apiv2/Client/EnableInteractiveSerialConsole/main.go
+++ b/internal/generated/snippets/baremetalsolution/apiv2/Client/EnableInteractiveSerialConsole/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/baremetalsolution/apiv2/Client/EvictLun/main.go
+++ b/internal/generated/snippets/baremetalsolution/apiv2/Client/EvictLun/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/baremetalsolution/apiv2/Client/EvictVolume/main.go
+++ b/internal/generated/snippets/baremetalsolution/apiv2/Client/EvictVolume/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/baremetalsolution/apiv2/Client/GetInstance/main.go
+++ b/internal/generated/snippets/baremetalsolution/apiv2/Client/GetInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/baremetalsolution/apiv2/Client/GetLocation/main.go
+++ b/internal/generated/snippets/baremetalsolution/apiv2/Client/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/baremetalsolution/apiv2/Client/GetLun/main.go
+++ b/internal/generated/snippets/baremetalsolution/apiv2/Client/GetLun/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/baremetalsolution/apiv2/Client/GetNetwork/main.go
+++ b/internal/generated/snippets/baremetalsolution/apiv2/Client/GetNetwork/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/baremetalsolution/apiv2/Client/GetNfsShare/main.go
+++ b/internal/generated/snippets/baremetalsolution/apiv2/Client/GetNfsShare/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/baremetalsolution/apiv2/Client/GetProvisioningConfig/main.go
+++ b/internal/generated/snippets/baremetalsolution/apiv2/Client/GetProvisioningConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/baremetalsolution/apiv2/Client/GetVolume/main.go
+++ b/internal/generated/snippets/baremetalsolution/apiv2/Client/GetVolume/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/baremetalsolution/apiv2/Client/GetVolumeSnapshot/main.go
+++ b/internal/generated/snippets/baremetalsolution/apiv2/Client/GetVolumeSnapshot/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/baremetalsolution/apiv2/Client/ListInstances/main.go
+++ b/internal/generated/snippets/baremetalsolution/apiv2/Client/ListInstances/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/baremetalsolution/apiv2/Client/ListLocations/main.go
+++ b/internal/generated/snippets/baremetalsolution/apiv2/Client/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/baremetalsolution/apiv2/Client/ListLuns/main.go
+++ b/internal/generated/snippets/baremetalsolution/apiv2/Client/ListLuns/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/baremetalsolution/apiv2/Client/ListNetworkUsage/main.go
+++ b/internal/generated/snippets/baremetalsolution/apiv2/Client/ListNetworkUsage/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/baremetalsolution/apiv2/Client/ListNetworks/main.go
+++ b/internal/generated/snippets/baremetalsolution/apiv2/Client/ListNetworks/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/baremetalsolution/apiv2/Client/ListNfsShares/main.go
+++ b/internal/generated/snippets/baremetalsolution/apiv2/Client/ListNfsShares/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/baremetalsolution/apiv2/Client/ListOSImages/main.go
+++ b/internal/generated/snippets/baremetalsolution/apiv2/Client/ListOSImages/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/baremetalsolution/apiv2/Client/ListProvisioningQuotas/main.go
+++ b/internal/generated/snippets/baremetalsolution/apiv2/Client/ListProvisioningQuotas/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/baremetalsolution/apiv2/Client/ListSSHKeys/main.go
+++ b/internal/generated/snippets/baremetalsolution/apiv2/Client/ListSSHKeys/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/baremetalsolution/apiv2/Client/ListVolumeSnapshots/main.go
+++ b/internal/generated/snippets/baremetalsolution/apiv2/Client/ListVolumeSnapshots/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/baremetalsolution/apiv2/Client/ListVolumes/main.go
+++ b/internal/generated/snippets/baremetalsolution/apiv2/Client/ListVolumes/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/baremetalsolution/apiv2/Client/RenameInstance/main.go
+++ b/internal/generated/snippets/baremetalsolution/apiv2/Client/RenameInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/baremetalsolution/apiv2/Client/RenameNetwork/main.go
+++ b/internal/generated/snippets/baremetalsolution/apiv2/Client/RenameNetwork/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/baremetalsolution/apiv2/Client/RenameNfsShare/main.go
+++ b/internal/generated/snippets/baremetalsolution/apiv2/Client/RenameNfsShare/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/baremetalsolution/apiv2/Client/RenameVolume/main.go
+++ b/internal/generated/snippets/baremetalsolution/apiv2/Client/RenameVolume/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/baremetalsolution/apiv2/Client/ResetInstance/main.go
+++ b/internal/generated/snippets/baremetalsolution/apiv2/Client/ResetInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/baremetalsolution/apiv2/Client/ResizeVolume/main.go
+++ b/internal/generated/snippets/baremetalsolution/apiv2/Client/ResizeVolume/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/baremetalsolution/apiv2/Client/RestoreVolumeSnapshot/main.go
+++ b/internal/generated/snippets/baremetalsolution/apiv2/Client/RestoreVolumeSnapshot/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/baremetalsolution/apiv2/Client/StartInstance/main.go
+++ b/internal/generated/snippets/baremetalsolution/apiv2/Client/StartInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/baremetalsolution/apiv2/Client/StopInstance/main.go
+++ b/internal/generated/snippets/baremetalsolution/apiv2/Client/StopInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/baremetalsolution/apiv2/Client/SubmitProvisioningConfig/main.go
+++ b/internal/generated/snippets/baremetalsolution/apiv2/Client/SubmitProvisioningConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/baremetalsolution/apiv2/Client/UpdateInstance/main.go
+++ b/internal/generated/snippets/baremetalsolution/apiv2/Client/UpdateInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/baremetalsolution/apiv2/Client/UpdateNetwork/main.go
+++ b/internal/generated/snippets/baremetalsolution/apiv2/Client/UpdateNetwork/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/baremetalsolution/apiv2/Client/UpdateNfsShare/main.go
+++ b/internal/generated/snippets/baremetalsolution/apiv2/Client/UpdateNfsShare/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/baremetalsolution/apiv2/Client/UpdateProvisioningConfig/main.go
+++ b/internal/generated/snippets/baremetalsolution/apiv2/Client/UpdateProvisioningConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/baremetalsolution/apiv2/Client/UpdateVolume/main.go
+++ b/internal/generated/snippets/baremetalsolution/apiv2/Client/UpdateVolume/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/batch/apiv1/Client/CancelJob/main.go
+++ b/internal/generated/snippets/batch/apiv1/Client/CancelJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/batch/apiv1/Client/CancelOperation/main.go
+++ b/internal/generated/snippets/batch/apiv1/Client/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/batch/apiv1/Client/CreateJob/main.go
+++ b/internal/generated/snippets/batch/apiv1/Client/CreateJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/batch/apiv1/Client/DeleteJob/main.go
+++ b/internal/generated/snippets/batch/apiv1/Client/DeleteJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/batch/apiv1/Client/DeleteOperation/main.go
+++ b/internal/generated/snippets/batch/apiv1/Client/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/batch/apiv1/Client/GetJob/main.go
+++ b/internal/generated/snippets/batch/apiv1/Client/GetJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/batch/apiv1/Client/GetLocation/main.go
+++ b/internal/generated/snippets/batch/apiv1/Client/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/batch/apiv1/Client/GetOperation/main.go
+++ b/internal/generated/snippets/batch/apiv1/Client/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/batch/apiv1/Client/GetTask/main.go
+++ b/internal/generated/snippets/batch/apiv1/Client/GetTask/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/batch/apiv1/Client/ListJobs/main.go
+++ b/internal/generated/snippets/batch/apiv1/Client/ListJobs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/batch/apiv1/Client/ListLocations/main.go
+++ b/internal/generated/snippets/batch/apiv1/Client/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/batch/apiv1/Client/ListOperations/main.go
+++ b/internal/generated/snippets/batch/apiv1/Client/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/batch/apiv1/Client/ListTasks/main.go
+++ b/internal/generated/snippets/batch/apiv1/Client/ListTasks/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/beyondcorp/appconnections/apiv1/Client/CancelOperation/main.go
+++ b/internal/generated/snippets/beyondcorp/appconnections/apiv1/Client/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/beyondcorp/appconnections/apiv1/Client/CreateAppConnection/main.go
+++ b/internal/generated/snippets/beyondcorp/appconnections/apiv1/Client/CreateAppConnection/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/beyondcorp/appconnections/apiv1/Client/DeleteAppConnection/main.go
+++ b/internal/generated/snippets/beyondcorp/appconnections/apiv1/Client/DeleteAppConnection/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/beyondcorp/appconnections/apiv1/Client/DeleteOperation/main.go
+++ b/internal/generated/snippets/beyondcorp/appconnections/apiv1/Client/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/beyondcorp/appconnections/apiv1/Client/GetAppConnection/main.go
+++ b/internal/generated/snippets/beyondcorp/appconnections/apiv1/Client/GetAppConnection/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/beyondcorp/appconnections/apiv1/Client/GetIamPolicy/main.go
+++ b/internal/generated/snippets/beyondcorp/appconnections/apiv1/Client/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/beyondcorp/appconnections/apiv1/Client/GetLocation/main.go
+++ b/internal/generated/snippets/beyondcorp/appconnections/apiv1/Client/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/beyondcorp/appconnections/apiv1/Client/GetOperation/main.go
+++ b/internal/generated/snippets/beyondcorp/appconnections/apiv1/Client/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/beyondcorp/appconnections/apiv1/Client/ListAppConnections/main.go
+++ b/internal/generated/snippets/beyondcorp/appconnections/apiv1/Client/ListAppConnections/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/beyondcorp/appconnections/apiv1/Client/ListLocations/main.go
+++ b/internal/generated/snippets/beyondcorp/appconnections/apiv1/Client/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/beyondcorp/appconnections/apiv1/Client/ListOperations/main.go
+++ b/internal/generated/snippets/beyondcorp/appconnections/apiv1/Client/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/beyondcorp/appconnections/apiv1/Client/ResolveAppConnections/main.go
+++ b/internal/generated/snippets/beyondcorp/appconnections/apiv1/Client/ResolveAppConnections/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/beyondcorp/appconnections/apiv1/Client/SetIamPolicy/main.go
+++ b/internal/generated/snippets/beyondcorp/appconnections/apiv1/Client/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/beyondcorp/appconnections/apiv1/Client/TestIamPermissions/main.go
+++ b/internal/generated/snippets/beyondcorp/appconnections/apiv1/Client/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/beyondcorp/appconnections/apiv1/Client/UpdateAppConnection/main.go
+++ b/internal/generated/snippets/beyondcorp/appconnections/apiv1/Client/UpdateAppConnection/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/beyondcorp/appconnectors/apiv1/Client/CancelOperation/main.go
+++ b/internal/generated/snippets/beyondcorp/appconnectors/apiv1/Client/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/beyondcorp/appconnectors/apiv1/Client/CreateAppConnector/main.go
+++ b/internal/generated/snippets/beyondcorp/appconnectors/apiv1/Client/CreateAppConnector/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/beyondcorp/appconnectors/apiv1/Client/DeleteAppConnector/main.go
+++ b/internal/generated/snippets/beyondcorp/appconnectors/apiv1/Client/DeleteAppConnector/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/beyondcorp/appconnectors/apiv1/Client/DeleteOperation/main.go
+++ b/internal/generated/snippets/beyondcorp/appconnectors/apiv1/Client/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/beyondcorp/appconnectors/apiv1/Client/GetAppConnector/main.go
+++ b/internal/generated/snippets/beyondcorp/appconnectors/apiv1/Client/GetAppConnector/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/beyondcorp/appconnectors/apiv1/Client/GetIamPolicy/main.go
+++ b/internal/generated/snippets/beyondcorp/appconnectors/apiv1/Client/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/beyondcorp/appconnectors/apiv1/Client/GetLocation/main.go
+++ b/internal/generated/snippets/beyondcorp/appconnectors/apiv1/Client/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/beyondcorp/appconnectors/apiv1/Client/GetOperation/main.go
+++ b/internal/generated/snippets/beyondcorp/appconnectors/apiv1/Client/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/beyondcorp/appconnectors/apiv1/Client/ListAppConnectors/main.go
+++ b/internal/generated/snippets/beyondcorp/appconnectors/apiv1/Client/ListAppConnectors/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/beyondcorp/appconnectors/apiv1/Client/ListLocations/main.go
+++ b/internal/generated/snippets/beyondcorp/appconnectors/apiv1/Client/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/beyondcorp/appconnectors/apiv1/Client/ListOperations/main.go
+++ b/internal/generated/snippets/beyondcorp/appconnectors/apiv1/Client/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/beyondcorp/appconnectors/apiv1/Client/ReportStatus/main.go
+++ b/internal/generated/snippets/beyondcorp/appconnectors/apiv1/Client/ReportStatus/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/beyondcorp/appconnectors/apiv1/Client/SetIamPolicy/main.go
+++ b/internal/generated/snippets/beyondcorp/appconnectors/apiv1/Client/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/beyondcorp/appconnectors/apiv1/Client/TestIamPermissions/main.go
+++ b/internal/generated/snippets/beyondcorp/appconnectors/apiv1/Client/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/beyondcorp/appconnectors/apiv1/Client/UpdateAppConnector/main.go
+++ b/internal/generated/snippets/beyondcorp/appconnectors/apiv1/Client/UpdateAppConnector/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/beyondcorp/appgateways/apiv1/Client/CancelOperation/main.go
+++ b/internal/generated/snippets/beyondcorp/appgateways/apiv1/Client/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/beyondcorp/appgateways/apiv1/Client/CreateAppGateway/main.go
+++ b/internal/generated/snippets/beyondcorp/appgateways/apiv1/Client/CreateAppGateway/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/beyondcorp/appgateways/apiv1/Client/DeleteAppGateway/main.go
+++ b/internal/generated/snippets/beyondcorp/appgateways/apiv1/Client/DeleteAppGateway/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/beyondcorp/appgateways/apiv1/Client/DeleteOperation/main.go
+++ b/internal/generated/snippets/beyondcorp/appgateways/apiv1/Client/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/beyondcorp/appgateways/apiv1/Client/GetAppGateway/main.go
+++ b/internal/generated/snippets/beyondcorp/appgateways/apiv1/Client/GetAppGateway/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/beyondcorp/appgateways/apiv1/Client/GetIamPolicy/main.go
+++ b/internal/generated/snippets/beyondcorp/appgateways/apiv1/Client/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/beyondcorp/appgateways/apiv1/Client/GetLocation/main.go
+++ b/internal/generated/snippets/beyondcorp/appgateways/apiv1/Client/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/beyondcorp/appgateways/apiv1/Client/GetOperation/main.go
+++ b/internal/generated/snippets/beyondcorp/appgateways/apiv1/Client/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/beyondcorp/appgateways/apiv1/Client/ListAppGateways/main.go
+++ b/internal/generated/snippets/beyondcorp/appgateways/apiv1/Client/ListAppGateways/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/beyondcorp/appgateways/apiv1/Client/ListLocations/main.go
+++ b/internal/generated/snippets/beyondcorp/appgateways/apiv1/Client/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/beyondcorp/appgateways/apiv1/Client/ListOperations/main.go
+++ b/internal/generated/snippets/beyondcorp/appgateways/apiv1/Client/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/beyondcorp/appgateways/apiv1/Client/SetIamPolicy/main.go
+++ b/internal/generated/snippets/beyondcorp/appgateways/apiv1/Client/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/beyondcorp/appgateways/apiv1/Client/TestIamPermissions/main.go
+++ b/internal/generated/snippets/beyondcorp/appgateways/apiv1/Client/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/beyondcorp/clientconnectorservices/apiv1/Client/CancelOperation/main.go
+++ b/internal/generated/snippets/beyondcorp/clientconnectorservices/apiv1/Client/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/beyondcorp/clientconnectorservices/apiv1/Client/CreateClientConnectorService/main.go
+++ b/internal/generated/snippets/beyondcorp/clientconnectorservices/apiv1/Client/CreateClientConnectorService/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/beyondcorp/clientconnectorservices/apiv1/Client/DeleteClientConnectorService/main.go
+++ b/internal/generated/snippets/beyondcorp/clientconnectorservices/apiv1/Client/DeleteClientConnectorService/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/beyondcorp/clientconnectorservices/apiv1/Client/DeleteOperation/main.go
+++ b/internal/generated/snippets/beyondcorp/clientconnectorservices/apiv1/Client/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/beyondcorp/clientconnectorservices/apiv1/Client/GetClientConnectorService/main.go
+++ b/internal/generated/snippets/beyondcorp/clientconnectorservices/apiv1/Client/GetClientConnectorService/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/beyondcorp/clientconnectorservices/apiv1/Client/GetIamPolicy/main.go
+++ b/internal/generated/snippets/beyondcorp/clientconnectorservices/apiv1/Client/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/beyondcorp/clientconnectorservices/apiv1/Client/GetLocation/main.go
+++ b/internal/generated/snippets/beyondcorp/clientconnectorservices/apiv1/Client/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/beyondcorp/clientconnectorservices/apiv1/Client/GetOperation/main.go
+++ b/internal/generated/snippets/beyondcorp/clientconnectorservices/apiv1/Client/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/beyondcorp/clientconnectorservices/apiv1/Client/ListClientConnectorServices/main.go
+++ b/internal/generated/snippets/beyondcorp/clientconnectorservices/apiv1/Client/ListClientConnectorServices/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/beyondcorp/clientconnectorservices/apiv1/Client/ListLocations/main.go
+++ b/internal/generated/snippets/beyondcorp/clientconnectorservices/apiv1/Client/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/beyondcorp/clientconnectorservices/apiv1/Client/ListOperations/main.go
+++ b/internal/generated/snippets/beyondcorp/clientconnectorservices/apiv1/Client/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/beyondcorp/clientconnectorservices/apiv1/Client/SetIamPolicy/main.go
+++ b/internal/generated/snippets/beyondcorp/clientconnectorservices/apiv1/Client/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/beyondcorp/clientconnectorservices/apiv1/Client/TestIamPermissions/main.go
+++ b/internal/generated/snippets/beyondcorp/clientconnectorservices/apiv1/Client/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/beyondcorp/clientconnectorservices/apiv1/Client/UpdateClientConnectorService/main.go
+++ b/internal/generated/snippets/beyondcorp/clientconnectorservices/apiv1/Client/UpdateClientConnectorService/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/beyondcorp/clientgateways/apiv1/Client/CancelOperation/main.go
+++ b/internal/generated/snippets/beyondcorp/clientgateways/apiv1/Client/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/beyondcorp/clientgateways/apiv1/Client/CreateClientGateway/main.go
+++ b/internal/generated/snippets/beyondcorp/clientgateways/apiv1/Client/CreateClientGateway/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/beyondcorp/clientgateways/apiv1/Client/DeleteClientGateway/main.go
+++ b/internal/generated/snippets/beyondcorp/clientgateways/apiv1/Client/DeleteClientGateway/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/beyondcorp/clientgateways/apiv1/Client/DeleteOperation/main.go
+++ b/internal/generated/snippets/beyondcorp/clientgateways/apiv1/Client/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/beyondcorp/clientgateways/apiv1/Client/GetClientGateway/main.go
+++ b/internal/generated/snippets/beyondcorp/clientgateways/apiv1/Client/GetClientGateway/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/beyondcorp/clientgateways/apiv1/Client/GetIamPolicy/main.go
+++ b/internal/generated/snippets/beyondcorp/clientgateways/apiv1/Client/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/beyondcorp/clientgateways/apiv1/Client/GetLocation/main.go
+++ b/internal/generated/snippets/beyondcorp/clientgateways/apiv1/Client/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/beyondcorp/clientgateways/apiv1/Client/GetOperation/main.go
+++ b/internal/generated/snippets/beyondcorp/clientgateways/apiv1/Client/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/beyondcorp/clientgateways/apiv1/Client/ListClientGateways/main.go
+++ b/internal/generated/snippets/beyondcorp/clientgateways/apiv1/Client/ListClientGateways/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/beyondcorp/clientgateways/apiv1/Client/ListLocations/main.go
+++ b/internal/generated/snippets/beyondcorp/clientgateways/apiv1/Client/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/beyondcorp/clientgateways/apiv1/Client/ListOperations/main.go
+++ b/internal/generated/snippets/beyondcorp/clientgateways/apiv1/Client/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/beyondcorp/clientgateways/apiv1/Client/SetIamPolicy/main.go
+++ b/internal/generated/snippets/beyondcorp/clientgateways/apiv1/Client/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/beyondcorp/clientgateways/apiv1/Client/TestIamPermissions/main.go
+++ b/internal/generated/snippets/beyondcorp/clientgateways/apiv1/Client/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/analyticshub/apiv1/Client/ApproveQueryTemplate/main.go
+++ b/internal/generated/snippets/bigquery/analyticshub/apiv1/Client/ApproveQueryTemplate/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/analyticshub/apiv1/Client/CreateDataExchange/main.go
+++ b/internal/generated/snippets/bigquery/analyticshub/apiv1/Client/CreateDataExchange/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/analyticshub/apiv1/Client/CreateListing/main.go
+++ b/internal/generated/snippets/bigquery/analyticshub/apiv1/Client/CreateListing/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/analyticshub/apiv1/Client/CreateQueryTemplate/main.go
+++ b/internal/generated/snippets/bigquery/analyticshub/apiv1/Client/CreateQueryTemplate/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/analyticshub/apiv1/Client/DeleteDataExchange/main.go
+++ b/internal/generated/snippets/bigquery/analyticshub/apiv1/Client/DeleteDataExchange/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/analyticshub/apiv1/Client/DeleteListing/main.go
+++ b/internal/generated/snippets/bigquery/analyticshub/apiv1/Client/DeleteListing/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/analyticshub/apiv1/Client/DeleteQueryTemplate/main.go
+++ b/internal/generated/snippets/bigquery/analyticshub/apiv1/Client/DeleteQueryTemplate/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/analyticshub/apiv1/Client/DeleteSubscription/main.go
+++ b/internal/generated/snippets/bigquery/analyticshub/apiv1/Client/DeleteSubscription/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/analyticshub/apiv1/Client/GetDataExchange/main.go
+++ b/internal/generated/snippets/bigquery/analyticshub/apiv1/Client/GetDataExchange/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/analyticshub/apiv1/Client/GetIamPolicy/main.go
+++ b/internal/generated/snippets/bigquery/analyticshub/apiv1/Client/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/analyticshub/apiv1/Client/GetListing/main.go
+++ b/internal/generated/snippets/bigquery/analyticshub/apiv1/Client/GetListing/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/analyticshub/apiv1/Client/GetQueryTemplate/main.go
+++ b/internal/generated/snippets/bigquery/analyticshub/apiv1/Client/GetQueryTemplate/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/analyticshub/apiv1/Client/GetSubscription/main.go
+++ b/internal/generated/snippets/bigquery/analyticshub/apiv1/Client/GetSubscription/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/analyticshub/apiv1/Client/ListDataExchanges/main.go
+++ b/internal/generated/snippets/bigquery/analyticshub/apiv1/Client/ListDataExchanges/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/analyticshub/apiv1/Client/ListListings/main.go
+++ b/internal/generated/snippets/bigquery/analyticshub/apiv1/Client/ListListings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/analyticshub/apiv1/Client/ListOrgDataExchanges/main.go
+++ b/internal/generated/snippets/bigquery/analyticshub/apiv1/Client/ListOrgDataExchanges/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/analyticshub/apiv1/Client/ListQueryTemplates/main.go
+++ b/internal/generated/snippets/bigquery/analyticshub/apiv1/Client/ListQueryTemplates/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/analyticshub/apiv1/Client/ListSharedResourceSubscriptions/main.go
+++ b/internal/generated/snippets/bigquery/analyticshub/apiv1/Client/ListSharedResourceSubscriptions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/analyticshub/apiv1/Client/ListSubscriptions/main.go
+++ b/internal/generated/snippets/bigquery/analyticshub/apiv1/Client/ListSubscriptions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/analyticshub/apiv1/Client/RefreshSubscription/main.go
+++ b/internal/generated/snippets/bigquery/analyticshub/apiv1/Client/RefreshSubscription/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/analyticshub/apiv1/Client/RevokeSubscription/main.go
+++ b/internal/generated/snippets/bigquery/analyticshub/apiv1/Client/RevokeSubscription/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/analyticshub/apiv1/Client/SetIamPolicy/main.go
+++ b/internal/generated/snippets/bigquery/analyticshub/apiv1/Client/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/analyticshub/apiv1/Client/SubmitQueryTemplate/main.go
+++ b/internal/generated/snippets/bigquery/analyticshub/apiv1/Client/SubmitQueryTemplate/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/analyticshub/apiv1/Client/SubscribeDataExchange/main.go
+++ b/internal/generated/snippets/bigquery/analyticshub/apiv1/Client/SubscribeDataExchange/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/analyticshub/apiv1/Client/SubscribeListing/main.go
+++ b/internal/generated/snippets/bigquery/analyticshub/apiv1/Client/SubscribeListing/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/analyticshub/apiv1/Client/TestIamPermissions/main.go
+++ b/internal/generated/snippets/bigquery/analyticshub/apiv1/Client/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/analyticshub/apiv1/Client/UpdateDataExchange/main.go
+++ b/internal/generated/snippets/bigquery/analyticshub/apiv1/Client/UpdateDataExchange/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/analyticshub/apiv1/Client/UpdateListing/main.go
+++ b/internal/generated/snippets/bigquery/analyticshub/apiv1/Client/UpdateListing/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/analyticshub/apiv1/Client/UpdateQueryTemplate/main.go
+++ b/internal/generated/snippets/bigquery/analyticshub/apiv1/Client/UpdateQueryTemplate/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/biglake/apiv1/MetastoreClient/CreateCatalog/main.go
+++ b/internal/generated/snippets/bigquery/biglake/apiv1/MetastoreClient/CreateCatalog/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/biglake/apiv1/MetastoreClient/CreateDatabase/main.go
+++ b/internal/generated/snippets/bigquery/biglake/apiv1/MetastoreClient/CreateDatabase/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/biglake/apiv1/MetastoreClient/CreateTable/main.go
+++ b/internal/generated/snippets/bigquery/biglake/apiv1/MetastoreClient/CreateTable/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/biglake/apiv1/MetastoreClient/DeleteCatalog/main.go
+++ b/internal/generated/snippets/bigquery/biglake/apiv1/MetastoreClient/DeleteCatalog/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/biglake/apiv1/MetastoreClient/DeleteDatabase/main.go
+++ b/internal/generated/snippets/bigquery/biglake/apiv1/MetastoreClient/DeleteDatabase/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/biglake/apiv1/MetastoreClient/DeleteTable/main.go
+++ b/internal/generated/snippets/bigquery/biglake/apiv1/MetastoreClient/DeleteTable/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/biglake/apiv1/MetastoreClient/GetCatalog/main.go
+++ b/internal/generated/snippets/bigquery/biglake/apiv1/MetastoreClient/GetCatalog/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/biglake/apiv1/MetastoreClient/GetDatabase/main.go
+++ b/internal/generated/snippets/bigquery/biglake/apiv1/MetastoreClient/GetDatabase/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/biglake/apiv1/MetastoreClient/GetTable/main.go
+++ b/internal/generated/snippets/bigquery/biglake/apiv1/MetastoreClient/GetTable/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/biglake/apiv1/MetastoreClient/ListCatalogs/main.go
+++ b/internal/generated/snippets/bigquery/biglake/apiv1/MetastoreClient/ListCatalogs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/biglake/apiv1/MetastoreClient/ListDatabases/main.go
+++ b/internal/generated/snippets/bigquery/biglake/apiv1/MetastoreClient/ListDatabases/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/biglake/apiv1/MetastoreClient/ListTables/main.go
+++ b/internal/generated/snippets/bigquery/biglake/apiv1/MetastoreClient/ListTables/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/biglake/apiv1/MetastoreClient/RenameTable/main.go
+++ b/internal/generated/snippets/bigquery/biglake/apiv1/MetastoreClient/RenameTable/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/biglake/apiv1/MetastoreClient/UpdateDatabase/main.go
+++ b/internal/generated/snippets/bigquery/biglake/apiv1/MetastoreClient/UpdateDatabase/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/biglake/apiv1/MetastoreClient/UpdateTable/main.go
+++ b/internal/generated/snippets/bigquery/biglake/apiv1/MetastoreClient/UpdateTable/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/biglake/apiv1alpha1/MetastoreClient/CheckLock/main.go
+++ b/internal/generated/snippets/bigquery/biglake/apiv1alpha1/MetastoreClient/CheckLock/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/biglake/apiv1alpha1/MetastoreClient/CreateCatalog/main.go
+++ b/internal/generated/snippets/bigquery/biglake/apiv1alpha1/MetastoreClient/CreateCatalog/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/biglake/apiv1alpha1/MetastoreClient/CreateDatabase/main.go
+++ b/internal/generated/snippets/bigquery/biglake/apiv1alpha1/MetastoreClient/CreateDatabase/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/biglake/apiv1alpha1/MetastoreClient/CreateLock/main.go
+++ b/internal/generated/snippets/bigquery/biglake/apiv1alpha1/MetastoreClient/CreateLock/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/biglake/apiv1alpha1/MetastoreClient/CreateTable/main.go
+++ b/internal/generated/snippets/bigquery/biglake/apiv1alpha1/MetastoreClient/CreateTable/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/biglake/apiv1alpha1/MetastoreClient/DeleteCatalog/main.go
+++ b/internal/generated/snippets/bigquery/biglake/apiv1alpha1/MetastoreClient/DeleteCatalog/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/biglake/apiv1alpha1/MetastoreClient/DeleteDatabase/main.go
+++ b/internal/generated/snippets/bigquery/biglake/apiv1alpha1/MetastoreClient/DeleteDatabase/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/biglake/apiv1alpha1/MetastoreClient/DeleteLock/main.go
+++ b/internal/generated/snippets/bigquery/biglake/apiv1alpha1/MetastoreClient/DeleteLock/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/biglake/apiv1alpha1/MetastoreClient/DeleteTable/main.go
+++ b/internal/generated/snippets/bigquery/biglake/apiv1alpha1/MetastoreClient/DeleteTable/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/biglake/apiv1alpha1/MetastoreClient/GetCatalog/main.go
+++ b/internal/generated/snippets/bigquery/biglake/apiv1alpha1/MetastoreClient/GetCatalog/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/biglake/apiv1alpha1/MetastoreClient/GetDatabase/main.go
+++ b/internal/generated/snippets/bigquery/biglake/apiv1alpha1/MetastoreClient/GetDatabase/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/biglake/apiv1alpha1/MetastoreClient/GetTable/main.go
+++ b/internal/generated/snippets/bigquery/biglake/apiv1alpha1/MetastoreClient/GetTable/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/biglake/apiv1alpha1/MetastoreClient/ListCatalogs/main.go
+++ b/internal/generated/snippets/bigquery/biglake/apiv1alpha1/MetastoreClient/ListCatalogs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/biglake/apiv1alpha1/MetastoreClient/ListDatabases/main.go
+++ b/internal/generated/snippets/bigquery/biglake/apiv1alpha1/MetastoreClient/ListDatabases/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/biglake/apiv1alpha1/MetastoreClient/ListLocks/main.go
+++ b/internal/generated/snippets/bigquery/biglake/apiv1alpha1/MetastoreClient/ListLocks/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/biglake/apiv1alpha1/MetastoreClient/ListTables/main.go
+++ b/internal/generated/snippets/bigquery/biglake/apiv1alpha1/MetastoreClient/ListTables/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/biglake/apiv1alpha1/MetastoreClient/RenameTable/main.go
+++ b/internal/generated/snippets/bigquery/biglake/apiv1alpha1/MetastoreClient/RenameTable/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/biglake/apiv1alpha1/MetastoreClient/UpdateDatabase/main.go
+++ b/internal/generated/snippets/bigquery/biglake/apiv1alpha1/MetastoreClient/UpdateDatabase/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/biglake/apiv1alpha1/MetastoreClient/UpdateTable/main.go
+++ b/internal/generated/snippets/bigquery/biglake/apiv1alpha1/MetastoreClient/UpdateTable/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/connection/apiv1/Client/CreateConnection/main.go
+++ b/internal/generated/snippets/bigquery/connection/apiv1/Client/CreateConnection/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/connection/apiv1/Client/DeleteConnection/main.go
+++ b/internal/generated/snippets/bigquery/connection/apiv1/Client/DeleteConnection/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/connection/apiv1/Client/GetConnection/main.go
+++ b/internal/generated/snippets/bigquery/connection/apiv1/Client/GetConnection/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/connection/apiv1/Client/GetIamPolicy/main.go
+++ b/internal/generated/snippets/bigquery/connection/apiv1/Client/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/connection/apiv1/Client/ListConnections/main.go
+++ b/internal/generated/snippets/bigquery/connection/apiv1/Client/ListConnections/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/connection/apiv1/Client/SetIamPolicy/main.go
+++ b/internal/generated/snippets/bigquery/connection/apiv1/Client/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/connection/apiv1/Client/TestIamPermissions/main.go
+++ b/internal/generated/snippets/bigquery/connection/apiv1/Client/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/connection/apiv1/Client/UpdateConnection/main.go
+++ b/internal/generated/snippets/bigquery/connection/apiv1/Client/UpdateConnection/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/connection/apiv1beta1/Client/CreateConnection/main.go
+++ b/internal/generated/snippets/bigquery/connection/apiv1beta1/Client/CreateConnection/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/connection/apiv1beta1/Client/DeleteConnection/main.go
+++ b/internal/generated/snippets/bigquery/connection/apiv1beta1/Client/DeleteConnection/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/connection/apiv1beta1/Client/GetConnection/main.go
+++ b/internal/generated/snippets/bigquery/connection/apiv1beta1/Client/GetConnection/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/connection/apiv1beta1/Client/GetIamPolicy/main.go
+++ b/internal/generated/snippets/bigquery/connection/apiv1beta1/Client/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/connection/apiv1beta1/Client/ListConnections/main.go
+++ b/internal/generated/snippets/bigquery/connection/apiv1beta1/Client/ListConnections/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/connection/apiv1beta1/Client/SetIamPolicy/main.go
+++ b/internal/generated/snippets/bigquery/connection/apiv1beta1/Client/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/connection/apiv1beta1/Client/TestIamPermissions/main.go
+++ b/internal/generated/snippets/bigquery/connection/apiv1beta1/Client/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/connection/apiv1beta1/Client/UpdateConnection/main.go
+++ b/internal/generated/snippets/bigquery/connection/apiv1beta1/Client/UpdateConnection/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/connection/apiv1beta1/Client/UpdateConnectionCredential/main.go
+++ b/internal/generated/snippets/bigquery/connection/apiv1beta1/Client/UpdateConnectionCredential/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/dataexchange/apiv1beta1/AnalyticsHubClient/CreateDataExchange/main.go
+++ b/internal/generated/snippets/bigquery/dataexchange/apiv1beta1/AnalyticsHubClient/CreateDataExchange/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/dataexchange/apiv1beta1/AnalyticsHubClient/CreateListing/main.go
+++ b/internal/generated/snippets/bigquery/dataexchange/apiv1beta1/AnalyticsHubClient/CreateListing/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/dataexchange/apiv1beta1/AnalyticsHubClient/DeleteDataExchange/main.go
+++ b/internal/generated/snippets/bigquery/dataexchange/apiv1beta1/AnalyticsHubClient/DeleteDataExchange/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/dataexchange/apiv1beta1/AnalyticsHubClient/DeleteListing/main.go
+++ b/internal/generated/snippets/bigquery/dataexchange/apiv1beta1/AnalyticsHubClient/DeleteListing/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/dataexchange/apiv1beta1/AnalyticsHubClient/GetDataExchange/main.go
+++ b/internal/generated/snippets/bigquery/dataexchange/apiv1beta1/AnalyticsHubClient/GetDataExchange/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/dataexchange/apiv1beta1/AnalyticsHubClient/GetIamPolicy/main.go
+++ b/internal/generated/snippets/bigquery/dataexchange/apiv1beta1/AnalyticsHubClient/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/dataexchange/apiv1beta1/AnalyticsHubClient/GetListing/main.go
+++ b/internal/generated/snippets/bigquery/dataexchange/apiv1beta1/AnalyticsHubClient/GetListing/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/dataexchange/apiv1beta1/AnalyticsHubClient/GetLocation/main.go
+++ b/internal/generated/snippets/bigquery/dataexchange/apiv1beta1/AnalyticsHubClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/dataexchange/apiv1beta1/AnalyticsHubClient/ListDataExchanges/main.go
+++ b/internal/generated/snippets/bigquery/dataexchange/apiv1beta1/AnalyticsHubClient/ListDataExchanges/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/dataexchange/apiv1beta1/AnalyticsHubClient/ListListings/main.go
+++ b/internal/generated/snippets/bigquery/dataexchange/apiv1beta1/AnalyticsHubClient/ListListings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/dataexchange/apiv1beta1/AnalyticsHubClient/ListLocations/main.go
+++ b/internal/generated/snippets/bigquery/dataexchange/apiv1beta1/AnalyticsHubClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/dataexchange/apiv1beta1/AnalyticsHubClient/ListOrgDataExchanges/main.go
+++ b/internal/generated/snippets/bigquery/dataexchange/apiv1beta1/AnalyticsHubClient/ListOrgDataExchanges/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/dataexchange/apiv1beta1/AnalyticsHubClient/SetIamPolicy/main.go
+++ b/internal/generated/snippets/bigquery/dataexchange/apiv1beta1/AnalyticsHubClient/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/dataexchange/apiv1beta1/AnalyticsHubClient/SubscribeListing/main.go
+++ b/internal/generated/snippets/bigquery/dataexchange/apiv1beta1/AnalyticsHubClient/SubscribeListing/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/dataexchange/apiv1beta1/AnalyticsHubClient/TestIamPermissions/main.go
+++ b/internal/generated/snippets/bigquery/dataexchange/apiv1beta1/AnalyticsHubClient/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/dataexchange/apiv1beta1/AnalyticsHubClient/UpdateDataExchange/main.go
+++ b/internal/generated/snippets/bigquery/dataexchange/apiv1beta1/AnalyticsHubClient/UpdateDataExchange/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/dataexchange/apiv1beta1/AnalyticsHubClient/UpdateListing/main.go
+++ b/internal/generated/snippets/bigquery/dataexchange/apiv1beta1/AnalyticsHubClient/UpdateListing/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/datapolicies/apiv1/DataPolicyClient/CreateDataPolicy/main.go
+++ b/internal/generated/snippets/bigquery/datapolicies/apiv1/DataPolicyClient/CreateDataPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/datapolicies/apiv1/DataPolicyClient/DeleteDataPolicy/main.go
+++ b/internal/generated/snippets/bigquery/datapolicies/apiv1/DataPolicyClient/DeleteDataPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/datapolicies/apiv1/DataPolicyClient/GetDataPolicy/main.go
+++ b/internal/generated/snippets/bigquery/datapolicies/apiv1/DataPolicyClient/GetDataPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/datapolicies/apiv1/DataPolicyClient/GetIamPolicy/main.go
+++ b/internal/generated/snippets/bigquery/datapolicies/apiv1/DataPolicyClient/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/datapolicies/apiv1/DataPolicyClient/ListDataPolicies/main.go
+++ b/internal/generated/snippets/bigquery/datapolicies/apiv1/DataPolicyClient/ListDataPolicies/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/datapolicies/apiv1/DataPolicyClient/RenameDataPolicy/main.go
+++ b/internal/generated/snippets/bigquery/datapolicies/apiv1/DataPolicyClient/RenameDataPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/datapolicies/apiv1/DataPolicyClient/SetIamPolicy/main.go
+++ b/internal/generated/snippets/bigquery/datapolicies/apiv1/DataPolicyClient/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/datapolicies/apiv1/DataPolicyClient/TestIamPermissions/main.go
+++ b/internal/generated/snippets/bigquery/datapolicies/apiv1/DataPolicyClient/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/datapolicies/apiv1/DataPolicyClient/UpdateDataPolicy/main.go
+++ b/internal/generated/snippets/bigquery/datapolicies/apiv1/DataPolicyClient/UpdateDataPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/datapolicies/apiv1beta1/DataPolicyClient/CreateDataPolicy/main.go
+++ b/internal/generated/snippets/bigquery/datapolicies/apiv1beta1/DataPolicyClient/CreateDataPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/datapolicies/apiv1beta1/DataPolicyClient/DeleteDataPolicy/main.go
+++ b/internal/generated/snippets/bigquery/datapolicies/apiv1beta1/DataPolicyClient/DeleteDataPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/datapolicies/apiv1beta1/DataPolicyClient/GetDataPolicy/main.go
+++ b/internal/generated/snippets/bigquery/datapolicies/apiv1beta1/DataPolicyClient/GetDataPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/datapolicies/apiv1beta1/DataPolicyClient/GetIamPolicy/main.go
+++ b/internal/generated/snippets/bigquery/datapolicies/apiv1beta1/DataPolicyClient/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/datapolicies/apiv1beta1/DataPolicyClient/ListDataPolicies/main.go
+++ b/internal/generated/snippets/bigquery/datapolicies/apiv1beta1/DataPolicyClient/ListDataPolicies/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/datapolicies/apiv1beta1/DataPolicyClient/SetIamPolicy/main.go
+++ b/internal/generated/snippets/bigquery/datapolicies/apiv1beta1/DataPolicyClient/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/datapolicies/apiv1beta1/DataPolicyClient/TestIamPermissions/main.go
+++ b/internal/generated/snippets/bigquery/datapolicies/apiv1beta1/DataPolicyClient/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/datapolicies/apiv1beta1/DataPolicyClient/UpdateDataPolicy/main.go
+++ b/internal/generated/snippets/bigquery/datapolicies/apiv1beta1/DataPolicyClient/UpdateDataPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/datapolicies/apiv2/DataPolicyClient/AddGrantees/main.go
+++ b/internal/generated/snippets/bigquery/datapolicies/apiv2/DataPolicyClient/AddGrantees/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/datapolicies/apiv2/DataPolicyClient/CreateDataPolicy/main.go
+++ b/internal/generated/snippets/bigquery/datapolicies/apiv2/DataPolicyClient/CreateDataPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/datapolicies/apiv2/DataPolicyClient/DeleteDataPolicy/main.go
+++ b/internal/generated/snippets/bigquery/datapolicies/apiv2/DataPolicyClient/DeleteDataPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/datapolicies/apiv2/DataPolicyClient/GetDataPolicy/main.go
+++ b/internal/generated/snippets/bigquery/datapolicies/apiv2/DataPolicyClient/GetDataPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/datapolicies/apiv2/DataPolicyClient/GetIamPolicy/main.go
+++ b/internal/generated/snippets/bigquery/datapolicies/apiv2/DataPolicyClient/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/datapolicies/apiv2/DataPolicyClient/ListDataPolicies/main.go
+++ b/internal/generated/snippets/bigquery/datapolicies/apiv2/DataPolicyClient/ListDataPolicies/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/datapolicies/apiv2/DataPolicyClient/RemoveGrantees/main.go
+++ b/internal/generated/snippets/bigquery/datapolicies/apiv2/DataPolicyClient/RemoveGrantees/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/datapolicies/apiv2/DataPolicyClient/SetIamPolicy/main.go
+++ b/internal/generated/snippets/bigquery/datapolicies/apiv2/DataPolicyClient/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/datapolicies/apiv2/DataPolicyClient/TestIamPermissions/main.go
+++ b/internal/generated/snippets/bigquery/datapolicies/apiv2/DataPolicyClient/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/datapolicies/apiv2/DataPolicyClient/UpdateDataPolicy/main.go
+++ b/internal/generated/snippets/bigquery/datapolicies/apiv2/DataPolicyClient/UpdateDataPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/datapolicies/apiv2beta1/DataPolicyClient/AddGrantees/main.go
+++ b/internal/generated/snippets/bigquery/datapolicies/apiv2beta1/DataPolicyClient/AddGrantees/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/datapolicies/apiv2beta1/DataPolicyClient/CreateDataPolicy/main.go
+++ b/internal/generated/snippets/bigquery/datapolicies/apiv2beta1/DataPolicyClient/CreateDataPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/datapolicies/apiv2beta1/DataPolicyClient/DeleteDataPolicy/main.go
+++ b/internal/generated/snippets/bigquery/datapolicies/apiv2beta1/DataPolicyClient/DeleteDataPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/datapolicies/apiv2beta1/DataPolicyClient/GetDataPolicy/main.go
+++ b/internal/generated/snippets/bigquery/datapolicies/apiv2beta1/DataPolicyClient/GetDataPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/datapolicies/apiv2beta1/DataPolicyClient/GetIamPolicy/main.go
+++ b/internal/generated/snippets/bigquery/datapolicies/apiv2beta1/DataPolicyClient/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/datapolicies/apiv2beta1/DataPolicyClient/ListDataPolicies/main.go
+++ b/internal/generated/snippets/bigquery/datapolicies/apiv2beta1/DataPolicyClient/ListDataPolicies/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/datapolicies/apiv2beta1/DataPolicyClient/RemoveGrantees/main.go
+++ b/internal/generated/snippets/bigquery/datapolicies/apiv2beta1/DataPolicyClient/RemoveGrantees/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/datapolicies/apiv2beta1/DataPolicyClient/SetIamPolicy/main.go
+++ b/internal/generated/snippets/bigquery/datapolicies/apiv2beta1/DataPolicyClient/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/datapolicies/apiv2beta1/DataPolicyClient/TestIamPermissions/main.go
+++ b/internal/generated/snippets/bigquery/datapolicies/apiv2beta1/DataPolicyClient/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/datapolicies/apiv2beta1/DataPolicyClient/UpdateDataPolicy/main.go
+++ b/internal/generated/snippets/bigquery/datapolicies/apiv2beta1/DataPolicyClient/UpdateDataPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/datatransfer/apiv1/Client/CheckValidCreds/main.go
+++ b/internal/generated/snippets/bigquery/datatransfer/apiv1/Client/CheckValidCreds/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/datatransfer/apiv1/Client/CreateTransferConfig/main.go
+++ b/internal/generated/snippets/bigquery/datatransfer/apiv1/Client/CreateTransferConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/datatransfer/apiv1/Client/DeleteTransferConfig/main.go
+++ b/internal/generated/snippets/bigquery/datatransfer/apiv1/Client/DeleteTransferConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/datatransfer/apiv1/Client/DeleteTransferRun/main.go
+++ b/internal/generated/snippets/bigquery/datatransfer/apiv1/Client/DeleteTransferRun/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/datatransfer/apiv1/Client/EnrollDataSources/main.go
+++ b/internal/generated/snippets/bigquery/datatransfer/apiv1/Client/EnrollDataSources/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/datatransfer/apiv1/Client/GetDataSource/main.go
+++ b/internal/generated/snippets/bigquery/datatransfer/apiv1/Client/GetDataSource/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/datatransfer/apiv1/Client/GetLocation/main.go
+++ b/internal/generated/snippets/bigquery/datatransfer/apiv1/Client/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/datatransfer/apiv1/Client/GetTransferConfig/main.go
+++ b/internal/generated/snippets/bigquery/datatransfer/apiv1/Client/GetTransferConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/datatransfer/apiv1/Client/GetTransferRun/main.go
+++ b/internal/generated/snippets/bigquery/datatransfer/apiv1/Client/GetTransferRun/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/datatransfer/apiv1/Client/ListDataSources/main.go
+++ b/internal/generated/snippets/bigquery/datatransfer/apiv1/Client/ListDataSources/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/datatransfer/apiv1/Client/ListLocations/main.go
+++ b/internal/generated/snippets/bigquery/datatransfer/apiv1/Client/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/datatransfer/apiv1/Client/ListTransferConfigs/main.go
+++ b/internal/generated/snippets/bigquery/datatransfer/apiv1/Client/ListTransferConfigs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/datatransfer/apiv1/Client/ListTransferLogs/main.go
+++ b/internal/generated/snippets/bigquery/datatransfer/apiv1/Client/ListTransferLogs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/datatransfer/apiv1/Client/ListTransferRuns/main.go
+++ b/internal/generated/snippets/bigquery/datatransfer/apiv1/Client/ListTransferRuns/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/datatransfer/apiv1/Client/ScheduleTransferRuns/main.go
+++ b/internal/generated/snippets/bigquery/datatransfer/apiv1/Client/ScheduleTransferRuns/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/datatransfer/apiv1/Client/StartManualTransferRuns/main.go
+++ b/internal/generated/snippets/bigquery/datatransfer/apiv1/Client/StartManualTransferRuns/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/datatransfer/apiv1/Client/UnenrollDataSources/main.go
+++ b/internal/generated/snippets/bigquery/datatransfer/apiv1/Client/UnenrollDataSources/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/datatransfer/apiv1/Client/UpdateTransferConfig/main.go
+++ b/internal/generated/snippets/bigquery/datatransfer/apiv1/Client/UpdateTransferConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/migration/apiv2/Client/CreateMigrationWorkflow/main.go
+++ b/internal/generated/snippets/bigquery/migration/apiv2/Client/CreateMigrationWorkflow/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/migration/apiv2/Client/DeleteMigrationWorkflow/main.go
+++ b/internal/generated/snippets/bigquery/migration/apiv2/Client/DeleteMigrationWorkflow/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/migration/apiv2/Client/GetMigrationSubtask/main.go
+++ b/internal/generated/snippets/bigquery/migration/apiv2/Client/GetMigrationSubtask/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/migration/apiv2/Client/GetMigrationWorkflow/main.go
+++ b/internal/generated/snippets/bigquery/migration/apiv2/Client/GetMigrationWorkflow/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/migration/apiv2/Client/ListMigrationSubtasks/main.go
+++ b/internal/generated/snippets/bigquery/migration/apiv2/Client/ListMigrationSubtasks/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/migration/apiv2/Client/ListMigrationWorkflows/main.go
+++ b/internal/generated/snippets/bigquery/migration/apiv2/Client/ListMigrationWorkflows/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/migration/apiv2/Client/StartMigrationWorkflow/main.go
+++ b/internal/generated/snippets/bigquery/migration/apiv2/Client/StartMigrationWorkflow/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/migration/apiv2alpha/Client/CreateMigrationWorkflow/main.go
+++ b/internal/generated/snippets/bigquery/migration/apiv2alpha/Client/CreateMigrationWorkflow/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/migration/apiv2alpha/Client/DeleteMigrationWorkflow/main.go
+++ b/internal/generated/snippets/bigquery/migration/apiv2alpha/Client/DeleteMigrationWorkflow/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/migration/apiv2alpha/Client/GetMigrationSubtask/main.go
+++ b/internal/generated/snippets/bigquery/migration/apiv2alpha/Client/GetMigrationSubtask/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/migration/apiv2alpha/Client/GetMigrationWorkflow/main.go
+++ b/internal/generated/snippets/bigquery/migration/apiv2alpha/Client/GetMigrationWorkflow/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/migration/apiv2alpha/Client/ListMigrationSubtasks/main.go
+++ b/internal/generated/snippets/bigquery/migration/apiv2alpha/Client/ListMigrationSubtasks/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/migration/apiv2alpha/Client/ListMigrationWorkflows/main.go
+++ b/internal/generated/snippets/bigquery/migration/apiv2alpha/Client/ListMigrationWorkflows/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/migration/apiv2alpha/Client/StartMigrationWorkflow/main.go
+++ b/internal/generated/snippets/bigquery/migration/apiv2alpha/Client/StartMigrationWorkflow/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/migration/apiv2alpha/SqlTranslationClient/TranslateQuery/main.go
+++ b/internal/generated/snippets/bigquery/migration/apiv2alpha/SqlTranslationClient/TranslateQuery/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/reservation/apiv1/Client/CreateAssignment/main.go
+++ b/internal/generated/snippets/bigquery/reservation/apiv1/Client/CreateAssignment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/reservation/apiv1/Client/CreateCapacityCommitment/main.go
+++ b/internal/generated/snippets/bigquery/reservation/apiv1/Client/CreateCapacityCommitment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/reservation/apiv1/Client/CreateReservation/main.go
+++ b/internal/generated/snippets/bigquery/reservation/apiv1/Client/CreateReservation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/reservation/apiv1/Client/CreateReservationGroup/main.go
+++ b/internal/generated/snippets/bigquery/reservation/apiv1/Client/CreateReservationGroup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/reservation/apiv1/Client/DeleteAssignment/main.go
+++ b/internal/generated/snippets/bigquery/reservation/apiv1/Client/DeleteAssignment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/reservation/apiv1/Client/DeleteCapacityCommitment/main.go
+++ b/internal/generated/snippets/bigquery/reservation/apiv1/Client/DeleteCapacityCommitment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/reservation/apiv1/Client/DeleteReservation/main.go
+++ b/internal/generated/snippets/bigquery/reservation/apiv1/Client/DeleteReservation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/reservation/apiv1/Client/DeleteReservationGroup/main.go
+++ b/internal/generated/snippets/bigquery/reservation/apiv1/Client/DeleteReservationGroup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/reservation/apiv1/Client/FailoverReservation/main.go
+++ b/internal/generated/snippets/bigquery/reservation/apiv1/Client/FailoverReservation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/reservation/apiv1/Client/GetBiReservation/main.go
+++ b/internal/generated/snippets/bigquery/reservation/apiv1/Client/GetBiReservation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/reservation/apiv1/Client/GetCapacityCommitment/main.go
+++ b/internal/generated/snippets/bigquery/reservation/apiv1/Client/GetCapacityCommitment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/reservation/apiv1/Client/GetIamPolicy/main.go
+++ b/internal/generated/snippets/bigquery/reservation/apiv1/Client/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/reservation/apiv1/Client/GetReservation/main.go
+++ b/internal/generated/snippets/bigquery/reservation/apiv1/Client/GetReservation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/reservation/apiv1/Client/GetReservationGroup/main.go
+++ b/internal/generated/snippets/bigquery/reservation/apiv1/Client/GetReservationGroup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/reservation/apiv1/Client/ListAssignments/main.go
+++ b/internal/generated/snippets/bigquery/reservation/apiv1/Client/ListAssignments/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/reservation/apiv1/Client/ListCapacityCommitments/main.go
+++ b/internal/generated/snippets/bigquery/reservation/apiv1/Client/ListCapacityCommitments/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/reservation/apiv1/Client/ListReservationGroups/main.go
+++ b/internal/generated/snippets/bigquery/reservation/apiv1/Client/ListReservationGroups/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/reservation/apiv1/Client/ListReservations/main.go
+++ b/internal/generated/snippets/bigquery/reservation/apiv1/Client/ListReservations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/reservation/apiv1/Client/MergeCapacityCommitments/main.go
+++ b/internal/generated/snippets/bigquery/reservation/apiv1/Client/MergeCapacityCommitments/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/reservation/apiv1/Client/MoveAssignment/main.go
+++ b/internal/generated/snippets/bigquery/reservation/apiv1/Client/MoveAssignment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/reservation/apiv1/Client/SearchAllAssignments/main.go
+++ b/internal/generated/snippets/bigquery/reservation/apiv1/Client/SearchAllAssignments/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/reservation/apiv1/Client/SearchAssignments/main.go
+++ b/internal/generated/snippets/bigquery/reservation/apiv1/Client/SearchAssignments/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/reservation/apiv1/Client/SetIamPolicy/main.go
+++ b/internal/generated/snippets/bigquery/reservation/apiv1/Client/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/reservation/apiv1/Client/SplitCapacityCommitment/main.go
+++ b/internal/generated/snippets/bigquery/reservation/apiv1/Client/SplitCapacityCommitment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/reservation/apiv1/Client/TestIamPermissions/main.go
+++ b/internal/generated/snippets/bigquery/reservation/apiv1/Client/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/reservation/apiv1/Client/UpdateAssignment/main.go
+++ b/internal/generated/snippets/bigquery/reservation/apiv1/Client/UpdateAssignment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/reservation/apiv1/Client/UpdateBiReservation/main.go
+++ b/internal/generated/snippets/bigquery/reservation/apiv1/Client/UpdateBiReservation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/reservation/apiv1/Client/UpdateCapacityCommitment/main.go
+++ b/internal/generated/snippets/bigquery/reservation/apiv1/Client/UpdateCapacityCommitment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/reservation/apiv1/Client/UpdateReservation/main.go
+++ b/internal/generated/snippets/bigquery/reservation/apiv1/Client/UpdateReservation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/storage/apiv1/BigQueryReadClient/CreateReadSession/main.go
+++ b/internal/generated/snippets/bigquery/storage/apiv1/BigQueryReadClient/CreateReadSession/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/storage/apiv1/BigQueryReadClient/SplitReadStream/main.go
+++ b/internal/generated/snippets/bigquery/storage/apiv1/BigQueryReadClient/SplitReadStream/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/storage/apiv1/BigQueryWriteClient/AppendRows/main.go
+++ b/internal/generated/snippets/bigquery/storage/apiv1/BigQueryWriteClient/AppendRows/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/storage/apiv1/BigQueryWriteClient/BatchCommitWriteStreams/main.go
+++ b/internal/generated/snippets/bigquery/storage/apiv1/BigQueryWriteClient/BatchCommitWriteStreams/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/storage/apiv1/BigQueryWriteClient/CreateWriteStream/main.go
+++ b/internal/generated/snippets/bigquery/storage/apiv1/BigQueryWriteClient/CreateWriteStream/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/storage/apiv1/BigQueryWriteClient/FinalizeWriteStream/main.go
+++ b/internal/generated/snippets/bigquery/storage/apiv1/BigQueryWriteClient/FinalizeWriteStream/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/storage/apiv1/BigQueryWriteClient/FlushRows/main.go
+++ b/internal/generated/snippets/bigquery/storage/apiv1/BigQueryWriteClient/FlushRows/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/storage/apiv1/BigQueryWriteClient/GetWriteStream/main.go
+++ b/internal/generated/snippets/bigquery/storage/apiv1/BigQueryWriteClient/GetWriteStream/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/storage/apiv1alpha/MetastorePartitionClient/BatchCreateMetastorePartitions/main.go
+++ b/internal/generated/snippets/bigquery/storage/apiv1alpha/MetastorePartitionClient/BatchCreateMetastorePartitions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/storage/apiv1alpha/MetastorePartitionClient/BatchDeleteMetastorePartitions/main.go
+++ b/internal/generated/snippets/bigquery/storage/apiv1alpha/MetastorePartitionClient/BatchDeleteMetastorePartitions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/storage/apiv1alpha/MetastorePartitionClient/BatchUpdateMetastorePartitions/main.go
+++ b/internal/generated/snippets/bigquery/storage/apiv1alpha/MetastorePartitionClient/BatchUpdateMetastorePartitions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/storage/apiv1alpha/MetastorePartitionClient/ListMetastorePartitions/main.go
+++ b/internal/generated/snippets/bigquery/storage/apiv1alpha/MetastorePartitionClient/ListMetastorePartitions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/storage/apiv1alpha/MetastorePartitionClient/StreamMetastorePartitions/main.go
+++ b/internal/generated/snippets/bigquery/storage/apiv1alpha/MetastorePartitionClient/StreamMetastorePartitions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/storage/apiv1beta/MetastorePartitionClient/BatchCreateMetastorePartitions/main.go
+++ b/internal/generated/snippets/bigquery/storage/apiv1beta/MetastorePartitionClient/BatchCreateMetastorePartitions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/storage/apiv1beta/MetastorePartitionClient/BatchDeleteMetastorePartitions/main.go
+++ b/internal/generated/snippets/bigquery/storage/apiv1beta/MetastorePartitionClient/BatchDeleteMetastorePartitions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/storage/apiv1beta/MetastorePartitionClient/BatchUpdateMetastorePartitions/main.go
+++ b/internal/generated/snippets/bigquery/storage/apiv1beta/MetastorePartitionClient/BatchUpdateMetastorePartitions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/storage/apiv1beta/MetastorePartitionClient/ListMetastorePartitions/main.go
+++ b/internal/generated/snippets/bigquery/storage/apiv1beta/MetastorePartitionClient/ListMetastorePartitions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/storage/apiv1beta/MetastorePartitionClient/StreamMetastorePartitions/main.go
+++ b/internal/generated/snippets/bigquery/storage/apiv1beta/MetastorePartitionClient/StreamMetastorePartitions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/storage/apiv1beta1/BigQueryStorageClient/BatchCreateReadSessionStreams/main.go
+++ b/internal/generated/snippets/bigquery/storage/apiv1beta1/BigQueryStorageClient/BatchCreateReadSessionStreams/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/storage/apiv1beta1/BigQueryStorageClient/CreateReadSession/main.go
+++ b/internal/generated/snippets/bigquery/storage/apiv1beta1/BigQueryStorageClient/CreateReadSession/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/storage/apiv1beta1/BigQueryStorageClient/FinalizeStream/main.go
+++ b/internal/generated/snippets/bigquery/storage/apiv1beta1/BigQueryStorageClient/FinalizeStream/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/storage/apiv1beta1/BigQueryStorageClient/SplitReadStream/main.go
+++ b/internal/generated/snippets/bigquery/storage/apiv1beta1/BigQueryStorageClient/SplitReadStream/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/storage/apiv1beta2/BigQueryReadClient/CreateReadSession/main.go
+++ b/internal/generated/snippets/bigquery/storage/apiv1beta2/BigQueryReadClient/CreateReadSession/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/storage/apiv1beta2/BigQueryReadClient/SplitReadStream/main.go
+++ b/internal/generated/snippets/bigquery/storage/apiv1beta2/BigQueryReadClient/SplitReadStream/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/storage/apiv1beta2/BigQueryWriteClient/AppendRows/main.go
+++ b/internal/generated/snippets/bigquery/storage/apiv1beta2/BigQueryWriteClient/AppendRows/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/storage/apiv1beta2/BigQueryWriteClient/BatchCommitWriteStreams/main.go
+++ b/internal/generated/snippets/bigquery/storage/apiv1beta2/BigQueryWriteClient/BatchCommitWriteStreams/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/storage/apiv1beta2/BigQueryWriteClient/CreateWriteStream/main.go
+++ b/internal/generated/snippets/bigquery/storage/apiv1beta2/BigQueryWriteClient/CreateWriteStream/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/storage/apiv1beta2/BigQueryWriteClient/FinalizeWriteStream/main.go
+++ b/internal/generated/snippets/bigquery/storage/apiv1beta2/BigQueryWriteClient/FinalizeWriteStream/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/storage/apiv1beta2/BigQueryWriteClient/FlushRows/main.go
+++ b/internal/generated/snippets/bigquery/storage/apiv1beta2/BigQueryWriteClient/FlushRows/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/storage/apiv1beta2/BigQueryWriteClient/GetWriteStream/main.go
+++ b/internal/generated/snippets/bigquery/storage/apiv1beta2/BigQueryWriteClient/GetWriteStream/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/v2/apiv2/DatasetClient/DeleteDataset/main.go
+++ b/internal/generated/snippets/bigquery/v2/apiv2/DatasetClient/DeleteDataset/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/v2/apiv2/DatasetClient/GetDataset/main.go
+++ b/internal/generated/snippets/bigquery/v2/apiv2/DatasetClient/GetDataset/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/v2/apiv2/DatasetClient/InsertDataset/main.go
+++ b/internal/generated/snippets/bigquery/v2/apiv2/DatasetClient/InsertDataset/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/v2/apiv2/DatasetClient/ListDatasets/main.go
+++ b/internal/generated/snippets/bigquery/v2/apiv2/DatasetClient/ListDatasets/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/v2/apiv2/DatasetClient/PatchDataset/main.go
+++ b/internal/generated/snippets/bigquery/v2/apiv2/DatasetClient/PatchDataset/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/v2/apiv2/DatasetClient/UndeleteDataset/main.go
+++ b/internal/generated/snippets/bigquery/v2/apiv2/DatasetClient/UndeleteDataset/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/v2/apiv2/DatasetClient/UpdateDataset/main.go
+++ b/internal/generated/snippets/bigquery/v2/apiv2/DatasetClient/UpdateDataset/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/v2/apiv2/JobClient/CancelJob/main.go
+++ b/internal/generated/snippets/bigquery/v2/apiv2/JobClient/CancelJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/v2/apiv2/JobClient/DeleteJob/main.go
+++ b/internal/generated/snippets/bigquery/v2/apiv2/JobClient/DeleteJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/v2/apiv2/JobClient/GetJob/main.go
+++ b/internal/generated/snippets/bigquery/v2/apiv2/JobClient/GetJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/v2/apiv2/JobClient/GetQueryResults/main.go
+++ b/internal/generated/snippets/bigquery/v2/apiv2/JobClient/GetQueryResults/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/v2/apiv2/JobClient/InsertJob/main.go
+++ b/internal/generated/snippets/bigquery/v2/apiv2/JobClient/InsertJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/v2/apiv2/JobClient/ListJobs/main.go
+++ b/internal/generated/snippets/bigquery/v2/apiv2/JobClient/ListJobs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/v2/apiv2/JobClient/Query/main.go
+++ b/internal/generated/snippets/bigquery/v2/apiv2/JobClient/Query/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/v2/apiv2/ModelClient/DeleteModel/main.go
+++ b/internal/generated/snippets/bigquery/v2/apiv2/ModelClient/DeleteModel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/v2/apiv2/ModelClient/GetModel/main.go
+++ b/internal/generated/snippets/bigquery/v2/apiv2/ModelClient/GetModel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/v2/apiv2/ModelClient/ListModels/main.go
+++ b/internal/generated/snippets/bigquery/v2/apiv2/ModelClient/ListModels/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/v2/apiv2/ModelClient/PatchModel/main.go
+++ b/internal/generated/snippets/bigquery/v2/apiv2/ModelClient/PatchModel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/v2/apiv2/ProjectClient/GetServiceAccount/main.go
+++ b/internal/generated/snippets/bigquery/v2/apiv2/ProjectClient/GetServiceAccount/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/v2/apiv2/RoutineClient/DeleteRoutine/main.go
+++ b/internal/generated/snippets/bigquery/v2/apiv2/RoutineClient/DeleteRoutine/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/v2/apiv2/RoutineClient/GetRoutine/main.go
+++ b/internal/generated/snippets/bigquery/v2/apiv2/RoutineClient/GetRoutine/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/v2/apiv2/RoutineClient/InsertRoutine/main.go
+++ b/internal/generated/snippets/bigquery/v2/apiv2/RoutineClient/InsertRoutine/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/v2/apiv2/RoutineClient/ListRoutines/main.go
+++ b/internal/generated/snippets/bigquery/v2/apiv2/RoutineClient/ListRoutines/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/v2/apiv2/RoutineClient/UpdateRoutine/main.go
+++ b/internal/generated/snippets/bigquery/v2/apiv2/RoutineClient/UpdateRoutine/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/v2/apiv2/RowAccessPolicyClient/BatchDeleteRowAccessPolicies/main.go
+++ b/internal/generated/snippets/bigquery/v2/apiv2/RowAccessPolicyClient/BatchDeleteRowAccessPolicies/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/v2/apiv2/RowAccessPolicyClient/CreateRowAccessPolicy/main.go
+++ b/internal/generated/snippets/bigquery/v2/apiv2/RowAccessPolicyClient/CreateRowAccessPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/v2/apiv2/RowAccessPolicyClient/DeleteRowAccessPolicy/main.go
+++ b/internal/generated/snippets/bigquery/v2/apiv2/RowAccessPolicyClient/DeleteRowAccessPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/v2/apiv2/RowAccessPolicyClient/GetRowAccessPolicy/main.go
+++ b/internal/generated/snippets/bigquery/v2/apiv2/RowAccessPolicyClient/GetRowAccessPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/v2/apiv2/RowAccessPolicyClient/ListRowAccessPolicies/main.go
+++ b/internal/generated/snippets/bigquery/v2/apiv2/RowAccessPolicyClient/ListRowAccessPolicies/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/v2/apiv2/RowAccessPolicyClient/UpdateRowAccessPolicy/main.go
+++ b/internal/generated/snippets/bigquery/v2/apiv2/RowAccessPolicyClient/UpdateRowAccessPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/v2/apiv2/TableClient/DeleteTable/main.go
+++ b/internal/generated/snippets/bigquery/v2/apiv2/TableClient/DeleteTable/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/v2/apiv2/TableClient/GetTable/main.go
+++ b/internal/generated/snippets/bigquery/v2/apiv2/TableClient/GetTable/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/v2/apiv2/TableClient/InsertTable/main.go
+++ b/internal/generated/snippets/bigquery/v2/apiv2/TableClient/InsertTable/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/v2/apiv2/TableClient/ListTables/main.go
+++ b/internal/generated/snippets/bigquery/v2/apiv2/TableClient/ListTables/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/v2/apiv2/TableClient/PatchTable/main.go
+++ b/internal/generated/snippets/bigquery/v2/apiv2/TableClient/PatchTable/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/bigquery/v2/apiv2/TableClient/UpdateTable/main.go
+++ b/internal/generated/snippets/bigquery/v2/apiv2/TableClient/UpdateTable/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/billing/apiv1/CloudBillingClient/CreateBillingAccount/main.go
+++ b/internal/generated/snippets/billing/apiv1/CloudBillingClient/CreateBillingAccount/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/billing/apiv1/CloudBillingClient/GetBillingAccount/main.go
+++ b/internal/generated/snippets/billing/apiv1/CloudBillingClient/GetBillingAccount/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/billing/apiv1/CloudBillingClient/GetIamPolicy/main.go
+++ b/internal/generated/snippets/billing/apiv1/CloudBillingClient/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/billing/apiv1/CloudBillingClient/GetProjectBillingInfo/main.go
+++ b/internal/generated/snippets/billing/apiv1/CloudBillingClient/GetProjectBillingInfo/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/billing/apiv1/CloudBillingClient/ListBillingAccounts/main.go
+++ b/internal/generated/snippets/billing/apiv1/CloudBillingClient/ListBillingAccounts/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/billing/apiv1/CloudBillingClient/ListProjectBillingInfo/main.go
+++ b/internal/generated/snippets/billing/apiv1/CloudBillingClient/ListProjectBillingInfo/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/billing/apiv1/CloudBillingClient/MoveBillingAccount/main.go
+++ b/internal/generated/snippets/billing/apiv1/CloudBillingClient/MoveBillingAccount/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/billing/apiv1/CloudBillingClient/SetIamPolicy/main.go
+++ b/internal/generated/snippets/billing/apiv1/CloudBillingClient/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/billing/apiv1/CloudBillingClient/TestIamPermissions/main.go
+++ b/internal/generated/snippets/billing/apiv1/CloudBillingClient/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/billing/apiv1/CloudBillingClient/UpdateBillingAccount/main.go
+++ b/internal/generated/snippets/billing/apiv1/CloudBillingClient/UpdateBillingAccount/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/billing/apiv1/CloudBillingClient/UpdateProjectBillingInfo/main.go
+++ b/internal/generated/snippets/billing/apiv1/CloudBillingClient/UpdateProjectBillingInfo/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/billing/apiv1/CloudCatalogClient/ListServices/main.go
+++ b/internal/generated/snippets/billing/apiv1/CloudCatalogClient/ListServices/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/billing/apiv1/CloudCatalogClient/ListSkus/main.go
+++ b/internal/generated/snippets/billing/apiv1/CloudCatalogClient/ListSkus/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/billing/budgets/apiv1/BudgetClient/CreateBudget/main.go
+++ b/internal/generated/snippets/billing/budgets/apiv1/BudgetClient/CreateBudget/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/billing/budgets/apiv1/BudgetClient/DeleteBudget/main.go
+++ b/internal/generated/snippets/billing/budgets/apiv1/BudgetClient/DeleteBudget/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/billing/budgets/apiv1/BudgetClient/GetBudget/main.go
+++ b/internal/generated/snippets/billing/budgets/apiv1/BudgetClient/GetBudget/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/billing/budgets/apiv1/BudgetClient/ListBudgets/main.go
+++ b/internal/generated/snippets/billing/budgets/apiv1/BudgetClient/ListBudgets/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/billing/budgets/apiv1/BudgetClient/UpdateBudget/main.go
+++ b/internal/generated/snippets/billing/budgets/apiv1/BudgetClient/UpdateBudget/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/billing/budgets/apiv1beta1/BudgetClient/CreateBudget/main.go
+++ b/internal/generated/snippets/billing/budgets/apiv1beta1/BudgetClient/CreateBudget/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/billing/budgets/apiv1beta1/BudgetClient/DeleteBudget/main.go
+++ b/internal/generated/snippets/billing/budgets/apiv1beta1/BudgetClient/DeleteBudget/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/billing/budgets/apiv1beta1/BudgetClient/GetBudget/main.go
+++ b/internal/generated/snippets/billing/budgets/apiv1beta1/BudgetClient/GetBudget/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/billing/budgets/apiv1beta1/BudgetClient/ListBudgets/main.go
+++ b/internal/generated/snippets/billing/budgets/apiv1beta1/BudgetClient/ListBudgets/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/billing/budgets/apiv1beta1/BudgetClient/UpdateBudget/main.go
+++ b/internal/generated/snippets/billing/budgets/apiv1beta1/BudgetClient/UpdateBudget/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/binaryauthorization/apiv1/BinauthzManagementClient/CreateAttestor/main.go
+++ b/internal/generated/snippets/binaryauthorization/apiv1/BinauthzManagementClient/CreateAttestor/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/binaryauthorization/apiv1/BinauthzManagementClient/DeleteAttestor/main.go
+++ b/internal/generated/snippets/binaryauthorization/apiv1/BinauthzManagementClient/DeleteAttestor/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/binaryauthorization/apiv1/BinauthzManagementClient/GetAttestor/main.go
+++ b/internal/generated/snippets/binaryauthorization/apiv1/BinauthzManagementClient/GetAttestor/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/binaryauthorization/apiv1/BinauthzManagementClient/GetPolicy/main.go
+++ b/internal/generated/snippets/binaryauthorization/apiv1/BinauthzManagementClient/GetPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/binaryauthorization/apiv1/BinauthzManagementClient/ListAttestors/main.go
+++ b/internal/generated/snippets/binaryauthorization/apiv1/BinauthzManagementClient/ListAttestors/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/binaryauthorization/apiv1/BinauthzManagementClient/UpdateAttestor/main.go
+++ b/internal/generated/snippets/binaryauthorization/apiv1/BinauthzManagementClient/UpdateAttestor/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/binaryauthorization/apiv1/BinauthzManagementClient/UpdatePolicy/main.go
+++ b/internal/generated/snippets/binaryauthorization/apiv1/BinauthzManagementClient/UpdatePolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/binaryauthorization/apiv1/SystemPolicyClient/GetSystemPolicy/main.go
+++ b/internal/generated/snippets/binaryauthorization/apiv1/SystemPolicyClient/GetSystemPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/binaryauthorization/apiv1/ValidationHelperClient/ValidateAttestationOccurrence/main.go
+++ b/internal/generated/snippets/binaryauthorization/apiv1/ValidationHelperClient/ValidateAttestationOccurrence/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/binaryauthorization/apiv1beta1/BinauthzManagementServiceV1Beta1Client/CreateAttestor/main.go
+++ b/internal/generated/snippets/binaryauthorization/apiv1beta1/BinauthzManagementServiceV1Beta1Client/CreateAttestor/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/binaryauthorization/apiv1beta1/BinauthzManagementServiceV1Beta1Client/DeleteAttestor/main.go
+++ b/internal/generated/snippets/binaryauthorization/apiv1beta1/BinauthzManagementServiceV1Beta1Client/DeleteAttestor/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/binaryauthorization/apiv1beta1/BinauthzManagementServiceV1Beta1Client/GetAttestor/main.go
+++ b/internal/generated/snippets/binaryauthorization/apiv1beta1/BinauthzManagementServiceV1Beta1Client/GetAttestor/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/binaryauthorization/apiv1beta1/BinauthzManagementServiceV1Beta1Client/GetPolicy/main.go
+++ b/internal/generated/snippets/binaryauthorization/apiv1beta1/BinauthzManagementServiceV1Beta1Client/GetPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/binaryauthorization/apiv1beta1/BinauthzManagementServiceV1Beta1Client/ListAttestors/main.go
+++ b/internal/generated/snippets/binaryauthorization/apiv1beta1/BinauthzManagementServiceV1Beta1Client/ListAttestors/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/binaryauthorization/apiv1beta1/BinauthzManagementServiceV1Beta1Client/UpdateAttestor/main.go
+++ b/internal/generated/snippets/binaryauthorization/apiv1beta1/BinauthzManagementServiceV1Beta1Client/UpdateAttestor/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/binaryauthorization/apiv1beta1/BinauthzManagementServiceV1Beta1Client/UpdatePolicy/main.go
+++ b/internal/generated/snippets/binaryauthorization/apiv1beta1/BinauthzManagementServiceV1Beta1Client/UpdatePolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/binaryauthorization/apiv1beta1/SystemPolicyV1Beta1Client/GetSystemPolicy/main.go
+++ b/internal/generated/snippets/binaryauthorization/apiv1beta1/SystemPolicyV1Beta1Client/GetSystemPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/capacityplanner/apiv1beta/UsageClient/ExportForecasts/main.go
+++ b/internal/generated/snippets/capacityplanner/apiv1beta/UsageClient/ExportForecasts/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/capacityplanner/apiv1beta/UsageClient/ExportReservationsUsage/main.go
+++ b/internal/generated/snippets/capacityplanner/apiv1beta/UsageClient/ExportReservationsUsage/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/capacityplanner/apiv1beta/UsageClient/ExportUsageHistories/main.go
+++ b/internal/generated/snippets/capacityplanner/apiv1beta/UsageClient/ExportUsageHistories/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/capacityplanner/apiv1beta/UsageClient/QueryForecasts/main.go
+++ b/internal/generated/snippets/capacityplanner/apiv1beta/UsageClient/QueryForecasts/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/capacityplanner/apiv1beta/UsageClient/QueryReservations/main.go
+++ b/internal/generated/snippets/capacityplanner/apiv1beta/UsageClient/QueryReservations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/capacityplanner/apiv1beta/UsageClient/QueryUsageHistories/main.go
+++ b/internal/generated/snippets/capacityplanner/apiv1beta/UsageClient/QueryUsageHistories/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/certificatemanager/apiv1/Client/CancelOperation/main.go
+++ b/internal/generated/snippets/certificatemanager/apiv1/Client/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/certificatemanager/apiv1/Client/CreateCertificate/main.go
+++ b/internal/generated/snippets/certificatemanager/apiv1/Client/CreateCertificate/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/certificatemanager/apiv1/Client/CreateCertificateIssuanceConfig/main.go
+++ b/internal/generated/snippets/certificatemanager/apiv1/Client/CreateCertificateIssuanceConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/certificatemanager/apiv1/Client/CreateCertificateMap/main.go
+++ b/internal/generated/snippets/certificatemanager/apiv1/Client/CreateCertificateMap/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/certificatemanager/apiv1/Client/CreateCertificateMapEntry/main.go
+++ b/internal/generated/snippets/certificatemanager/apiv1/Client/CreateCertificateMapEntry/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/certificatemanager/apiv1/Client/CreateDnsAuthorization/main.go
+++ b/internal/generated/snippets/certificatemanager/apiv1/Client/CreateDnsAuthorization/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/certificatemanager/apiv1/Client/CreateTrustConfig/main.go
+++ b/internal/generated/snippets/certificatemanager/apiv1/Client/CreateTrustConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/certificatemanager/apiv1/Client/DeleteCertificate/main.go
+++ b/internal/generated/snippets/certificatemanager/apiv1/Client/DeleteCertificate/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/certificatemanager/apiv1/Client/DeleteCertificateIssuanceConfig/main.go
+++ b/internal/generated/snippets/certificatemanager/apiv1/Client/DeleteCertificateIssuanceConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/certificatemanager/apiv1/Client/DeleteCertificateMap/main.go
+++ b/internal/generated/snippets/certificatemanager/apiv1/Client/DeleteCertificateMap/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/certificatemanager/apiv1/Client/DeleteCertificateMapEntry/main.go
+++ b/internal/generated/snippets/certificatemanager/apiv1/Client/DeleteCertificateMapEntry/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/certificatemanager/apiv1/Client/DeleteDnsAuthorization/main.go
+++ b/internal/generated/snippets/certificatemanager/apiv1/Client/DeleteDnsAuthorization/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/certificatemanager/apiv1/Client/DeleteOperation/main.go
+++ b/internal/generated/snippets/certificatemanager/apiv1/Client/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/certificatemanager/apiv1/Client/DeleteTrustConfig/main.go
+++ b/internal/generated/snippets/certificatemanager/apiv1/Client/DeleteTrustConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/certificatemanager/apiv1/Client/GetCertificate/main.go
+++ b/internal/generated/snippets/certificatemanager/apiv1/Client/GetCertificate/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/certificatemanager/apiv1/Client/GetCertificateIssuanceConfig/main.go
+++ b/internal/generated/snippets/certificatemanager/apiv1/Client/GetCertificateIssuanceConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/certificatemanager/apiv1/Client/GetCertificateMap/main.go
+++ b/internal/generated/snippets/certificatemanager/apiv1/Client/GetCertificateMap/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/certificatemanager/apiv1/Client/GetCertificateMapEntry/main.go
+++ b/internal/generated/snippets/certificatemanager/apiv1/Client/GetCertificateMapEntry/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/certificatemanager/apiv1/Client/GetDnsAuthorization/main.go
+++ b/internal/generated/snippets/certificatemanager/apiv1/Client/GetDnsAuthorization/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/certificatemanager/apiv1/Client/GetLocation/main.go
+++ b/internal/generated/snippets/certificatemanager/apiv1/Client/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/certificatemanager/apiv1/Client/GetOperation/main.go
+++ b/internal/generated/snippets/certificatemanager/apiv1/Client/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/certificatemanager/apiv1/Client/GetTrustConfig/main.go
+++ b/internal/generated/snippets/certificatemanager/apiv1/Client/GetTrustConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/certificatemanager/apiv1/Client/ListCertificateIssuanceConfigs/main.go
+++ b/internal/generated/snippets/certificatemanager/apiv1/Client/ListCertificateIssuanceConfigs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/certificatemanager/apiv1/Client/ListCertificateMapEntries/main.go
+++ b/internal/generated/snippets/certificatemanager/apiv1/Client/ListCertificateMapEntries/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/certificatemanager/apiv1/Client/ListCertificateMaps/main.go
+++ b/internal/generated/snippets/certificatemanager/apiv1/Client/ListCertificateMaps/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/certificatemanager/apiv1/Client/ListCertificates/main.go
+++ b/internal/generated/snippets/certificatemanager/apiv1/Client/ListCertificates/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/certificatemanager/apiv1/Client/ListDnsAuthorizations/main.go
+++ b/internal/generated/snippets/certificatemanager/apiv1/Client/ListDnsAuthorizations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/certificatemanager/apiv1/Client/ListLocations/main.go
+++ b/internal/generated/snippets/certificatemanager/apiv1/Client/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/certificatemanager/apiv1/Client/ListOperations/main.go
+++ b/internal/generated/snippets/certificatemanager/apiv1/Client/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/certificatemanager/apiv1/Client/ListTrustConfigs/main.go
+++ b/internal/generated/snippets/certificatemanager/apiv1/Client/ListTrustConfigs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/certificatemanager/apiv1/Client/UpdateCertificate/main.go
+++ b/internal/generated/snippets/certificatemanager/apiv1/Client/UpdateCertificate/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/certificatemanager/apiv1/Client/UpdateCertificateMap/main.go
+++ b/internal/generated/snippets/certificatemanager/apiv1/Client/UpdateCertificateMap/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/certificatemanager/apiv1/Client/UpdateCertificateMapEntry/main.go
+++ b/internal/generated/snippets/certificatemanager/apiv1/Client/UpdateCertificateMapEntry/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/certificatemanager/apiv1/Client/UpdateDnsAuthorization/main.go
+++ b/internal/generated/snippets/certificatemanager/apiv1/Client/UpdateDnsAuthorization/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/certificatemanager/apiv1/Client/UpdateTrustConfig/main.go
+++ b/internal/generated/snippets/certificatemanager/apiv1/Client/UpdateTrustConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/channel/apiv1/CloudChannelClient/ActivateEntitlement/main.go
+++ b/internal/generated/snippets/channel/apiv1/CloudChannelClient/ActivateEntitlement/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/channel/apiv1/CloudChannelClient/CancelEntitlement/main.go
+++ b/internal/generated/snippets/channel/apiv1/CloudChannelClient/CancelEntitlement/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/channel/apiv1/CloudChannelClient/CancelOperation/main.go
+++ b/internal/generated/snippets/channel/apiv1/CloudChannelClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/channel/apiv1/CloudChannelClient/ChangeOffer/main.go
+++ b/internal/generated/snippets/channel/apiv1/CloudChannelClient/ChangeOffer/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/channel/apiv1/CloudChannelClient/ChangeParameters/main.go
+++ b/internal/generated/snippets/channel/apiv1/CloudChannelClient/ChangeParameters/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/channel/apiv1/CloudChannelClient/ChangeRenewalSettings/main.go
+++ b/internal/generated/snippets/channel/apiv1/CloudChannelClient/ChangeRenewalSettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/channel/apiv1/CloudChannelClient/CheckCloudIdentityAccountsExist/main.go
+++ b/internal/generated/snippets/channel/apiv1/CloudChannelClient/CheckCloudIdentityAccountsExist/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/channel/apiv1/CloudChannelClient/CreateChannelPartnerLink/main.go
+++ b/internal/generated/snippets/channel/apiv1/CloudChannelClient/CreateChannelPartnerLink/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/channel/apiv1/CloudChannelClient/CreateChannelPartnerRepricingConfig/main.go
+++ b/internal/generated/snippets/channel/apiv1/CloudChannelClient/CreateChannelPartnerRepricingConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/channel/apiv1/CloudChannelClient/CreateCustomer/main.go
+++ b/internal/generated/snippets/channel/apiv1/CloudChannelClient/CreateCustomer/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/channel/apiv1/CloudChannelClient/CreateCustomerRepricingConfig/main.go
+++ b/internal/generated/snippets/channel/apiv1/CloudChannelClient/CreateCustomerRepricingConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/channel/apiv1/CloudChannelClient/CreateEntitlement/main.go
+++ b/internal/generated/snippets/channel/apiv1/CloudChannelClient/CreateEntitlement/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/channel/apiv1/CloudChannelClient/DeleteChannelPartnerRepricingConfig/main.go
+++ b/internal/generated/snippets/channel/apiv1/CloudChannelClient/DeleteChannelPartnerRepricingConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/channel/apiv1/CloudChannelClient/DeleteCustomer/main.go
+++ b/internal/generated/snippets/channel/apiv1/CloudChannelClient/DeleteCustomer/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/channel/apiv1/CloudChannelClient/DeleteCustomerRepricingConfig/main.go
+++ b/internal/generated/snippets/channel/apiv1/CloudChannelClient/DeleteCustomerRepricingConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/channel/apiv1/CloudChannelClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/channel/apiv1/CloudChannelClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/channel/apiv1/CloudChannelClient/GetChannelPartnerLink/main.go
+++ b/internal/generated/snippets/channel/apiv1/CloudChannelClient/GetChannelPartnerLink/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/channel/apiv1/CloudChannelClient/GetChannelPartnerRepricingConfig/main.go
+++ b/internal/generated/snippets/channel/apiv1/CloudChannelClient/GetChannelPartnerRepricingConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/channel/apiv1/CloudChannelClient/GetCustomer/main.go
+++ b/internal/generated/snippets/channel/apiv1/CloudChannelClient/GetCustomer/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/channel/apiv1/CloudChannelClient/GetCustomerRepricingConfig/main.go
+++ b/internal/generated/snippets/channel/apiv1/CloudChannelClient/GetCustomerRepricingConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/channel/apiv1/CloudChannelClient/GetEntitlement/main.go
+++ b/internal/generated/snippets/channel/apiv1/CloudChannelClient/GetEntitlement/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/channel/apiv1/CloudChannelClient/GetOperation/main.go
+++ b/internal/generated/snippets/channel/apiv1/CloudChannelClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/channel/apiv1/CloudChannelClient/ImportCustomer/main.go
+++ b/internal/generated/snippets/channel/apiv1/CloudChannelClient/ImportCustomer/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/channel/apiv1/CloudChannelClient/ListChannelPartnerLinks/main.go
+++ b/internal/generated/snippets/channel/apiv1/CloudChannelClient/ListChannelPartnerLinks/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/channel/apiv1/CloudChannelClient/ListChannelPartnerRepricingConfigs/main.go
+++ b/internal/generated/snippets/channel/apiv1/CloudChannelClient/ListChannelPartnerRepricingConfigs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/channel/apiv1/CloudChannelClient/ListCustomerRepricingConfigs/main.go
+++ b/internal/generated/snippets/channel/apiv1/CloudChannelClient/ListCustomerRepricingConfigs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/channel/apiv1/CloudChannelClient/ListCustomers/main.go
+++ b/internal/generated/snippets/channel/apiv1/CloudChannelClient/ListCustomers/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/channel/apiv1/CloudChannelClient/ListEntitlementChanges/main.go
+++ b/internal/generated/snippets/channel/apiv1/CloudChannelClient/ListEntitlementChanges/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/channel/apiv1/CloudChannelClient/ListEntitlements/main.go
+++ b/internal/generated/snippets/channel/apiv1/CloudChannelClient/ListEntitlements/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/channel/apiv1/CloudChannelClient/ListOffers/main.go
+++ b/internal/generated/snippets/channel/apiv1/CloudChannelClient/ListOffers/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/channel/apiv1/CloudChannelClient/ListOperations/main.go
+++ b/internal/generated/snippets/channel/apiv1/CloudChannelClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/channel/apiv1/CloudChannelClient/ListProducts/main.go
+++ b/internal/generated/snippets/channel/apiv1/CloudChannelClient/ListProducts/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/channel/apiv1/CloudChannelClient/ListPurchasableOffers/main.go
+++ b/internal/generated/snippets/channel/apiv1/CloudChannelClient/ListPurchasableOffers/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/channel/apiv1/CloudChannelClient/ListPurchasableSkus/main.go
+++ b/internal/generated/snippets/channel/apiv1/CloudChannelClient/ListPurchasableSkus/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/channel/apiv1/CloudChannelClient/ListSkuGroupBillableSkus/main.go
+++ b/internal/generated/snippets/channel/apiv1/CloudChannelClient/ListSkuGroupBillableSkus/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/channel/apiv1/CloudChannelClient/ListSkuGroups/main.go
+++ b/internal/generated/snippets/channel/apiv1/CloudChannelClient/ListSkuGroups/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/channel/apiv1/CloudChannelClient/ListSkus/main.go
+++ b/internal/generated/snippets/channel/apiv1/CloudChannelClient/ListSkus/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/channel/apiv1/CloudChannelClient/ListSubscribers/main.go
+++ b/internal/generated/snippets/channel/apiv1/CloudChannelClient/ListSubscribers/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/channel/apiv1/CloudChannelClient/ListTransferableOffers/main.go
+++ b/internal/generated/snippets/channel/apiv1/CloudChannelClient/ListTransferableOffers/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/channel/apiv1/CloudChannelClient/ListTransferableSkus/main.go
+++ b/internal/generated/snippets/channel/apiv1/CloudChannelClient/ListTransferableSkus/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/channel/apiv1/CloudChannelClient/LookupOffer/main.go
+++ b/internal/generated/snippets/channel/apiv1/CloudChannelClient/LookupOffer/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/channel/apiv1/CloudChannelClient/ProvisionCloudIdentity/main.go
+++ b/internal/generated/snippets/channel/apiv1/CloudChannelClient/ProvisionCloudIdentity/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/channel/apiv1/CloudChannelClient/QueryEligibleBillingAccounts/main.go
+++ b/internal/generated/snippets/channel/apiv1/CloudChannelClient/QueryEligibleBillingAccounts/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/channel/apiv1/CloudChannelClient/RegisterSubscriber/main.go
+++ b/internal/generated/snippets/channel/apiv1/CloudChannelClient/RegisterSubscriber/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/channel/apiv1/CloudChannelClient/StartPaidService/main.go
+++ b/internal/generated/snippets/channel/apiv1/CloudChannelClient/StartPaidService/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/channel/apiv1/CloudChannelClient/SuspendEntitlement/main.go
+++ b/internal/generated/snippets/channel/apiv1/CloudChannelClient/SuspendEntitlement/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/channel/apiv1/CloudChannelClient/TransferEntitlements/main.go
+++ b/internal/generated/snippets/channel/apiv1/CloudChannelClient/TransferEntitlements/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/channel/apiv1/CloudChannelClient/TransferEntitlementsToGoogle/main.go
+++ b/internal/generated/snippets/channel/apiv1/CloudChannelClient/TransferEntitlementsToGoogle/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/channel/apiv1/CloudChannelClient/UnregisterSubscriber/main.go
+++ b/internal/generated/snippets/channel/apiv1/CloudChannelClient/UnregisterSubscriber/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/channel/apiv1/CloudChannelClient/UpdateChannelPartnerLink/main.go
+++ b/internal/generated/snippets/channel/apiv1/CloudChannelClient/UpdateChannelPartnerLink/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/channel/apiv1/CloudChannelClient/UpdateChannelPartnerRepricingConfig/main.go
+++ b/internal/generated/snippets/channel/apiv1/CloudChannelClient/UpdateChannelPartnerRepricingConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/channel/apiv1/CloudChannelClient/UpdateCustomer/main.go
+++ b/internal/generated/snippets/channel/apiv1/CloudChannelClient/UpdateCustomer/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/channel/apiv1/CloudChannelClient/UpdateCustomerRepricingConfig/main.go
+++ b/internal/generated/snippets/channel/apiv1/CloudChannelClient/UpdateCustomerRepricingConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/channel/apiv1/CloudChannelReportsClient/CancelOperation/main.go
+++ b/internal/generated/snippets/channel/apiv1/CloudChannelReportsClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/channel/apiv1/CloudChannelReportsClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/channel/apiv1/CloudChannelReportsClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/channel/apiv1/CloudChannelReportsClient/FetchReportResults/main.go
+++ b/internal/generated/snippets/channel/apiv1/CloudChannelReportsClient/FetchReportResults/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/channel/apiv1/CloudChannelReportsClient/GetOperation/main.go
+++ b/internal/generated/snippets/channel/apiv1/CloudChannelReportsClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/channel/apiv1/CloudChannelReportsClient/ListOperations/main.go
+++ b/internal/generated/snippets/channel/apiv1/CloudChannelReportsClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/channel/apiv1/CloudChannelReportsClient/ListReports/main.go
+++ b/internal/generated/snippets/channel/apiv1/CloudChannelReportsClient/ListReports/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/channel/apiv1/CloudChannelReportsClient/RunReportJob/main.go
+++ b/internal/generated/snippets/channel/apiv1/CloudChannelReportsClient/RunReportJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chat/apiv1/Client/CompleteImportSpace/main.go
+++ b/internal/generated/snippets/chat/apiv1/Client/CompleteImportSpace/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chat/apiv1/Client/CreateCustomEmoji/main.go
+++ b/internal/generated/snippets/chat/apiv1/Client/CreateCustomEmoji/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chat/apiv1/Client/CreateMembership/main.go
+++ b/internal/generated/snippets/chat/apiv1/Client/CreateMembership/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chat/apiv1/Client/CreateMessage/main.go
+++ b/internal/generated/snippets/chat/apiv1/Client/CreateMessage/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chat/apiv1/Client/CreateReaction/main.go
+++ b/internal/generated/snippets/chat/apiv1/Client/CreateReaction/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chat/apiv1/Client/CreateSpace/main.go
+++ b/internal/generated/snippets/chat/apiv1/Client/CreateSpace/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chat/apiv1/Client/DeleteCustomEmoji/main.go
+++ b/internal/generated/snippets/chat/apiv1/Client/DeleteCustomEmoji/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chat/apiv1/Client/DeleteMembership/main.go
+++ b/internal/generated/snippets/chat/apiv1/Client/DeleteMembership/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chat/apiv1/Client/DeleteMessage/main.go
+++ b/internal/generated/snippets/chat/apiv1/Client/DeleteMessage/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chat/apiv1/Client/DeleteReaction/main.go
+++ b/internal/generated/snippets/chat/apiv1/Client/DeleteReaction/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chat/apiv1/Client/DeleteSpace/main.go
+++ b/internal/generated/snippets/chat/apiv1/Client/DeleteSpace/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chat/apiv1/Client/FindDirectMessage/main.go
+++ b/internal/generated/snippets/chat/apiv1/Client/FindDirectMessage/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chat/apiv1/Client/GetAttachment/main.go
+++ b/internal/generated/snippets/chat/apiv1/Client/GetAttachment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chat/apiv1/Client/GetCustomEmoji/main.go
+++ b/internal/generated/snippets/chat/apiv1/Client/GetCustomEmoji/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chat/apiv1/Client/GetMembership/main.go
+++ b/internal/generated/snippets/chat/apiv1/Client/GetMembership/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chat/apiv1/Client/GetMessage/main.go
+++ b/internal/generated/snippets/chat/apiv1/Client/GetMessage/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chat/apiv1/Client/GetSpace/main.go
+++ b/internal/generated/snippets/chat/apiv1/Client/GetSpace/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chat/apiv1/Client/GetSpaceEvent/main.go
+++ b/internal/generated/snippets/chat/apiv1/Client/GetSpaceEvent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chat/apiv1/Client/GetSpaceNotificationSetting/main.go
+++ b/internal/generated/snippets/chat/apiv1/Client/GetSpaceNotificationSetting/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chat/apiv1/Client/GetSpaceReadState/main.go
+++ b/internal/generated/snippets/chat/apiv1/Client/GetSpaceReadState/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chat/apiv1/Client/GetThreadReadState/main.go
+++ b/internal/generated/snippets/chat/apiv1/Client/GetThreadReadState/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chat/apiv1/Client/ListCustomEmojis/main.go
+++ b/internal/generated/snippets/chat/apiv1/Client/ListCustomEmojis/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chat/apiv1/Client/ListMemberships/main.go
+++ b/internal/generated/snippets/chat/apiv1/Client/ListMemberships/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chat/apiv1/Client/ListMessages/main.go
+++ b/internal/generated/snippets/chat/apiv1/Client/ListMessages/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chat/apiv1/Client/ListReactions/main.go
+++ b/internal/generated/snippets/chat/apiv1/Client/ListReactions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chat/apiv1/Client/ListSpaceEvents/main.go
+++ b/internal/generated/snippets/chat/apiv1/Client/ListSpaceEvents/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chat/apiv1/Client/ListSpaces/main.go
+++ b/internal/generated/snippets/chat/apiv1/Client/ListSpaces/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chat/apiv1/Client/SearchSpaces/main.go
+++ b/internal/generated/snippets/chat/apiv1/Client/SearchSpaces/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chat/apiv1/Client/SetUpSpace/main.go
+++ b/internal/generated/snippets/chat/apiv1/Client/SetUpSpace/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chat/apiv1/Client/UpdateMembership/main.go
+++ b/internal/generated/snippets/chat/apiv1/Client/UpdateMembership/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chat/apiv1/Client/UpdateMessage/main.go
+++ b/internal/generated/snippets/chat/apiv1/Client/UpdateMessage/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chat/apiv1/Client/UpdateSpace/main.go
+++ b/internal/generated/snippets/chat/apiv1/Client/UpdateSpace/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chat/apiv1/Client/UpdateSpaceNotificationSetting/main.go
+++ b/internal/generated/snippets/chat/apiv1/Client/UpdateSpaceNotificationSetting/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chat/apiv1/Client/UpdateSpaceReadState/main.go
+++ b/internal/generated/snippets/chat/apiv1/Client/UpdateSpaceReadState/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chat/apiv1/Client/UploadAttachment/main.go
+++ b/internal/generated/snippets/chat/apiv1/Client/UploadAttachment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chronicle/apiv1/DataAccessControlClient/CancelOperation/main.go
+++ b/internal/generated/snippets/chronicle/apiv1/DataAccessControlClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chronicle/apiv1/DataAccessControlClient/CreateDataAccessLabel/main.go
+++ b/internal/generated/snippets/chronicle/apiv1/DataAccessControlClient/CreateDataAccessLabel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chronicle/apiv1/DataAccessControlClient/CreateDataAccessScope/main.go
+++ b/internal/generated/snippets/chronicle/apiv1/DataAccessControlClient/CreateDataAccessScope/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chronicle/apiv1/DataAccessControlClient/DeleteDataAccessLabel/main.go
+++ b/internal/generated/snippets/chronicle/apiv1/DataAccessControlClient/DeleteDataAccessLabel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chronicle/apiv1/DataAccessControlClient/DeleteDataAccessScope/main.go
+++ b/internal/generated/snippets/chronicle/apiv1/DataAccessControlClient/DeleteDataAccessScope/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chronicle/apiv1/DataAccessControlClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/chronicle/apiv1/DataAccessControlClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chronicle/apiv1/DataAccessControlClient/GetDataAccessLabel/main.go
+++ b/internal/generated/snippets/chronicle/apiv1/DataAccessControlClient/GetDataAccessLabel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chronicle/apiv1/DataAccessControlClient/GetDataAccessScope/main.go
+++ b/internal/generated/snippets/chronicle/apiv1/DataAccessControlClient/GetDataAccessScope/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chronicle/apiv1/DataAccessControlClient/GetOperation/main.go
+++ b/internal/generated/snippets/chronicle/apiv1/DataAccessControlClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chronicle/apiv1/DataAccessControlClient/ListDataAccessLabels/main.go
+++ b/internal/generated/snippets/chronicle/apiv1/DataAccessControlClient/ListDataAccessLabels/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chronicle/apiv1/DataAccessControlClient/ListDataAccessScopes/main.go
+++ b/internal/generated/snippets/chronicle/apiv1/DataAccessControlClient/ListDataAccessScopes/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chronicle/apiv1/DataAccessControlClient/ListOperations/main.go
+++ b/internal/generated/snippets/chronicle/apiv1/DataAccessControlClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chronicle/apiv1/DataAccessControlClient/UpdateDataAccessLabel/main.go
+++ b/internal/generated/snippets/chronicle/apiv1/DataAccessControlClient/UpdateDataAccessLabel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chronicle/apiv1/DataAccessControlClient/UpdateDataAccessScope/main.go
+++ b/internal/generated/snippets/chronicle/apiv1/DataAccessControlClient/UpdateDataAccessScope/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chronicle/apiv1/EntityClient/CancelOperation/main.go
+++ b/internal/generated/snippets/chronicle/apiv1/EntityClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chronicle/apiv1/EntityClient/CreateWatchlist/main.go
+++ b/internal/generated/snippets/chronicle/apiv1/EntityClient/CreateWatchlist/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chronicle/apiv1/EntityClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/chronicle/apiv1/EntityClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chronicle/apiv1/EntityClient/DeleteWatchlist/main.go
+++ b/internal/generated/snippets/chronicle/apiv1/EntityClient/DeleteWatchlist/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chronicle/apiv1/EntityClient/GetOperation/main.go
+++ b/internal/generated/snippets/chronicle/apiv1/EntityClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chronicle/apiv1/EntityClient/GetWatchlist/main.go
+++ b/internal/generated/snippets/chronicle/apiv1/EntityClient/GetWatchlist/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chronicle/apiv1/EntityClient/ListOperations/main.go
+++ b/internal/generated/snippets/chronicle/apiv1/EntityClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chronicle/apiv1/EntityClient/ListWatchlists/main.go
+++ b/internal/generated/snippets/chronicle/apiv1/EntityClient/ListWatchlists/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chronicle/apiv1/EntityClient/UpdateWatchlist/main.go
+++ b/internal/generated/snippets/chronicle/apiv1/EntityClient/UpdateWatchlist/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chronicle/apiv1/InstanceClient/CancelOperation/main.go
+++ b/internal/generated/snippets/chronicle/apiv1/InstanceClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chronicle/apiv1/InstanceClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/chronicle/apiv1/InstanceClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chronicle/apiv1/InstanceClient/GetInstance/main.go
+++ b/internal/generated/snippets/chronicle/apiv1/InstanceClient/GetInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chronicle/apiv1/InstanceClient/GetOperation/main.go
+++ b/internal/generated/snippets/chronicle/apiv1/InstanceClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chronicle/apiv1/InstanceClient/ListOperations/main.go
+++ b/internal/generated/snippets/chronicle/apiv1/InstanceClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chronicle/apiv1/ReferenceListClient/CancelOperation/main.go
+++ b/internal/generated/snippets/chronicle/apiv1/ReferenceListClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chronicle/apiv1/ReferenceListClient/CreateReferenceList/main.go
+++ b/internal/generated/snippets/chronicle/apiv1/ReferenceListClient/CreateReferenceList/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chronicle/apiv1/ReferenceListClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/chronicle/apiv1/ReferenceListClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chronicle/apiv1/ReferenceListClient/GetOperation/main.go
+++ b/internal/generated/snippets/chronicle/apiv1/ReferenceListClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chronicle/apiv1/ReferenceListClient/GetReferenceList/main.go
+++ b/internal/generated/snippets/chronicle/apiv1/ReferenceListClient/GetReferenceList/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chronicle/apiv1/ReferenceListClient/ListOperations/main.go
+++ b/internal/generated/snippets/chronicle/apiv1/ReferenceListClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chronicle/apiv1/ReferenceListClient/ListReferenceLists/main.go
+++ b/internal/generated/snippets/chronicle/apiv1/ReferenceListClient/ListReferenceLists/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chronicle/apiv1/ReferenceListClient/UpdateReferenceList/main.go
+++ b/internal/generated/snippets/chronicle/apiv1/ReferenceListClient/UpdateReferenceList/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chronicle/apiv1/RuleClient/CancelOperation/main.go
+++ b/internal/generated/snippets/chronicle/apiv1/RuleClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chronicle/apiv1/RuleClient/CreateRetrohunt/main.go
+++ b/internal/generated/snippets/chronicle/apiv1/RuleClient/CreateRetrohunt/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chronicle/apiv1/RuleClient/CreateRule/main.go
+++ b/internal/generated/snippets/chronicle/apiv1/RuleClient/CreateRule/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chronicle/apiv1/RuleClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/chronicle/apiv1/RuleClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chronicle/apiv1/RuleClient/DeleteRule/main.go
+++ b/internal/generated/snippets/chronicle/apiv1/RuleClient/DeleteRule/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chronicle/apiv1/RuleClient/GetOperation/main.go
+++ b/internal/generated/snippets/chronicle/apiv1/RuleClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chronicle/apiv1/RuleClient/GetRetrohunt/main.go
+++ b/internal/generated/snippets/chronicle/apiv1/RuleClient/GetRetrohunt/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chronicle/apiv1/RuleClient/GetRule/main.go
+++ b/internal/generated/snippets/chronicle/apiv1/RuleClient/GetRule/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chronicle/apiv1/RuleClient/GetRuleDeployment/main.go
+++ b/internal/generated/snippets/chronicle/apiv1/RuleClient/GetRuleDeployment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chronicle/apiv1/RuleClient/ListOperations/main.go
+++ b/internal/generated/snippets/chronicle/apiv1/RuleClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chronicle/apiv1/RuleClient/ListRetrohunts/main.go
+++ b/internal/generated/snippets/chronicle/apiv1/RuleClient/ListRetrohunts/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chronicle/apiv1/RuleClient/ListRuleDeployments/main.go
+++ b/internal/generated/snippets/chronicle/apiv1/RuleClient/ListRuleDeployments/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chronicle/apiv1/RuleClient/ListRuleRevisions/main.go
+++ b/internal/generated/snippets/chronicle/apiv1/RuleClient/ListRuleRevisions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chronicle/apiv1/RuleClient/ListRules/main.go
+++ b/internal/generated/snippets/chronicle/apiv1/RuleClient/ListRules/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chronicle/apiv1/RuleClient/UpdateRule/main.go
+++ b/internal/generated/snippets/chronicle/apiv1/RuleClient/UpdateRule/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/chronicle/apiv1/RuleClient/UpdateRuleDeployment/main.go
+++ b/internal/generated/snippets/chronicle/apiv1/RuleClient/UpdateRuleDeployment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudbuild/apiv1/v2/Client/ApproveBuild/main.go
+++ b/internal/generated/snippets/cloudbuild/apiv1/v2/Client/ApproveBuild/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudbuild/apiv1/v2/Client/CancelBuild/main.go
+++ b/internal/generated/snippets/cloudbuild/apiv1/v2/Client/CancelBuild/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudbuild/apiv1/v2/Client/CreateBuild/main.go
+++ b/internal/generated/snippets/cloudbuild/apiv1/v2/Client/CreateBuild/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudbuild/apiv1/v2/Client/CreateBuildTrigger/main.go
+++ b/internal/generated/snippets/cloudbuild/apiv1/v2/Client/CreateBuildTrigger/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudbuild/apiv1/v2/Client/CreateWorkerPool/main.go
+++ b/internal/generated/snippets/cloudbuild/apiv1/v2/Client/CreateWorkerPool/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudbuild/apiv1/v2/Client/DeleteBuildTrigger/main.go
+++ b/internal/generated/snippets/cloudbuild/apiv1/v2/Client/DeleteBuildTrigger/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudbuild/apiv1/v2/Client/DeleteWorkerPool/main.go
+++ b/internal/generated/snippets/cloudbuild/apiv1/v2/Client/DeleteWorkerPool/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudbuild/apiv1/v2/Client/GetBuild/main.go
+++ b/internal/generated/snippets/cloudbuild/apiv1/v2/Client/GetBuild/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudbuild/apiv1/v2/Client/GetBuildTrigger/main.go
+++ b/internal/generated/snippets/cloudbuild/apiv1/v2/Client/GetBuildTrigger/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudbuild/apiv1/v2/Client/GetDefaultServiceAccount/main.go
+++ b/internal/generated/snippets/cloudbuild/apiv1/v2/Client/GetDefaultServiceAccount/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudbuild/apiv1/v2/Client/GetWorkerPool/main.go
+++ b/internal/generated/snippets/cloudbuild/apiv1/v2/Client/GetWorkerPool/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudbuild/apiv1/v2/Client/ListBuildTriggers/main.go
+++ b/internal/generated/snippets/cloudbuild/apiv1/v2/Client/ListBuildTriggers/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudbuild/apiv1/v2/Client/ListBuilds/main.go
+++ b/internal/generated/snippets/cloudbuild/apiv1/v2/Client/ListBuilds/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudbuild/apiv1/v2/Client/ListWorkerPools/main.go
+++ b/internal/generated/snippets/cloudbuild/apiv1/v2/Client/ListWorkerPools/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudbuild/apiv1/v2/Client/ReceiveTriggerWebhook/main.go
+++ b/internal/generated/snippets/cloudbuild/apiv1/v2/Client/ReceiveTriggerWebhook/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudbuild/apiv1/v2/Client/RetryBuild/main.go
+++ b/internal/generated/snippets/cloudbuild/apiv1/v2/Client/RetryBuild/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudbuild/apiv1/v2/Client/RunBuildTrigger/main.go
+++ b/internal/generated/snippets/cloudbuild/apiv1/v2/Client/RunBuildTrigger/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudbuild/apiv1/v2/Client/UpdateBuildTrigger/main.go
+++ b/internal/generated/snippets/cloudbuild/apiv1/v2/Client/UpdateBuildTrigger/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudbuild/apiv1/v2/Client/UpdateWorkerPool/main.go
+++ b/internal/generated/snippets/cloudbuild/apiv1/v2/Client/UpdateWorkerPool/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudbuild/apiv2/RepositoryManagerClient/BatchCreateRepositories/main.go
+++ b/internal/generated/snippets/cloudbuild/apiv2/RepositoryManagerClient/BatchCreateRepositories/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudbuild/apiv2/RepositoryManagerClient/CancelOperation/main.go
+++ b/internal/generated/snippets/cloudbuild/apiv2/RepositoryManagerClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudbuild/apiv2/RepositoryManagerClient/CreateConnection/main.go
+++ b/internal/generated/snippets/cloudbuild/apiv2/RepositoryManagerClient/CreateConnection/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudbuild/apiv2/RepositoryManagerClient/CreateRepository/main.go
+++ b/internal/generated/snippets/cloudbuild/apiv2/RepositoryManagerClient/CreateRepository/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudbuild/apiv2/RepositoryManagerClient/DeleteConnection/main.go
+++ b/internal/generated/snippets/cloudbuild/apiv2/RepositoryManagerClient/DeleteConnection/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudbuild/apiv2/RepositoryManagerClient/DeleteRepository/main.go
+++ b/internal/generated/snippets/cloudbuild/apiv2/RepositoryManagerClient/DeleteRepository/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudbuild/apiv2/RepositoryManagerClient/FetchGitRefs/main.go
+++ b/internal/generated/snippets/cloudbuild/apiv2/RepositoryManagerClient/FetchGitRefs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudbuild/apiv2/RepositoryManagerClient/FetchLinkableRepositories/main.go
+++ b/internal/generated/snippets/cloudbuild/apiv2/RepositoryManagerClient/FetchLinkableRepositories/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudbuild/apiv2/RepositoryManagerClient/FetchReadToken/main.go
+++ b/internal/generated/snippets/cloudbuild/apiv2/RepositoryManagerClient/FetchReadToken/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudbuild/apiv2/RepositoryManagerClient/FetchReadWriteToken/main.go
+++ b/internal/generated/snippets/cloudbuild/apiv2/RepositoryManagerClient/FetchReadWriteToken/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudbuild/apiv2/RepositoryManagerClient/GetConnection/main.go
+++ b/internal/generated/snippets/cloudbuild/apiv2/RepositoryManagerClient/GetConnection/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudbuild/apiv2/RepositoryManagerClient/GetIamPolicy/main.go
+++ b/internal/generated/snippets/cloudbuild/apiv2/RepositoryManagerClient/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudbuild/apiv2/RepositoryManagerClient/GetOperation/main.go
+++ b/internal/generated/snippets/cloudbuild/apiv2/RepositoryManagerClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudbuild/apiv2/RepositoryManagerClient/GetRepository/main.go
+++ b/internal/generated/snippets/cloudbuild/apiv2/RepositoryManagerClient/GetRepository/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudbuild/apiv2/RepositoryManagerClient/ListConnections/main.go
+++ b/internal/generated/snippets/cloudbuild/apiv2/RepositoryManagerClient/ListConnections/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudbuild/apiv2/RepositoryManagerClient/ListRepositories/main.go
+++ b/internal/generated/snippets/cloudbuild/apiv2/RepositoryManagerClient/ListRepositories/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudbuild/apiv2/RepositoryManagerClient/SetIamPolicy/main.go
+++ b/internal/generated/snippets/cloudbuild/apiv2/RepositoryManagerClient/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudbuild/apiv2/RepositoryManagerClient/TestIamPermissions/main.go
+++ b/internal/generated/snippets/cloudbuild/apiv2/RepositoryManagerClient/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudbuild/apiv2/RepositoryManagerClient/UpdateConnection/main.go
+++ b/internal/generated/snippets/cloudbuild/apiv2/RepositoryManagerClient/UpdateConnection/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudcontrolspartner/apiv1/CloudControlsPartnerCoreClient/CreateCustomer/main.go
+++ b/internal/generated/snippets/cloudcontrolspartner/apiv1/CloudControlsPartnerCoreClient/CreateCustomer/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudcontrolspartner/apiv1/CloudControlsPartnerCoreClient/DeleteCustomer/main.go
+++ b/internal/generated/snippets/cloudcontrolspartner/apiv1/CloudControlsPartnerCoreClient/DeleteCustomer/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudcontrolspartner/apiv1/CloudControlsPartnerCoreClient/GetCustomer/main.go
+++ b/internal/generated/snippets/cloudcontrolspartner/apiv1/CloudControlsPartnerCoreClient/GetCustomer/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudcontrolspartner/apiv1/CloudControlsPartnerCoreClient/GetEkmConnections/main.go
+++ b/internal/generated/snippets/cloudcontrolspartner/apiv1/CloudControlsPartnerCoreClient/GetEkmConnections/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudcontrolspartner/apiv1/CloudControlsPartnerCoreClient/GetPartner/main.go
+++ b/internal/generated/snippets/cloudcontrolspartner/apiv1/CloudControlsPartnerCoreClient/GetPartner/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudcontrolspartner/apiv1/CloudControlsPartnerCoreClient/GetPartnerPermissions/main.go
+++ b/internal/generated/snippets/cloudcontrolspartner/apiv1/CloudControlsPartnerCoreClient/GetPartnerPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudcontrolspartner/apiv1/CloudControlsPartnerCoreClient/GetWorkload/main.go
+++ b/internal/generated/snippets/cloudcontrolspartner/apiv1/CloudControlsPartnerCoreClient/GetWorkload/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudcontrolspartner/apiv1/CloudControlsPartnerCoreClient/ListAccessApprovalRequests/main.go
+++ b/internal/generated/snippets/cloudcontrolspartner/apiv1/CloudControlsPartnerCoreClient/ListAccessApprovalRequests/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudcontrolspartner/apiv1/CloudControlsPartnerCoreClient/ListCustomers/main.go
+++ b/internal/generated/snippets/cloudcontrolspartner/apiv1/CloudControlsPartnerCoreClient/ListCustomers/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudcontrolspartner/apiv1/CloudControlsPartnerCoreClient/ListWorkloads/main.go
+++ b/internal/generated/snippets/cloudcontrolspartner/apiv1/CloudControlsPartnerCoreClient/ListWorkloads/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudcontrolspartner/apiv1/CloudControlsPartnerCoreClient/UpdateCustomer/main.go
+++ b/internal/generated/snippets/cloudcontrolspartner/apiv1/CloudControlsPartnerCoreClient/UpdateCustomer/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudcontrolspartner/apiv1/CloudControlsPartnerMonitoringClient/GetViolation/main.go
+++ b/internal/generated/snippets/cloudcontrolspartner/apiv1/CloudControlsPartnerMonitoringClient/GetViolation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudcontrolspartner/apiv1/CloudControlsPartnerMonitoringClient/ListViolations/main.go
+++ b/internal/generated/snippets/cloudcontrolspartner/apiv1/CloudControlsPartnerMonitoringClient/ListViolations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudcontrolspartner/apiv1beta/CloudControlsPartnerCoreClient/CreateCustomer/main.go
+++ b/internal/generated/snippets/cloudcontrolspartner/apiv1beta/CloudControlsPartnerCoreClient/CreateCustomer/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudcontrolspartner/apiv1beta/CloudControlsPartnerCoreClient/DeleteCustomer/main.go
+++ b/internal/generated/snippets/cloudcontrolspartner/apiv1beta/CloudControlsPartnerCoreClient/DeleteCustomer/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudcontrolspartner/apiv1beta/CloudControlsPartnerCoreClient/GetCustomer/main.go
+++ b/internal/generated/snippets/cloudcontrolspartner/apiv1beta/CloudControlsPartnerCoreClient/GetCustomer/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudcontrolspartner/apiv1beta/CloudControlsPartnerCoreClient/GetEkmConnections/main.go
+++ b/internal/generated/snippets/cloudcontrolspartner/apiv1beta/CloudControlsPartnerCoreClient/GetEkmConnections/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudcontrolspartner/apiv1beta/CloudControlsPartnerCoreClient/GetPartner/main.go
+++ b/internal/generated/snippets/cloudcontrolspartner/apiv1beta/CloudControlsPartnerCoreClient/GetPartner/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudcontrolspartner/apiv1beta/CloudControlsPartnerCoreClient/GetPartnerPermissions/main.go
+++ b/internal/generated/snippets/cloudcontrolspartner/apiv1beta/CloudControlsPartnerCoreClient/GetPartnerPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudcontrolspartner/apiv1beta/CloudControlsPartnerCoreClient/GetWorkload/main.go
+++ b/internal/generated/snippets/cloudcontrolspartner/apiv1beta/CloudControlsPartnerCoreClient/GetWorkload/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudcontrolspartner/apiv1beta/CloudControlsPartnerCoreClient/ListAccessApprovalRequests/main.go
+++ b/internal/generated/snippets/cloudcontrolspartner/apiv1beta/CloudControlsPartnerCoreClient/ListAccessApprovalRequests/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudcontrolspartner/apiv1beta/CloudControlsPartnerCoreClient/ListCustomers/main.go
+++ b/internal/generated/snippets/cloudcontrolspartner/apiv1beta/CloudControlsPartnerCoreClient/ListCustomers/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudcontrolspartner/apiv1beta/CloudControlsPartnerCoreClient/ListWorkloads/main.go
+++ b/internal/generated/snippets/cloudcontrolspartner/apiv1beta/CloudControlsPartnerCoreClient/ListWorkloads/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudcontrolspartner/apiv1beta/CloudControlsPartnerCoreClient/UpdateCustomer/main.go
+++ b/internal/generated/snippets/cloudcontrolspartner/apiv1beta/CloudControlsPartnerCoreClient/UpdateCustomer/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudcontrolspartner/apiv1beta/CloudControlsPartnerMonitoringClient/GetViolation/main.go
+++ b/internal/generated/snippets/cloudcontrolspartner/apiv1beta/CloudControlsPartnerMonitoringClient/GetViolation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudcontrolspartner/apiv1beta/CloudControlsPartnerMonitoringClient/ListViolations/main.go
+++ b/internal/generated/snippets/cloudcontrolspartner/apiv1beta/CloudControlsPartnerMonitoringClient/ListViolations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/ApplyConversionWorkspace/main.go
+++ b/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/ApplyConversionWorkspace/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/CancelOperation/main.go
+++ b/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/CommitConversionWorkspace/main.go
+++ b/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/CommitConversionWorkspace/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/ConvertConversionWorkspace/main.go
+++ b/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/ConvertConversionWorkspace/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/CreateConnectionProfile/main.go
+++ b/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/CreateConnectionProfile/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/CreateConversionWorkspace/main.go
+++ b/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/CreateConversionWorkspace/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/CreateMappingRule/main.go
+++ b/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/CreateMappingRule/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/CreateMigrationJob/main.go
+++ b/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/CreateMigrationJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/CreatePrivateConnection/main.go
+++ b/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/CreatePrivateConnection/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/DeleteConnectionProfile/main.go
+++ b/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/DeleteConnectionProfile/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/DeleteConversionWorkspace/main.go
+++ b/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/DeleteConversionWorkspace/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/DeleteMappingRule/main.go
+++ b/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/DeleteMappingRule/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/DeleteMigrationJob/main.go
+++ b/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/DeleteMigrationJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/DeletePrivateConnection/main.go
+++ b/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/DeletePrivateConnection/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/DescribeConversionWorkspaceRevisions/main.go
+++ b/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/DescribeConversionWorkspaceRevisions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/DescribeDatabaseEntities/main.go
+++ b/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/DescribeDatabaseEntities/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/FetchStaticIps/main.go
+++ b/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/FetchStaticIps/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/GenerateSshScript/main.go
+++ b/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/GenerateSshScript/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/GenerateTcpProxyScript/main.go
+++ b/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/GenerateTcpProxyScript/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/GetConnectionProfile/main.go
+++ b/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/GetConnectionProfile/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/GetConversionWorkspace/main.go
+++ b/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/GetConversionWorkspace/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/GetIamPolicy/main.go
+++ b/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/GetLocation/main.go
+++ b/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/GetMappingRule/main.go
+++ b/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/GetMappingRule/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/GetMigrationJob/main.go
+++ b/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/GetMigrationJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/GetOperation/main.go
+++ b/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/GetPrivateConnection/main.go
+++ b/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/GetPrivateConnection/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/ImportMappingRules/main.go
+++ b/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/ImportMappingRules/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/ListConnectionProfiles/main.go
+++ b/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/ListConnectionProfiles/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/ListConversionWorkspaces/main.go
+++ b/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/ListConversionWorkspaces/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/ListLocations/main.go
+++ b/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/ListMappingRules/main.go
+++ b/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/ListMappingRules/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/ListMigrationJobs/main.go
+++ b/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/ListMigrationJobs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/ListOperations/main.go
+++ b/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/ListPrivateConnections/main.go
+++ b/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/ListPrivateConnections/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/PromoteMigrationJob/main.go
+++ b/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/PromoteMigrationJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/RestartMigrationJob/main.go
+++ b/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/RestartMigrationJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/ResumeMigrationJob/main.go
+++ b/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/ResumeMigrationJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/RollbackConversionWorkspace/main.go
+++ b/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/RollbackConversionWorkspace/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/SearchBackgroundJobs/main.go
+++ b/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/SearchBackgroundJobs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/SeedConversionWorkspace/main.go
+++ b/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/SeedConversionWorkspace/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/SetIamPolicy/main.go
+++ b/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/StartMigrationJob/main.go
+++ b/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/StartMigrationJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/StopMigrationJob/main.go
+++ b/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/StopMigrationJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/TestIamPermissions/main.go
+++ b/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/UpdateConnectionProfile/main.go
+++ b/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/UpdateConnectionProfile/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/UpdateConversionWorkspace/main.go
+++ b/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/UpdateConversionWorkspace/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/UpdateMigrationJob/main.go
+++ b/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/UpdateMigrationJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/VerifyMigrationJob/main.go
+++ b/internal/generated/snippets/clouddms/apiv1/DataMigrationClient/VerifyMigrationJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudprofiler/apiv2/ExportClient/ListProfiles/main.go
+++ b/internal/generated/snippets/cloudprofiler/apiv2/ExportClient/ListProfiles/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudprofiler/apiv2/ProfilerClient/CreateOfflineProfile/main.go
+++ b/internal/generated/snippets/cloudprofiler/apiv2/ProfilerClient/CreateOfflineProfile/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudprofiler/apiv2/ProfilerClient/CreateProfile/main.go
+++ b/internal/generated/snippets/cloudprofiler/apiv2/ProfilerClient/CreateProfile/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudprofiler/apiv2/ProfilerClient/UpdateProfile/main.go
+++ b/internal/generated/snippets/cloudprofiler/apiv2/ProfilerClient/UpdateProfile/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudquotas/apiv1/Client/CreateQuotaPreference/main.go
+++ b/internal/generated/snippets/cloudquotas/apiv1/Client/CreateQuotaPreference/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudquotas/apiv1/Client/GetQuotaInfo/main.go
+++ b/internal/generated/snippets/cloudquotas/apiv1/Client/GetQuotaInfo/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudquotas/apiv1/Client/GetQuotaPreference/main.go
+++ b/internal/generated/snippets/cloudquotas/apiv1/Client/GetQuotaPreference/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudquotas/apiv1/Client/ListQuotaInfos/main.go
+++ b/internal/generated/snippets/cloudquotas/apiv1/Client/ListQuotaInfos/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudquotas/apiv1/Client/ListQuotaPreferences/main.go
+++ b/internal/generated/snippets/cloudquotas/apiv1/Client/ListQuotaPreferences/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudquotas/apiv1/Client/UpdateQuotaPreference/main.go
+++ b/internal/generated/snippets/cloudquotas/apiv1/Client/UpdateQuotaPreference/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudquotas/apiv1beta/Client/CreateQuotaPreference/main.go
+++ b/internal/generated/snippets/cloudquotas/apiv1beta/Client/CreateQuotaPreference/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudquotas/apiv1beta/Client/GetQuotaInfo/main.go
+++ b/internal/generated/snippets/cloudquotas/apiv1beta/Client/GetQuotaInfo/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudquotas/apiv1beta/Client/GetQuotaPreference/main.go
+++ b/internal/generated/snippets/cloudquotas/apiv1beta/Client/GetQuotaPreference/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudquotas/apiv1beta/Client/ListQuotaInfos/main.go
+++ b/internal/generated/snippets/cloudquotas/apiv1beta/Client/ListQuotaInfos/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudquotas/apiv1beta/Client/ListQuotaPreferences/main.go
+++ b/internal/generated/snippets/cloudquotas/apiv1beta/Client/ListQuotaPreferences/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudquotas/apiv1beta/Client/UpdateQuotaPreference/main.go
+++ b/internal/generated/snippets/cloudquotas/apiv1beta/Client/UpdateQuotaPreference/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudquotas/apiv1beta/QuotaAdjusterSettingsManagerClient/GetQuotaAdjusterSettings/main.go
+++ b/internal/generated/snippets/cloudquotas/apiv1beta/QuotaAdjusterSettingsManagerClient/GetQuotaAdjusterSettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudquotas/apiv1beta/QuotaAdjusterSettingsManagerClient/UpdateQuotaAdjusterSettings/main.go
+++ b/internal/generated/snippets/cloudquotas/apiv1beta/QuotaAdjusterSettingsManagerClient/UpdateQuotaAdjusterSettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudtasks/apiv2/Client/CreateQueue/main.go
+++ b/internal/generated/snippets/cloudtasks/apiv2/Client/CreateQueue/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudtasks/apiv2/Client/CreateTask/main.go
+++ b/internal/generated/snippets/cloudtasks/apiv2/Client/CreateTask/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudtasks/apiv2/Client/DeleteQueue/main.go
+++ b/internal/generated/snippets/cloudtasks/apiv2/Client/DeleteQueue/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudtasks/apiv2/Client/DeleteTask/main.go
+++ b/internal/generated/snippets/cloudtasks/apiv2/Client/DeleteTask/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudtasks/apiv2/Client/GetIamPolicy/main.go
+++ b/internal/generated/snippets/cloudtasks/apiv2/Client/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudtasks/apiv2/Client/GetLocation/main.go
+++ b/internal/generated/snippets/cloudtasks/apiv2/Client/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudtasks/apiv2/Client/GetQueue/main.go
+++ b/internal/generated/snippets/cloudtasks/apiv2/Client/GetQueue/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudtasks/apiv2/Client/GetTask/main.go
+++ b/internal/generated/snippets/cloudtasks/apiv2/Client/GetTask/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudtasks/apiv2/Client/ListLocations/main.go
+++ b/internal/generated/snippets/cloudtasks/apiv2/Client/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudtasks/apiv2/Client/ListQueues/main.go
+++ b/internal/generated/snippets/cloudtasks/apiv2/Client/ListQueues/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudtasks/apiv2/Client/ListTasks/main.go
+++ b/internal/generated/snippets/cloudtasks/apiv2/Client/ListTasks/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudtasks/apiv2/Client/PauseQueue/main.go
+++ b/internal/generated/snippets/cloudtasks/apiv2/Client/PauseQueue/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudtasks/apiv2/Client/PurgeQueue/main.go
+++ b/internal/generated/snippets/cloudtasks/apiv2/Client/PurgeQueue/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudtasks/apiv2/Client/ResumeQueue/main.go
+++ b/internal/generated/snippets/cloudtasks/apiv2/Client/ResumeQueue/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudtasks/apiv2/Client/RunTask/main.go
+++ b/internal/generated/snippets/cloudtasks/apiv2/Client/RunTask/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudtasks/apiv2/Client/SetIamPolicy/main.go
+++ b/internal/generated/snippets/cloudtasks/apiv2/Client/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudtasks/apiv2/Client/TestIamPermissions/main.go
+++ b/internal/generated/snippets/cloudtasks/apiv2/Client/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudtasks/apiv2/Client/UpdateQueue/main.go
+++ b/internal/generated/snippets/cloudtasks/apiv2/Client/UpdateQueue/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudtasks/apiv2beta2/Client/AcknowledgeTask/main.go
+++ b/internal/generated/snippets/cloudtasks/apiv2beta2/Client/AcknowledgeTask/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudtasks/apiv2beta2/Client/CancelLease/main.go
+++ b/internal/generated/snippets/cloudtasks/apiv2beta2/Client/CancelLease/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudtasks/apiv2beta2/Client/CreateQueue/main.go
+++ b/internal/generated/snippets/cloudtasks/apiv2beta2/Client/CreateQueue/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudtasks/apiv2beta2/Client/CreateTask/main.go
+++ b/internal/generated/snippets/cloudtasks/apiv2beta2/Client/CreateTask/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudtasks/apiv2beta2/Client/DeleteQueue/main.go
+++ b/internal/generated/snippets/cloudtasks/apiv2beta2/Client/DeleteQueue/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudtasks/apiv2beta2/Client/DeleteTask/main.go
+++ b/internal/generated/snippets/cloudtasks/apiv2beta2/Client/DeleteTask/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudtasks/apiv2beta2/Client/GetIamPolicy/main.go
+++ b/internal/generated/snippets/cloudtasks/apiv2beta2/Client/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudtasks/apiv2beta2/Client/GetLocation/main.go
+++ b/internal/generated/snippets/cloudtasks/apiv2beta2/Client/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudtasks/apiv2beta2/Client/GetQueue/main.go
+++ b/internal/generated/snippets/cloudtasks/apiv2beta2/Client/GetQueue/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudtasks/apiv2beta2/Client/GetTask/main.go
+++ b/internal/generated/snippets/cloudtasks/apiv2beta2/Client/GetTask/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudtasks/apiv2beta2/Client/LeaseTasks/main.go
+++ b/internal/generated/snippets/cloudtasks/apiv2beta2/Client/LeaseTasks/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudtasks/apiv2beta2/Client/ListLocations/main.go
+++ b/internal/generated/snippets/cloudtasks/apiv2beta2/Client/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudtasks/apiv2beta2/Client/ListQueues/main.go
+++ b/internal/generated/snippets/cloudtasks/apiv2beta2/Client/ListQueues/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudtasks/apiv2beta2/Client/ListTasks/main.go
+++ b/internal/generated/snippets/cloudtasks/apiv2beta2/Client/ListTasks/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudtasks/apiv2beta2/Client/PauseQueue/main.go
+++ b/internal/generated/snippets/cloudtasks/apiv2beta2/Client/PauseQueue/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudtasks/apiv2beta2/Client/PurgeQueue/main.go
+++ b/internal/generated/snippets/cloudtasks/apiv2beta2/Client/PurgeQueue/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudtasks/apiv2beta2/Client/RenewLease/main.go
+++ b/internal/generated/snippets/cloudtasks/apiv2beta2/Client/RenewLease/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudtasks/apiv2beta2/Client/ResumeQueue/main.go
+++ b/internal/generated/snippets/cloudtasks/apiv2beta2/Client/ResumeQueue/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudtasks/apiv2beta2/Client/RunTask/main.go
+++ b/internal/generated/snippets/cloudtasks/apiv2beta2/Client/RunTask/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudtasks/apiv2beta2/Client/SetIamPolicy/main.go
+++ b/internal/generated/snippets/cloudtasks/apiv2beta2/Client/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudtasks/apiv2beta2/Client/TestIamPermissions/main.go
+++ b/internal/generated/snippets/cloudtasks/apiv2beta2/Client/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudtasks/apiv2beta2/Client/UpdateQueue/main.go
+++ b/internal/generated/snippets/cloudtasks/apiv2beta2/Client/UpdateQueue/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudtasks/apiv2beta2/Client/UploadQueueYaml/main.go
+++ b/internal/generated/snippets/cloudtasks/apiv2beta2/Client/UploadQueueYaml/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudtasks/apiv2beta3/Client/CreateQueue/main.go
+++ b/internal/generated/snippets/cloudtasks/apiv2beta3/Client/CreateQueue/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudtasks/apiv2beta3/Client/CreateTask/main.go
+++ b/internal/generated/snippets/cloudtasks/apiv2beta3/Client/CreateTask/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudtasks/apiv2beta3/Client/DeleteQueue/main.go
+++ b/internal/generated/snippets/cloudtasks/apiv2beta3/Client/DeleteQueue/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudtasks/apiv2beta3/Client/DeleteTask/main.go
+++ b/internal/generated/snippets/cloudtasks/apiv2beta3/Client/DeleteTask/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudtasks/apiv2beta3/Client/GetIamPolicy/main.go
+++ b/internal/generated/snippets/cloudtasks/apiv2beta3/Client/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudtasks/apiv2beta3/Client/GetLocation/main.go
+++ b/internal/generated/snippets/cloudtasks/apiv2beta3/Client/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudtasks/apiv2beta3/Client/GetQueue/main.go
+++ b/internal/generated/snippets/cloudtasks/apiv2beta3/Client/GetQueue/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudtasks/apiv2beta3/Client/GetTask/main.go
+++ b/internal/generated/snippets/cloudtasks/apiv2beta3/Client/GetTask/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudtasks/apiv2beta3/Client/ListLocations/main.go
+++ b/internal/generated/snippets/cloudtasks/apiv2beta3/Client/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudtasks/apiv2beta3/Client/ListQueues/main.go
+++ b/internal/generated/snippets/cloudtasks/apiv2beta3/Client/ListQueues/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudtasks/apiv2beta3/Client/ListTasks/main.go
+++ b/internal/generated/snippets/cloudtasks/apiv2beta3/Client/ListTasks/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudtasks/apiv2beta3/Client/PauseQueue/main.go
+++ b/internal/generated/snippets/cloudtasks/apiv2beta3/Client/PauseQueue/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudtasks/apiv2beta3/Client/PurgeQueue/main.go
+++ b/internal/generated/snippets/cloudtasks/apiv2beta3/Client/PurgeQueue/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudtasks/apiv2beta3/Client/ResumeQueue/main.go
+++ b/internal/generated/snippets/cloudtasks/apiv2beta3/Client/ResumeQueue/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudtasks/apiv2beta3/Client/RunTask/main.go
+++ b/internal/generated/snippets/cloudtasks/apiv2beta3/Client/RunTask/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudtasks/apiv2beta3/Client/SetIamPolicy/main.go
+++ b/internal/generated/snippets/cloudtasks/apiv2beta3/Client/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudtasks/apiv2beta3/Client/TestIamPermissions/main.go
+++ b/internal/generated/snippets/cloudtasks/apiv2beta3/Client/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/cloudtasks/apiv2beta3/Client/UpdateQueue/main.go
+++ b/internal/generated/snippets/cloudtasks/apiv2beta3/Client/UpdateQueue/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/commerce/consumer/procurement/apiv1/ConsumerProcurementClient/CancelOrder/main.go
+++ b/internal/generated/snippets/commerce/consumer/procurement/apiv1/ConsumerProcurementClient/CancelOrder/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/commerce/consumer/procurement/apiv1/ConsumerProcurementClient/GetOperation/main.go
+++ b/internal/generated/snippets/commerce/consumer/procurement/apiv1/ConsumerProcurementClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/commerce/consumer/procurement/apiv1/ConsumerProcurementClient/GetOrder/main.go
+++ b/internal/generated/snippets/commerce/consumer/procurement/apiv1/ConsumerProcurementClient/GetOrder/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/commerce/consumer/procurement/apiv1/ConsumerProcurementClient/ListOrders/main.go
+++ b/internal/generated/snippets/commerce/consumer/procurement/apiv1/ConsumerProcurementClient/ListOrders/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/commerce/consumer/procurement/apiv1/ConsumerProcurementClient/ModifyOrder/main.go
+++ b/internal/generated/snippets/commerce/consumer/procurement/apiv1/ConsumerProcurementClient/ModifyOrder/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/commerce/consumer/procurement/apiv1/ConsumerProcurementClient/PlaceOrder/main.go
+++ b/internal/generated/snippets/commerce/consumer/procurement/apiv1/ConsumerProcurementClient/PlaceOrder/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/commerce/consumer/procurement/apiv1/LicenseManagementClient/Assign/main.go
+++ b/internal/generated/snippets/commerce/consumer/procurement/apiv1/LicenseManagementClient/Assign/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/commerce/consumer/procurement/apiv1/LicenseManagementClient/EnumerateLicensedUsers/main.go
+++ b/internal/generated/snippets/commerce/consumer/procurement/apiv1/LicenseManagementClient/EnumerateLicensedUsers/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/commerce/consumer/procurement/apiv1/LicenseManagementClient/GetLicensePool/main.go
+++ b/internal/generated/snippets/commerce/consumer/procurement/apiv1/LicenseManagementClient/GetLicensePool/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/commerce/consumer/procurement/apiv1/LicenseManagementClient/GetOperation/main.go
+++ b/internal/generated/snippets/commerce/consumer/procurement/apiv1/LicenseManagementClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/commerce/consumer/procurement/apiv1/LicenseManagementClient/Unassign/main.go
+++ b/internal/generated/snippets/commerce/consumer/procurement/apiv1/LicenseManagementClient/Unassign/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/commerce/consumer/procurement/apiv1/LicenseManagementClient/UpdateLicensePool/main.go
+++ b/internal/generated/snippets/commerce/consumer/procurement/apiv1/LicenseManagementClient/UpdateLicensePool/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/confidentialcomputing/apiv1/Client/CreateChallenge/main.go
+++ b/internal/generated/snippets/confidentialcomputing/apiv1/Client/CreateChallenge/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/confidentialcomputing/apiv1/Client/GetLocation/main.go
+++ b/internal/generated/snippets/confidentialcomputing/apiv1/Client/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/confidentialcomputing/apiv1/Client/ListLocations/main.go
+++ b/internal/generated/snippets/confidentialcomputing/apiv1/Client/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/confidentialcomputing/apiv1/Client/VerifyAttestation/main.go
+++ b/internal/generated/snippets/confidentialcomputing/apiv1/Client/VerifyAttestation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/confidentialcomputing/apiv1/Client/VerifyConfidentialGke/main.go
+++ b/internal/generated/snippets/confidentialcomputing/apiv1/Client/VerifyConfidentialGke/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/confidentialcomputing/apiv1/Client/VerifyConfidentialSpace/main.go
+++ b/internal/generated/snippets/confidentialcomputing/apiv1/Client/VerifyConfidentialSpace/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/confidentialcomputing/apiv1alpha1/Client/CreateChallenge/main.go
+++ b/internal/generated/snippets/confidentialcomputing/apiv1alpha1/Client/CreateChallenge/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/confidentialcomputing/apiv1alpha1/Client/GetLocation/main.go
+++ b/internal/generated/snippets/confidentialcomputing/apiv1alpha1/Client/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/confidentialcomputing/apiv1alpha1/Client/ListLocations/main.go
+++ b/internal/generated/snippets/confidentialcomputing/apiv1alpha1/Client/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/confidentialcomputing/apiv1alpha1/Client/VerifyAttestation/main.go
+++ b/internal/generated/snippets/confidentialcomputing/apiv1alpha1/Client/VerifyAttestation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/configdelivery/apiv1/Client/AbortRollout/main.go
+++ b/internal/generated/snippets/configdelivery/apiv1/Client/AbortRollout/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/configdelivery/apiv1/Client/CancelOperation/main.go
+++ b/internal/generated/snippets/configdelivery/apiv1/Client/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/configdelivery/apiv1/Client/CreateFleetPackage/main.go
+++ b/internal/generated/snippets/configdelivery/apiv1/Client/CreateFleetPackage/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/configdelivery/apiv1/Client/CreateRelease/main.go
+++ b/internal/generated/snippets/configdelivery/apiv1/Client/CreateRelease/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/configdelivery/apiv1/Client/CreateResourceBundle/main.go
+++ b/internal/generated/snippets/configdelivery/apiv1/Client/CreateResourceBundle/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/configdelivery/apiv1/Client/CreateVariant/main.go
+++ b/internal/generated/snippets/configdelivery/apiv1/Client/CreateVariant/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/configdelivery/apiv1/Client/DeleteFleetPackage/main.go
+++ b/internal/generated/snippets/configdelivery/apiv1/Client/DeleteFleetPackage/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/configdelivery/apiv1/Client/DeleteOperation/main.go
+++ b/internal/generated/snippets/configdelivery/apiv1/Client/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/configdelivery/apiv1/Client/DeleteRelease/main.go
+++ b/internal/generated/snippets/configdelivery/apiv1/Client/DeleteRelease/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/configdelivery/apiv1/Client/DeleteResourceBundle/main.go
+++ b/internal/generated/snippets/configdelivery/apiv1/Client/DeleteResourceBundle/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/configdelivery/apiv1/Client/DeleteVariant/main.go
+++ b/internal/generated/snippets/configdelivery/apiv1/Client/DeleteVariant/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/configdelivery/apiv1/Client/GetFleetPackage/main.go
+++ b/internal/generated/snippets/configdelivery/apiv1/Client/GetFleetPackage/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/configdelivery/apiv1/Client/GetLocation/main.go
+++ b/internal/generated/snippets/configdelivery/apiv1/Client/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/configdelivery/apiv1/Client/GetOperation/main.go
+++ b/internal/generated/snippets/configdelivery/apiv1/Client/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/configdelivery/apiv1/Client/GetRelease/main.go
+++ b/internal/generated/snippets/configdelivery/apiv1/Client/GetRelease/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/configdelivery/apiv1/Client/GetResourceBundle/main.go
+++ b/internal/generated/snippets/configdelivery/apiv1/Client/GetResourceBundle/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/configdelivery/apiv1/Client/GetRollout/main.go
+++ b/internal/generated/snippets/configdelivery/apiv1/Client/GetRollout/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/configdelivery/apiv1/Client/GetVariant/main.go
+++ b/internal/generated/snippets/configdelivery/apiv1/Client/GetVariant/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/configdelivery/apiv1/Client/ListFleetPackages/main.go
+++ b/internal/generated/snippets/configdelivery/apiv1/Client/ListFleetPackages/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/configdelivery/apiv1/Client/ListLocations/main.go
+++ b/internal/generated/snippets/configdelivery/apiv1/Client/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/configdelivery/apiv1/Client/ListOperations/main.go
+++ b/internal/generated/snippets/configdelivery/apiv1/Client/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/configdelivery/apiv1/Client/ListReleases/main.go
+++ b/internal/generated/snippets/configdelivery/apiv1/Client/ListReleases/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/configdelivery/apiv1/Client/ListResourceBundles/main.go
+++ b/internal/generated/snippets/configdelivery/apiv1/Client/ListResourceBundles/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/configdelivery/apiv1/Client/ListRollouts/main.go
+++ b/internal/generated/snippets/configdelivery/apiv1/Client/ListRollouts/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/configdelivery/apiv1/Client/ListVariants/main.go
+++ b/internal/generated/snippets/configdelivery/apiv1/Client/ListVariants/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/configdelivery/apiv1/Client/ResumeRollout/main.go
+++ b/internal/generated/snippets/configdelivery/apiv1/Client/ResumeRollout/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/configdelivery/apiv1/Client/SuspendRollout/main.go
+++ b/internal/generated/snippets/configdelivery/apiv1/Client/SuspendRollout/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/configdelivery/apiv1/Client/UpdateFleetPackage/main.go
+++ b/internal/generated/snippets/configdelivery/apiv1/Client/UpdateFleetPackage/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/configdelivery/apiv1/Client/UpdateRelease/main.go
+++ b/internal/generated/snippets/configdelivery/apiv1/Client/UpdateRelease/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/configdelivery/apiv1/Client/UpdateResourceBundle/main.go
+++ b/internal/generated/snippets/configdelivery/apiv1/Client/UpdateResourceBundle/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/configdelivery/apiv1/Client/UpdateVariant/main.go
+++ b/internal/generated/snippets/configdelivery/apiv1/Client/UpdateVariant/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/configdelivery/apiv1beta/Client/AbortRollout/main.go
+++ b/internal/generated/snippets/configdelivery/apiv1beta/Client/AbortRollout/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/configdelivery/apiv1beta/Client/CancelOperation/main.go
+++ b/internal/generated/snippets/configdelivery/apiv1beta/Client/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/configdelivery/apiv1beta/Client/CreateFleetPackage/main.go
+++ b/internal/generated/snippets/configdelivery/apiv1beta/Client/CreateFleetPackage/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/configdelivery/apiv1beta/Client/CreateRelease/main.go
+++ b/internal/generated/snippets/configdelivery/apiv1beta/Client/CreateRelease/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/configdelivery/apiv1beta/Client/CreateResourceBundle/main.go
+++ b/internal/generated/snippets/configdelivery/apiv1beta/Client/CreateResourceBundle/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/configdelivery/apiv1beta/Client/CreateVariant/main.go
+++ b/internal/generated/snippets/configdelivery/apiv1beta/Client/CreateVariant/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/configdelivery/apiv1beta/Client/DeleteFleetPackage/main.go
+++ b/internal/generated/snippets/configdelivery/apiv1beta/Client/DeleteFleetPackage/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/configdelivery/apiv1beta/Client/DeleteOperation/main.go
+++ b/internal/generated/snippets/configdelivery/apiv1beta/Client/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/configdelivery/apiv1beta/Client/DeleteRelease/main.go
+++ b/internal/generated/snippets/configdelivery/apiv1beta/Client/DeleteRelease/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/configdelivery/apiv1beta/Client/DeleteResourceBundle/main.go
+++ b/internal/generated/snippets/configdelivery/apiv1beta/Client/DeleteResourceBundle/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/configdelivery/apiv1beta/Client/DeleteVariant/main.go
+++ b/internal/generated/snippets/configdelivery/apiv1beta/Client/DeleteVariant/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/configdelivery/apiv1beta/Client/GetFleetPackage/main.go
+++ b/internal/generated/snippets/configdelivery/apiv1beta/Client/GetFleetPackage/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/configdelivery/apiv1beta/Client/GetLocation/main.go
+++ b/internal/generated/snippets/configdelivery/apiv1beta/Client/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/configdelivery/apiv1beta/Client/GetOperation/main.go
+++ b/internal/generated/snippets/configdelivery/apiv1beta/Client/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/configdelivery/apiv1beta/Client/GetRelease/main.go
+++ b/internal/generated/snippets/configdelivery/apiv1beta/Client/GetRelease/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/configdelivery/apiv1beta/Client/GetResourceBundle/main.go
+++ b/internal/generated/snippets/configdelivery/apiv1beta/Client/GetResourceBundle/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/configdelivery/apiv1beta/Client/GetRollout/main.go
+++ b/internal/generated/snippets/configdelivery/apiv1beta/Client/GetRollout/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/configdelivery/apiv1beta/Client/GetVariant/main.go
+++ b/internal/generated/snippets/configdelivery/apiv1beta/Client/GetVariant/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/configdelivery/apiv1beta/Client/ListFleetPackages/main.go
+++ b/internal/generated/snippets/configdelivery/apiv1beta/Client/ListFleetPackages/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/configdelivery/apiv1beta/Client/ListLocations/main.go
+++ b/internal/generated/snippets/configdelivery/apiv1beta/Client/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/configdelivery/apiv1beta/Client/ListOperations/main.go
+++ b/internal/generated/snippets/configdelivery/apiv1beta/Client/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/configdelivery/apiv1beta/Client/ListReleases/main.go
+++ b/internal/generated/snippets/configdelivery/apiv1beta/Client/ListReleases/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/configdelivery/apiv1beta/Client/ListResourceBundles/main.go
+++ b/internal/generated/snippets/configdelivery/apiv1beta/Client/ListResourceBundles/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/configdelivery/apiv1beta/Client/ListRollouts/main.go
+++ b/internal/generated/snippets/configdelivery/apiv1beta/Client/ListRollouts/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/configdelivery/apiv1beta/Client/ListVariants/main.go
+++ b/internal/generated/snippets/configdelivery/apiv1beta/Client/ListVariants/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/configdelivery/apiv1beta/Client/ResumeRollout/main.go
+++ b/internal/generated/snippets/configdelivery/apiv1beta/Client/ResumeRollout/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/configdelivery/apiv1beta/Client/SuspendRollout/main.go
+++ b/internal/generated/snippets/configdelivery/apiv1beta/Client/SuspendRollout/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/configdelivery/apiv1beta/Client/UpdateFleetPackage/main.go
+++ b/internal/generated/snippets/configdelivery/apiv1beta/Client/UpdateFleetPackage/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/configdelivery/apiv1beta/Client/UpdateRelease/main.go
+++ b/internal/generated/snippets/configdelivery/apiv1beta/Client/UpdateRelease/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/configdelivery/apiv1beta/Client/UpdateResourceBundle/main.go
+++ b/internal/generated/snippets/configdelivery/apiv1beta/Client/UpdateResourceBundle/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/configdelivery/apiv1beta/Client/UpdateVariant/main.go
+++ b/internal/generated/snippets/configdelivery/apiv1beta/Client/UpdateVariant/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/contactcenterinsights/apiv1/Client/BulkAnalyzeConversations/main.go
+++ b/internal/generated/snippets/contactcenterinsights/apiv1/Client/BulkAnalyzeConversations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/contactcenterinsights/apiv1/Client/BulkDeleteConversations/main.go
+++ b/internal/generated/snippets/contactcenterinsights/apiv1/Client/BulkDeleteConversations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/contactcenterinsights/apiv1/Client/BulkDownloadFeedbackLabels/main.go
+++ b/internal/generated/snippets/contactcenterinsights/apiv1/Client/BulkDownloadFeedbackLabels/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/contactcenterinsights/apiv1/Client/BulkUploadFeedbackLabels/main.go
+++ b/internal/generated/snippets/contactcenterinsights/apiv1/Client/BulkUploadFeedbackLabels/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/contactcenterinsights/apiv1/Client/CalculateIssueModelStats/main.go
+++ b/internal/generated/snippets/contactcenterinsights/apiv1/Client/CalculateIssueModelStats/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/contactcenterinsights/apiv1/Client/CalculateStats/main.go
+++ b/internal/generated/snippets/contactcenterinsights/apiv1/Client/CalculateStats/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/contactcenterinsights/apiv1/Client/CancelOperation/main.go
+++ b/internal/generated/snippets/contactcenterinsights/apiv1/Client/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/contactcenterinsights/apiv1/Client/CreateAnalysis/main.go
+++ b/internal/generated/snippets/contactcenterinsights/apiv1/Client/CreateAnalysis/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/contactcenterinsights/apiv1/Client/CreateAnalysisRule/main.go
+++ b/internal/generated/snippets/contactcenterinsights/apiv1/Client/CreateAnalysisRule/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/contactcenterinsights/apiv1/Client/CreateConversation/main.go
+++ b/internal/generated/snippets/contactcenterinsights/apiv1/Client/CreateConversation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/contactcenterinsights/apiv1/Client/CreateFeedbackLabel/main.go
+++ b/internal/generated/snippets/contactcenterinsights/apiv1/Client/CreateFeedbackLabel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/contactcenterinsights/apiv1/Client/CreateIssueModel/main.go
+++ b/internal/generated/snippets/contactcenterinsights/apiv1/Client/CreateIssueModel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/contactcenterinsights/apiv1/Client/CreatePhraseMatcher/main.go
+++ b/internal/generated/snippets/contactcenterinsights/apiv1/Client/CreatePhraseMatcher/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/contactcenterinsights/apiv1/Client/CreateQaQuestion/main.go
+++ b/internal/generated/snippets/contactcenterinsights/apiv1/Client/CreateQaQuestion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/contactcenterinsights/apiv1/Client/CreateQaScorecard/main.go
+++ b/internal/generated/snippets/contactcenterinsights/apiv1/Client/CreateQaScorecard/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/contactcenterinsights/apiv1/Client/CreateQaScorecardRevision/main.go
+++ b/internal/generated/snippets/contactcenterinsights/apiv1/Client/CreateQaScorecardRevision/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/contactcenterinsights/apiv1/Client/CreateView/main.go
+++ b/internal/generated/snippets/contactcenterinsights/apiv1/Client/CreateView/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/contactcenterinsights/apiv1/Client/DeleteAnalysis/main.go
+++ b/internal/generated/snippets/contactcenterinsights/apiv1/Client/DeleteAnalysis/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/contactcenterinsights/apiv1/Client/DeleteAnalysisRule/main.go
+++ b/internal/generated/snippets/contactcenterinsights/apiv1/Client/DeleteAnalysisRule/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/contactcenterinsights/apiv1/Client/DeleteConversation/main.go
+++ b/internal/generated/snippets/contactcenterinsights/apiv1/Client/DeleteConversation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/contactcenterinsights/apiv1/Client/DeleteFeedbackLabel/main.go
+++ b/internal/generated/snippets/contactcenterinsights/apiv1/Client/DeleteFeedbackLabel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/contactcenterinsights/apiv1/Client/DeleteIssue/main.go
+++ b/internal/generated/snippets/contactcenterinsights/apiv1/Client/DeleteIssue/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/contactcenterinsights/apiv1/Client/DeleteIssueModel/main.go
+++ b/internal/generated/snippets/contactcenterinsights/apiv1/Client/DeleteIssueModel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/contactcenterinsights/apiv1/Client/DeletePhraseMatcher/main.go
+++ b/internal/generated/snippets/contactcenterinsights/apiv1/Client/DeletePhraseMatcher/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/contactcenterinsights/apiv1/Client/DeleteQaQuestion/main.go
+++ b/internal/generated/snippets/contactcenterinsights/apiv1/Client/DeleteQaQuestion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/contactcenterinsights/apiv1/Client/DeleteQaScorecard/main.go
+++ b/internal/generated/snippets/contactcenterinsights/apiv1/Client/DeleteQaScorecard/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/contactcenterinsights/apiv1/Client/DeleteQaScorecardRevision/main.go
+++ b/internal/generated/snippets/contactcenterinsights/apiv1/Client/DeleteQaScorecardRevision/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/contactcenterinsights/apiv1/Client/DeleteView/main.go
+++ b/internal/generated/snippets/contactcenterinsights/apiv1/Client/DeleteView/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/contactcenterinsights/apiv1/Client/DeployIssueModel/main.go
+++ b/internal/generated/snippets/contactcenterinsights/apiv1/Client/DeployIssueModel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/contactcenterinsights/apiv1/Client/DeployQaScorecardRevision/main.go
+++ b/internal/generated/snippets/contactcenterinsights/apiv1/Client/DeployQaScorecardRevision/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/contactcenterinsights/apiv1/Client/ExportInsightsData/main.go
+++ b/internal/generated/snippets/contactcenterinsights/apiv1/Client/ExportInsightsData/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/contactcenterinsights/apiv1/Client/ExportIssueModel/main.go
+++ b/internal/generated/snippets/contactcenterinsights/apiv1/Client/ExportIssueModel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/contactcenterinsights/apiv1/Client/GetAnalysis/main.go
+++ b/internal/generated/snippets/contactcenterinsights/apiv1/Client/GetAnalysis/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/contactcenterinsights/apiv1/Client/GetAnalysisRule/main.go
+++ b/internal/generated/snippets/contactcenterinsights/apiv1/Client/GetAnalysisRule/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/contactcenterinsights/apiv1/Client/GetConversation/main.go
+++ b/internal/generated/snippets/contactcenterinsights/apiv1/Client/GetConversation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/contactcenterinsights/apiv1/Client/GetEncryptionSpec/main.go
+++ b/internal/generated/snippets/contactcenterinsights/apiv1/Client/GetEncryptionSpec/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/contactcenterinsights/apiv1/Client/GetFeedbackLabel/main.go
+++ b/internal/generated/snippets/contactcenterinsights/apiv1/Client/GetFeedbackLabel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/contactcenterinsights/apiv1/Client/GetIssue/main.go
+++ b/internal/generated/snippets/contactcenterinsights/apiv1/Client/GetIssue/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/contactcenterinsights/apiv1/Client/GetIssueModel/main.go
+++ b/internal/generated/snippets/contactcenterinsights/apiv1/Client/GetIssueModel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/contactcenterinsights/apiv1/Client/GetOperation/main.go
+++ b/internal/generated/snippets/contactcenterinsights/apiv1/Client/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/contactcenterinsights/apiv1/Client/GetPhraseMatcher/main.go
+++ b/internal/generated/snippets/contactcenterinsights/apiv1/Client/GetPhraseMatcher/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/contactcenterinsights/apiv1/Client/GetQaQuestion/main.go
+++ b/internal/generated/snippets/contactcenterinsights/apiv1/Client/GetQaQuestion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/contactcenterinsights/apiv1/Client/GetQaScorecard/main.go
+++ b/internal/generated/snippets/contactcenterinsights/apiv1/Client/GetQaScorecard/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/contactcenterinsights/apiv1/Client/GetQaScorecardRevision/main.go
+++ b/internal/generated/snippets/contactcenterinsights/apiv1/Client/GetQaScorecardRevision/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/contactcenterinsights/apiv1/Client/GetSettings/main.go
+++ b/internal/generated/snippets/contactcenterinsights/apiv1/Client/GetSettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/contactcenterinsights/apiv1/Client/GetView/main.go
+++ b/internal/generated/snippets/contactcenterinsights/apiv1/Client/GetView/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/contactcenterinsights/apiv1/Client/ImportIssueModel/main.go
+++ b/internal/generated/snippets/contactcenterinsights/apiv1/Client/ImportIssueModel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/contactcenterinsights/apiv1/Client/IngestConversations/main.go
+++ b/internal/generated/snippets/contactcenterinsights/apiv1/Client/IngestConversations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/contactcenterinsights/apiv1/Client/InitializeEncryptionSpec/main.go
+++ b/internal/generated/snippets/contactcenterinsights/apiv1/Client/InitializeEncryptionSpec/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/contactcenterinsights/apiv1/Client/ListAllFeedbackLabels/main.go
+++ b/internal/generated/snippets/contactcenterinsights/apiv1/Client/ListAllFeedbackLabels/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/contactcenterinsights/apiv1/Client/ListAnalyses/main.go
+++ b/internal/generated/snippets/contactcenterinsights/apiv1/Client/ListAnalyses/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/contactcenterinsights/apiv1/Client/ListAnalysisRules/main.go
+++ b/internal/generated/snippets/contactcenterinsights/apiv1/Client/ListAnalysisRules/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/contactcenterinsights/apiv1/Client/ListConversations/main.go
+++ b/internal/generated/snippets/contactcenterinsights/apiv1/Client/ListConversations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/contactcenterinsights/apiv1/Client/ListFeedbackLabels/main.go
+++ b/internal/generated/snippets/contactcenterinsights/apiv1/Client/ListFeedbackLabels/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/contactcenterinsights/apiv1/Client/ListIssueModels/main.go
+++ b/internal/generated/snippets/contactcenterinsights/apiv1/Client/ListIssueModels/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/contactcenterinsights/apiv1/Client/ListIssues/main.go
+++ b/internal/generated/snippets/contactcenterinsights/apiv1/Client/ListIssues/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/contactcenterinsights/apiv1/Client/ListOperations/main.go
+++ b/internal/generated/snippets/contactcenterinsights/apiv1/Client/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/contactcenterinsights/apiv1/Client/ListPhraseMatchers/main.go
+++ b/internal/generated/snippets/contactcenterinsights/apiv1/Client/ListPhraseMatchers/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/contactcenterinsights/apiv1/Client/ListQaQuestions/main.go
+++ b/internal/generated/snippets/contactcenterinsights/apiv1/Client/ListQaQuestions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/contactcenterinsights/apiv1/Client/ListQaScorecardRevisions/main.go
+++ b/internal/generated/snippets/contactcenterinsights/apiv1/Client/ListQaScorecardRevisions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/contactcenterinsights/apiv1/Client/ListQaScorecards/main.go
+++ b/internal/generated/snippets/contactcenterinsights/apiv1/Client/ListQaScorecards/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/contactcenterinsights/apiv1/Client/ListViews/main.go
+++ b/internal/generated/snippets/contactcenterinsights/apiv1/Client/ListViews/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/contactcenterinsights/apiv1/Client/QueryMetrics/main.go
+++ b/internal/generated/snippets/contactcenterinsights/apiv1/Client/QueryMetrics/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/contactcenterinsights/apiv1/Client/TuneQaScorecardRevision/main.go
+++ b/internal/generated/snippets/contactcenterinsights/apiv1/Client/TuneQaScorecardRevision/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/contactcenterinsights/apiv1/Client/UndeployIssueModel/main.go
+++ b/internal/generated/snippets/contactcenterinsights/apiv1/Client/UndeployIssueModel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/contactcenterinsights/apiv1/Client/UndeployQaScorecardRevision/main.go
+++ b/internal/generated/snippets/contactcenterinsights/apiv1/Client/UndeployQaScorecardRevision/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/contactcenterinsights/apiv1/Client/UpdateAnalysisRule/main.go
+++ b/internal/generated/snippets/contactcenterinsights/apiv1/Client/UpdateAnalysisRule/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/contactcenterinsights/apiv1/Client/UpdateConversation/main.go
+++ b/internal/generated/snippets/contactcenterinsights/apiv1/Client/UpdateConversation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/contactcenterinsights/apiv1/Client/UpdateFeedbackLabel/main.go
+++ b/internal/generated/snippets/contactcenterinsights/apiv1/Client/UpdateFeedbackLabel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/contactcenterinsights/apiv1/Client/UpdateIssue/main.go
+++ b/internal/generated/snippets/contactcenterinsights/apiv1/Client/UpdateIssue/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/contactcenterinsights/apiv1/Client/UpdateIssueModel/main.go
+++ b/internal/generated/snippets/contactcenterinsights/apiv1/Client/UpdateIssueModel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/contactcenterinsights/apiv1/Client/UpdatePhraseMatcher/main.go
+++ b/internal/generated/snippets/contactcenterinsights/apiv1/Client/UpdatePhraseMatcher/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/contactcenterinsights/apiv1/Client/UpdateQaQuestion/main.go
+++ b/internal/generated/snippets/contactcenterinsights/apiv1/Client/UpdateQaQuestion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/contactcenterinsights/apiv1/Client/UpdateQaScorecard/main.go
+++ b/internal/generated/snippets/contactcenterinsights/apiv1/Client/UpdateQaScorecard/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/contactcenterinsights/apiv1/Client/UpdateSettings/main.go
+++ b/internal/generated/snippets/contactcenterinsights/apiv1/Client/UpdateSettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/contactcenterinsights/apiv1/Client/UpdateView/main.go
+++ b/internal/generated/snippets/contactcenterinsights/apiv1/Client/UpdateView/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/contactcenterinsights/apiv1/Client/UploadConversation/main.go
+++ b/internal/generated/snippets/contactcenterinsights/apiv1/Client/UploadConversation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/container/apiv1/ClusterManagerClient/CancelOperation/main.go
+++ b/internal/generated/snippets/container/apiv1/ClusterManagerClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/container/apiv1/ClusterManagerClient/CheckAutopilotCompatibility/main.go
+++ b/internal/generated/snippets/container/apiv1/ClusterManagerClient/CheckAutopilotCompatibility/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/container/apiv1/ClusterManagerClient/CompleteIPRotation/main.go
+++ b/internal/generated/snippets/container/apiv1/ClusterManagerClient/CompleteIPRotation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/container/apiv1/ClusterManagerClient/CompleteNodePoolUpgrade/main.go
+++ b/internal/generated/snippets/container/apiv1/ClusterManagerClient/CompleteNodePoolUpgrade/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/container/apiv1/ClusterManagerClient/CreateCluster/main.go
+++ b/internal/generated/snippets/container/apiv1/ClusterManagerClient/CreateCluster/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/container/apiv1/ClusterManagerClient/CreateNodePool/main.go
+++ b/internal/generated/snippets/container/apiv1/ClusterManagerClient/CreateNodePool/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/container/apiv1/ClusterManagerClient/DeleteCluster/main.go
+++ b/internal/generated/snippets/container/apiv1/ClusterManagerClient/DeleteCluster/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/container/apiv1/ClusterManagerClient/DeleteNodePool/main.go
+++ b/internal/generated/snippets/container/apiv1/ClusterManagerClient/DeleteNodePool/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/container/apiv1/ClusterManagerClient/FetchClusterUpgradeInfo/main.go
+++ b/internal/generated/snippets/container/apiv1/ClusterManagerClient/FetchClusterUpgradeInfo/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/container/apiv1/ClusterManagerClient/FetchNodePoolUpgradeInfo/main.go
+++ b/internal/generated/snippets/container/apiv1/ClusterManagerClient/FetchNodePoolUpgradeInfo/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/container/apiv1/ClusterManagerClient/GetCluster/main.go
+++ b/internal/generated/snippets/container/apiv1/ClusterManagerClient/GetCluster/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/container/apiv1/ClusterManagerClient/GetJSONWebKeys/main.go
+++ b/internal/generated/snippets/container/apiv1/ClusterManagerClient/GetJSONWebKeys/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/container/apiv1/ClusterManagerClient/GetNodePool/main.go
+++ b/internal/generated/snippets/container/apiv1/ClusterManagerClient/GetNodePool/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/container/apiv1/ClusterManagerClient/GetOperation/main.go
+++ b/internal/generated/snippets/container/apiv1/ClusterManagerClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/container/apiv1/ClusterManagerClient/GetServerConfig/main.go
+++ b/internal/generated/snippets/container/apiv1/ClusterManagerClient/GetServerConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/container/apiv1/ClusterManagerClient/ListClusters/main.go
+++ b/internal/generated/snippets/container/apiv1/ClusterManagerClient/ListClusters/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/container/apiv1/ClusterManagerClient/ListNodePools/main.go
+++ b/internal/generated/snippets/container/apiv1/ClusterManagerClient/ListNodePools/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/container/apiv1/ClusterManagerClient/ListOperations/main.go
+++ b/internal/generated/snippets/container/apiv1/ClusterManagerClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/container/apiv1/ClusterManagerClient/ListUsableSubnetworks/main.go
+++ b/internal/generated/snippets/container/apiv1/ClusterManagerClient/ListUsableSubnetworks/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/container/apiv1/ClusterManagerClient/RollbackNodePoolUpgrade/main.go
+++ b/internal/generated/snippets/container/apiv1/ClusterManagerClient/RollbackNodePoolUpgrade/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/container/apiv1/ClusterManagerClient/SetAddonsConfig/main.go
+++ b/internal/generated/snippets/container/apiv1/ClusterManagerClient/SetAddonsConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/container/apiv1/ClusterManagerClient/SetLabels/main.go
+++ b/internal/generated/snippets/container/apiv1/ClusterManagerClient/SetLabels/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/container/apiv1/ClusterManagerClient/SetLegacyAbac/main.go
+++ b/internal/generated/snippets/container/apiv1/ClusterManagerClient/SetLegacyAbac/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/container/apiv1/ClusterManagerClient/SetLocations/main.go
+++ b/internal/generated/snippets/container/apiv1/ClusterManagerClient/SetLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/container/apiv1/ClusterManagerClient/SetLoggingService/main.go
+++ b/internal/generated/snippets/container/apiv1/ClusterManagerClient/SetLoggingService/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/container/apiv1/ClusterManagerClient/SetMaintenancePolicy/main.go
+++ b/internal/generated/snippets/container/apiv1/ClusterManagerClient/SetMaintenancePolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/container/apiv1/ClusterManagerClient/SetMasterAuth/main.go
+++ b/internal/generated/snippets/container/apiv1/ClusterManagerClient/SetMasterAuth/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/container/apiv1/ClusterManagerClient/SetMonitoringService/main.go
+++ b/internal/generated/snippets/container/apiv1/ClusterManagerClient/SetMonitoringService/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/container/apiv1/ClusterManagerClient/SetNetworkPolicy/main.go
+++ b/internal/generated/snippets/container/apiv1/ClusterManagerClient/SetNetworkPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/container/apiv1/ClusterManagerClient/SetNodePoolAutoscaling/main.go
+++ b/internal/generated/snippets/container/apiv1/ClusterManagerClient/SetNodePoolAutoscaling/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/container/apiv1/ClusterManagerClient/SetNodePoolManagement/main.go
+++ b/internal/generated/snippets/container/apiv1/ClusterManagerClient/SetNodePoolManagement/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/container/apiv1/ClusterManagerClient/SetNodePoolSize/main.go
+++ b/internal/generated/snippets/container/apiv1/ClusterManagerClient/SetNodePoolSize/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/container/apiv1/ClusterManagerClient/StartIPRotation/main.go
+++ b/internal/generated/snippets/container/apiv1/ClusterManagerClient/StartIPRotation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/container/apiv1/ClusterManagerClient/UpdateCluster/main.go
+++ b/internal/generated/snippets/container/apiv1/ClusterManagerClient/UpdateCluster/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/container/apiv1/ClusterManagerClient/UpdateMaster/main.go
+++ b/internal/generated/snippets/container/apiv1/ClusterManagerClient/UpdateMaster/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/container/apiv1/ClusterManagerClient/UpdateNodePool/main.go
+++ b/internal/generated/snippets/container/apiv1/ClusterManagerClient/UpdateNodePool/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/containeranalysis/apiv1beta1/ContainerAnalysisV1Beta1Client/ExportSBOM/main.go
+++ b/internal/generated/snippets/containeranalysis/apiv1beta1/ContainerAnalysisV1Beta1Client/ExportSBOM/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/containeranalysis/apiv1beta1/ContainerAnalysisV1Beta1Client/GeneratePackagesSummary/main.go
+++ b/internal/generated/snippets/containeranalysis/apiv1beta1/ContainerAnalysisV1Beta1Client/GeneratePackagesSummary/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/containeranalysis/apiv1beta1/ContainerAnalysisV1Beta1Client/GetIamPolicy/main.go
+++ b/internal/generated/snippets/containeranalysis/apiv1beta1/ContainerAnalysisV1Beta1Client/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/containeranalysis/apiv1beta1/ContainerAnalysisV1Beta1Client/SetIamPolicy/main.go
+++ b/internal/generated/snippets/containeranalysis/apiv1beta1/ContainerAnalysisV1Beta1Client/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/containeranalysis/apiv1beta1/ContainerAnalysisV1Beta1Client/TestIamPermissions/main.go
+++ b/internal/generated/snippets/containeranalysis/apiv1beta1/ContainerAnalysisV1Beta1Client/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/containeranalysis/apiv1beta1/GrafeasV1Beta1Client/BatchCreateNotes/main.go
+++ b/internal/generated/snippets/containeranalysis/apiv1beta1/GrafeasV1Beta1Client/BatchCreateNotes/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/containeranalysis/apiv1beta1/GrafeasV1Beta1Client/BatchCreateOccurrences/main.go
+++ b/internal/generated/snippets/containeranalysis/apiv1beta1/GrafeasV1Beta1Client/BatchCreateOccurrences/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/containeranalysis/apiv1beta1/GrafeasV1Beta1Client/CreateNote/main.go
+++ b/internal/generated/snippets/containeranalysis/apiv1beta1/GrafeasV1Beta1Client/CreateNote/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/containeranalysis/apiv1beta1/GrafeasV1Beta1Client/CreateOccurrence/main.go
+++ b/internal/generated/snippets/containeranalysis/apiv1beta1/GrafeasV1Beta1Client/CreateOccurrence/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/containeranalysis/apiv1beta1/GrafeasV1Beta1Client/DeleteNote/main.go
+++ b/internal/generated/snippets/containeranalysis/apiv1beta1/GrafeasV1Beta1Client/DeleteNote/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/containeranalysis/apiv1beta1/GrafeasV1Beta1Client/DeleteOccurrence/main.go
+++ b/internal/generated/snippets/containeranalysis/apiv1beta1/GrafeasV1Beta1Client/DeleteOccurrence/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/containeranalysis/apiv1beta1/GrafeasV1Beta1Client/GetNote/main.go
+++ b/internal/generated/snippets/containeranalysis/apiv1beta1/GrafeasV1Beta1Client/GetNote/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/containeranalysis/apiv1beta1/GrafeasV1Beta1Client/GetOccurrence/main.go
+++ b/internal/generated/snippets/containeranalysis/apiv1beta1/GrafeasV1Beta1Client/GetOccurrence/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/containeranalysis/apiv1beta1/GrafeasV1Beta1Client/GetOccurrenceNote/main.go
+++ b/internal/generated/snippets/containeranalysis/apiv1beta1/GrafeasV1Beta1Client/GetOccurrenceNote/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/containeranalysis/apiv1beta1/GrafeasV1Beta1Client/GetVulnerabilityOccurrencesSummary/main.go
+++ b/internal/generated/snippets/containeranalysis/apiv1beta1/GrafeasV1Beta1Client/GetVulnerabilityOccurrencesSummary/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/containeranalysis/apiv1beta1/GrafeasV1Beta1Client/ListNoteOccurrences/main.go
+++ b/internal/generated/snippets/containeranalysis/apiv1beta1/GrafeasV1Beta1Client/ListNoteOccurrences/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/containeranalysis/apiv1beta1/GrafeasV1Beta1Client/ListNotes/main.go
+++ b/internal/generated/snippets/containeranalysis/apiv1beta1/GrafeasV1Beta1Client/ListNotes/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/containeranalysis/apiv1beta1/GrafeasV1Beta1Client/ListOccurrences/main.go
+++ b/internal/generated/snippets/containeranalysis/apiv1beta1/GrafeasV1Beta1Client/ListOccurrences/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/containeranalysis/apiv1beta1/GrafeasV1Beta1Client/UpdateNote/main.go
+++ b/internal/generated/snippets/containeranalysis/apiv1beta1/GrafeasV1Beta1Client/UpdateNote/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/containeranalysis/apiv1beta1/GrafeasV1Beta1Client/UpdateOccurrence/main.go
+++ b/internal/generated/snippets/containeranalysis/apiv1beta1/GrafeasV1Beta1Client/UpdateOccurrence/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1/Client/CancelOperation/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1/Client/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1/Client/CreateEntry/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1/Client/CreateEntry/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1/Client/CreateEntryGroup/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1/Client/CreateEntryGroup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1/Client/CreateTag/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1/Client/CreateTag/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1/Client/CreateTagTemplate/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1/Client/CreateTagTemplate/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1/Client/CreateTagTemplateField/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1/Client/CreateTagTemplateField/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1/Client/DeleteEntry/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1/Client/DeleteEntry/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1/Client/DeleteEntryGroup/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1/Client/DeleteEntryGroup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1/Client/DeleteOperation/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1/Client/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1/Client/DeleteTag/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1/Client/DeleteTag/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1/Client/DeleteTagTemplate/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1/Client/DeleteTagTemplate/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1/Client/DeleteTagTemplateField/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1/Client/DeleteTagTemplateField/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1/Client/GetEntry/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1/Client/GetEntry/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1/Client/GetEntryGroup/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1/Client/GetEntryGroup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1/Client/GetIamPolicy/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1/Client/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1/Client/GetOperation/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1/Client/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1/Client/GetTagTemplate/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1/Client/GetTagTemplate/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1/Client/ImportEntries/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1/Client/ImportEntries/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1/Client/ListEntries/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1/Client/ListEntries/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1/Client/ListEntryGroups/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1/Client/ListEntryGroups/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1/Client/ListOperations/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1/Client/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1/Client/ListTags/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1/Client/ListTags/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1/Client/LookupEntry/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1/Client/LookupEntry/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1/Client/ModifyEntryContacts/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1/Client/ModifyEntryContacts/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1/Client/ModifyEntryOverview/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1/Client/ModifyEntryOverview/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1/Client/ReconcileTags/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1/Client/ReconcileTags/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1/Client/RenameTagTemplateField/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1/Client/RenameTagTemplateField/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1/Client/RenameTagTemplateFieldEnumValue/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1/Client/RenameTagTemplateFieldEnumValue/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1/Client/RetrieveConfig/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1/Client/RetrieveConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1/Client/RetrieveEffectiveConfig/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1/Client/RetrieveEffectiveConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1/Client/SearchCatalog/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1/Client/SearchCatalog/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1/Client/SetConfig/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1/Client/SetConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1/Client/SetIamPolicy/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1/Client/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1/Client/StarEntry/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1/Client/StarEntry/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1/Client/TestIamPermissions/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1/Client/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1/Client/UnstarEntry/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1/Client/UnstarEntry/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1/Client/UpdateEntry/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1/Client/UpdateEntry/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1/Client/UpdateEntryGroup/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1/Client/UpdateEntryGroup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1/Client/UpdateTag/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1/Client/UpdateTag/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1/Client/UpdateTagTemplate/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1/Client/UpdateTagTemplate/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1/Client/UpdateTagTemplateField/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1/Client/UpdateTagTemplateField/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1/PolicyTagManagerClient/CancelOperation/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1/PolicyTagManagerClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1/PolicyTagManagerClient/CreatePolicyTag/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1/PolicyTagManagerClient/CreatePolicyTag/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1/PolicyTagManagerClient/CreateTaxonomy/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1/PolicyTagManagerClient/CreateTaxonomy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1/PolicyTagManagerClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1/PolicyTagManagerClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1/PolicyTagManagerClient/DeletePolicyTag/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1/PolicyTagManagerClient/DeletePolicyTag/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1/PolicyTagManagerClient/DeleteTaxonomy/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1/PolicyTagManagerClient/DeleteTaxonomy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1/PolicyTagManagerClient/GetIamPolicy/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1/PolicyTagManagerClient/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1/PolicyTagManagerClient/GetOperation/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1/PolicyTagManagerClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1/PolicyTagManagerClient/GetPolicyTag/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1/PolicyTagManagerClient/GetPolicyTag/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1/PolicyTagManagerClient/GetTaxonomy/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1/PolicyTagManagerClient/GetTaxonomy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1/PolicyTagManagerClient/ListOperations/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1/PolicyTagManagerClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1/PolicyTagManagerClient/ListPolicyTags/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1/PolicyTagManagerClient/ListPolicyTags/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1/PolicyTagManagerClient/ListTaxonomies/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1/PolicyTagManagerClient/ListTaxonomies/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1/PolicyTagManagerClient/SetIamPolicy/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1/PolicyTagManagerClient/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1/PolicyTagManagerClient/TestIamPermissions/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1/PolicyTagManagerClient/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1/PolicyTagManagerClient/UpdatePolicyTag/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1/PolicyTagManagerClient/UpdatePolicyTag/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1/PolicyTagManagerClient/UpdateTaxonomy/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1/PolicyTagManagerClient/UpdateTaxonomy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1/PolicyTagManagerSerializationClient/CancelOperation/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1/PolicyTagManagerSerializationClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1/PolicyTagManagerSerializationClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1/PolicyTagManagerSerializationClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1/PolicyTagManagerSerializationClient/ExportTaxonomies/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1/PolicyTagManagerSerializationClient/ExportTaxonomies/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1/PolicyTagManagerSerializationClient/GetOperation/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1/PolicyTagManagerSerializationClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1/PolicyTagManagerSerializationClient/ImportTaxonomies/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1/PolicyTagManagerSerializationClient/ImportTaxonomies/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1/PolicyTagManagerSerializationClient/ListOperations/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1/PolicyTagManagerSerializationClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1/PolicyTagManagerSerializationClient/ReplaceTaxonomy/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1/PolicyTagManagerSerializationClient/ReplaceTaxonomy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1beta1/Client/CreateEntry/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1beta1/Client/CreateEntry/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1beta1/Client/CreateEntryGroup/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1beta1/Client/CreateEntryGroup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1beta1/Client/CreateTag/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1beta1/Client/CreateTag/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1beta1/Client/CreateTagTemplate/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1beta1/Client/CreateTagTemplate/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1beta1/Client/CreateTagTemplateField/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1beta1/Client/CreateTagTemplateField/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1beta1/Client/DeleteEntry/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1beta1/Client/DeleteEntry/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1beta1/Client/DeleteEntryGroup/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1beta1/Client/DeleteEntryGroup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1beta1/Client/DeleteTag/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1beta1/Client/DeleteTag/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1beta1/Client/DeleteTagTemplate/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1beta1/Client/DeleteTagTemplate/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1beta1/Client/DeleteTagTemplateField/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1beta1/Client/DeleteTagTemplateField/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1beta1/Client/GetEntry/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1beta1/Client/GetEntry/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1beta1/Client/GetEntryGroup/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1beta1/Client/GetEntryGroup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1beta1/Client/GetIamPolicy/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1beta1/Client/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1beta1/Client/GetTagTemplate/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1beta1/Client/GetTagTemplate/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1beta1/Client/ListEntries/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1beta1/Client/ListEntries/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1beta1/Client/ListEntryGroups/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1beta1/Client/ListEntryGroups/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1beta1/Client/ListTags/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1beta1/Client/ListTags/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1beta1/Client/LookupEntry/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1beta1/Client/LookupEntry/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1beta1/Client/RenameTagTemplateField/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1beta1/Client/RenameTagTemplateField/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1beta1/Client/RenameTagTemplateFieldEnumValue/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1beta1/Client/RenameTagTemplateFieldEnumValue/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1beta1/Client/SearchCatalog/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1beta1/Client/SearchCatalog/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1beta1/Client/SetIamPolicy/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1beta1/Client/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1beta1/Client/TestIamPermissions/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1beta1/Client/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1beta1/Client/UpdateEntry/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1beta1/Client/UpdateEntry/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1beta1/Client/UpdateEntryGroup/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1beta1/Client/UpdateEntryGroup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1beta1/Client/UpdateTag/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1beta1/Client/UpdateTag/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1beta1/Client/UpdateTagTemplate/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1beta1/Client/UpdateTagTemplate/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1beta1/Client/UpdateTagTemplateField/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1beta1/Client/UpdateTagTemplateField/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1beta1/PolicyTagManagerClient/CreatePolicyTag/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1beta1/PolicyTagManagerClient/CreatePolicyTag/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1beta1/PolicyTagManagerClient/CreateTaxonomy/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1beta1/PolicyTagManagerClient/CreateTaxonomy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1beta1/PolicyTagManagerClient/DeletePolicyTag/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1beta1/PolicyTagManagerClient/DeletePolicyTag/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1beta1/PolicyTagManagerClient/DeleteTaxonomy/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1beta1/PolicyTagManagerClient/DeleteTaxonomy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1beta1/PolicyTagManagerClient/GetIamPolicy/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1beta1/PolicyTagManagerClient/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1beta1/PolicyTagManagerClient/GetPolicyTag/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1beta1/PolicyTagManagerClient/GetPolicyTag/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1beta1/PolicyTagManagerClient/GetTaxonomy/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1beta1/PolicyTagManagerClient/GetTaxonomy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1beta1/PolicyTagManagerClient/ListPolicyTags/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1beta1/PolicyTagManagerClient/ListPolicyTags/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1beta1/PolicyTagManagerClient/ListTaxonomies/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1beta1/PolicyTagManagerClient/ListTaxonomies/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1beta1/PolicyTagManagerClient/SetIamPolicy/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1beta1/PolicyTagManagerClient/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1beta1/PolicyTagManagerClient/TestIamPermissions/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1beta1/PolicyTagManagerClient/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1beta1/PolicyTagManagerClient/UpdatePolicyTag/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1beta1/PolicyTagManagerClient/UpdatePolicyTag/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1beta1/PolicyTagManagerClient/UpdateTaxonomy/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1beta1/PolicyTagManagerClient/UpdateTaxonomy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1beta1/PolicyTagManagerSerializationClient/ExportTaxonomies/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1beta1/PolicyTagManagerSerializationClient/ExportTaxonomies/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/apiv1beta1/PolicyTagManagerSerializationClient/ImportTaxonomies/main.go
+++ b/internal/generated/snippets/datacatalog/apiv1beta1/PolicyTagManagerSerializationClient/ImportTaxonomies/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/lineage/apiv1/Client/BatchSearchLinkProcesses/main.go
+++ b/internal/generated/snippets/datacatalog/lineage/apiv1/Client/BatchSearchLinkProcesses/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/lineage/apiv1/Client/CancelOperation/main.go
+++ b/internal/generated/snippets/datacatalog/lineage/apiv1/Client/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/lineage/apiv1/Client/CreateLineageEvent/main.go
+++ b/internal/generated/snippets/datacatalog/lineage/apiv1/Client/CreateLineageEvent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/lineage/apiv1/Client/CreateProcess/main.go
+++ b/internal/generated/snippets/datacatalog/lineage/apiv1/Client/CreateProcess/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/lineage/apiv1/Client/CreateRun/main.go
+++ b/internal/generated/snippets/datacatalog/lineage/apiv1/Client/CreateRun/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/lineage/apiv1/Client/DeleteLineageEvent/main.go
+++ b/internal/generated/snippets/datacatalog/lineage/apiv1/Client/DeleteLineageEvent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/lineage/apiv1/Client/DeleteOperation/main.go
+++ b/internal/generated/snippets/datacatalog/lineage/apiv1/Client/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/lineage/apiv1/Client/DeleteProcess/main.go
+++ b/internal/generated/snippets/datacatalog/lineage/apiv1/Client/DeleteProcess/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/lineage/apiv1/Client/DeleteRun/main.go
+++ b/internal/generated/snippets/datacatalog/lineage/apiv1/Client/DeleteRun/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/lineage/apiv1/Client/GetLineageEvent/main.go
+++ b/internal/generated/snippets/datacatalog/lineage/apiv1/Client/GetLineageEvent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/lineage/apiv1/Client/GetOperation/main.go
+++ b/internal/generated/snippets/datacatalog/lineage/apiv1/Client/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/lineage/apiv1/Client/GetProcess/main.go
+++ b/internal/generated/snippets/datacatalog/lineage/apiv1/Client/GetProcess/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/lineage/apiv1/Client/GetRun/main.go
+++ b/internal/generated/snippets/datacatalog/lineage/apiv1/Client/GetRun/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/lineage/apiv1/Client/ListLineageEvents/main.go
+++ b/internal/generated/snippets/datacatalog/lineage/apiv1/Client/ListLineageEvents/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/lineage/apiv1/Client/ListOperations/main.go
+++ b/internal/generated/snippets/datacatalog/lineage/apiv1/Client/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/lineage/apiv1/Client/ListProcesses/main.go
+++ b/internal/generated/snippets/datacatalog/lineage/apiv1/Client/ListProcesses/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/lineage/apiv1/Client/ListRuns/main.go
+++ b/internal/generated/snippets/datacatalog/lineage/apiv1/Client/ListRuns/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/lineage/apiv1/Client/ProcessOpenLineageRunEvent/main.go
+++ b/internal/generated/snippets/datacatalog/lineage/apiv1/Client/ProcessOpenLineageRunEvent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/lineage/apiv1/Client/SearchLinks/main.go
+++ b/internal/generated/snippets/datacatalog/lineage/apiv1/Client/SearchLinks/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/lineage/apiv1/Client/UpdateProcess/main.go
+++ b/internal/generated/snippets/datacatalog/lineage/apiv1/Client/UpdateProcess/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datacatalog/lineage/apiv1/Client/UpdateRun/main.go
+++ b/internal/generated/snippets/datacatalog/lineage/apiv1/Client/UpdateRun/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataflow/apiv1beta3/FlexTemplatesClient/LaunchFlexTemplate/main.go
+++ b/internal/generated/snippets/dataflow/apiv1beta3/FlexTemplatesClient/LaunchFlexTemplate/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataflow/apiv1beta3/JobsV1Beta3Client/AggregatedListJobs/main.go
+++ b/internal/generated/snippets/dataflow/apiv1beta3/JobsV1Beta3Client/AggregatedListJobs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataflow/apiv1beta3/JobsV1Beta3Client/CheckActiveJobs/main.go
+++ b/internal/generated/snippets/dataflow/apiv1beta3/JobsV1Beta3Client/CheckActiveJobs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataflow/apiv1beta3/JobsV1Beta3Client/CreateJob/main.go
+++ b/internal/generated/snippets/dataflow/apiv1beta3/JobsV1Beta3Client/CreateJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataflow/apiv1beta3/JobsV1Beta3Client/GetJob/main.go
+++ b/internal/generated/snippets/dataflow/apiv1beta3/JobsV1Beta3Client/GetJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataflow/apiv1beta3/JobsV1Beta3Client/ListJobs/main.go
+++ b/internal/generated/snippets/dataflow/apiv1beta3/JobsV1Beta3Client/ListJobs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataflow/apiv1beta3/JobsV1Beta3Client/SnapshotJob/main.go
+++ b/internal/generated/snippets/dataflow/apiv1beta3/JobsV1Beta3Client/SnapshotJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataflow/apiv1beta3/JobsV1Beta3Client/UpdateJob/main.go
+++ b/internal/generated/snippets/dataflow/apiv1beta3/JobsV1Beta3Client/UpdateJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataflow/apiv1beta3/MessagesV1Beta3Client/ListJobMessages/main.go
+++ b/internal/generated/snippets/dataflow/apiv1beta3/MessagesV1Beta3Client/ListJobMessages/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataflow/apiv1beta3/MetricsV1Beta3Client/GetJobExecutionDetails/main.go
+++ b/internal/generated/snippets/dataflow/apiv1beta3/MetricsV1Beta3Client/GetJobExecutionDetails/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataflow/apiv1beta3/MetricsV1Beta3Client/GetJobMetrics/main.go
+++ b/internal/generated/snippets/dataflow/apiv1beta3/MetricsV1Beta3Client/GetJobMetrics/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataflow/apiv1beta3/MetricsV1Beta3Client/GetStageExecutionDetails/main.go
+++ b/internal/generated/snippets/dataflow/apiv1beta3/MetricsV1Beta3Client/GetStageExecutionDetails/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataflow/apiv1beta3/SnapshotsV1Beta3Client/DeleteSnapshot/main.go
+++ b/internal/generated/snippets/dataflow/apiv1beta3/SnapshotsV1Beta3Client/DeleteSnapshot/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataflow/apiv1beta3/SnapshotsV1Beta3Client/GetSnapshot/main.go
+++ b/internal/generated/snippets/dataflow/apiv1beta3/SnapshotsV1Beta3Client/GetSnapshot/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataflow/apiv1beta3/SnapshotsV1Beta3Client/ListSnapshots/main.go
+++ b/internal/generated/snippets/dataflow/apiv1beta3/SnapshotsV1Beta3Client/ListSnapshots/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataflow/apiv1beta3/TemplatesClient/CreateJobFromTemplate/main.go
+++ b/internal/generated/snippets/dataflow/apiv1beta3/TemplatesClient/CreateJobFromTemplate/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataflow/apiv1beta3/TemplatesClient/GetTemplate/main.go
+++ b/internal/generated/snippets/dataflow/apiv1beta3/TemplatesClient/GetTemplate/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataflow/apiv1beta3/TemplatesClient/LaunchTemplate/main.go
+++ b/internal/generated/snippets/dataflow/apiv1beta3/TemplatesClient/LaunchTemplate/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1/Client/CancelWorkflowInvocation/main.go
+++ b/internal/generated/snippets/dataform/apiv1/Client/CancelWorkflowInvocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1/Client/CommitRepositoryChanges/main.go
+++ b/internal/generated/snippets/dataform/apiv1/Client/CommitRepositoryChanges/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1/Client/CommitWorkspaceChanges/main.go
+++ b/internal/generated/snippets/dataform/apiv1/Client/CommitWorkspaceChanges/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1/Client/ComputeRepositoryAccessTokenStatus/main.go
+++ b/internal/generated/snippets/dataform/apiv1/Client/ComputeRepositoryAccessTokenStatus/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1/Client/CreateCompilationResult/main.go
+++ b/internal/generated/snippets/dataform/apiv1/Client/CreateCompilationResult/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1/Client/CreateReleaseConfig/main.go
+++ b/internal/generated/snippets/dataform/apiv1/Client/CreateReleaseConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1/Client/CreateRepository/main.go
+++ b/internal/generated/snippets/dataform/apiv1/Client/CreateRepository/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1/Client/CreateWorkflowConfig/main.go
+++ b/internal/generated/snippets/dataform/apiv1/Client/CreateWorkflowConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1/Client/CreateWorkflowInvocation/main.go
+++ b/internal/generated/snippets/dataform/apiv1/Client/CreateWorkflowInvocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1/Client/CreateWorkspace/main.go
+++ b/internal/generated/snippets/dataform/apiv1/Client/CreateWorkspace/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1/Client/DeleteReleaseConfig/main.go
+++ b/internal/generated/snippets/dataform/apiv1/Client/DeleteReleaseConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1/Client/DeleteRepository/main.go
+++ b/internal/generated/snippets/dataform/apiv1/Client/DeleteRepository/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1/Client/DeleteWorkflowConfig/main.go
+++ b/internal/generated/snippets/dataform/apiv1/Client/DeleteWorkflowConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1/Client/DeleteWorkflowInvocation/main.go
+++ b/internal/generated/snippets/dataform/apiv1/Client/DeleteWorkflowInvocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1/Client/DeleteWorkspace/main.go
+++ b/internal/generated/snippets/dataform/apiv1/Client/DeleteWorkspace/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1/Client/FetchFileDiff/main.go
+++ b/internal/generated/snippets/dataform/apiv1/Client/FetchFileDiff/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1/Client/FetchFileGitStatuses/main.go
+++ b/internal/generated/snippets/dataform/apiv1/Client/FetchFileGitStatuses/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1/Client/FetchGitAheadBehind/main.go
+++ b/internal/generated/snippets/dataform/apiv1/Client/FetchGitAheadBehind/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1/Client/FetchRemoteBranches/main.go
+++ b/internal/generated/snippets/dataform/apiv1/Client/FetchRemoteBranches/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1/Client/FetchRepositoryHistory/main.go
+++ b/internal/generated/snippets/dataform/apiv1/Client/FetchRepositoryHistory/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1/Client/GetCompilationResult/main.go
+++ b/internal/generated/snippets/dataform/apiv1/Client/GetCompilationResult/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1/Client/GetConfig/main.go
+++ b/internal/generated/snippets/dataform/apiv1/Client/GetConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1/Client/GetIamPolicy/main.go
+++ b/internal/generated/snippets/dataform/apiv1/Client/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1/Client/GetLocation/main.go
+++ b/internal/generated/snippets/dataform/apiv1/Client/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1/Client/GetReleaseConfig/main.go
+++ b/internal/generated/snippets/dataform/apiv1/Client/GetReleaseConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1/Client/GetRepository/main.go
+++ b/internal/generated/snippets/dataform/apiv1/Client/GetRepository/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1/Client/GetWorkflowConfig/main.go
+++ b/internal/generated/snippets/dataform/apiv1/Client/GetWorkflowConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1/Client/GetWorkflowInvocation/main.go
+++ b/internal/generated/snippets/dataform/apiv1/Client/GetWorkflowInvocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1/Client/GetWorkspace/main.go
+++ b/internal/generated/snippets/dataform/apiv1/Client/GetWorkspace/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1/Client/InstallNpmPackages/main.go
+++ b/internal/generated/snippets/dataform/apiv1/Client/InstallNpmPackages/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1/Client/ListCompilationResults/main.go
+++ b/internal/generated/snippets/dataform/apiv1/Client/ListCompilationResults/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1/Client/ListLocations/main.go
+++ b/internal/generated/snippets/dataform/apiv1/Client/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1/Client/ListReleaseConfigs/main.go
+++ b/internal/generated/snippets/dataform/apiv1/Client/ListReleaseConfigs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1/Client/ListRepositories/main.go
+++ b/internal/generated/snippets/dataform/apiv1/Client/ListRepositories/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1/Client/ListWorkflowConfigs/main.go
+++ b/internal/generated/snippets/dataform/apiv1/Client/ListWorkflowConfigs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1/Client/ListWorkflowInvocations/main.go
+++ b/internal/generated/snippets/dataform/apiv1/Client/ListWorkflowInvocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1/Client/ListWorkspaces/main.go
+++ b/internal/generated/snippets/dataform/apiv1/Client/ListWorkspaces/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1/Client/MakeDirectory/main.go
+++ b/internal/generated/snippets/dataform/apiv1/Client/MakeDirectory/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1/Client/MoveDirectory/main.go
+++ b/internal/generated/snippets/dataform/apiv1/Client/MoveDirectory/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1/Client/MoveFile/main.go
+++ b/internal/generated/snippets/dataform/apiv1/Client/MoveFile/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1/Client/PullGitCommits/main.go
+++ b/internal/generated/snippets/dataform/apiv1/Client/PullGitCommits/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1/Client/PushGitCommits/main.go
+++ b/internal/generated/snippets/dataform/apiv1/Client/PushGitCommits/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1/Client/QueryCompilationResultActions/main.go
+++ b/internal/generated/snippets/dataform/apiv1/Client/QueryCompilationResultActions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1/Client/QueryDirectoryContents/main.go
+++ b/internal/generated/snippets/dataform/apiv1/Client/QueryDirectoryContents/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1/Client/QueryRepositoryDirectoryContents/main.go
+++ b/internal/generated/snippets/dataform/apiv1/Client/QueryRepositoryDirectoryContents/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1/Client/QueryWorkflowInvocationActions/main.go
+++ b/internal/generated/snippets/dataform/apiv1/Client/QueryWorkflowInvocationActions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1/Client/ReadFile/main.go
+++ b/internal/generated/snippets/dataform/apiv1/Client/ReadFile/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1/Client/ReadRepositoryFile/main.go
+++ b/internal/generated/snippets/dataform/apiv1/Client/ReadRepositoryFile/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1/Client/RemoveDirectory/main.go
+++ b/internal/generated/snippets/dataform/apiv1/Client/RemoveDirectory/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1/Client/RemoveFile/main.go
+++ b/internal/generated/snippets/dataform/apiv1/Client/RemoveFile/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1/Client/ResetWorkspaceChanges/main.go
+++ b/internal/generated/snippets/dataform/apiv1/Client/ResetWorkspaceChanges/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1/Client/SearchFiles/main.go
+++ b/internal/generated/snippets/dataform/apiv1/Client/SearchFiles/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1/Client/SetIamPolicy/main.go
+++ b/internal/generated/snippets/dataform/apiv1/Client/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1/Client/TestIamPermissions/main.go
+++ b/internal/generated/snippets/dataform/apiv1/Client/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1/Client/UpdateConfig/main.go
+++ b/internal/generated/snippets/dataform/apiv1/Client/UpdateConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1/Client/UpdateReleaseConfig/main.go
+++ b/internal/generated/snippets/dataform/apiv1/Client/UpdateReleaseConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1/Client/UpdateRepository/main.go
+++ b/internal/generated/snippets/dataform/apiv1/Client/UpdateRepository/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1/Client/UpdateWorkflowConfig/main.go
+++ b/internal/generated/snippets/dataform/apiv1/Client/UpdateWorkflowConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1/Client/WriteFile/main.go
+++ b/internal/generated/snippets/dataform/apiv1/Client/WriteFile/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1beta1/Client/CancelWorkflowInvocation/main.go
+++ b/internal/generated/snippets/dataform/apiv1beta1/Client/CancelWorkflowInvocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1beta1/Client/CommitRepositoryChanges/main.go
+++ b/internal/generated/snippets/dataform/apiv1beta1/Client/CommitRepositoryChanges/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1beta1/Client/CommitWorkspaceChanges/main.go
+++ b/internal/generated/snippets/dataform/apiv1beta1/Client/CommitWorkspaceChanges/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1beta1/Client/ComputeRepositoryAccessTokenStatus/main.go
+++ b/internal/generated/snippets/dataform/apiv1beta1/Client/ComputeRepositoryAccessTokenStatus/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1beta1/Client/CreateCompilationResult/main.go
+++ b/internal/generated/snippets/dataform/apiv1beta1/Client/CreateCompilationResult/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1beta1/Client/CreateReleaseConfig/main.go
+++ b/internal/generated/snippets/dataform/apiv1beta1/Client/CreateReleaseConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1beta1/Client/CreateRepository/main.go
+++ b/internal/generated/snippets/dataform/apiv1beta1/Client/CreateRepository/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1beta1/Client/CreateWorkflowConfig/main.go
+++ b/internal/generated/snippets/dataform/apiv1beta1/Client/CreateWorkflowConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1beta1/Client/CreateWorkflowInvocation/main.go
+++ b/internal/generated/snippets/dataform/apiv1beta1/Client/CreateWorkflowInvocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1beta1/Client/CreateWorkspace/main.go
+++ b/internal/generated/snippets/dataform/apiv1beta1/Client/CreateWorkspace/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1beta1/Client/DeleteReleaseConfig/main.go
+++ b/internal/generated/snippets/dataform/apiv1beta1/Client/DeleteReleaseConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1beta1/Client/DeleteRepository/main.go
+++ b/internal/generated/snippets/dataform/apiv1beta1/Client/DeleteRepository/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1beta1/Client/DeleteWorkflowConfig/main.go
+++ b/internal/generated/snippets/dataform/apiv1beta1/Client/DeleteWorkflowConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1beta1/Client/DeleteWorkflowInvocation/main.go
+++ b/internal/generated/snippets/dataform/apiv1beta1/Client/DeleteWorkflowInvocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1beta1/Client/DeleteWorkspace/main.go
+++ b/internal/generated/snippets/dataform/apiv1beta1/Client/DeleteWorkspace/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1beta1/Client/FetchFileDiff/main.go
+++ b/internal/generated/snippets/dataform/apiv1beta1/Client/FetchFileDiff/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1beta1/Client/FetchFileGitStatuses/main.go
+++ b/internal/generated/snippets/dataform/apiv1beta1/Client/FetchFileGitStatuses/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1beta1/Client/FetchGitAheadBehind/main.go
+++ b/internal/generated/snippets/dataform/apiv1beta1/Client/FetchGitAheadBehind/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1beta1/Client/FetchRemoteBranches/main.go
+++ b/internal/generated/snippets/dataform/apiv1beta1/Client/FetchRemoteBranches/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1beta1/Client/FetchRepositoryHistory/main.go
+++ b/internal/generated/snippets/dataform/apiv1beta1/Client/FetchRepositoryHistory/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1beta1/Client/GetCompilationResult/main.go
+++ b/internal/generated/snippets/dataform/apiv1beta1/Client/GetCompilationResult/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1beta1/Client/GetConfig/main.go
+++ b/internal/generated/snippets/dataform/apiv1beta1/Client/GetConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1beta1/Client/GetIamPolicy/main.go
+++ b/internal/generated/snippets/dataform/apiv1beta1/Client/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1beta1/Client/GetLocation/main.go
+++ b/internal/generated/snippets/dataform/apiv1beta1/Client/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1beta1/Client/GetReleaseConfig/main.go
+++ b/internal/generated/snippets/dataform/apiv1beta1/Client/GetReleaseConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1beta1/Client/GetRepository/main.go
+++ b/internal/generated/snippets/dataform/apiv1beta1/Client/GetRepository/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1beta1/Client/GetWorkflowConfig/main.go
+++ b/internal/generated/snippets/dataform/apiv1beta1/Client/GetWorkflowConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1beta1/Client/GetWorkflowInvocation/main.go
+++ b/internal/generated/snippets/dataform/apiv1beta1/Client/GetWorkflowInvocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1beta1/Client/GetWorkspace/main.go
+++ b/internal/generated/snippets/dataform/apiv1beta1/Client/GetWorkspace/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1beta1/Client/InstallNpmPackages/main.go
+++ b/internal/generated/snippets/dataform/apiv1beta1/Client/InstallNpmPackages/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1beta1/Client/ListCompilationResults/main.go
+++ b/internal/generated/snippets/dataform/apiv1beta1/Client/ListCompilationResults/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1beta1/Client/ListLocations/main.go
+++ b/internal/generated/snippets/dataform/apiv1beta1/Client/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1beta1/Client/ListReleaseConfigs/main.go
+++ b/internal/generated/snippets/dataform/apiv1beta1/Client/ListReleaseConfigs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1beta1/Client/ListRepositories/main.go
+++ b/internal/generated/snippets/dataform/apiv1beta1/Client/ListRepositories/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1beta1/Client/ListWorkflowConfigs/main.go
+++ b/internal/generated/snippets/dataform/apiv1beta1/Client/ListWorkflowConfigs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1beta1/Client/ListWorkflowInvocations/main.go
+++ b/internal/generated/snippets/dataform/apiv1beta1/Client/ListWorkflowInvocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1beta1/Client/ListWorkspaces/main.go
+++ b/internal/generated/snippets/dataform/apiv1beta1/Client/ListWorkspaces/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1beta1/Client/MakeDirectory/main.go
+++ b/internal/generated/snippets/dataform/apiv1beta1/Client/MakeDirectory/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1beta1/Client/MoveDirectory/main.go
+++ b/internal/generated/snippets/dataform/apiv1beta1/Client/MoveDirectory/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1beta1/Client/MoveFile/main.go
+++ b/internal/generated/snippets/dataform/apiv1beta1/Client/MoveFile/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1beta1/Client/PullGitCommits/main.go
+++ b/internal/generated/snippets/dataform/apiv1beta1/Client/PullGitCommits/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1beta1/Client/PushGitCommits/main.go
+++ b/internal/generated/snippets/dataform/apiv1beta1/Client/PushGitCommits/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1beta1/Client/QueryCompilationResultActions/main.go
+++ b/internal/generated/snippets/dataform/apiv1beta1/Client/QueryCompilationResultActions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1beta1/Client/QueryDirectoryContents/main.go
+++ b/internal/generated/snippets/dataform/apiv1beta1/Client/QueryDirectoryContents/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1beta1/Client/QueryRepositoryDirectoryContents/main.go
+++ b/internal/generated/snippets/dataform/apiv1beta1/Client/QueryRepositoryDirectoryContents/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1beta1/Client/QueryWorkflowInvocationActions/main.go
+++ b/internal/generated/snippets/dataform/apiv1beta1/Client/QueryWorkflowInvocationActions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1beta1/Client/ReadFile/main.go
+++ b/internal/generated/snippets/dataform/apiv1beta1/Client/ReadFile/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1beta1/Client/ReadRepositoryFile/main.go
+++ b/internal/generated/snippets/dataform/apiv1beta1/Client/ReadRepositoryFile/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1beta1/Client/RemoveDirectory/main.go
+++ b/internal/generated/snippets/dataform/apiv1beta1/Client/RemoveDirectory/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1beta1/Client/RemoveFile/main.go
+++ b/internal/generated/snippets/dataform/apiv1beta1/Client/RemoveFile/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1beta1/Client/ResetWorkspaceChanges/main.go
+++ b/internal/generated/snippets/dataform/apiv1beta1/Client/ResetWorkspaceChanges/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1beta1/Client/SearchFiles/main.go
+++ b/internal/generated/snippets/dataform/apiv1beta1/Client/SearchFiles/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1beta1/Client/SetIamPolicy/main.go
+++ b/internal/generated/snippets/dataform/apiv1beta1/Client/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1beta1/Client/TestIamPermissions/main.go
+++ b/internal/generated/snippets/dataform/apiv1beta1/Client/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1beta1/Client/UpdateConfig/main.go
+++ b/internal/generated/snippets/dataform/apiv1beta1/Client/UpdateConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1beta1/Client/UpdateReleaseConfig/main.go
+++ b/internal/generated/snippets/dataform/apiv1beta1/Client/UpdateReleaseConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1beta1/Client/UpdateRepository/main.go
+++ b/internal/generated/snippets/dataform/apiv1beta1/Client/UpdateRepository/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1beta1/Client/UpdateWorkflowConfig/main.go
+++ b/internal/generated/snippets/dataform/apiv1beta1/Client/UpdateWorkflowConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataform/apiv1beta1/Client/WriteFile/main.go
+++ b/internal/generated/snippets/dataform/apiv1beta1/Client/WriteFile/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datafusion/apiv1/Client/CreateInstance/main.go
+++ b/internal/generated/snippets/datafusion/apiv1/Client/CreateInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datafusion/apiv1/Client/DeleteInstance/main.go
+++ b/internal/generated/snippets/datafusion/apiv1/Client/DeleteInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datafusion/apiv1/Client/GetInstance/main.go
+++ b/internal/generated/snippets/datafusion/apiv1/Client/GetInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datafusion/apiv1/Client/ListAvailableVersions/main.go
+++ b/internal/generated/snippets/datafusion/apiv1/Client/ListAvailableVersions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datafusion/apiv1/Client/ListInstances/main.go
+++ b/internal/generated/snippets/datafusion/apiv1/Client/ListInstances/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datafusion/apiv1/Client/RestartInstance/main.go
+++ b/internal/generated/snippets/datafusion/apiv1/Client/RestartInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datafusion/apiv1/Client/UpdateInstance/main.go
+++ b/internal/generated/snippets/datafusion/apiv1/Client/UpdateInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datalabeling/apiv1beta1/Client/CreateAnnotationSpecSet/main.go
+++ b/internal/generated/snippets/datalabeling/apiv1beta1/Client/CreateAnnotationSpecSet/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datalabeling/apiv1beta1/Client/CreateDataset/main.go
+++ b/internal/generated/snippets/datalabeling/apiv1beta1/Client/CreateDataset/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datalabeling/apiv1beta1/Client/CreateEvaluationJob/main.go
+++ b/internal/generated/snippets/datalabeling/apiv1beta1/Client/CreateEvaluationJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datalabeling/apiv1beta1/Client/CreateInstruction/main.go
+++ b/internal/generated/snippets/datalabeling/apiv1beta1/Client/CreateInstruction/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datalabeling/apiv1beta1/Client/DeleteAnnotatedDataset/main.go
+++ b/internal/generated/snippets/datalabeling/apiv1beta1/Client/DeleteAnnotatedDataset/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datalabeling/apiv1beta1/Client/DeleteAnnotationSpecSet/main.go
+++ b/internal/generated/snippets/datalabeling/apiv1beta1/Client/DeleteAnnotationSpecSet/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datalabeling/apiv1beta1/Client/DeleteDataset/main.go
+++ b/internal/generated/snippets/datalabeling/apiv1beta1/Client/DeleteDataset/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datalabeling/apiv1beta1/Client/DeleteEvaluationJob/main.go
+++ b/internal/generated/snippets/datalabeling/apiv1beta1/Client/DeleteEvaluationJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datalabeling/apiv1beta1/Client/DeleteInstruction/main.go
+++ b/internal/generated/snippets/datalabeling/apiv1beta1/Client/DeleteInstruction/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datalabeling/apiv1beta1/Client/ExportData/main.go
+++ b/internal/generated/snippets/datalabeling/apiv1beta1/Client/ExportData/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datalabeling/apiv1beta1/Client/GetAnnotatedDataset/main.go
+++ b/internal/generated/snippets/datalabeling/apiv1beta1/Client/GetAnnotatedDataset/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datalabeling/apiv1beta1/Client/GetAnnotationSpecSet/main.go
+++ b/internal/generated/snippets/datalabeling/apiv1beta1/Client/GetAnnotationSpecSet/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datalabeling/apiv1beta1/Client/GetDataItem/main.go
+++ b/internal/generated/snippets/datalabeling/apiv1beta1/Client/GetDataItem/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datalabeling/apiv1beta1/Client/GetDataset/main.go
+++ b/internal/generated/snippets/datalabeling/apiv1beta1/Client/GetDataset/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datalabeling/apiv1beta1/Client/GetEvaluation/main.go
+++ b/internal/generated/snippets/datalabeling/apiv1beta1/Client/GetEvaluation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datalabeling/apiv1beta1/Client/GetEvaluationJob/main.go
+++ b/internal/generated/snippets/datalabeling/apiv1beta1/Client/GetEvaluationJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datalabeling/apiv1beta1/Client/GetExample/main.go
+++ b/internal/generated/snippets/datalabeling/apiv1beta1/Client/GetExample/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datalabeling/apiv1beta1/Client/GetInstruction/main.go
+++ b/internal/generated/snippets/datalabeling/apiv1beta1/Client/GetInstruction/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datalabeling/apiv1beta1/Client/ImportData/main.go
+++ b/internal/generated/snippets/datalabeling/apiv1beta1/Client/ImportData/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datalabeling/apiv1beta1/Client/LabelImage/main.go
+++ b/internal/generated/snippets/datalabeling/apiv1beta1/Client/LabelImage/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datalabeling/apiv1beta1/Client/LabelText/main.go
+++ b/internal/generated/snippets/datalabeling/apiv1beta1/Client/LabelText/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datalabeling/apiv1beta1/Client/LabelVideo/main.go
+++ b/internal/generated/snippets/datalabeling/apiv1beta1/Client/LabelVideo/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datalabeling/apiv1beta1/Client/ListAnnotatedDatasets/main.go
+++ b/internal/generated/snippets/datalabeling/apiv1beta1/Client/ListAnnotatedDatasets/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datalabeling/apiv1beta1/Client/ListAnnotationSpecSets/main.go
+++ b/internal/generated/snippets/datalabeling/apiv1beta1/Client/ListAnnotationSpecSets/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datalabeling/apiv1beta1/Client/ListDataItems/main.go
+++ b/internal/generated/snippets/datalabeling/apiv1beta1/Client/ListDataItems/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datalabeling/apiv1beta1/Client/ListDatasets/main.go
+++ b/internal/generated/snippets/datalabeling/apiv1beta1/Client/ListDatasets/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datalabeling/apiv1beta1/Client/ListEvaluationJobs/main.go
+++ b/internal/generated/snippets/datalabeling/apiv1beta1/Client/ListEvaluationJobs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datalabeling/apiv1beta1/Client/ListExamples/main.go
+++ b/internal/generated/snippets/datalabeling/apiv1beta1/Client/ListExamples/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datalabeling/apiv1beta1/Client/ListInstructions/main.go
+++ b/internal/generated/snippets/datalabeling/apiv1beta1/Client/ListInstructions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datalabeling/apiv1beta1/Client/PauseEvaluationJob/main.go
+++ b/internal/generated/snippets/datalabeling/apiv1beta1/Client/PauseEvaluationJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datalabeling/apiv1beta1/Client/ResumeEvaluationJob/main.go
+++ b/internal/generated/snippets/datalabeling/apiv1beta1/Client/ResumeEvaluationJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datalabeling/apiv1beta1/Client/SearchEvaluations/main.go
+++ b/internal/generated/snippets/datalabeling/apiv1beta1/Client/SearchEvaluations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datalabeling/apiv1beta1/Client/SearchExampleComparisons/main.go
+++ b/internal/generated/snippets/datalabeling/apiv1beta1/Client/SearchExampleComparisons/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datalabeling/apiv1beta1/Client/UpdateEvaluationJob/main.go
+++ b/internal/generated/snippets/datalabeling/apiv1beta1/Client/UpdateEvaluationJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/BusinessGlossaryClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/BusinessGlossaryClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/BusinessGlossaryClient/CreateGlossary/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/BusinessGlossaryClient/CreateGlossary/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/BusinessGlossaryClient/CreateGlossaryCategory/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/BusinessGlossaryClient/CreateGlossaryCategory/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/BusinessGlossaryClient/CreateGlossaryTerm/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/BusinessGlossaryClient/CreateGlossaryTerm/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/BusinessGlossaryClient/DeleteGlossary/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/BusinessGlossaryClient/DeleteGlossary/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/BusinessGlossaryClient/DeleteGlossaryCategory/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/BusinessGlossaryClient/DeleteGlossaryCategory/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/BusinessGlossaryClient/DeleteGlossaryTerm/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/BusinessGlossaryClient/DeleteGlossaryTerm/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/BusinessGlossaryClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/BusinessGlossaryClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/BusinessGlossaryClient/GetGlossary/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/BusinessGlossaryClient/GetGlossary/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/BusinessGlossaryClient/GetGlossaryCategory/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/BusinessGlossaryClient/GetGlossaryCategory/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/BusinessGlossaryClient/GetGlossaryTerm/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/BusinessGlossaryClient/GetGlossaryTerm/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/BusinessGlossaryClient/GetLocation/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/BusinessGlossaryClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/BusinessGlossaryClient/GetOperation/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/BusinessGlossaryClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/BusinessGlossaryClient/ListGlossaries/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/BusinessGlossaryClient/ListGlossaries/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/BusinessGlossaryClient/ListGlossaryCategories/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/BusinessGlossaryClient/ListGlossaryCategories/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/BusinessGlossaryClient/ListGlossaryTerms/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/BusinessGlossaryClient/ListGlossaryTerms/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/BusinessGlossaryClient/ListLocations/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/BusinessGlossaryClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/BusinessGlossaryClient/ListOperations/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/BusinessGlossaryClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/BusinessGlossaryClient/UpdateGlossary/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/BusinessGlossaryClient/UpdateGlossary/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/BusinessGlossaryClient/UpdateGlossaryCategory/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/BusinessGlossaryClient/UpdateGlossaryCategory/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/BusinessGlossaryClient/UpdateGlossaryTerm/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/BusinessGlossaryClient/UpdateGlossaryTerm/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/CatalogClient/CancelMetadataJob/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/CatalogClient/CancelMetadataJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/CatalogClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/CatalogClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/CatalogClient/CreateAspectType/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/CatalogClient/CreateAspectType/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/CatalogClient/CreateEntry/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/CatalogClient/CreateEntry/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/CatalogClient/CreateEntryGroup/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/CatalogClient/CreateEntryGroup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/CatalogClient/CreateEntryLink/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/CatalogClient/CreateEntryLink/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/CatalogClient/CreateEntryType/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/CatalogClient/CreateEntryType/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/CatalogClient/CreateMetadataJob/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/CatalogClient/CreateMetadataJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/CatalogClient/DeleteAspectType/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/CatalogClient/DeleteAspectType/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/CatalogClient/DeleteEntry/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/CatalogClient/DeleteEntry/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/CatalogClient/DeleteEntryGroup/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/CatalogClient/DeleteEntryGroup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/CatalogClient/DeleteEntryLink/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/CatalogClient/DeleteEntryLink/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/CatalogClient/DeleteEntryType/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/CatalogClient/DeleteEntryType/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/CatalogClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/CatalogClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/CatalogClient/GetAspectType/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/CatalogClient/GetAspectType/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/CatalogClient/GetEntry/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/CatalogClient/GetEntry/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/CatalogClient/GetEntryGroup/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/CatalogClient/GetEntryGroup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/CatalogClient/GetEntryLink/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/CatalogClient/GetEntryLink/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/CatalogClient/GetEntryType/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/CatalogClient/GetEntryType/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/CatalogClient/GetLocation/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/CatalogClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/CatalogClient/GetMetadataJob/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/CatalogClient/GetMetadataJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/CatalogClient/GetOperation/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/CatalogClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/CatalogClient/ListAspectTypes/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/CatalogClient/ListAspectTypes/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/CatalogClient/ListEntries/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/CatalogClient/ListEntries/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/CatalogClient/ListEntryGroups/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/CatalogClient/ListEntryGroups/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/CatalogClient/ListEntryTypes/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/CatalogClient/ListEntryTypes/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/CatalogClient/ListLocations/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/CatalogClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/CatalogClient/ListMetadataJobs/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/CatalogClient/ListMetadataJobs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/CatalogClient/ListOperations/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/CatalogClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/CatalogClient/LookupEntry/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/CatalogClient/LookupEntry/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/CatalogClient/SearchEntries/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/CatalogClient/SearchEntries/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/CatalogClient/UpdateAspectType/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/CatalogClient/UpdateAspectType/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/CatalogClient/UpdateEntry/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/CatalogClient/UpdateEntry/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/CatalogClient/UpdateEntryGroup/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/CatalogClient/UpdateEntryGroup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/CatalogClient/UpdateEntryType/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/CatalogClient/UpdateEntryType/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/Client/CancelJob/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/Client/CancelJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/Client/CancelOperation/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/Client/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/Client/CreateAsset/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/Client/CreateAsset/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/Client/CreateEnvironment/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/Client/CreateEnvironment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/Client/CreateLake/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/Client/CreateLake/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/Client/CreateTask/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/Client/CreateTask/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/Client/CreateZone/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/Client/CreateZone/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/Client/DeleteAsset/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/Client/DeleteAsset/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/Client/DeleteEnvironment/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/Client/DeleteEnvironment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/Client/DeleteLake/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/Client/DeleteLake/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/Client/DeleteOperation/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/Client/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/Client/DeleteTask/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/Client/DeleteTask/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/Client/DeleteZone/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/Client/DeleteZone/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/Client/GetAsset/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/Client/GetAsset/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/Client/GetEnvironment/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/Client/GetEnvironment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/Client/GetJob/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/Client/GetJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/Client/GetLake/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/Client/GetLake/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/Client/GetLocation/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/Client/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/Client/GetOperation/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/Client/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/Client/GetTask/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/Client/GetTask/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/Client/GetZone/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/Client/GetZone/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/Client/ListAssetActions/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/Client/ListAssetActions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/Client/ListAssets/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/Client/ListAssets/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/Client/ListEnvironments/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/Client/ListEnvironments/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/Client/ListJobs/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/Client/ListJobs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/Client/ListLakeActions/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/Client/ListLakeActions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/Client/ListLakes/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/Client/ListLakes/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/Client/ListLocations/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/Client/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/Client/ListOperations/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/Client/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/Client/ListSessions/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/Client/ListSessions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/Client/ListTasks/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/Client/ListTasks/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/Client/ListZoneActions/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/Client/ListZoneActions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/Client/ListZones/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/Client/ListZones/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/Client/RunTask/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/Client/RunTask/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/Client/UpdateAsset/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/Client/UpdateAsset/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/Client/UpdateEnvironment/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/Client/UpdateEnvironment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/Client/UpdateLake/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/Client/UpdateLake/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/Client/UpdateTask/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/Client/UpdateTask/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/Client/UpdateZone/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/Client/UpdateZone/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/CmekClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/CmekClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/CmekClient/CreateEncryptionConfig/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/CmekClient/CreateEncryptionConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/CmekClient/DeleteEncryptionConfig/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/CmekClient/DeleteEncryptionConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/CmekClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/CmekClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/CmekClient/GetEncryptionConfig/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/CmekClient/GetEncryptionConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/CmekClient/GetLocation/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/CmekClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/CmekClient/GetOperation/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/CmekClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/CmekClient/ListEncryptionConfigs/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/CmekClient/ListEncryptionConfigs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/CmekClient/ListLocations/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/CmekClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/CmekClient/ListOperations/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/CmekClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/CmekClient/UpdateEncryptionConfig/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/CmekClient/UpdateEncryptionConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/ContentClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/ContentClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/ContentClient/CreateContent/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/ContentClient/CreateContent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/ContentClient/DeleteContent/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/ContentClient/DeleteContent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/ContentClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/ContentClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/ContentClient/GetContent/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/ContentClient/GetContent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/ContentClient/GetIamPolicy/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/ContentClient/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/ContentClient/GetLocation/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/ContentClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/ContentClient/GetOperation/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/ContentClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/ContentClient/ListContent/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/ContentClient/ListContent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/ContentClient/ListLocations/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/ContentClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/ContentClient/ListOperations/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/ContentClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/ContentClient/SetIamPolicy/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/ContentClient/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/ContentClient/TestIamPermissions/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/ContentClient/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/ContentClient/UpdateContent/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/ContentClient/UpdateContent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/DataScanClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/DataScanClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/DataScanClient/CreateDataScan/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/DataScanClient/CreateDataScan/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/DataScanClient/DeleteDataScan/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/DataScanClient/DeleteDataScan/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/DataScanClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/DataScanClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/DataScanClient/GenerateDataQualityRules/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/DataScanClient/GenerateDataQualityRules/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/DataScanClient/GetDataScan/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/DataScanClient/GetDataScan/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/DataScanClient/GetDataScanJob/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/DataScanClient/GetDataScanJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/DataScanClient/GetLocation/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/DataScanClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/DataScanClient/GetOperation/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/DataScanClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/DataScanClient/ListDataScanJobs/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/DataScanClient/ListDataScanJobs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/DataScanClient/ListDataScans/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/DataScanClient/ListDataScans/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/DataScanClient/ListLocations/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/DataScanClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/DataScanClient/ListOperations/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/DataScanClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/DataScanClient/RunDataScan/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/DataScanClient/RunDataScan/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/DataScanClient/UpdateDataScan/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/DataScanClient/UpdateDataScan/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/DataTaxonomyClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/DataTaxonomyClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/DataTaxonomyClient/CreateDataAttribute/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/DataTaxonomyClient/CreateDataAttribute/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/DataTaxonomyClient/CreateDataAttributeBinding/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/DataTaxonomyClient/CreateDataAttributeBinding/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/DataTaxonomyClient/CreateDataTaxonomy/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/DataTaxonomyClient/CreateDataTaxonomy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/DataTaxonomyClient/DeleteDataAttribute/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/DataTaxonomyClient/DeleteDataAttribute/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/DataTaxonomyClient/DeleteDataAttributeBinding/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/DataTaxonomyClient/DeleteDataAttributeBinding/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/DataTaxonomyClient/DeleteDataTaxonomy/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/DataTaxonomyClient/DeleteDataTaxonomy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/DataTaxonomyClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/DataTaxonomyClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/DataTaxonomyClient/GetDataAttribute/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/DataTaxonomyClient/GetDataAttribute/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/DataTaxonomyClient/GetDataAttributeBinding/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/DataTaxonomyClient/GetDataAttributeBinding/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/DataTaxonomyClient/GetDataTaxonomy/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/DataTaxonomyClient/GetDataTaxonomy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/DataTaxonomyClient/GetLocation/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/DataTaxonomyClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/DataTaxonomyClient/GetOperation/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/DataTaxonomyClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/DataTaxonomyClient/ListDataAttributeBindings/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/DataTaxonomyClient/ListDataAttributeBindings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/DataTaxonomyClient/ListDataAttributes/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/DataTaxonomyClient/ListDataAttributes/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/DataTaxonomyClient/ListDataTaxonomies/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/DataTaxonomyClient/ListDataTaxonomies/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/DataTaxonomyClient/ListLocations/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/DataTaxonomyClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/DataTaxonomyClient/ListOperations/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/DataTaxonomyClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/DataTaxonomyClient/UpdateDataAttribute/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/DataTaxonomyClient/UpdateDataAttribute/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/DataTaxonomyClient/UpdateDataAttributeBinding/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/DataTaxonomyClient/UpdateDataAttributeBinding/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/DataTaxonomyClient/UpdateDataTaxonomy/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/DataTaxonomyClient/UpdateDataTaxonomy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/MetadataClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/MetadataClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/MetadataClient/CreateEntity/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/MetadataClient/CreateEntity/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/MetadataClient/CreatePartition/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/MetadataClient/CreatePartition/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/MetadataClient/DeleteEntity/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/MetadataClient/DeleteEntity/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/MetadataClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/MetadataClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/MetadataClient/DeletePartition/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/MetadataClient/DeletePartition/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/MetadataClient/GetEntity/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/MetadataClient/GetEntity/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/MetadataClient/GetLocation/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/MetadataClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/MetadataClient/GetOperation/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/MetadataClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/MetadataClient/GetPartition/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/MetadataClient/GetPartition/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/MetadataClient/ListEntities/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/MetadataClient/ListEntities/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/MetadataClient/ListLocations/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/MetadataClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/MetadataClient/ListOperations/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/MetadataClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/MetadataClient/ListPartitions/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/MetadataClient/ListPartitions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataplex/apiv1/MetadataClient/UpdateEntity/main.go
+++ b/internal/generated/snippets/dataplex/apiv1/MetadataClient/UpdateEntity/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/AutoscalingPolicyClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/AutoscalingPolicyClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/AutoscalingPolicyClient/CreateAutoscalingPolicy/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/AutoscalingPolicyClient/CreateAutoscalingPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/AutoscalingPolicyClient/DeleteAutoscalingPolicy/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/AutoscalingPolicyClient/DeleteAutoscalingPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/AutoscalingPolicyClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/AutoscalingPolicyClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/AutoscalingPolicyClient/GetAutoscalingPolicy/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/AutoscalingPolicyClient/GetAutoscalingPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/AutoscalingPolicyClient/GetIamPolicy/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/AutoscalingPolicyClient/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/AutoscalingPolicyClient/GetOperation/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/AutoscalingPolicyClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/AutoscalingPolicyClient/ListAutoscalingPolicies/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/AutoscalingPolicyClient/ListAutoscalingPolicies/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/AutoscalingPolicyClient/ListOperations/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/AutoscalingPolicyClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/AutoscalingPolicyClient/SetIamPolicy/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/AutoscalingPolicyClient/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/AutoscalingPolicyClient/TestIamPermissions/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/AutoscalingPolicyClient/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/AutoscalingPolicyClient/UpdateAutoscalingPolicy/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/AutoscalingPolicyClient/UpdateAutoscalingPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/BatchControllerClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/BatchControllerClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/BatchControllerClient/CreateBatch/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/BatchControllerClient/CreateBatch/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/BatchControllerClient/DeleteBatch/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/BatchControllerClient/DeleteBatch/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/BatchControllerClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/BatchControllerClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/BatchControllerClient/GetBatch/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/BatchControllerClient/GetBatch/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/BatchControllerClient/GetIamPolicy/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/BatchControllerClient/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/BatchControllerClient/GetOperation/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/BatchControllerClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/BatchControllerClient/ListBatches/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/BatchControllerClient/ListBatches/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/BatchControllerClient/ListOperations/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/BatchControllerClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/BatchControllerClient/SetIamPolicy/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/BatchControllerClient/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/BatchControllerClient/TestIamPermissions/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/BatchControllerClient/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/ClusterControllerClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/ClusterControllerClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/ClusterControllerClient/CreateCluster/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/ClusterControllerClient/CreateCluster/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/ClusterControllerClient/DeleteCluster/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/ClusterControllerClient/DeleteCluster/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/ClusterControllerClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/ClusterControllerClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/ClusterControllerClient/DiagnoseCluster/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/ClusterControllerClient/DiagnoseCluster/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/ClusterControllerClient/GetCluster/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/ClusterControllerClient/GetCluster/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/ClusterControllerClient/GetIamPolicy/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/ClusterControllerClient/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/ClusterControllerClient/GetOperation/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/ClusterControllerClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/ClusterControllerClient/ListClusters/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/ClusterControllerClient/ListClusters/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/ClusterControllerClient/ListOperations/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/ClusterControllerClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/ClusterControllerClient/SetIamPolicy/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/ClusterControllerClient/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/ClusterControllerClient/StartCluster/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/ClusterControllerClient/StartCluster/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/ClusterControllerClient/StopCluster/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/ClusterControllerClient/StopCluster/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/ClusterControllerClient/TestIamPermissions/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/ClusterControllerClient/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/ClusterControllerClient/UpdateCluster/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/ClusterControllerClient/UpdateCluster/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/JobControllerClient/CancelJob/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/JobControllerClient/CancelJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/JobControllerClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/JobControllerClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/JobControllerClient/DeleteJob/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/JobControllerClient/DeleteJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/JobControllerClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/JobControllerClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/JobControllerClient/GetIamPolicy/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/JobControllerClient/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/JobControllerClient/GetJob/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/JobControllerClient/GetJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/JobControllerClient/GetOperation/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/JobControllerClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/JobControllerClient/ListJobs/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/JobControllerClient/ListJobs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/JobControllerClient/ListOperations/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/JobControllerClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/JobControllerClient/SetIamPolicy/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/JobControllerClient/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/JobControllerClient/SubmitJob/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/JobControllerClient/SubmitJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/JobControllerClient/SubmitJobAsOperation/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/JobControllerClient/SubmitJobAsOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/JobControllerClient/TestIamPermissions/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/JobControllerClient/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/JobControllerClient/UpdateJob/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/JobControllerClient/UpdateJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/NodeGroupControllerClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/NodeGroupControllerClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/NodeGroupControllerClient/CreateNodeGroup/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/NodeGroupControllerClient/CreateNodeGroup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/NodeGroupControllerClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/NodeGroupControllerClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/NodeGroupControllerClient/GetIamPolicy/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/NodeGroupControllerClient/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/NodeGroupControllerClient/GetNodeGroup/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/NodeGroupControllerClient/GetNodeGroup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/NodeGroupControllerClient/GetOperation/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/NodeGroupControllerClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/NodeGroupControllerClient/ListOperations/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/NodeGroupControllerClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/NodeGroupControllerClient/ResizeNodeGroup/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/NodeGroupControllerClient/ResizeNodeGroup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/NodeGroupControllerClient/SetIamPolicy/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/NodeGroupControllerClient/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/NodeGroupControllerClient/TestIamPermissions/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/NodeGroupControllerClient/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/SessionControllerClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/SessionControllerClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/SessionControllerClient/CreateSession/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/SessionControllerClient/CreateSession/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/SessionControllerClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/SessionControllerClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/SessionControllerClient/DeleteSession/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/SessionControllerClient/DeleteSession/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/SessionControllerClient/GetIamPolicy/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/SessionControllerClient/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/SessionControllerClient/GetOperation/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/SessionControllerClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/SessionControllerClient/GetSession/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/SessionControllerClient/GetSession/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/SessionControllerClient/ListOperations/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/SessionControllerClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/SessionControllerClient/ListSessions/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/SessionControllerClient/ListSessions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/SessionControllerClient/SetIamPolicy/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/SessionControllerClient/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/SessionControllerClient/TerminateSession/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/SessionControllerClient/TerminateSession/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/SessionControllerClient/TestIamPermissions/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/SessionControllerClient/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/SessionTemplateControllerClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/SessionTemplateControllerClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/SessionTemplateControllerClient/CreateSessionTemplate/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/SessionTemplateControllerClient/CreateSessionTemplate/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/SessionTemplateControllerClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/SessionTemplateControllerClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/SessionTemplateControllerClient/DeleteSessionTemplate/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/SessionTemplateControllerClient/DeleteSessionTemplate/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/SessionTemplateControllerClient/GetIamPolicy/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/SessionTemplateControllerClient/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/SessionTemplateControllerClient/GetOperation/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/SessionTemplateControllerClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/SessionTemplateControllerClient/GetSessionTemplate/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/SessionTemplateControllerClient/GetSessionTemplate/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/SessionTemplateControllerClient/ListOperations/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/SessionTemplateControllerClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/SessionTemplateControllerClient/ListSessionTemplates/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/SessionTemplateControllerClient/ListSessionTemplates/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/SessionTemplateControllerClient/SetIamPolicy/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/SessionTemplateControllerClient/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/SessionTemplateControllerClient/TestIamPermissions/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/SessionTemplateControllerClient/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/SessionTemplateControllerClient/UpdateSessionTemplate/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/SessionTemplateControllerClient/UpdateSessionTemplate/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/WorkflowTemplateClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/WorkflowTemplateClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/WorkflowTemplateClient/CreateWorkflowTemplate/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/WorkflowTemplateClient/CreateWorkflowTemplate/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/WorkflowTemplateClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/WorkflowTemplateClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/WorkflowTemplateClient/DeleteWorkflowTemplate/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/WorkflowTemplateClient/DeleteWorkflowTemplate/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/WorkflowTemplateClient/GetIamPolicy/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/WorkflowTemplateClient/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/WorkflowTemplateClient/GetOperation/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/WorkflowTemplateClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/WorkflowTemplateClient/GetWorkflowTemplate/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/WorkflowTemplateClient/GetWorkflowTemplate/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/WorkflowTemplateClient/InstantiateInlineWorkflowTemplate/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/WorkflowTemplateClient/InstantiateInlineWorkflowTemplate/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/WorkflowTemplateClient/InstantiateWorkflowTemplate/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/WorkflowTemplateClient/InstantiateWorkflowTemplate/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/WorkflowTemplateClient/ListOperations/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/WorkflowTemplateClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/WorkflowTemplateClient/ListWorkflowTemplates/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/WorkflowTemplateClient/ListWorkflowTemplates/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/WorkflowTemplateClient/SetIamPolicy/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/WorkflowTemplateClient/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/WorkflowTemplateClient/TestIamPermissions/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/WorkflowTemplateClient/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataproc/apiv1/WorkflowTemplateClient/UpdateWorkflowTemplate/main.go
+++ b/internal/generated/snippets/dataproc/apiv1/WorkflowTemplateClient/UpdateWorkflowTemplate/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataqna/apiv1alpha/AutoSuggestionClient/SuggestQueries/main.go
+++ b/internal/generated/snippets/dataqna/apiv1alpha/AutoSuggestionClient/SuggestQueries/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataqna/apiv1alpha/QuestionClient/CreateQuestion/main.go
+++ b/internal/generated/snippets/dataqna/apiv1alpha/QuestionClient/CreateQuestion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataqna/apiv1alpha/QuestionClient/ExecuteQuestion/main.go
+++ b/internal/generated/snippets/dataqna/apiv1alpha/QuestionClient/ExecuteQuestion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataqna/apiv1alpha/QuestionClient/GetQuestion/main.go
+++ b/internal/generated/snippets/dataqna/apiv1alpha/QuestionClient/GetQuestion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataqna/apiv1alpha/QuestionClient/GetUserFeedback/main.go
+++ b/internal/generated/snippets/dataqna/apiv1alpha/QuestionClient/GetUserFeedback/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dataqna/apiv1alpha/QuestionClient/UpdateUserFeedback/main.go
+++ b/internal/generated/snippets/dataqna/apiv1alpha/QuestionClient/UpdateUserFeedback/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datastore/admin/apiv1/DatastoreAdminClient/CancelOperation/main.go
+++ b/internal/generated/snippets/datastore/admin/apiv1/DatastoreAdminClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datastore/admin/apiv1/DatastoreAdminClient/CreateIndex/main.go
+++ b/internal/generated/snippets/datastore/admin/apiv1/DatastoreAdminClient/CreateIndex/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datastore/admin/apiv1/DatastoreAdminClient/DeleteIndex/main.go
+++ b/internal/generated/snippets/datastore/admin/apiv1/DatastoreAdminClient/DeleteIndex/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datastore/admin/apiv1/DatastoreAdminClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/datastore/admin/apiv1/DatastoreAdminClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datastore/admin/apiv1/DatastoreAdminClient/ExportEntities/main.go
+++ b/internal/generated/snippets/datastore/admin/apiv1/DatastoreAdminClient/ExportEntities/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datastore/admin/apiv1/DatastoreAdminClient/GetIndex/main.go
+++ b/internal/generated/snippets/datastore/admin/apiv1/DatastoreAdminClient/GetIndex/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datastore/admin/apiv1/DatastoreAdminClient/GetOperation/main.go
+++ b/internal/generated/snippets/datastore/admin/apiv1/DatastoreAdminClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datastore/admin/apiv1/DatastoreAdminClient/ImportEntities/main.go
+++ b/internal/generated/snippets/datastore/admin/apiv1/DatastoreAdminClient/ImportEntities/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datastore/admin/apiv1/DatastoreAdminClient/ListIndexes/main.go
+++ b/internal/generated/snippets/datastore/admin/apiv1/DatastoreAdminClient/ListIndexes/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datastore/admin/apiv1/DatastoreAdminClient/ListOperations/main.go
+++ b/internal/generated/snippets/datastore/admin/apiv1/DatastoreAdminClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datastream/apiv1/Client/CancelOperation/main.go
+++ b/internal/generated/snippets/datastream/apiv1/Client/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datastream/apiv1/Client/CreateConnectionProfile/main.go
+++ b/internal/generated/snippets/datastream/apiv1/Client/CreateConnectionProfile/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datastream/apiv1/Client/CreatePrivateConnection/main.go
+++ b/internal/generated/snippets/datastream/apiv1/Client/CreatePrivateConnection/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datastream/apiv1/Client/CreateRoute/main.go
+++ b/internal/generated/snippets/datastream/apiv1/Client/CreateRoute/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datastream/apiv1/Client/CreateStream/main.go
+++ b/internal/generated/snippets/datastream/apiv1/Client/CreateStream/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datastream/apiv1/Client/DeleteConnectionProfile/main.go
+++ b/internal/generated/snippets/datastream/apiv1/Client/DeleteConnectionProfile/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datastream/apiv1/Client/DeleteOperation/main.go
+++ b/internal/generated/snippets/datastream/apiv1/Client/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datastream/apiv1/Client/DeletePrivateConnection/main.go
+++ b/internal/generated/snippets/datastream/apiv1/Client/DeletePrivateConnection/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datastream/apiv1/Client/DeleteRoute/main.go
+++ b/internal/generated/snippets/datastream/apiv1/Client/DeleteRoute/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datastream/apiv1/Client/DeleteStream/main.go
+++ b/internal/generated/snippets/datastream/apiv1/Client/DeleteStream/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datastream/apiv1/Client/DiscoverConnectionProfile/main.go
+++ b/internal/generated/snippets/datastream/apiv1/Client/DiscoverConnectionProfile/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datastream/apiv1/Client/FetchStaticIps/main.go
+++ b/internal/generated/snippets/datastream/apiv1/Client/FetchStaticIps/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datastream/apiv1/Client/GetConnectionProfile/main.go
+++ b/internal/generated/snippets/datastream/apiv1/Client/GetConnectionProfile/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datastream/apiv1/Client/GetLocation/main.go
+++ b/internal/generated/snippets/datastream/apiv1/Client/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datastream/apiv1/Client/GetOperation/main.go
+++ b/internal/generated/snippets/datastream/apiv1/Client/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datastream/apiv1/Client/GetPrivateConnection/main.go
+++ b/internal/generated/snippets/datastream/apiv1/Client/GetPrivateConnection/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datastream/apiv1/Client/GetRoute/main.go
+++ b/internal/generated/snippets/datastream/apiv1/Client/GetRoute/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datastream/apiv1/Client/GetStream/main.go
+++ b/internal/generated/snippets/datastream/apiv1/Client/GetStream/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datastream/apiv1/Client/GetStreamObject/main.go
+++ b/internal/generated/snippets/datastream/apiv1/Client/GetStreamObject/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datastream/apiv1/Client/ListConnectionProfiles/main.go
+++ b/internal/generated/snippets/datastream/apiv1/Client/ListConnectionProfiles/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datastream/apiv1/Client/ListLocations/main.go
+++ b/internal/generated/snippets/datastream/apiv1/Client/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datastream/apiv1/Client/ListOperations/main.go
+++ b/internal/generated/snippets/datastream/apiv1/Client/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datastream/apiv1/Client/ListPrivateConnections/main.go
+++ b/internal/generated/snippets/datastream/apiv1/Client/ListPrivateConnections/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datastream/apiv1/Client/ListRoutes/main.go
+++ b/internal/generated/snippets/datastream/apiv1/Client/ListRoutes/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datastream/apiv1/Client/ListStreamObjects/main.go
+++ b/internal/generated/snippets/datastream/apiv1/Client/ListStreamObjects/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datastream/apiv1/Client/ListStreams/main.go
+++ b/internal/generated/snippets/datastream/apiv1/Client/ListStreams/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datastream/apiv1/Client/LookupStreamObject/main.go
+++ b/internal/generated/snippets/datastream/apiv1/Client/LookupStreamObject/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datastream/apiv1/Client/RunStream/main.go
+++ b/internal/generated/snippets/datastream/apiv1/Client/RunStream/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datastream/apiv1/Client/StartBackfillJob/main.go
+++ b/internal/generated/snippets/datastream/apiv1/Client/StartBackfillJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datastream/apiv1/Client/StopBackfillJob/main.go
+++ b/internal/generated/snippets/datastream/apiv1/Client/StopBackfillJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datastream/apiv1/Client/UpdateConnectionProfile/main.go
+++ b/internal/generated/snippets/datastream/apiv1/Client/UpdateConnectionProfile/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datastream/apiv1/Client/UpdateStream/main.go
+++ b/internal/generated/snippets/datastream/apiv1/Client/UpdateStream/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datastream/apiv1alpha1/Client/CreateConnectionProfile/main.go
+++ b/internal/generated/snippets/datastream/apiv1alpha1/Client/CreateConnectionProfile/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datastream/apiv1alpha1/Client/CreatePrivateConnection/main.go
+++ b/internal/generated/snippets/datastream/apiv1alpha1/Client/CreatePrivateConnection/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datastream/apiv1alpha1/Client/CreateRoute/main.go
+++ b/internal/generated/snippets/datastream/apiv1alpha1/Client/CreateRoute/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datastream/apiv1alpha1/Client/CreateStream/main.go
+++ b/internal/generated/snippets/datastream/apiv1alpha1/Client/CreateStream/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datastream/apiv1alpha1/Client/DeleteConnectionProfile/main.go
+++ b/internal/generated/snippets/datastream/apiv1alpha1/Client/DeleteConnectionProfile/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datastream/apiv1alpha1/Client/DeletePrivateConnection/main.go
+++ b/internal/generated/snippets/datastream/apiv1alpha1/Client/DeletePrivateConnection/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datastream/apiv1alpha1/Client/DeleteRoute/main.go
+++ b/internal/generated/snippets/datastream/apiv1alpha1/Client/DeleteRoute/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datastream/apiv1alpha1/Client/DeleteStream/main.go
+++ b/internal/generated/snippets/datastream/apiv1alpha1/Client/DeleteStream/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datastream/apiv1alpha1/Client/DiscoverConnectionProfile/main.go
+++ b/internal/generated/snippets/datastream/apiv1alpha1/Client/DiscoverConnectionProfile/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datastream/apiv1alpha1/Client/FetchErrors/main.go
+++ b/internal/generated/snippets/datastream/apiv1alpha1/Client/FetchErrors/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datastream/apiv1alpha1/Client/FetchStaticIps/main.go
+++ b/internal/generated/snippets/datastream/apiv1alpha1/Client/FetchStaticIps/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datastream/apiv1alpha1/Client/GetConnectionProfile/main.go
+++ b/internal/generated/snippets/datastream/apiv1alpha1/Client/GetConnectionProfile/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datastream/apiv1alpha1/Client/GetPrivateConnection/main.go
+++ b/internal/generated/snippets/datastream/apiv1alpha1/Client/GetPrivateConnection/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datastream/apiv1alpha1/Client/GetRoute/main.go
+++ b/internal/generated/snippets/datastream/apiv1alpha1/Client/GetRoute/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datastream/apiv1alpha1/Client/GetStream/main.go
+++ b/internal/generated/snippets/datastream/apiv1alpha1/Client/GetStream/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datastream/apiv1alpha1/Client/ListConnectionProfiles/main.go
+++ b/internal/generated/snippets/datastream/apiv1alpha1/Client/ListConnectionProfiles/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datastream/apiv1alpha1/Client/ListPrivateConnections/main.go
+++ b/internal/generated/snippets/datastream/apiv1alpha1/Client/ListPrivateConnections/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datastream/apiv1alpha1/Client/ListRoutes/main.go
+++ b/internal/generated/snippets/datastream/apiv1alpha1/Client/ListRoutes/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datastream/apiv1alpha1/Client/ListStreams/main.go
+++ b/internal/generated/snippets/datastream/apiv1alpha1/Client/ListStreams/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datastream/apiv1alpha1/Client/UpdateConnectionProfile/main.go
+++ b/internal/generated/snippets/datastream/apiv1alpha1/Client/UpdateConnectionProfile/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/datastream/apiv1alpha1/Client/UpdateStream/main.go
+++ b/internal/generated/snippets/datastream/apiv1alpha1/Client/UpdateStream/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/deploy/apiv1/CloudDeployClient/AbandonRelease/main.go
+++ b/internal/generated/snippets/deploy/apiv1/CloudDeployClient/AbandonRelease/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/deploy/apiv1/CloudDeployClient/AdvanceRollout/main.go
+++ b/internal/generated/snippets/deploy/apiv1/CloudDeployClient/AdvanceRollout/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/deploy/apiv1/CloudDeployClient/ApproveRollout/main.go
+++ b/internal/generated/snippets/deploy/apiv1/CloudDeployClient/ApproveRollout/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/deploy/apiv1/CloudDeployClient/CancelAutomationRun/main.go
+++ b/internal/generated/snippets/deploy/apiv1/CloudDeployClient/CancelAutomationRun/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/deploy/apiv1/CloudDeployClient/CancelOperation/main.go
+++ b/internal/generated/snippets/deploy/apiv1/CloudDeployClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/deploy/apiv1/CloudDeployClient/CancelRollout/main.go
+++ b/internal/generated/snippets/deploy/apiv1/CloudDeployClient/CancelRollout/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/deploy/apiv1/CloudDeployClient/CreateAutomation/main.go
+++ b/internal/generated/snippets/deploy/apiv1/CloudDeployClient/CreateAutomation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/deploy/apiv1/CloudDeployClient/CreateCustomTargetType/main.go
+++ b/internal/generated/snippets/deploy/apiv1/CloudDeployClient/CreateCustomTargetType/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/deploy/apiv1/CloudDeployClient/CreateDeliveryPipeline/main.go
+++ b/internal/generated/snippets/deploy/apiv1/CloudDeployClient/CreateDeliveryPipeline/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/deploy/apiv1/CloudDeployClient/CreateDeployPolicy/main.go
+++ b/internal/generated/snippets/deploy/apiv1/CloudDeployClient/CreateDeployPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/deploy/apiv1/CloudDeployClient/CreateRelease/main.go
+++ b/internal/generated/snippets/deploy/apiv1/CloudDeployClient/CreateRelease/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/deploy/apiv1/CloudDeployClient/CreateRollout/main.go
+++ b/internal/generated/snippets/deploy/apiv1/CloudDeployClient/CreateRollout/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/deploy/apiv1/CloudDeployClient/CreateTarget/main.go
+++ b/internal/generated/snippets/deploy/apiv1/CloudDeployClient/CreateTarget/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/deploy/apiv1/CloudDeployClient/DeleteAutomation/main.go
+++ b/internal/generated/snippets/deploy/apiv1/CloudDeployClient/DeleteAutomation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/deploy/apiv1/CloudDeployClient/DeleteCustomTargetType/main.go
+++ b/internal/generated/snippets/deploy/apiv1/CloudDeployClient/DeleteCustomTargetType/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/deploy/apiv1/CloudDeployClient/DeleteDeliveryPipeline/main.go
+++ b/internal/generated/snippets/deploy/apiv1/CloudDeployClient/DeleteDeliveryPipeline/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/deploy/apiv1/CloudDeployClient/DeleteDeployPolicy/main.go
+++ b/internal/generated/snippets/deploy/apiv1/CloudDeployClient/DeleteDeployPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/deploy/apiv1/CloudDeployClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/deploy/apiv1/CloudDeployClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/deploy/apiv1/CloudDeployClient/DeleteTarget/main.go
+++ b/internal/generated/snippets/deploy/apiv1/CloudDeployClient/DeleteTarget/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/deploy/apiv1/CloudDeployClient/GetAutomation/main.go
+++ b/internal/generated/snippets/deploy/apiv1/CloudDeployClient/GetAutomation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/deploy/apiv1/CloudDeployClient/GetAutomationRun/main.go
+++ b/internal/generated/snippets/deploy/apiv1/CloudDeployClient/GetAutomationRun/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/deploy/apiv1/CloudDeployClient/GetConfig/main.go
+++ b/internal/generated/snippets/deploy/apiv1/CloudDeployClient/GetConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/deploy/apiv1/CloudDeployClient/GetCustomTargetType/main.go
+++ b/internal/generated/snippets/deploy/apiv1/CloudDeployClient/GetCustomTargetType/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/deploy/apiv1/CloudDeployClient/GetDeliveryPipeline/main.go
+++ b/internal/generated/snippets/deploy/apiv1/CloudDeployClient/GetDeliveryPipeline/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/deploy/apiv1/CloudDeployClient/GetDeployPolicy/main.go
+++ b/internal/generated/snippets/deploy/apiv1/CloudDeployClient/GetDeployPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/deploy/apiv1/CloudDeployClient/GetIamPolicy/main.go
+++ b/internal/generated/snippets/deploy/apiv1/CloudDeployClient/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/deploy/apiv1/CloudDeployClient/GetJobRun/main.go
+++ b/internal/generated/snippets/deploy/apiv1/CloudDeployClient/GetJobRun/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/deploy/apiv1/CloudDeployClient/GetLocation/main.go
+++ b/internal/generated/snippets/deploy/apiv1/CloudDeployClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/deploy/apiv1/CloudDeployClient/GetOperation/main.go
+++ b/internal/generated/snippets/deploy/apiv1/CloudDeployClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/deploy/apiv1/CloudDeployClient/GetRelease/main.go
+++ b/internal/generated/snippets/deploy/apiv1/CloudDeployClient/GetRelease/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/deploy/apiv1/CloudDeployClient/GetRollout/main.go
+++ b/internal/generated/snippets/deploy/apiv1/CloudDeployClient/GetRollout/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/deploy/apiv1/CloudDeployClient/GetTarget/main.go
+++ b/internal/generated/snippets/deploy/apiv1/CloudDeployClient/GetTarget/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/deploy/apiv1/CloudDeployClient/IgnoreJob/main.go
+++ b/internal/generated/snippets/deploy/apiv1/CloudDeployClient/IgnoreJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/deploy/apiv1/CloudDeployClient/ListAutomationRuns/main.go
+++ b/internal/generated/snippets/deploy/apiv1/CloudDeployClient/ListAutomationRuns/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/deploy/apiv1/CloudDeployClient/ListAutomations/main.go
+++ b/internal/generated/snippets/deploy/apiv1/CloudDeployClient/ListAutomations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/deploy/apiv1/CloudDeployClient/ListCustomTargetTypes/main.go
+++ b/internal/generated/snippets/deploy/apiv1/CloudDeployClient/ListCustomTargetTypes/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/deploy/apiv1/CloudDeployClient/ListDeliveryPipelines/main.go
+++ b/internal/generated/snippets/deploy/apiv1/CloudDeployClient/ListDeliveryPipelines/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/deploy/apiv1/CloudDeployClient/ListDeployPolicies/main.go
+++ b/internal/generated/snippets/deploy/apiv1/CloudDeployClient/ListDeployPolicies/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/deploy/apiv1/CloudDeployClient/ListJobRuns/main.go
+++ b/internal/generated/snippets/deploy/apiv1/CloudDeployClient/ListJobRuns/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/deploy/apiv1/CloudDeployClient/ListLocations/main.go
+++ b/internal/generated/snippets/deploy/apiv1/CloudDeployClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/deploy/apiv1/CloudDeployClient/ListOperations/main.go
+++ b/internal/generated/snippets/deploy/apiv1/CloudDeployClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/deploy/apiv1/CloudDeployClient/ListReleases/main.go
+++ b/internal/generated/snippets/deploy/apiv1/CloudDeployClient/ListReleases/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/deploy/apiv1/CloudDeployClient/ListRollouts/main.go
+++ b/internal/generated/snippets/deploy/apiv1/CloudDeployClient/ListRollouts/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/deploy/apiv1/CloudDeployClient/ListTargets/main.go
+++ b/internal/generated/snippets/deploy/apiv1/CloudDeployClient/ListTargets/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/deploy/apiv1/CloudDeployClient/RetryJob/main.go
+++ b/internal/generated/snippets/deploy/apiv1/CloudDeployClient/RetryJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/deploy/apiv1/CloudDeployClient/RollbackTarget/main.go
+++ b/internal/generated/snippets/deploy/apiv1/CloudDeployClient/RollbackTarget/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/deploy/apiv1/CloudDeployClient/SetIamPolicy/main.go
+++ b/internal/generated/snippets/deploy/apiv1/CloudDeployClient/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/deploy/apiv1/CloudDeployClient/TerminateJobRun/main.go
+++ b/internal/generated/snippets/deploy/apiv1/CloudDeployClient/TerminateJobRun/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/deploy/apiv1/CloudDeployClient/TestIamPermissions/main.go
+++ b/internal/generated/snippets/deploy/apiv1/CloudDeployClient/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/deploy/apiv1/CloudDeployClient/UpdateAutomation/main.go
+++ b/internal/generated/snippets/deploy/apiv1/CloudDeployClient/UpdateAutomation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/deploy/apiv1/CloudDeployClient/UpdateCustomTargetType/main.go
+++ b/internal/generated/snippets/deploy/apiv1/CloudDeployClient/UpdateCustomTargetType/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/deploy/apiv1/CloudDeployClient/UpdateDeliveryPipeline/main.go
+++ b/internal/generated/snippets/deploy/apiv1/CloudDeployClient/UpdateDeliveryPipeline/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/deploy/apiv1/CloudDeployClient/UpdateDeployPolicy/main.go
+++ b/internal/generated/snippets/deploy/apiv1/CloudDeployClient/UpdateDeployPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/deploy/apiv1/CloudDeployClient/UpdateTarget/main.go
+++ b/internal/generated/snippets/deploy/apiv1/CloudDeployClient/UpdateTarget/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/developerconnect/apiv1/Client/CancelOperation/main.go
+++ b/internal/generated/snippets/developerconnect/apiv1/Client/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/developerconnect/apiv1/Client/CreateAccountConnector/main.go
+++ b/internal/generated/snippets/developerconnect/apiv1/Client/CreateAccountConnector/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/developerconnect/apiv1/Client/CreateConnection/main.go
+++ b/internal/generated/snippets/developerconnect/apiv1/Client/CreateConnection/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/developerconnect/apiv1/Client/CreateGitRepositoryLink/main.go
+++ b/internal/generated/snippets/developerconnect/apiv1/Client/CreateGitRepositoryLink/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/developerconnect/apiv1/Client/DeleteAccountConnector/main.go
+++ b/internal/generated/snippets/developerconnect/apiv1/Client/DeleteAccountConnector/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/developerconnect/apiv1/Client/DeleteConnection/main.go
+++ b/internal/generated/snippets/developerconnect/apiv1/Client/DeleteConnection/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/developerconnect/apiv1/Client/DeleteGitRepositoryLink/main.go
+++ b/internal/generated/snippets/developerconnect/apiv1/Client/DeleteGitRepositoryLink/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/developerconnect/apiv1/Client/DeleteOperation/main.go
+++ b/internal/generated/snippets/developerconnect/apiv1/Client/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/developerconnect/apiv1/Client/DeleteSelf/main.go
+++ b/internal/generated/snippets/developerconnect/apiv1/Client/DeleteSelf/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/developerconnect/apiv1/Client/DeleteUser/main.go
+++ b/internal/generated/snippets/developerconnect/apiv1/Client/DeleteUser/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/developerconnect/apiv1/Client/FetchAccessToken/main.go
+++ b/internal/generated/snippets/developerconnect/apiv1/Client/FetchAccessToken/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/developerconnect/apiv1/Client/FetchGitHubInstallations/main.go
+++ b/internal/generated/snippets/developerconnect/apiv1/Client/FetchGitHubInstallations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/developerconnect/apiv1/Client/FetchGitRefs/main.go
+++ b/internal/generated/snippets/developerconnect/apiv1/Client/FetchGitRefs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/developerconnect/apiv1/Client/FetchLinkableGitRepositories/main.go
+++ b/internal/generated/snippets/developerconnect/apiv1/Client/FetchLinkableGitRepositories/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/developerconnect/apiv1/Client/FetchReadToken/main.go
+++ b/internal/generated/snippets/developerconnect/apiv1/Client/FetchReadToken/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/developerconnect/apiv1/Client/FetchReadWriteToken/main.go
+++ b/internal/generated/snippets/developerconnect/apiv1/Client/FetchReadWriteToken/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/developerconnect/apiv1/Client/FetchSelf/main.go
+++ b/internal/generated/snippets/developerconnect/apiv1/Client/FetchSelf/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/developerconnect/apiv1/Client/GetAccountConnector/main.go
+++ b/internal/generated/snippets/developerconnect/apiv1/Client/GetAccountConnector/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/developerconnect/apiv1/Client/GetConnection/main.go
+++ b/internal/generated/snippets/developerconnect/apiv1/Client/GetConnection/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/developerconnect/apiv1/Client/GetGitRepositoryLink/main.go
+++ b/internal/generated/snippets/developerconnect/apiv1/Client/GetGitRepositoryLink/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/developerconnect/apiv1/Client/GetLocation/main.go
+++ b/internal/generated/snippets/developerconnect/apiv1/Client/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/developerconnect/apiv1/Client/GetOperation/main.go
+++ b/internal/generated/snippets/developerconnect/apiv1/Client/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/developerconnect/apiv1/Client/ListAccountConnectors/main.go
+++ b/internal/generated/snippets/developerconnect/apiv1/Client/ListAccountConnectors/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/developerconnect/apiv1/Client/ListConnections/main.go
+++ b/internal/generated/snippets/developerconnect/apiv1/Client/ListConnections/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/developerconnect/apiv1/Client/ListGitRepositoryLinks/main.go
+++ b/internal/generated/snippets/developerconnect/apiv1/Client/ListGitRepositoryLinks/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/developerconnect/apiv1/Client/ListLocations/main.go
+++ b/internal/generated/snippets/developerconnect/apiv1/Client/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/developerconnect/apiv1/Client/ListOperations/main.go
+++ b/internal/generated/snippets/developerconnect/apiv1/Client/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/developerconnect/apiv1/Client/ListUsers/main.go
+++ b/internal/generated/snippets/developerconnect/apiv1/Client/ListUsers/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/developerconnect/apiv1/Client/UpdateAccountConnector/main.go
+++ b/internal/generated/snippets/developerconnect/apiv1/Client/UpdateAccountConnector/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/developerconnect/apiv1/Client/UpdateConnection/main.go
+++ b/internal/generated/snippets/developerconnect/apiv1/Client/UpdateConnection/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/developerconnect/apiv1/InsightsConfigClient/CancelOperation/main.go
+++ b/internal/generated/snippets/developerconnect/apiv1/InsightsConfigClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/developerconnect/apiv1/InsightsConfigClient/CreateInsightsConfig/main.go
+++ b/internal/generated/snippets/developerconnect/apiv1/InsightsConfigClient/CreateInsightsConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/developerconnect/apiv1/InsightsConfigClient/DeleteInsightsConfig/main.go
+++ b/internal/generated/snippets/developerconnect/apiv1/InsightsConfigClient/DeleteInsightsConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/developerconnect/apiv1/InsightsConfigClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/developerconnect/apiv1/InsightsConfigClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/developerconnect/apiv1/InsightsConfigClient/GetInsightsConfig/main.go
+++ b/internal/generated/snippets/developerconnect/apiv1/InsightsConfigClient/GetInsightsConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/developerconnect/apiv1/InsightsConfigClient/GetLocation/main.go
+++ b/internal/generated/snippets/developerconnect/apiv1/InsightsConfigClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/developerconnect/apiv1/InsightsConfigClient/GetOperation/main.go
+++ b/internal/generated/snippets/developerconnect/apiv1/InsightsConfigClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/developerconnect/apiv1/InsightsConfigClient/ListInsightsConfigs/main.go
+++ b/internal/generated/snippets/developerconnect/apiv1/InsightsConfigClient/ListInsightsConfigs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/developerconnect/apiv1/InsightsConfigClient/ListLocations/main.go
+++ b/internal/generated/snippets/developerconnect/apiv1/InsightsConfigClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/developerconnect/apiv1/InsightsConfigClient/ListOperations/main.go
+++ b/internal/generated/snippets/developerconnect/apiv1/InsightsConfigClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/developerconnect/apiv1/InsightsConfigClient/UpdateInsightsConfig/main.go
+++ b/internal/generated/snippets/developerconnect/apiv1/InsightsConfigClient/UpdateInsightsConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/devicestreaming/apiv1/DirectAccessClient/AdbConnect/main.go
+++ b/internal/generated/snippets/devicestreaming/apiv1/DirectAccessClient/AdbConnect/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/devicestreaming/apiv1/DirectAccessClient/CancelDeviceSession/main.go
+++ b/internal/generated/snippets/devicestreaming/apiv1/DirectAccessClient/CancelDeviceSession/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/devicestreaming/apiv1/DirectAccessClient/CreateDeviceSession/main.go
+++ b/internal/generated/snippets/devicestreaming/apiv1/DirectAccessClient/CreateDeviceSession/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/devicestreaming/apiv1/DirectAccessClient/GetDeviceSession/main.go
+++ b/internal/generated/snippets/devicestreaming/apiv1/DirectAccessClient/GetDeviceSession/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/devicestreaming/apiv1/DirectAccessClient/ListDeviceSessions/main.go
+++ b/internal/generated/snippets/devicestreaming/apiv1/DirectAccessClient/ListDeviceSessions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/devicestreaming/apiv1/DirectAccessClient/UpdateDeviceSession/main.go
+++ b/internal/generated/snippets/devicestreaming/apiv1/DirectAccessClient/UpdateDeviceSession/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/AgentsClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/AgentsClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/AgentsClient/DeleteAgent/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/AgentsClient/DeleteAgent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/AgentsClient/ExportAgent/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/AgentsClient/ExportAgent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/AgentsClient/GetAgent/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/AgentsClient/GetAgent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/AgentsClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/AgentsClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/AgentsClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/AgentsClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/AgentsClient/GetValidationResult/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/AgentsClient/GetValidationResult/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/AgentsClient/ImportAgent/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/AgentsClient/ImportAgent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/AgentsClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/AgentsClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/AgentsClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/AgentsClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/AgentsClient/RestoreAgent/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/AgentsClient/RestoreAgent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/AgentsClient/SearchAgents/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/AgentsClient/SearchAgents/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/AgentsClient/SetAgent/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/AgentsClient/SetAgent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/AgentsClient/TrainAgent/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/AgentsClient/TrainAgent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/AnswerRecordsClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/AnswerRecordsClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/AnswerRecordsClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/AnswerRecordsClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/AnswerRecordsClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/AnswerRecordsClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/AnswerRecordsClient/ListAnswerRecords/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/AnswerRecordsClient/ListAnswerRecords/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/AnswerRecordsClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/AnswerRecordsClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/AnswerRecordsClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/AnswerRecordsClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/AnswerRecordsClient/UpdateAnswerRecord/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/AnswerRecordsClient/UpdateAnswerRecord/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ContextsClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ContextsClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ContextsClient/CreateContext/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ContextsClient/CreateContext/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ContextsClient/DeleteAllContexts/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ContextsClient/DeleteAllContexts/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ContextsClient/DeleteContext/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ContextsClient/DeleteContext/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ContextsClient/GetContext/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ContextsClient/GetContext/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ContextsClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ContextsClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ContextsClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ContextsClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ContextsClient/ListContexts/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ContextsClient/ListContexts/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ContextsClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ContextsClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ContextsClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ContextsClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ContextsClient/UpdateContext/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ContextsClient/UpdateContext/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ConversationDatasetsClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ConversationDatasetsClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ConversationDatasetsClient/CreateConversationDataset/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ConversationDatasetsClient/CreateConversationDataset/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ConversationDatasetsClient/DeleteConversationDataset/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ConversationDatasetsClient/DeleteConversationDataset/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ConversationDatasetsClient/GetConversationDataset/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ConversationDatasetsClient/GetConversationDataset/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ConversationDatasetsClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ConversationDatasetsClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ConversationDatasetsClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ConversationDatasetsClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ConversationDatasetsClient/ImportConversationData/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ConversationDatasetsClient/ImportConversationData/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ConversationDatasetsClient/ListConversationDatasets/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ConversationDatasetsClient/ListConversationDatasets/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ConversationDatasetsClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ConversationDatasetsClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ConversationDatasetsClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ConversationDatasetsClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ConversationModelsClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ConversationModelsClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ConversationModelsClient/CreateConversationModel/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ConversationModelsClient/CreateConversationModel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ConversationModelsClient/CreateConversationModelEvaluation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ConversationModelsClient/CreateConversationModelEvaluation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ConversationModelsClient/DeleteConversationModel/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ConversationModelsClient/DeleteConversationModel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ConversationModelsClient/DeployConversationModel/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ConversationModelsClient/DeployConversationModel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ConversationModelsClient/GetConversationModel/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ConversationModelsClient/GetConversationModel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ConversationModelsClient/GetConversationModelEvaluation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ConversationModelsClient/GetConversationModelEvaluation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ConversationModelsClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ConversationModelsClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ConversationModelsClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ConversationModelsClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ConversationModelsClient/ListConversationModelEvaluations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ConversationModelsClient/ListConversationModelEvaluations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ConversationModelsClient/ListConversationModels/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ConversationModelsClient/ListConversationModels/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ConversationModelsClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ConversationModelsClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ConversationModelsClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ConversationModelsClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ConversationModelsClient/UndeployConversationModel/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ConversationModelsClient/UndeployConversationModel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ConversationProfilesClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ConversationProfilesClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ConversationProfilesClient/ClearSuggestionFeatureConfig/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ConversationProfilesClient/ClearSuggestionFeatureConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ConversationProfilesClient/CreateConversationProfile/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ConversationProfilesClient/CreateConversationProfile/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ConversationProfilesClient/DeleteConversationProfile/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ConversationProfilesClient/DeleteConversationProfile/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ConversationProfilesClient/GetConversationProfile/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ConversationProfilesClient/GetConversationProfile/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ConversationProfilesClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ConversationProfilesClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ConversationProfilesClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ConversationProfilesClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ConversationProfilesClient/ListConversationProfiles/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ConversationProfilesClient/ListConversationProfiles/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ConversationProfilesClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ConversationProfilesClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ConversationProfilesClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ConversationProfilesClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ConversationProfilesClient/SetSuggestionFeatureConfig/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ConversationProfilesClient/SetSuggestionFeatureConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ConversationProfilesClient/UpdateConversationProfile/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ConversationProfilesClient/UpdateConversationProfile/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ConversationsClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ConversationsClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ConversationsClient/CompleteConversation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ConversationsClient/CompleteConversation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ConversationsClient/CreateConversation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ConversationsClient/CreateConversation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ConversationsClient/GenerateStatelessSuggestion/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ConversationsClient/GenerateStatelessSuggestion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ConversationsClient/GenerateStatelessSummary/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ConversationsClient/GenerateStatelessSummary/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ConversationsClient/GenerateSuggestions/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ConversationsClient/GenerateSuggestions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ConversationsClient/GetConversation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ConversationsClient/GetConversation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ConversationsClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ConversationsClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ConversationsClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ConversationsClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ConversationsClient/IngestContextReferences/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ConversationsClient/IngestContextReferences/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ConversationsClient/ListConversations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ConversationsClient/ListConversations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ConversationsClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ConversationsClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ConversationsClient/ListMessages/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ConversationsClient/ListMessages/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ConversationsClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ConversationsClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ConversationsClient/SearchKnowledge/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ConversationsClient/SearchKnowledge/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ConversationsClient/SuggestConversationSummary/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ConversationsClient/SuggestConversationSummary/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/DocumentsClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/DocumentsClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/DocumentsClient/CreateDocument/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/DocumentsClient/CreateDocument/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/DocumentsClient/DeleteDocument/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/DocumentsClient/DeleteDocument/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/DocumentsClient/ExportDocument/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/DocumentsClient/ExportDocument/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/DocumentsClient/GetDocument/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/DocumentsClient/GetDocument/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/DocumentsClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/DocumentsClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/DocumentsClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/DocumentsClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/DocumentsClient/ImportDocuments/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/DocumentsClient/ImportDocuments/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/DocumentsClient/ListDocuments/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/DocumentsClient/ListDocuments/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/DocumentsClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/DocumentsClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/DocumentsClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/DocumentsClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/DocumentsClient/ReloadDocument/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/DocumentsClient/ReloadDocument/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/DocumentsClient/UpdateDocument/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/DocumentsClient/UpdateDocument/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/EncryptionSpecClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/EncryptionSpecClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/EncryptionSpecClient/GetEncryptionSpec/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/EncryptionSpecClient/GetEncryptionSpec/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/EncryptionSpecClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/EncryptionSpecClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/EncryptionSpecClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/EncryptionSpecClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/EncryptionSpecClient/InitializeEncryptionSpec/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/EncryptionSpecClient/InitializeEncryptionSpec/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/EncryptionSpecClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/EncryptionSpecClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/EncryptionSpecClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/EncryptionSpecClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/EntityTypesClient/BatchCreateEntities/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/EntityTypesClient/BatchCreateEntities/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/EntityTypesClient/BatchDeleteEntities/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/EntityTypesClient/BatchDeleteEntities/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/EntityTypesClient/BatchDeleteEntityTypes/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/EntityTypesClient/BatchDeleteEntityTypes/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/EntityTypesClient/BatchUpdateEntities/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/EntityTypesClient/BatchUpdateEntities/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/EntityTypesClient/BatchUpdateEntityTypes/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/EntityTypesClient/BatchUpdateEntityTypes/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/EntityTypesClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/EntityTypesClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/EntityTypesClient/CreateEntityType/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/EntityTypesClient/CreateEntityType/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/EntityTypesClient/DeleteEntityType/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/EntityTypesClient/DeleteEntityType/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/EntityTypesClient/GetEntityType/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/EntityTypesClient/GetEntityType/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/EntityTypesClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/EntityTypesClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/EntityTypesClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/EntityTypesClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/EntityTypesClient/ListEntityTypes/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/EntityTypesClient/ListEntityTypes/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/EntityTypesClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/EntityTypesClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/EntityTypesClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/EntityTypesClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/EntityTypesClient/UpdateEntityType/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/EntityTypesClient/UpdateEntityType/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/EnvironmentsClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/EnvironmentsClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/EnvironmentsClient/CreateEnvironment/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/EnvironmentsClient/CreateEnvironment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/EnvironmentsClient/DeleteEnvironment/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/EnvironmentsClient/DeleteEnvironment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/EnvironmentsClient/GetEnvironment/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/EnvironmentsClient/GetEnvironment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/EnvironmentsClient/GetEnvironmentHistory/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/EnvironmentsClient/GetEnvironmentHistory/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/EnvironmentsClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/EnvironmentsClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/EnvironmentsClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/EnvironmentsClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/EnvironmentsClient/ListEnvironments/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/EnvironmentsClient/ListEnvironments/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/EnvironmentsClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/EnvironmentsClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/EnvironmentsClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/EnvironmentsClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/EnvironmentsClient/UpdateEnvironment/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/EnvironmentsClient/UpdateEnvironment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/FulfillmentsClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/FulfillmentsClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/FulfillmentsClient/GetFulfillment/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/FulfillmentsClient/GetFulfillment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/FulfillmentsClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/FulfillmentsClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/FulfillmentsClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/FulfillmentsClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/FulfillmentsClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/FulfillmentsClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/FulfillmentsClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/FulfillmentsClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/FulfillmentsClient/UpdateFulfillment/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/FulfillmentsClient/UpdateFulfillment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/GeneratorEvaluationsClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/GeneratorEvaluationsClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/GeneratorEvaluationsClient/CreateGeneratorEvaluation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/GeneratorEvaluationsClient/CreateGeneratorEvaluation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/GeneratorEvaluationsClient/DeleteGeneratorEvaluation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/GeneratorEvaluationsClient/DeleteGeneratorEvaluation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/GeneratorEvaluationsClient/GetGeneratorEvaluation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/GeneratorEvaluationsClient/GetGeneratorEvaluation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/GeneratorEvaluationsClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/GeneratorEvaluationsClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/GeneratorEvaluationsClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/GeneratorEvaluationsClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/GeneratorEvaluationsClient/ListGeneratorEvaluations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/GeneratorEvaluationsClient/ListGeneratorEvaluations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/GeneratorEvaluationsClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/GeneratorEvaluationsClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/GeneratorEvaluationsClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/GeneratorEvaluationsClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/GeneratorsClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/GeneratorsClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/GeneratorsClient/CreateGenerator/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/GeneratorsClient/CreateGenerator/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/GeneratorsClient/DeleteGenerator/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/GeneratorsClient/DeleteGenerator/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/GeneratorsClient/GetGenerator/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/GeneratorsClient/GetGenerator/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/GeneratorsClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/GeneratorsClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/GeneratorsClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/GeneratorsClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/GeneratorsClient/ListGenerators/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/GeneratorsClient/ListGenerators/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/GeneratorsClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/GeneratorsClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/GeneratorsClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/GeneratorsClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/GeneratorsClient/UpdateGenerator/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/GeneratorsClient/UpdateGenerator/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/IntentsClient/BatchDeleteIntents/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/IntentsClient/BatchDeleteIntents/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/IntentsClient/BatchUpdateIntents/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/IntentsClient/BatchUpdateIntents/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/IntentsClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/IntentsClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/IntentsClient/CreateIntent/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/IntentsClient/CreateIntent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/IntentsClient/DeleteIntent/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/IntentsClient/DeleteIntent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/IntentsClient/GetIntent/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/IntentsClient/GetIntent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/IntentsClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/IntentsClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/IntentsClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/IntentsClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/IntentsClient/ListIntents/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/IntentsClient/ListIntents/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/IntentsClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/IntentsClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/IntentsClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/IntentsClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/IntentsClient/UpdateIntent/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/IntentsClient/UpdateIntent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/KnowledgeBasesClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/KnowledgeBasesClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/KnowledgeBasesClient/CreateKnowledgeBase/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/KnowledgeBasesClient/CreateKnowledgeBase/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/KnowledgeBasesClient/DeleteKnowledgeBase/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/KnowledgeBasesClient/DeleteKnowledgeBase/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/KnowledgeBasesClient/GetKnowledgeBase/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/KnowledgeBasesClient/GetKnowledgeBase/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/KnowledgeBasesClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/KnowledgeBasesClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/KnowledgeBasesClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/KnowledgeBasesClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/KnowledgeBasesClient/ListKnowledgeBases/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/KnowledgeBasesClient/ListKnowledgeBases/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/KnowledgeBasesClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/KnowledgeBasesClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/KnowledgeBasesClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/KnowledgeBasesClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/KnowledgeBasesClient/UpdateKnowledgeBase/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/KnowledgeBasesClient/UpdateKnowledgeBase/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ParticipantsClient/AnalyzeContent/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ParticipantsClient/AnalyzeContent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ParticipantsClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ParticipantsClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ParticipantsClient/CreateParticipant/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ParticipantsClient/CreateParticipant/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ParticipantsClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ParticipantsClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ParticipantsClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ParticipantsClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ParticipantsClient/GetParticipant/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ParticipantsClient/GetParticipant/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ParticipantsClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ParticipantsClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ParticipantsClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ParticipantsClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ParticipantsClient/ListParticipants/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ParticipantsClient/ListParticipants/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ParticipantsClient/StreamingAnalyzeContent/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ParticipantsClient/StreamingAnalyzeContent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ParticipantsClient/SuggestArticles/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ParticipantsClient/SuggestArticles/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ParticipantsClient/SuggestFaqAnswers/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ParticipantsClient/SuggestFaqAnswers/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ParticipantsClient/SuggestKnowledgeAssist/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ParticipantsClient/SuggestKnowledgeAssist/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ParticipantsClient/SuggestSmartReplies/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ParticipantsClient/SuggestSmartReplies/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ParticipantsClient/UpdateParticipant/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ParticipantsClient/UpdateParticipant/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/SessionEntityTypesClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/SessionEntityTypesClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/SessionEntityTypesClient/CreateSessionEntityType/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/SessionEntityTypesClient/CreateSessionEntityType/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/SessionEntityTypesClient/DeleteSessionEntityType/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/SessionEntityTypesClient/DeleteSessionEntityType/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/SessionEntityTypesClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/SessionEntityTypesClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/SessionEntityTypesClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/SessionEntityTypesClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/SessionEntityTypesClient/GetSessionEntityType/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/SessionEntityTypesClient/GetSessionEntityType/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/SessionEntityTypesClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/SessionEntityTypesClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/SessionEntityTypesClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/SessionEntityTypesClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/SessionEntityTypesClient/ListSessionEntityTypes/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/SessionEntityTypesClient/ListSessionEntityTypes/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/SessionEntityTypesClient/UpdateSessionEntityType/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/SessionEntityTypesClient/UpdateSessionEntityType/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/SessionsClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/SessionsClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/SessionsClient/DetectIntent/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/SessionsClient/DetectIntent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/SessionsClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/SessionsClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/SessionsClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/SessionsClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/SessionsClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/SessionsClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/SessionsClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/SessionsClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/SessionsClient/StreamingDetectIntent/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/SessionsClient/StreamingDetectIntent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/SipTrunksClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/SipTrunksClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/SipTrunksClient/CreateSipTrunk/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/SipTrunksClient/CreateSipTrunk/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/SipTrunksClient/DeleteSipTrunk/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/SipTrunksClient/DeleteSipTrunk/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/SipTrunksClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/SipTrunksClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/SipTrunksClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/SipTrunksClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/SipTrunksClient/GetSipTrunk/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/SipTrunksClient/GetSipTrunk/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/SipTrunksClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/SipTrunksClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/SipTrunksClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/SipTrunksClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/SipTrunksClient/ListSipTrunks/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/SipTrunksClient/ListSipTrunks/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/SipTrunksClient/UpdateSipTrunk/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/SipTrunksClient/UpdateSipTrunk/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ToolsClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ToolsClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ToolsClient/CreateTool/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ToolsClient/CreateTool/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ToolsClient/DeleteTool/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ToolsClient/DeleteTool/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ToolsClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ToolsClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ToolsClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ToolsClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ToolsClient/GetTool/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ToolsClient/GetTool/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ToolsClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ToolsClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ToolsClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ToolsClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ToolsClient/ListTools/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ToolsClient/ListTools/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/ToolsClient/UpdateTool/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/ToolsClient/UpdateTool/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/VersionsClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/VersionsClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/VersionsClient/CreateVersion/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/VersionsClient/CreateVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/VersionsClient/DeleteVersion/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/VersionsClient/DeleteVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/VersionsClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/VersionsClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/VersionsClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/VersionsClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/VersionsClient/GetVersion/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/VersionsClient/GetVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/VersionsClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/VersionsClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/VersionsClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/VersionsClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/VersionsClient/ListVersions/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/VersionsClient/ListVersions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2/VersionsClient/UpdateVersion/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2/VersionsClient/UpdateVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/AgentsClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/AgentsClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/AgentsClient/DeleteAgent/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/AgentsClient/DeleteAgent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/AgentsClient/ExportAgent/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/AgentsClient/ExportAgent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/AgentsClient/GetAgent/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/AgentsClient/GetAgent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/AgentsClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/AgentsClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/AgentsClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/AgentsClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/AgentsClient/GetValidationResult/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/AgentsClient/GetValidationResult/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/AgentsClient/ImportAgent/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/AgentsClient/ImportAgent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/AgentsClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/AgentsClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/AgentsClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/AgentsClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/AgentsClient/RestoreAgent/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/AgentsClient/RestoreAgent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/AgentsClient/SearchAgents/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/AgentsClient/SearchAgents/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/AgentsClient/SetAgent/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/AgentsClient/SetAgent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/AgentsClient/TrainAgent/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/AgentsClient/TrainAgent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/AnswerRecordsClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/AnswerRecordsClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/AnswerRecordsClient/GetAnswerRecord/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/AnswerRecordsClient/GetAnswerRecord/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/AnswerRecordsClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/AnswerRecordsClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/AnswerRecordsClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/AnswerRecordsClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/AnswerRecordsClient/ListAnswerRecords/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/AnswerRecordsClient/ListAnswerRecords/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/AnswerRecordsClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/AnswerRecordsClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/AnswerRecordsClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/AnswerRecordsClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/AnswerRecordsClient/UpdateAnswerRecord/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/AnswerRecordsClient/UpdateAnswerRecord/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/ContextsClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/ContextsClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/ContextsClient/CreateContext/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/ContextsClient/CreateContext/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/ContextsClient/DeleteAllContexts/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/ContextsClient/DeleteAllContexts/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/ContextsClient/DeleteContext/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/ContextsClient/DeleteContext/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/ContextsClient/GetContext/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/ContextsClient/GetContext/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/ContextsClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/ContextsClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/ContextsClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/ContextsClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/ContextsClient/ListContexts/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/ContextsClient/ListContexts/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/ContextsClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/ContextsClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/ContextsClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/ContextsClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/ContextsClient/UpdateContext/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/ContextsClient/UpdateContext/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/ConversationProfilesClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/ConversationProfilesClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/ConversationProfilesClient/ClearSuggestionFeatureConfig/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/ConversationProfilesClient/ClearSuggestionFeatureConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/ConversationProfilesClient/CreateConversationProfile/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/ConversationProfilesClient/CreateConversationProfile/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/ConversationProfilesClient/DeleteConversationProfile/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/ConversationProfilesClient/DeleteConversationProfile/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/ConversationProfilesClient/GetConversationProfile/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/ConversationProfilesClient/GetConversationProfile/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/ConversationProfilesClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/ConversationProfilesClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/ConversationProfilesClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/ConversationProfilesClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/ConversationProfilesClient/ListConversationProfiles/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/ConversationProfilesClient/ListConversationProfiles/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/ConversationProfilesClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/ConversationProfilesClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/ConversationProfilesClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/ConversationProfilesClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/ConversationProfilesClient/SetSuggestionFeatureConfig/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/ConversationProfilesClient/SetSuggestionFeatureConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/ConversationProfilesClient/UpdateConversationProfile/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/ConversationProfilesClient/UpdateConversationProfile/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/ConversationsClient/BatchCreateMessages/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/ConversationsClient/BatchCreateMessages/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/ConversationsClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/ConversationsClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/ConversationsClient/CompleteConversation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/ConversationsClient/CompleteConversation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/ConversationsClient/CreateConversation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/ConversationsClient/CreateConversation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/ConversationsClient/GenerateStatelessSuggestion/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/ConversationsClient/GenerateStatelessSuggestion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/ConversationsClient/GenerateStatelessSummary/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/ConversationsClient/GenerateStatelessSummary/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/ConversationsClient/GenerateSuggestions/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/ConversationsClient/GenerateSuggestions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/ConversationsClient/GetConversation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/ConversationsClient/GetConversation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/ConversationsClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/ConversationsClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/ConversationsClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/ConversationsClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/ConversationsClient/IngestContextReferences/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/ConversationsClient/IngestContextReferences/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/ConversationsClient/ListConversations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/ConversationsClient/ListConversations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/ConversationsClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/ConversationsClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/ConversationsClient/ListMessages/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/ConversationsClient/ListMessages/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/ConversationsClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/ConversationsClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/ConversationsClient/SearchKnowledge/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/ConversationsClient/SearchKnowledge/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/ConversationsClient/SuggestConversationSummary/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/ConversationsClient/SuggestConversationSummary/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/DocumentsClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/DocumentsClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/DocumentsClient/CreateDocument/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/DocumentsClient/CreateDocument/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/DocumentsClient/DeleteDocument/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/DocumentsClient/DeleteDocument/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/DocumentsClient/GetDocument/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/DocumentsClient/GetDocument/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/DocumentsClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/DocumentsClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/DocumentsClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/DocumentsClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/DocumentsClient/ImportDocuments/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/DocumentsClient/ImportDocuments/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/DocumentsClient/ListDocuments/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/DocumentsClient/ListDocuments/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/DocumentsClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/DocumentsClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/DocumentsClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/DocumentsClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/DocumentsClient/ReloadDocument/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/DocumentsClient/ReloadDocument/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/DocumentsClient/UpdateDocument/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/DocumentsClient/UpdateDocument/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/EncryptionSpecClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/EncryptionSpecClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/EncryptionSpecClient/GetEncryptionSpec/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/EncryptionSpecClient/GetEncryptionSpec/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/EncryptionSpecClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/EncryptionSpecClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/EncryptionSpecClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/EncryptionSpecClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/EncryptionSpecClient/InitializeEncryptionSpec/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/EncryptionSpecClient/InitializeEncryptionSpec/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/EncryptionSpecClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/EncryptionSpecClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/EncryptionSpecClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/EncryptionSpecClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/EntityTypesClient/BatchCreateEntities/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/EntityTypesClient/BatchCreateEntities/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/EntityTypesClient/BatchDeleteEntities/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/EntityTypesClient/BatchDeleteEntities/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/EntityTypesClient/BatchDeleteEntityTypes/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/EntityTypesClient/BatchDeleteEntityTypes/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/EntityTypesClient/BatchUpdateEntities/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/EntityTypesClient/BatchUpdateEntities/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/EntityTypesClient/BatchUpdateEntityTypes/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/EntityTypesClient/BatchUpdateEntityTypes/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/EntityTypesClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/EntityTypesClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/EntityTypesClient/CreateEntityType/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/EntityTypesClient/CreateEntityType/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/EntityTypesClient/DeleteEntityType/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/EntityTypesClient/DeleteEntityType/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/EntityTypesClient/GetEntityType/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/EntityTypesClient/GetEntityType/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/EntityTypesClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/EntityTypesClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/EntityTypesClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/EntityTypesClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/EntityTypesClient/ListEntityTypes/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/EntityTypesClient/ListEntityTypes/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/EntityTypesClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/EntityTypesClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/EntityTypesClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/EntityTypesClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/EntityTypesClient/UpdateEntityType/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/EntityTypesClient/UpdateEntityType/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/EnvironmentsClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/EnvironmentsClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/EnvironmentsClient/CreateEnvironment/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/EnvironmentsClient/CreateEnvironment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/EnvironmentsClient/DeleteEnvironment/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/EnvironmentsClient/DeleteEnvironment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/EnvironmentsClient/GetEnvironment/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/EnvironmentsClient/GetEnvironment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/EnvironmentsClient/GetEnvironmentHistory/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/EnvironmentsClient/GetEnvironmentHistory/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/EnvironmentsClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/EnvironmentsClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/EnvironmentsClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/EnvironmentsClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/EnvironmentsClient/ListEnvironments/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/EnvironmentsClient/ListEnvironments/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/EnvironmentsClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/EnvironmentsClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/EnvironmentsClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/EnvironmentsClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/EnvironmentsClient/UpdateEnvironment/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/EnvironmentsClient/UpdateEnvironment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/FulfillmentsClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/FulfillmentsClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/FulfillmentsClient/GetFulfillment/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/FulfillmentsClient/GetFulfillment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/FulfillmentsClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/FulfillmentsClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/FulfillmentsClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/FulfillmentsClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/FulfillmentsClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/FulfillmentsClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/FulfillmentsClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/FulfillmentsClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/FulfillmentsClient/UpdateFulfillment/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/FulfillmentsClient/UpdateFulfillment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/GeneratorEvaluationsClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/GeneratorEvaluationsClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/GeneratorEvaluationsClient/CreateGeneratorEvaluation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/GeneratorEvaluationsClient/CreateGeneratorEvaluation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/GeneratorEvaluationsClient/DeleteGeneratorEvaluation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/GeneratorEvaluationsClient/DeleteGeneratorEvaluation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/GeneratorEvaluationsClient/GetGeneratorEvaluation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/GeneratorEvaluationsClient/GetGeneratorEvaluation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/GeneratorEvaluationsClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/GeneratorEvaluationsClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/GeneratorEvaluationsClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/GeneratorEvaluationsClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/GeneratorEvaluationsClient/ListGeneratorEvaluations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/GeneratorEvaluationsClient/ListGeneratorEvaluations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/GeneratorEvaluationsClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/GeneratorEvaluationsClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/GeneratorEvaluationsClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/GeneratorEvaluationsClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/GeneratorsClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/GeneratorsClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/GeneratorsClient/CreateGenerator/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/GeneratorsClient/CreateGenerator/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/GeneratorsClient/DeleteGenerator/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/GeneratorsClient/DeleteGenerator/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/GeneratorsClient/GetGenerator/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/GeneratorsClient/GetGenerator/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/GeneratorsClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/GeneratorsClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/GeneratorsClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/GeneratorsClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/GeneratorsClient/ListGenerators/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/GeneratorsClient/ListGenerators/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/GeneratorsClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/GeneratorsClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/GeneratorsClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/GeneratorsClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/GeneratorsClient/UpdateGenerator/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/GeneratorsClient/UpdateGenerator/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/IntentsClient/BatchDeleteIntents/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/IntentsClient/BatchDeleteIntents/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/IntentsClient/BatchUpdateIntents/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/IntentsClient/BatchUpdateIntents/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/IntentsClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/IntentsClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/IntentsClient/CreateIntent/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/IntentsClient/CreateIntent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/IntentsClient/DeleteIntent/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/IntentsClient/DeleteIntent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/IntentsClient/GetIntent/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/IntentsClient/GetIntent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/IntentsClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/IntentsClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/IntentsClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/IntentsClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/IntentsClient/ListIntents/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/IntentsClient/ListIntents/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/IntentsClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/IntentsClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/IntentsClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/IntentsClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/IntentsClient/UpdateIntent/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/IntentsClient/UpdateIntent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/KnowledgeBasesClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/KnowledgeBasesClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/KnowledgeBasesClient/CreateKnowledgeBase/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/KnowledgeBasesClient/CreateKnowledgeBase/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/KnowledgeBasesClient/DeleteKnowledgeBase/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/KnowledgeBasesClient/DeleteKnowledgeBase/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/KnowledgeBasesClient/GetKnowledgeBase/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/KnowledgeBasesClient/GetKnowledgeBase/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/KnowledgeBasesClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/KnowledgeBasesClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/KnowledgeBasesClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/KnowledgeBasesClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/KnowledgeBasesClient/ListKnowledgeBases/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/KnowledgeBasesClient/ListKnowledgeBases/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/KnowledgeBasesClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/KnowledgeBasesClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/KnowledgeBasesClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/KnowledgeBasesClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/KnowledgeBasesClient/UpdateKnowledgeBase/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/KnowledgeBasesClient/UpdateKnowledgeBase/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/ParticipantsClient/AnalyzeContent/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/ParticipantsClient/AnalyzeContent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/ParticipantsClient/BidiStreamingAnalyzeContent/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/ParticipantsClient/BidiStreamingAnalyzeContent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/ParticipantsClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/ParticipantsClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/ParticipantsClient/CompileSuggestion/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/ParticipantsClient/CompileSuggestion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/ParticipantsClient/CreateParticipant/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/ParticipantsClient/CreateParticipant/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/ParticipantsClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/ParticipantsClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/ParticipantsClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/ParticipantsClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/ParticipantsClient/GetParticipant/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/ParticipantsClient/GetParticipant/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/ParticipantsClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/ParticipantsClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/ParticipantsClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/ParticipantsClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/ParticipantsClient/ListParticipants/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/ParticipantsClient/ListParticipants/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/ParticipantsClient/ListSuggestions/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/ParticipantsClient/ListSuggestions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/ParticipantsClient/StreamingAnalyzeContent/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/ParticipantsClient/StreamingAnalyzeContent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/ParticipantsClient/SuggestArticles/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/ParticipantsClient/SuggestArticles/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/ParticipantsClient/SuggestFaqAnswers/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/ParticipantsClient/SuggestFaqAnswers/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/ParticipantsClient/SuggestKnowledgeAssist/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/ParticipantsClient/SuggestKnowledgeAssist/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/ParticipantsClient/SuggestSmartReplies/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/ParticipantsClient/SuggestSmartReplies/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/ParticipantsClient/UpdateParticipant/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/ParticipantsClient/UpdateParticipant/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/PhoneNumbersClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/PhoneNumbersClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/PhoneNumbersClient/DeletePhoneNumber/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/PhoneNumbersClient/DeletePhoneNumber/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/PhoneNumbersClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/PhoneNumbersClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/PhoneNumbersClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/PhoneNumbersClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/PhoneNumbersClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/PhoneNumbersClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/PhoneNumbersClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/PhoneNumbersClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/PhoneNumbersClient/ListPhoneNumbers/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/PhoneNumbersClient/ListPhoneNumbers/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/PhoneNumbersClient/UndeletePhoneNumber/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/PhoneNumbersClient/UndeletePhoneNumber/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/PhoneNumbersClient/UpdatePhoneNumber/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/PhoneNumbersClient/UpdatePhoneNumber/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/SessionEntityTypesClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/SessionEntityTypesClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/SessionEntityTypesClient/CreateSessionEntityType/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/SessionEntityTypesClient/CreateSessionEntityType/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/SessionEntityTypesClient/DeleteSessionEntityType/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/SessionEntityTypesClient/DeleteSessionEntityType/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/SessionEntityTypesClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/SessionEntityTypesClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/SessionEntityTypesClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/SessionEntityTypesClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/SessionEntityTypesClient/GetSessionEntityType/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/SessionEntityTypesClient/GetSessionEntityType/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/SessionEntityTypesClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/SessionEntityTypesClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/SessionEntityTypesClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/SessionEntityTypesClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/SessionEntityTypesClient/ListSessionEntityTypes/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/SessionEntityTypesClient/ListSessionEntityTypes/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/SessionEntityTypesClient/UpdateSessionEntityType/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/SessionEntityTypesClient/UpdateSessionEntityType/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/SessionsClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/SessionsClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/SessionsClient/DetectIntent/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/SessionsClient/DetectIntent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/SessionsClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/SessionsClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/SessionsClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/SessionsClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/SessionsClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/SessionsClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/SessionsClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/SessionsClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/SessionsClient/StreamingDetectIntent/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/SessionsClient/StreamingDetectIntent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/SipTrunksClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/SipTrunksClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/SipTrunksClient/CreateSipTrunk/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/SipTrunksClient/CreateSipTrunk/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/SipTrunksClient/DeleteSipTrunk/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/SipTrunksClient/DeleteSipTrunk/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/SipTrunksClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/SipTrunksClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/SipTrunksClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/SipTrunksClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/SipTrunksClient/GetSipTrunk/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/SipTrunksClient/GetSipTrunk/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/SipTrunksClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/SipTrunksClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/SipTrunksClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/SipTrunksClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/SipTrunksClient/ListSipTrunks/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/SipTrunksClient/ListSipTrunks/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/SipTrunksClient/UpdateSipTrunk/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/SipTrunksClient/UpdateSipTrunk/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/ToolsClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/ToolsClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/ToolsClient/CreateTool/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/ToolsClient/CreateTool/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/ToolsClient/DeleteTool/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/ToolsClient/DeleteTool/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/ToolsClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/ToolsClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/ToolsClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/ToolsClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/ToolsClient/GetTool/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/ToolsClient/GetTool/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/ToolsClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/ToolsClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/ToolsClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/ToolsClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/ToolsClient/ListTools/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/ToolsClient/ListTools/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/ToolsClient/UpdateTool/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/ToolsClient/UpdateTool/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/VersionsClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/VersionsClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/VersionsClient/CreateVersion/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/VersionsClient/CreateVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/VersionsClient/DeleteVersion/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/VersionsClient/DeleteVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/VersionsClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/VersionsClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/VersionsClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/VersionsClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/VersionsClient/GetVersion/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/VersionsClient/GetVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/VersionsClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/VersionsClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/VersionsClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/VersionsClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/VersionsClient/ListVersions/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/VersionsClient/ListVersions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/apiv2beta1/VersionsClient/UpdateVersion/main.go
+++ b/internal/generated/snippets/dialogflow/apiv2beta1/VersionsClient/UpdateVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/AgentsClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/AgentsClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/AgentsClient/CreateAgent/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/AgentsClient/CreateAgent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/AgentsClient/DeleteAgent/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/AgentsClient/DeleteAgent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/AgentsClient/ExportAgent/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/AgentsClient/ExportAgent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/AgentsClient/GetAgent/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/AgentsClient/GetAgent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/AgentsClient/GetAgentValidationResult/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/AgentsClient/GetAgentValidationResult/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/AgentsClient/GetGenerativeSettings/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/AgentsClient/GetGenerativeSettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/AgentsClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/AgentsClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/AgentsClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/AgentsClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/AgentsClient/ListAgents/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/AgentsClient/ListAgents/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/AgentsClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/AgentsClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/AgentsClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/AgentsClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/AgentsClient/RestoreAgent/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/AgentsClient/RestoreAgent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/AgentsClient/UpdateAgent/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/AgentsClient/UpdateAgent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/AgentsClient/UpdateGenerativeSettings/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/AgentsClient/UpdateGenerativeSettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/AgentsClient/ValidateAgent/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/AgentsClient/ValidateAgent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/ChangelogsClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/ChangelogsClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/ChangelogsClient/GetChangelog/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/ChangelogsClient/GetChangelog/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/ChangelogsClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/ChangelogsClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/ChangelogsClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/ChangelogsClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/ChangelogsClient/ListChangelogs/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/ChangelogsClient/ListChangelogs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/ChangelogsClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/ChangelogsClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/ChangelogsClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/ChangelogsClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/DeploymentsClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/DeploymentsClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/DeploymentsClient/GetDeployment/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/DeploymentsClient/GetDeployment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/DeploymentsClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/DeploymentsClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/DeploymentsClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/DeploymentsClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/DeploymentsClient/ListDeployments/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/DeploymentsClient/ListDeployments/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/DeploymentsClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/DeploymentsClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/DeploymentsClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/DeploymentsClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/EntityTypesClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/EntityTypesClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/EntityTypesClient/CreateEntityType/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/EntityTypesClient/CreateEntityType/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/EntityTypesClient/DeleteEntityType/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/EntityTypesClient/DeleteEntityType/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/EntityTypesClient/ExportEntityTypes/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/EntityTypesClient/ExportEntityTypes/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/EntityTypesClient/GetEntityType/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/EntityTypesClient/GetEntityType/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/EntityTypesClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/EntityTypesClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/EntityTypesClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/EntityTypesClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/EntityTypesClient/ImportEntityTypes/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/EntityTypesClient/ImportEntityTypes/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/EntityTypesClient/ListEntityTypes/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/EntityTypesClient/ListEntityTypes/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/EntityTypesClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/EntityTypesClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/EntityTypesClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/EntityTypesClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/EntityTypesClient/UpdateEntityType/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/EntityTypesClient/UpdateEntityType/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/EnvironmentsClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/EnvironmentsClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/EnvironmentsClient/CreateEnvironment/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/EnvironmentsClient/CreateEnvironment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/EnvironmentsClient/DeleteEnvironment/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/EnvironmentsClient/DeleteEnvironment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/EnvironmentsClient/DeployFlow/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/EnvironmentsClient/DeployFlow/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/EnvironmentsClient/GetEnvironment/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/EnvironmentsClient/GetEnvironment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/EnvironmentsClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/EnvironmentsClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/EnvironmentsClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/EnvironmentsClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/EnvironmentsClient/ListContinuousTestResults/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/EnvironmentsClient/ListContinuousTestResults/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/EnvironmentsClient/ListEnvironments/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/EnvironmentsClient/ListEnvironments/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/EnvironmentsClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/EnvironmentsClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/EnvironmentsClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/EnvironmentsClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/EnvironmentsClient/LookupEnvironmentHistory/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/EnvironmentsClient/LookupEnvironmentHistory/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/EnvironmentsClient/RunContinuousTest/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/EnvironmentsClient/RunContinuousTest/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/EnvironmentsClient/UpdateEnvironment/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/EnvironmentsClient/UpdateEnvironment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/ExperimentsClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/ExperimentsClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/ExperimentsClient/CreateExperiment/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/ExperimentsClient/CreateExperiment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/ExperimentsClient/DeleteExperiment/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/ExperimentsClient/DeleteExperiment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/ExperimentsClient/GetExperiment/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/ExperimentsClient/GetExperiment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/ExperimentsClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/ExperimentsClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/ExperimentsClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/ExperimentsClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/ExperimentsClient/ListExperiments/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/ExperimentsClient/ListExperiments/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/ExperimentsClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/ExperimentsClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/ExperimentsClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/ExperimentsClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/ExperimentsClient/StartExperiment/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/ExperimentsClient/StartExperiment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/ExperimentsClient/StopExperiment/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/ExperimentsClient/StopExperiment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/ExperimentsClient/UpdateExperiment/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/ExperimentsClient/UpdateExperiment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/FlowsClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/FlowsClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/FlowsClient/CreateFlow/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/FlowsClient/CreateFlow/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/FlowsClient/DeleteFlow/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/FlowsClient/DeleteFlow/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/FlowsClient/ExportFlow/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/FlowsClient/ExportFlow/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/FlowsClient/GetFlow/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/FlowsClient/GetFlow/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/FlowsClient/GetFlowValidationResult/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/FlowsClient/GetFlowValidationResult/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/FlowsClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/FlowsClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/FlowsClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/FlowsClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/FlowsClient/ImportFlow/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/FlowsClient/ImportFlow/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/FlowsClient/ListFlows/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/FlowsClient/ListFlows/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/FlowsClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/FlowsClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/FlowsClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/FlowsClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/FlowsClient/TrainFlow/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/FlowsClient/TrainFlow/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/FlowsClient/UpdateFlow/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/FlowsClient/UpdateFlow/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/FlowsClient/ValidateFlow/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/FlowsClient/ValidateFlow/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/GeneratorsClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/GeneratorsClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/GeneratorsClient/CreateGenerator/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/GeneratorsClient/CreateGenerator/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/GeneratorsClient/DeleteGenerator/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/GeneratorsClient/DeleteGenerator/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/GeneratorsClient/GetGenerator/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/GeneratorsClient/GetGenerator/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/GeneratorsClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/GeneratorsClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/GeneratorsClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/GeneratorsClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/GeneratorsClient/ListGenerators/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/GeneratorsClient/ListGenerators/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/GeneratorsClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/GeneratorsClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/GeneratorsClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/GeneratorsClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/GeneratorsClient/UpdateGenerator/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/GeneratorsClient/UpdateGenerator/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/IntentsClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/IntentsClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/IntentsClient/CreateIntent/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/IntentsClient/CreateIntent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/IntentsClient/DeleteIntent/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/IntentsClient/DeleteIntent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/IntentsClient/ExportIntents/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/IntentsClient/ExportIntents/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/IntentsClient/GetIntent/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/IntentsClient/GetIntent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/IntentsClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/IntentsClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/IntentsClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/IntentsClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/IntentsClient/ImportIntents/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/IntentsClient/ImportIntents/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/IntentsClient/ListIntents/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/IntentsClient/ListIntents/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/IntentsClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/IntentsClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/IntentsClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/IntentsClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/IntentsClient/UpdateIntent/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/IntentsClient/UpdateIntent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/PagesClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/PagesClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/PagesClient/CreatePage/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/PagesClient/CreatePage/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/PagesClient/DeletePage/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/PagesClient/DeletePage/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/PagesClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/PagesClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/PagesClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/PagesClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/PagesClient/GetPage/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/PagesClient/GetPage/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/PagesClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/PagesClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/PagesClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/PagesClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/PagesClient/ListPages/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/PagesClient/ListPages/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/PagesClient/UpdatePage/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/PagesClient/UpdatePage/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/SecuritySettingsClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/SecuritySettingsClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/SecuritySettingsClient/CreateSecuritySettings/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/SecuritySettingsClient/CreateSecuritySettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/SecuritySettingsClient/DeleteSecuritySettings/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/SecuritySettingsClient/DeleteSecuritySettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/SecuritySettingsClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/SecuritySettingsClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/SecuritySettingsClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/SecuritySettingsClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/SecuritySettingsClient/GetSecuritySettings/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/SecuritySettingsClient/GetSecuritySettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/SecuritySettingsClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/SecuritySettingsClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/SecuritySettingsClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/SecuritySettingsClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/SecuritySettingsClient/ListSecuritySettings/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/SecuritySettingsClient/ListSecuritySettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/SecuritySettingsClient/UpdateSecuritySettings/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/SecuritySettingsClient/UpdateSecuritySettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/SessionEntityTypesClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/SessionEntityTypesClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/SessionEntityTypesClient/CreateSessionEntityType/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/SessionEntityTypesClient/CreateSessionEntityType/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/SessionEntityTypesClient/DeleteSessionEntityType/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/SessionEntityTypesClient/DeleteSessionEntityType/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/SessionEntityTypesClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/SessionEntityTypesClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/SessionEntityTypesClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/SessionEntityTypesClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/SessionEntityTypesClient/GetSessionEntityType/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/SessionEntityTypesClient/GetSessionEntityType/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/SessionEntityTypesClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/SessionEntityTypesClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/SessionEntityTypesClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/SessionEntityTypesClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/SessionEntityTypesClient/ListSessionEntityTypes/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/SessionEntityTypesClient/ListSessionEntityTypes/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/SessionEntityTypesClient/UpdateSessionEntityType/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/SessionEntityTypesClient/UpdateSessionEntityType/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/SessionsClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/SessionsClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/SessionsClient/DetectIntent/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/SessionsClient/DetectIntent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/SessionsClient/FulfillIntent/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/SessionsClient/FulfillIntent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/SessionsClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/SessionsClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/SessionsClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/SessionsClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/SessionsClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/SessionsClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/SessionsClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/SessionsClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/SessionsClient/MatchIntent/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/SessionsClient/MatchIntent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/SessionsClient/StreamingDetectIntent/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/SessionsClient/StreamingDetectIntent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/SessionsClient/SubmitAnswerFeedback/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/SessionsClient/SubmitAnswerFeedback/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/TestCasesClient/BatchDeleteTestCases/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/TestCasesClient/BatchDeleteTestCases/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/TestCasesClient/BatchRunTestCases/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/TestCasesClient/BatchRunTestCases/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/TestCasesClient/CalculateCoverage/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/TestCasesClient/CalculateCoverage/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/TestCasesClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/TestCasesClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/TestCasesClient/CreateTestCase/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/TestCasesClient/CreateTestCase/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/TestCasesClient/ExportTestCases/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/TestCasesClient/ExportTestCases/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/TestCasesClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/TestCasesClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/TestCasesClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/TestCasesClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/TestCasesClient/GetTestCase/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/TestCasesClient/GetTestCase/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/TestCasesClient/GetTestCaseResult/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/TestCasesClient/GetTestCaseResult/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/TestCasesClient/ImportTestCases/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/TestCasesClient/ImportTestCases/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/TestCasesClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/TestCasesClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/TestCasesClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/TestCasesClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/TestCasesClient/ListTestCaseResults/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/TestCasesClient/ListTestCaseResults/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/TestCasesClient/ListTestCases/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/TestCasesClient/ListTestCases/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/TestCasesClient/RunTestCase/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/TestCasesClient/RunTestCase/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/TestCasesClient/UpdateTestCase/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/TestCasesClient/UpdateTestCase/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/TransitionRouteGroupsClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/TransitionRouteGroupsClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/TransitionRouteGroupsClient/CreateTransitionRouteGroup/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/TransitionRouteGroupsClient/CreateTransitionRouteGroup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/TransitionRouteGroupsClient/DeleteTransitionRouteGroup/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/TransitionRouteGroupsClient/DeleteTransitionRouteGroup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/TransitionRouteGroupsClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/TransitionRouteGroupsClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/TransitionRouteGroupsClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/TransitionRouteGroupsClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/TransitionRouteGroupsClient/GetTransitionRouteGroup/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/TransitionRouteGroupsClient/GetTransitionRouteGroup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/TransitionRouteGroupsClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/TransitionRouteGroupsClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/TransitionRouteGroupsClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/TransitionRouteGroupsClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/TransitionRouteGroupsClient/ListTransitionRouteGroups/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/TransitionRouteGroupsClient/ListTransitionRouteGroups/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/TransitionRouteGroupsClient/UpdateTransitionRouteGroup/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/TransitionRouteGroupsClient/UpdateTransitionRouteGroup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/VersionsClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/VersionsClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/VersionsClient/CompareVersions/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/VersionsClient/CompareVersions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/VersionsClient/CreateVersion/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/VersionsClient/CreateVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/VersionsClient/DeleteVersion/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/VersionsClient/DeleteVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/VersionsClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/VersionsClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/VersionsClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/VersionsClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/VersionsClient/GetVersion/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/VersionsClient/GetVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/VersionsClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/VersionsClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/VersionsClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/VersionsClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/VersionsClient/ListVersions/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/VersionsClient/ListVersions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/VersionsClient/LoadVersion/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/VersionsClient/LoadVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/VersionsClient/UpdateVersion/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/VersionsClient/UpdateVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/WebhooksClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/WebhooksClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/WebhooksClient/CreateWebhook/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/WebhooksClient/CreateWebhook/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/WebhooksClient/DeleteWebhook/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/WebhooksClient/DeleteWebhook/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/WebhooksClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/WebhooksClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/WebhooksClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/WebhooksClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/WebhooksClient/GetWebhook/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/WebhooksClient/GetWebhook/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/WebhooksClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/WebhooksClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/WebhooksClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/WebhooksClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/WebhooksClient/ListWebhooks/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/WebhooksClient/ListWebhooks/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3/WebhooksClient/UpdateWebhook/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3/WebhooksClient/UpdateWebhook/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/AgentsClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/AgentsClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/AgentsClient/CreateAgent/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/AgentsClient/CreateAgent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/AgentsClient/DeleteAgent/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/AgentsClient/DeleteAgent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/AgentsClient/ExportAgent/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/AgentsClient/ExportAgent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/AgentsClient/GetAgent/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/AgentsClient/GetAgent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/AgentsClient/GetAgentValidationResult/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/AgentsClient/GetAgentValidationResult/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/AgentsClient/GetGenerativeSettings/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/AgentsClient/GetGenerativeSettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/AgentsClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/AgentsClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/AgentsClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/AgentsClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/AgentsClient/ListAgents/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/AgentsClient/ListAgents/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/AgentsClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/AgentsClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/AgentsClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/AgentsClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/AgentsClient/RestoreAgent/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/AgentsClient/RestoreAgent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/AgentsClient/UpdateAgent/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/AgentsClient/UpdateAgent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/AgentsClient/UpdateGenerativeSettings/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/AgentsClient/UpdateGenerativeSettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/AgentsClient/ValidateAgent/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/AgentsClient/ValidateAgent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/ChangelogsClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/ChangelogsClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/ChangelogsClient/GetChangelog/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/ChangelogsClient/GetChangelog/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/ChangelogsClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/ChangelogsClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/ChangelogsClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/ChangelogsClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/ChangelogsClient/ListChangelogs/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/ChangelogsClient/ListChangelogs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/ChangelogsClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/ChangelogsClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/ChangelogsClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/ChangelogsClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/ConversationHistoryClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/ConversationHistoryClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/ConversationHistoryClient/DeleteConversation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/ConversationHistoryClient/DeleteConversation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/ConversationHistoryClient/GetConversation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/ConversationHistoryClient/GetConversation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/ConversationHistoryClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/ConversationHistoryClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/ConversationHistoryClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/ConversationHistoryClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/ConversationHistoryClient/ListConversations/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/ConversationHistoryClient/ListConversations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/ConversationHistoryClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/ConversationHistoryClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/ConversationHistoryClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/ConversationHistoryClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/DeploymentsClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/DeploymentsClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/DeploymentsClient/GetDeployment/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/DeploymentsClient/GetDeployment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/DeploymentsClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/DeploymentsClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/DeploymentsClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/DeploymentsClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/DeploymentsClient/ListDeployments/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/DeploymentsClient/ListDeployments/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/DeploymentsClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/DeploymentsClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/DeploymentsClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/DeploymentsClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/EntityTypesClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/EntityTypesClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/EntityTypesClient/CreateEntityType/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/EntityTypesClient/CreateEntityType/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/EntityTypesClient/DeleteEntityType/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/EntityTypesClient/DeleteEntityType/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/EntityTypesClient/ExportEntityTypes/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/EntityTypesClient/ExportEntityTypes/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/EntityTypesClient/GetEntityType/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/EntityTypesClient/GetEntityType/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/EntityTypesClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/EntityTypesClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/EntityTypesClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/EntityTypesClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/EntityTypesClient/ImportEntityTypes/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/EntityTypesClient/ImportEntityTypes/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/EntityTypesClient/ListEntityTypes/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/EntityTypesClient/ListEntityTypes/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/EntityTypesClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/EntityTypesClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/EntityTypesClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/EntityTypesClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/EntityTypesClient/UpdateEntityType/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/EntityTypesClient/UpdateEntityType/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/EnvironmentsClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/EnvironmentsClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/EnvironmentsClient/CreateEnvironment/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/EnvironmentsClient/CreateEnvironment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/EnvironmentsClient/DeleteEnvironment/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/EnvironmentsClient/DeleteEnvironment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/EnvironmentsClient/DeployFlow/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/EnvironmentsClient/DeployFlow/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/EnvironmentsClient/GetEnvironment/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/EnvironmentsClient/GetEnvironment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/EnvironmentsClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/EnvironmentsClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/EnvironmentsClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/EnvironmentsClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/EnvironmentsClient/ListContinuousTestResults/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/EnvironmentsClient/ListContinuousTestResults/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/EnvironmentsClient/ListEnvironments/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/EnvironmentsClient/ListEnvironments/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/EnvironmentsClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/EnvironmentsClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/EnvironmentsClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/EnvironmentsClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/EnvironmentsClient/LookupEnvironmentHistory/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/EnvironmentsClient/LookupEnvironmentHistory/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/EnvironmentsClient/RunContinuousTest/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/EnvironmentsClient/RunContinuousTest/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/EnvironmentsClient/UpdateEnvironment/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/EnvironmentsClient/UpdateEnvironment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/ExamplesClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/ExamplesClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/ExamplesClient/CreateExample/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/ExamplesClient/CreateExample/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/ExamplesClient/DeleteExample/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/ExamplesClient/DeleteExample/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/ExamplesClient/GetExample/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/ExamplesClient/GetExample/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/ExamplesClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/ExamplesClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/ExamplesClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/ExamplesClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/ExamplesClient/ListExamples/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/ExamplesClient/ListExamples/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/ExamplesClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/ExamplesClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/ExamplesClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/ExamplesClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/ExamplesClient/UpdateExample/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/ExamplesClient/UpdateExample/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/ExperimentsClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/ExperimentsClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/ExperimentsClient/CreateExperiment/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/ExperimentsClient/CreateExperiment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/ExperimentsClient/DeleteExperiment/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/ExperimentsClient/DeleteExperiment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/ExperimentsClient/GetExperiment/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/ExperimentsClient/GetExperiment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/ExperimentsClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/ExperimentsClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/ExperimentsClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/ExperimentsClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/ExperimentsClient/ListExperiments/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/ExperimentsClient/ListExperiments/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/ExperimentsClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/ExperimentsClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/ExperimentsClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/ExperimentsClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/ExperimentsClient/StartExperiment/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/ExperimentsClient/StartExperiment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/ExperimentsClient/StopExperiment/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/ExperimentsClient/StopExperiment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/ExperimentsClient/UpdateExperiment/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/ExperimentsClient/UpdateExperiment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/FlowsClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/FlowsClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/FlowsClient/CreateFlow/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/FlowsClient/CreateFlow/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/FlowsClient/DeleteFlow/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/FlowsClient/DeleteFlow/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/FlowsClient/ExportFlow/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/FlowsClient/ExportFlow/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/FlowsClient/GetFlow/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/FlowsClient/GetFlow/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/FlowsClient/GetFlowValidationResult/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/FlowsClient/GetFlowValidationResult/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/FlowsClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/FlowsClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/FlowsClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/FlowsClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/FlowsClient/ImportFlow/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/FlowsClient/ImportFlow/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/FlowsClient/ListFlows/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/FlowsClient/ListFlows/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/FlowsClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/FlowsClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/FlowsClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/FlowsClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/FlowsClient/TrainFlow/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/FlowsClient/TrainFlow/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/FlowsClient/UpdateFlow/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/FlowsClient/UpdateFlow/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/FlowsClient/ValidateFlow/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/FlowsClient/ValidateFlow/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/GeneratorsClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/GeneratorsClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/GeneratorsClient/CreateGenerator/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/GeneratorsClient/CreateGenerator/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/GeneratorsClient/DeleteGenerator/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/GeneratorsClient/DeleteGenerator/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/GeneratorsClient/GetGenerator/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/GeneratorsClient/GetGenerator/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/GeneratorsClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/GeneratorsClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/GeneratorsClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/GeneratorsClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/GeneratorsClient/ListGenerators/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/GeneratorsClient/ListGenerators/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/GeneratorsClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/GeneratorsClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/GeneratorsClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/GeneratorsClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/GeneratorsClient/UpdateGenerator/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/GeneratorsClient/UpdateGenerator/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/IntentsClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/IntentsClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/IntentsClient/CreateIntent/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/IntentsClient/CreateIntent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/IntentsClient/DeleteIntent/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/IntentsClient/DeleteIntent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/IntentsClient/ExportIntents/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/IntentsClient/ExportIntents/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/IntentsClient/GetIntent/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/IntentsClient/GetIntent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/IntentsClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/IntentsClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/IntentsClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/IntentsClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/IntentsClient/ImportIntents/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/IntentsClient/ImportIntents/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/IntentsClient/ListIntents/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/IntentsClient/ListIntents/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/IntentsClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/IntentsClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/IntentsClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/IntentsClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/IntentsClient/UpdateIntent/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/IntentsClient/UpdateIntent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/PagesClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/PagesClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/PagesClient/CreatePage/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/PagesClient/CreatePage/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/PagesClient/DeletePage/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/PagesClient/DeletePage/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/PagesClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/PagesClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/PagesClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/PagesClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/PagesClient/GetPage/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/PagesClient/GetPage/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/PagesClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/PagesClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/PagesClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/PagesClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/PagesClient/ListPages/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/PagesClient/ListPages/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/PagesClient/UpdatePage/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/PagesClient/UpdatePage/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/PlaybooksClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/PlaybooksClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/PlaybooksClient/CreatePlaybook/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/PlaybooksClient/CreatePlaybook/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/PlaybooksClient/CreatePlaybookVersion/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/PlaybooksClient/CreatePlaybookVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/PlaybooksClient/DeletePlaybook/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/PlaybooksClient/DeletePlaybook/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/PlaybooksClient/DeletePlaybookVersion/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/PlaybooksClient/DeletePlaybookVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/PlaybooksClient/ExportPlaybook/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/PlaybooksClient/ExportPlaybook/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/PlaybooksClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/PlaybooksClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/PlaybooksClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/PlaybooksClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/PlaybooksClient/GetPlaybook/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/PlaybooksClient/GetPlaybook/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/PlaybooksClient/GetPlaybookVersion/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/PlaybooksClient/GetPlaybookVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/PlaybooksClient/ImportPlaybook/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/PlaybooksClient/ImportPlaybook/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/PlaybooksClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/PlaybooksClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/PlaybooksClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/PlaybooksClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/PlaybooksClient/ListPlaybookVersions/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/PlaybooksClient/ListPlaybookVersions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/PlaybooksClient/ListPlaybooks/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/PlaybooksClient/ListPlaybooks/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/PlaybooksClient/RestorePlaybookVersion/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/PlaybooksClient/RestorePlaybookVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/PlaybooksClient/UpdatePlaybook/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/PlaybooksClient/UpdatePlaybook/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/SecuritySettingsClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/SecuritySettingsClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/SecuritySettingsClient/CreateSecuritySettings/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/SecuritySettingsClient/CreateSecuritySettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/SecuritySettingsClient/DeleteSecuritySettings/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/SecuritySettingsClient/DeleteSecuritySettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/SecuritySettingsClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/SecuritySettingsClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/SecuritySettingsClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/SecuritySettingsClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/SecuritySettingsClient/GetSecuritySettings/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/SecuritySettingsClient/GetSecuritySettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/SecuritySettingsClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/SecuritySettingsClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/SecuritySettingsClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/SecuritySettingsClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/SecuritySettingsClient/ListSecuritySettings/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/SecuritySettingsClient/ListSecuritySettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/SecuritySettingsClient/UpdateSecuritySettings/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/SecuritySettingsClient/UpdateSecuritySettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/SessionEntityTypesClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/SessionEntityTypesClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/SessionEntityTypesClient/CreateSessionEntityType/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/SessionEntityTypesClient/CreateSessionEntityType/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/SessionEntityTypesClient/DeleteSessionEntityType/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/SessionEntityTypesClient/DeleteSessionEntityType/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/SessionEntityTypesClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/SessionEntityTypesClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/SessionEntityTypesClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/SessionEntityTypesClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/SessionEntityTypesClient/GetSessionEntityType/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/SessionEntityTypesClient/GetSessionEntityType/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/SessionEntityTypesClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/SessionEntityTypesClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/SessionEntityTypesClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/SessionEntityTypesClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/SessionEntityTypesClient/ListSessionEntityTypes/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/SessionEntityTypesClient/ListSessionEntityTypes/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/SessionEntityTypesClient/UpdateSessionEntityType/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/SessionEntityTypesClient/UpdateSessionEntityType/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/SessionsClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/SessionsClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/SessionsClient/DetectIntent/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/SessionsClient/DetectIntent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/SessionsClient/FulfillIntent/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/SessionsClient/FulfillIntent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/SessionsClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/SessionsClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/SessionsClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/SessionsClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/SessionsClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/SessionsClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/SessionsClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/SessionsClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/SessionsClient/MatchIntent/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/SessionsClient/MatchIntent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/SessionsClient/StreamingDetectIntent/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/SessionsClient/StreamingDetectIntent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/SessionsClient/SubmitAnswerFeedback/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/SessionsClient/SubmitAnswerFeedback/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/TestCasesClient/BatchDeleteTestCases/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/TestCasesClient/BatchDeleteTestCases/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/TestCasesClient/BatchRunTestCases/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/TestCasesClient/BatchRunTestCases/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/TestCasesClient/CalculateCoverage/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/TestCasesClient/CalculateCoverage/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/TestCasesClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/TestCasesClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/TestCasesClient/CreateTestCase/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/TestCasesClient/CreateTestCase/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/TestCasesClient/ExportTestCases/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/TestCasesClient/ExportTestCases/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/TestCasesClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/TestCasesClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/TestCasesClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/TestCasesClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/TestCasesClient/GetTestCase/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/TestCasesClient/GetTestCase/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/TestCasesClient/GetTestCaseResult/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/TestCasesClient/GetTestCaseResult/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/TestCasesClient/ImportTestCases/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/TestCasesClient/ImportTestCases/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/TestCasesClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/TestCasesClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/TestCasesClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/TestCasesClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/TestCasesClient/ListTestCaseResults/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/TestCasesClient/ListTestCaseResults/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/TestCasesClient/ListTestCases/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/TestCasesClient/ListTestCases/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/TestCasesClient/RunTestCase/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/TestCasesClient/RunTestCase/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/TestCasesClient/UpdateTestCase/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/TestCasesClient/UpdateTestCase/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/ToolsClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/ToolsClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/ToolsClient/CreateTool/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/ToolsClient/CreateTool/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/ToolsClient/CreateToolVersion/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/ToolsClient/CreateToolVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/ToolsClient/DeleteTool/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/ToolsClient/DeleteTool/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/ToolsClient/DeleteToolVersion/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/ToolsClient/DeleteToolVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/ToolsClient/ExportTools/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/ToolsClient/ExportTools/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/ToolsClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/ToolsClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/ToolsClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/ToolsClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/ToolsClient/GetTool/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/ToolsClient/GetTool/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/ToolsClient/GetToolVersion/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/ToolsClient/GetToolVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/ToolsClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/ToolsClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/ToolsClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/ToolsClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/ToolsClient/ListToolVersions/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/ToolsClient/ListToolVersions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/ToolsClient/ListTools/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/ToolsClient/ListTools/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/ToolsClient/RestoreToolVersion/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/ToolsClient/RestoreToolVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/ToolsClient/UpdateTool/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/ToolsClient/UpdateTool/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/TransitionRouteGroupsClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/TransitionRouteGroupsClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/TransitionRouteGroupsClient/CreateTransitionRouteGroup/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/TransitionRouteGroupsClient/CreateTransitionRouteGroup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/TransitionRouteGroupsClient/DeleteTransitionRouteGroup/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/TransitionRouteGroupsClient/DeleteTransitionRouteGroup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/TransitionRouteGroupsClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/TransitionRouteGroupsClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/TransitionRouteGroupsClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/TransitionRouteGroupsClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/TransitionRouteGroupsClient/GetTransitionRouteGroup/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/TransitionRouteGroupsClient/GetTransitionRouteGroup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/TransitionRouteGroupsClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/TransitionRouteGroupsClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/TransitionRouteGroupsClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/TransitionRouteGroupsClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/TransitionRouteGroupsClient/ListTransitionRouteGroups/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/TransitionRouteGroupsClient/ListTransitionRouteGroups/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/TransitionRouteGroupsClient/UpdateTransitionRouteGroup/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/TransitionRouteGroupsClient/UpdateTransitionRouteGroup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/VersionsClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/VersionsClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/VersionsClient/CompareVersions/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/VersionsClient/CompareVersions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/VersionsClient/CreateVersion/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/VersionsClient/CreateVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/VersionsClient/DeleteVersion/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/VersionsClient/DeleteVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/VersionsClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/VersionsClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/VersionsClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/VersionsClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/VersionsClient/GetVersion/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/VersionsClient/GetVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/VersionsClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/VersionsClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/VersionsClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/VersionsClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/VersionsClient/ListVersions/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/VersionsClient/ListVersions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/VersionsClient/LoadVersion/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/VersionsClient/LoadVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/VersionsClient/UpdateVersion/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/VersionsClient/UpdateVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/WebhooksClient/CancelOperation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/WebhooksClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/WebhooksClient/CreateWebhook/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/WebhooksClient/CreateWebhook/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/WebhooksClient/DeleteWebhook/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/WebhooksClient/DeleteWebhook/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/WebhooksClient/GetLocation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/WebhooksClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/WebhooksClient/GetOperation/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/WebhooksClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/WebhooksClient/GetWebhook/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/WebhooksClient/GetWebhook/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/WebhooksClient/ListLocations/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/WebhooksClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/WebhooksClient/ListOperations/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/WebhooksClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/WebhooksClient/ListWebhooks/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/WebhooksClient/ListWebhooks/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dialogflow/cx/apiv3beta1/WebhooksClient/UpdateWebhook/main.go
+++ b/internal/generated/snippets/dialogflow/cx/apiv3beta1/WebhooksClient/UpdateWebhook/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/AssistantClient/CancelOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/AssistantClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/AssistantClient/GetOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/AssistantClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/AssistantClient/ListOperations/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/AssistantClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/CmekConfigClient/CancelOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/CmekConfigClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/CmekConfigClient/DeleteCmekConfig/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/CmekConfigClient/DeleteCmekConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/CmekConfigClient/GetCmekConfig/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/CmekConfigClient/GetCmekConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/CmekConfigClient/GetOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/CmekConfigClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/CmekConfigClient/ListCmekConfigs/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/CmekConfigClient/ListCmekConfigs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/CmekConfigClient/ListOperations/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/CmekConfigClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/CmekConfigClient/UpdateCmekConfig/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/CmekConfigClient/UpdateCmekConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/CompletionClient/CancelOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/CompletionClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/CompletionClient/CompleteQuery/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/CompletionClient/CompleteQuery/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/CompletionClient/GetOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/CompletionClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/CompletionClient/ImportCompletionSuggestions/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/CompletionClient/ImportCompletionSuggestions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/CompletionClient/ImportSuggestionDenyListEntries/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/CompletionClient/ImportSuggestionDenyListEntries/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/CompletionClient/ListOperations/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/CompletionClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/CompletionClient/PurgeCompletionSuggestions/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/CompletionClient/PurgeCompletionSuggestions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/CompletionClient/PurgeSuggestionDenyListEntries/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/CompletionClient/PurgeSuggestionDenyListEntries/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/ControlClient/CancelOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/ControlClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/ControlClient/CreateControl/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/ControlClient/CreateControl/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/ControlClient/DeleteControl/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/ControlClient/DeleteControl/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/ControlClient/GetControl/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/ControlClient/GetControl/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/ControlClient/GetOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/ControlClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/ControlClient/ListControls/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/ControlClient/ListControls/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/ControlClient/ListOperations/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/ControlClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/ControlClient/UpdateControl/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/ControlClient/UpdateControl/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/ConversationalSearchClient/AnswerQuery/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/ConversationalSearchClient/AnswerQuery/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/ConversationalSearchClient/CancelOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/ConversationalSearchClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/ConversationalSearchClient/ConverseConversation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/ConversationalSearchClient/ConverseConversation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/ConversationalSearchClient/CreateConversation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/ConversationalSearchClient/CreateConversation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/ConversationalSearchClient/CreateSession/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/ConversationalSearchClient/CreateSession/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/ConversationalSearchClient/DeleteConversation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/ConversationalSearchClient/DeleteConversation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/ConversationalSearchClient/DeleteSession/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/ConversationalSearchClient/DeleteSession/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/ConversationalSearchClient/GetAnswer/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/ConversationalSearchClient/GetAnswer/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/ConversationalSearchClient/GetConversation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/ConversationalSearchClient/GetConversation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/ConversationalSearchClient/GetOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/ConversationalSearchClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/ConversationalSearchClient/GetSession/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/ConversationalSearchClient/GetSession/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/ConversationalSearchClient/ListConversations/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/ConversationalSearchClient/ListConversations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/ConversationalSearchClient/ListOperations/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/ConversationalSearchClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/ConversationalSearchClient/ListSessions/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/ConversationalSearchClient/ListSessions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/ConversationalSearchClient/UpdateConversation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/ConversationalSearchClient/UpdateConversation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/ConversationalSearchClient/UpdateSession/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/ConversationalSearchClient/UpdateSession/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/DataStoreClient/CancelOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/DataStoreClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/DataStoreClient/CreateDataStore/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/DataStoreClient/CreateDataStore/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/DataStoreClient/DeleteDataStore/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/DataStoreClient/DeleteDataStore/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/DataStoreClient/GetDataStore/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/DataStoreClient/GetDataStore/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/DataStoreClient/GetOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/DataStoreClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/DataStoreClient/ListDataStores/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/DataStoreClient/ListDataStores/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/DataStoreClient/ListOperations/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/DataStoreClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/DataStoreClient/UpdateDataStore/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/DataStoreClient/UpdateDataStore/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/DocumentClient/BatchGetDocumentsMetadata/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/DocumentClient/BatchGetDocumentsMetadata/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/DocumentClient/CancelOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/DocumentClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/DocumentClient/CreateDocument/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/DocumentClient/CreateDocument/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/DocumentClient/DeleteDocument/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/DocumentClient/DeleteDocument/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/DocumentClient/GetDocument/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/DocumentClient/GetDocument/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/DocumentClient/GetOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/DocumentClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/DocumentClient/ImportDocuments/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/DocumentClient/ImportDocuments/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/DocumentClient/ListDocuments/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/DocumentClient/ListDocuments/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/DocumentClient/ListOperations/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/DocumentClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/DocumentClient/PurgeDocuments/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/DocumentClient/PurgeDocuments/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/DocumentClient/UpdateDocument/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/DocumentClient/UpdateDocument/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/EngineClient/CancelOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/EngineClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/EngineClient/CreateEngine/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/EngineClient/CreateEngine/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/EngineClient/DeleteEngine/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/EngineClient/DeleteEngine/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/EngineClient/GetEngine/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/EngineClient/GetEngine/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/EngineClient/GetOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/EngineClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/EngineClient/ListEngines/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/EngineClient/ListEngines/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/EngineClient/ListOperations/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/EngineClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/EngineClient/UpdateEngine/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/EngineClient/UpdateEngine/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/GroundedGenerationClient/CancelOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/GroundedGenerationClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/GroundedGenerationClient/CheckGrounding/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/GroundedGenerationClient/CheckGrounding/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/GroundedGenerationClient/GenerateGroundedContent/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/GroundedGenerationClient/GenerateGroundedContent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/GroundedGenerationClient/GetOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/GroundedGenerationClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/GroundedGenerationClient/ListOperations/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/GroundedGenerationClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/GroundedGenerationClient/StreamGenerateGroundedContent/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/GroundedGenerationClient/StreamGenerateGroundedContent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/IdentityMappingStoreClient/CancelOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/IdentityMappingStoreClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/IdentityMappingStoreClient/CreateIdentityMappingStore/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/IdentityMappingStoreClient/CreateIdentityMappingStore/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/IdentityMappingStoreClient/DeleteIdentityMappingStore/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/IdentityMappingStoreClient/DeleteIdentityMappingStore/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/IdentityMappingStoreClient/GetIdentityMappingStore/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/IdentityMappingStoreClient/GetIdentityMappingStore/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/IdentityMappingStoreClient/GetOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/IdentityMappingStoreClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/IdentityMappingStoreClient/ImportIdentityMappings/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/IdentityMappingStoreClient/ImportIdentityMappings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/IdentityMappingStoreClient/ListIdentityMappingStores/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/IdentityMappingStoreClient/ListIdentityMappingStores/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/IdentityMappingStoreClient/ListIdentityMappings/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/IdentityMappingStoreClient/ListIdentityMappings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/IdentityMappingStoreClient/ListOperations/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/IdentityMappingStoreClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/IdentityMappingStoreClient/PurgeIdentityMappings/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/IdentityMappingStoreClient/PurgeIdentityMappings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/ProjectClient/CancelOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/ProjectClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/ProjectClient/GetOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/ProjectClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/ProjectClient/ListOperations/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/ProjectClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/ProjectClient/ProvisionProject/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/ProjectClient/ProvisionProject/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/RankClient/CancelOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/RankClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/RankClient/GetOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/RankClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/RankClient/ListOperations/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/RankClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/RankClient/Rank/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/RankClient/Rank/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/RecommendationClient/CancelOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/RecommendationClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/RecommendationClient/GetOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/RecommendationClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/RecommendationClient/ListOperations/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/RecommendationClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/RecommendationClient/Recommend/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/RecommendationClient/Recommend/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/SchemaClient/CancelOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/SchemaClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/SchemaClient/CreateSchema/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/SchemaClient/CreateSchema/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/SchemaClient/DeleteSchema/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/SchemaClient/DeleteSchema/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/SchemaClient/GetOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/SchemaClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/SchemaClient/GetSchema/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/SchemaClient/GetSchema/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/SchemaClient/ListOperations/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/SchemaClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/SchemaClient/ListSchemas/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/SchemaClient/ListSchemas/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/SchemaClient/UpdateSchema/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/SchemaClient/UpdateSchema/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/SearchClient/CancelOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/SearchClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/SearchClient/GetOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/SearchClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/SearchClient/ListOperations/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/SearchClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/SearchClient/Search/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/SearchClient/Search/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/SearchClient/SearchLite/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/SearchClient/SearchLite/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/SearchTuningClient/CancelOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/SearchTuningClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/SearchTuningClient/GetOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/SearchTuningClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/SearchTuningClient/ListCustomModels/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/SearchTuningClient/ListCustomModels/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/SearchTuningClient/ListOperations/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/SearchTuningClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/SearchTuningClient/TrainCustomModel/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/SearchTuningClient/TrainCustomModel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/ServingConfigClient/CancelOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/ServingConfigClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/ServingConfigClient/GetOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/ServingConfigClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/ServingConfigClient/ListOperations/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/ServingConfigClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/ServingConfigClient/UpdateServingConfig/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/ServingConfigClient/UpdateServingConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/SessionClient/CancelOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/SessionClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/SessionClient/CreateSession/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/SessionClient/CreateSession/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/SessionClient/DeleteSession/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/SessionClient/DeleteSession/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/SessionClient/GetOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/SessionClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/SessionClient/GetSession/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/SessionClient/GetSession/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/SessionClient/ListOperations/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/SessionClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/SessionClient/ListSessions/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/SessionClient/ListSessions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/SessionClient/UpdateSession/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/SessionClient/UpdateSession/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/SiteSearchEngineClient/BatchCreateTargetSites/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/SiteSearchEngineClient/BatchCreateTargetSites/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/SiteSearchEngineClient/BatchVerifyTargetSites/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/SiteSearchEngineClient/BatchVerifyTargetSites/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/SiteSearchEngineClient/CancelOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/SiteSearchEngineClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/SiteSearchEngineClient/CreateSitemap/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/SiteSearchEngineClient/CreateSitemap/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/SiteSearchEngineClient/CreateTargetSite/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/SiteSearchEngineClient/CreateTargetSite/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/SiteSearchEngineClient/DeleteSitemap/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/SiteSearchEngineClient/DeleteSitemap/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/SiteSearchEngineClient/DeleteTargetSite/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/SiteSearchEngineClient/DeleteTargetSite/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/SiteSearchEngineClient/DisableAdvancedSiteSearch/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/SiteSearchEngineClient/DisableAdvancedSiteSearch/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/SiteSearchEngineClient/EnableAdvancedSiteSearch/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/SiteSearchEngineClient/EnableAdvancedSiteSearch/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/SiteSearchEngineClient/FetchDomainVerificationStatus/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/SiteSearchEngineClient/FetchDomainVerificationStatus/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/SiteSearchEngineClient/FetchSitemaps/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/SiteSearchEngineClient/FetchSitemaps/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/SiteSearchEngineClient/GetOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/SiteSearchEngineClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/SiteSearchEngineClient/GetSiteSearchEngine/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/SiteSearchEngineClient/GetSiteSearchEngine/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/SiteSearchEngineClient/GetTargetSite/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/SiteSearchEngineClient/GetTargetSite/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/SiteSearchEngineClient/ListOperations/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/SiteSearchEngineClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/SiteSearchEngineClient/ListTargetSites/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/SiteSearchEngineClient/ListTargetSites/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/SiteSearchEngineClient/RecrawlUris/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/SiteSearchEngineClient/RecrawlUris/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/SiteSearchEngineClient/UpdateTargetSite/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/SiteSearchEngineClient/UpdateTargetSite/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/UserEventClient/CancelOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/UserEventClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/UserEventClient/CollectUserEvent/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/UserEventClient/CollectUserEvent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/UserEventClient/GetOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/UserEventClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/UserEventClient/ImportUserEvents/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/UserEventClient/ImportUserEvents/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/UserEventClient/ListOperations/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/UserEventClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/UserEventClient/PurgeUserEvents/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/UserEventClient/PurgeUserEvents/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/UserEventClient/WriteUserEvent/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/UserEventClient/WriteUserEvent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/UserLicenseClient/BatchUpdateUserLicenses/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/UserLicenseClient/BatchUpdateUserLicenses/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/UserLicenseClient/CancelOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/UserLicenseClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/UserLicenseClient/GetOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/UserLicenseClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/UserLicenseClient/ListOperations/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/UserLicenseClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1/UserLicenseClient/ListUserLicenses/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1/UserLicenseClient/ListUserLicenses/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/AclConfigClient/CancelOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/AclConfigClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/AclConfigClient/GetAclConfig/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/AclConfigClient/GetAclConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/AclConfigClient/GetOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/AclConfigClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/AclConfigClient/ListOperations/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/AclConfigClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/AclConfigClient/UpdateAclConfig/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/AclConfigClient/UpdateAclConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/ChunkClient/CancelOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/ChunkClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/ChunkClient/GetChunk/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/ChunkClient/GetChunk/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/ChunkClient/GetOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/ChunkClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/ChunkClient/ListChunks/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/ChunkClient/ListChunks/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/ChunkClient/ListOperations/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/ChunkClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/CompletionClient/CancelOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/CompletionClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/CompletionClient/CompleteQuery/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/CompletionClient/CompleteQuery/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/CompletionClient/GetOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/CompletionClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/CompletionClient/ImportCompletionSuggestions/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/CompletionClient/ImportCompletionSuggestions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/CompletionClient/ImportSuggestionDenyListEntries/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/CompletionClient/ImportSuggestionDenyListEntries/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/CompletionClient/ListOperations/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/CompletionClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/CompletionClient/PurgeCompletionSuggestions/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/CompletionClient/PurgeCompletionSuggestions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/CompletionClient/PurgeSuggestionDenyListEntries/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/CompletionClient/PurgeSuggestionDenyListEntries/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/ControlClient/CancelOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/ControlClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/ControlClient/CreateControl/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/ControlClient/CreateControl/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/ControlClient/DeleteControl/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/ControlClient/DeleteControl/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/ControlClient/GetControl/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/ControlClient/GetControl/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/ControlClient/GetOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/ControlClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/ControlClient/ListControls/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/ControlClient/ListControls/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/ControlClient/ListOperations/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/ControlClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/ControlClient/UpdateControl/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/ControlClient/UpdateControl/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/ConversationalSearchClient/AnswerQuery/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/ConversationalSearchClient/AnswerQuery/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/ConversationalSearchClient/CancelOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/ConversationalSearchClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/ConversationalSearchClient/ConverseConversation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/ConversationalSearchClient/ConverseConversation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/ConversationalSearchClient/CreateConversation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/ConversationalSearchClient/CreateConversation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/ConversationalSearchClient/CreateSession/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/ConversationalSearchClient/CreateSession/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/ConversationalSearchClient/DeleteConversation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/ConversationalSearchClient/DeleteConversation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/ConversationalSearchClient/DeleteSession/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/ConversationalSearchClient/DeleteSession/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/ConversationalSearchClient/GetAnswer/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/ConversationalSearchClient/GetAnswer/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/ConversationalSearchClient/GetConversation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/ConversationalSearchClient/GetConversation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/ConversationalSearchClient/GetOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/ConversationalSearchClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/ConversationalSearchClient/GetSession/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/ConversationalSearchClient/GetSession/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/ConversationalSearchClient/ListConversations/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/ConversationalSearchClient/ListConversations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/ConversationalSearchClient/ListOperations/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/ConversationalSearchClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/ConversationalSearchClient/ListSessions/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/ConversationalSearchClient/ListSessions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/ConversationalSearchClient/UpdateConversation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/ConversationalSearchClient/UpdateConversation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/ConversationalSearchClient/UpdateSession/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/ConversationalSearchClient/UpdateSession/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/DataStoreClient/CancelOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/DataStoreClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/DataStoreClient/CreateDataStore/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/DataStoreClient/CreateDataStore/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/DataStoreClient/DeleteDataStore/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/DataStoreClient/DeleteDataStore/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/DataStoreClient/GetDataStore/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/DataStoreClient/GetDataStore/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/DataStoreClient/GetDocumentProcessingConfig/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/DataStoreClient/GetDocumentProcessingConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/DataStoreClient/GetOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/DataStoreClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/DataStoreClient/ListDataStores/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/DataStoreClient/ListDataStores/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/DataStoreClient/ListOperations/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/DataStoreClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/DataStoreClient/UpdateDataStore/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/DataStoreClient/UpdateDataStore/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/DataStoreClient/UpdateDocumentProcessingConfig/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/DataStoreClient/UpdateDocumentProcessingConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/DocumentClient/BatchGetDocumentsMetadata/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/DocumentClient/BatchGetDocumentsMetadata/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/DocumentClient/CancelOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/DocumentClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/DocumentClient/CreateDocument/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/DocumentClient/CreateDocument/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/DocumentClient/DeleteDocument/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/DocumentClient/DeleteDocument/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/DocumentClient/GetDocument/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/DocumentClient/GetDocument/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/DocumentClient/GetOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/DocumentClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/DocumentClient/GetProcessedDocument/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/DocumentClient/GetProcessedDocument/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/DocumentClient/ImportDocuments/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/DocumentClient/ImportDocuments/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/DocumentClient/ListDocuments/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/DocumentClient/ListDocuments/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/DocumentClient/ListOperations/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/DocumentClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/DocumentClient/PurgeDocuments/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/DocumentClient/PurgeDocuments/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/DocumentClient/UpdateDocument/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/DocumentClient/UpdateDocument/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/EngineClient/CancelOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/EngineClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/EngineClient/CreateEngine/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/EngineClient/CreateEngine/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/EngineClient/DeleteEngine/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/EngineClient/DeleteEngine/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/EngineClient/GetEngine/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/EngineClient/GetEngine/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/EngineClient/GetOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/EngineClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/EngineClient/ListEngines/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/EngineClient/ListEngines/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/EngineClient/ListOperations/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/EngineClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/EngineClient/PauseEngine/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/EngineClient/PauseEngine/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/EngineClient/ResumeEngine/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/EngineClient/ResumeEngine/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/EngineClient/TuneEngine/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/EngineClient/TuneEngine/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/EngineClient/UpdateEngine/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/EngineClient/UpdateEngine/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/EstimateBillingClient/CancelOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/EstimateBillingClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/EstimateBillingClient/EstimateDataSize/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/EstimateBillingClient/EstimateDataSize/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/EstimateBillingClient/GetOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/EstimateBillingClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/EstimateBillingClient/ListOperations/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/EstimateBillingClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/EvaluationClient/CancelOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/EvaluationClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/EvaluationClient/CreateEvaluation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/EvaluationClient/CreateEvaluation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/EvaluationClient/GetEvaluation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/EvaluationClient/GetEvaluation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/EvaluationClient/GetOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/EvaluationClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/EvaluationClient/ListEvaluationResults/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/EvaluationClient/ListEvaluationResults/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/EvaluationClient/ListEvaluations/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/EvaluationClient/ListEvaluations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/EvaluationClient/ListOperations/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/EvaluationClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/GroundedGenerationClient/CancelOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/GroundedGenerationClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/GroundedGenerationClient/CheckGrounding/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/GroundedGenerationClient/CheckGrounding/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/GroundedGenerationClient/GetOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/GroundedGenerationClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/GroundedGenerationClient/ListOperations/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/GroundedGenerationClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/ProjectClient/CancelOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/ProjectClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/ProjectClient/GetOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/ProjectClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/ProjectClient/GetProject/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/ProjectClient/GetProject/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/ProjectClient/ListOperations/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/ProjectClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/ProjectClient/ProvisionProject/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/ProjectClient/ProvisionProject/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/ProjectClient/ReportConsentChange/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/ProjectClient/ReportConsentChange/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/RankClient/CancelOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/RankClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/RankClient/GetOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/RankClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/RankClient/ListOperations/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/RankClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/RankClient/Rank/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/RankClient/Rank/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/RecommendationClient/CancelOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/RecommendationClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/RecommendationClient/GetOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/RecommendationClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/RecommendationClient/ListOperations/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/RecommendationClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/RecommendationClient/Recommend/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/RecommendationClient/Recommend/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/SampleQueryClient/CancelOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/SampleQueryClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/SampleQueryClient/CreateSampleQuery/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/SampleQueryClient/CreateSampleQuery/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/SampleQueryClient/DeleteSampleQuery/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/SampleQueryClient/DeleteSampleQuery/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/SampleQueryClient/GetOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/SampleQueryClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/SampleQueryClient/GetSampleQuery/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/SampleQueryClient/GetSampleQuery/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/SampleQueryClient/ImportSampleQueries/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/SampleQueryClient/ImportSampleQueries/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/SampleQueryClient/ListOperations/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/SampleQueryClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/SampleQueryClient/ListSampleQueries/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/SampleQueryClient/ListSampleQueries/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/SampleQueryClient/UpdateSampleQuery/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/SampleQueryClient/UpdateSampleQuery/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/SampleQuerySetClient/CancelOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/SampleQuerySetClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/SampleQuerySetClient/CreateSampleQuerySet/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/SampleQuerySetClient/CreateSampleQuerySet/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/SampleQuerySetClient/DeleteSampleQuerySet/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/SampleQuerySetClient/DeleteSampleQuerySet/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/SampleQuerySetClient/GetOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/SampleQuerySetClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/SampleQuerySetClient/GetSampleQuerySet/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/SampleQuerySetClient/GetSampleQuerySet/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/SampleQuerySetClient/ListOperations/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/SampleQuerySetClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/SampleQuerySetClient/ListSampleQuerySets/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/SampleQuerySetClient/ListSampleQuerySets/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/SampleQuerySetClient/UpdateSampleQuerySet/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/SampleQuerySetClient/UpdateSampleQuerySet/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/SchemaClient/CancelOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/SchemaClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/SchemaClient/CreateSchema/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/SchemaClient/CreateSchema/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/SchemaClient/DeleteSchema/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/SchemaClient/DeleteSchema/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/SchemaClient/GetOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/SchemaClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/SchemaClient/GetSchema/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/SchemaClient/GetSchema/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/SchemaClient/ListOperations/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/SchemaClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/SchemaClient/ListSchemas/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/SchemaClient/ListSchemas/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/SchemaClient/UpdateSchema/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/SchemaClient/UpdateSchema/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/SearchClient/CancelOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/SearchClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/SearchClient/GetOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/SearchClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/SearchClient/ListOperations/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/SearchClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/SearchClient/Search/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/SearchClient/Search/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/SearchTuningClient/CancelOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/SearchTuningClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/SearchTuningClient/GetOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/SearchTuningClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/SearchTuningClient/ListCustomModels/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/SearchTuningClient/ListCustomModels/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/SearchTuningClient/ListOperations/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/SearchTuningClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/SearchTuningClient/TrainCustomModel/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/SearchTuningClient/TrainCustomModel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/ServingConfigClient/CancelOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/ServingConfigClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/ServingConfigClient/GetOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/ServingConfigClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/ServingConfigClient/GetServingConfig/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/ServingConfigClient/GetServingConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/ServingConfigClient/ListOperations/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/ServingConfigClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/ServingConfigClient/ListServingConfigs/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/ServingConfigClient/ListServingConfigs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/ServingConfigClient/UpdateServingConfig/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/ServingConfigClient/UpdateServingConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/SessionClient/CancelOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/SessionClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/SessionClient/CreateSession/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/SessionClient/CreateSession/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/SessionClient/DeleteSession/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/SessionClient/DeleteSession/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/SessionClient/GetOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/SessionClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/SessionClient/GetSession/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/SessionClient/GetSession/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/SessionClient/ListFiles/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/SessionClient/ListFiles/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/SessionClient/ListOperations/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/SessionClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/SessionClient/ListSessions/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/SessionClient/ListSessions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/SessionClient/UpdateSession/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/SessionClient/UpdateSession/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/SiteSearchEngineClient/BatchCreateTargetSites/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/SiteSearchEngineClient/BatchCreateTargetSites/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/SiteSearchEngineClient/BatchVerifyTargetSites/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/SiteSearchEngineClient/BatchVerifyTargetSites/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/SiteSearchEngineClient/CancelOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/SiteSearchEngineClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/SiteSearchEngineClient/CreateTargetSite/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/SiteSearchEngineClient/CreateTargetSite/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/SiteSearchEngineClient/DeleteTargetSite/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/SiteSearchEngineClient/DeleteTargetSite/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/SiteSearchEngineClient/DisableAdvancedSiteSearch/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/SiteSearchEngineClient/DisableAdvancedSiteSearch/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/SiteSearchEngineClient/EnableAdvancedSiteSearch/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/SiteSearchEngineClient/EnableAdvancedSiteSearch/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/SiteSearchEngineClient/FetchDomainVerificationStatus/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/SiteSearchEngineClient/FetchDomainVerificationStatus/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/SiteSearchEngineClient/GetOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/SiteSearchEngineClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/SiteSearchEngineClient/GetSiteSearchEngine/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/SiteSearchEngineClient/GetSiteSearchEngine/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/SiteSearchEngineClient/GetTargetSite/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/SiteSearchEngineClient/GetTargetSite/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/SiteSearchEngineClient/GetUriPatternDocumentData/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/SiteSearchEngineClient/GetUriPatternDocumentData/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/SiteSearchEngineClient/ListOperations/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/SiteSearchEngineClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/SiteSearchEngineClient/ListTargetSites/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/SiteSearchEngineClient/ListTargetSites/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/SiteSearchEngineClient/RecrawlUris/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/SiteSearchEngineClient/RecrawlUris/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/SiteSearchEngineClient/SetUriPatternDocumentData/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/SiteSearchEngineClient/SetUriPatternDocumentData/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/SiteSearchEngineClient/UpdateTargetSite/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/SiteSearchEngineClient/UpdateTargetSite/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/UserEventClient/CancelOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/UserEventClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/UserEventClient/CollectUserEvent/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/UserEventClient/CollectUserEvent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/UserEventClient/GetOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/UserEventClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/UserEventClient/ImportUserEvents/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/UserEventClient/ImportUserEvents/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/UserEventClient/ListOperations/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/UserEventClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/UserEventClient/PurgeUserEvents/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/UserEventClient/PurgeUserEvents/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1alpha/UserEventClient/WriteUserEvent/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1alpha/UserEventClient/WriteUserEvent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/CompletionClient/AdvancedCompleteQuery/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/CompletionClient/AdvancedCompleteQuery/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/CompletionClient/CancelOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/CompletionClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/CompletionClient/CompleteQuery/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/CompletionClient/CompleteQuery/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/CompletionClient/GetOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/CompletionClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/CompletionClient/ImportCompletionSuggestions/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/CompletionClient/ImportCompletionSuggestions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/CompletionClient/ImportSuggestionDenyListEntries/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/CompletionClient/ImportSuggestionDenyListEntries/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/CompletionClient/ListOperations/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/CompletionClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/CompletionClient/PurgeCompletionSuggestions/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/CompletionClient/PurgeCompletionSuggestions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/CompletionClient/PurgeSuggestionDenyListEntries/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/CompletionClient/PurgeSuggestionDenyListEntries/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/ControlClient/CancelOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/ControlClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/ControlClient/CreateControl/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/ControlClient/CreateControl/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/ControlClient/DeleteControl/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/ControlClient/DeleteControl/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/ControlClient/GetControl/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/ControlClient/GetControl/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/ControlClient/GetOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/ControlClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/ControlClient/ListControls/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/ControlClient/ListControls/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/ControlClient/ListOperations/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/ControlClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/ControlClient/UpdateControl/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/ControlClient/UpdateControl/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/ConversationalSearchClient/AnswerQuery/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/ConversationalSearchClient/AnswerQuery/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/ConversationalSearchClient/CancelOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/ConversationalSearchClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/ConversationalSearchClient/ConverseConversation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/ConversationalSearchClient/ConverseConversation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/ConversationalSearchClient/CreateConversation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/ConversationalSearchClient/CreateConversation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/ConversationalSearchClient/CreateSession/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/ConversationalSearchClient/CreateSession/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/ConversationalSearchClient/DeleteConversation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/ConversationalSearchClient/DeleteConversation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/ConversationalSearchClient/DeleteSession/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/ConversationalSearchClient/DeleteSession/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/ConversationalSearchClient/GetAnswer/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/ConversationalSearchClient/GetAnswer/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/ConversationalSearchClient/GetConversation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/ConversationalSearchClient/GetConversation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/ConversationalSearchClient/GetOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/ConversationalSearchClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/ConversationalSearchClient/GetSession/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/ConversationalSearchClient/GetSession/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/ConversationalSearchClient/ListConversations/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/ConversationalSearchClient/ListConversations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/ConversationalSearchClient/ListOperations/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/ConversationalSearchClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/ConversationalSearchClient/ListSessions/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/ConversationalSearchClient/ListSessions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/ConversationalSearchClient/UpdateConversation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/ConversationalSearchClient/UpdateConversation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/ConversationalSearchClient/UpdateSession/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/ConversationalSearchClient/UpdateSession/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/DataStoreClient/CancelOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/DataStoreClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/DataStoreClient/CreateDataStore/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/DataStoreClient/CreateDataStore/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/DataStoreClient/DeleteDataStore/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/DataStoreClient/DeleteDataStore/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/DataStoreClient/GetDataStore/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/DataStoreClient/GetDataStore/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/DataStoreClient/GetOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/DataStoreClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/DataStoreClient/ListDataStores/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/DataStoreClient/ListDataStores/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/DataStoreClient/ListOperations/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/DataStoreClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/DataStoreClient/UpdateDataStore/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/DataStoreClient/UpdateDataStore/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/DocumentClient/BatchGetDocumentsMetadata/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/DocumentClient/BatchGetDocumentsMetadata/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/DocumentClient/CancelOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/DocumentClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/DocumentClient/CreateDocument/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/DocumentClient/CreateDocument/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/DocumentClient/DeleteDocument/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/DocumentClient/DeleteDocument/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/DocumentClient/GetDocument/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/DocumentClient/GetDocument/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/DocumentClient/GetOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/DocumentClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/DocumentClient/ImportDocuments/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/DocumentClient/ImportDocuments/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/DocumentClient/ListDocuments/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/DocumentClient/ListDocuments/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/DocumentClient/ListOperations/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/DocumentClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/DocumentClient/PurgeDocuments/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/DocumentClient/PurgeDocuments/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/DocumentClient/UpdateDocument/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/DocumentClient/UpdateDocument/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/EngineClient/CancelOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/EngineClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/EngineClient/CreateEngine/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/EngineClient/CreateEngine/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/EngineClient/DeleteEngine/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/EngineClient/DeleteEngine/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/EngineClient/GetEngine/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/EngineClient/GetEngine/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/EngineClient/GetOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/EngineClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/EngineClient/ListEngines/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/EngineClient/ListEngines/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/EngineClient/ListOperations/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/EngineClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/EngineClient/PauseEngine/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/EngineClient/PauseEngine/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/EngineClient/ResumeEngine/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/EngineClient/ResumeEngine/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/EngineClient/TuneEngine/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/EngineClient/TuneEngine/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/EngineClient/UpdateEngine/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/EngineClient/UpdateEngine/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/EvaluationClient/CancelOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/EvaluationClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/EvaluationClient/CreateEvaluation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/EvaluationClient/CreateEvaluation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/EvaluationClient/GetEvaluation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/EvaluationClient/GetEvaluation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/EvaluationClient/GetOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/EvaluationClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/EvaluationClient/ListEvaluationResults/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/EvaluationClient/ListEvaluationResults/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/EvaluationClient/ListEvaluations/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/EvaluationClient/ListEvaluations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/EvaluationClient/ListOperations/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/EvaluationClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/GroundedGenerationClient/CancelOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/GroundedGenerationClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/GroundedGenerationClient/CheckGrounding/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/GroundedGenerationClient/CheckGrounding/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/GroundedGenerationClient/GenerateGroundedContent/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/GroundedGenerationClient/GenerateGroundedContent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/GroundedGenerationClient/GetOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/GroundedGenerationClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/GroundedGenerationClient/ListOperations/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/GroundedGenerationClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/GroundedGenerationClient/StreamGenerateGroundedContent/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/GroundedGenerationClient/StreamGenerateGroundedContent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/ProjectClient/CancelOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/ProjectClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/ProjectClient/GetOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/ProjectClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/ProjectClient/ListOperations/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/ProjectClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/ProjectClient/ProvisionProject/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/ProjectClient/ProvisionProject/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/RankClient/CancelOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/RankClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/RankClient/GetOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/RankClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/RankClient/ListOperations/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/RankClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/RankClient/Rank/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/RankClient/Rank/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/RecommendationClient/CancelOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/RecommendationClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/RecommendationClient/GetOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/RecommendationClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/RecommendationClient/ListOperations/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/RecommendationClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/RecommendationClient/Recommend/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/RecommendationClient/Recommend/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/SampleQueryClient/CancelOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/SampleQueryClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/SampleQueryClient/CreateSampleQuery/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/SampleQueryClient/CreateSampleQuery/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/SampleQueryClient/DeleteSampleQuery/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/SampleQueryClient/DeleteSampleQuery/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/SampleQueryClient/GetOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/SampleQueryClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/SampleQueryClient/GetSampleQuery/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/SampleQueryClient/GetSampleQuery/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/SampleQueryClient/ImportSampleQueries/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/SampleQueryClient/ImportSampleQueries/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/SampleQueryClient/ListOperations/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/SampleQueryClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/SampleQueryClient/ListSampleQueries/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/SampleQueryClient/ListSampleQueries/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/SampleQueryClient/UpdateSampleQuery/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/SampleQueryClient/UpdateSampleQuery/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/SampleQuerySetClient/CancelOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/SampleQuerySetClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/SampleQuerySetClient/CreateSampleQuerySet/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/SampleQuerySetClient/CreateSampleQuerySet/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/SampleQuerySetClient/DeleteSampleQuerySet/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/SampleQuerySetClient/DeleteSampleQuerySet/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/SampleQuerySetClient/GetOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/SampleQuerySetClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/SampleQuerySetClient/GetSampleQuerySet/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/SampleQuerySetClient/GetSampleQuerySet/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/SampleQuerySetClient/ListOperations/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/SampleQuerySetClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/SampleQuerySetClient/ListSampleQuerySets/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/SampleQuerySetClient/ListSampleQuerySets/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/SampleQuerySetClient/UpdateSampleQuerySet/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/SampleQuerySetClient/UpdateSampleQuerySet/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/SchemaClient/CancelOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/SchemaClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/SchemaClient/CreateSchema/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/SchemaClient/CreateSchema/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/SchemaClient/DeleteSchema/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/SchemaClient/DeleteSchema/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/SchemaClient/GetOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/SchemaClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/SchemaClient/GetSchema/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/SchemaClient/GetSchema/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/SchemaClient/ListOperations/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/SchemaClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/SchemaClient/ListSchemas/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/SchemaClient/ListSchemas/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/SchemaClient/UpdateSchema/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/SchemaClient/UpdateSchema/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/SearchClient/CancelOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/SearchClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/SearchClient/GetOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/SearchClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/SearchClient/ListOperations/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/SearchClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/SearchClient/Search/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/SearchClient/Search/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/SearchClient/SearchLite/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/SearchClient/SearchLite/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/SearchTuningClient/CancelOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/SearchTuningClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/SearchTuningClient/GetOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/SearchTuningClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/SearchTuningClient/ListCustomModels/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/SearchTuningClient/ListCustomModels/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/SearchTuningClient/ListOperations/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/SearchTuningClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/SearchTuningClient/TrainCustomModel/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/SearchTuningClient/TrainCustomModel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/ServingConfigClient/CancelOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/ServingConfigClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/ServingConfigClient/GetOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/ServingConfigClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/ServingConfigClient/GetServingConfig/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/ServingConfigClient/GetServingConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/ServingConfigClient/ListOperations/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/ServingConfigClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/ServingConfigClient/ListServingConfigs/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/ServingConfigClient/ListServingConfigs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/ServingConfigClient/UpdateServingConfig/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/ServingConfigClient/UpdateServingConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/SessionClient/CancelOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/SessionClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/SessionClient/CreateSession/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/SessionClient/CreateSession/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/SessionClient/DeleteSession/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/SessionClient/DeleteSession/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/SessionClient/GetOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/SessionClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/SessionClient/GetSession/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/SessionClient/GetSession/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/SessionClient/ListOperations/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/SessionClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/SessionClient/ListSessions/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/SessionClient/ListSessions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/SessionClient/UpdateSession/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/SessionClient/UpdateSession/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/SiteSearchEngineClient/BatchCreateTargetSites/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/SiteSearchEngineClient/BatchCreateTargetSites/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/SiteSearchEngineClient/BatchVerifyTargetSites/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/SiteSearchEngineClient/BatchVerifyTargetSites/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/SiteSearchEngineClient/CancelOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/SiteSearchEngineClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/SiteSearchEngineClient/CreateSitemap/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/SiteSearchEngineClient/CreateSitemap/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/SiteSearchEngineClient/CreateTargetSite/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/SiteSearchEngineClient/CreateTargetSite/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/SiteSearchEngineClient/DeleteSitemap/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/SiteSearchEngineClient/DeleteSitemap/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/SiteSearchEngineClient/DeleteTargetSite/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/SiteSearchEngineClient/DeleteTargetSite/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/SiteSearchEngineClient/DisableAdvancedSiteSearch/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/SiteSearchEngineClient/DisableAdvancedSiteSearch/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/SiteSearchEngineClient/EnableAdvancedSiteSearch/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/SiteSearchEngineClient/EnableAdvancedSiteSearch/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/SiteSearchEngineClient/FetchDomainVerificationStatus/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/SiteSearchEngineClient/FetchDomainVerificationStatus/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/SiteSearchEngineClient/FetchSitemaps/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/SiteSearchEngineClient/FetchSitemaps/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/SiteSearchEngineClient/GetOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/SiteSearchEngineClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/SiteSearchEngineClient/GetSiteSearchEngine/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/SiteSearchEngineClient/GetSiteSearchEngine/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/SiteSearchEngineClient/GetTargetSite/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/SiteSearchEngineClient/GetTargetSite/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/SiteSearchEngineClient/ListOperations/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/SiteSearchEngineClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/SiteSearchEngineClient/ListTargetSites/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/SiteSearchEngineClient/ListTargetSites/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/SiteSearchEngineClient/RecrawlUris/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/SiteSearchEngineClient/RecrawlUris/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/SiteSearchEngineClient/UpdateTargetSite/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/SiteSearchEngineClient/UpdateTargetSite/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/UserEventClient/CancelOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/UserEventClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/UserEventClient/CollectUserEvent/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/UserEventClient/CollectUserEvent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/UserEventClient/GetOperation/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/UserEventClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/UserEventClient/ImportUserEvents/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/UserEventClient/ImportUserEvents/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/UserEventClient/ListOperations/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/UserEventClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/UserEventClient/PurgeUserEvents/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/UserEventClient/PurgeUserEvents/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/discoveryengine/apiv1beta/UserEventClient/WriteUserEvent/main.go
+++ b/internal/generated/snippets/discoveryengine/apiv1beta/UserEventClient/WriteUserEvent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dlp/apiv2/Client/ActivateJobTrigger/main.go
+++ b/internal/generated/snippets/dlp/apiv2/Client/ActivateJobTrigger/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dlp/apiv2/Client/CancelDlpJob/main.go
+++ b/internal/generated/snippets/dlp/apiv2/Client/CancelDlpJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dlp/apiv2/Client/CreateConnection/main.go
+++ b/internal/generated/snippets/dlp/apiv2/Client/CreateConnection/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dlp/apiv2/Client/CreateDeidentifyTemplate/main.go
+++ b/internal/generated/snippets/dlp/apiv2/Client/CreateDeidentifyTemplate/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dlp/apiv2/Client/CreateDiscoveryConfig/main.go
+++ b/internal/generated/snippets/dlp/apiv2/Client/CreateDiscoveryConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dlp/apiv2/Client/CreateDlpJob/main.go
+++ b/internal/generated/snippets/dlp/apiv2/Client/CreateDlpJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dlp/apiv2/Client/CreateInspectTemplate/main.go
+++ b/internal/generated/snippets/dlp/apiv2/Client/CreateInspectTemplate/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dlp/apiv2/Client/CreateJobTrigger/main.go
+++ b/internal/generated/snippets/dlp/apiv2/Client/CreateJobTrigger/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dlp/apiv2/Client/CreateStoredInfoType/main.go
+++ b/internal/generated/snippets/dlp/apiv2/Client/CreateStoredInfoType/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dlp/apiv2/Client/DeidentifyContent/main.go
+++ b/internal/generated/snippets/dlp/apiv2/Client/DeidentifyContent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dlp/apiv2/Client/DeleteConnection/main.go
+++ b/internal/generated/snippets/dlp/apiv2/Client/DeleteConnection/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dlp/apiv2/Client/DeleteDeidentifyTemplate/main.go
+++ b/internal/generated/snippets/dlp/apiv2/Client/DeleteDeidentifyTemplate/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dlp/apiv2/Client/DeleteDiscoveryConfig/main.go
+++ b/internal/generated/snippets/dlp/apiv2/Client/DeleteDiscoveryConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dlp/apiv2/Client/DeleteDlpJob/main.go
+++ b/internal/generated/snippets/dlp/apiv2/Client/DeleteDlpJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dlp/apiv2/Client/DeleteFileStoreDataProfile/main.go
+++ b/internal/generated/snippets/dlp/apiv2/Client/DeleteFileStoreDataProfile/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dlp/apiv2/Client/DeleteInspectTemplate/main.go
+++ b/internal/generated/snippets/dlp/apiv2/Client/DeleteInspectTemplate/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dlp/apiv2/Client/DeleteJobTrigger/main.go
+++ b/internal/generated/snippets/dlp/apiv2/Client/DeleteJobTrigger/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dlp/apiv2/Client/DeleteStoredInfoType/main.go
+++ b/internal/generated/snippets/dlp/apiv2/Client/DeleteStoredInfoType/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dlp/apiv2/Client/DeleteTableDataProfile/main.go
+++ b/internal/generated/snippets/dlp/apiv2/Client/DeleteTableDataProfile/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dlp/apiv2/Client/FinishDlpJob/main.go
+++ b/internal/generated/snippets/dlp/apiv2/Client/FinishDlpJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dlp/apiv2/Client/GetColumnDataProfile/main.go
+++ b/internal/generated/snippets/dlp/apiv2/Client/GetColumnDataProfile/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dlp/apiv2/Client/GetConnection/main.go
+++ b/internal/generated/snippets/dlp/apiv2/Client/GetConnection/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dlp/apiv2/Client/GetDeidentifyTemplate/main.go
+++ b/internal/generated/snippets/dlp/apiv2/Client/GetDeidentifyTemplate/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dlp/apiv2/Client/GetDiscoveryConfig/main.go
+++ b/internal/generated/snippets/dlp/apiv2/Client/GetDiscoveryConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dlp/apiv2/Client/GetDlpJob/main.go
+++ b/internal/generated/snippets/dlp/apiv2/Client/GetDlpJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dlp/apiv2/Client/GetFileStoreDataProfile/main.go
+++ b/internal/generated/snippets/dlp/apiv2/Client/GetFileStoreDataProfile/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dlp/apiv2/Client/GetInspectTemplate/main.go
+++ b/internal/generated/snippets/dlp/apiv2/Client/GetInspectTemplate/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dlp/apiv2/Client/GetJobTrigger/main.go
+++ b/internal/generated/snippets/dlp/apiv2/Client/GetJobTrigger/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dlp/apiv2/Client/GetProjectDataProfile/main.go
+++ b/internal/generated/snippets/dlp/apiv2/Client/GetProjectDataProfile/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dlp/apiv2/Client/GetStoredInfoType/main.go
+++ b/internal/generated/snippets/dlp/apiv2/Client/GetStoredInfoType/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dlp/apiv2/Client/GetTableDataProfile/main.go
+++ b/internal/generated/snippets/dlp/apiv2/Client/GetTableDataProfile/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dlp/apiv2/Client/HybridInspectDlpJob/main.go
+++ b/internal/generated/snippets/dlp/apiv2/Client/HybridInspectDlpJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dlp/apiv2/Client/HybridInspectJobTrigger/main.go
+++ b/internal/generated/snippets/dlp/apiv2/Client/HybridInspectJobTrigger/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dlp/apiv2/Client/InspectContent/main.go
+++ b/internal/generated/snippets/dlp/apiv2/Client/InspectContent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dlp/apiv2/Client/ListColumnDataProfiles/main.go
+++ b/internal/generated/snippets/dlp/apiv2/Client/ListColumnDataProfiles/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dlp/apiv2/Client/ListConnections/main.go
+++ b/internal/generated/snippets/dlp/apiv2/Client/ListConnections/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dlp/apiv2/Client/ListDeidentifyTemplates/main.go
+++ b/internal/generated/snippets/dlp/apiv2/Client/ListDeidentifyTemplates/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dlp/apiv2/Client/ListDiscoveryConfigs/main.go
+++ b/internal/generated/snippets/dlp/apiv2/Client/ListDiscoveryConfigs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dlp/apiv2/Client/ListDlpJobs/main.go
+++ b/internal/generated/snippets/dlp/apiv2/Client/ListDlpJobs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dlp/apiv2/Client/ListFileStoreDataProfiles/main.go
+++ b/internal/generated/snippets/dlp/apiv2/Client/ListFileStoreDataProfiles/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dlp/apiv2/Client/ListInfoTypes/main.go
+++ b/internal/generated/snippets/dlp/apiv2/Client/ListInfoTypes/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dlp/apiv2/Client/ListInspectTemplates/main.go
+++ b/internal/generated/snippets/dlp/apiv2/Client/ListInspectTemplates/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dlp/apiv2/Client/ListJobTriggers/main.go
+++ b/internal/generated/snippets/dlp/apiv2/Client/ListJobTriggers/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dlp/apiv2/Client/ListProjectDataProfiles/main.go
+++ b/internal/generated/snippets/dlp/apiv2/Client/ListProjectDataProfiles/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dlp/apiv2/Client/ListStoredInfoTypes/main.go
+++ b/internal/generated/snippets/dlp/apiv2/Client/ListStoredInfoTypes/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dlp/apiv2/Client/ListTableDataProfiles/main.go
+++ b/internal/generated/snippets/dlp/apiv2/Client/ListTableDataProfiles/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dlp/apiv2/Client/RedactImage/main.go
+++ b/internal/generated/snippets/dlp/apiv2/Client/RedactImage/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dlp/apiv2/Client/ReidentifyContent/main.go
+++ b/internal/generated/snippets/dlp/apiv2/Client/ReidentifyContent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dlp/apiv2/Client/SearchConnections/main.go
+++ b/internal/generated/snippets/dlp/apiv2/Client/SearchConnections/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dlp/apiv2/Client/UpdateConnection/main.go
+++ b/internal/generated/snippets/dlp/apiv2/Client/UpdateConnection/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dlp/apiv2/Client/UpdateDeidentifyTemplate/main.go
+++ b/internal/generated/snippets/dlp/apiv2/Client/UpdateDeidentifyTemplate/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dlp/apiv2/Client/UpdateDiscoveryConfig/main.go
+++ b/internal/generated/snippets/dlp/apiv2/Client/UpdateDiscoveryConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dlp/apiv2/Client/UpdateInspectTemplate/main.go
+++ b/internal/generated/snippets/dlp/apiv2/Client/UpdateInspectTemplate/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dlp/apiv2/Client/UpdateJobTrigger/main.go
+++ b/internal/generated/snippets/dlp/apiv2/Client/UpdateJobTrigger/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/dlp/apiv2/Client/UpdateStoredInfoType/main.go
+++ b/internal/generated/snippets/dlp/apiv2/Client/UpdateStoredInfoType/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/documentai/apiv1/DocumentProcessorClient/BatchProcessDocuments/main.go
+++ b/internal/generated/snippets/documentai/apiv1/DocumentProcessorClient/BatchProcessDocuments/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/documentai/apiv1/DocumentProcessorClient/CancelOperation/main.go
+++ b/internal/generated/snippets/documentai/apiv1/DocumentProcessorClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/documentai/apiv1/DocumentProcessorClient/CreateProcessor/main.go
+++ b/internal/generated/snippets/documentai/apiv1/DocumentProcessorClient/CreateProcessor/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/documentai/apiv1/DocumentProcessorClient/DeleteProcessor/main.go
+++ b/internal/generated/snippets/documentai/apiv1/DocumentProcessorClient/DeleteProcessor/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/documentai/apiv1/DocumentProcessorClient/DeleteProcessorVersion/main.go
+++ b/internal/generated/snippets/documentai/apiv1/DocumentProcessorClient/DeleteProcessorVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/documentai/apiv1/DocumentProcessorClient/DeployProcessorVersion/main.go
+++ b/internal/generated/snippets/documentai/apiv1/DocumentProcessorClient/DeployProcessorVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/documentai/apiv1/DocumentProcessorClient/DisableProcessor/main.go
+++ b/internal/generated/snippets/documentai/apiv1/DocumentProcessorClient/DisableProcessor/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/documentai/apiv1/DocumentProcessorClient/EnableProcessor/main.go
+++ b/internal/generated/snippets/documentai/apiv1/DocumentProcessorClient/EnableProcessor/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/documentai/apiv1/DocumentProcessorClient/EvaluateProcessorVersion/main.go
+++ b/internal/generated/snippets/documentai/apiv1/DocumentProcessorClient/EvaluateProcessorVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/documentai/apiv1/DocumentProcessorClient/FetchProcessorTypes/main.go
+++ b/internal/generated/snippets/documentai/apiv1/DocumentProcessorClient/FetchProcessorTypes/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/documentai/apiv1/DocumentProcessorClient/GetEvaluation/main.go
+++ b/internal/generated/snippets/documentai/apiv1/DocumentProcessorClient/GetEvaluation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/documentai/apiv1/DocumentProcessorClient/GetLocation/main.go
+++ b/internal/generated/snippets/documentai/apiv1/DocumentProcessorClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/documentai/apiv1/DocumentProcessorClient/GetOperation/main.go
+++ b/internal/generated/snippets/documentai/apiv1/DocumentProcessorClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/documentai/apiv1/DocumentProcessorClient/GetProcessor/main.go
+++ b/internal/generated/snippets/documentai/apiv1/DocumentProcessorClient/GetProcessor/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/documentai/apiv1/DocumentProcessorClient/GetProcessorType/main.go
+++ b/internal/generated/snippets/documentai/apiv1/DocumentProcessorClient/GetProcessorType/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/documentai/apiv1/DocumentProcessorClient/GetProcessorVersion/main.go
+++ b/internal/generated/snippets/documentai/apiv1/DocumentProcessorClient/GetProcessorVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/documentai/apiv1/DocumentProcessorClient/ListEvaluations/main.go
+++ b/internal/generated/snippets/documentai/apiv1/DocumentProcessorClient/ListEvaluations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/documentai/apiv1/DocumentProcessorClient/ListLocations/main.go
+++ b/internal/generated/snippets/documentai/apiv1/DocumentProcessorClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/documentai/apiv1/DocumentProcessorClient/ListOperations/main.go
+++ b/internal/generated/snippets/documentai/apiv1/DocumentProcessorClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/documentai/apiv1/DocumentProcessorClient/ListProcessorTypes/main.go
+++ b/internal/generated/snippets/documentai/apiv1/DocumentProcessorClient/ListProcessorTypes/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/documentai/apiv1/DocumentProcessorClient/ListProcessorVersions/main.go
+++ b/internal/generated/snippets/documentai/apiv1/DocumentProcessorClient/ListProcessorVersions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/documentai/apiv1/DocumentProcessorClient/ListProcessors/main.go
+++ b/internal/generated/snippets/documentai/apiv1/DocumentProcessorClient/ListProcessors/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/documentai/apiv1/DocumentProcessorClient/ProcessDocument/main.go
+++ b/internal/generated/snippets/documentai/apiv1/DocumentProcessorClient/ProcessDocument/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/documentai/apiv1/DocumentProcessorClient/ReviewDocument/main.go
+++ b/internal/generated/snippets/documentai/apiv1/DocumentProcessorClient/ReviewDocument/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/documentai/apiv1/DocumentProcessorClient/SetDefaultProcessorVersion/main.go
+++ b/internal/generated/snippets/documentai/apiv1/DocumentProcessorClient/SetDefaultProcessorVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/documentai/apiv1/DocumentProcessorClient/TrainProcessorVersion/main.go
+++ b/internal/generated/snippets/documentai/apiv1/DocumentProcessorClient/TrainProcessorVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/documentai/apiv1/DocumentProcessorClient/UndeployProcessorVersion/main.go
+++ b/internal/generated/snippets/documentai/apiv1/DocumentProcessorClient/UndeployProcessorVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/documentai/apiv1beta3/DocumentClient/BatchDeleteDocuments/main.go
+++ b/internal/generated/snippets/documentai/apiv1beta3/DocumentClient/BatchDeleteDocuments/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/documentai/apiv1beta3/DocumentClient/CancelOperation/main.go
+++ b/internal/generated/snippets/documentai/apiv1beta3/DocumentClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/documentai/apiv1beta3/DocumentClient/GetDatasetSchema/main.go
+++ b/internal/generated/snippets/documentai/apiv1beta3/DocumentClient/GetDatasetSchema/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/documentai/apiv1beta3/DocumentClient/GetDocument/main.go
+++ b/internal/generated/snippets/documentai/apiv1beta3/DocumentClient/GetDocument/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/documentai/apiv1beta3/DocumentClient/GetLocation/main.go
+++ b/internal/generated/snippets/documentai/apiv1beta3/DocumentClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/documentai/apiv1beta3/DocumentClient/GetOperation/main.go
+++ b/internal/generated/snippets/documentai/apiv1beta3/DocumentClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/documentai/apiv1beta3/DocumentClient/ImportDocuments/main.go
+++ b/internal/generated/snippets/documentai/apiv1beta3/DocumentClient/ImportDocuments/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/documentai/apiv1beta3/DocumentClient/ListDocuments/main.go
+++ b/internal/generated/snippets/documentai/apiv1beta3/DocumentClient/ListDocuments/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/documentai/apiv1beta3/DocumentClient/ListLocations/main.go
+++ b/internal/generated/snippets/documentai/apiv1beta3/DocumentClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/documentai/apiv1beta3/DocumentClient/ListOperations/main.go
+++ b/internal/generated/snippets/documentai/apiv1beta3/DocumentClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/documentai/apiv1beta3/DocumentClient/UpdateDataset/main.go
+++ b/internal/generated/snippets/documentai/apiv1beta3/DocumentClient/UpdateDataset/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/documentai/apiv1beta3/DocumentClient/UpdateDatasetSchema/main.go
+++ b/internal/generated/snippets/documentai/apiv1beta3/DocumentClient/UpdateDatasetSchema/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/documentai/apiv1beta3/DocumentProcessorClient/BatchProcessDocuments/main.go
+++ b/internal/generated/snippets/documentai/apiv1beta3/DocumentProcessorClient/BatchProcessDocuments/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/documentai/apiv1beta3/DocumentProcessorClient/CancelOperation/main.go
+++ b/internal/generated/snippets/documentai/apiv1beta3/DocumentProcessorClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/documentai/apiv1beta3/DocumentProcessorClient/CreateProcessor/main.go
+++ b/internal/generated/snippets/documentai/apiv1beta3/DocumentProcessorClient/CreateProcessor/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/documentai/apiv1beta3/DocumentProcessorClient/DeleteProcessor/main.go
+++ b/internal/generated/snippets/documentai/apiv1beta3/DocumentProcessorClient/DeleteProcessor/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/documentai/apiv1beta3/DocumentProcessorClient/DeleteProcessorVersion/main.go
+++ b/internal/generated/snippets/documentai/apiv1beta3/DocumentProcessorClient/DeleteProcessorVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/documentai/apiv1beta3/DocumentProcessorClient/DeployProcessorVersion/main.go
+++ b/internal/generated/snippets/documentai/apiv1beta3/DocumentProcessorClient/DeployProcessorVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/documentai/apiv1beta3/DocumentProcessorClient/DisableProcessor/main.go
+++ b/internal/generated/snippets/documentai/apiv1beta3/DocumentProcessorClient/DisableProcessor/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/documentai/apiv1beta3/DocumentProcessorClient/EnableProcessor/main.go
+++ b/internal/generated/snippets/documentai/apiv1beta3/DocumentProcessorClient/EnableProcessor/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/documentai/apiv1beta3/DocumentProcessorClient/EvaluateProcessorVersion/main.go
+++ b/internal/generated/snippets/documentai/apiv1beta3/DocumentProcessorClient/EvaluateProcessorVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/documentai/apiv1beta3/DocumentProcessorClient/FetchProcessorTypes/main.go
+++ b/internal/generated/snippets/documentai/apiv1beta3/DocumentProcessorClient/FetchProcessorTypes/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/documentai/apiv1beta3/DocumentProcessorClient/GetEvaluation/main.go
+++ b/internal/generated/snippets/documentai/apiv1beta3/DocumentProcessorClient/GetEvaluation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/documentai/apiv1beta3/DocumentProcessorClient/GetLocation/main.go
+++ b/internal/generated/snippets/documentai/apiv1beta3/DocumentProcessorClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/documentai/apiv1beta3/DocumentProcessorClient/GetOperation/main.go
+++ b/internal/generated/snippets/documentai/apiv1beta3/DocumentProcessorClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/documentai/apiv1beta3/DocumentProcessorClient/GetProcessor/main.go
+++ b/internal/generated/snippets/documentai/apiv1beta3/DocumentProcessorClient/GetProcessor/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/documentai/apiv1beta3/DocumentProcessorClient/GetProcessorType/main.go
+++ b/internal/generated/snippets/documentai/apiv1beta3/DocumentProcessorClient/GetProcessorType/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/documentai/apiv1beta3/DocumentProcessorClient/GetProcessorVersion/main.go
+++ b/internal/generated/snippets/documentai/apiv1beta3/DocumentProcessorClient/GetProcessorVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/documentai/apiv1beta3/DocumentProcessorClient/ImportProcessorVersion/main.go
+++ b/internal/generated/snippets/documentai/apiv1beta3/DocumentProcessorClient/ImportProcessorVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/documentai/apiv1beta3/DocumentProcessorClient/ListEvaluations/main.go
+++ b/internal/generated/snippets/documentai/apiv1beta3/DocumentProcessorClient/ListEvaluations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/documentai/apiv1beta3/DocumentProcessorClient/ListLocations/main.go
+++ b/internal/generated/snippets/documentai/apiv1beta3/DocumentProcessorClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/documentai/apiv1beta3/DocumentProcessorClient/ListOperations/main.go
+++ b/internal/generated/snippets/documentai/apiv1beta3/DocumentProcessorClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/documentai/apiv1beta3/DocumentProcessorClient/ListProcessorTypes/main.go
+++ b/internal/generated/snippets/documentai/apiv1beta3/DocumentProcessorClient/ListProcessorTypes/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/documentai/apiv1beta3/DocumentProcessorClient/ListProcessorVersions/main.go
+++ b/internal/generated/snippets/documentai/apiv1beta3/DocumentProcessorClient/ListProcessorVersions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/documentai/apiv1beta3/DocumentProcessorClient/ListProcessors/main.go
+++ b/internal/generated/snippets/documentai/apiv1beta3/DocumentProcessorClient/ListProcessors/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/documentai/apiv1beta3/DocumentProcessorClient/ProcessDocument/main.go
+++ b/internal/generated/snippets/documentai/apiv1beta3/DocumentProcessorClient/ProcessDocument/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/documentai/apiv1beta3/DocumentProcessorClient/ReviewDocument/main.go
+++ b/internal/generated/snippets/documentai/apiv1beta3/DocumentProcessorClient/ReviewDocument/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/documentai/apiv1beta3/DocumentProcessorClient/SetDefaultProcessorVersion/main.go
+++ b/internal/generated/snippets/documentai/apiv1beta3/DocumentProcessorClient/SetDefaultProcessorVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/documentai/apiv1beta3/DocumentProcessorClient/TrainProcessorVersion/main.go
+++ b/internal/generated/snippets/documentai/apiv1beta3/DocumentProcessorClient/TrainProcessorVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/documentai/apiv1beta3/DocumentProcessorClient/UndeployProcessorVersion/main.go
+++ b/internal/generated/snippets/documentai/apiv1beta3/DocumentProcessorClient/UndeployProcessorVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/domains/apiv1beta1/Client/ConfigureContactSettings/main.go
+++ b/internal/generated/snippets/domains/apiv1beta1/Client/ConfigureContactSettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/domains/apiv1beta1/Client/ConfigureDnsSettings/main.go
+++ b/internal/generated/snippets/domains/apiv1beta1/Client/ConfigureDnsSettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/domains/apiv1beta1/Client/ConfigureManagementSettings/main.go
+++ b/internal/generated/snippets/domains/apiv1beta1/Client/ConfigureManagementSettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/domains/apiv1beta1/Client/DeleteRegistration/main.go
+++ b/internal/generated/snippets/domains/apiv1beta1/Client/DeleteRegistration/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/domains/apiv1beta1/Client/ExportRegistration/main.go
+++ b/internal/generated/snippets/domains/apiv1beta1/Client/ExportRegistration/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/domains/apiv1beta1/Client/GetRegistration/main.go
+++ b/internal/generated/snippets/domains/apiv1beta1/Client/GetRegistration/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/domains/apiv1beta1/Client/ListRegistrations/main.go
+++ b/internal/generated/snippets/domains/apiv1beta1/Client/ListRegistrations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/domains/apiv1beta1/Client/RegisterDomain/main.go
+++ b/internal/generated/snippets/domains/apiv1beta1/Client/RegisterDomain/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/domains/apiv1beta1/Client/ResetAuthorizationCode/main.go
+++ b/internal/generated/snippets/domains/apiv1beta1/Client/ResetAuthorizationCode/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/domains/apiv1beta1/Client/RetrieveAuthorizationCode/main.go
+++ b/internal/generated/snippets/domains/apiv1beta1/Client/RetrieveAuthorizationCode/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/domains/apiv1beta1/Client/RetrieveRegisterParameters/main.go
+++ b/internal/generated/snippets/domains/apiv1beta1/Client/RetrieveRegisterParameters/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/domains/apiv1beta1/Client/RetrieveTransferParameters/main.go
+++ b/internal/generated/snippets/domains/apiv1beta1/Client/RetrieveTransferParameters/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/domains/apiv1beta1/Client/SearchDomains/main.go
+++ b/internal/generated/snippets/domains/apiv1beta1/Client/SearchDomains/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/domains/apiv1beta1/Client/TransferDomain/main.go
+++ b/internal/generated/snippets/domains/apiv1beta1/Client/TransferDomain/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/domains/apiv1beta1/Client/UpdateRegistration/main.go
+++ b/internal/generated/snippets/domains/apiv1beta1/Client/UpdateRegistration/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/edgecontainer/apiv1/Client/CancelOperation/main.go
+++ b/internal/generated/snippets/edgecontainer/apiv1/Client/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/edgecontainer/apiv1/Client/CreateCluster/main.go
+++ b/internal/generated/snippets/edgecontainer/apiv1/Client/CreateCluster/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/edgecontainer/apiv1/Client/CreateNodePool/main.go
+++ b/internal/generated/snippets/edgecontainer/apiv1/Client/CreateNodePool/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/edgecontainer/apiv1/Client/CreateVpnConnection/main.go
+++ b/internal/generated/snippets/edgecontainer/apiv1/Client/CreateVpnConnection/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/edgecontainer/apiv1/Client/DeleteCluster/main.go
+++ b/internal/generated/snippets/edgecontainer/apiv1/Client/DeleteCluster/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/edgecontainer/apiv1/Client/DeleteNodePool/main.go
+++ b/internal/generated/snippets/edgecontainer/apiv1/Client/DeleteNodePool/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/edgecontainer/apiv1/Client/DeleteOperation/main.go
+++ b/internal/generated/snippets/edgecontainer/apiv1/Client/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/edgecontainer/apiv1/Client/DeleteVpnConnection/main.go
+++ b/internal/generated/snippets/edgecontainer/apiv1/Client/DeleteVpnConnection/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/edgecontainer/apiv1/Client/GenerateAccessToken/main.go
+++ b/internal/generated/snippets/edgecontainer/apiv1/Client/GenerateAccessToken/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/edgecontainer/apiv1/Client/GenerateOfflineCredential/main.go
+++ b/internal/generated/snippets/edgecontainer/apiv1/Client/GenerateOfflineCredential/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/edgecontainer/apiv1/Client/GetCluster/main.go
+++ b/internal/generated/snippets/edgecontainer/apiv1/Client/GetCluster/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/edgecontainer/apiv1/Client/GetLocation/main.go
+++ b/internal/generated/snippets/edgecontainer/apiv1/Client/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/edgecontainer/apiv1/Client/GetMachine/main.go
+++ b/internal/generated/snippets/edgecontainer/apiv1/Client/GetMachine/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/edgecontainer/apiv1/Client/GetNodePool/main.go
+++ b/internal/generated/snippets/edgecontainer/apiv1/Client/GetNodePool/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/edgecontainer/apiv1/Client/GetOperation/main.go
+++ b/internal/generated/snippets/edgecontainer/apiv1/Client/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/edgecontainer/apiv1/Client/GetServerConfig/main.go
+++ b/internal/generated/snippets/edgecontainer/apiv1/Client/GetServerConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/edgecontainer/apiv1/Client/GetVpnConnection/main.go
+++ b/internal/generated/snippets/edgecontainer/apiv1/Client/GetVpnConnection/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/edgecontainer/apiv1/Client/ListClusters/main.go
+++ b/internal/generated/snippets/edgecontainer/apiv1/Client/ListClusters/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/edgecontainer/apiv1/Client/ListLocations/main.go
+++ b/internal/generated/snippets/edgecontainer/apiv1/Client/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/edgecontainer/apiv1/Client/ListMachines/main.go
+++ b/internal/generated/snippets/edgecontainer/apiv1/Client/ListMachines/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/edgecontainer/apiv1/Client/ListNodePools/main.go
+++ b/internal/generated/snippets/edgecontainer/apiv1/Client/ListNodePools/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/edgecontainer/apiv1/Client/ListOperations/main.go
+++ b/internal/generated/snippets/edgecontainer/apiv1/Client/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/edgecontainer/apiv1/Client/ListVpnConnections/main.go
+++ b/internal/generated/snippets/edgecontainer/apiv1/Client/ListVpnConnections/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/edgecontainer/apiv1/Client/UpdateCluster/main.go
+++ b/internal/generated/snippets/edgecontainer/apiv1/Client/UpdateCluster/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/edgecontainer/apiv1/Client/UpdateNodePool/main.go
+++ b/internal/generated/snippets/edgecontainer/apiv1/Client/UpdateNodePool/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/edgecontainer/apiv1/Client/UpgradeCluster/main.go
+++ b/internal/generated/snippets/edgecontainer/apiv1/Client/UpgradeCluster/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/edgenetwork/apiv1/Client/CancelOperation/main.go
+++ b/internal/generated/snippets/edgenetwork/apiv1/Client/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/edgenetwork/apiv1/Client/CreateInterconnectAttachment/main.go
+++ b/internal/generated/snippets/edgenetwork/apiv1/Client/CreateInterconnectAttachment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/edgenetwork/apiv1/Client/CreateNetwork/main.go
+++ b/internal/generated/snippets/edgenetwork/apiv1/Client/CreateNetwork/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/edgenetwork/apiv1/Client/CreateRouter/main.go
+++ b/internal/generated/snippets/edgenetwork/apiv1/Client/CreateRouter/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/edgenetwork/apiv1/Client/CreateSubnet/main.go
+++ b/internal/generated/snippets/edgenetwork/apiv1/Client/CreateSubnet/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/edgenetwork/apiv1/Client/DeleteInterconnectAttachment/main.go
+++ b/internal/generated/snippets/edgenetwork/apiv1/Client/DeleteInterconnectAttachment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/edgenetwork/apiv1/Client/DeleteNetwork/main.go
+++ b/internal/generated/snippets/edgenetwork/apiv1/Client/DeleteNetwork/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/edgenetwork/apiv1/Client/DeleteOperation/main.go
+++ b/internal/generated/snippets/edgenetwork/apiv1/Client/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/edgenetwork/apiv1/Client/DeleteRouter/main.go
+++ b/internal/generated/snippets/edgenetwork/apiv1/Client/DeleteRouter/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/edgenetwork/apiv1/Client/DeleteSubnet/main.go
+++ b/internal/generated/snippets/edgenetwork/apiv1/Client/DeleteSubnet/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/edgenetwork/apiv1/Client/DiagnoseInterconnect/main.go
+++ b/internal/generated/snippets/edgenetwork/apiv1/Client/DiagnoseInterconnect/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/edgenetwork/apiv1/Client/DiagnoseNetwork/main.go
+++ b/internal/generated/snippets/edgenetwork/apiv1/Client/DiagnoseNetwork/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/edgenetwork/apiv1/Client/DiagnoseRouter/main.go
+++ b/internal/generated/snippets/edgenetwork/apiv1/Client/DiagnoseRouter/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/edgenetwork/apiv1/Client/GetInterconnect/main.go
+++ b/internal/generated/snippets/edgenetwork/apiv1/Client/GetInterconnect/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/edgenetwork/apiv1/Client/GetInterconnectAttachment/main.go
+++ b/internal/generated/snippets/edgenetwork/apiv1/Client/GetInterconnectAttachment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/edgenetwork/apiv1/Client/GetLocation/main.go
+++ b/internal/generated/snippets/edgenetwork/apiv1/Client/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/edgenetwork/apiv1/Client/GetNetwork/main.go
+++ b/internal/generated/snippets/edgenetwork/apiv1/Client/GetNetwork/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/edgenetwork/apiv1/Client/GetOperation/main.go
+++ b/internal/generated/snippets/edgenetwork/apiv1/Client/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/edgenetwork/apiv1/Client/GetRouter/main.go
+++ b/internal/generated/snippets/edgenetwork/apiv1/Client/GetRouter/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/edgenetwork/apiv1/Client/GetSubnet/main.go
+++ b/internal/generated/snippets/edgenetwork/apiv1/Client/GetSubnet/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/edgenetwork/apiv1/Client/GetZone/main.go
+++ b/internal/generated/snippets/edgenetwork/apiv1/Client/GetZone/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/edgenetwork/apiv1/Client/InitializeZone/main.go
+++ b/internal/generated/snippets/edgenetwork/apiv1/Client/InitializeZone/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/edgenetwork/apiv1/Client/ListInterconnectAttachments/main.go
+++ b/internal/generated/snippets/edgenetwork/apiv1/Client/ListInterconnectAttachments/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/edgenetwork/apiv1/Client/ListInterconnects/main.go
+++ b/internal/generated/snippets/edgenetwork/apiv1/Client/ListInterconnects/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/edgenetwork/apiv1/Client/ListLocations/main.go
+++ b/internal/generated/snippets/edgenetwork/apiv1/Client/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/edgenetwork/apiv1/Client/ListNetworks/main.go
+++ b/internal/generated/snippets/edgenetwork/apiv1/Client/ListNetworks/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/edgenetwork/apiv1/Client/ListOperations/main.go
+++ b/internal/generated/snippets/edgenetwork/apiv1/Client/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/edgenetwork/apiv1/Client/ListRouters/main.go
+++ b/internal/generated/snippets/edgenetwork/apiv1/Client/ListRouters/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/edgenetwork/apiv1/Client/ListSubnets/main.go
+++ b/internal/generated/snippets/edgenetwork/apiv1/Client/ListSubnets/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/edgenetwork/apiv1/Client/ListZones/main.go
+++ b/internal/generated/snippets/edgenetwork/apiv1/Client/ListZones/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/edgenetwork/apiv1/Client/UpdateRouter/main.go
+++ b/internal/generated/snippets/edgenetwork/apiv1/Client/UpdateRouter/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/edgenetwork/apiv1/Client/UpdateSubnet/main.go
+++ b/internal/generated/snippets/edgenetwork/apiv1/Client/UpdateSubnet/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/errorreporting/apiv1beta1/ErrorGroupClient/GetGroup/main.go
+++ b/internal/generated/snippets/errorreporting/apiv1beta1/ErrorGroupClient/GetGroup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/errorreporting/apiv1beta1/ErrorGroupClient/UpdateGroup/main.go
+++ b/internal/generated/snippets/errorreporting/apiv1beta1/ErrorGroupClient/UpdateGroup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/errorreporting/apiv1beta1/ErrorStatsClient/DeleteEvents/main.go
+++ b/internal/generated/snippets/errorreporting/apiv1beta1/ErrorStatsClient/DeleteEvents/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/errorreporting/apiv1beta1/ErrorStatsClient/ListEvents/main.go
+++ b/internal/generated/snippets/errorreporting/apiv1beta1/ErrorStatsClient/ListEvents/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/errorreporting/apiv1beta1/ErrorStatsClient/ListGroupStats/main.go
+++ b/internal/generated/snippets/errorreporting/apiv1beta1/ErrorStatsClient/ListGroupStats/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/errorreporting/apiv1beta1/ReportErrorsClient/ReportErrorEvent/main.go
+++ b/internal/generated/snippets/errorreporting/apiv1beta1/ReportErrorsClient/ReportErrorEvent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/essentialcontacts/apiv1/Client/ComputeContacts/main.go
+++ b/internal/generated/snippets/essentialcontacts/apiv1/Client/ComputeContacts/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/essentialcontacts/apiv1/Client/CreateContact/main.go
+++ b/internal/generated/snippets/essentialcontacts/apiv1/Client/CreateContact/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/essentialcontacts/apiv1/Client/DeleteContact/main.go
+++ b/internal/generated/snippets/essentialcontacts/apiv1/Client/DeleteContact/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/essentialcontacts/apiv1/Client/GetContact/main.go
+++ b/internal/generated/snippets/essentialcontacts/apiv1/Client/GetContact/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/essentialcontacts/apiv1/Client/ListContacts/main.go
+++ b/internal/generated/snippets/essentialcontacts/apiv1/Client/ListContacts/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/essentialcontacts/apiv1/Client/SendTestMessage/main.go
+++ b/internal/generated/snippets/essentialcontacts/apiv1/Client/SendTestMessage/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/essentialcontacts/apiv1/Client/UpdateContact/main.go
+++ b/internal/generated/snippets/essentialcontacts/apiv1/Client/UpdateContact/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/eventarc/apiv1/Client/CancelOperation/main.go
+++ b/internal/generated/snippets/eventarc/apiv1/Client/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/eventarc/apiv1/Client/CreateChannel/main.go
+++ b/internal/generated/snippets/eventarc/apiv1/Client/CreateChannel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/eventarc/apiv1/Client/CreateChannelConnection/main.go
+++ b/internal/generated/snippets/eventarc/apiv1/Client/CreateChannelConnection/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/eventarc/apiv1/Client/CreateEnrollment/main.go
+++ b/internal/generated/snippets/eventarc/apiv1/Client/CreateEnrollment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/eventarc/apiv1/Client/CreateGoogleApiSource/main.go
+++ b/internal/generated/snippets/eventarc/apiv1/Client/CreateGoogleApiSource/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/eventarc/apiv1/Client/CreateMessageBus/main.go
+++ b/internal/generated/snippets/eventarc/apiv1/Client/CreateMessageBus/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/eventarc/apiv1/Client/CreatePipeline/main.go
+++ b/internal/generated/snippets/eventarc/apiv1/Client/CreatePipeline/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/eventarc/apiv1/Client/CreateTrigger/main.go
+++ b/internal/generated/snippets/eventarc/apiv1/Client/CreateTrigger/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/eventarc/apiv1/Client/DeleteChannel/main.go
+++ b/internal/generated/snippets/eventarc/apiv1/Client/DeleteChannel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/eventarc/apiv1/Client/DeleteChannelConnection/main.go
+++ b/internal/generated/snippets/eventarc/apiv1/Client/DeleteChannelConnection/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/eventarc/apiv1/Client/DeleteEnrollment/main.go
+++ b/internal/generated/snippets/eventarc/apiv1/Client/DeleteEnrollment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/eventarc/apiv1/Client/DeleteGoogleApiSource/main.go
+++ b/internal/generated/snippets/eventarc/apiv1/Client/DeleteGoogleApiSource/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/eventarc/apiv1/Client/DeleteMessageBus/main.go
+++ b/internal/generated/snippets/eventarc/apiv1/Client/DeleteMessageBus/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/eventarc/apiv1/Client/DeleteOperation/main.go
+++ b/internal/generated/snippets/eventarc/apiv1/Client/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/eventarc/apiv1/Client/DeletePipeline/main.go
+++ b/internal/generated/snippets/eventarc/apiv1/Client/DeletePipeline/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/eventarc/apiv1/Client/DeleteTrigger/main.go
+++ b/internal/generated/snippets/eventarc/apiv1/Client/DeleteTrigger/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/eventarc/apiv1/Client/GetChannel/main.go
+++ b/internal/generated/snippets/eventarc/apiv1/Client/GetChannel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/eventarc/apiv1/Client/GetChannelConnection/main.go
+++ b/internal/generated/snippets/eventarc/apiv1/Client/GetChannelConnection/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/eventarc/apiv1/Client/GetEnrollment/main.go
+++ b/internal/generated/snippets/eventarc/apiv1/Client/GetEnrollment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/eventarc/apiv1/Client/GetGoogleApiSource/main.go
+++ b/internal/generated/snippets/eventarc/apiv1/Client/GetGoogleApiSource/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/eventarc/apiv1/Client/GetGoogleChannelConfig/main.go
+++ b/internal/generated/snippets/eventarc/apiv1/Client/GetGoogleChannelConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/eventarc/apiv1/Client/GetIamPolicy/main.go
+++ b/internal/generated/snippets/eventarc/apiv1/Client/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/eventarc/apiv1/Client/GetLocation/main.go
+++ b/internal/generated/snippets/eventarc/apiv1/Client/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/eventarc/apiv1/Client/GetMessageBus/main.go
+++ b/internal/generated/snippets/eventarc/apiv1/Client/GetMessageBus/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/eventarc/apiv1/Client/GetOperation/main.go
+++ b/internal/generated/snippets/eventarc/apiv1/Client/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/eventarc/apiv1/Client/GetPipeline/main.go
+++ b/internal/generated/snippets/eventarc/apiv1/Client/GetPipeline/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/eventarc/apiv1/Client/GetProvider/main.go
+++ b/internal/generated/snippets/eventarc/apiv1/Client/GetProvider/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/eventarc/apiv1/Client/GetTrigger/main.go
+++ b/internal/generated/snippets/eventarc/apiv1/Client/GetTrigger/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/eventarc/apiv1/Client/ListChannelConnections/main.go
+++ b/internal/generated/snippets/eventarc/apiv1/Client/ListChannelConnections/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/eventarc/apiv1/Client/ListChannels/main.go
+++ b/internal/generated/snippets/eventarc/apiv1/Client/ListChannels/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/eventarc/apiv1/Client/ListEnrollments/main.go
+++ b/internal/generated/snippets/eventarc/apiv1/Client/ListEnrollments/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/eventarc/apiv1/Client/ListGoogleApiSources/main.go
+++ b/internal/generated/snippets/eventarc/apiv1/Client/ListGoogleApiSources/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/eventarc/apiv1/Client/ListLocations/main.go
+++ b/internal/generated/snippets/eventarc/apiv1/Client/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/eventarc/apiv1/Client/ListMessageBusEnrollments/main.go
+++ b/internal/generated/snippets/eventarc/apiv1/Client/ListMessageBusEnrollments/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/eventarc/apiv1/Client/ListMessageBuses/main.go
+++ b/internal/generated/snippets/eventarc/apiv1/Client/ListMessageBuses/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/eventarc/apiv1/Client/ListOperations/main.go
+++ b/internal/generated/snippets/eventarc/apiv1/Client/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/eventarc/apiv1/Client/ListPipelines/main.go
+++ b/internal/generated/snippets/eventarc/apiv1/Client/ListPipelines/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/eventarc/apiv1/Client/ListProviders/main.go
+++ b/internal/generated/snippets/eventarc/apiv1/Client/ListProviders/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/eventarc/apiv1/Client/ListTriggers/main.go
+++ b/internal/generated/snippets/eventarc/apiv1/Client/ListTriggers/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/eventarc/apiv1/Client/SetIamPolicy/main.go
+++ b/internal/generated/snippets/eventarc/apiv1/Client/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/eventarc/apiv1/Client/TestIamPermissions/main.go
+++ b/internal/generated/snippets/eventarc/apiv1/Client/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/eventarc/apiv1/Client/UpdateChannel/main.go
+++ b/internal/generated/snippets/eventarc/apiv1/Client/UpdateChannel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/eventarc/apiv1/Client/UpdateEnrollment/main.go
+++ b/internal/generated/snippets/eventarc/apiv1/Client/UpdateEnrollment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/eventarc/apiv1/Client/UpdateGoogleApiSource/main.go
+++ b/internal/generated/snippets/eventarc/apiv1/Client/UpdateGoogleApiSource/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/eventarc/apiv1/Client/UpdateGoogleChannelConfig/main.go
+++ b/internal/generated/snippets/eventarc/apiv1/Client/UpdateGoogleChannelConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/eventarc/apiv1/Client/UpdateMessageBus/main.go
+++ b/internal/generated/snippets/eventarc/apiv1/Client/UpdateMessageBus/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/eventarc/apiv1/Client/UpdatePipeline/main.go
+++ b/internal/generated/snippets/eventarc/apiv1/Client/UpdatePipeline/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/eventarc/apiv1/Client/UpdateTrigger/main.go
+++ b/internal/generated/snippets/eventarc/apiv1/Client/UpdateTrigger/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/eventarc/publishing/apiv1/PublisherClient/Publish/main.go
+++ b/internal/generated/snippets/eventarc/publishing/apiv1/PublisherClient/Publish/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/eventarc/publishing/apiv1/PublisherClient/PublishChannelConnectionEvents/main.go
+++ b/internal/generated/snippets/eventarc/publishing/apiv1/PublisherClient/PublishChannelConnectionEvents/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/eventarc/publishing/apiv1/PublisherClient/PublishEvents/main.go
+++ b/internal/generated/snippets/eventarc/publishing/apiv1/PublisherClient/PublishEvents/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/filestore/apiv1/CloudFilestoreManagerClient/CancelOperation/main.go
+++ b/internal/generated/snippets/filestore/apiv1/CloudFilestoreManagerClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/filestore/apiv1/CloudFilestoreManagerClient/CreateBackup/main.go
+++ b/internal/generated/snippets/filestore/apiv1/CloudFilestoreManagerClient/CreateBackup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/filestore/apiv1/CloudFilestoreManagerClient/CreateInstance/main.go
+++ b/internal/generated/snippets/filestore/apiv1/CloudFilestoreManagerClient/CreateInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/filestore/apiv1/CloudFilestoreManagerClient/CreateSnapshot/main.go
+++ b/internal/generated/snippets/filestore/apiv1/CloudFilestoreManagerClient/CreateSnapshot/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/filestore/apiv1/CloudFilestoreManagerClient/DeleteBackup/main.go
+++ b/internal/generated/snippets/filestore/apiv1/CloudFilestoreManagerClient/DeleteBackup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/filestore/apiv1/CloudFilestoreManagerClient/DeleteInstance/main.go
+++ b/internal/generated/snippets/filestore/apiv1/CloudFilestoreManagerClient/DeleteInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/filestore/apiv1/CloudFilestoreManagerClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/filestore/apiv1/CloudFilestoreManagerClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/filestore/apiv1/CloudFilestoreManagerClient/DeleteSnapshot/main.go
+++ b/internal/generated/snippets/filestore/apiv1/CloudFilestoreManagerClient/DeleteSnapshot/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/filestore/apiv1/CloudFilestoreManagerClient/GetBackup/main.go
+++ b/internal/generated/snippets/filestore/apiv1/CloudFilestoreManagerClient/GetBackup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/filestore/apiv1/CloudFilestoreManagerClient/GetInstance/main.go
+++ b/internal/generated/snippets/filestore/apiv1/CloudFilestoreManagerClient/GetInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/filestore/apiv1/CloudFilestoreManagerClient/GetLocation/main.go
+++ b/internal/generated/snippets/filestore/apiv1/CloudFilestoreManagerClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/filestore/apiv1/CloudFilestoreManagerClient/GetOperation/main.go
+++ b/internal/generated/snippets/filestore/apiv1/CloudFilestoreManagerClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/filestore/apiv1/CloudFilestoreManagerClient/GetSnapshot/main.go
+++ b/internal/generated/snippets/filestore/apiv1/CloudFilestoreManagerClient/GetSnapshot/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/filestore/apiv1/CloudFilestoreManagerClient/ListBackups/main.go
+++ b/internal/generated/snippets/filestore/apiv1/CloudFilestoreManagerClient/ListBackups/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/filestore/apiv1/CloudFilestoreManagerClient/ListInstances/main.go
+++ b/internal/generated/snippets/filestore/apiv1/CloudFilestoreManagerClient/ListInstances/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/filestore/apiv1/CloudFilestoreManagerClient/ListLocations/main.go
+++ b/internal/generated/snippets/filestore/apiv1/CloudFilestoreManagerClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/filestore/apiv1/CloudFilestoreManagerClient/ListOperations/main.go
+++ b/internal/generated/snippets/filestore/apiv1/CloudFilestoreManagerClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/filestore/apiv1/CloudFilestoreManagerClient/ListSnapshots/main.go
+++ b/internal/generated/snippets/filestore/apiv1/CloudFilestoreManagerClient/ListSnapshots/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/filestore/apiv1/CloudFilestoreManagerClient/PromoteReplica/main.go
+++ b/internal/generated/snippets/filestore/apiv1/CloudFilestoreManagerClient/PromoteReplica/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/filestore/apiv1/CloudFilestoreManagerClient/RestoreInstance/main.go
+++ b/internal/generated/snippets/filestore/apiv1/CloudFilestoreManagerClient/RestoreInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/filestore/apiv1/CloudFilestoreManagerClient/RevertInstance/main.go
+++ b/internal/generated/snippets/filestore/apiv1/CloudFilestoreManagerClient/RevertInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/filestore/apiv1/CloudFilestoreManagerClient/UpdateBackup/main.go
+++ b/internal/generated/snippets/filestore/apiv1/CloudFilestoreManagerClient/UpdateBackup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/filestore/apiv1/CloudFilestoreManagerClient/UpdateInstance/main.go
+++ b/internal/generated/snippets/filestore/apiv1/CloudFilestoreManagerClient/UpdateInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/filestore/apiv1/CloudFilestoreManagerClient/UpdateSnapshot/main.go
+++ b/internal/generated/snippets/filestore/apiv1/CloudFilestoreManagerClient/UpdateSnapshot/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/financialservices/apiv1/AMLClient/CancelOperation/main.go
+++ b/internal/generated/snippets/financialservices/apiv1/AMLClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/financialservices/apiv1/AMLClient/CreateBacktestResult/main.go
+++ b/internal/generated/snippets/financialservices/apiv1/AMLClient/CreateBacktestResult/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/financialservices/apiv1/AMLClient/CreateDataset/main.go
+++ b/internal/generated/snippets/financialservices/apiv1/AMLClient/CreateDataset/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/financialservices/apiv1/AMLClient/CreateEngineConfig/main.go
+++ b/internal/generated/snippets/financialservices/apiv1/AMLClient/CreateEngineConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/financialservices/apiv1/AMLClient/CreateInstance/main.go
+++ b/internal/generated/snippets/financialservices/apiv1/AMLClient/CreateInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/financialservices/apiv1/AMLClient/CreateModel/main.go
+++ b/internal/generated/snippets/financialservices/apiv1/AMLClient/CreateModel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/financialservices/apiv1/AMLClient/CreatePredictionResult/main.go
+++ b/internal/generated/snippets/financialservices/apiv1/AMLClient/CreatePredictionResult/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/financialservices/apiv1/AMLClient/DeleteBacktestResult/main.go
+++ b/internal/generated/snippets/financialservices/apiv1/AMLClient/DeleteBacktestResult/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/financialservices/apiv1/AMLClient/DeleteDataset/main.go
+++ b/internal/generated/snippets/financialservices/apiv1/AMLClient/DeleteDataset/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/financialservices/apiv1/AMLClient/DeleteEngineConfig/main.go
+++ b/internal/generated/snippets/financialservices/apiv1/AMLClient/DeleteEngineConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/financialservices/apiv1/AMLClient/DeleteInstance/main.go
+++ b/internal/generated/snippets/financialservices/apiv1/AMLClient/DeleteInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/financialservices/apiv1/AMLClient/DeleteModel/main.go
+++ b/internal/generated/snippets/financialservices/apiv1/AMLClient/DeleteModel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/financialservices/apiv1/AMLClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/financialservices/apiv1/AMLClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/financialservices/apiv1/AMLClient/DeletePredictionResult/main.go
+++ b/internal/generated/snippets/financialservices/apiv1/AMLClient/DeletePredictionResult/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/financialservices/apiv1/AMLClient/ExportBacktestResultMetadata/main.go
+++ b/internal/generated/snippets/financialservices/apiv1/AMLClient/ExportBacktestResultMetadata/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/financialservices/apiv1/AMLClient/ExportEngineConfigMetadata/main.go
+++ b/internal/generated/snippets/financialservices/apiv1/AMLClient/ExportEngineConfigMetadata/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/financialservices/apiv1/AMLClient/ExportModelMetadata/main.go
+++ b/internal/generated/snippets/financialservices/apiv1/AMLClient/ExportModelMetadata/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/financialservices/apiv1/AMLClient/ExportPredictionResultMetadata/main.go
+++ b/internal/generated/snippets/financialservices/apiv1/AMLClient/ExportPredictionResultMetadata/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/financialservices/apiv1/AMLClient/ExportRegisteredParties/main.go
+++ b/internal/generated/snippets/financialservices/apiv1/AMLClient/ExportRegisteredParties/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/financialservices/apiv1/AMLClient/GetBacktestResult/main.go
+++ b/internal/generated/snippets/financialservices/apiv1/AMLClient/GetBacktestResult/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/financialservices/apiv1/AMLClient/GetDataset/main.go
+++ b/internal/generated/snippets/financialservices/apiv1/AMLClient/GetDataset/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/financialservices/apiv1/AMLClient/GetEngineConfig/main.go
+++ b/internal/generated/snippets/financialservices/apiv1/AMLClient/GetEngineConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/financialservices/apiv1/AMLClient/GetEngineVersion/main.go
+++ b/internal/generated/snippets/financialservices/apiv1/AMLClient/GetEngineVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/financialservices/apiv1/AMLClient/GetInstance/main.go
+++ b/internal/generated/snippets/financialservices/apiv1/AMLClient/GetInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/financialservices/apiv1/AMLClient/GetLocation/main.go
+++ b/internal/generated/snippets/financialservices/apiv1/AMLClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/financialservices/apiv1/AMLClient/GetModel/main.go
+++ b/internal/generated/snippets/financialservices/apiv1/AMLClient/GetModel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/financialservices/apiv1/AMLClient/GetOperation/main.go
+++ b/internal/generated/snippets/financialservices/apiv1/AMLClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/financialservices/apiv1/AMLClient/GetPredictionResult/main.go
+++ b/internal/generated/snippets/financialservices/apiv1/AMLClient/GetPredictionResult/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/financialservices/apiv1/AMLClient/ImportRegisteredParties/main.go
+++ b/internal/generated/snippets/financialservices/apiv1/AMLClient/ImportRegisteredParties/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/financialservices/apiv1/AMLClient/ListBacktestResults/main.go
+++ b/internal/generated/snippets/financialservices/apiv1/AMLClient/ListBacktestResults/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/financialservices/apiv1/AMLClient/ListDatasets/main.go
+++ b/internal/generated/snippets/financialservices/apiv1/AMLClient/ListDatasets/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/financialservices/apiv1/AMLClient/ListEngineConfigs/main.go
+++ b/internal/generated/snippets/financialservices/apiv1/AMLClient/ListEngineConfigs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/financialservices/apiv1/AMLClient/ListEngineVersions/main.go
+++ b/internal/generated/snippets/financialservices/apiv1/AMLClient/ListEngineVersions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/financialservices/apiv1/AMLClient/ListInstances/main.go
+++ b/internal/generated/snippets/financialservices/apiv1/AMLClient/ListInstances/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/financialservices/apiv1/AMLClient/ListLocations/main.go
+++ b/internal/generated/snippets/financialservices/apiv1/AMLClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/financialservices/apiv1/AMLClient/ListModels/main.go
+++ b/internal/generated/snippets/financialservices/apiv1/AMLClient/ListModels/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/financialservices/apiv1/AMLClient/ListOperations/main.go
+++ b/internal/generated/snippets/financialservices/apiv1/AMLClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/financialservices/apiv1/AMLClient/ListPredictionResults/main.go
+++ b/internal/generated/snippets/financialservices/apiv1/AMLClient/ListPredictionResults/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/financialservices/apiv1/AMLClient/UpdateBacktestResult/main.go
+++ b/internal/generated/snippets/financialservices/apiv1/AMLClient/UpdateBacktestResult/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/financialservices/apiv1/AMLClient/UpdateDataset/main.go
+++ b/internal/generated/snippets/financialservices/apiv1/AMLClient/UpdateDataset/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/financialservices/apiv1/AMLClient/UpdateEngineConfig/main.go
+++ b/internal/generated/snippets/financialservices/apiv1/AMLClient/UpdateEngineConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/financialservices/apiv1/AMLClient/UpdateInstance/main.go
+++ b/internal/generated/snippets/financialservices/apiv1/AMLClient/UpdateInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/financialservices/apiv1/AMLClient/UpdateModel/main.go
+++ b/internal/generated/snippets/financialservices/apiv1/AMLClient/UpdateModel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/financialservices/apiv1/AMLClient/UpdatePredictionResult/main.go
+++ b/internal/generated/snippets/financialservices/apiv1/AMLClient/UpdatePredictionResult/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/firestore/apiv1/Client/BatchWrite/main.go
+++ b/internal/generated/snippets/firestore/apiv1/Client/BatchWrite/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/firestore/apiv1/Client/BeginTransaction/main.go
+++ b/internal/generated/snippets/firestore/apiv1/Client/BeginTransaction/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/firestore/apiv1/Client/CancelOperation/main.go
+++ b/internal/generated/snippets/firestore/apiv1/Client/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/firestore/apiv1/Client/Commit/main.go
+++ b/internal/generated/snippets/firestore/apiv1/Client/Commit/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/firestore/apiv1/Client/CreateDocument/main.go
+++ b/internal/generated/snippets/firestore/apiv1/Client/CreateDocument/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/firestore/apiv1/Client/DeleteDocument/main.go
+++ b/internal/generated/snippets/firestore/apiv1/Client/DeleteDocument/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/firestore/apiv1/Client/DeleteOperation/main.go
+++ b/internal/generated/snippets/firestore/apiv1/Client/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/firestore/apiv1/Client/GetDocument/main.go
+++ b/internal/generated/snippets/firestore/apiv1/Client/GetDocument/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/firestore/apiv1/Client/GetOperation/main.go
+++ b/internal/generated/snippets/firestore/apiv1/Client/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/firestore/apiv1/Client/ListCollectionIds/main.go
+++ b/internal/generated/snippets/firestore/apiv1/Client/ListCollectionIds/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/firestore/apiv1/Client/ListDocuments/main.go
+++ b/internal/generated/snippets/firestore/apiv1/Client/ListDocuments/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/firestore/apiv1/Client/ListOperations/main.go
+++ b/internal/generated/snippets/firestore/apiv1/Client/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/firestore/apiv1/Client/Listen/main.go
+++ b/internal/generated/snippets/firestore/apiv1/Client/Listen/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/firestore/apiv1/Client/PartitionQuery/main.go
+++ b/internal/generated/snippets/firestore/apiv1/Client/PartitionQuery/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/firestore/apiv1/Client/Rollback/main.go
+++ b/internal/generated/snippets/firestore/apiv1/Client/Rollback/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/firestore/apiv1/Client/UpdateDocument/main.go
+++ b/internal/generated/snippets/firestore/apiv1/Client/UpdateDocument/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/firestore/apiv1/Client/Write/main.go
+++ b/internal/generated/snippets/firestore/apiv1/Client/Write/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/firestore/apiv1/admin/FirestoreAdminClient/BulkDeleteDocuments/main.go
+++ b/internal/generated/snippets/firestore/apiv1/admin/FirestoreAdminClient/BulkDeleteDocuments/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/firestore/apiv1/admin/FirestoreAdminClient/CancelOperation/main.go
+++ b/internal/generated/snippets/firestore/apiv1/admin/FirestoreAdminClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/firestore/apiv1/admin/FirestoreAdminClient/CloneDatabase/main.go
+++ b/internal/generated/snippets/firestore/apiv1/admin/FirestoreAdminClient/CloneDatabase/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/firestore/apiv1/admin/FirestoreAdminClient/CreateBackupSchedule/main.go
+++ b/internal/generated/snippets/firestore/apiv1/admin/FirestoreAdminClient/CreateBackupSchedule/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/firestore/apiv1/admin/FirestoreAdminClient/CreateDatabase/main.go
+++ b/internal/generated/snippets/firestore/apiv1/admin/FirestoreAdminClient/CreateDatabase/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/firestore/apiv1/admin/FirestoreAdminClient/CreateIndex/main.go
+++ b/internal/generated/snippets/firestore/apiv1/admin/FirestoreAdminClient/CreateIndex/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/firestore/apiv1/admin/FirestoreAdminClient/CreateUserCreds/main.go
+++ b/internal/generated/snippets/firestore/apiv1/admin/FirestoreAdminClient/CreateUserCreds/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/firestore/apiv1/admin/FirestoreAdminClient/DeleteBackup/main.go
+++ b/internal/generated/snippets/firestore/apiv1/admin/FirestoreAdminClient/DeleteBackup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/firestore/apiv1/admin/FirestoreAdminClient/DeleteBackupSchedule/main.go
+++ b/internal/generated/snippets/firestore/apiv1/admin/FirestoreAdminClient/DeleteBackupSchedule/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/firestore/apiv1/admin/FirestoreAdminClient/DeleteDatabase/main.go
+++ b/internal/generated/snippets/firestore/apiv1/admin/FirestoreAdminClient/DeleteDatabase/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/firestore/apiv1/admin/FirestoreAdminClient/DeleteIndex/main.go
+++ b/internal/generated/snippets/firestore/apiv1/admin/FirestoreAdminClient/DeleteIndex/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/firestore/apiv1/admin/FirestoreAdminClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/firestore/apiv1/admin/FirestoreAdminClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/firestore/apiv1/admin/FirestoreAdminClient/DeleteUserCreds/main.go
+++ b/internal/generated/snippets/firestore/apiv1/admin/FirestoreAdminClient/DeleteUserCreds/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/firestore/apiv1/admin/FirestoreAdminClient/DisableUserCreds/main.go
+++ b/internal/generated/snippets/firestore/apiv1/admin/FirestoreAdminClient/DisableUserCreds/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/firestore/apiv1/admin/FirestoreAdminClient/EnableUserCreds/main.go
+++ b/internal/generated/snippets/firestore/apiv1/admin/FirestoreAdminClient/EnableUserCreds/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/firestore/apiv1/admin/FirestoreAdminClient/ExportDocuments/main.go
+++ b/internal/generated/snippets/firestore/apiv1/admin/FirestoreAdminClient/ExportDocuments/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/firestore/apiv1/admin/FirestoreAdminClient/GetBackup/main.go
+++ b/internal/generated/snippets/firestore/apiv1/admin/FirestoreAdminClient/GetBackup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/firestore/apiv1/admin/FirestoreAdminClient/GetBackupSchedule/main.go
+++ b/internal/generated/snippets/firestore/apiv1/admin/FirestoreAdminClient/GetBackupSchedule/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/firestore/apiv1/admin/FirestoreAdminClient/GetDatabase/main.go
+++ b/internal/generated/snippets/firestore/apiv1/admin/FirestoreAdminClient/GetDatabase/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/firestore/apiv1/admin/FirestoreAdminClient/GetField/main.go
+++ b/internal/generated/snippets/firestore/apiv1/admin/FirestoreAdminClient/GetField/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/firestore/apiv1/admin/FirestoreAdminClient/GetIndex/main.go
+++ b/internal/generated/snippets/firestore/apiv1/admin/FirestoreAdminClient/GetIndex/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/firestore/apiv1/admin/FirestoreAdminClient/GetOperation/main.go
+++ b/internal/generated/snippets/firestore/apiv1/admin/FirestoreAdminClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/firestore/apiv1/admin/FirestoreAdminClient/GetUserCreds/main.go
+++ b/internal/generated/snippets/firestore/apiv1/admin/FirestoreAdminClient/GetUserCreds/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/firestore/apiv1/admin/FirestoreAdminClient/ImportDocuments/main.go
+++ b/internal/generated/snippets/firestore/apiv1/admin/FirestoreAdminClient/ImportDocuments/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/firestore/apiv1/admin/FirestoreAdminClient/ListBackupSchedules/main.go
+++ b/internal/generated/snippets/firestore/apiv1/admin/FirestoreAdminClient/ListBackupSchedules/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/firestore/apiv1/admin/FirestoreAdminClient/ListBackups/main.go
+++ b/internal/generated/snippets/firestore/apiv1/admin/FirestoreAdminClient/ListBackups/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/firestore/apiv1/admin/FirestoreAdminClient/ListDatabases/main.go
+++ b/internal/generated/snippets/firestore/apiv1/admin/FirestoreAdminClient/ListDatabases/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/firestore/apiv1/admin/FirestoreAdminClient/ListFields/main.go
+++ b/internal/generated/snippets/firestore/apiv1/admin/FirestoreAdminClient/ListFields/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/firestore/apiv1/admin/FirestoreAdminClient/ListIndexes/main.go
+++ b/internal/generated/snippets/firestore/apiv1/admin/FirestoreAdminClient/ListIndexes/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/firestore/apiv1/admin/FirestoreAdminClient/ListOperations/main.go
+++ b/internal/generated/snippets/firestore/apiv1/admin/FirestoreAdminClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/firestore/apiv1/admin/FirestoreAdminClient/ListUserCreds/main.go
+++ b/internal/generated/snippets/firestore/apiv1/admin/FirestoreAdminClient/ListUserCreds/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/firestore/apiv1/admin/FirestoreAdminClient/ResetUserPassword/main.go
+++ b/internal/generated/snippets/firestore/apiv1/admin/FirestoreAdminClient/ResetUserPassword/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/firestore/apiv1/admin/FirestoreAdminClient/RestoreDatabase/main.go
+++ b/internal/generated/snippets/firestore/apiv1/admin/FirestoreAdminClient/RestoreDatabase/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/firestore/apiv1/admin/FirestoreAdminClient/UpdateBackupSchedule/main.go
+++ b/internal/generated/snippets/firestore/apiv1/admin/FirestoreAdminClient/UpdateBackupSchedule/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/firestore/apiv1/admin/FirestoreAdminClient/UpdateDatabase/main.go
+++ b/internal/generated/snippets/firestore/apiv1/admin/FirestoreAdminClient/UpdateDatabase/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/firestore/apiv1/admin/FirestoreAdminClient/UpdateField/main.go
+++ b/internal/generated/snippets/firestore/apiv1/admin/FirestoreAdminClient/UpdateField/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/functions/apiv1/CloudFunctionsClient/CallFunction/main.go
+++ b/internal/generated/snippets/functions/apiv1/CloudFunctionsClient/CallFunction/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/functions/apiv1/CloudFunctionsClient/CreateFunction/main.go
+++ b/internal/generated/snippets/functions/apiv1/CloudFunctionsClient/CreateFunction/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/functions/apiv1/CloudFunctionsClient/DeleteFunction/main.go
+++ b/internal/generated/snippets/functions/apiv1/CloudFunctionsClient/DeleteFunction/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/functions/apiv1/CloudFunctionsClient/GenerateDownloadUrl/main.go
+++ b/internal/generated/snippets/functions/apiv1/CloudFunctionsClient/GenerateDownloadUrl/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/functions/apiv1/CloudFunctionsClient/GenerateUploadUrl/main.go
+++ b/internal/generated/snippets/functions/apiv1/CloudFunctionsClient/GenerateUploadUrl/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/functions/apiv1/CloudFunctionsClient/GetFunction/main.go
+++ b/internal/generated/snippets/functions/apiv1/CloudFunctionsClient/GetFunction/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/functions/apiv1/CloudFunctionsClient/GetIamPolicy/main.go
+++ b/internal/generated/snippets/functions/apiv1/CloudFunctionsClient/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/functions/apiv1/CloudFunctionsClient/GetOperation/main.go
+++ b/internal/generated/snippets/functions/apiv1/CloudFunctionsClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/functions/apiv1/CloudFunctionsClient/ListFunctions/main.go
+++ b/internal/generated/snippets/functions/apiv1/CloudFunctionsClient/ListFunctions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/functions/apiv1/CloudFunctionsClient/ListLocations/main.go
+++ b/internal/generated/snippets/functions/apiv1/CloudFunctionsClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/functions/apiv1/CloudFunctionsClient/ListOperations/main.go
+++ b/internal/generated/snippets/functions/apiv1/CloudFunctionsClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/functions/apiv1/CloudFunctionsClient/SetIamPolicy/main.go
+++ b/internal/generated/snippets/functions/apiv1/CloudFunctionsClient/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/functions/apiv1/CloudFunctionsClient/TestIamPermissions/main.go
+++ b/internal/generated/snippets/functions/apiv1/CloudFunctionsClient/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/functions/apiv1/CloudFunctionsClient/UpdateFunction/main.go
+++ b/internal/generated/snippets/functions/apiv1/CloudFunctionsClient/UpdateFunction/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/functions/apiv2/FunctionClient/CreateFunction/main.go
+++ b/internal/generated/snippets/functions/apiv2/FunctionClient/CreateFunction/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/functions/apiv2/FunctionClient/DeleteFunction/main.go
+++ b/internal/generated/snippets/functions/apiv2/FunctionClient/DeleteFunction/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/functions/apiv2/FunctionClient/GenerateDownloadUrl/main.go
+++ b/internal/generated/snippets/functions/apiv2/FunctionClient/GenerateDownloadUrl/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/functions/apiv2/FunctionClient/GenerateUploadUrl/main.go
+++ b/internal/generated/snippets/functions/apiv2/FunctionClient/GenerateUploadUrl/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/functions/apiv2/FunctionClient/GetFunction/main.go
+++ b/internal/generated/snippets/functions/apiv2/FunctionClient/GetFunction/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/functions/apiv2/FunctionClient/GetIamPolicy/main.go
+++ b/internal/generated/snippets/functions/apiv2/FunctionClient/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/functions/apiv2/FunctionClient/GetOperation/main.go
+++ b/internal/generated/snippets/functions/apiv2/FunctionClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/functions/apiv2/FunctionClient/ListFunctions/main.go
+++ b/internal/generated/snippets/functions/apiv2/FunctionClient/ListFunctions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/functions/apiv2/FunctionClient/ListLocations/main.go
+++ b/internal/generated/snippets/functions/apiv2/FunctionClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/functions/apiv2/FunctionClient/ListOperations/main.go
+++ b/internal/generated/snippets/functions/apiv2/FunctionClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/functions/apiv2/FunctionClient/ListRuntimes/main.go
+++ b/internal/generated/snippets/functions/apiv2/FunctionClient/ListRuntimes/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/functions/apiv2/FunctionClient/SetIamPolicy/main.go
+++ b/internal/generated/snippets/functions/apiv2/FunctionClient/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/functions/apiv2/FunctionClient/TestIamPermissions/main.go
+++ b/internal/generated/snippets/functions/apiv2/FunctionClient/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/functions/apiv2/FunctionClient/UpdateFunction/main.go
+++ b/internal/generated/snippets/functions/apiv2/FunctionClient/UpdateFunction/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/functions/apiv2beta/FunctionClient/CreateFunction/main.go
+++ b/internal/generated/snippets/functions/apiv2beta/FunctionClient/CreateFunction/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/functions/apiv2beta/FunctionClient/DeleteFunction/main.go
+++ b/internal/generated/snippets/functions/apiv2beta/FunctionClient/DeleteFunction/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/functions/apiv2beta/FunctionClient/GenerateDownloadUrl/main.go
+++ b/internal/generated/snippets/functions/apiv2beta/FunctionClient/GenerateDownloadUrl/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/functions/apiv2beta/FunctionClient/GenerateUploadUrl/main.go
+++ b/internal/generated/snippets/functions/apiv2beta/FunctionClient/GenerateUploadUrl/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/functions/apiv2beta/FunctionClient/GetFunction/main.go
+++ b/internal/generated/snippets/functions/apiv2beta/FunctionClient/GetFunction/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/functions/apiv2beta/FunctionClient/GetIamPolicy/main.go
+++ b/internal/generated/snippets/functions/apiv2beta/FunctionClient/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/functions/apiv2beta/FunctionClient/GetOperation/main.go
+++ b/internal/generated/snippets/functions/apiv2beta/FunctionClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/functions/apiv2beta/FunctionClient/ListFunctions/main.go
+++ b/internal/generated/snippets/functions/apiv2beta/FunctionClient/ListFunctions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/functions/apiv2beta/FunctionClient/ListLocations/main.go
+++ b/internal/generated/snippets/functions/apiv2beta/FunctionClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/functions/apiv2beta/FunctionClient/ListOperations/main.go
+++ b/internal/generated/snippets/functions/apiv2beta/FunctionClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/functions/apiv2beta/FunctionClient/ListRuntimes/main.go
+++ b/internal/generated/snippets/functions/apiv2beta/FunctionClient/ListRuntimes/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/functions/apiv2beta/FunctionClient/SetIamPolicy/main.go
+++ b/internal/generated/snippets/functions/apiv2beta/FunctionClient/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/functions/apiv2beta/FunctionClient/TestIamPermissions/main.go
+++ b/internal/generated/snippets/functions/apiv2beta/FunctionClient/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/functions/apiv2beta/FunctionClient/UpdateFunction/main.go
+++ b/internal/generated/snippets/functions/apiv2beta/FunctionClient/UpdateFunction/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/CancelOperation/main.go
+++ b/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/CreateBackup/main.go
+++ b/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/CreateBackup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/CreateBackupChannel/main.go
+++ b/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/CreateBackupChannel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/CreateBackupPlan/main.go
+++ b/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/CreateBackupPlan/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/CreateRestore/main.go
+++ b/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/CreateRestore/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/CreateRestoreChannel/main.go
+++ b/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/CreateRestoreChannel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/CreateRestorePlan/main.go
+++ b/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/CreateRestorePlan/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/DeleteBackup/main.go
+++ b/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/DeleteBackup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/DeleteBackupChannel/main.go
+++ b/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/DeleteBackupChannel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/DeleteBackupPlan/main.go
+++ b/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/DeleteBackupPlan/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/DeleteRestore/main.go
+++ b/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/DeleteRestore/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/DeleteRestoreChannel/main.go
+++ b/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/DeleteRestoreChannel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/DeleteRestorePlan/main.go
+++ b/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/DeleteRestorePlan/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/GetBackup/main.go
+++ b/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/GetBackup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/GetBackupChannel/main.go
+++ b/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/GetBackupChannel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/GetBackupIndexDownloadUrl/main.go
+++ b/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/GetBackupIndexDownloadUrl/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/GetBackupPlan/main.go
+++ b/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/GetBackupPlan/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/GetBackupPlanBinding/main.go
+++ b/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/GetBackupPlanBinding/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/GetIamPolicy/main.go
+++ b/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/GetLocation/main.go
+++ b/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/GetOperation/main.go
+++ b/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/GetRestore/main.go
+++ b/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/GetRestore/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/GetRestoreChannel/main.go
+++ b/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/GetRestoreChannel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/GetRestorePlan/main.go
+++ b/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/GetRestorePlan/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/GetRestorePlanBinding/main.go
+++ b/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/GetRestorePlanBinding/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/GetVolumeBackup/main.go
+++ b/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/GetVolumeBackup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/GetVolumeRestore/main.go
+++ b/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/GetVolumeRestore/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/ListBackupChannels/main.go
+++ b/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/ListBackupChannels/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/ListBackupPlanBindings/main.go
+++ b/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/ListBackupPlanBindings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/ListBackupPlans/main.go
+++ b/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/ListBackupPlans/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/ListBackups/main.go
+++ b/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/ListBackups/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/ListLocations/main.go
+++ b/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/ListOperations/main.go
+++ b/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/ListRestoreChannels/main.go
+++ b/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/ListRestoreChannels/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/ListRestorePlanBindings/main.go
+++ b/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/ListRestorePlanBindings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/ListRestorePlans/main.go
+++ b/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/ListRestorePlans/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/ListRestores/main.go
+++ b/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/ListRestores/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/ListVolumeBackups/main.go
+++ b/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/ListVolumeBackups/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/ListVolumeRestores/main.go
+++ b/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/ListVolumeRestores/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/SetIamPolicy/main.go
+++ b/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/TestIamPermissions/main.go
+++ b/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/UpdateBackup/main.go
+++ b/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/UpdateBackup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/UpdateBackupChannel/main.go
+++ b/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/UpdateBackupChannel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/UpdateBackupPlan/main.go
+++ b/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/UpdateBackupPlan/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/UpdateRestore/main.go
+++ b/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/UpdateRestore/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/UpdateRestoreChannel/main.go
+++ b/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/UpdateRestoreChannel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/UpdateRestorePlan/main.go
+++ b/internal/generated/snippets/gkebackup/apiv1/BackupForGKEClient/UpdateRestorePlan/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkeconnect/gateway/apiv1/GatewayControlClient/GenerateCredentials/main.go
+++ b/internal/generated/snippets/gkeconnect/gateway/apiv1/GatewayControlClient/GenerateCredentials/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkeconnect/gateway/apiv1beta1/GatewayControlClient/GenerateCredentials/main.go
+++ b/internal/generated/snippets/gkeconnect/gateway/apiv1beta1/GatewayControlClient/GenerateCredentials/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkehub/apiv1beta1/GkeHubMembershipClient/CancelOperation/main.go
+++ b/internal/generated/snippets/gkehub/apiv1beta1/GkeHubMembershipClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkehub/apiv1beta1/GkeHubMembershipClient/CreateMembership/main.go
+++ b/internal/generated/snippets/gkehub/apiv1beta1/GkeHubMembershipClient/CreateMembership/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkehub/apiv1beta1/GkeHubMembershipClient/DeleteMembership/main.go
+++ b/internal/generated/snippets/gkehub/apiv1beta1/GkeHubMembershipClient/DeleteMembership/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkehub/apiv1beta1/GkeHubMembershipClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/gkehub/apiv1beta1/GkeHubMembershipClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkehub/apiv1beta1/GkeHubMembershipClient/GenerateConnectManifest/main.go
+++ b/internal/generated/snippets/gkehub/apiv1beta1/GkeHubMembershipClient/GenerateConnectManifest/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkehub/apiv1beta1/GkeHubMembershipClient/GenerateExclusivityManifest/main.go
+++ b/internal/generated/snippets/gkehub/apiv1beta1/GkeHubMembershipClient/GenerateExclusivityManifest/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkehub/apiv1beta1/GkeHubMembershipClient/GetIamPolicy/main.go
+++ b/internal/generated/snippets/gkehub/apiv1beta1/GkeHubMembershipClient/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkehub/apiv1beta1/GkeHubMembershipClient/GetLocation/main.go
+++ b/internal/generated/snippets/gkehub/apiv1beta1/GkeHubMembershipClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkehub/apiv1beta1/GkeHubMembershipClient/GetMembership/main.go
+++ b/internal/generated/snippets/gkehub/apiv1beta1/GkeHubMembershipClient/GetMembership/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkehub/apiv1beta1/GkeHubMembershipClient/GetOperation/main.go
+++ b/internal/generated/snippets/gkehub/apiv1beta1/GkeHubMembershipClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkehub/apiv1beta1/GkeHubMembershipClient/ListLocations/main.go
+++ b/internal/generated/snippets/gkehub/apiv1beta1/GkeHubMembershipClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkehub/apiv1beta1/GkeHubMembershipClient/ListMemberships/main.go
+++ b/internal/generated/snippets/gkehub/apiv1beta1/GkeHubMembershipClient/ListMemberships/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkehub/apiv1beta1/GkeHubMembershipClient/ListOperations/main.go
+++ b/internal/generated/snippets/gkehub/apiv1beta1/GkeHubMembershipClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkehub/apiv1beta1/GkeHubMembershipClient/SetIamPolicy/main.go
+++ b/internal/generated/snippets/gkehub/apiv1beta1/GkeHubMembershipClient/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkehub/apiv1beta1/GkeHubMembershipClient/TestIamPermissions/main.go
+++ b/internal/generated/snippets/gkehub/apiv1beta1/GkeHubMembershipClient/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkehub/apiv1beta1/GkeHubMembershipClient/UpdateMembership/main.go
+++ b/internal/generated/snippets/gkehub/apiv1beta1/GkeHubMembershipClient/UpdateMembership/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkehub/apiv1beta1/GkeHubMembershipClient/ValidateExclusivity/main.go
+++ b/internal/generated/snippets/gkehub/apiv1beta1/GkeHubMembershipClient/ValidateExclusivity/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkemulticloud/apiv1/AttachedClustersClient/CancelOperation/main.go
+++ b/internal/generated/snippets/gkemulticloud/apiv1/AttachedClustersClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkemulticloud/apiv1/AttachedClustersClient/CreateAttachedCluster/main.go
+++ b/internal/generated/snippets/gkemulticloud/apiv1/AttachedClustersClient/CreateAttachedCluster/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkemulticloud/apiv1/AttachedClustersClient/DeleteAttachedCluster/main.go
+++ b/internal/generated/snippets/gkemulticloud/apiv1/AttachedClustersClient/DeleteAttachedCluster/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkemulticloud/apiv1/AttachedClustersClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/gkemulticloud/apiv1/AttachedClustersClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkemulticloud/apiv1/AttachedClustersClient/GenerateAttachedClusterAgentToken/main.go
+++ b/internal/generated/snippets/gkemulticloud/apiv1/AttachedClustersClient/GenerateAttachedClusterAgentToken/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkemulticloud/apiv1/AttachedClustersClient/GenerateAttachedClusterInstallManifest/main.go
+++ b/internal/generated/snippets/gkemulticloud/apiv1/AttachedClustersClient/GenerateAttachedClusterInstallManifest/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkemulticloud/apiv1/AttachedClustersClient/GetAttachedCluster/main.go
+++ b/internal/generated/snippets/gkemulticloud/apiv1/AttachedClustersClient/GetAttachedCluster/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkemulticloud/apiv1/AttachedClustersClient/GetAttachedServerConfig/main.go
+++ b/internal/generated/snippets/gkemulticloud/apiv1/AttachedClustersClient/GetAttachedServerConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkemulticloud/apiv1/AttachedClustersClient/GetOperation/main.go
+++ b/internal/generated/snippets/gkemulticloud/apiv1/AttachedClustersClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkemulticloud/apiv1/AttachedClustersClient/ImportAttachedCluster/main.go
+++ b/internal/generated/snippets/gkemulticloud/apiv1/AttachedClustersClient/ImportAttachedCluster/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkemulticloud/apiv1/AttachedClustersClient/ListAttachedClusters/main.go
+++ b/internal/generated/snippets/gkemulticloud/apiv1/AttachedClustersClient/ListAttachedClusters/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkemulticloud/apiv1/AttachedClustersClient/ListOperations/main.go
+++ b/internal/generated/snippets/gkemulticloud/apiv1/AttachedClustersClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkemulticloud/apiv1/AttachedClustersClient/UpdateAttachedCluster/main.go
+++ b/internal/generated/snippets/gkemulticloud/apiv1/AttachedClustersClient/UpdateAttachedCluster/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkemulticloud/apiv1/AwsClustersClient/CancelOperation/main.go
+++ b/internal/generated/snippets/gkemulticloud/apiv1/AwsClustersClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkemulticloud/apiv1/AwsClustersClient/CreateAwsCluster/main.go
+++ b/internal/generated/snippets/gkemulticloud/apiv1/AwsClustersClient/CreateAwsCluster/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkemulticloud/apiv1/AwsClustersClient/CreateAwsNodePool/main.go
+++ b/internal/generated/snippets/gkemulticloud/apiv1/AwsClustersClient/CreateAwsNodePool/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkemulticloud/apiv1/AwsClustersClient/DeleteAwsCluster/main.go
+++ b/internal/generated/snippets/gkemulticloud/apiv1/AwsClustersClient/DeleteAwsCluster/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkemulticloud/apiv1/AwsClustersClient/DeleteAwsNodePool/main.go
+++ b/internal/generated/snippets/gkemulticloud/apiv1/AwsClustersClient/DeleteAwsNodePool/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkemulticloud/apiv1/AwsClustersClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/gkemulticloud/apiv1/AwsClustersClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkemulticloud/apiv1/AwsClustersClient/GenerateAwsAccessToken/main.go
+++ b/internal/generated/snippets/gkemulticloud/apiv1/AwsClustersClient/GenerateAwsAccessToken/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkemulticloud/apiv1/AwsClustersClient/GenerateAwsClusterAgentToken/main.go
+++ b/internal/generated/snippets/gkemulticloud/apiv1/AwsClustersClient/GenerateAwsClusterAgentToken/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkemulticloud/apiv1/AwsClustersClient/GetAwsCluster/main.go
+++ b/internal/generated/snippets/gkemulticloud/apiv1/AwsClustersClient/GetAwsCluster/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkemulticloud/apiv1/AwsClustersClient/GetAwsJsonWebKeys/main.go
+++ b/internal/generated/snippets/gkemulticloud/apiv1/AwsClustersClient/GetAwsJsonWebKeys/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkemulticloud/apiv1/AwsClustersClient/GetAwsNodePool/main.go
+++ b/internal/generated/snippets/gkemulticloud/apiv1/AwsClustersClient/GetAwsNodePool/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkemulticloud/apiv1/AwsClustersClient/GetAwsOpenIdConfig/main.go
+++ b/internal/generated/snippets/gkemulticloud/apiv1/AwsClustersClient/GetAwsOpenIdConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkemulticloud/apiv1/AwsClustersClient/GetAwsServerConfig/main.go
+++ b/internal/generated/snippets/gkemulticloud/apiv1/AwsClustersClient/GetAwsServerConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkemulticloud/apiv1/AwsClustersClient/GetOperation/main.go
+++ b/internal/generated/snippets/gkemulticloud/apiv1/AwsClustersClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkemulticloud/apiv1/AwsClustersClient/ListAwsClusters/main.go
+++ b/internal/generated/snippets/gkemulticloud/apiv1/AwsClustersClient/ListAwsClusters/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkemulticloud/apiv1/AwsClustersClient/ListAwsNodePools/main.go
+++ b/internal/generated/snippets/gkemulticloud/apiv1/AwsClustersClient/ListAwsNodePools/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkemulticloud/apiv1/AwsClustersClient/ListOperations/main.go
+++ b/internal/generated/snippets/gkemulticloud/apiv1/AwsClustersClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkemulticloud/apiv1/AwsClustersClient/RollbackAwsNodePoolUpdate/main.go
+++ b/internal/generated/snippets/gkemulticloud/apiv1/AwsClustersClient/RollbackAwsNodePoolUpdate/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkemulticloud/apiv1/AwsClustersClient/UpdateAwsCluster/main.go
+++ b/internal/generated/snippets/gkemulticloud/apiv1/AwsClustersClient/UpdateAwsCluster/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkemulticloud/apiv1/AwsClustersClient/UpdateAwsNodePool/main.go
+++ b/internal/generated/snippets/gkemulticloud/apiv1/AwsClustersClient/UpdateAwsNodePool/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkemulticloud/apiv1/AzureClustersClient/CancelOperation/main.go
+++ b/internal/generated/snippets/gkemulticloud/apiv1/AzureClustersClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkemulticloud/apiv1/AzureClustersClient/CreateAzureClient/main.go
+++ b/internal/generated/snippets/gkemulticloud/apiv1/AzureClustersClient/CreateAzureClient/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkemulticloud/apiv1/AzureClustersClient/CreateAzureCluster/main.go
+++ b/internal/generated/snippets/gkemulticloud/apiv1/AzureClustersClient/CreateAzureCluster/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkemulticloud/apiv1/AzureClustersClient/CreateAzureNodePool/main.go
+++ b/internal/generated/snippets/gkemulticloud/apiv1/AzureClustersClient/CreateAzureNodePool/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkemulticloud/apiv1/AzureClustersClient/DeleteAzureClient/main.go
+++ b/internal/generated/snippets/gkemulticloud/apiv1/AzureClustersClient/DeleteAzureClient/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkemulticloud/apiv1/AzureClustersClient/DeleteAzureCluster/main.go
+++ b/internal/generated/snippets/gkemulticloud/apiv1/AzureClustersClient/DeleteAzureCluster/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkemulticloud/apiv1/AzureClustersClient/DeleteAzureNodePool/main.go
+++ b/internal/generated/snippets/gkemulticloud/apiv1/AzureClustersClient/DeleteAzureNodePool/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkemulticloud/apiv1/AzureClustersClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/gkemulticloud/apiv1/AzureClustersClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkemulticloud/apiv1/AzureClustersClient/GenerateAzureAccessToken/main.go
+++ b/internal/generated/snippets/gkemulticloud/apiv1/AzureClustersClient/GenerateAzureAccessToken/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkemulticloud/apiv1/AzureClustersClient/GenerateAzureClusterAgentToken/main.go
+++ b/internal/generated/snippets/gkemulticloud/apiv1/AzureClustersClient/GenerateAzureClusterAgentToken/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkemulticloud/apiv1/AzureClustersClient/GetAzureClient/main.go
+++ b/internal/generated/snippets/gkemulticloud/apiv1/AzureClustersClient/GetAzureClient/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkemulticloud/apiv1/AzureClustersClient/GetAzureCluster/main.go
+++ b/internal/generated/snippets/gkemulticloud/apiv1/AzureClustersClient/GetAzureCluster/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkemulticloud/apiv1/AzureClustersClient/GetAzureJsonWebKeys/main.go
+++ b/internal/generated/snippets/gkemulticloud/apiv1/AzureClustersClient/GetAzureJsonWebKeys/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkemulticloud/apiv1/AzureClustersClient/GetAzureNodePool/main.go
+++ b/internal/generated/snippets/gkemulticloud/apiv1/AzureClustersClient/GetAzureNodePool/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkemulticloud/apiv1/AzureClustersClient/GetAzureOpenIdConfig/main.go
+++ b/internal/generated/snippets/gkemulticloud/apiv1/AzureClustersClient/GetAzureOpenIdConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkemulticloud/apiv1/AzureClustersClient/GetAzureServerConfig/main.go
+++ b/internal/generated/snippets/gkemulticloud/apiv1/AzureClustersClient/GetAzureServerConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkemulticloud/apiv1/AzureClustersClient/GetOperation/main.go
+++ b/internal/generated/snippets/gkemulticloud/apiv1/AzureClustersClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkemulticloud/apiv1/AzureClustersClient/ListAzureClients/main.go
+++ b/internal/generated/snippets/gkemulticloud/apiv1/AzureClustersClient/ListAzureClients/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkemulticloud/apiv1/AzureClustersClient/ListAzureClusters/main.go
+++ b/internal/generated/snippets/gkemulticloud/apiv1/AzureClustersClient/ListAzureClusters/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkemulticloud/apiv1/AzureClustersClient/ListAzureNodePools/main.go
+++ b/internal/generated/snippets/gkemulticloud/apiv1/AzureClustersClient/ListAzureNodePools/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkemulticloud/apiv1/AzureClustersClient/ListOperations/main.go
+++ b/internal/generated/snippets/gkemulticloud/apiv1/AzureClustersClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkemulticloud/apiv1/AzureClustersClient/UpdateAzureCluster/main.go
+++ b/internal/generated/snippets/gkemulticloud/apiv1/AzureClustersClient/UpdateAzureCluster/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkemulticloud/apiv1/AzureClustersClient/UpdateAzureNodePool/main.go
+++ b/internal/generated/snippets/gkemulticloud/apiv1/AzureClustersClient/UpdateAzureNodePool/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkerecommender/apiv1/GkeInferenceQuickstartClient/FetchBenchmarkingData/main.go
+++ b/internal/generated/snippets/gkerecommender/apiv1/GkeInferenceQuickstartClient/FetchBenchmarkingData/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkerecommender/apiv1/GkeInferenceQuickstartClient/FetchModelServerVersions/main.go
+++ b/internal/generated/snippets/gkerecommender/apiv1/GkeInferenceQuickstartClient/FetchModelServerVersions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkerecommender/apiv1/GkeInferenceQuickstartClient/FetchModelServers/main.go
+++ b/internal/generated/snippets/gkerecommender/apiv1/GkeInferenceQuickstartClient/FetchModelServers/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkerecommender/apiv1/GkeInferenceQuickstartClient/FetchModels/main.go
+++ b/internal/generated/snippets/gkerecommender/apiv1/GkeInferenceQuickstartClient/FetchModels/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkerecommender/apiv1/GkeInferenceQuickstartClient/FetchProfiles/main.go
+++ b/internal/generated/snippets/gkerecommender/apiv1/GkeInferenceQuickstartClient/FetchProfiles/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gkerecommender/apiv1/GkeInferenceQuickstartClient/GenerateOptimizedManifest/main.go
+++ b/internal/generated/snippets/gkerecommender/apiv1/GkeInferenceQuickstartClient/GenerateOptimizedManifest/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gsuiteaddons/apiv1/Client/CreateDeployment/main.go
+++ b/internal/generated/snippets/gsuiteaddons/apiv1/Client/CreateDeployment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gsuiteaddons/apiv1/Client/DeleteDeployment/main.go
+++ b/internal/generated/snippets/gsuiteaddons/apiv1/Client/DeleteDeployment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gsuiteaddons/apiv1/Client/GetAuthorization/main.go
+++ b/internal/generated/snippets/gsuiteaddons/apiv1/Client/GetAuthorization/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gsuiteaddons/apiv1/Client/GetDeployment/main.go
+++ b/internal/generated/snippets/gsuiteaddons/apiv1/Client/GetDeployment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gsuiteaddons/apiv1/Client/GetInstallStatus/main.go
+++ b/internal/generated/snippets/gsuiteaddons/apiv1/Client/GetInstallStatus/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gsuiteaddons/apiv1/Client/InstallDeployment/main.go
+++ b/internal/generated/snippets/gsuiteaddons/apiv1/Client/InstallDeployment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gsuiteaddons/apiv1/Client/ListDeployments/main.go
+++ b/internal/generated/snippets/gsuiteaddons/apiv1/Client/ListDeployments/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gsuiteaddons/apiv1/Client/ReplaceDeployment/main.go
+++ b/internal/generated/snippets/gsuiteaddons/apiv1/Client/ReplaceDeployment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/gsuiteaddons/apiv1/Client/UninstallDeployment/main.go
+++ b/internal/generated/snippets/gsuiteaddons/apiv1/Client/UninstallDeployment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/hypercomputecluster/apiv1beta/Client/CancelOperation/main.go
+++ b/internal/generated/snippets/hypercomputecluster/apiv1beta/Client/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/hypercomputecluster/apiv1beta/Client/CreateCluster/main.go
+++ b/internal/generated/snippets/hypercomputecluster/apiv1beta/Client/CreateCluster/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/hypercomputecluster/apiv1beta/Client/DeleteCluster/main.go
+++ b/internal/generated/snippets/hypercomputecluster/apiv1beta/Client/DeleteCluster/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/hypercomputecluster/apiv1beta/Client/DeleteOperation/main.go
+++ b/internal/generated/snippets/hypercomputecluster/apiv1beta/Client/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/hypercomputecluster/apiv1beta/Client/GetCluster/main.go
+++ b/internal/generated/snippets/hypercomputecluster/apiv1beta/Client/GetCluster/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/hypercomputecluster/apiv1beta/Client/GetLocation/main.go
+++ b/internal/generated/snippets/hypercomputecluster/apiv1beta/Client/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/hypercomputecluster/apiv1beta/Client/GetOperation/main.go
+++ b/internal/generated/snippets/hypercomputecluster/apiv1beta/Client/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/hypercomputecluster/apiv1beta/Client/ListClusters/main.go
+++ b/internal/generated/snippets/hypercomputecluster/apiv1beta/Client/ListClusters/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/hypercomputecluster/apiv1beta/Client/ListLocations/main.go
+++ b/internal/generated/snippets/hypercomputecluster/apiv1beta/Client/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/hypercomputecluster/apiv1beta/Client/ListOperations/main.go
+++ b/internal/generated/snippets/hypercomputecluster/apiv1beta/Client/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/hypercomputecluster/apiv1beta/Client/UpdateCluster/main.go
+++ b/internal/generated/snippets/hypercomputecluster/apiv1beta/Client/UpdateCluster/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iam/apiv1/IamPolicyClient/GetIamPolicy/main.go
+++ b/internal/generated/snippets/iam/apiv1/IamPolicyClient/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iam/apiv1/IamPolicyClient/SetIamPolicy/main.go
+++ b/internal/generated/snippets/iam/apiv1/IamPolicyClient/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iam/apiv1/IamPolicyClient/TestIamPermissions/main.go
+++ b/internal/generated/snippets/iam/apiv1/IamPolicyClient/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iam/apiv2/PoliciesClient/CreatePolicy/main.go
+++ b/internal/generated/snippets/iam/apiv2/PoliciesClient/CreatePolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iam/apiv2/PoliciesClient/DeletePolicy/main.go
+++ b/internal/generated/snippets/iam/apiv2/PoliciesClient/DeletePolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iam/apiv2/PoliciesClient/GetOperation/main.go
+++ b/internal/generated/snippets/iam/apiv2/PoliciesClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iam/apiv2/PoliciesClient/GetPolicy/main.go
+++ b/internal/generated/snippets/iam/apiv2/PoliciesClient/GetPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iam/apiv2/PoliciesClient/ListPolicies/main.go
+++ b/internal/generated/snippets/iam/apiv2/PoliciesClient/ListPolicies/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iam/apiv2/PoliciesClient/UpdatePolicy/main.go
+++ b/internal/generated/snippets/iam/apiv2/PoliciesClient/UpdatePolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iam/apiv3/PolicyBindingsClient/CreatePolicyBinding/main.go
+++ b/internal/generated/snippets/iam/apiv3/PolicyBindingsClient/CreatePolicyBinding/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iam/apiv3/PolicyBindingsClient/DeletePolicyBinding/main.go
+++ b/internal/generated/snippets/iam/apiv3/PolicyBindingsClient/DeletePolicyBinding/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iam/apiv3/PolicyBindingsClient/GetOperation/main.go
+++ b/internal/generated/snippets/iam/apiv3/PolicyBindingsClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iam/apiv3/PolicyBindingsClient/GetPolicyBinding/main.go
+++ b/internal/generated/snippets/iam/apiv3/PolicyBindingsClient/GetPolicyBinding/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iam/apiv3/PolicyBindingsClient/ListPolicyBindings/main.go
+++ b/internal/generated/snippets/iam/apiv3/PolicyBindingsClient/ListPolicyBindings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iam/apiv3/PolicyBindingsClient/SearchTargetPolicyBindings/main.go
+++ b/internal/generated/snippets/iam/apiv3/PolicyBindingsClient/SearchTargetPolicyBindings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iam/apiv3/PolicyBindingsClient/UpdatePolicyBinding/main.go
+++ b/internal/generated/snippets/iam/apiv3/PolicyBindingsClient/UpdatePolicyBinding/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iam/apiv3/PrincipalAccessBoundaryPoliciesClient/CreatePrincipalAccessBoundaryPolicy/main.go
+++ b/internal/generated/snippets/iam/apiv3/PrincipalAccessBoundaryPoliciesClient/CreatePrincipalAccessBoundaryPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iam/apiv3/PrincipalAccessBoundaryPoliciesClient/DeletePrincipalAccessBoundaryPolicy/main.go
+++ b/internal/generated/snippets/iam/apiv3/PrincipalAccessBoundaryPoliciesClient/DeletePrincipalAccessBoundaryPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iam/apiv3/PrincipalAccessBoundaryPoliciesClient/GetOperation/main.go
+++ b/internal/generated/snippets/iam/apiv3/PrincipalAccessBoundaryPoliciesClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iam/apiv3/PrincipalAccessBoundaryPoliciesClient/GetPrincipalAccessBoundaryPolicy/main.go
+++ b/internal/generated/snippets/iam/apiv3/PrincipalAccessBoundaryPoliciesClient/GetPrincipalAccessBoundaryPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iam/apiv3/PrincipalAccessBoundaryPoliciesClient/ListPrincipalAccessBoundaryPolicies/main.go
+++ b/internal/generated/snippets/iam/apiv3/PrincipalAccessBoundaryPoliciesClient/ListPrincipalAccessBoundaryPolicies/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iam/apiv3/PrincipalAccessBoundaryPoliciesClient/SearchPrincipalAccessBoundaryPolicyBindings/main.go
+++ b/internal/generated/snippets/iam/apiv3/PrincipalAccessBoundaryPoliciesClient/SearchPrincipalAccessBoundaryPolicyBindings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iam/apiv3/PrincipalAccessBoundaryPoliciesClient/UpdatePrincipalAccessBoundaryPolicy/main.go
+++ b/internal/generated/snippets/iam/apiv3/PrincipalAccessBoundaryPoliciesClient/UpdatePrincipalAccessBoundaryPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iam/apiv3beta/PolicyBindingsClient/CreatePolicyBinding/main.go
+++ b/internal/generated/snippets/iam/apiv3beta/PolicyBindingsClient/CreatePolicyBinding/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iam/apiv3beta/PolicyBindingsClient/DeletePolicyBinding/main.go
+++ b/internal/generated/snippets/iam/apiv3beta/PolicyBindingsClient/DeletePolicyBinding/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iam/apiv3beta/PolicyBindingsClient/GetOperation/main.go
+++ b/internal/generated/snippets/iam/apiv3beta/PolicyBindingsClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iam/apiv3beta/PolicyBindingsClient/GetPolicyBinding/main.go
+++ b/internal/generated/snippets/iam/apiv3beta/PolicyBindingsClient/GetPolicyBinding/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iam/apiv3beta/PolicyBindingsClient/ListPolicyBindings/main.go
+++ b/internal/generated/snippets/iam/apiv3beta/PolicyBindingsClient/ListPolicyBindings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iam/apiv3beta/PolicyBindingsClient/SearchTargetPolicyBindings/main.go
+++ b/internal/generated/snippets/iam/apiv3beta/PolicyBindingsClient/SearchTargetPolicyBindings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iam/apiv3beta/PolicyBindingsClient/UpdatePolicyBinding/main.go
+++ b/internal/generated/snippets/iam/apiv3beta/PolicyBindingsClient/UpdatePolicyBinding/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iam/apiv3beta/PrincipalAccessBoundaryPoliciesClient/CreatePrincipalAccessBoundaryPolicy/main.go
+++ b/internal/generated/snippets/iam/apiv3beta/PrincipalAccessBoundaryPoliciesClient/CreatePrincipalAccessBoundaryPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iam/apiv3beta/PrincipalAccessBoundaryPoliciesClient/DeletePrincipalAccessBoundaryPolicy/main.go
+++ b/internal/generated/snippets/iam/apiv3beta/PrincipalAccessBoundaryPoliciesClient/DeletePrincipalAccessBoundaryPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iam/apiv3beta/PrincipalAccessBoundaryPoliciesClient/GetOperation/main.go
+++ b/internal/generated/snippets/iam/apiv3beta/PrincipalAccessBoundaryPoliciesClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iam/apiv3beta/PrincipalAccessBoundaryPoliciesClient/GetPrincipalAccessBoundaryPolicy/main.go
+++ b/internal/generated/snippets/iam/apiv3beta/PrincipalAccessBoundaryPoliciesClient/GetPrincipalAccessBoundaryPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iam/apiv3beta/PrincipalAccessBoundaryPoliciesClient/ListPrincipalAccessBoundaryPolicies/main.go
+++ b/internal/generated/snippets/iam/apiv3beta/PrincipalAccessBoundaryPoliciesClient/ListPrincipalAccessBoundaryPolicies/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iam/apiv3beta/PrincipalAccessBoundaryPoliciesClient/SearchPrincipalAccessBoundaryPolicyBindings/main.go
+++ b/internal/generated/snippets/iam/apiv3beta/PrincipalAccessBoundaryPoliciesClient/SearchPrincipalAccessBoundaryPolicyBindings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iam/apiv3beta/PrincipalAccessBoundaryPoliciesClient/UpdatePrincipalAccessBoundaryPolicy/main.go
+++ b/internal/generated/snippets/iam/apiv3beta/PrincipalAccessBoundaryPoliciesClient/UpdatePrincipalAccessBoundaryPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iam/credentials/apiv1/IamCredentialsClient/GenerateAccessToken/main.go
+++ b/internal/generated/snippets/iam/credentials/apiv1/IamCredentialsClient/GenerateAccessToken/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iam/credentials/apiv1/IamCredentialsClient/GenerateIdToken/main.go
+++ b/internal/generated/snippets/iam/credentials/apiv1/IamCredentialsClient/GenerateIdToken/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iam/credentials/apiv1/IamCredentialsClient/SignBlob/main.go
+++ b/internal/generated/snippets/iam/credentials/apiv1/IamCredentialsClient/SignBlob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iam/credentials/apiv1/IamCredentialsClient/SignJwt/main.go
+++ b/internal/generated/snippets/iam/credentials/apiv1/IamCredentialsClient/SignJwt/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iap/apiv1/IdentityAwareProxyAdminClient/CreateTunnelDestGroup/main.go
+++ b/internal/generated/snippets/iap/apiv1/IdentityAwareProxyAdminClient/CreateTunnelDestGroup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iap/apiv1/IdentityAwareProxyAdminClient/DeleteTunnelDestGroup/main.go
+++ b/internal/generated/snippets/iap/apiv1/IdentityAwareProxyAdminClient/DeleteTunnelDestGroup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iap/apiv1/IdentityAwareProxyAdminClient/GetIamPolicy/main.go
+++ b/internal/generated/snippets/iap/apiv1/IdentityAwareProxyAdminClient/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iap/apiv1/IdentityAwareProxyAdminClient/GetIapSettings/main.go
+++ b/internal/generated/snippets/iap/apiv1/IdentityAwareProxyAdminClient/GetIapSettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iap/apiv1/IdentityAwareProxyAdminClient/GetTunnelDestGroup/main.go
+++ b/internal/generated/snippets/iap/apiv1/IdentityAwareProxyAdminClient/GetTunnelDestGroup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iap/apiv1/IdentityAwareProxyAdminClient/ListTunnelDestGroups/main.go
+++ b/internal/generated/snippets/iap/apiv1/IdentityAwareProxyAdminClient/ListTunnelDestGroups/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iap/apiv1/IdentityAwareProxyAdminClient/SetIamPolicy/main.go
+++ b/internal/generated/snippets/iap/apiv1/IdentityAwareProxyAdminClient/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iap/apiv1/IdentityAwareProxyAdminClient/TestIamPermissions/main.go
+++ b/internal/generated/snippets/iap/apiv1/IdentityAwareProxyAdminClient/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iap/apiv1/IdentityAwareProxyAdminClient/UpdateIapSettings/main.go
+++ b/internal/generated/snippets/iap/apiv1/IdentityAwareProxyAdminClient/UpdateIapSettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iap/apiv1/IdentityAwareProxyAdminClient/UpdateTunnelDestGroup/main.go
+++ b/internal/generated/snippets/iap/apiv1/IdentityAwareProxyAdminClient/UpdateTunnelDestGroup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iap/apiv1/IdentityAwareProxyAdminClient/ValidateIapAttributeExpression/main.go
+++ b/internal/generated/snippets/iap/apiv1/IdentityAwareProxyAdminClient/ValidateIapAttributeExpression/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iap/apiv1/IdentityAwareProxyOAuthClient/CreateBrand/main.go
+++ b/internal/generated/snippets/iap/apiv1/IdentityAwareProxyOAuthClient/CreateBrand/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iap/apiv1/IdentityAwareProxyOAuthClient/CreateIdentityAwareProxyClient/main.go
+++ b/internal/generated/snippets/iap/apiv1/IdentityAwareProxyOAuthClient/CreateIdentityAwareProxyClient/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iap/apiv1/IdentityAwareProxyOAuthClient/DeleteIdentityAwareProxyClient/main.go
+++ b/internal/generated/snippets/iap/apiv1/IdentityAwareProxyOAuthClient/DeleteIdentityAwareProxyClient/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iap/apiv1/IdentityAwareProxyOAuthClient/GetBrand/main.go
+++ b/internal/generated/snippets/iap/apiv1/IdentityAwareProxyOAuthClient/GetBrand/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iap/apiv1/IdentityAwareProxyOAuthClient/GetIdentityAwareProxyClient/main.go
+++ b/internal/generated/snippets/iap/apiv1/IdentityAwareProxyOAuthClient/GetIdentityAwareProxyClient/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iap/apiv1/IdentityAwareProxyOAuthClient/ListBrands/main.go
+++ b/internal/generated/snippets/iap/apiv1/IdentityAwareProxyOAuthClient/ListBrands/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iap/apiv1/IdentityAwareProxyOAuthClient/ListIdentityAwareProxyClients/main.go
+++ b/internal/generated/snippets/iap/apiv1/IdentityAwareProxyOAuthClient/ListIdentityAwareProxyClients/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iap/apiv1/IdentityAwareProxyOAuthClient/ResetIdentityAwareProxyClientSecret/main.go
+++ b/internal/generated/snippets/iap/apiv1/IdentityAwareProxyOAuthClient/ResetIdentityAwareProxyClientSecret/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/identitytoolkit/apiv2/AccountManagementClient/FinalizeMfaEnrollment/main.go
+++ b/internal/generated/snippets/identitytoolkit/apiv2/AccountManagementClient/FinalizeMfaEnrollment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/identitytoolkit/apiv2/AccountManagementClient/StartMfaEnrollment/main.go
+++ b/internal/generated/snippets/identitytoolkit/apiv2/AccountManagementClient/StartMfaEnrollment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/identitytoolkit/apiv2/AccountManagementClient/WithdrawMfa/main.go
+++ b/internal/generated/snippets/identitytoolkit/apiv2/AccountManagementClient/WithdrawMfa/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/identitytoolkit/apiv2/AuthenticationClient/FinalizeMfaSignIn/main.go
+++ b/internal/generated/snippets/identitytoolkit/apiv2/AuthenticationClient/FinalizeMfaSignIn/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/identitytoolkit/apiv2/AuthenticationClient/StartMfaSignIn/main.go
+++ b/internal/generated/snippets/identitytoolkit/apiv2/AuthenticationClient/StartMfaSignIn/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ids/apiv1/Client/CreateEndpoint/main.go
+++ b/internal/generated/snippets/ids/apiv1/Client/CreateEndpoint/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ids/apiv1/Client/DeleteEndpoint/main.go
+++ b/internal/generated/snippets/ids/apiv1/Client/DeleteEndpoint/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ids/apiv1/Client/GetEndpoint/main.go
+++ b/internal/generated/snippets/ids/apiv1/Client/GetEndpoint/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/ids/apiv1/Client/ListEndpoints/main.go
+++ b/internal/generated/snippets/ids/apiv1/Client/ListEndpoints/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iot/apiv1/DeviceManagerClient/BindDeviceToGateway/main.go
+++ b/internal/generated/snippets/iot/apiv1/DeviceManagerClient/BindDeviceToGateway/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iot/apiv1/DeviceManagerClient/CreateDevice/main.go
+++ b/internal/generated/snippets/iot/apiv1/DeviceManagerClient/CreateDevice/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iot/apiv1/DeviceManagerClient/CreateDeviceRegistry/main.go
+++ b/internal/generated/snippets/iot/apiv1/DeviceManagerClient/CreateDeviceRegistry/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iot/apiv1/DeviceManagerClient/DeleteDevice/main.go
+++ b/internal/generated/snippets/iot/apiv1/DeviceManagerClient/DeleteDevice/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iot/apiv1/DeviceManagerClient/DeleteDeviceRegistry/main.go
+++ b/internal/generated/snippets/iot/apiv1/DeviceManagerClient/DeleteDeviceRegistry/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iot/apiv1/DeviceManagerClient/GetDevice/main.go
+++ b/internal/generated/snippets/iot/apiv1/DeviceManagerClient/GetDevice/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iot/apiv1/DeviceManagerClient/GetDeviceRegistry/main.go
+++ b/internal/generated/snippets/iot/apiv1/DeviceManagerClient/GetDeviceRegistry/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iot/apiv1/DeviceManagerClient/GetIamPolicy/main.go
+++ b/internal/generated/snippets/iot/apiv1/DeviceManagerClient/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iot/apiv1/DeviceManagerClient/ListDeviceConfigVersions/main.go
+++ b/internal/generated/snippets/iot/apiv1/DeviceManagerClient/ListDeviceConfigVersions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iot/apiv1/DeviceManagerClient/ListDeviceRegistries/main.go
+++ b/internal/generated/snippets/iot/apiv1/DeviceManagerClient/ListDeviceRegistries/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iot/apiv1/DeviceManagerClient/ListDeviceStates/main.go
+++ b/internal/generated/snippets/iot/apiv1/DeviceManagerClient/ListDeviceStates/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iot/apiv1/DeviceManagerClient/ListDevices/main.go
+++ b/internal/generated/snippets/iot/apiv1/DeviceManagerClient/ListDevices/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iot/apiv1/DeviceManagerClient/ModifyCloudToDeviceConfig/main.go
+++ b/internal/generated/snippets/iot/apiv1/DeviceManagerClient/ModifyCloudToDeviceConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iot/apiv1/DeviceManagerClient/SendCommandToDevice/main.go
+++ b/internal/generated/snippets/iot/apiv1/DeviceManagerClient/SendCommandToDevice/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iot/apiv1/DeviceManagerClient/SetIamPolicy/main.go
+++ b/internal/generated/snippets/iot/apiv1/DeviceManagerClient/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iot/apiv1/DeviceManagerClient/TestIamPermissions/main.go
+++ b/internal/generated/snippets/iot/apiv1/DeviceManagerClient/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iot/apiv1/DeviceManagerClient/UnbindDeviceFromGateway/main.go
+++ b/internal/generated/snippets/iot/apiv1/DeviceManagerClient/UnbindDeviceFromGateway/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iot/apiv1/DeviceManagerClient/UpdateDevice/main.go
+++ b/internal/generated/snippets/iot/apiv1/DeviceManagerClient/UpdateDevice/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/iot/apiv1/DeviceManagerClient/UpdateDeviceRegistry/main.go
+++ b/internal/generated/snippets/iot/apiv1/DeviceManagerClient/UpdateDeviceRegistry/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/language/apiv1/Client/AnalyzeEntities/main.go
+++ b/internal/generated/snippets/language/apiv1/Client/AnalyzeEntities/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/language/apiv1/Client/AnalyzeEntitySentiment/main.go
+++ b/internal/generated/snippets/language/apiv1/Client/AnalyzeEntitySentiment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/language/apiv1/Client/AnalyzeSentiment/main.go
+++ b/internal/generated/snippets/language/apiv1/Client/AnalyzeSentiment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/language/apiv1/Client/AnalyzeSyntax/main.go
+++ b/internal/generated/snippets/language/apiv1/Client/AnalyzeSyntax/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/language/apiv1/Client/AnnotateText/main.go
+++ b/internal/generated/snippets/language/apiv1/Client/AnnotateText/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/language/apiv1/Client/ClassifyText/main.go
+++ b/internal/generated/snippets/language/apiv1/Client/ClassifyText/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/language/apiv1/Client/ModerateText/main.go
+++ b/internal/generated/snippets/language/apiv1/Client/ModerateText/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/language/apiv1beta2/Client/AnalyzeEntities/main.go
+++ b/internal/generated/snippets/language/apiv1beta2/Client/AnalyzeEntities/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/language/apiv1beta2/Client/AnalyzeEntitySentiment/main.go
+++ b/internal/generated/snippets/language/apiv1beta2/Client/AnalyzeEntitySentiment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/language/apiv1beta2/Client/AnalyzeSentiment/main.go
+++ b/internal/generated/snippets/language/apiv1beta2/Client/AnalyzeSentiment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/language/apiv1beta2/Client/AnalyzeSyntax/main.go
+++ b/internal/generated/snippets/language/apiv1beta2/Client/AnalyzeSyntax/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/language/apiv1beta2/Client/AnnotateText/main.go
+++ b/internal/generated/snippets/language/apiv1beta2/Client/AnnotateText/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/language/apiv1beta2/Client/ClassifyText/main.go
+++ b/internal/generated/snippets/language/apiv1beta2/Client/ClassifyText/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/language/apiv1beta2/Client/ModerateText/main.go
+++ b/internal/generated/snippets/language/apiv1beta2/Client/ModerateText/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/language/apiv2/Client/AnalyzeEntities/main.go
+++ b/internal/generated/snippets/language/apiv2/Client/AnalyzeEntities/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/language/apiv2/Client/AnalyzeSentiment/main.go
+++ b/internal/generated/snippets/language/apiv2/Client/AnalyzeSentiment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/language/apiv2/Client/AnnotateText/main.go
+++ b/internal/generated/snippets/language/apiv2/Client/AnnotateText/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/language/apiv2/Client/ClassifyText/main.go
+++ b/internal/generated/snippets/language/apiv2/Client/ClassifyText/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/language/apiv2/Client/ModerateText/main.go
+++ b/internal/generated/snippets/language/apiv2/Client/ModerateText/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/licensemanager/apiv1/Client/AggregateUsage/main.go
+++ b/internal/generated/snippets/licensemanager/apiv1/Client/AggregateUsage/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/licensemanager/apiv1/Client/CancelOperation/main.go
+++ b/internal/generated/snippets/licensemanager/apiv1/Client/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/licensemanager/apiv1/Client/CreateConfiguration/main.go
+++ b/internal/generated/snippets/licensemanager/apiv1/Client/CreateConfiguration/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/licensemanager/apiv1/Client/DeactivateConfiguration/main.go
+++ b/internal/generated/snippets/licensemanager/apiv1/Client/DeactivateConfiguration/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/licensemanager/apiv1/Client/DeleteConfiguration/main.go
+++ b/internal/generated/snippets/licensemanager/apiv1/Client/DeleteConfiguration/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/licensemanager/apiv1/Client/DeleteOperation/main.go
+++ b/internal/generated/snippets/licensemanager/apiv1/Client/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/licensemanager/apiv1/Client/GetConfiguration/main.go
+++ b/internal/generated/snippets/licensemanager/apiv1/Client/GetConfiguration/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/licensemanager/apiv1/Client/GetInstance/main.go
+++ b/internal/generated/snippets/licensemanager/apiv1/Client/GetInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/licensemanager/apiv1/Client/GetLocation/main.go
+++ b/internal/generated/snippets/licensemanager/apiv1/Client/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/licensemanager/apiv1/Client/GetOperation/main.go
+++ b/internal/generated/snippets/licensemanager/apiv1/Client/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/licensemanager/apiv1/Client/GetProduct/main.go
+++ b/internal/generated/snippets/licensemanager/apiv1/Client/GetProduct/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/licensemanager/apiv1/Client/ListConfigurations/main.go
+++ b/internal/generated/snippets/licensemanager/apiv1/Client/ListConfigurations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/licensemanager/apiv1/Client/ListInstances/main.go
+++ b/internal/generated/snippets/licensemanager/apiv1/Client/ListInstances/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/licensemanager/apiv1/Client/ListLocations/main.go
+++ b/internal/generated/snippets/licensemanager/apiv1/Client/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/licensemanager/apiv1/Client/ListOperations/main.go
+++ b/internal/generated/snippets/licensemanager/apiv1/Client/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/licensemanager/apiv1/Client/ListProducts/main.go
+++ b/internal/generated/snippets/licensemanager/apiv1/Client/ListProducts/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/licensemanager/apiv1/Client/QueryConfigurationLicenseUsage/main.go
+++ b/internal/generated/snippets/licensemanager/apiv1/Client/QueryConfigurationLicenseUsage/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/licensemanager/apiv1/Client/ReactivateConfiguration/main.go
+++ b/internal/generated/snippets/licensemanager/apiv1/Client/ReactivateConfiguration/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/licensemanager/apiv1/Client/UpdateConfiguration/main.go
+++ b/internal/generated/snippets/licensemanager/apiv1/Client/UpdateConfiguration/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/lifesciences/apiv2beta/WorkflowsServiceV2BetaClient/CancelOperation/main.go
+++ b/internal/generated/snippets/lifesciences/apiv2beta/WorkflowsServiceV2BetaClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/lifesciences/apiv2beta/WorkflowsServiceV2BetaClient/GetLocation/main.go
+++ b/internal/generated/snippets/lifesciences/apiv2beta/WorkflowsServiceV2BetaClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/lifesciences/apiv2beta/WorkflowsServiceV2BetaClient/GetOperation/main.go
+++ b/internal/generated/snippets/lifesciences/apiv2beta/WorkflowsServiceV2BetaClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/lifesciences/apiv2beta/WorkflowsServiceV2BetaClient/ListLocations/main.go
+++ b/internal/generated/snippets/lifesciences/apiv2beta/WorkflowsServiceV2BetaClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/lifesciences/apiv2beta/WorkflowsServiceV2BetaClient/ListOperations/main.go
+++ b/internal/generated/snippets/lifesciences/apiv2beta/WorkflowsServiceV2BetaClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/lifesciences/apiv2beta/WorkflowsServiceV2BetaClient/RunPipeline/main.go
+++ b/internal/generated/snippets/lifesciences/apiv2beta/WorkflowsServiceV2BetaClient/RunPipeline/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/locationfinder/apiv1/CloudLocationFinderClient/GetCloudLocation/main.go
+++ b/internal/generated/snippets/locationfinder/apiv1/CloudLocationFinderClient/GetCloudLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/locationfinder/apiv1/CloudLocationFinderClient/GetLocation/main.go
+++ b/internal/generated/snippets/locationfinder/apiv1/CloudLocationFinderClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/locationfinder/apiv1/CloudLocationFinderClient/ListCloudLocations/main.go
+++ b/internal/generated/snippets/locationfinder/apiv1/CloudLocationFinderClient/ListCloudLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/locationfinder/apiv1/CloudLocationFinderClient/ListLocations/main.go
+++ b/internal/generated/snippets/locationfinder/apiv1/CloudLocationFinderClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/locationfinder/apiv1/CloudLocationFinderClient/SearchCloudLocations/main.go
+++ b/internal/generated/snippets/locationfinder/apiv1/CloudLocationFinderClient/SearchCloudLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/logging/apiv2/Client/CancelOperation/main.go
+++ b/internal/generated/snippets/logging/apiv2/Client/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/logging/apiv2/Client/DeleteLog/main.go
+++ b/internal/generated/snippets/logging/apiv2/Client/DeleteLog/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/logging/apiv2/Client/GetOperation/main.go
+++ b/internal/generated/snippets/logging/apiv2/Client/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/logging/apiv2/Client/ListLogEntries/main.go
+++ b/internal/generated/snippets/logging/apiv2/Client/ListLogEntries/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/logging/apiv2/Client/ListLogs/main.go
+++ b/internal/generated/snippets/logging/apiv2/Client/ListLogs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/logging/apiv2/Client/ListMonitoredResourceDescriptors/main.go
+++ b/internal/generated/snippets/logging/apiv2/Client/ListMonitoredResourceDescriptors/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/logging/apiv2/Client/ListOperations/main.go
+++ b/internal/generated/snippets/logging/apiv2/Client/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/logging/apiv2/Client/TailLogEntries/main.go
+++ b/internal/generated/snippets/logging/apiv2/Client/TailLogEntries/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/logging/apiv2/Client/WriteLogEntries/main.go
+++ b/internal/generated/snippets/logging/apiv2/Client/WriteLogEntries/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/logging/apiv2/ConfigClient/CancelOperation/main.go
+++ b/internal/generated/snippets/logging/apiv2/ConfigClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/logging/apiv2/ConfigClient/CopyLogEntries/main.go
+++ b/internal/generated/snippets/logging/apiv2/ConfigClient/CopyLogEntries/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/logging/apiv2/ConfigClient/CreateBucket/main.go
+++ b/internal/generated/snippets/logging/apiv2/ConfigClient/CreateBucket/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/logging/apiv2/ConfigClient/CreateBucketAsync/main.go
+++ b/internal/generated/snippets/logging/apiv2/ConfigClient/CreateBucketAsync/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/logging/apiv2/ConfigClient/CreateExclusion/main.go
+++ b/internal/generated/snippets/logging/apiv2/ConfigClient/CreateExclusion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/logging/apiv2/ConfigClient/CreateLink/main.go
+++ b/internal/generated/snippets/logging/apiv2/ConfigClient/CreateLink/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/logging/apiv2/ConfigClient/CreateSink/main.go
+++ b/internal/generated/snippets/logging/apiv2/ConfigClient/CreateSink/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/logging/apiv2/ConfigClient/CreateView/main.go
+++ b/internal/generated/snippets/logging/apiv2/ConfigClient/CreateView/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/logging/apiv2/ConfigClient/DeleteBucket/main.go
+++ b/internal/generated/snippets/logging/apiv2/ConfigClient/DeleteBucket/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/logging/apiv2/ConfigClient/DeleteExclusion/main.go
+++ b/internal/generated/snippets/logging/apiv2/ConfigClient/DeleteExclusion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/logging/apiv2/ConfigClient/DeleteLink/main.go
+++ b/internal/generated/snippets/logging/apiv2/ConfigClient/DeleteLink/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/logging/apiv2/ConfigClient/DeleteSink/main.go
+++ b/internal/generated/snippets/logging/apiv2/ConfigClient/DeleteSink/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/logging/apiv2/ConfigClient/DeleteView/main.go
+++ b/internal/generated/snippets/logging/apiv2/ConfigClient/DeleteView/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/logging/apiv2/ConfigClient/GetBucket/main.go
+++ b/internal/generated/snippets/logging/apiv2/ConfigClient/GetBucket/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/logging/apiv2/ConfigClient/GetCmekSettings/main.go
+++ b/internal/generated/snippets/logging/apiv2/ConfigClient/GetCmekSettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/logging/apiv2/ConfigClient/GetExclusion/main.go
+++ b/internal/generated/snippets/logging/apiv2/ConfigClient/GetExclusion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/logging/apiv2/ConfigClient/GetLink/main.go
+++ b/internal/generated/snippets/logging/apiv2/ConfigClient/GetLink/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/logging/apiv2/ConfigClient/GetOperation/main.go
+++ b/internal/generated/snippets/logging/apiv2/ConfigClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/logging/apiv2/ConfigClient/GetSettings/main.go
+++ b/internal/generated/snippets/logging/apiv2/ConfigClient/GetSettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/logging/apiv2/ConfigClient/GetSink/main.go
+++ b/internal/generated/snippets/logging/apiv2/ConfigClient/GetSink/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/logging/apiv2/ConfigClient/GetView/main.go
+++ b/internal/generated/snippets/logging/apiv2/ConfigClient/GetView/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/logging/apiv2/ConfigClient/ListBuckets/main.go
+++ b/internal/generated/snippets/logging/apiv2/ConfigClient/ListBuckets/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/logging/apiv2/ConfigClient/ListExclusions/main.go
+++ b/internal/generated/snippets/logging/apiv2/ConfigClient/ListExclusions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/logging/apiv2/ConfigClient/ListLinks/main.go
+++ b/internal/generated/snippets/logging/apiv2/ConfigClient/ListLinks/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/logging/apiv2/ConfigClient/ListOperations/main.go
+++ b/internal/generated/snippets/logging/apiv2/ConfigClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/logging/apiv2/ConfigClient/ListSinks/main.go
+++ b/internal/generated/snippets/logging/apiv2/ConfigClient/ListSinks/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/logging/apiv2/ConfigClient/ListViews/main.go
+++ b/internal/generated/snippets/logging/apiv2/ConfigClient/ListViews/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/logging/apiv2/ConfigClient/UndeleteBucket/main.go
+++ b/internal/generated/snippets/logging/apiv2/ConfigClient/UndeleteBucket/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/logging/apiv2/ConfigClient/UpdateBucket/main.go
+++ b/internal/generated/snippets/logging/apiv2/ConfigClient/UpdateBucket/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/logging/apiv2/ConfigClient/UpdateBucketAsync/main.go
+++ b/internal/generated/snippets/logging/apiv2/ConfigClient/UpdateBucketAsync/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/logging/apiv2/ConfigClient/UpdateCmekSettings/main.go
+++ b/internal/generated/snippets/logging/apiv2/ConfigClient/UpdateCmekSettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/logging/apiv2/ConfigClient/UpdateExclusion/main.go
+++ b/internal/generated/snippets/logging/apiv2/ConfigClient/UpdateExclusion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/logging/apiv2/ConfigClient/UpdateSettings/main.go
+++ b/internal/generated/snippets/logging/apiv2/ConfigClient/UpdateSettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/logging/apiv2/ConfigClient/UpdateSink/main.go
+++ b/internal/generated/snippets/logging/apiv2/ConfigClient/UpdateSink/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/logging/apiv2/ConfigClient/UpdateView/main.go
+++ b/internal/generated/snippets/logging/apiv2/ConfigClient/UpdateView/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/logging/apiv2/MetricsClient/CancelOperation/main.go
+++ b/internal/generated/snippets/logging/apiv2/MetricsClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/logging/apiv2/MetricsClient/CreateLogMetric/main.go
+++ b/internal/generated/snippets/logging/apiv2/MetricsClient/CreateLogMetric/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/logging/apiv2/MetricsClient/DeleteLogMetric/main.go
+++ b/internal/generated/snippets/logging/apiv2/MetricsClient/DeleteLogMetric/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/logging/apiv2/MetricsClient/GetLogMetric/main.go
+++ b/internal/generated/snippets/logging/apiv2/MetricsClient/GetLogMetric/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/logging/apiv2/MetricsClient/GetOperation/main.go
+++ b/internal/generated/snippets/logging/apiv2/MetricsClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/logging/apiv2/MetricsClient/ListLogMetrics/main.go
+++ b/internal/generated/snippets/logging/apiv2/MetricsClient/ListLogMetrics/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/logging/apiv2/MetricsClient/ListOperations/main.go
+++ b/internal/generated/snippets/logging/apiv2/MetricsClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/logging/apiv2/MetricsClient/UpdateLogMetric/main.go
+++ b/internal/generated/snippets/logging/apiv2/MetricsClient/UpdateLogMetric/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/longrunning/autogen/OperationsClient/CancelOperation/main.go
+++ b/internal/generated/snippets/longrunning/autogen/OperationsClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/longrunning/autogen/OperationsClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/longrunning/autogen/OperationsClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/longrunning/autogen/OperationsClient/GetOperation/main.go
+++ b/internal/generated/snippets/longrunning/autogen/OperationsClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/longrunning/autogen/OperationsClient/ListOperations/main.go
+++ b/internal/generated/snippets/longrunning/autogen/OperationsClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/longrunning/autogen/OperationsClient/WaitOperation/main.go
+++ b/internal/generated/snippets/longrunning/autogen/OperationsClient/WaitOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/lustre/apiv1/Client/CancelOperation/main.go
+++ b/internal/generated/snippets/lustre/apiv1/Client/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/lustre/apiv1/Client/CreateInstance/main.go
+++ b/internal/generated/snippets/lustre/apiv1/Client/CreateInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/lustre/apiv1/Client/DeleteInstance/main.go
+++ b/internal/generated/snippets/lustre/apiv1/Client/DeleteInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/lustre/apiv1/Client/DeleteOperation/main.go
+++ b/internal/generated/snippets/lustre/apiv1/Client/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/lustre/apiv1/Client/ExportData/main.go
+++ b/internal/generated/snippets/lustre/apiv1/Client/ExportData/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/lustre/apiv1/Client/GetInstance/main.go
+++ b/internal/generated/snippets/lustre/apiv1/Client/GetInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/lustre/apiv1/Client/GetLocation/main.go
+++ b/internal/generated/snippets/lustre/apiv1/Client/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/lustre/apiv1/Client/GetOperation/main.go
+++ b/internal/generated/snippets/lustre/apiv1/Client/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/lustre/apiv1/Client/ImportData/main.go
+++ b/internal/generated/snippets/lustre/apiv1/Client/ImportData/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/lustre/apiv1/Client/ListInstances/main.go
+++ b/internal/generated/snippets/lustre/apiv1/Client/ListInstances/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/lustre/apiv1/Client/ListLocations/main.go
+++ b/internal/generated/snippets/lustre/apiv1/Client/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/lustre/apiv1/Client/ListOperations/main.go
+++ b/internal/generated/snippets/lustre/apiv1/Client/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/lustre/apiv1/Client/UpdateInstance/main.go
+++ b/internal/generated/snippets/lustre/apiv1/Client/UpdateInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/maintenance/api/apiv1/MaintenanceClient/GetLocation/main.go
+++ b/internal/generated/snippets/maintenance/api/apiv1/MaintenanceClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/maintenance/api/apiv1/MaintenanceClient/GetResourceMaintenance/main.go
+++ b/internal/generated/snippets/maintenance/api/apiv1/MaintenanceClient/GetResourceMaintenance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/maintenance/api/apiv1/MaintenanceClient/ListLocations/main.go
+++ b/internal/generated/snippets/maintenance/api/apiv1/MaintenanceClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/maintenance/api/apiv1/MaintenanceClient/ListResourceMaintenances/main.go
+++ b/internal/generated/snippets/maintenance/api/apiv1/MaintenanceClient/ListResourceMaintenances/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/maintenance/api/apiv1/MaintenanceClient/SummarizeMaintenances/main.go
+++ b/internal/generated/snippets/maintenance/api/apiv1/MaintenanceClient/SummarizeMaintenances/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/maintenance/api/apiv1beta/MaintenanceClient/GetLocation/main.go
+++ b/internal/generated/snippets/maintenance/api/apiv1beta/MaintenanceClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/maintenance/api/apiv1beta/MaintenanceClient/GetResourceMaintenance/main.go
+++ b/internal/generated/snippets/maintenance/api/apiv1beta/MaintenanceClient/GetResourceMaintenance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/maintenance/api/apiv1beta/MaintenanceClient/ListLocations/main.go
+++ b/internal/generated/snippets/maintenance/api/apiv1beta/MaintenanceClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/maintenance/api/apiv1beta/MaintenanceClient/ListResourceMaintenances/main.go
+++ b/internal/generated/snippets/maintenance/api/apiv1beta/MaintenanceClient/ListResourceMaintenances/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/maintenance/api/apiv1beta/MaintenanceClient/SummarizeMaintenances/main.go
+++ b/internal/generated/snippets/maintenance/api/apiv1beta/MaintenanceClient/SummarizeMaintenances/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedidentities/apiv1/Client/AttachTrust/main.go
+++ b/internal/generated/snippets/managedidentities/apiv1/Client/AttachTrust/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedidentities/apiv1/Client/CreateMicrosoftAdDomain/main.go
+++ b/internal/generated/snippets/managedidentities/apiv1/Client/CreateMicrosoftAdDomain/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedidentities/apiv1/Client/DeleteDomain/main.go
+++ b/internal/generated/snippets/managedidentities/apiv1/Client/DeleteDomain/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedidentities/apiv1/Client/DetachTrust/main.go
+++ b/internal/generated/snippets/managedidentities/apiv1/Client/DetachTrust/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedidentities/apiv1/Client/GetDomain/main.go
+++ b/internal/generated/snippets/managedidentities/apiv1/Client/GetDomain/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedidentities/apiv1/Client/ListDomains/main.go
+++ b/internal/generated/snippets/managedidentities/apiv1/Client/ListDomains/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedidentities/apiv1/Client/ReconfigureTrust/main.go
+++ b/internal/generated/snippets/managedidentities/apiv1/Client/ReconfigureTrust/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedidentities/apiv1/Client/ResetAdminPassword/main.go
+++ b/internal/generated/snippets/managedidentities/apiv1/Client/ResetAdminPassword/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedidentities/apiv1/Client/UpdateDomain/main.go
+++ b/internal/generated/snippets/managedidentities/apiv1/Client/UpdateDomain/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedidentities/apiv1/Client/ValidateTrust/main.go
+++ b/internal/generated/snippets/managedidentities/apiv1/Client/ValidateTrust/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/apiv1/Client/AddAclEntry/main.go
+++ b/internal/generated/snippets/managedkafka/apiv1/Client/AddAclEntry/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/apiv1/Client/CancelOperation/main.go
+++ b/internal/generated/snippets/managedkafka/apiv1/Client/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/apiv1/Client/CreateAcl/main.go
+++ b/internal/generated/snippets/managedkafka/apiv1/Client/CreateAcl/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/apiv1/Client/CreateCluster/main.go
+++ b/internal/generated/snippets/managedkafka/apiv1/Client/CreateCluster/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/apiv1/Client/CreateTopic/main.go
+++ b/internal/generated/snippets/managedkafka/apiv1/Client/CreateTopic/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/apiv1/Client/DeleteAcl/main.go
+++ b/internal/generated/snippets/managedkafka/apiv1/Client/DeleteAcl/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/apiv1/Client/DeleteCluster/main.go
+++ b/internal/generated/snippets/managedkafka/apiv1/Client/DeleteCluster/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/apiv1/Client/DeleteConsumerGroup/main.go
+++ b/internal/generated/snippets/managedkafka/apiv1/Client/DeleteConsumerGroup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/apiv1/Client/DeleteOperation/main.go
+++ b/internal/generated/snippets/managedkafka/apiv1/Client/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/apiv1/Client/DeleteTopic/main.go
+++ b/internal/generated/snippets/managedkafka/apiv1/Client/DeleteTopic/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/apiv1/Client/GetAcl/main.go
+++ b/internal/generated/snippets/managedkafka/apiv1/Client/GetAcl/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/apiv1/Client/GetCluster/main.go
+++ b/internal/generated/snippets/managedkafka/apiv1/Client/GetCluster/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/apiv1/Client/GetConsumerGroup/main.go
+++ b/internal/generated/snippets/managedkafka/apiv1/Client/GetConsumerGroup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/apiv1/Client/GetLocation/main.go
+++ b/internal/generated/snippets/managedkafka/apiv1/Client/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/apiv1/Client/GetOperation/main.go
+++ b/internal/generated/snippets/managedkafka/apiv1/Client/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/apiv1/Client/GetTopic/main.go
+++ b/internal/generated/snippets/managedkafka/apiv1/Client/GetTopic/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/apiv1/Client/ListAcls/main.go
+++ b/internal/generated/snippets/managedkafka/apiv1/Client/ListAcls/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/apiv1/Client/ListClusters/main.go
+++ b/internal/generated/snippets/managedkafka/apiv1/Client/ListClusters/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/apiv1/Client/ListConsumerGroups/main.go
+++ b/internal/generated/snippets/managedkafka/apiv1/Client/ListConsumerGroups/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/apiv1/Client/ListLocations/main.go
+++ b/internal/generated/snippets/managedkafka/apiv1/Client/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/apiv1/Client/ListOperations/main.go
+++ b/internal/generated/snippets/managedkafka/apiv1/Client/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/apiv1/Client/ListTopics/main.go
+++ b/internal/generated/snippets/managedkafka/apiv1/Client/ListTopics/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/apiv1/Client/RemoveAclEntry/main.go
+++ b/internal/generated/snippets/managedkafka/apiv1/Client/RemoveAclEntry/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/apiv1/Client/UpdateAcl/main.go
+++ b/internal/generated/snippets/managedkafka/apiv1/Client/UpdateAcl/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/apiv1/Client/UpdateCluster/main.go
+++ b/internal/generated/snippets/managedkafka/apiv1/Client/UpdateCluster/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/apiv1/Client/UpdateConsumerGroup/main.go
+++ b/internal/generated/snippets/managedkafka/apiv1/Client/UpdateConsumerGroup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/apiv1/Client/UpdateTopic/main.go
+++ b/internal/generated/snippets/managedkafka/apiv1/Client/UpdateTopic/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/apiv1/ManagedKafkaConnectClient/CancelOperation/main.go
+++ b/internal/generated/snippets/managedkafka/apiv1/ManagedKafkaConnectClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/apiv1/ManagedKafkaConnectClient/CreateConnectCluster/main.go
+++ b/internal/generated/snippets/managedkafka/apiv1/ManagedKafkaConnectClient/CreateConnectCluster/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/apiv1/ManagedKafkaConnectClient/CreateConnector/main.go
+++ b/internal/generated/snippets/managedkafka/apiv1/ManagedKafkaConnectClient/CreateConnector/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/apiv1/ManagedKafkaConnectClient/DeleteConnectCluster/main.go
+++ b/internal/generated/snippets/managedkafka/apiv1/ManagedKafkaConnectClient/DeleteConnectCluster/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/apiv1/ManagedKafkaConnectClient/DeleteConnector/main.go
+++ b/internal/generated/snippets/managedkafka/apiv1/ManagedKafkaConnectClient/DeleteConnector/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/apiv1/ManagedKafkaConnectClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/managedkafka/apiv1/ManagedKafkaConnectClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/apiv1/ManagedKafkaConnectClient/GetConnectCluster/main.go
+++ b/internal/generated/snippets/managedkafka/apiv1/ManagedKafkaConnectClient/GetConnectCluster/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/apiv1/ManagedKafkaConnectClient/GetConnector/main.go
+++ b/internal/generated/snippets/managedkafka/apiv1/ManagedKafkaConnectClient/GetConnector/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/apiv1/ManagedKafkaConnectClient/GetLocation/main.go
+++ b/internal/generated/snippets/managedkafka/apiv1/ManagedKafkaConnectClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/apiv1/ManagedKafkaConnectClient/GetOperation/main.go
+++ b/internal/generated/snippets/managedkafka/apiv1/ManagedKafkaConnectClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/apiv1/ManagedKafkaConnectClient/ListConnectClusters/main.go
+++ b/internal/generated/snippets/managedkafka/apiv1/ManagedKafkaConnectClient/ListConnectClusters/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/apiv1/ManagedKafkaConnectClient/ListConnectors/main.go
+++ b/internal/generated/snippets/managedkafka/apiv1/ManagedKafkaConnectClient/ListConnectors/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/apiv1/ManagedKafkaConnectClient/ListLocations/main.go
+++ b/internal/generated/snippets/managedkafka/apiv1/ManagedKafkaConnectClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/apiv1/ManagedKafkaConnectClient/ListOperations/main.go
+++ b/internal/generated/snippets/managedkafka/apiv1/ManagedKafkaConnectClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/apiv1/ManagedKafkaConnectClient/PauseConnector/main.go
+++ b/internal/generated/snippets/managedkafka/apiv1/ManagedKafkaConnectClient/PauseConnector/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/apiv1/ManagedKafkaConnectClient/RestartConnector/main.go
+++ b/internal/generated/snippets/managedkafka/apiv1/ManagedKafkaConnectClient/RestartConnector/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/apiv1/ManagedKafkaConnectClient/ResumeConnector/main.go
+++ b/internal/generated/snippets/managedkafka/apiv1/ManagedKafkaConnectClient/ResumeConnector/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/apiv1/ManagedKafkaConnectClient/StopConnector/main.go
+++ b/internal/generated/snippets/managedkafka/apiv1/ManagedKafkaConnectClient/StopConnector/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/apiv1/ManagedKafkaConnectClient/UpdateConnectCluster/main.go
+++ b/internal/generated/snippets/managedkafka/apiv1/ManagedKafkaConnectClient/UpdateConnectCluster/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/apiv1/ManagedKafkaConnectClient/UpdateConnector/main.go
+++ b/internal/generated/snippets/managedkafka/apiv1/ManagedKafkaConnectClient/UpdateConnector/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/schemaregistry/apiv1/ManagedSchemaRegistryClient/CancelOperation/main.go
+++ b/internal/generated/snippets/managedkafka/schemaregistry/apiv1/ManagedSchemaRegistryClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/schemaregistry/apiv1/ManagedSchemaRegistryClient/CheckCompatibility/main.go
+++ b/internal/generated/snippets/managedkafka/schemaregistry/apiv1/ManagedSchemaRegistryClient/CheckCompatibility/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/schemaregistry/apiv1/ManagedSchemaRegistryClient/CreateSchemaRegistry/main.go
+++ b/internal/generated/snippets/managedkafka/schemaregistry/apiv1/ManagedSchemaRegistryClient/CreateSchemaRegistry/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/schemaregistry/apiv1/ManagedSchemaRegistryClient/CreateVersion/main.go
+++ b/internal/generated/snippets/managedkafka/schemaregistry/apiv1/ManagedSchemaRegistryClient/CreateVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/schemaregistry/apiv1/ManagedSchemaRegistryClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/managedkafka/schemaregistry/apiv1/ManagedSchemaRegistryClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/schemaregistry/apiv1/ManagedSchemaRegistryClient/DeleteSchemaConfig/main.go
+++ b/internal/generated/snippets/managedkafka/schemaregistry/apiv1/ManagedSchemaRegistryClient/DeleteSchemaConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/schemaregistry/apiv1/ManagedSchemaRegistryClient/DeleteSchemaMode/main.go
+++ b/internal/generated/snippets/managedkafka/schemaregistry/apiv1/ManagedSchemaRegistryClient/DeleteSchemaMode/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/schemaregistry/apiv1/ManagedSchemaRegistryClient/DeleteSchemaRegistry/main.go
+++ b/internal/generated/snippets/managedkafka/schemaregistry/apiv1/ManagedSchemaRegistryClient/DeleteSchemaRegistry/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/schemaregistry/apiv1/ManagedSchemaRegistryClient/DeleteSubject/main.go
+++ b/internal/generated/snippets/managedkafka/schemaregistry/apiv1/ManagedSchemaRegistryClient/DeleteSubject/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/schemaregistry/apiv1/ManagedSchemaRegistryClient/DeleteVersion/main.go
+++ b/internal/generated/snippets/managedkafka/schemaregistry/apiv1/ManagedSchemaRegistryClient/DeleteVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/schemaregistry/apiv1/ManagedSchemaRegistryClient/GetContext/main.go
+++ b/internal/generated/snippets/managedkafka/schemaregistry/apiv1/ManagedSchemaRegistryClient/GetContext/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/schemaregistry/apiv1/ManagedSchemaRegistryClient/GetLocation/main.go
+++ b/internal/generated/snippets/managedkafka/schemaregistry/apiv1/ManagedSchemaRegistryClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/schemaregistry/apiv1/ManagedSchemaRegistryClient/GetOperation/main.go
+++ b/internal/generated/snippets/managedkafka/schemaregistry/apiv1/ManagedSchemaRegistryClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/schemaregistry/apiv1/ManagedSchemaRegistryClient/GetRawSchema/main.go
+++ b/internal/generated/snippets/managedkafka/schemaregistry/apiv1/ManagedSchemaRegistryClient/GetRawSchema/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/schemaregistry/apiv1/ManagedSchemaRegistryClient/GetRawSchemaVersion/main.go
+++ b/internal/generated/snippets/managedkafka/schemaregistry/apiv1/ManagedSchemaRegistryClient/GetRawSchemaVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/schemaregistry/apiv1/ManagedSchemaRegistryClient/GetSchema/main.go
+++ b/internal/generated/snippets/managedkafka/schemaregistry/apiv1/ManagedSchemaRegistryClient/GetSchema/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/schemaregistry/apiv1/ManagedSchemaRegistryClient/GetSchemaConfig/main.go
+++ b/internal/generated/snippets/managedkafka/schemaregistry/apiv1/ManagedSchemaRegistryClient/GetSchemaConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/schemaregistry/apiv1/ManagedSchemaRegistryClient/GetSchemaMode/main.go
+++ b/internal/generated/snippets/managedkafka/schemaregistry/apiv1/ManagedSchemaRegistryClient/GetSchemaMode/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/schemaregistry/apiv1/ManagedSchemaRegistryClient/GetSchemaRegistry/main.go
+++ b/internal/generated/snippets/managedkafka/schemaregistry/apiv1/ManagedSchemaRegistryClient/GetSchemaRegistry/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/schemaregistry/apiv1/ManagedSchemaRegistryClient/GetVersion/main.go
+++ b/internal/generated/snippets/managedkafka/schemaregistry/apiv1/ManagedSchemaRegistryClient/GetVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/schemaregistry/apiv1/ManagedSchemaRegistryClient/ListContexts/main.go
+++ b/internal/generated/snippets/managedkafka/schemaregistry/apiv1/ManagedSchemaRegistryClient/ListContexts/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/schemaregistry/apiv1/ManagedSchemaRegistryClient/ListLocations/main.go
+++ b/internal/generated/snippets/managedkafka/schemaregistry/apiv1/ManagedSchemaRegistryClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/schemaregistry/apiv1/ManagedSchemaRegistryClient/ListOperations/main.go
+++ b/internal/generated/snippets/managedkafka/schemaregistry/apiv1/ManagedSchemaRegistryClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/schemaregistry/apiv1/ManagedSchemaRegistryClient/ListReferencedSchemas/main.go
+++ b/internal/generated/snippets/managedkafka/schemaregistry/apiv1/ManagedSchemaRegistryClient/ListReferencedSchemas/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/schemaregistry/apiv1/ManagedSchemaRegistryClient/ListSchemaRegistries/main.go
+++ b/internal/generated/snippets/managedkafka/schemaregistry/apiv1/ManagedSchemaRegistryClient/ListSchemaRegistries/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/schemaregistry/apiv1/ManagedSchemaRegistryClient/ListSchemaTypes/main.go
+++ b/internal/generated/snippets/managedkafka/schemaregistry/apiv1/ManagedSchemaRegistryClient/ListSchemaTypes/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/schemaregistry/apiv1/ManagedSchemaRegistryClient/ListSchemaVersions/main.go
+++ b/internal/generated/snippets/managedkafka/schemaregistry/apiv1/ManagedSchemaRegistryClient/ListSchemaVersions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/schemaregistry/apiv1/ManagedSchemaRegistryClient/ListSubjects/main.go
+++ b/internal/generated/snippets/managedkafka/schemaregistry/apiv1/ManagedSchemaRegistryClient/ListSubjects/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/schemaregistry/apiv1/ManagedSchemaRegistryClient/ListSubjectsBySchemaId/main.go
+++ b/internal/generated/snippets/managedkafka/schemaregistry/apiv1/ManagedSchemaRegistryClient/ListSubjectsBySchemaId/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/schemaregistry/apiv1/ManagedSchemaRegistryClient/ListVersions/main.go
+++ b/internal/generated/snippets/managedkafka/schemaregistry/apiv1/ManagedSchemaRegistryClient/ListVersions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/schemaregistry/apiv1/ManagedSchemaRegistryClient/LookupVersion/main.go
+++ b/internal/generated/snippets/managedkafka/schemaregistry/apiv1/ManagedSchemaRegistryClient/LookupVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/schemaregistry/apiv1/ManagedSchemaRegistryClient/UpdateSchemaConfig/main.go
+++ b/internal/generated/snippets/managedkafka/schemaregistry/apiv1/ManagedSchemaRegistryClient/UpdateSchemaConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/managedkafka/schemaregistry/apiv1/ManagedSchemaRegistryClient/UpdateSchemaMode/main.go
+++ b/internal/generated/snippets/managedkafka/schemaregistry/apiv1/ManagedSchemaRegistryClient/UpdateSchemaMode/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/maps/addressvalidation/apiv1/Client/ProvideValidationFeedback/main.go
+++ b/internal/generated/snippets/maps/addressvalidation/apiv1/Client/ProvideValidationFeedback/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/maps/addressvalidation/apiv1/Client/ValidateAddress/main.go
+++ b/internal/generated/snippets/maps/addressvalidation/apiv1/Client/ValidateAddress/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/maps/areainsights/apiv1/Client/ComputeInsights/main.go
+++ b/internal/generated/snippets/maps/areainsights/apiv1/Client/ComputeInsights/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/maps/fleetengine/apiv1/TripClient/CreateTrip/main.go
+++ b/internal/generated/snippets/maps/fleetengine/apiv1/TripClient/CreateTrip/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/maps/fleetengine/apiv1/TripClient/DeleteTrip/main.go
+++ b/internal/generated/snippets/maps/fleetengine/apiv1/TripClient/DeleteTrip/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/maps/fleetengine/apiv1/TripClient/GetTrip/main.go
+++ b/internal/generated/snippets/maps/fleetengine/apiv1/TripClient/GetTrip/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/maps/fleetengine/apiv1/TripClient/ReportBillableTrip/main.go
+++ b/internal/generated/snippets/maps/fleetengine/apiv1/TripClient/ReportBillableTrip/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/maps/fleetengine/apiv1/TripClient/SearchTrips/main.go
+++ b/internal/generated/snippets/maps/fleetengine/apiv1/TripClient/SearchTrips/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/maps/fleetengine/apiv1/TripClient/UpdateTrip/main.go
+++ b/internal/generated/snippets/maps/fleetengine/apiv1/TripClient/UpdateTrip/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/maps/fleetengine/apiv1/VehicleClient/CreateVehicle/main.go
+++ b/internal/generated/snippets/maps/fleetengine/apiv1/VehicleClient/CreateVehicle/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/maps/fleetengine/apiv1/VehicleClient/DeleteVehicle/main.go
+++ b/internal/generated/snippets/maps/fleetengine/apiv1/VehicleClient/DeleteVehicle/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/maps/fleetengine/apiv1/VehicleClient/GetVehicle/main.go
+++ b/internal/generated/snippets/maps/fleetengine/apiv1/VehicleClient/GetVehicle/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/maps/fleetengine/apiv1/VehicleClient/ListVehicles/main.go
+++ b/internal/generated/snippets/maps/fleetengine/apiv1/VehicleClient/ListVehicles/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/maps/fleetengine/apiv1/VehicleClient/SearchVehicles/main.go
+++ b/internal/generated/snippets/maps/fleetengine/apiv1/VehicleClient/SearchVehicles/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/maps/fleetengine/apiv1/VehicleClient/UpdateVehicle/main.go
+++ b/internal/generated/snippets/maps/fleetengine/apiv1/VehicleClient/UpdateVehicle/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/maps/fleetengine/apiv1/VehicleClient/UpdateVehicleAttributes/main.go
+++ b/internal/generated/snippets/maps/fleetengine/apiv1/VehicleClient/UpdateVehicleAttributes/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/maps/fleetengine/delivery/apiv1/Client/BatchCreateTasks/main.go
+++ b/internal/generated/snippets/maps/fleetengine/delivery/apiv1/Client/BatchCreateTasks/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/maps/fleetengine/delivery/apiv1/Client/CreateDeliveryVehicle/main.go
+++ b/internal/generated/snippets/maps/fleetengine/delivery/apiv1/Client/CreateDeliveryVehicle/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/maps/fleetengine/delivery/apiv1/Client/CreateTask/main.go
+++ b/internal/generated/snippets/maps/fleetengine/delivery/apiv1/Client/CreateTask/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/maps/fleetengine/delivery/apiv1/Client/DeleteDeliveryVehicle/main.go
+++ b/internal/generated/snippets/maps/fleetengine/delivery/apiv1/Client/DeleteDeliveryVehicle/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/maps/fleetengine/delivery/apiv1/Client/DeleteTask/main.go
+++ b/internal/generated/snippets/maps/fleetengine/delivery/apiv1/Client/DeleteTask/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/maps/fleetengine/delivery/apiv1/Client/GetDeliveryVehicle/main.go
+++ b/internal/generated/snippets/maps/fleetengine/delivery/apiv1/Client/GetDeliveryVehicle/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/maps/fleetengine/delivery/apiv1/Client/GetTask/main.go
+++ b/internal/generated/snippets/maps/fleetengine/delivery/apiv1/Client/GetTask/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/maps/fleetengine/delivery/apiv1/Client/GetTaskTrackingInfo/main.go
+++ b/internal/generated/snippets/maps/fleetengine/delivery/apiv1/Client/GetTaskTrackingInfo/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/maps/fleetengine/delivery/apiv1/Client/ListDeliveryVehicles/main.go
+++ b/internal/generated/snippets/maps/fleetengine/delivery/apiv1/Client/ListDeliveryVehicles/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/maps/fleetengine/delivery/apiv1/Client/ListTasks/main.go
+++ b/internal/generated/snippets/maps/fleetengine/delivery/apiv1/Client/ListTasks/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/maps/fleetengine/delivery/apiv1/Client/UpdateDeliveryVehicle/main.go
+++ b/internal/generated/snippets/maps/fleetengine/delivery/apiv1/Client/UpdateDeliveryVehicle/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/maps/fleetengine/delivery/apiv1/Client/UpdateTask/main.go
+++ b/internal/generated/snippets/maps/fleetengine/delivery/apiv1/Client/UpdateTask/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/maps/places/apiv1/Client/AutocompletePlaces/main.go
+++ b/internal/generated/snippets/maps/places/apiv1/Client/AutocompletePlaces/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/maps/places/apiv1/Client/GetPhotoMedia/main.go
+++ b/internal/generated/snippets/maps/places/apiv1/Client/GetPhotoMedia/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/maps/places/apiv1/Client/GetPlace/main.go
+++ b/internal/generated/snippets/maps/places/apiv1/Client/GetPlace/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/maps/places/apiv1/Client/SearchNearby/main.go
+++ b/internal/generated/snippets/maps/places/apiv1/Client/SearchNearby/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/maps/places/apiv1/Client/SearchText/main.go
+++ b/internal/generated/snippets/maps/places/apiv1/Client/SearchText/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/maps/routeoptimization/apiv1/Client/BatchOptimizeTours/main.go
+++ b/internal/generated/snippets/maps/routeoptimization/apiv1/Client/BatchOptimizeTours/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/maps/routeoptimization/apiv1/Client/GetOperation/main.go
+++ b/internal/generated/snippets/maps/routeoptimization/apiv1/Client/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/maps/routeoptimization/apiv1/Client/OptimizeTours/main.go
+++ b/internal/generated/snippets/maps/routeoptimization/apiv1/Client/OptimizeTours/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/maps/routeoptimization/apiv1/Client/OptimizeToursLongRunning/main.go
+++ b/internal/generated/snippets/maps/routeoptimization/apiv1/Client/OptimizeToursLongRunning/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/maps/routeoptimization/apiv1/Client/OptimizeToursUri/main.go
+++ b/internal/generated/snippets/maps/routeoptimization/apiv1/Client/OptimizeToursUri/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/maps/routing/apiv2/RoutesClient/ComputeRoutes/main.go
+++ b/internal/generated/snippets/maps/routing/apiv2/RoutesClient/ComputeRoutes/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/maps/solar/apiv1/Client/FindClosestBuildingInsights/main.go
+++ b/internal/generated/snippets/maps/solar/apiv1/Client/FindClosestBuildingInsights/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/maps/solar/apiv1/Client/GetDataLayers/main.go
+++ b/internal/generated/snippets/maps/solar/apiv1/Client/GetDataLayers/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/maps/solar/apiv1/Client/GetGeoTiff/main.go
+++ b/internal/generated/snippets/maps/solar/apiv1/Client/GetGeoTiff/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/mediatranslation/apiv1beta1/SpeechTranslationClient/StreamingTranslateSpeech/main.go
+++ b/internal/generated/snippets/mediatranslation/apiv1beta1/SpeechTranslationClient/StreamingTranslateSpeech/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/memcache/apiv1/CloudMemcacheClient/ApplyParameters/main.go
+++ b/internal/generated/snippets/memcache/apiv1/CloudMemcacheClient/ApplyParameters/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/memcache/apiv1/CloudMemcacheClient/CancelOperation/main.go
+++ b/internal/generated/snippets/memcache/apiv1/CloudMemcacheClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/memcache/apiv1/CloudMemcacheClient/CreateInstance/main.go
+++ b/internal/generated/snippets/memcache/apiv1/CloudMemcacheClient/CreateInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/memcache/apiv1/CloudMemcacheClient/DeleteInstance/main.go
+++ b/internal/generated/snippets/memcache/apiv1/CloudMemcacheClient/DeleteInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/memcache/apiv1/CloudMemcacheClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/memcache/apiv1/CloudMemcacheClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/memcache/apiv1/CloudMemcacheClient/GetInstance/main.go
+++ b/internal/generated/snippets/memcache/apiv1/CloudMemcacheClient/GetInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/memcache/apiv1/CloudMemcacheClient/GetLocation/main.go
+++ b/internal/generated/snippets/memcache/apiv1/CloudMemcacheClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/memcache/apiv1/CloudMemcacheClient/GetOperation/main.go
+++ b/internal/generated/snippets/memcache/apiv1/CloudMemcacheClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/memcache/apiv1/CloudMemcacheClient/ListInstances/main.go
+++ b/internal/generated/snippets/memcache/apiv1/CloudMemcacheClient/ListInstances/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/memcache/apiv1/CloudMemcacheClient/ListLocations/main.go
+++ b/internal/generated/snippets/memcache/apiv1/CloudMemcacheClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/memcache/apiv1/CloudMemcacheClient/ListOperations/main.go
+++ b/internal/generated/snippets/memcache/apiv1/CloudMemcacheClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/memcache/apiv1/CloudMemcacheClient/RescheduleMaintenance/main.go
+++ b/internal/generated/snippets/memcache/apiv1/CloudMemcacheClient/RescheduleMaintenance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/memcache/apiv1/CloudMemcacheClient/UpdateInstance/main.go
+++ b/internal/generated/snippets/memcache/apiv1/CloudMemcacheClient/UpdateInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/memcache/apiv1/CloudMemcacheClient/UpdateParameters/main.go
+++ b/internal/generated/snippets/memcache/apiv1/CloudMemcacheClient/UpdateParameters/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/memcache/apiv1beta2/CloudMemcacheClient/ApplyParameters/main.go
+++ b/internal/generated/snippets/memcache/apiv1beta2/CloudMemcacheClient/ApplyParameters/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/memcache/apiv1beta2/CloudMemcacheClient/ApplySoftwareUpdate/main.go
+++ b/internal/generated/snippets/memcache/apiv1beta2/CloudMemcacheClient/ApplySoftwareUpdate/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/memcache/apiv1beta2/CloudMemcacheClient/CancelOperation/main.go
+++ b/internal/generated/snippets/memcache/apiv1beta2/CloudMemcacheClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/memcache/apiv1beta2/CloudMemcacheClient/CreateInstance/main.go
+++ b/internal/generated/snippets/memcache/apiv1beta2/CloudMemcacheClient/CreateInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/memcache/apiv1beta2/CloudMemcacheClient/DeleteInstance/main.go
+++ b/internal/generated/snippets/memcache/apiv1beta2/CloudMemcacheClient/DeleteInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/memcache/apiv1beta2/CloudMemcacheClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/memcache/apiv1beta2/CloudMemcacheClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/memcache/apiv1beta2/CloudMemcacheClient/GetInstance/main.go
+++ b/internal/generated/snippets/memcache/apiv1beta2/CloudMemcacheClient/GetInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/memcache/apiv1beta2/CloudMemcacheClient/GetLocation/main.go
+++ b/internal/generated/snippets/memcache/apiv1beta2/CloudMemcacheClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/memcache/apiv1beta2/CloudMemcacheClient/GetOperation/main.go
+++ b/internal/generated/snippets/memcache/apiv1beta2/CloudMemcacheClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/memcache/apiv1beta2/CloudMemcacheClient/ListInstances/main.go
+++ b/internal/generated/snippets/memcache/apiv1beta2/CloudMemcacheClient/ListInstances/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/memcache/apiv1beta2/CloudMemcacheClient/ListLocations/main.go
+++ b/internal/generated/snippets/memcache/apiv1beta2/CloudMemcacheClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/memcache/apiv1beta2/CloudMemcacheClient/ListOperations/main.go
+++ b/internal/generated/snippets/memcache/apiv1beta2/CloudMemcacheClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/memcache/apiv1beta2/CloudMemcacheClient/RescheduleMaintenance/main.go
+++ b/internal/generated/snippets/memcache/apiv1beta2/CloudMemcacheClient/RescheduleMaintenance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/memcache/apiv1beta2/CloudMemcacheClient/UpdateInstance/main.go
+++ b/internal/generated/snippets/memcache/apiv1beta2/CloudMemcacheClient/UpdateInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/memcache/apiv1beta2/CloudMemcacheClient/UpdateParameters/main.go
+++ b/internal/generated/snippets/memcache/apiv1beta2/CloudMemcacheClient/UpdateParameters/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/memorystore/apiv1/Client/BackupInstance/main.go
+++ b/internal/generated/snippets/memorystore/apiv1/Client/BackupInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/memorystore/apiv1/Client/CancelOperation/main.go
+++ b/internal/generated/snippets/memorystore/apiv1/Client/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/memorystore/apiv1/Client/CreateInstance/main.go
+++ b/internal/generated/snippets/memorystore/apiv1/Client/CreateInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/memorystore/apiv1/Client/DeleteBackup/main.go
+++ b/internal/generated/snippets/memorystore/apiv1/Client/DeleteBackup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/memorystore/apiv1/Client/DeleteInstance/main.go
+++ b/internal/generated/snippets/memorystore/apiv1/Client/DeleteInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/memorystore/apiv1/Client/DeleteOperation/main.go
+++ b/internal/generated/snippets/memorystore/apiv1/Client/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/memorystore/apiv1/Client/ExportBackup/main.go
+++ b/internal/generated/snippets/memorystore/apiv1/Client/ExportBackup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/memorystore/apiv1/Client/GetBackup/main.go
+++ b/internal/generated/snippets/memorystore/apiv1/Client/GetBackup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/memorystore/apiv1/Client/GetBackupCollection/main.go
+++ b/internal/generated/snippets/memorystore/apiv1/Client/GetBackupCollection/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/memorystore/apiv1/Client/GetCertificateAuthority/main.go
+++ b/internal/generated/snippets/memorystore/apiv1/Client/GetCertificateAuthority/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/memorystore/apiv1/Client/GetInstance/main.go
+++ b/internal/generated/snippets/memorystore/apiv1/Client/GetInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/memorystore/apiv1/Client/GetLocation/main.go
+++ b/internal/generated/snippets/memorystore/apiv1/Client/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/memorystore/apiv1/Client/GetOperation/main.go
+++ b/internal/generated/snippets/memorystore/apiv1/Client/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/memorystore/apiv1/Client/ListBackupCollections/main.go
+++ b/internal/generated/snippets/memorystore/apiv1/Client/ListBackupCollections/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/memorystore/apiv1/Client/ListBackups/main.go
+++ b/internal/generated/snippets/memorystore/apiv1/Client/ListBackups/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/memorystore/apiv1/Client/ListInstances/main.go
+++ b/internal/generated/snippets/memorystore/apiv1/Client/ListInstances/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/memorystore/apiv1/Client/ListLocations/main.go
+++ b/internal/generated/snippets/memorystore/apiv1/Client/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/memorystore/apiv1/Client/ListOperations/main.go
+++ b/internal/generated/snippets/memorystore/apiv1/Client/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/memorystore/apiv1/Client/RescheduleMaintenance/main.go
+++ b/internal/generated/snippets/memorystore/apiv1/Client/RescheduleMaintenance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/memorystore/apiv1/Client/UpdateInstance/main.go
+++ b/internal/generated/snippets/memorystore/apiv1/Client/UpdateInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/memorystore/apiv1beta/Client/CancelOperation/main.go
+++ b/internal/generated/snippets/memorystore/apiv1beta/Client/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/memorystore/apiv1beta/Client/CreateInstance/main.go
+++ b/internal/generated/snippets/memorystore/apiv1beta/Client/CreateInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/memorystore/apiv1beta/Client/DeleteInstance/main.go
+++ b/internal/generated/snippets/memorystore/apiv1beta/Client/DeleteInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/memorystore/apiv1beta/Client/DeleteOperation/main.go
+++ b/internal/generated/snippets/memorystore/apiv1beta/Client/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/memorystore/apiv1beta/Client/GetCertificateAuthority/main.go
+++ b/internal/generated/snippets/memorystore/apiv1beta/Client/GetCertificateAuthority/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/memorystore/apiv1beta/Client/GetInstance/main.go
+++ b/internal/generated/snippets/memorystore/apiv1beta/Client/GetInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/memorystore/apiv1beta/Client/GetLocation/main.go
+++ b/internal/generated/snippets/memorystore/apiv1beta/Client/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/memorystore/apiv1beta/Client/GetOperation/main.go
+++ b/internal/generated/snippets/memorystore/apiv1beta/Client/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/memorystore/apiv1beta/Client/ListInstances/main.go
+++ b/internal/generated/snippets/memorystore/apiv1beta/Client/ListInstances/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/memorystore/apiv1beta/Client/ListLocations/main.go
+++ b/internal/generated/snippets/memorystore/apiv1beta/Client/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/memorystore/apiv1beta/Client/ListOperations/main.go
+++ b/internal/generated/snippets/memorystore/apiv1beta/Client/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/memorystore/apiv1beta/Client/UpdateInstance/main.go
+++ b/internal/generated/snippets/memorystore/apiv1beta/Client/UpdateInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1/DataprocMetastoreClient/AlterMetadataResourceLocation/main.go
+++ b/internal/generated/snippets/metastore/apiv1/DataprocMetastoreClient/AlterMetadataResourceLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1/DataprocMetastoreClient/CancelOperation/main.go
+++ b/internal/generated/snippets/metastore/apiv1/DataprocMetastoreClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1/DataprocMetastoreClient/CreateBackup/main.go
+++ b/internal/generated/snippets/metastore/apiv1/DataprocMetastoreClient/CreateBackup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1/DataprocMetastoreClient/CreateMetadataImport/main.go
+++ b/internal/generated/snippets/metastore/apiv1/DataprocMetastoreClient/CreateMetadataImport/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1/DataprocMetastoreClient/CreateService/main.go
+++ b/internal/generated/snippets/metastore/apiv1/DataprocMetastoreClient/CreateService/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1/DataprocMetastoreClient/DeleteBackup/main.go
+++ b/internal/generated/snippets/metastore/apiv1/DataprocMetastoreClient/DeleteBackup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1/DataprocMetastoreClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/metastore/apiv1/DataprocMetastoreClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1/DataprocMetastoreClient/DeleteService/main.go
+++ b/internal/generated/snippets/metastore/apiv1/DataprocMetastoreClient/DeleteService/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1/DataprocMetastoreClient/ExportMetadata/main.go
+++ b/internal/generated/snippets/metastore/apiv1/DataprocMetastoreClient/ExportMetadata/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1/DataprocMetastoreClient/GetBackup/main.go
+++ b/internal/generated/snippets/metastore/apiv1/DataprocMetastoreClient/GetBackup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1/DataprocMetastoreClient/GetIamPolicy/main.go
+++ b/internal/generated/snippets/metastore/apiv1/DataprocMetastoreClient/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1/DataprocMetastoreClient/GetLocation/main.go
+++ b/internal/generated/snippets/metastore/apiv1/DataprocMetastoreClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1/DataprocMetastoreClient/GetMetadataImport/main.go
+++ b/internal/generated/snippets/metastore/apiv1/DataprocMetastoreClient/GetMetadataImport/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1/DataprocMetastoreClient/GetOperation/main.go
+++ b/internal/generated/snippets/metastore/apiv1/DataprocMetastoreClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1/DataprocMetastoreClient/GetService/main.go
+++ b/internal/generated/snippets/metastore/apiv1/DataprocMetastoreClient/GetService/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1/DataprocMetastoreClient/ListBackups/main.go
+++ b/internal/generated/snippets/metastore/apiv1/DataprocMetastoreClient/ListBackups/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1/DataprocMetastoreClient/ListLocations/main.go
+++ b/internal/generated/snippets/metastore/apiv1/DataprocMetastoreClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1/DataprocMetastoreClient/ListMetadataImports/main.go
+++ b/internal/generated/snippets/metastore/apiv1/DataprocMetastoreClient/ListMetadataImports/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1/DataprocMetastoreClient/ListOperations/main.go
+++ b/internal/generated/snippets/metastore/apiv1/DataprocMetastoreClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1/DataprocMetastoreClient/ListServices/main.go
+++ b/internal/generated/snippets/metastore/apiv1/DataprocMetastoreClient/ListServices/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1/DataprocMetastoreClient/MoveTableToDatabase/main.go
+++ b/internal/generated/snippets/metastore/apiv1/DataprocMetastoreClient/MoveTableToDatabase/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1/DataprocMetastoreClient/QueryMetadata/main.go
+++ b/internal/generated/snippets/metastore/apiv1/DataprocMetastoreClient/QueryMetadata/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1/DataprocMetastoreClient/RestoreService/main.go
+++ b/internal/generated/snippets/metastore/apiv1/DataprocMetastoreClient/RestoreService/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1/DataprocMetastoreClient/SetIamPolicy/main.go
+++ b/internal/generated/snippets/metastore/apiv1/DataprocMetastoreClient/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1/DataprocMetastoreClient/TestIamPermissions/main.go
+++ b/internal/generated/snippets/metastore/apiv1/DataprocMetastoreClient/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1/DataprocMetastoreClient/UpdateMetadataImport/main.go
+++ b/internal/generated/snippets/metastore/apiv1/DataprocMetastoreClient/UpdateMetadataImport/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1/DataprocMetastoreClient/UpdateService/main.go
+++ b/internal/generated/snippets/metastore/apiv1/DataprocMetastoreClient/UpdateService/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1/DataprocMetastoreFederationClient/CancelOperation/main.go
+++ b/internal/generated/snippets/metastore/apiv1/DataprocMetastoreFederationClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1/DataprocMetastoreFederationClient/CreateFederation/main.go
+++ b/internal/generated/snippets/metastore/apiv1/DataprocMetastoreFederationClient/CreateFederation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1/DataprocMetastoreFederationClient/DeleteFederation/main.go
+++ b/internal/generated/snippets/metastore/apiv1/DataprocMetastoreFederationClient/DeleteFederation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1/DataprocMetastoreFederationClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/metastore/apiv1/DataprocMetastoreFederationClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1/DataprocMetastoreFederationClient/GetFederation/main.go
+++ b/internal/generated/snippets/metastore/apiv1/DataprocMetastoreFederationClient/GetFederation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1/DataprocMetastoreFederationClient/GetIamPolicy/main.go
+++ b/internal/generated/snippets/metastore/apiv1/DataprocMetastoreFederationClient/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1/DataprocMetastoreFederationClient/GetLocation/main.go
+++ b/internal/generated/snippets/metastore/apiv1/DataprocMetastoreFederationClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1/DataprocMetastoreFederationClient/GetOperation/main.go
+++ b/internal/generated/snippets/metastore/apiv1/DataprocMetastoreFederationClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1/DataprocMetastoreFederationClient/ListFederations/main.go
+++ b/internal/generated/snippets/metastore/apiv1/DataprocMetastoreFederationClient/ListFederations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1/DataprocMetastoreFederationClient/ListLocations/main.go
+++ b/internal/generated/snippets/metastore/apiv1/DataprocMetastoreFederationClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1/DataprocMetastoreFederationClient/ListOperations/main.go
+++ b/internal/generated/snippets/metastore/apiv1/DataprocMetastoreFederationClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1/DataprocMetastoreFederationClient/SetIamPolicy/main.go
+++ b/internal/generated/snippets/metastore/apiv1/DataprocMetastoreFederationClient/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1/DataprocMetastoreFederationClient/TestIamPermissions/main.go
+++ b/internal/generated/snippets/metastore/apiv1/DataprocMetastoreFederationClient/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1/DataprocMetastoreFederationClient/UpdateFederation/main.go
+++ b/internal/generated/snippets/metastore/apiv1/DataprocMetastoreFederationClient/UpdateFederation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreClient/AlterMetadataResourceLocation/main.go
+++ b/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreClient/AlterMetadataResourceLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreClient/CancelOperation/main.go
+++ b/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreClient/CreateBackup/main.go
+++ b/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreClient/CreateBackup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreClient/CreateMetadataImport/main.go
+++ b/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreClient/CreateMetadataImport/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreClient/CreateService/main.go
+++ b/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreClient/CreateService/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreClient/DeleteBackup/main.go
+++ b/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreClient/DeleteBackup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreClient/DeleteService/main.go
+++ b/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreClient/DeleteService/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreClient/ExportMetadata/main.go
+++ b/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreClient/ExportMetadata/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreClient/GetBackup/main.go
+++ b/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreClient/GetBackup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreClient/GetIamPolicy/main.go
+++ b/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreClient/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreClient/GetLocation/main.go
+++ b/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreClient/GetMetadataImport/main.go
+++ b/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreClient/GetMetadataImport/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreClient/GetOperation/main.go
+++ b/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreClient/GetService/main.go
+++ b/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreClient/GetService/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreClient/ListBackups/main.go
+++ b/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreClient/ListBackups/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreClient/ListLocations/main.go
+++ b/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreClient/ListMetadataImports/main.go
+++ b/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreClient/ListMetadataImports/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreClient/ListOperations/main.go
+++ b/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreClient/ListServices/main.go
+++ b/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreClient/ListServices/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreClient/MoveTableToDatabase/main.go
+++ b/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreClient/MoveTableToDatabase/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreClient/QueryMetadata/main.go
+++ b/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreClient/QueryMetadata/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreClient/RemoveIamPolicy/main.go
+++ b/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreClient/RemoveIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreClient/RestoreService/main.go
+++ b/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreClient/RestoreService/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreClient/SetIamPolicy/main.go
+++ b/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreClient/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreClient/TestIamPermissions/main.go
+++ b/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreClient/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreClient/UpdateMetadataImport/main.go
+++ b/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreClient/UpdateMetadataImport/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreClient/UpdateService/main.go
+++ b/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreClient/UpdateService/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreFederationClient/CancelOperation/main.go
+++ b/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreFederationClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreFederationClient/CreateFederation/main.go
+++ b/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreFederationClient/CreateFederation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreFederationClient/DeleteFederation/main.go
+++ b/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreFederationClient/DeleteFederation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreFederationClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreFederationClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreFederationClient/GetFederation/main.go
+++ b/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreFederationClient/GetFederation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreFederationClient/GetIamPolicy/main.go
+++ b/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreFederationClient/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreFederationClient/GetLocation/main.go
+++ b/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreFederationClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreFederationClient/GetOperation/main.go
+++ b/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreFederationClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreFederationClient/ListFederations/main.go
+++ b/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreFederationClient/ListFederations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreFederationClient/ListLocations/main.go
+++ b/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreFederationClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreFederationClient/ListOperations/main.go
+++ b/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreFederationClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreFederationClient/SetIamPolicy/main.go
+++ b/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreFederationClient/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreFederationClient/TestIamPermissions/main.go
+++ b/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreFederationClient/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreFederationClient/UpdateFederation/main.go
+++ b/internal/generated/snippets/metastore/apiv1alpha/DataprocMetastoreFederationClient/UpdateFederation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreClient/AlterMetadataResourceLocation/main.go
+++ b/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreClient/AlterMetadataResourceLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreClient/CancelOperation/main.go
+++ b/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreClient/CreateBackup/main.go
+++ b/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreClient/CreateBackup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreClient/CreateMetadataImport/main.go
+++ b/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreClient/CreateMetadataImport/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreClient/CreateService/main.go
+++ b/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreClient/CreateService/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreClient/DeleteBackup/main.go
+++ b/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreClient/DeleteBackup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreClient/DeleteService/main.go
+++ b/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreClient/DeleteService/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreClient/ExportMetadata/main.go
+++ b/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreClient/ExportMetadata/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreClient/GetBackup/main.go
+++ b/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreClient/GetBackup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreClient/GetIamPolicy/main.go
+++ b/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreClient/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreClient/GetLocation/main.go
+++ b/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreClient/GetMetadataImport/main.go
+++ b/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreClient/GetMetadataImport/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreClient/GetOperation/main.go
+++ b/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreClient/GetService/main.go
+++ b/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreClient/GetService/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreClient/ListBackups/main.go
+++ b/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreClient/ListBackups/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreClient/ListLocations/main.go
+++ b/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreClient/ListMetadataImports/main.go
+++ b/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreClient/ListMetadataImports/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreClient/ListOperations/main.go
+++ b/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreClient/ListServices/main.go
+++ b/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreClient/ListServices/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreClient/MoveTableToDatabase/main.go
+++ b/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreClient/MoveTableToDatabase/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreClient/QueryMetadata/main.go
+++ b/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreClient/QueryMetadata/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreClient/RemoveIamPolicy/main.go
+++ b/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreClient/RemoveIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreClient/RestoreService/main.go
+++ b/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreClient/RestoreService/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreClient/SetIamPolicy/main.go
+++ b/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreClient/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreClient/TestIamPermissions/main.go
+++ b/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreClient/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreClient/UpdateMetadataImport/main.go
+++ b/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreClient/UpdateMetadataImport/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreClient/UpdateService/main.go
+++ b/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreClient/UpdateService/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreFederationClient/CancelOperation/main.go
+++ b/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreFederationClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreFederationClient/CreateFederation/main.go
+++ b/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreFederationClient/CreateFederation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreFederationClient/DeleteFederation/main.go
+++ b/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreFederationClient/DeleteFederation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreFederationClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreFederationClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreFederationClient/GetFederation/main.go
+++ b/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreFederationClient/GetFederation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreFederationClient/GetIamPolicy/main.go
+++ b/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreFederationClient/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreFederationClient/GetLocation/main.go
+++ b/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreFederationClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreFederationClient/GetOperation/main.go
+++ b/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreFederationClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreFederationClient/ListFederations/main.go
+++ b/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreFederationClient/ListFederations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreFederationClient/ListLocations/main.go
+++ b/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreFederationClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreFederationClient/ListOperations/main.go
+++ b/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreFederationClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreFederationClient/SetIamPolicy/main.go
+++ b/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreFederationClient/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreFederationClient/TestIamPermissions/main.go
+++ b/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreFederationClient/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreFederationClient/UpdateFederation/main.go
+++ b/internal/generated/snippets/metastore/apiv1beta/DataprocMetastoreFederationClient/UpdateFederation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/migrationcenter/apiv1/Client/AddAssetsToGroup/main.go
+++ b/internal/generated/snippets/migrationcenter/apiv1/Client/AddAssetsToGroup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/migrationcenter/apiv1/Client/AggregateAssetsValues/main.go
+++ b/internal/generated/snippets/migrationcenter/apiv1/Client/AggregateAssetsValues/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/migrationcenter/apiv1/Client/BatchDeleteAssets/main.go
+++ b/internal/generated/snippets/migrationcenter/apiv1/Client/BatchDeleteAssets/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/migrationcenter/apiv1/Client/BatchUpdateAssets/main.go
+++ b/internal/generated/snippets/migrationcenter/apiv1/Client/BatchUpdateAssets/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/migrationcenter/apiv1/Client/CancelOperation/main.go
+++ b/internal/generated/snippets/migrationcenter/apiv1/Client/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/migrationcenter/apiv1/Client/CreateGroup/main.go
+++ b/internal/generated/snippets/migrationcenter/apiv1/Client/CreateGroup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/migrationcenter/apiv1/Client/CreateImportDataFile/main.go
+++ b/internal/generated/snippets/migrationcenter/apiv1/Client/CreateImportDataFile/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/migrationcenter/apiv1/Client/CreateImportJob/main.go
+++ b/internal/generated/snippets/migrationcenter/apiv1/Client/CreateImportJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/migrationcenter/apiv1/Client/CreatePreferenceSet/main.go
+++ b/internal/generated/snippets/migrationcenter/apiv1/Client/CreatePreferenceSet/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/migrationcenter/apiv1/Client/CreateReport/main.go
+++ b/internal/generated/snippets/migrationcenter/apiv1/Client/CreateReport/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/migrationcenter/apiv1/Client/CreateReportConfig/main.go
+++ b/internal/generated/snippets/migrationcenter/apiv1/Client/CreateReportConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/migrationcenter/apiv1/Client/CreateSource/main.go
+++ b/internal/generated/snippets/migrationcenter/apiv1/Client/CreateSource/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/migrationcenter/apiv1/Client/DeleteAsset/main.go
+++ b/internal/generated/snippets/migrationcenter/apiv1/Client/DeleteAsset/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/migrationcenter/apiv1/Client/DeleteGroup/main.go
+++ b/internal/generated/snippets/migrationcenter/apiv1/Client/DeleteGroup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/migrationcenter/apiv1/Client/DeleteImportDataFile/main.go
+++ b/internal/generated/snippets/migrationcenter/apiv1/Client/DeleteImportDataFile/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/migrationcenter/apiv1/Client/DeleteImportJob/main.go
+++ b/internal/generated/snippets/migrationcenter/apiv1/Client/DeleteImportJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/migrationcenter/apiv1/Client/DeleteOperation/main.go
+++ b/internal/generated/snippets/migrationcenter/apiv1/Client/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/migrationcenter/apiv1/Client/DeletePreferenceSet/main.go
+++ b/internal/generated/snippets/migrationcenter/apiv1/Client/DeletePreferenceSet/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/migrationcenter/apiv1/Client/DeleteReport/main.go
+++ b/internal/generated/snippets/migrationcenter/apiv1/Client/DeleteReport/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/migrationcenter/apiv1/Client/DeleteReportConfig/main.go
+++ b/internal/generated/snippets/migrationcenter/apiv1/Client/DeleteReportConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/migrationcenter/apiv1/Client/DeleteSource/main.go
+++ b/internal/generated/snippets/migrationcenter/apiv1/Client/DeleteSource/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/migrationcenter/apiv1/Client/GetAsset/main.go
+++ b/internal/generated/snippets/migrationcenter/apiv1/Client/GetAsset/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/migrationcenter/apiv1/Client/GetErrorFrame/main.go
+++ b/internal/generated/snippets/migrationcenter/apiv1/Client/GetErrorFrame/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/migrationcenter/apiv1/Client/GetGroup/main.go
+++ b/internal/generated/snippets/migrationcenter/apiv1/Client/GetGroup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/migrationcenter/apiv1/Client/GetImportDataFile/main.go
+++ b/internal/generated/snippets/migrationcenter/apiv1/Client/GetImportDataFile/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/migrationcenter/apiv1/Client/GetImportJob/main.go
+++ b/internal/generated/snippets/migrationcenter/apiv1/Client/GetImportJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/migrationcenter/apiv1/Client/GetLocation/main.go
+++ b/internal/generated/snippets/migrationcenter/apiv1/Client/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/migrationcenter/apiv1/Client/GetOperation/main.go
+++ b/internal/generated/snippets/migrationcenter/apiv1/Client/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/migrationcenter/apiv1/Client/GetPreferenceSet/main.go
+++ b/internal/generated/snippets/migrationcenter/apiv1/Client/GetPreferenceSet/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/migrationcenter/apiv1/Client/GetReport/main.go
+++ b/internal/generated/snippets/migrationcenter/apiv1/Client/GetReport/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/migrationcenter/apiv1/Client/GetReportConfig/main.go
+++ b/internal/generated/snippets/migrationcenter/apiv1/Client/GetReportConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/migrationcenter/apiv1/Client/GetSettings/main.go
+++ b/internal/generated/snippets/migrationcenter/apiv1/Client/GetSettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/migrationcenter/apiv1/Client/GetSource/main.go
+++ b/internal/generated/snippets/migrationcenter/apiv1/Client/GetSource/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/migrationcenter/apiv1/Client/ListAssets/main.go
+++ b/internal/generated/snippets/migrationcenter/apiv1/Client/ListAssets/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/migrationcenter/apiv1/Client/ListErrorFrames/main.go
+++ b/internal/generated/snippets/migrationcenter/apiv1/Client/ListErrorFrames/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/migrationcenter/apiv1/Client/ListGroups/main.go
+++ b/internal/generated/snippets/migrationcenter/apiv1/Client/ListGroups/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/migrationcenter/apiv1/Client/ListImportDataFiles/main.go
+++ b/internal/generated/snippets/migrationcenter/apiv1/Client/ListImportDataFiles/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/migrationcenter/apiv1/Client/ListImportJobs/main.go
+++ b/internal/generated/snippets/migrationcenter/apiv1/Client/ListImportJobs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/migrationcenter/apiv1/Client/ListLocations/main.go
+++ b/internal/generated/snippets/migrationcenter/apiv1/Client/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/migrationcenter/apiv1/Client/ListOperations/main.go
+++ b/internal/generated/snippets/migrationcenter/apiv1/Client/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/migrationcenter/apiv1/Client/ListPreferenceSets/main.go
+++ b/internal/generated/snippets/migrationcenter/apiv1/Client/ListPreferenceSets/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/migrationcenter/apiv1/Client/ListReportConfigs/main.go
+++ b/internal/generated/snippets/migrationcenter/apiv1/Client/ListReportConfigs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/migrationcenter/apiv1/Client/ListReports/main.go
+++ b/internal/generated/snippets/migrationcenter/apiv1/Client/ListReports/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/migrationcenter/apiv1/Client/ListSources/main.go
+++ b/internal/generated/snippets/migrationcenter/apiv1/Client/ListSources/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/migrationcenter/apiv1/Client/RemoveAssetsFromGroup/main.go
+++ b/internal/generated/snippets/migrationcenter/apiv1/Client/RemoveAssetsFromGroup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/migrationcenter/apiv1/Client/ReportAssetFrames/main.go
+++ b/internal/generated/snippets/migrationcenter/apiv1/Client/ReportAssetFrames/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/migrationcenter/apiv1/Client/RunImportJob/main.go
+++ b/internal/generated/snippets/migrationcenter/apiv1/Client/RunImportJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/migrationcenter/apiv1/Client/UpdateAsset/main.go
+++ b/internal/generated/snippets/migrationcenter/apiv1/Client/UpdateAsset/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/migrationcenter/apiv1/Client/UpdateGroup/main.go
+++ b/internal/generated/snippets/migrationcenter/apiv1/Client/UpdateGroup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/migrationcenter/apiv1/Client/UpdateImportJob/main.go
+++ b/internal/generated/snippets/migrationcenter/apiv1/Client/UpdateImportJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/migrationcenter/apiv1/Client/UpdatePreferenceSet/main.go
+++ b/internal/generated/snippets/migrationcenter/apiv1/Client/UpdatePreferenceSet/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/migrationcenter/apiv1/Client/UpdateSettings/main.go
+++ b/internal/generated/snippets/migrationcenter/apiv1/Client/UpdateSettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/migrationcenter/apiv1/Client/UpdateSource/main.go
+++ b/internal/generated/snippets/migrationcenter/apiv1/Client/UpdateSource/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/migrationcenter/apiv1/Client/ValidateImportJob/main.go
+++ b/internal/generated/snippets/migrationcenter/apiv1/Client/ValidateImportJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/modelarmor/apiv1/Client/CreateTemplate/main.go
+++ b/internal/generated/snippets/modelarmor/apiv1/Client/CreateTemplate/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/modelarmor/apiv1/Client/DeleteTemplate/main.go
+++ b/internal/generated/snippets/modelarmor/apiv1/Client/DeleteTemplate/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/modelarmor/apiv1/Client/GetFloorSetting/main.go
+++ b/internal/generated/snippets/modelarmor/apiv1/Client/GetFloorSetting/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/modelarmor/apiv1/Client/GetLocation/main.go
+++ b/internal/generated/snippets/modelarmor/apiv1/Client/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/modelarmor/apiv1/Client/GetTemplate/main.go
+++ b/internal/generated/snippets/modelarmor/apiv1/Client/GetTemplate/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/modelarmor/apiv1/Client/ListLocations/main.go
+++ b/internal/generated/snippets/modelarmor/apiv1/Client/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/modelarmor/apiv1/Client/ListTemplates/main.go
+++ b/internal/generated/snippets/modelarmor/apiv1/Client/ListTemplates/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/modelarmor/apiv1/Client/SanitizeModelResponse/main.go
+++ b/internal/generated/snippets/modelarmor/apiv1/Client/SanitizeModelResponse/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/modelarmor/apiv1/Client/SanitizeUserPrompt/main.go
+++ b/internal/generated/snippets/modelarmor/apiv1/Client/SanitizeUserPrompt/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/modelarmor/apiv1/Client/UpdateFloorSetting/main.go
+++ b/internal/generated/snippets/modelarmor/apiv1/Client/UpdateFloorSetting/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/modelarmor/apiv1/Client/UpdateTemplate/main.go
+++ b/internal/generated/snippets/modelarmor/apiv1/Client/UpdateTemplate/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/modelarmor/apiv1beta/Client/CreateTemplate/main.go
+++ b/internal/generated/snippets/modelarmor/apiv1beta/Client/CreateTemplate/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/modelarmor/apiv1beta/Client/DeleteTemplate/main.go
+++ b/internal/generated/snippets/modelarmor/apiv1beta/Client/DeleteTemplate/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/modelarmor/apiv1beta/Client/GetFloorSetting/main.go
+++ b/internal/generated/snippets/modelarmor/apiv1beta/Client/GetFloorSetting/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/modelarmor/apiv1beta/Client/GetLocation/main.go
+++ b/internal/generated/snippets/modelarmor/apiv1beta/Client/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/modelarmor/apiv1beta/Client/GetTemplate/main.go
+++ b/internal/generated/snippets/modelarmor/apiv1beta/Client/GetTemplate/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/modelarmor/apiv1beta/Client/ListLocations/main.go
+++ b/internal/generated/snippets/modelarmor/apiv1beta/Client/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/modelarmor/apiv1beta/Client/ListTemplates/main.go
+++ b/internal/generated/snippets/modelarmor/apiv1beta/Client/ListTemplates/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/modelarmor/apiv1beta/Client/SanitizeModelResponse/main.go
+++ b/internal/generated/snippets/modelarmor/apiv1beta/Client/SanitizeModelResponse/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/modelarmor/apiv1beta/Client/SanitizeUserPrompt/main.go
+++ b/internal/generated/snippets/modelarmor/apiv1beta/Client/SanitizeUserPrompt/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/modelarmor/apiv1beta/Client/UpdateFloorSetting/main.go
+++ b/internal/generated/snippets/modelarmor/apiv1beta/Client/UpdateFloorSetting/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/modelarmor/apiv1beta/Client/UpdateTemplate/main.go
+++ b/internal/generated/snippets/modelarmor/apiv1beta/Client/UpdateTemplate/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/monitoring/apiv3/v2/AlertPolicyClient/CreateAlertPolicy/main.go
+++ b/internal/generated/snippets/monitoring/apiv3/v2/AlertPolicyClient/CreateAlertPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/monitoring/apiv3/v2/AlertPolicyClient/DeleteAlertPolicy/main.go
+++ b/internal/generated/snippets/monitoring/apiv3/v2/AlertPolicyClient/DeleteAlertPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/monitoring/apiv3/v2/AlertPolicyClient/GetAlertPolicy/main.go
+++ b/internal/generated/snippets/monitoring/apiv3/v2/AlertPolicyClient/GetAlertPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/monitoring/apiv3/v2/AlertPolicyClient/ListAlertPolicies/main.go
+++ b/internal/generated/snippets/monitoring/apiv3/v2/AlertPolicyClient/ListAlertPolicies/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/monitoring/apiv3/v2/AlertPolicyClient/UpdateAlertPolicy/main.go
+++ b/internal/generated/snippets/monitoring/apiv3/v2/AlertPolicyClient/UpdateAlertPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/monitoring/apiv3/v2/GroupClient/CreateGroup/main.go
+++ b/internal/generated/snippets/monitoring/apiv3/v2/GroupClient/CreateGroup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/monitoring/apiv3/v2/GroupClient/DeleteGroup/main.go
+++ b/internal/generated/snippets/monitoring/apiv3/v2/GroupClient/DeleteGroup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/monitoring/apiv3/v2/GroupClient/GetGroup/main.go
+++ b/internal/generated/snippets/monitoring/apiv3/v2/GroupClient/GetGroup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/monitoring/apiv3/v2/GroupClient/ListGroupMembers/main.go
+++ b/internal/generated/snippets/monitoring/apiv3/v2/GroupClient/ListGroupMembers/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/monitoring/apiv3/v2/GroupClient/ListGroups/main.go
+++ b/internal/generated/snippets/monitoring/apiv3/v2/GroupClient/ListGroups/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/monitoring/apiv3/v2/GroupClient/UpdateGroup/main.go
+++ b/internal/generated/snippets/monitoring/apiv3/v2/GroupClient/UpdateGroup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/monitoring/apiv3/v2/MetricClient/CreateMetricDescriptor/main.go
+++ b/internal/generated/snippets/monitoring/apiv3/v2/MetricClient/CreateMetricDescriptor/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/monitoring/apiv3/v2/MetricClient/CreateServiceTimeSeries/main.go
+++ b/internal/generated/snippets/monitoring/apiv3/v2/MetricClient/CreateServiceTimeSeries/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/monitoring/apiv3/v2/MetricClient/CreateTimeSeries/main.go
+++ b/internal/generated/snippets/monitoring/apiv3/v2/MetricClient/CreateTimeSeries/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/monitoring/apiv3/v2/MetricClient/DeleteMetricDescriptor/main.go
+++ b/internal/generated/snippets/monitoring/apiv3/v2/MetricClient/DeleteMetricDescriptor/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/monitoring/apiv3/v2/MetricClient/GetMetricDescriptor/main.go
+++ b/internal/generated/snippets/monitoring/apiv3/v2/MetricClient/GetMetricDescriptor/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/monitoring/apiv3/v2/MetricClient/GetMonitoredResourceDescriptor/main.go
+++ b/internal/generated/snippets/monitoring/apiv3/v2/MetricClient/GetMonitoredResourceDescriptor/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/monitoring/apiv3/v2/MetricClient/ListMetricDescriptors/main.go
+++ b/internal/generated/snippets/monitoring/apiv3/v2/MetricClient/ListMetricDescriptors/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/monitoring/apiv3/v2/MetricClient/ListMonitoredResourceDescriptors/main.go
+++ b/internal/generated/snippets/monitoring/apiv3/v2/MetricClient/ListMonitoredResourceDescriptors/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/monitoring/apiv3/v2/MetricClient/ListTimeSeries/main.go
+++ b/internal/generated/snippets/monitoring/apiv3/v2/MetricClient/ListTimeSeries/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/monitoring/apiv3/v2/NotificationChannelClient/CreateNotificationChannel/main.go
+++ b/internal/generated/snippets/monitoring/apiv3/v2/NotificationChannelClient/CreateNotificationChannel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/monitoring/apiv3/v2/NotificationChannelClient/DeleteNotificationChannel/main.go
+++ b/internal/generated/snippets/monitoring/apiv3/v2/NotificationChannelClient/DeleteNotificationChannel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/monitoring/apiv3/v2/NotificationChannelClient/GetNotificationChannel/main.go
+++ b/internal/generated/snippets/monitoring/apiv3/v2/NotificationChannelClient/GetNotificationChannel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/monitoring/apiv3/v2/NotificationChannelClient/GetNotificationChannelDescriptor/main.go
+++ b/internal/generated/snippets/monitoring/apiv3/v2/NotificationChannelClient/GetNotificationChannelDescriptor/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/monitoring/apiv3/v2/NotificationChannelClient/GetNotificationChannelVerificationCode/main.go
+++ b/internal/generated/snippets/monitoring/apiv3/v2/NotificationChannelClient/GetNotificationChannelVerificationCode/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/monitoring/apiv3/v2/NotificationChannelClient/ListNotificationChannelDescriptors/main.go
+++ b/internal/generated/snippets/monitoring/apiv3/v2/NotificationChannelClient/ListNotificationChannelDescriptors/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/monitoring/apiv3/v2/NotificationChannelClient/ListNotificationChannels/main.go
+++ b/internal/generated/snippets/monitoring/apiv3/v2/NotificationChannelClient/ListNotificationChannels/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/monitoring/apiv3/v2/NotificationChannelClient/SendNotificationChannelVerificationCode/main.go
+++ b/internal/generated/snippets/monitoring/apiv3/v2/NotificationChannelClient/SendNotificationChannelVerificationCode/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/monitoring/apiv3/v2/NotificationChannelClient/UpdateNotificationChannel/main.go
+++ b/internal/generated/snippets/monitoring/apiv3/v2/NotificationChannelClient/UpdateNotificationChannel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/monitoring/apiv3/v2/NotificationChannelClient/VerifyNotificationChannel/main.go
+++ b/internal/generated/snippets/monitoring/apiv3/v2/NotificationChannelClient/VerifyNotificationChannel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/monitoring/apiv3/v2/QueryClient/QueryTimeSeries/main.go
+++ b/internal/generated/snippets/monitoring/apiv3/v2/QueryClient/QueryTimeSeries/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/monitoring/apiv3/v2/ServiceMonitoringClient/CreateService/main.go
+++ b/internal/generated/snippets/monitoring/apiv3/v2/ServiceMonitoringClient/CreateService/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/monitoring/apiv3/v2/ServiceMonitoringClient/CreateServiceLevelObjective/main.go
+++ b/internal/generated/snippets/monitoring/apiv3/v2/ServiceMonitoringClient/CreateServiceLevelObjective/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/monitoring/apiv3/v2/ServiceMonitoringClient/DeleteService/main.go
+++ b/internal/generated/snippets/monitoring/apiv3/v2/ServiceMonitoringClient/DeleteService/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/monitoring/apiv3/v2/ServiceMonitoringClient/DeleteServiceLevelObjective/main.go
+++ b/internal/generated/snippets/monitoring/apiv3/v2/ServiceMonitoringClient/DeleteServiceLevelObjective/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/monitoring/apiv3/v2/ServiceMonitoringClient/GetService/main.go
+++ b/internal/generated/snippets/monitoring/apiv3/v2/ServiceMonitoringClient/GetService/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/monitoring/apiv3/v2/ServiceMonitoringClient/GetServiceLevelObjective/main.go
+++ b/internal/generated/snippets/monitoring/apiv3/v2/ServiceMonitoringClient/GetServiceLevelObjective/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/monitoring/apiv3/v2/ServiceMonitoringClient/ListServiceLevelObjectives/main.go
+++ b/internal/generated/snippets/monitoring/apiv3/v2/ServiceMonitoringClient/ListServiceLevelObjectives/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/monitoring/apiv3/v2/ServiceMonitoringClient/ListServices/main.go
+++ b/internal/generated/snippets/monitoring/apiv3/v2/ServiceMonitoringClient/ListServices/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/monitoring/apiv3/v2/ServiceMonitoringClient/UpdateService/main.go
+++ b/internal/generated/snippets/monitoring/apiv3/v2/ServiceMonitoringClient/UpdateService/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/monitoring/apiv3/v2/ServiceMonitoringClient/UpdateServiceLevelObjective/main.go
+++ b/internal/generated/snippets/monitoring/apiv3/v2/ServiceMonitoringClient/UpdateServiceLevelObjective/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/monitoring/apiv3/v2/SnoozeClient/CreateSnooze/main.go
+++ b/internal/generated/snippets/monitoring/apiv3/v2/SnoozeClient/CreateSnooze/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/monitoring/apiv3/v2/SnoozeClient/GetSnooze/main.go
+++ b/internal/generated/snippets/monitoring/apiv3/v2/SnoozeClient/GetSnooze/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/monitoring/apiv3/v2/SnoozeClient/ListSnoozes/main.go
+++ b/internal/generated/snippets/monitoring/apiv3/v2/SnoozeClient/ListSnoozes/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/monitoring/apiv3/v2/SnoozeClient/UpdateSnooze/main.go
+++ b/internal/generated/snippets/monitoring/apiv3/v2/SnoozeClient/UpdateSnooze/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/monitoring/apiv3/v2/UptimeCheckClient/CreateUptimeCheckConfig/main.go
+++ b/internal/generated/snippets/monitoring/apiv3/v2/UptimeCheckClient/CreateUptimeCheckConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/monitoring/apiv3/v2/UptimeCheckClient/DeleteUptimeCheckConfig/main.go
+++ b/internal/generated/snippets/monitoring/apiv3/v2/UptimeCheckClient/DeleteUptimeCheckConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/monitoring/apiv3/v2/UptimeCheckClient/GetUptimeCheckConfig/main.go
+++ b/internal/generated/snippets/monitoring/apiv3/v2/UptimeCheckClient/GetUptimeCheckConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/monitoring/apiv3/v2/UptimeCheckClient/ListUptimeCheckConfigs/main.go
+++ b/internal/generated/snippets/monitoring/apiv3/v2/UptimeCheckClient/ListUptimeCheckConfigs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/monitoring/apiv3/v2/UptimeCheckClient/ListUptimeCheckIps/main.go
+++ b/internal/generated/snippets/monitoring/apiv3/v2/UptimeCheckClient/ListUptimeCheckIps/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/monitoring/apiv3/v2/UptimeCheckClient/UpdateUptimeCheckConfig/main.go
+++ b/internal/generated/snippets/monitoring/apiv3/v2/UptimeCheckClient/UpdateUptimeCheckConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/monitoring/dashboard/apiv1/DashboardsClient/CreateDashboard/main.go
+++ b/internal/generated/snippets/monitoring/dashboard/apiv1/DashboardsClient/CreateDashboard/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/monitoring/dashboard/apiv1/DashboardsClient/DeleteDashboard/main.go
+++ b/internal/generated/snippets/monitoring/dashboard/apiv1/DashboardsClient/DeleteDashboard/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/monitoring/dashboard/apiv1/DashboardsClient/GetDashboard/main.go
+++ b/internal/generated/snippets/monitoring/dashboard/apiv1/DashboardsClient/GetDashboard/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/monitoring/dashboard/apiv1/DashboardsClient/ListDashboards/main.go
+++ b/internal/generated/snippets/monitoring/dashboard/apiv1/DashboardsClient/ListDashboards/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/monitoring/dashboard/apiv1/DashboardsClient/UpdateDashboard/main.go
+++ b/internal/generated/snippets/monitoring/dashboard/apiv1/DashboardsClient/UpdateDashboard/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/monitoring/metricsscope/apiv1/MetricsScopesClient/CreateMonitoredProject/main.go
+++ b/internal/generated/snippets/monitoring/metricsscope/apiv1/MetricsScopesClient/CreateMonitoredProject/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/monitoring/metricsscope/apiv1/MetricsScopesClient/DeleteMonitoredProject/main.go
+++ b/internal/generated/snippets/monitoring/metricsscope/apiv1/MetricsScopesClient/DeleteMonitoredProject/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/monitoring/metricsscope/apiv1/MetricsScopesClient/GetMetricsScope/main.go
+++ b/internal/generated/snippets/monitoring/metricsscope/apiv1/MetricsScopesClient/GetMetricsScope/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/monitoring/metricsscope/apiv1/MetricsScopesClient/ListMetricsScopesByMonitoredProject/main.go
+++ b/internal/generated/snippets/monitoring/metricsscope/apiv1/MetricsScopesClient/ListMetricsScopesByMonitoredProject/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/CrossNetworkAutomationClient/CancelOperation/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/CrossNetworkAutomationClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/CrossNetworkAutomationClient/CreateServiceConnectionMap/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/CrossNetworkAutomationClient/CreateServiceConnectionMap/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/CrossNetworkAutomationClient/CreateServiceConnectionPolicy/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/CrossNetworkAutomationClient/CreateServiceConnectionPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/CrossNetworkAutomationClient/CreateServiceConnectionToken/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/CrossNetworkAutomationClient/CreateServiceConnectionToken/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/CrossNetworkAutomationClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/CrossNetworkAutomationClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/CrossNetworkAutomationClient/DeleteServiceClass/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/CrossNetworkAutomationClient/DeleteServiceClass/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/CrossNetworkAutomationClient/DeleteServiceConnectionMap/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/CrossNetworkAutomationClient/DeleteServiceConnectionMap/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/CrossNetworkAutomationClient/DeleteServiceConnectionPolicy/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/CrossNetworkAutomationClient/DeleteServiceConnectionPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/CrossNetworkAutomationClient/DeleteServiceConnectionToken/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/CrossNetworkAutomationClient/DeleteServiceConnectionToken/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/CrossNetworkAutomationClient/GetIamPolicy/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/CrossNetworkAutomationClient/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/CrossNetworkAutomationClient/GetLocation/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/CrossNetworkAutomationClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/CrossNetworkAutomationClient/GetOperation/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/CrossNetworkAutomationClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/CrossNetworkAutomationClient/GetServiceClass/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/CrossNetworkAutomationClient/GetServiceClass/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/CrossNetworkAutomationClient/GetServiceConnectionMap/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/CrossNetworkAutomationClient/GetServiceConnectionMap/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/CrossNetworkAutomationClient/GetServiceConnectionPolicy/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/CrossNetworkAutomationClient/GetServiceConnectionPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/CrossNetworkAutomationClient/GetServiceConnectionToken/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/CrossNetworkAutomationClient/GetServiceConnectionToken/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/CrossNetworkAutomationClient/ListLocations/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/CrossNetworkAutomationClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/CrossNetworkAutomationClient/ListOperations/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/CrossNetworkAutomationClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/CrossNetworkAutomationClient/ListServiceClasses/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/CrossNetworkAutomationClient/ListServiceClasses/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/CrossNetworkAutomationClient/ListServiceConnectionMaps/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/CrossNetworkAutomationClient/ListServiceConnectionMaps/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/CrossNetworkAutomationClient/ListServiceConnectionPolicies/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/CrossNetworkAutomationClient/ListServiceConnectionPolicies/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/CrossNetworkAutomationClient/ListServiceConnectionTokens/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/CrossNetworkAutomationClient/ListServiceConnectionTokens/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/CrossNetworkAutomationClient/SetIamPolicy/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/CrossNetworkAutomationClient/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/CrossNetworkAutomationClient/TestIamPermissions/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/CrossNetworkAutomationClient/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/CrossNetworkAutomationClient/UpdateServiceClass/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/CrossNetworkAutomationClient/UpdateServiceClass/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/CrossNetworkAutomationClient/UpdateServiceConnectionMap/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/CrossNetworkAutomationClient/UpdateServiceConnectionMap/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/CrossNetworkAutomationClient/UpdateServiceConnectionPolicy/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/CrossNetworkAutomationClient/UpdateServiceConnectionPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/DataTransferClient/CancelOperation/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/DataTransferClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/DataTransferClient/CreateDestination/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/DataTransferClient/CreateDestination/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/DataTransferClient/CreateMulticloudDataTransferConfig/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/DataTransferClient/CreateMulticloudDataTransferConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/DataTransferClient/DeleteDestination/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/DataTransferClient/DeleteDestination/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/DataTransferClient/DeleteMulticloudDataTransferConfig/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/DataTransferClient/DeleteMulticloudDataTransferConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/DataTransferClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/DataTransferClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/DataTransferClient/GetDestination/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/DataTransferClient/GetDestination/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/DataTransferClient/GetIamPolicy/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/DataTransferClient/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/DataTransferClient/GetLocation/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/DataTransferClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/DataTransferClient/GetMulticloudDataTransferConfig/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/DataTransferClient/GetMulticloudDataTransferConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/DataTransferClient/GetMulticloudDataTransferSupportedService/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/DataTransferClient/GetMulticloudDataTransferSupportedService/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/DataTransferClient/GetOperation/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/DataTransferClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/DataTransferClient/ListDestinations/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/DataTransferClient/ListDestinations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/DataTransferClient/ListLocations/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/DataTransferClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/DataTransferClient/ListMulticloudDataTransferConfigs/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/DataTransferClient/ListMulticloudDataTransferConfigs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/DataTransferClient/ListMulticloudDataTransferSupportedServices/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/DataTransferClient/ListMulticloudDataTransferSupportedServices/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/DataTransferClient/ListOperations/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/DataTransferClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/DataTransferClient/SetIamPolicy/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/DataTransferClient/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/DataTransferClient/TestIamPermissions/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/DataTransferClient/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/DataTransferClient/UpdateDestination/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/DataTransferClient/UpdateDestination/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/DataTransferClient/UpdateMulticloudDataTransferConfig/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/DataTransferClient/UpdateMulticloudDataTransferConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/HubClient/AcceptHubSpoke/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/HubClient/AcceptHubSpoke/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/HubClient/AcceptSpokeUpdate/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/HubClient/AcceptSpokeUpdate/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/HubClient/CancelOperation/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/HubClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/HubClient/CreateHub/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/HubClient/CreateHub/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/HubClient/CreateSpoke/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/HubClient/CreateSpoke/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/HubClient/DeleteHub/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/HubClient/DeleteHub/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/HubClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/HubClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/HubClient/DeleteSpoke/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/HubClient/DeleteSpoke/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/HubClient/GetGroup/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/HubClient/GetGroup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/HubClient/GetHub/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/HubClient/GetHub/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/HubClient/GetIamPolicy/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/HubClient/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/HubClient/GetLocation/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/HubClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/HubClient/GetOperation/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/HubClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/HubClient/GetRoute/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/HubClient/GetRoute/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/HubClient/GetRouteTable/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/HubClient/GetRouteTable/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/HubClient/GetSpoke/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/HubClient/GetSpoke/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/HubClient/ListGroups/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/HubClient/ListGroups/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/HubClient/ListHubSpokes/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/HubClient/ListHubSpokes/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/HubClient/ListHubs/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/HubClient/ListHubs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/HubClient/ListLocations/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/HubClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/HubClient/ListOperations/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/HubClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/HubClient/ListRouteTables/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/HubClient/ListRouteTables/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/HubClient/ListRoutes/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/HubClient/ListRoutes/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/HubClient/ListSpokes/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/HubClient/ListSpokes/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/HubClient/QueryHubStatus/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/HubClient/QueryHubStatus/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/HubClient/RejectHubSpoke/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/HubClient/RejectHubSpoke/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/HubClient/RejectSpokeUpdate/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/HubClient/RejectSpokeUpdate/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/HubClient/SetIamPolicy/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/HubClient/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/HubClient/TestIamPermissions/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/HubClient/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/HubClient/UpdateGroup/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/HubClient/UpdateGroup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/HubClient/UpdateHub/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/HubClient/UpdateHub/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/HubClient/UpdateSpoke/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/HubClient/UpdateSpoke/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/InternalRangeClient/CancelOperation/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/InternalRangeClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/InternalRangeClient/CreateInternalRange/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/InternalRangeClient/CreateInternalRange/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/InternalRangeClient/DeleteInternalRange/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/InternalRangeClient/DeleteInternalRange/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/InternalRangeClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/InternalRangeClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/InternalRangeClient/GetIamPolicy/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/InternalRangeClient/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/InternalRangeClient/GetInternalRange/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/InternalRangeClient/GetInternalRange/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/InternalRangeClient/GetLocation/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/InternalRangeClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/InternalRangeClient/GetOperation/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/InternalRangeClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/InternalRangeClient/ListInternalRanges/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/InternalRangeClient/ListInternalRanges/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/InternalRangeClient/ListLocations/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/InternalRangeClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/InternalRangeClient/ListOperations/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/InternalRangeClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/InternalRangeClient/SetIamPolicy/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/InternalRangeClient/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/InternalRangeClient/TestIamPermissions/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/InternalRangeClient/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/InternalRangeClient/UpdateInternalRange/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/InternalRangeClient/UpdateInternalRange/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/PolicyBasedRoutingClient/CancelOperation/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/PolicyBasedRoutingClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/PolicyBasedRoutingClient/CreatePolicyBasedRoute/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/PolicyBasedRoutingClient/CreatePolicyBasedRoute/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/PolicyBasedRoutingClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/PolicyBasedRoutingClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/PolicyBasedRoutingClient/DeletePolicyBasedRoute/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/PolicyBasedRoutingClient/DeletePolicyBasedRoute/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/PolicyBasedRoutingClient/GetIamPolicy/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/PolicyBasedRoutingClient/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/PolicyBasedRoutingClient/GetLocation/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/PolicyBasedRoutingClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/PolicyBasedRoutingClient/GetOperation/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/PolicyBasedRoutingClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/PolicyBasedRoutingClient/GetPolicyBasedRoute/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/PolicyBasedRoutingClient/GetPolicyBasedRoute/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/PolicyBasedRoutingClient/ListLocations/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/PolicyBasedRoutingClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/PolicyBasedRoutingClient/ListOperations/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/PolicyBasedRoutingClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/PolicyBasedRoutingClient/ListPolicyBasedRoutes/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/PolicyBasedRoutingClient/ListPolicyBasedRoutes/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/PolicyBasedRoutingClient/SetIamPolicy/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/PolicyBasedRoutingClient/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1/PolicyBasedRoutingClient/TestIamPermissions/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1/PolicyBasedRoutingClient/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1alpha1/HubClient/CreateHub/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1alpha1/HubClient/CreateHub/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1alpha1/HubClient/CreateSpoke/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1alpha1/HubClient/CreateSpoke/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1alpha1/HubClient/DeleteHub/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1alpha1/HubClient/DeleteHub/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1alpha1/HubClient/DeleteSpoke/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1alpha1/HubClient/DeleteSpoke/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1alpha1/HubClient/GetHub/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1alpha1/HubClient/GetHub/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1alpha1/HubClient/GetSpoke/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1alpha1/HubClient/GetSpoke/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1alpha1/HubClient/ListHubs/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1alpha1/HubClient/ListHubs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1alpha1/HubClient/ListSpokes/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1alpha1/HubClient/ListSpokes/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1alpha1/HubClient/UpdateHub/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1alpha1/HubClient/UpdateHub/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkconnectivity/apiv1alpha1/HubClient/UpdateSpoke/main.go
+++ b/internal/generated/snippets/networkconnectivity/apiv1alpha1/HubClient/UpdateSpoke/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkmanagement/apiv1/OrganizationVpcFlowLogsClient/CancelOperation/main.go
+++ b/internal/generated/snippets/networkmanagement/apiv1/OrganizationVpcFlowLogsClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkmanagement/apiv1/OrganizationVpcFlowLogsClient/CreateVpcFlowLogsConfig/main.go
+++ b/internal/generated/snippets/networkmanagement/apiv1/OrganizationVpcFlowLogsClient/CreateVpcFlowLogsConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkmanagement/apiv1/OrganizationVpcFlowLogsClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/networkmanagement/apiv1/OrganizationVpcFlowLogsClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkmanagement/apiv1/OrganizationVpcFlowLogsClient/DeleteVpcFlowLogsConfig/main.go
+++ b/internal/generated/snippets/networkmanagement/apiv1/OrganizationVpcFlowLogsClient/DeleteVpcFlowLogsConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkmanagement/apiv1/OrganizationVpcFlowLogsClient/GetIamPolicy/main.go
+++ b/internal/generated/snippets/networkmanagement/apiv1/OrganizationVpcFlowLogsClient/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkmanagement/apiv1/OrganizationVpcFlowLogsClient/GetLocation/main.go
+++ b/internal/generated/snippets/networkmanagement/apiv1/OrganizationVpcFlowLogsClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkmanagement/apiv1/OrganizationVpcFlowLogsClient/GetOperation/main.go
+++ b/internal/generated/snippets/networkmanagement/apiv1/OrganizationVpcFlowLogsClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkmanagement/apiv1/OrganizationVpcFlowLogsClient/GetVpcFlowLogsConfig/main.go
+++ b/internal/generated/snippets/networkmanagement/apiv1/OrganizationVpcFlowLogsClient/GetVpcFlowLogsConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkmanagement/apiv1/OrganizationVpcFlowLogsClient/ListLocations/main.go
+++ b/internal/generated/snippets/networkmanagement/apiv1/OrganizationVpcFlowLogsClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkmanagement/apiv1/OrganizationVpcFlowLogsClient/ListOperations/main.go
+++ b/internal/generated/snippets/networkmanagement/apiv1/OrganizationVpcFlowLogsClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkmanagement/apiv1/OrganizationVpcFlowLogsClient/ListVpcFlowLogsConfigs/main.go
+++ b/internal/generated/snippets/networkmanagement/apiv1/OrganizationVpcFlowLogsClient/ListVpcFlowLogsConfigs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkmanagement/apiv1/OrganizationVpcFlowLogsClient/SetIamPolicy/main.go
+++ b/internal/generated/snippets/networkmanagement/apiv1/OrganizationVpcFlowLogsClient/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkmanagement/apiv1/OrganizationVpcFlowLogsClient/TestIamPermissions/main.go
+++ b/internal/generated/snippets/networkmanagement/apiv1/OrganizationVpcFlowLogsClient/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkmanagement/apiv1/OrganizationVpcFlowLogsClient/UpdateVpcFlowLogsConfig/main.go
+++ b/internal/generated/snippets/networkmanagement/apiv1/OrganizationVpcFlowLogsClient/UpdateVpcFlowLogsConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkmanagement/apiv1/ReachabilityClient/CancelOperation/main.go
+++ b/internal/generated/snippets/networkmanagement/apiv1/ReachabilityClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkmanagement/apiv1/ReachabilityClient/CreateConnectivityTest/main.go
+++ b/internal/generated/snippets/networkmanagement/apiv1/ReachabilityClient/CreateConnectivityTest/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkmanagement/apiv1/ReachabilityClient/DeleteConnectivityTest/main.go
+++ b/internal/generated/snippets/networkmanagement/apiv1/ReachabilityClient/DeleteConnectivityTest/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkmanagement/apiv1/ReachabilityClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/networkmanagement/apiv1/ReachabilityClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkmanagement/apiv1/ReachabilityClient/GetConnectivityTest/main.go
+++ b/internal/generated/snippets/networkmanagement/apiv1/ReachabilityClient/GetConnectivityTest/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkmanagement/apiv1/ReachabilityClient/GetIamPolicy/main.go
+++ b/internal/generated/snippets/networkmanagement/apiv1/ReachabilityClient/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkmanagement/apiv1/ReachabilityClient/GetLocation/main.go
+++ b/internal/generated/snippets/networkmanagement/apiv1/ReachabilityClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkmanagement/apiv1/ReachabilityClient/GetOperation/main.go
+++ b/internal/generated/snippets/networkmanagement/apiv1/ReachabilityClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkmanagement/apiv1/ReachabilityClient/ListConnectivityTests/main.go
+++ b/internal/generated/snippets/networkmanagement/apiv1/ReachabilityClient/ListConnectivityTests/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkmanagement/apiv1/ReachabilityClient/ListLocations/main.go
+++ b/internal/generated/snippets/networkmanagement/apiv1/ReachabilityClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkmanagement/apiv1/ReachabilityClient/ListOperations/main.go
+++ b/internal/generated/snippets/networkmanagement/apiv1/ReachabilityClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkmanagement/apiv1/ReachabilityClient/RerunConnectivityTest/main.go
+++ b/internal/generated/snippets/networkmanagement/apiv1/ReachabilityClient/RerunConnectivityTest/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkmanagement/apiv1/ReachabilityClient/SetIamPolicy/main.go
+++ b/internal/generated/snippets/networkmanagement/apiv1/ReachabilityClient/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkmanagement/apiv1/ReachabilityClient/TestIamPermissions/main.go
+++ b/internal/generated/snippets/networkmanagement/apiv1/ReachabilityClient/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkmanagement/apiv1/ReachabilityClient/UpdateConnectivityTest/main.go
+++ b/internal/generated/snippets/networkmanagement/apiv1/ReachabilityClient/UpdateConnectivityTest/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkmanagement/apiv1/VpcFlowLogsClient/CancelOperation/main.go
+++ b/internal/generated/snippets/networkmanagement/apiv1/VpcFlowLogsClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkmanagement/apiv1/VpcFlowLogsClient/CreateVpcFlowLogsConfig/main.go
+++ b/internal/generated/snippets/networkmanagement/apiv1/VpcFlowLogsClient/CreateVpcFlowLogsConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkmanagement/apiv1/VpcFlowLogsClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/networkmanagement/apiv1/VpcFlowLogsClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkmanagement/apiv1/VpcFlowLogsClient/DeleteVpcFlowLogsConfig/main.go
+++ b/internal/generated/snippets/networkmanagement/apiv1/VpcFlowLogsClient/DeleteVpcFlowLogsConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkmanagement/apiv1/VpcFlowLogsClient/GetIamPolicy/main.go
+++ b/internal/generated/snippets/networkmanagement/apiv1/VpcFlowLogsClient/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkmanagement/apiv1/VpcFlowLogsClient/GetLocation/main.go
+++ b/internal/generated/snippets/networkmanagement/apiv1/VpcFlowLogsClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkmanagement/apiv1/VpcFlowLogsClient/GetOperation/main.go
+++ b/internal/generated/snippets/networkmanagement/apiv1/VpcFlowLogsClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkmanagement/apiv1/VpcFlowLogsClient/GetVpcFlowLogsConfig/main.go
+++ b/internal/generated/snippets/networkmanagement/apiv1/VpcFlowLogsClient/GetVpcFlowLogsConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkmanagement/apiv1/VpcFlowLogsClient/ListLocations/main.go
+++ b/internal/generated/snippets/networkmanagement/apiv1/VpcFlowLogsClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkmanagement/apiv1/VpcFlowLogsClient/ListOperations/main.go
+++ b/internal/generated/snippets/networkmanagement/apiv1/VpcFlowLogsClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkmanagement/apiv1/VpcFlowLogsClient/ListVpcFlowLogsConfigs/main.go
+++ b/internal/generated/snippets/networkmanagement/apiv1/VpcFlowLogsClient/ListVpcFlowLogsConfigs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkmanagement/apiv1/VpcFlowLogsClient/QueryOrgVpcFlowLogsConfigs/main.go
+++ b/internal/generated/snippets/networkmanagement/apiv1/VpcFlowLogsClient/QueryOrgVpcFlowLogsConfigs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkmanagement/apiv1/VpcFlowLogsClient/SetIamPolicy/main.go
+++ b/internal/generated/snippets/networkmanagement/apiv1/VpcFlowLogsClient/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkmanagement/apiv1/VpcFlowLogsClient/ShowEffectiveFlowLogsConfigs/main.go
+++ b/internal/generated/snippets/networkmanagement/apiv1/VpcFlowLogsClient/ShowEffectiveFlowLogsConfigs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkmanagement/apiv1/VpcFlowLogsClient/TestIamPermissions/main.go
+++ b/internal/generated/snippets/networkmanagement/apiv1/VpcFlowLogsClient/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkmanagement/apiv1/VpcFlowLogsClient/UpdateVpcFlowLogsConfig/main.go
+++ b/internal/generated/snippets/networkmanagement/apiv1/VpcFlowLogsClient/UpdateVpcFlowLogsConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networksecurity/apiv1beta1/Client/CancelOperation/main.go
+++ b/internal/generated/snippets/networksecurity/apiv1beta1/Client/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networksecurity/apiv1beta1/Client/CreateAuthorizationPolicy/main.go
+++ b/internal/generated/snippets/networksecurity/apiv1beta1/Client/CreateAuthorizationPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networksecurity/apiv1beta1/Client/CreateClientTlsPolicy/main.go
+++ b/internal/generated/snippets/networksecurity/apiv1beta1/Client/CreateClientTlsPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networksecurity/apiv1beta1/Client/CreateServerTlsPolicy/main.go
+++ b/internal/generated/snippets/networksecurity/apiv1beta1/Client/CreateServerTlsPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networksecurity/apiv1beta1/Client/DeleteAuthorizationPolicy/main.go
+++ b/internal/generated/snippets/networksecurity/apiv1beta1/Client/DeleteAuthorizationPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networksecurity/apiv1beta1/Client/DeleteClientTlsPolicy/main.go
+++ b/internal/generated/snippets/networksecurity/apiv1beta1/Client/DeleteClientTlsPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networksecurity/apiv1beta1/Client/DeleteOperation/main.go
+++ b/internal/generated/snippets/networksecurity/apiv1beta1/Client/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networksecurity/apiv1beta1/Client/DeleteServerTlsPolicy/main.go
+++ b/internal/generated/snippets/networksecurity/apiv1beta1/Client/DeleteServerTlsPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networksecurity/apiv1beta1/Client/GetAuthorizationPolicy/main.go
+++ b/internal/generated/snippets/networksecurity/apiv1beta1/Client/GetAuthorizationPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networksecurity/apiv1beta1/Client/GetClientTlsPolicy/main.go
+++ b/internal/generated/snippets/networksecurity/apiv1beta1/Client/GetClientTlsPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networksecurity/apiv1beta1/Client/GetIamPolicy/main.go
+++ b/internal/generated/snippets/networksecurity/apiv1beta1/Client/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networksecurity/apiv1beta1/Client/GetLocation/main.go
+++ b/internal/generated/snippets/networksecurity/apiv1beta1/Client/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networksecurity/apiv1beta1/Client/GetOperation/main.go
+++ b/internal/generated/snippets/networksecurity/apiv1beta1/Client/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networksecurity/apiv1beta1/Client/GetServerTlsPolicy/main.go
+++ b/internal/generated/snippets/networksecurity/apiv1beta1/Client/GetServerTlsPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networksecurity/apiv1beta1/Client/ListAuthorizationPolicies/main.go
+++ b/internal/generated/snippets/networksecurity/apiv1beta1/Client/ListAuthorizationPolicies/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networksecurity/apiv1beta1/Client/ListClientTlsPolicies/main.go
+++ b/internal/generated/snippets/networksecurity/apiv1beta1/Client/ListClientTlsPolicies/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networksecurity/apiv1beta1/Client/ListLocations/main.go
+++ b/internal/generated/snippets/networksecurity/apiv1beta1/Client/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networksecurity/apiv1beta1/Client/ListOperations/main.go
+++ b/internal/generated/snippets/networksecurity/apiv1beta1/Client/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networksecurity/apiv1beta1/Client/ListServerTlsPolicies/main.go
+++ b/internal/generated/snippets/networksecurity/apiv1beta1/Client/ListServerTlsPolicies/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networksecurity/apiv1beta1/Client/SetIamPolicy/main.go
+++ b/internal/generated/snippets/networksecurity/apiv1beta1/Client/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networksecurity/apiv1beta1/Client/TestIamPermissions/main.go
+++ b/internal/generated/snippets/networksecurity/apiv1beta1/Client/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networksecurity/apiv1beta1/Client/UpdateAuthorizationPolicy/main.go
+++ b/internal/generated/snippets/networksecurity/apiv1beta1/Client/UpdateAuthorizationPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networksecurity/apiv1beta1/Client/UpdateClientTlsPolicy/main.go
+++ b/internal/generated/snippets/networksecurity/apiv1beta1/Client/UpdateClientTlsPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networksecurity/apiv1beta1/Client/UpdateServerTlsPolicy/main.go
+++ b/internal/generated/snippets/networksecurity/apiv1beta1/Client/UpdateServerTlsPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networksecurity/apiv1beta1/DnsThreatDetectorClient/CancelOperation/main.go
+++ b/internal/generated/snippets/networksecurity/apiv1beta1/DnsThreatDetectorClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networksecurity/apiv1beta1/DnsThreatDetectorClient/CreateDnsThreatDetector/main.go
+++ b/internal/generated/snippets/networksecurity/apiv1beta1/DnsThreatDetectorClient/CreateDnsThreatDetector/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networksecurity/apiv1beta1/DnsThreatDetectorClient/DeleteDnsThreatDetector/main.go
+++ b/internal/generated/snippets/networksecurity/apiv1beta1/DnsThreatDetectorClient/DeleteDnsThreatDetector/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networksecurity/apiv1beta1/DnsThreatDetectorClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/networksecurity/apiv1beta1/DnsThreatDetectorClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networksecurity/apiv1beta1/DnsThreatDetectorClient/GetDnsThreatDetector/main.go
+++ b/internal/generated/snippets/networksecurity/apiv1beta1/DnsThreatDetectorClient/GetDnsThreatDetector/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networksecurity/apiv1beta1/DnsThreatDetectorClient/GetIamPolicy/main.go
+++ b/internal/generated/snippets/networksecurity/apiv1beta1/DnsThreatDetectorClient/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networksecurity/apiv1beta1/DnsThreatDetectorClient/GetLocation/main.go
+++ b/internal/generated/snippets/networksecurity/apiv1beta1/DnsThreatDetectorClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networksecurity/apiv1beta1/DnsThreatDetectorClient/GetOperation/main.go
+++ b/internal/generated/snippets/networksecurity/apiv1beta1/DnsThreatDetectorClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networksecurity/apiv1beta1/DnsThreatDetectorClient/ListDnsThreatDetectors/main.go
+++ b/internal/generated/snippets/networksecurity/apiv1beta1/DnsThreatDetectorClient/ListDnsThreatDetectors/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networksecurity/apiv1beta1/DnsThreatDetectorClient/ListLocations/main.go
+++ b/internal/generated/snippets/networksecurity/apiv1beta1/DnsThreatDetectorClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networksecurity/apiv1beta1/DnsThreatDetectorClient/ListOperations/main.go
+++ b/internal/generated/snippets/networksecurity/apiv1beta1/DnsThreatDetectorClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networksecurity/apiv1beta1/DnsThreatDetectorClient/SetIamPolicy/main.go
+++ b/internal/generated/snippets/networksecurity/apiv1beta1/DnsThreatDetectorClient/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networksecurity/apiv1beta1/DnsThreatDetectorClient/TestIamPermissions/main.go
+++ b/internal/generated/snippets/networksecurity/apiv1beta1/DnsThreatDetectorClient/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networksecurity/apiv1beta1/DnsThreatDetectorClient/UpdateDnsThreatDetector/main.go
+++ b/internal/generated/snippets/networksecurity/apiv1beta1/DnsThreatDetectorClient/UpdateDnsThreatDetector/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/Client/CancelOperation/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/Client/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/Client/CreateEndpointPolicy/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/Client/CreateEndpointPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/Client/CreateGateway/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/Client/CreateGateway/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/Client/CreateGrpcRoute/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/Client/CreateGrpcRoute/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/Client/CreateHttpRoute/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/Client/CreateHttpRoute/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/Client/CreateMesh/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/Client/CreateMesh/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/Client/CreateServiceBinding/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/Client/CreateServiceBinding/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/Client/CreateServiceLbPolicy/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/Client/CreateServiceLbPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/Client/CreateTcpRoute/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/Client/CreateTcpRoute/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/Client/CreateTlsRoute/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/Client/CreateTlsRoute/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/Client/CreateWasmPlugin/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/Client/CreateWasmPlugin/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/Client/CreateWasmPluginVersion/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/Client/CreateWasmPluginVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/Client/DeleteEndpointPolicy/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/Client/DeleteEndpointPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/Client/DeleteGateway/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/Client/DeleteGateway/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/Client/DeleteGrpcRoute/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/Client/DeleteGrpcRoute/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/Client/DeleteHttpRoute/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/Client/DeleteHttpRoute/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/Client/DeleteMesh/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/Client/DeleteMesh/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/Client/DeleteOperation/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/Client/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/Client/DeleteServiceBinding/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/Client/DeleteServiceBinding/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/Client/DeleteServiceLbPolicy/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/Client/DeleteServiceLbPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/Client/DeleteTcpRoute/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/Client/DeleteTcpRoute/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/Client/DeleteTlsRoute/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/Client/DeleteTlsRoute/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/Client/DeleteWasmPlugin/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/Client/DeleteWasmPlugin/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/Client/DeleteWasmPluginVersion/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/Client/DeleteWasmPluginVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/Client/GetEndpointPolicy/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/Client/GetEndpointPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/Client/GetGateway/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/Client/GetGateway/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/Client/GetGatewayRouteView/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/Client/GetGatewayRouteView/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/Client/GetGrpcRoute/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/Client/GetGrpcRoute/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/Client/GetHttpRoute/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/Client/GetHttpRoute/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/Client/GetIamPolicy/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/Client/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/Client/GetLocation/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/Client/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/Client/GetMesh/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/Client/GetMesh/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/Client/GetMeshRouteView/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/Client/GetMeshRouteView/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/Client/GetOperation/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/Client/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/Client/GetServiceBinding/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/Client/GetServiceBinding/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/Client/GetServiceLbPolicy/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/Client/GetServiceLbPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/Client/GetTcpRoute/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/Client/GetTcpRoute/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/Client/GetTlsRoute/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/Client/GetTlsRoute/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/Client/GetWasmPlugin/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/Client/GetWasmPlugin/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/Client/GetWasmPluginVersion/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/Client/GetWasmPluginVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/Client/ListEndpointPolicies/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/Client/ListEndpointPolicies/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/Client/ListGatewayRouteViews/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/Client/ListGatewayRouteViews/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/Client/ListGateways/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/Client/ListGateways/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/Client/ListGrpcRoutes/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/Client/ListGrpcRoutes/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/Client/ListHttpRoutes/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/Client/ListHttpRoutes/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/Client/ListLocations/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/Client/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/Client/ListMeshRouteViews/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/Client/ListMeshRouteViews/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/Client/ListMeshes/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/Client/ListMeshes/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/Client/ListOperations/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/Client/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/Client/ListServiceBindings/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/Client/ListServiceBindings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/Client/ListServiceLbPolicies/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/Client/ListServiceLbPolicies/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/Client/ListTcpRoutes/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/Client/ListTcpRoutes/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/Client/ListTlsRoutes/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/Client/ListTlsRoutes/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/Client/ListWasmPluginVersions/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/Client/ListWasmPluginVersions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/Client/ListWasmPlugins/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/Client/ListWasmPlugins/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/Client/SetIamPolicy/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/Client/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/Client/TestIamPermissions/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/Client/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/Client/UpdateEndpointPolicy/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/Client/UpdateEndpointPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/Client/UpdateGateway/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/Client/UpdateGateway/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/Client/UpdateGrpcRoute/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/Client/UpdateGrpcRoute/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/Client/UpdateHttpRoute/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/Client/UpdateHttpRoute/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/Client/UpdateMesh/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/Client/UpdateMesh/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/Client/UpdateServiceBinding/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/Client/UpdateServiceBinding/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/Client/UpdateServiceLbPolicy/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/Client/UpdateServiceLbPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/Client/UpdateTcpRoute/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/Client/UpdateTcpRoute/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/Client/UpdateTlsRoute/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/Client/UpdateTlsRoute/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/Client/UpdateWasmPlugin/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/Client/UpdateWasmPlugin/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/DepClient/CancelOperation/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/DepClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/DepClient/CreateAuthzExtension/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/DepClient/CreateAuthzExtension/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/DepClient/CreateLbEdgeExtension/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/DepClient/CreateLbEdgeExtension/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/DepClient/CreateLbRouteExtension/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/DepClient/CreateLbRouteExtension/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/DepClient/CreateLbTrafficExtension/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/DepClient/CreateLbTrafficExtension/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/DepClient/DeleteAuthzExtension/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/DepClient/DeleteAuthzExtension/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/DepClient/DeleteLbEdgeExtension/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/DepClient/DeleteLbEdgeExtension/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/DepClient/DeleteLbRouteExtension/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/DepClient/DeleteLbRouteExtension/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/DepClient/DeleteLbTrafficExtension/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/DepClient/DeleteLbTrafficExtension/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/DepClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/DepClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/DepClient/GetAuthzExtension/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/DepClient/GetAuthzExtension/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/DepClient/GetIamPolicy/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/DepClient/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/DepClient/GetLbEdgeExtension/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/DepClient/GetLbEdgeExtension/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/DepClient/GetLbRouteExtension/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/DepClient/GetLbRouteExtension/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/DepClient/GetLbTrafficExtension/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/DepClient/GetLbTrafficExtension/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/DepClient/GetLocation/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/DepClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/DepClient/GetOperation/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/DepClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/DepClient/ListAuthzExtensions/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/DepClient/ListAuthzExtensions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/DepClient/ListLbEdgeExtensions/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/DepClient/ListLbEdgeExtensions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/DepClient/ListLbRouteExtensions/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/DepClient/ListLbRouteExtensions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/DepClient/ListLbTrafficExtensions/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/DepClient/ListLbTrafficExtensions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/DepClient/ListLocations/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/DepClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/DepClient/ListOperations/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/DepClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/DepClient/SetIamPolicy/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/DepClient/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/DepClient/TestIamPermissions/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/DepClient/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/DepClient/UpdateAuthzExtension/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/DepClient/UpdateAuthzExtension/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/DepClient/UpdateLbEdgeExtension/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/DepClient/UpdateLbEdgeExtension/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/DepClient/UpdateLbRouteExtension/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/DepClient/UpdateLbRouteExtension/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/networkservices/apiv1/DepClient/UpdateLbTrafficExtension/main.go
+++ b/internal/generated/snippets/networkservices/apiv1/DepClient/UpdateLbTrafficExtension/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1/ManagedNotebookClient/CancelOperation/main.go
+++ b/internal/generated/snippets/notebooks/apiv1/ManagedNotebookClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1/ManagedNotebookClient/CreateRuntime/main.go
+++ b/internal/generated/snippets/notebooks/apiv1/ManagedNotebookClient/CreateRuntime/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1/ManagedNotebookClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/notebooks/apiv1/ManagedNotebookClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1/ManagedNotebookClient/DeleteRuntime/main.go
+++ b/internal/generated/snippets/notebooks/apiv1/ManagedNotebookClient/DeleteRuntime/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1/ManagedNotebookClient/DiagnoseRuntime/main.go
+++ b/internal/generated/snippets/notebooks/apiv1/ManagedNotebookClient/DiagnoseRuntime/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1/ManagedNotebookClient/GetIamPolicy/main.go
+++ b/internal/generated/snippets/notebooks/apiv1/ManagedNotebookClient/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1/ManagedNotebookClient/GetLocation/main.go
+++ b/internal/generated/snippets/notebooks/apiv1/ManagedNotebookClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1/ManagedNotebookClient/GetOperation/main.go
+++ b/internal/generated/snippets/notebooks/apiv1/ManagedNotebookClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1/ManagedNotebookClient/GetRuntime/main.go
+++ b/internal/generated/snippets/notebooks/apiv1/ManagedNotebookClient/GetRuntime/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1/ManagedNotebookClient/ListLocations/main.go
+++ b/internal/generated/snippets/notebooks/apiv1/ManagedNotebookClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1/ManagedNotebookClient/ListOperations/main.go
+++ b/internal/generated/snippets/notebooks/apiv1/ManagedNotebookClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1/ManagedNotebookClient/ListRuntimes/main.go
+++ b/internal/generated/snippets/notebooks/apiv1/ManagedNotebookClient/ListRuntimes/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1/ManagedNotebookClient/RefreshRuntimeTokenInternal/main.go
+++ b/internal/generated/snippets/notebooks/apiv1/ManagedNotebookClient/RefreshRuntimeTokenInternal/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1/ManagedNotebookClient/ReportRuntimeEvent/main.go
+++ b/internal/generated/snippets/notebooks/apiv1/ManagedNotebookClient/ReportRuntimeEvent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1/ManagedNotebookClient/ResetRuntime/main.go
+++ b/internal/generated/snippets/notebooks/apiv1/ManagedNotebookClient/ResetRuntime/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1/ManagedNotebookClient/SetIamPolicy/main.go
+++ b/internal/generated/snippets/notebooks/apiv1/ManagedNotebookClient/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1/ManagedNotebookClient/StartRuntime/main.go
+++ b/internal/generated/snippets/notebooks/apiv1/ManagedNotebookClient/StartRuntime/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1/ManagedNotebookClient/StopRuntime/main.go
+++ b/internal/generated/snippets/notebooks/apiv1/ManagedNotebookClient/StopRuntime/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1/ManagedNotebookClient/SwitchRuntime/main.go
+++ b/internal/generated/snippets/notebooks/apiv1/ManagedNotebookClient/SwitchRuntime/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1/ManagedNotebookClient/TestIamPermissions/main.go
+++ b/internal/generated/snippets/notebooks/apiv1/ManagedNotebookClient/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1/ManagedNotebookClient/UpdateRuntime/main.go
+++ b/internal/generated/snippets/notebooks/apiv1/ManagedNotebookClient/UpdateRuntime/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1/ManagedNotebookClient/UpgradeRuntime/main.go
+++ b/internal/generated/snippets/notebooks/apiv1/ManagedNotebookClient/UpgradeRuntime/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1/NotebookClient/CancelOperation/main.go
+++ b/internal/generated/snippets/notebooks/apiv1/NotebookClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1/NotebookClient/CreateEnvironment/main.go
+++ b/internal/generated/snippets/notebooks/apiv1/NotebookClient/CreateEnvironment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1/NotebookClient/CreateExecution/main.go
+++ b/internal/generated/snippets/notebooks/apiv1/NotebookClient/CreateExecution/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1/NotebookClient/CreateInstance/main.go
+++ b/internal/generated/snippets/notebooks/apiv1/NotebookClient/CreateInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1/NotebookClient/CreateSchedule/main.go
+++ b/internal/generated/snippets/notebooks/apiv1/NotebookClient/CreateSchedule/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1/NotebookClient/DeleteEnvironment/main.go
+++ b/internal/generated/snippets/notebooks/apiv1/NotebookClient/DeleteEnvironment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1/NotebookClient/DeleteExecution/main.go
+++ b/internal/generated/snippets/notebooks/apiv1/NotebookClient/DeleteExecution/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1/NotebookClient/DeleteInstance/main.go
+++ b/internal/generated/snippets/notebooks/apiv1/NotebookClient/DeleteInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1/NotebookClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/notebooks/apiv1/NotebookClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1/NotebookClient/DeleteSchedule/main.go
+++ b/internal/generated/snippets/notebooks/apiv1/NotebookClient/DeleteSchedule/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1/NotebookClient/DiagnoseInstance/main.go
+++ b/internal/generated/snippets/notebooks/apiv1/NotebookClient/DiagnoseInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1/NotebookClient/GetEnvironment/main.go
+++ b/internal/generated/snippets/notebooks/apiv1/NotebookClient/GetEnvironment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1/NotebookClient/GetExecution/main.go
+++ b/internal/generated/snippets/notebooks/apiv1/NotebookClient/GetExecution/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1/NotebookClient/GetIamPolicy/main.go
+++ b/internal/generated/snippets/notebooks/apiv1/NotebookClient/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1/NotebookClient/GetInstance/main.go
+++ b/internal/generated/snippets/notebooks/apiv1/NotebookClient/GetInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1/NotebookClient/GetInstanceHealth/main.go
+++ b/internal/generated/snippets/notebooks/apiv1/NotebookClient/GetInstanceHealth/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1/NotebookClient/GetLocation/main.go
+++ b/internal/generated/snippets/notebooks/apiv1/NotebookClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1/NotebookClient/GetOperation/main.go
+++ b/internal/generated/snippets/notebooks/apiv1/NotebookClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1/NotebookClient/GetSchedule/main.go
+++ b/internal/generated/snippets/notebooks/apiv1/NotebookClient/GetSchedule/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1/NotebookClient/IsInstanceUpgradeable/main.go
+++ b/internal/generated/snippets/notebooks/apiv1/NotebookClient/IsInstanceUpgradeable/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1/NotebookClient/ListEnvironments/main.go
+++ b/internal/generated/snippets/notebooks/apiv1/NotebookClient/ListEnvironments/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1/NotebookClient/ListExecutions/main.go
+++ b/internal/generated/snippets/notebooks/apiv1/NotebookClient/ListExecutions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1/NotebookClient/ListInstances/main.go
+++ b/internal/generated/snippets/notebooks/apiv1/NotebookClient/ListInstances/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1/NotebookClient/ListLocations/main.go
+++ b/internal/generated/snippets/notebooks/apiv1/NotebookClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1/NotebookClient/ListOperations/main.go
+++ b/internal/generated/snippets/notebooks/apiv1/NotebookClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1/NotebookClient/ListSchedules/main.go
+++ b/internal/generated/snippets/notebooks/apiv1/NotebookClient/ListSchedules/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1/NotebookClient/RegisterInstance/main.go
+++ b/internal/generated/snippets/notebooks/apiv1/NotebookClient/RegisterInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1/NotebookClient/ReportInstanceInfo/main.go
+++ b/internal/generated/snippets/notebooks/apiv1/NotebookClient/ReportInstanceInfo/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1/NotebookClient/ResetInstance/main.go
+++ b/internal/generated/snippets/notebooks/apiv1/NotebookClient/ResetInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1/NotebookClient/RollbackInstance/main.go
+++ b/internal/generated/snippets/notebooks/apiv1/NotebookClient/RollbackInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1/NotebookClient/SetIamPolicy/main.go
+++ b/internal/generated/snippets/notebooks/apiv1/NotebookClient/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1/NotebookClient/SetInstanceAccelerator/main.go
+++ b/internal/generated/snippets/notebooks/apiv1/NotebookClient/SetInstanceAccelerator/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1/NotebookClient/SetInstanceLabels/main.go
+++ b/internal/generated/snippets/notebooks/apiv1/NotebookClient/SetInstanceLabels/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1/NotebookClient/SetInstanceMachineType/main.go
+++ b/internal/generated/snippets/notebooks/apiv1/NotebookClient/SetInstanceMachineType/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1/NotebookClient/StartInstance/main.go
+++ b/internal/generated/snippets/notebooks/apiv1/NotebookClient/StartInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1/NotebookClient/StopInstance/main.go
+++ b/internal/generated/snippets/notebooks/apiv1/NotebookClient/StopInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1/NotebookClient/TestIamPermissions/main.go
+++ b/internal/generated/snippets/notebooks/apiv1/NotebookClient/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1/NotebookClient/TriggerSchedule/main.go
+++ b/internal/generated/snippets/notebooks/apiv1/NotebookClient/TriggerSchedule/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1/NotebookClient/UpdateInstanceConfig/main.go
+++ b/internal/generated/snippets/notebooks/apiv1/NotebookClient/UpdateInstanceConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1/NotebookClient/UpdateInstanceMetadataItems/main.go
+++ b/internal/generated/snippets/notebooks/apiv1/NotebookClient/UpdateInstanceMetadataItems/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1/NotebookClient/UpdateShieldedInstanceConfig/main.go
+++ b/internal/generated/snippets/notebooks/apiv1/NotebookClient/UpdateShieldedInstanceConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1/NotebookClient/UpgradeInstance/main.go
+++ b/internal/generated/snippets/notebooks/apiv1/NotebookClient/UpgradeInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1/NotebookClient/UpgradeInstanceInternal/main.go
+++ b/internal/generated/snippets/notebooks/apiv1/NotebookClient/UpgradeInstanceInternal/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1beta1/NotebookClient/CancelOperation/main.go
+++ b/internal/generated/snippets/notebooks/apiv1beta1/NotebookClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1beta1/NotebookClient/CreateEnvironment/main.go
+++ b/internal/generated/snippets/notebooks/apiv1beta1/NotebookClient/CreateEnvironment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1beta1/NotebookClient/CreateInstance/main.go
+++ b/internal/generated/snippets/notebooks/apiv1beta1/NotebookClient/CreateInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1beta1/NotebookClient/DeleteEnvironment/main.go
+++ b/internal/generated/snippets/notebooks/apiv1beta1/NotebookClient/DeleteEnvironment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1beta1/NotebookClient/DeleteInstance/main.go
+++ b/internal/generated/snippets/notebooks/apiv1beta1/NotebookClient/DeleteInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1beta1/NotebookClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/notebooks/apiv1beta1/NotebookClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1beta1/NotebookClient/GetEnvironment/main.go
+++ b/internal/generated/snippets/notebooks/apiv1beta1/NotebookClient/GetEnvironment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1beta1/NotebookClient/GetIamPolicy/main.go
+++ b/internal/generated/snippets/notebooks/apiv1beta1/NotebookClient/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1beta1/NotebookClient/GetInstance/main.go
+++ b/internal/generated/snippets/notebooks/apiv1beta1/NotebookClient/GetInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1beta1/NotebookClient/GetLocation/main.go
+++ b/internal/generated/snippets/notebooks/apiv1beta1/NotebookClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1beta1/NotebookClient/GetOperation/main.go
+++ b/internal/generated/snippets/notebooks/apiv1beta1/NotebookClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1beta1/NotebookClient/IsInstanceUpgradeable/main.go
+++ b/internal/generated/snippets/notebooks/apiv1beta1/NotebookClient/IsInstanceUpgradeable/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1beta1/NotebookClient/ListEnvironments/main.go
+++ b/internal/generated/snippets/notebooks/apiv1beta1/NotebookClient/ListEnvironments/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1beta1/NotebookClient/ListInstances/main.go
+++ b/internal/generated/snippets/notebooks/apiv1beta1/NotebookClient/ListInstances/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1beta1/NotebookClient/ListLocations/main.go
+++ b/internal/generated/snippets/notebooks/apiv1beta1/NotebookClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1beta1/NotebookClient/ListOperations/main.go
+++ b/internal/generated/snippets/notebooks/apiv1beta1/NotebookClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1beta1/NotebookClient/RegisterInstance/main.go
+++ b/internal/generated/snippets/notebooks/apiv1beta1/NotebookClient/RegisterInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1beta1/NotebookClient/ReportInstanceInfo/main.go
+++ b/internal/generated/snippets/notebooks/apiv1beta1/NotebookClient/ReportInstanceInfo/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1beta1/NotebookClient/ResetInstance/main.go
+++ b/internal/generated/snippets/notebooks/apiv1beta1/NotebookClient/ResetInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1beta1/NotebookClient/SetIamPolicy/main.go
+++ b/internal/generated/snippets/notebooks/apiv1beta1/NotebookClient/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1beta1/NotebookClient/SetInstanceAccelerator/main.go
+++ b/internal/generated/snippets/notebooks/apiv1beta1/NotebookClient/SetInstanceAccelerator/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1beta1/NotebookClient/SetInstanceLabels/main.go
+++ b/internal/generated/snippets/notebooks/apiv1beta1/NotebookClient/SetInstanceLabels/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1beta1/NotebookClient/SetInstanceMachineType/main.go
+++ b/internal/generated/snippets/notebooks/apiv1beta1/NotebookClient/SetInstanceMachineType/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1beta1/NotebookClient/StartInstance/main.go
+++ b/internal/generated/snippets/notebooks/apiv1beta1/NotebookClient/StartInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1beta1/NotebookClient/StopInstance/main.go
+++ b/internal/generated/snippets/notebooks/apiv1beta1/NotebookClient/StopInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1beta1/NotebookClient/TestIamPermissions/main.go
+++ b/internal/generated/snippets/notebooks/apiv1beta1/NotebookClient/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1beta1/NotebookClient/UpgradeInstance/main.go
+++ b/internal/generated/snippets/notebooks/apiv1beta1/NotebookClient/UpgradeInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv1beta1/NotebookClient/UpgradeInstanceInternal/main.go
+++ b/internal/generated/snippets/notebooks/apiv1beta1/NotebookClient/UpgradeInstanceInternal/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv2/NotebookClient/CancelOperation/main.go
+++ b/internal/generated/snippets/notebooks/apiv2/NotebookClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv2/NotebookClient/CheckInstanceUpgradability/main.go
+++ b/internal/generated/snippets/notebooks/apiv2/NotebookClient/CheckInstanceUpgradability/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv2/NotebookClient/CreateInstance/main.go
+++ b/internal/generated/snippets/notebooks/apiv2/NotebookClient/CreateInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv2/NotebookClient/DeleteInstance/main.go
+++ b/internal/generated/snippets/notebooks/apiv2/NotebookClient/DeleteInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv2/NotebookClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/notebooks/apiv2/NotebookClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv2/NotebookClient/DiagnoseInstance/main.go
+++ b/internal/generated/snippets/notebooks/apiv2/NotebookClient/DiagnoseInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv2/NotebookClient/GetIamPolicy/main.go
+++ b/internal/generated/snippets/notebooks/apiv2/NotebookClient/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv2/NotebookClient/GetInstance/main.go
+++ b/internal/generated/snippets/notebooks/apiv2/NotebookClient/GetInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv2/NotebookClient/GetLocation/main.go
+++ b/internal/generated/snippets/notebooks/apiv2/NotebookClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv2/NotebookClient/GetOperation/main.go
+++ b/internal/generated/snippets/notebooks/apiv2/NotebookClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv2/NotebookClient/ListInstances/main.go
+++ b/internal/generated/snippets/notebooks/apiv2/NotebookClient/ListInstances/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv2/NotebookClient/ListLocations/main.go
+++ b/internal/generated/snippets/notebooks/apiv2/NotebookClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv2/NotebookClient/ListOperations/main.go
+++ b/internal/generated/snippets/notebooks/apiv2/NotebookClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv2/NotebookClient/ResetInstance/main.go
+++ b/internal/generated/snippets/notebooks/apiv2/NotebookClient/ResetInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv2/NotebookClient/RollbackInstance/main.go
+++ b/internal/generated/snippets/notebooks/apiv2/NotebookClient/RollbackInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv2/NotebookClient/SetIamPolicy/main.go
+++ b/internal/generated/snippets/notebooks/apiv2/NotebookClient/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv2/NotebookClient/StartInstance/main.go
+++ b/internal/generated/snippets/notebooks/apiv2/NotebookClient/StartInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv2/NotebookClient/StopInstance/main.go
+++ b/internal/generated/snippets/notebooks/apiv2/NotebookClient/StopInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv2/NotebookClient/TestIamPermissions/main.go
+++ b/internal/generated/snippets/notebooks/apiv2/NotebookClient/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv2/NotebookClient/UpdateInstance/main.go
+++ b/internal/generated/snippets/notebooks/apiv2/NotebookClient/UpdateInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/notebooks/apiv2/NotebookClient/UpgradeInstance/main.go
+++ b/internal/generated/snippets/notebooks/apiv2/NotebookClient/UpgradeInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/optimization/apiv1/FleetRoutingClient/BatchOptimizeTours/main.go
+++ b/internal/generated/snippets/optimization/apiv1/FleetRoutingClient/BatchOptimizeTours/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/optimization/apiv1/FleetRoutingClient/GetOperation/main.go
+++ b/internal/generated/snippets/optimization/apiv1/FleetRoutingClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/optimization/apiv1/FleetRoutingClient/OptimizeTours/main.go
+++ b/internal/generated/snippets/optimization/apiv1/FleetRoutingClient/OptimizeTours/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oracledatabase/apiv1/Client/CancelOperation/main.go
+++ b/internal/generated/snippets/oracledatabase/apiv1/Client/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oracledatabase/apiv1/Client/CreateAutonomousDatabase/main.go
+++ b/internal/generated/snippets/oracledatabase/apiv1/Client/CreateAutonomousDatabase/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oracledatabase/apiv1/Client/CreateCloudExadataInfrastructure/main.go
+++ b/internal/generated/snippets/oracledatabase/apiv1/Client/CreateCloudExadataInfrastructure/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oracledatabase/apiv1/Client/CreateCloudVmCluster/main.go
+++ b/internal/generated/snippets/oracledatabase/apiv1/Client/CreateCloudVmCluster/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oracledatabase/apiv1/Client/CreateDbSystem/main.go
+++ b/internal/generated/snippets/oracledatabase/apiv1/Client/CreateDbSystem/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oracledatabase/apiv1/Client/CreateExadbVmCluster/main.go
+++ b/internal/generated/snippets/oracledatabase/apiv1/Client/CreateExadbVmCluster/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oracledatabase/apiv1/Client/CreateExascaleDbStorageVault/main.go
+++ b/internal/generated/snippets/oracledatabase/apiv1/Client/CreateExascaleDbStorageVault/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oracledatabase/apiv1/Client/CreateOdbNetwork/main.go
+++ b/internal/generated/snippets/oracledatabase/apiv1/Client/CreateOdbNetwork/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oracledatabase/apiv1/Client/CreateOdbSubnet/main.go
+++ b/internal/generated/snippets/oracledatabase/apiv1/Client/CreateOdbSubnet/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oracledatabase/apiv1/Client/DeleteAutonomousDatabase/main.go
+++ b/internal/generated/snippets/oracledatabase/apiv1/Client/DeleteAutonomousDatabase/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oracledatabase/apiv1/Client/DeleteCloudExadataInfrastructure/main.go
+++ b/internal/generated/snippets/oracledatabase/apiv1/Client/DeleteCloudExadataInfrastructure/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oracledatabase/apiv1/Client/DeleteCloudVmCluster/main.go
+++ b/internal/generated/snippets/oracledatabase/apiv1/Client/DeleteCloudVmCluster/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oracledatabase/apiv1/Client/DeleteDbSystem/main.go
+++ b/internal/generated/snippets/oracledatabase/apiv1/Client/DeleteDbSystem/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oracledatabase/apiv1/Client/DeleteExadbVmCluster/main.go
+++ b/internal/generated/snippets/oracledatabase/apiv1/Client/DeleteExadbVmCluster/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oracledatabase/apiv1/Client/DeleteExascaleDbStorageVault/main.go
+++ b/internal/generated/snippets/oracledatabase/apiv1/Client/DeleteExascaleDbStorageVault/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oracledatabase/apiv1/Client/DeleteOdbNetwork/main.go
+++ b/internal/generated/snippets/oracledatabase/apiv1/Client/DeleteOdbNetwork/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oracledatabase/apiv1/Client/DeleteOdbSubnet/main.go
+++ b/internal/generated/snippets/oracledatabase/apiv1/Client/DeleteOdbSubnet/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oracledatabase/apiv1/Client/DeleteOperation/main.go
+++ b/internal/generated/snippets/oracledatabase/apiv1/Client/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oracledatabase/apiv1/Client/FailoverAutonomousDatabase/main.go
+++ b/internal/generated/snippets/oracledatabase/apiv1/Client/FailoverAutonomousDatabase/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oracledatabase/apiv1/Client/GenerateAutonomousDatabaseWallet/main.go
+++ b/internal/generated/snippets/oracledatabase/apiv1/Client/GenerateAutonomousDatabaseWallet/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oracledatabase/apiv1/Client/GetAutonomousDatabase/main.go
+++ b/internal/generated/snippets/oracledatabase/apiv1/Client/GetAutonomousDatabase/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oracledatabase/apiv1/Client/GetCloudExadataInfrastructure/main.go
+++ b/internal/generated/snippets/oracledatabase/apiv1/Client/GetCloudExadataInfrastructure/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oracledatabase/apiv1/Client/GetCloudVmCluster/main.go
+++ b/internal/generated/snippets/oracledatabase/apiv1/Client/GetCloudVmCluster/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oracledatabase/apiv1/Client/GetDatabase/main.go
+++ b/internal/generated/snippets/oracledatabase/apiv1/Client/GetDatabase/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oracledatabase/apiv1/Client/GetDbSystem/main.go
+++ b/internal/generated/snippets/oracledatabase/apiv1/Client/GetDbSystem/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oracledatabase/apiv1/Client/GetExadbVmCluster/main.go
+++ b/internal/generated/snippets/oracledatabase/apiv1/Client/GetExadbVmCluster/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oracledatabase/apiv1/Client/GetExascaleDbStorageVault/main.go
+++ b/internal/generated/snippets/oracledatabase/apiv1/Client/GetExascaleDbStorageVault/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oracledatabase/apiv1/Client/GetLocation/main.go
+++ b/internal/generated/snippets/oracledatabase/apiv1/Client/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oracledatabase/apiv1/Client/GetOdbNetwork/main.go
+++ b/internal/generated/snippets/oracledatabase/apiv1/Client/GetOdbNetwork/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oracledatabase/apiv1/Client/GetOdbSubnet/main.go
+++ b/internal/generated/snippets/oracledatabase/apiv1/Client/GetOdbSubnet/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oracledatabase/apiv1/Client/GetOperation/main.go
+++ b/internal/generated/snippets/oracledatabase/apiv1/Client/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oracledatabase/apiv1/Client/GetPluggableDatabase/main.go
+++ b/internal/generated/snippets/oracledatabase/apiv1/Client/GetPluggableDatabase/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oracledatabase/apiv1/Client/ListAutonomousDatabaseBackups/main.go
+++ b/internal/generated/snippets/oracledatabase/apiv1/Client/ListAutonomousDatabaseBackups/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oracledatabase/apiv1/Client/ListAutonomousDatabaseCharacterSets/main.go
+++ b/internal/generated/snippets/oracledatabase/apiv1/Client/ListAutonomousDatabaseCharacterSets/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oracledatabase/apiv1/Client/ListAutonomousDatabases/main.go
+++ b/internal/generated/snippets/oracledatabase/apiv1/Client/ListAutonomousDatabases/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oracledatabase/apiv1/Client/ListAutonomousDbVersions/main.go
+++ b/internal/generated/snippets/oracledatabase/apiv1/Client/ListAutonomousDbVersions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oracledatabase/apiv1/Client/ListCloudExadataInfrastructures/main.go
+++ b/internal/generated/snippets/oracledatabase/apiv1/Client/ListCloudExadataInfrastructures/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oracledatabase/apiv1/Client/ListCloudVmClusters/main.go
+++ b/internal/generated/snippets/oracledatabase/apiv1/Client/ListCloudVmClusters/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oracledatabase/apiv1/Client/ListDatabaseCharacterSets/main.go
+++ b/internal/generated/snippets/oracledatabase/apiv1/Client/ListDatabaseCharacterSets/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oracledatabase/apiv1/Client/ListDatabases/main.go
+++ b/internal/generated/snippets/oracledatabase/apiv1/Client/ListDatabases/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oracledatabase/apiv1/Client/ListDbNodes/main.go
+++ b/internal/generated/snippets/oracledatabase/apiv1/Client/ListDbNodes/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oracledatabase/apiv1/Client/ListDbServers/main.go
+++ b/internal/generated/snippets/oracledatabase/apiv1/Client/ListDbServers/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oracledatabase/apiv1/Client/ListDbSystemInitialStorageSizes/main.go
+++ b/internal/generated/snippets/oracledatabase/apiv1/Client/ListDbSystemInitialStorageSizes/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oracledatabase/apiv1/Client/ListDbSystemShapes/main.go
+++ b/internal/generated/snippets/oracledatabase/apiv1/Client/ListDbSystemShapes/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oracledatabase/apiv1/Client/ListDbSystems/main.go
+++ b/internal/generated/snippets/oracledatabase/apiv1/Client/ListDbSystems/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oracledatabase/apiv1/Client/ListDbVersions/main.go
+++ b/internal/generated/snippets/oracledatabase/apiv1/Client/ListDbVersions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oracledatabase/apiv1/Client/ListEntitlements/main.go
+++ b/internal/generated/snippets/oracledatabase/apiv1/Client/ListEntitlements/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oracledatabase/apiv1/Client/ListExadbVmClusters/main.go
+++ b/internal/generated/snippets/oracledatabase/apiv1/Client/ListExadbVmClusters/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oracledatabase/apiv1/Client/ListExascaleDbStorageVaults/main.go
+++ b/internal/generated/snippets/oracledatabase/apiv1/Client/ListExascaleDbStorageVaults/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oracledatabase/apiv1/Client/ListGiVersions/main.go
+++ b/internal/generated/snippets/oracledatabase/apiv1/Client/ListGiVersions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oracledatabase/apiv1/Client/ListLocations/main.go
+++ b/internal/generated/snippets/oracledatabase/apiv1/Client/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oracledatabase/apiv1/Client/ListMinorVersions/main.go
+++ b/internal/generated/snippets/oracledatabase/apiv1/Client/ListMinorVersions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oracledatabase/apiv1/Client/ListOdbNetworks/main.go
+++ b/internal/generated/snippets/oracledatabase/apiv1/Client/ListOdbNetworks/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oracledatabase/apiv1/Client/ListOdbSubnets/main.go
+++ b/internal/generated/snippets/oracledatabase/apiv1/Client/ListOdbSubnets/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oracledatabase/apiv1/Client/ListOperations/main.go
+++ b/internal/generated/snippets/oracledatabase/apiv1/Client/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oracledatabase/apiv1/Client/ListPluggableDatabases/main.go
+++ b/internal/generated/snippets/oracledatabase/apiv1/Client/ListPluggableDatabases/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oracledatabase/apiv1/Client/RemoveVirtualMachineExadbVmCluster/main.go
+++ b/internal/generated/snippets/oracledatabase/apiv1/Client/RemoveVirtualMachineExadbVmCluster/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oracledatabase/apiv1/Client/RestartAutonomousDatabase/main.go
+++ b/internal/generated/snippets/oracledatabase/apiv1/Client/RestartAutonomousDatabase/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oracledatabase/apiv1/Client/RestoreAutonomousDatabase/main.go
+++ b/internal/generated/snippets/oracledatabase/apiv1/Client/RestoreAutonomousDatabase/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oracledatabase/apiv1/Client/StartAutonomousDatabase/main.go
+++ b/internal/generated/snippets/oracledatabase/apiv1/Client/StartAutonomousDatabase/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oracledatabase/apiv1/Client/StopAutonomousDatabase/main.go
+++ b/internal/generated/snippets/oracledatabase/apiv1/Client/StopAutonomousDatabase/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oracledatabase/apiv1/Client/SwitchoverAutonomousDatabase/main.go
+++ b/internal/generated/snippets/oracledatabase/apiv1/Client/SwitchoverAutonomousDatabase/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oracledatabase/apiv1/Client/UpdateAutonomousDatabase/main.go
+++ b/internal/generated/snippets/oracledatabase/apiv1/Client/UpdateAutonomousDatabase/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oracledatabase/apiv1/Client/UpdateExadbVmCluster/main.go
+++ b/internal/generated/snippets/oracledatabase/apiv1/Client/UpdateExadbVmCluster/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/orchestration/airflow/service/apiv1/EnvironmentsClient/CheckUpgrade/main.go
+++ b/internal/generated/snippets/orchestration/airflow/service/apiv1/EnvironmentsClient/CheckUpgrade/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/orchestration/airflow/service/apiv1/EnvironmentsClient/CreateEnvironment/main.go
+++ b/internal/generated/snippets/orchestration/airflow/service/apiv1/EnvironmentsClient/CreateEnvironment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/orchestration/airflow/service/apiv1/EnvironmentsClient/CreateUserWorkloadsConfigMap/main.go
+++ b/internal/generated/snippets/orchestration/airflow/service/apiv1/EnvironmentsClient/CreateUserWorkloadsConfigMap/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/orchestration/airflow/service/apiv1/EnvironmentsClient/CreateUserWorkloadsSecret/main.go
+++ b/internal/generated/snippets/orchestration/airflow/service/apiv1/EnvironmentsClient/CreateUserWorkloadsSecret/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/orchestration/airflow/service/apiv1/EnvironmentsClient/DatabaseFailover/main.go
+++ b/internal/generated/snippets/orchestration/airflow/service/apiv1/EnvironmentsClient/DatabaseFailover/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/orchestration/airflow/service/apiv1/EnvironmentsClient/DeleteEnvironment/main.go
+++ b/internal/generated/snippets/orchestration/airflow/service/apiv1/EnvironmentsClient/DeleteEnvironment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/orchestration/airflow/service/apiv1/EnvironmentsClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/orchestration/airflow/service/apiv1/EnvironmentsClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/orchestration/airflow/service/apiv1/EnvironmentsClient/DeleteUserWorkloadsConfigMap/main.go
+++ b/internal/generated/snippets/orchestration/airflow/service/apiv1/EnvironmentsClient/DeleteUserWorkloadsConfigMap/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/orchestration/airflow/service/apiv1/EnvironmentsClient/DeleteUserWorkloadsSecret/main.go
+++ b/internal/generated/snippets/orchestration/airflow/service/apiv1/EnvironmentsClient/DeleteUserWorkloadsSecret/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/orchestration/airflow/service/apiv1/EnvironmentsClient/ExecuteAirflowCommand/main.go
+++ b/internal/generated/snippets/orchestration/airflow/service/apiv1/EnvironmentsClient/ExecuteAirflowCommand/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/orchestration/airflow/service/apiv1/EnvironmentsClient/FetchDatabaseProperties/main.go
+++ b/internal/generated/snippets/orchestration/airflow/service/apiv1/EnvironmentsClient/FetchDatabaseProperties/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/orchestration/airflow/service/apiv1/EnvironmentsClient/GetEnvironment/main.go
+++ b/internal/generated/snippets/orchestration/airflow/service/apiv1/EnvironmentsClient/GetEnvironment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/orchestration/airflow/service/apiv1/EnvironmentsClient/GetOperation/main.go
+++ b/internal/generated/snippets/orchestration/airflow/service/apiv1/EnvironmentsClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/orchestration/airflow/service/apiv1/EnvironmentsClient/GetUserWorkloadsConfigMap/main.go
+++ b/internal/generated/snippets/orchestration/airflow/service/apiv1/EnvironmentsClient/GetUserWorkloadsConfigMap/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/orchestration/airflow/service/apiv1/EnvironmentsClient/GetUserWorkloadsSecret/main.go
+++ b/internal/generated/snippets/orchestration/airflow/service/apiv1/EnvironmentsClient/GetUserWorkloadsSecret/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/orchestration/airflow/service/apiv1/EnvironmentsClient/ListEnvironments/main.go
+++ b/internal/generated/snippets/orchestration/airflow/service/apiv1/EnvironmentsClient/ListEnvironments/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/orchestration/airflow/service/apiv1/EnvironmentsClient/ListOperations/main.go
+++ b/internal/generated/snippets/orchestration/airflow/service/apiv1/EnvironmentsClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/orchestration/airflow/service/apiv1/EnvironmentsClient/ListUserWorkloadsConfigMaps/main.go
+++ b/internal/generated/snippets/orchestration/airflow/service/apiv1/EnvironmentsClient/ListUserWorkloadsConfigMaps/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/orchestration/airflow/service/apiv1/EnvironmentsClient/ListUserWorkloadsSecrets/main.go
+++ b/internal/generated/snippets/orchestration/airflow/service/apiv1/EnvironmentsClient/ListUserWorkloadsSecrets/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/orchestration/airflow/service/apiv1/EnvironmentsClient/ListWorkloads/main.go
+++ b/internal/generated/snippets/orchestration/airflow/service/apiv1/EnvironmentsClient/ListWorkloads/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/orchestration/airflow/service/apiv1/EnvironmentsClient/LoadSnapshot/main.go
+++ b/internal/generated/snippets/orchestration/airflow/service/apiv1/EnvironmentsClient/LoadSnapshot/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/orchestration/airflow/service/apiv1/EnvironmentsClient/PollAirflowCommand/main.go
+++ b/internal/generated/snippets/orchestration/airflow/service/apiv1/EnvironmentsClient/PollAirflowCommand/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/orchestration/airflow/service/apiv1/EnvironmentsClient/SaveSnapshot/main.go
+++ b/internal/generated/snippets/orchestration/airflow/service/apiv1/EnvironmentsClient/SaveSnapshot/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/orchestration/airflow/service/apiv1/EnvironmentsClient/StopAirflowCommand/main.go
+++ b/internal/generated/snippets/orchestration/airflow/service/apiv1/EnvironmentsClient/StopAirflowCommand/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/orchestration/airflow/service/apiv1/EnvironmentsClient/UpdateEnvironment/main.go
+++ b/internal/generated/snippets/orchestration/airflow/service/apiv1/EnvironmentsClient/UpdateEnvironment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/orchestration/airflow/service/apiv1/EnvironmentsClient/UpdateUserWorkloadsConfigMap/main.go
+++ b/internal/generated/snippets/orchestration/airflow/service/apiv1/EnvironmentsClient/UpdateUserWorkloadsConfigMap/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/orchestration/airflow/service/apiv1/EnvironmentsClient/UpdateUserWorkloadsSecret/main.go
+++ b/internal/generated/snippets/orchestration/airflow/service/apiv1/EnvironmentsClient/UpdateUserWorkloadsSecret/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/orchestration/airflow/service/apiv1/ImageVersionsClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/orchestration/airflow/service/apiv1/ImageVersionsClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/orchestration/airflow/service/apiv1/ImageVersionsClient/GetOperation/main.go
+++ b/internal/generated/snippets/orchestration/airflow/service/apiv1/ImageVersionsClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/orchestration/airflow/service/apiv1/ImageVersionsClient/ListImageVersions/main.go
+++ b/internal/generated/snippets/orchestration/airflow/service/apiv1/ImageVersionsClient/ListImageVersions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/orchestration/airflow/service/apiv1/ImageVersionsClient/ListOperations/main.go
+++ b/internal/generated/snippets/orchestration/airflow/service/apiv1/ImageVersionsClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/orgpolicy/apiv2/Client/CreateCustomConstraint/main.go
+++ b/internal/generated/snippets/orgpolicy/apiv2/Client/CreateCustomConstraint/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/orgpolicy/apiv2/Client/CreatePolicy/main.go
+++ b/internal/generated/snippets/orgpolicy/apiv2/Client/CreatePolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/orgpolicy/apiv2/Client/DeleteCustomConstraint/main.go
+++ b/internal/generated/snippets/orgpolicy/apiv2/Client/DeleteCustomConstraint/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/orgpolicy/apiv2/Client/DeletePolicy/main.go
+++ b/internal/generated/snippets/orgpolicy/apiv2/Client/DeletePolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/orgpolicy/apiv2/Client/GetCustomConstraint/main.go
+++ b/internal/generated/snippets/orgpolicy/apiv2/Client/GetCustomConstraint/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/orgpolicy/apiv2/Client/GetEffectivePolicy/main.go
+++ b/internal/generated/snippets/orgpolicy/apiv2/Client/GetEffectivePolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/orgpolicy/apiv2/Client/GetPolicy/main.go
+++ b/internal/generated/snippets/orgpolicy/apiv2/Client/GetPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/orgpolicy/apiv2/Client/ListConstraints/main.go
+++ b/internal/generated/snippets/orgpolicy/apiv2/Client/ListConstraints/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/orgpolicy/apiv2/Client/ListCustomConstraints/main.go
+++ b/internal/generated/snippets/orgpolicy/apiv2/Client/ListCustomConstraints/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/orgpolicy/apiv2/Client/ListPolicies/main.go
+++ b/internal/generated/snippets/orgpolicy/apiv2/Client/ListPolicies/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/orgpolicy/apiv2/Client/UpdateCustomConstraint/main.go
+++ b/internal/generated/snippets/orgpolicy/apiv2/Client/UpdateCustomConstraint/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/orgpolicy/apiv2/Client/UpdatePolicy/main.go
+++ b/internal/generated/snippets/orgpolicy/apiv2/Client/UpdatePolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/osconfig/agentendpoint/apiv1/Client/RegisterAgent/main.go
+++ b/internal/generated/snippets/osconfig/agentendpoint/apiv1/Client/RegisterAgent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/osconfig/agentendpoint/apiv1/Client/ReportInventory/main.go
+++ b/internal/generated/snippets/osconfig/agentendpoint/apiv1/Client/ReportInventory/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/osconfig/agentendpoint/apiv1/Client/ReportTaskComplete/main.go
+++ b/internal/generated/snippets/osconfig/agentendpoint/apiv1/Client/ReportTaskComplete/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/osconfig/agentendpoint/apiv1/Client/ReportTaskProgress/main.go
+++ b/internal/generated/snippets/osconfig/agentendpoint/apiv1/Client/ReportTaskProgress/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/osconfig/agentendpoint/apiv1/Client/StartNextTask/main.go
+++ b/internal/generated/snippets/osconfig/agentendpoint/apiv1/Client/StartNextTask/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/osconfig/agentendpoint/apiv1beta/Client/LookupEffectiveGuestPolicy/main.go
+++ b/internal/generated/snippets/osconfig/agentendpoint/apiv1beta/Client/LookupEffectiveGuestPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/osconfig/agentendpoint/apiv1beta/Client/RegisterAgent/main.go
+++ b/internal/generated/snippets/osconfig/agentendpoint/apiv1beta/Client/RegisterAgent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/osconfig/agentendpoint/apiv1beta/Client/ReportTaskComplete/main.go
+++ b/internal/generated/snippets/osconfig/agentendpoint/apiv1beta/Client/ReportTaskComplete/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/osconfig/agentendpoint/apiv1beta/Client/ReportTaskProgress/main.go
+++ b/internal/generated/snippets/osconfig/agentendpoint/apiv1beta/Client/ReportTaskProgress/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/osconfig/agentendpoint/apiv1beta/Client/StartNextTask/main.go
+++ b/internal/generated/snippets/osconfig/agentendpoint/apiv1beta/Client/StartNextTask/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/osconfig/apiv1/Client/CancelPatchJob/main.go
+++ b/internal/generated/snippets/osconfig/apiv1/Client/CancelPatchJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/osconfig/apiv1/Client/CreatePatchDeployment/main.go
+++ b/internal/generated/snippets/osconfig/apiv1/Client/CreatePatchDeployment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/osconfig/apiv1/Client/DeletePatchDeployment/main.go
+++ b/internal/generated/snippets/osconfig/apiv1/Client/DeletePatchDeployment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/osconfig/apiv1/Client/ExecutePatchJob/main.go
+++ b/internal/generated/snippets/osconfig/apiv1/Client/ExecutePatchJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/osconfig/apiv1/Client/GetPatchDeployment/main.go
+++ b/internal/generated/snippets/osconfig/apiv1/Client/GetPatchDeployment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/osconfig/apiv1/Client/GetPatchJob/main.go
+++ b/internal/generated/snippets/osconfig/apiv1/Client/GetPatchJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/osconfig/apiv1/Client/ListPatchDeployments/main.go
+++ b/internal/generated/snippets/osconfig/apiv1/Client/ListPatchDeployments/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/osconfig/apiv1/Client/ListPatchJobInstanceDetails/main.go
+++ b/internal/generated/snippets/osconfig/apiv1/Client/ListPatchJobInstanceDetails/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/osconfig/apiv1/Client/ListPatchJobs/main.go
+++ b/internal/generated/snippets/osconfig/apiv1/Client/ListPatchJobs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/osconfig/apiv1/Client/PausePatchDeployment/main.go
+++ b/internal/generated/snippets/osconfig/apiv1/Client/PausePatchDeployment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/osconfig/apiv1/Client/ResumePatchDeployment/main.go
+++ b/internal/generated/snippets/osconfig/apiv1/Client/ResumePatchDeployment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/osconfig/apiv1/Client/UpdatePatchDeployment/main.go
+++ b/internal/generated/snippets/osconfig/apiv1/Client/UpdatePatchDeployment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/osconfig/apiv1/OsConfigZonalClient/CreateOSPolicyAssignment/main.go
+++ b/internal/generated/snippets/osconfig/apiv1/OsConfigZonalClient/CreateOSPolicyAssignment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/osconfig/apiv1/OsConfigZonalClient/DeleteOSPolicyAssignment/main.go
+++ b/internal/generated/snippets/osconfig/apiv1/OsConfigZonalClient/DeleteOSPolicyAssignment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/osconfig/apiv1/OsConfigZonalClient/GetInventory/main.go
+++ b/internal/generated/snippets/osconfig/apiv1/OsConfigZonalClient/GetInventory/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/osconfig/apiv1/OsConfigZonalClient/GetOSPolicyAssignment/main.go
+++ b/internal/generated/snippets/osconfig/apiv1/OsConfigZonalClient/GetOSPolicyAssignment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/osconfig/apiv1/OsConfigZonalClient/GetOSPolicyAssignmentReport/main.go
+++ b/internal/generated/snippets/osconfig/apiv1/OsConfigZonalClient/GetOSPolicyAssignmentReport/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/osconfig/apiv1/OsConfigZonalClient/GetVulnerabilityReport/main.go
+++ b/internal/generated/snippets/osconfig/apiv1/OsConfigZonalClient/GetVulnerabilityReport/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/osconfig/apiv1/OsConfigZonalClient/ListInventories/main.go
+++ b/internal/generated/snippets/osconfig/apiv1/OsConfigZonalClient/ListInventories/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/osconfig/apiv1/OsConfigZonalClient/ListOSPolicyAssignmentReports/main.go
+++ b/internal/generated/snippets/osconfig/apiv1/OsConfigZonalClient/ListOSPolicyAssignmentReports/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/osconfig/apiv1/OsConfigZonalClient/ListOSPolicyAssignmentRevisions/main.go
+++ b/internal/generated/snippets/osconfig/apiv1/OsConfigZonalClient/ListOSPolicyAssignmentRevisions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/osconfig/apiv1/OsConfigZonalClient/ListOSPolicyAssignments/main.go
+++ b/internal/generated/snippets/osconfig/apiv1/OsConfigZonalClient/ListOSPolicyAssignments/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/osconfig/apiv1/OsConfigZonalClient/ListVulnerabilityReports/main.go
+++ b/internal/generated/snippets/osconfig/apiv1/OsConfigZonalClient/ListVulnerabilityReports/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/osconfig/apiv1/OsConfigZonalClient/UpdateOSPolicyAssignment/main.go
+++ b/internal/generated/snippets/osconfig/apiv1/OsConfigZonalClient/UpdateOSPolicyAssignment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/osconfig/apiv1alpha/OsConfigZonalClient/CreateOSPolicyAssignment/main.go
+++ b/internal/generated/snippets/osconfig/apiv1alpha/OsConfigZonalClient/CreateOSPolicyAssignment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/osconfig/apiv1alpha/OsConfigZonalClient/DeleteOSPolicyAssignment/main.go
+++ b/internal/generated/snippets/osconfig/apiv1alpha/OsConfigZonalClient/DeleteOSPolicyAssignment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/osconfig/apiv1alpha/OsConfigZonalClient/GetInstanceOSPoliciesCompliance/main.go
+++ b/internal/generated/snippets/osconfig/apiv1alpha/OsConfigZonalClient/GetInstanceOSPoliciesCompliance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/osconfig/apiv1alpha/OsConfigZonalClient/GetInventory/main.go
+++ b/internal/generated/snippets/osconfig/apiv1alpha/OsConfigZonalClient/GetInventory/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/osconfig/apiv1alpha/OsConfigZonalClient/GetOSPolicyAssignment/main.go
+++ b/internal/generated/snippets/osconfig/apiv1alpha/OsConfigZonalClient/GetOSPolicyAssignment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/osconfig/apiv1alpha/OsConfigZonalClient/GetOSPolicyAssignmentReport/main.go
+++ b/internal/generated/snippets/osconfig/apiv1alpha/OsConfigZonalClient/GetOSPolicyAssignmentReport/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/osconfig/apiv1alpha/OsConfigZonalClient/GetVulnerabilityReport/main.go
+++ b/internal/generated/snippets/osconfig/apiv1alpha/OsConfigZonalClient/GetVulnerabilityReport/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/osconfig/apiv1alpha/OsConfigZonalClient/ListInstanceOSPoliciesCompliances/main.go
+++ b/internal/generated/snippets/osconfig/apiv1alpha/OsConfigZonalClient/ListInstanceOSPoliciesCompliances/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/osconfig/apiv1alpha/OsConfigZonalClient/ListInventories/main.go
+++ b/internal/generated/snippets/osconfig/apiv1alpha/OsConfigZonalClient/ListInventories/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/osconfig/apiv1alpha/OsConfigZonalClient/ListOSPolicyAssignmentReports/main.go
+++ b/internal/generated/snippets/osconfig/apiv1alpha/OsConfigZonalClient/ListOSPolicyAssignmentReports/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/osconfig/apiv1alpha/OsConfigZonalClient/ListOSPolicyAssignmentRevisions/main.go
+++ b/internal/generated/snippets/osconfig/apiv1alpha/OsConfigZonalClient/ListOSPolicyAssignmentRevisions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/osconfig/apiv1alpha/OsConfigZonalClient/ListOSPolicyAssignments/main.go
+++ b/internal/generated/snippets/osconfig/apiv1alpha/OsConfigZonalClient/ListOSPolicyAssignments/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/osconfig/apiv1alpha/OsConfigZonalClient/ListVulnerabilityReports/main.go
+++ b/internal/generated/snippets/osconfig/apiv1alpha/OsConfigZonalClient/ListVulnerabilityReports/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/osconfig/apiv1alpha/OsConfigZonalClient/UpdateOSPolicyAssignment/main.go
+++ b/internal/generated/snippets/osconfig/apiv1alpha/OsConfigZonalClient/UpdateOSPolicyAssignment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/osconfig/apiv1beta/Client/CancelPatchJob/main.go
+++ b/internal/generated/snippets/osconfig/apiv1beta/Client/CancelPatchJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/osconfig/apiv1beta/Client/CreateGuestPolicy/main.go
+++ b/internal/generated/snippets/osconfig/apiv1beta/Client/CreateGuestPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/osconfig/apiv1beta/Client/CreatePatchDeployment/main.go
+++ b/internal/generated/snippets/osconfig/apiv1beta/Client/CreatePatchDeployment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/osconfig/apiv1beta/Client/DeleteGuestPolicy/main.go
+++ b/internal/generated/snippets/osconfig/apiv1beta/Client/DeleteGuestPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/osconfig/apiv1beta/Client/DeletePatchDeployment/main.go
+++ b/internal/generated/snippets/osconfig/apiv1beta/Client/DeletePatchDeployment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/osconfig/apiv1beta/Client/ExecutePatchJob/main.go
+++ b/internal/generated/snippets/osconfig/apiv1beta/Client/ExecutePatchJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/osconfig/apiv1beta/Client/GetGuestPolicy/main.go
+++ b/internal/generated/snippets/osconfig/apiv1beta/Client/GetGuestPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/osconfig/apiv1beta/Client/GetPatchDeployment/main.go
+++ b/internal/generated/snippets/osconfig/apiv1beta/Client/GetPatchDeployment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/osconfig/apiv1beta/Client/GetPatchJob/main.go
+++ b/internal/generated/snippets/osconfig/apiv1beta/Client/GetPatchJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/osconfig/apiv1beta/Client/ListGuestPolicies/main.go
+++ b/internal/generated/snippets/osconfig/apiv1beta/Client/ListGuestPolicies/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/osconfig/apiv1beta/Client/ListPatchDeployments/main.go
+++ b/internal/generated/snippets/osconfig/apiv1beta/Client/ListPatchDeployments/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/osconfig/apiv1beta/Client/ListPatchJobInstanceDetails/main.go
+++ b/internal/generated/snippets/osconfig/apiv1beta/Client/ListPatchJobInstanceDetails/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/osconfig/apiv1beta/Client/ListPatchJobs/main.go
+++ b/internal/generated/snippets/osconfig/apiv1beta/Client/ListPatchJobs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/osconfig/apiv1beta/Client/LookupEffectiveGuestPolicy/main.go
+++ b/internal/generated/snippets/osconfig/apiv1beta/Client/LookupEffectiveGuestPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/osconfig/apiv1beta/Client/PausePatchDeployment/main.go
+++ b/internal/generated/snippets/osconfig/apiv1beta/Client/PausePatchDeployment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/osconfig/apiv1beta/Client/ResumePatchDeployment/main.go
+++ b/internal/generated/snippets/osconfig/apiv1beta/Client/ResumePatchDeployment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/osconfig/apiv1beta/Client/UpdateGuestPolicy/main.go
+++ b/internal/generated/snippets/osconfig/apiv1beta/Client/UpdateGuestPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/osconfig/apiv1beta/Client/UpdatePatchDeployment/main.go
+++ b/internal/generated/snippets/osconfig/apiv1beta/Client/UpdatePatchDeployment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oslogin/apiv1/Client/CreateSshPublicKey/main.go
+++ b/internal/generated/snippets/oslogin/apiv1/Client/CreateSshPublicKey/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oslogin/apiv1/Client/DeletePosixAccount/main.go
+++ b/internal/generated/snippets/oslogin/apiv1/Client/DeletePosixAccount/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oslogin/apiv1/Client/DeleteSshPublicKey/main.go
+++ b/internal/generated/snippets/oslogin/apiv1/Client/DeleteSshPublicKey/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oslogin/apiv1/Client/GetLoginProfile/main.go
+++ b/internal/generated/snippets/oslogin/apiv1/Client/GetLoginProfile/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oslogin/apiv1/Client/GetSshPublicKey/main.go
+++ b/internal/generated/snippets/oslogin/apiv1/Client/GetSshPublicKey/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oslogin/apiv1/Client/ImportSshPublicKey/main.go
+++ b/internal/generated/snippets/oslogin/apiv1/Client/ImportSshPublicKey/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oslogin/apiv1/Client/UpdateSshPublicKey/main.go
+++ b/internal/generated/snippets/oslogin/apiv1/Client/UpdateSshPublicKey/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oslogin/apiv1beta/Client/CreateSshPublicKey/main.go
+++ b/internal/generated/snippets/oslogin/apiv1beta/Client/CreateSshPublicKey/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oslogin/apiv1beta/Client/DeletePosixAccount/main.go
+++ b/internal/generated/snippets/oslogin/apiv1beta/Client/DeletePosixAccount/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oslogin/apiv1beta/Client/DeleteSshPublicKey/main.go
+++ b/internal/generated/snippets/oslogin/apiv1beta/Client/DeleteSshPublicKey/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oslogin/apiv1beta/Client/GetLoginProfile/main.go
+++ b/internal/generated/snippets/oslogin/apiv1beta/Client/GetLoginProfile/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oslogin/apiv1beta/Client/GetSshPublicKey/main.go
+++ b/internal/generated/snippets/oslogin/apiv1beta/Client/GetSshPublicKey/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oslogin/apiv1beta/Client/ImportSshPublicKey/main.go
+++ b/internal/generated/snippets/oslogin/apiv1beta/Client/ImportSshPublicKey/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oslogin/apiv1beta/Client/SignSshPublicKey/main.go
+++ b/internal/generated/snippets/oslogin/apiv1beta/Client/SignSshPublicKey/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/oslogin/apiv1beta/Client/UpdateSshPublicKey/main.go
+++ b/internal/generated/snippets/oslogin/apiv1beta/Client/UpdateSshPublicKey/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/parallelstore/apiv1/Client/CancelOperation/main.go
+++ b/internal/generated/snippets/parallelstore/apiv1/Client/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/parallelstore/apiv1/Client/CreateInstance/main.go
+++ b/internal/generated/snippets/parallelstore/apiv1/Client/CreateInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/parallelstore/apiv1/Client/DeleteInstance/main.go
+++ b/internal/generated/snippets/parallelstore/apiv1/Client/DeleteInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/parallelstore/apiv1/Client/DeleteOperation/main.go
+++ b/internal/generated/snippets/parallelstore/apiv1/Client/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/parallelstore/apiv1/Client/ExportData/main.go
+++ b/internal/generated/snippets/parallelstore/apiv1/Client/ExportData/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/parallelstore/apiv1/Client/GetInstance/main.go
+++ b/internal/generated/snippets/parallelstore/apiv1/Client/GetInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/parallelstore/apiv1/Client/GetLocation/main.go
+++ b/internal/generated/snippets/parallelstore/apiv1/Client/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/parallelstore/apiv1/Client/GetOperation/main.go
+++ b/internal/generated/snippets/parallelstore/apiv1/Client/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/parallelstore/apiv1/Client/ImportData/main.go
+++ b/internal/generated/snippets/parallelstore/apiv1/Client/ImportData/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/parallelstore/apiv1/Client/ListInstances/main.go
+++ b/internal/generated/snippets/parallelstore/apiv1/Client/ListInstances/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/parallelstore/apiv1/Client/ListLocations/main.go
+++ b/internal/generated/snippets/parallelstore/apiv1/Client/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/parallelstore/apiv1/Client/ListOperations/main.go
+++ b/internal/generated/snippets/parallelstore/apiv1/Client/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/parallelstore/apiv1/Client/UpdateInstance/main.go
+++ b/internal/generated/snippets/parallelstore/apiv1/Client/UpdateInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/parallelstore/apiv1beta/Client/CancelOperation/main.go
+++ b/internal/generated/snippets/parallelstore/apiv1beta/Client/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/parallelstore/apiv1beta/Client/CreateInstance/main.go
+++ b/internal/generated/snippets/parallelstore/apiv1beta/Client/CreateInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/parallelstore/apiv1beta/Client/DeleteInstance/main.go
+++ b/internal/generated/snippets/parallelstore/apiv1beta/Client/DeleteInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/parallelstore/apiv1beta/Client/DeleteOperation/main.go
+++ b/internal/generated/snippets/parallelstore/apiv1beta/Client/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/parallelstore/apiv1beta/Client/ExportData/main.go
+++ b/internal/generated/snippets/parallelstore/apiv1beta/Client/ExportData/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/parallelstore/apiv1beta/Client/GetInstance/main.go
+++ b/internal/generated/snippets/parallelstore/apiv1beta/Client/GetInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/parallelstore/apiv1beta/Client/GetLocation/main.go
+++ b/internal/generated/snippets/parallelstore/apiv1beta/Client/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/parallelstore/apiv1beta/Client/GetOperation/main.go
+++ b/internal/generated/snippets/parallelstore/apiv1beta/Client/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/parallelstore/apiv1beta/Client/ImportData/main.go
+++ b/internal/generated/snippets/parallelstore/apiv1beta/Client/ImportData/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/parallelstore/apiv1beta/Client/ListInstances/main.go
+++ b/internal/generated/snippets/parallelstore/apiv1beta/Client/ListInstances/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/parallelstore/apiv1beta/Client/ListLocations/main.go
+++ b/internal/generated/snippets/parallelstore/apiv1beta/Client/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/parallelstore/apiv1beta/Client/ListOperations/main.go
+++ b/internal/generated/snippets/parallelstore/apiv1beta/Client/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/parallelstore/apiv1beta/Client/UpdateInstance/main.go
+++ b/internal/generated/snippets/parallelstore/apiv1beta/Client/UpdateInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/parametermanager/apiv1/Client/CreateParameter/main.go
+++ b/internal/generated/snippets/parametermanager/apiv1/Client/CreateParameter/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/parametermanager/apiv1/Client/CreateParameterVersion/main.go
+++ b/internal/generated/snippets/parametermanager/apiv1/Client/CreateParameterVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/parametermanager/apiv1/Client/DeleteParameter/main.go
+++ b/internal/generated/snippets/parametermanager/apiv1/Client/DeleteParameter/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/parametermanager/apiv1/Client/DeleteParameterVersion/main.go
+++ b/internal/generated/snippets/parametermanager/apiv1/Client/DeleteParameterVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/parametermanager/apiv1/Client/GetLocation/main.go
+++ b/internal/generated/snippets/parametermanager/apiv1/Client/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/parametermanager/apiv1/Client/GetParameter/main.go
+++ b/internal/generated/snippets/parametermanager/apiv1/Client/GetParameter/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/parametermanager/apiv1/Client/GetParameterVersion/main.go
+++ b/internal/generated/snippets/parametermanager/apiv1/Client/GetParameterVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/parametermanager/apiv1/Client/ListLocations/main.go
+++ b/internal/generated/snippets/parametermanager/apiv1/Client/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/parametermanager/apiv1/Client/ListParameterVersions/main.go
+++ b/internal/generated/snippets/parametermanager/apiv1/Client/ListParameterVersions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/parametermanager/apiv1/Client/ListParameters/main.go
+++ b/internal/generated/snippets/parametermanager/apiv1/Client/ListParameters/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/parametermanager/apiv1/Client/RenderParameterVersion/main.go
+++ b/internal/generated/snippets/parametermanager/apiv1/Client/RenderParameterVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/parametermanager/apiv1/Client/UpdateParameter/main.go
+++ b/internal/generated/snippets/parametermanager/apiv1/Client/UpdateParameter/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/parametermanager/apiv1/Client/UpdateParameterVersion/main.go
+++ b/internal/generated/snippets/parametermanager/apiv1/Client/UpdateParameterVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/phishingprotection/apiv1beta1/PhishingProtectionServiceV1Beta1Client/ReportPhishing/main.go
+++ b/internal/generated/snippets/phishingprotection/apiv1beta1/PhishingProtectionServiceV1Beta1Client/ReportPhishing/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/policysimulator/apiv1/OrgPolicyViolationsPreviewClient/CreateOrgPolicyViolationsPreview/main.go
+++ b/internal/generated/snippets/policysimulator/apiv1/OrgPolicyViolationsPreviewClient/CreateOrgPolicyViolationsPreview/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/policysimulator/apiv1/OrgPolicyViolationsPreviewClient/GetOperation/main.go
+++ b/internal/generated/snippets/policysimulator/apiv1/OrgPolicyViolationsPreviewClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/policysimulator/apiv1/OrgPolicyViolationsPreviewClient/GetOrgPolicyViolationsPreview/main.go
+++ b/internal/generated/snippets/policysimulator/apiv1/OrgPolicyViolationsPreviewClient/GetOrgPolicyViolationsPreview/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/policysimulator/apiv1/OrgPolicyViolationsPreviewClient/ListOperations/main.go
+++ b/internal/generated/snippets/policysimulator/apiv1/OrgPolicyViolationsPreviewClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/policysimulator/apiv1/OrgPolicyViolationsPreviewClient/ListOrgPolicyViolations/main.go
+++ b/internal/generated/snippets/policysimulator/apiv1/OrgPolicyViolationsPreviewClient/ListOrgPolicyViolations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/policysimulator/apiv1/OrgPolicyViolationsPreviewClient/ListOrgPolicyViolationsPreviews/main.go
+++ b/internal/generated/snippets/policysimulator/apiv1/OrgPolicyViolationsPreviewClient/ListOrgPolicyViolationsPreviews/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/policysimulator/apiv1/SimulatorClient/CreateReplay/main.go
+++ b/internal/generated/snippets/policysimulator/apiv1/SimulatorClient/CreateReplay/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/policysimulator/apiv1/SimulatorClient/GetOperation/main.go
+++ b/internal/generated/snippets/policysimulator/apiv1/SimulatorClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/policysimulator/apiv1/SimulatorClient/GetReplay/main.go
+++ b/internal/generated/snippets/policysimulator/apiv1/SimulatorClient/GetReplay/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/policysimulator/apiv1/SimulatorClient/ListOperations/main.go
+++ b/internal/generated/snippets/policysimulator/apiv1/SimulatorClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/policysimulator/apiv1/SimulatorClient/ListReplayResults/main.go
+++ b/internal/generated/snippets/policysimulator/apiv1/SimulatorClient/ListReplayResults/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/policytroubleshooter/apiv1/IamCheckerClient/TroubleshootIamPolicy/main.go
+++ b/internal/generated/snippets/policytroubleshooter/apiv1/IamCheckerClient/TroubleshootIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/policytroubleshooter/iam/apiv3/PolicyTroubleshooterClient/TroubleshootIamPolicy/main.go
+++ b/internal/generated/snippets/policytroubleshooter/iam/apiv3/PolicyTroubleshooterClient/TroubleshootIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/privatecatalog/apiv1beta1/Client/SearchCatalogs/main.go
+++ b/internal/generated/snippets/privatecatalog/apiv1beta1/Client/SearchCatalogs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/privatecatalog/apiv1beta1/Client/SearchProducts/main.go
+++ b/internal/generated/snippets/privatecatalog/apiv1beta1/Client/SearchProducts/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/privatecatalog/apiv1beta1/Client/SearchVersions/main.go
+++ b/internal/generated/snippets/privatecatalog/apiv1beta1/Client/SearchVersions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/privilegedaccessmanager/apiv1/Client/ApproveGrant/main.go
+++ b/internal/generated/snippets/privilegedaccessmanager/apiv1/Client/ApproveGrant/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/privilegedaccessmanager/apiv1/Client/CheckOnboardingStatus/main.go
+++ b/internal/generated/snippets/privilegedaccessmanager/apiv1/Client/CheckOnboardingStatus/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/privilegedaccessmanager/apiv1/Client/CreateEntitlement/main.go
+++ b/internal/generated/snippets/privilegedaccessmanager/apiv1/Client/CreateEntitlement/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/privilegedaccessmanager/apiv1/Client/CreateGrant/main.go
+++ b/internal/generated/snippets/privilegedaccessmanager/apiv1/Client/CreateGrant/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/privilegedaccessmanager/apiv1/Client/DeleteEntitlement/main.go
+++ b/internal/generated/snippets/privilegedaccessmanager/apiv1/Client/DeleteEntitlement/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/privilegedaccessmanager/apiv1/Client/DeleteOperation/main.go
+++ b/internal/generated/snippets/privilegedaccessmanager/apiv1/Client/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/privilegedaccessmanager/apiv1/Client/DenyGrant/main.go
+++ b/internal/generated/snippets/privilegedaccessmanager/apiv1/Client/DenyGrant/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/privilegedaccessmanager/apiv1/Client/GetEntitlement/main.go
+++ b/internal/generated/snippets/privilegedaccessmanager/apiv1/Client/GetEntitlement/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/privilegedaccessmanager/apiv1/Client/GetGrant/main.go
+++ b/internal/generated/snippets/privilegedaccessmanager/apiv1/Client/GetGrant/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/privilegedaccessmanager/apiv1/Client/GetLocation/main.go
+++ b/internal/generated/snippets/privilegedaccessmanager/apiv1/Client/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/privilegedaccessmanager/apiv1/Client/GetOperation/main.go
+++ b/internal/generated/snippets/privilegedaccessmanager/apiv1/Client/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/privilegedaccessmanager/apiv1/Client/ListEntitlements/main.go
+++ b/internal/generated/snippets/privilegedaccessmanager/apiv1/Client/ListEntitlements/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/privilegedaccessmanager/apiv1/Client/ListGrants/main.go
+++ b/internal/generated/snippets/privilegedaccessmanager/apiv1/Client/ListGrants/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/privilegedaccessmanager/apiv1/Client/ListLocations/main.go
+++ b/internal/generated/snippets/privilegedaccessmanager/apiv1/Client/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/privilegedaccessmanager/apiv1/Client/ListOperations/main.go
+++ b/internal/generated/snippets/privilegedaccessmanager/apiv1/Client/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/privilegedaccessmanager/apiv1/Client/RevokeGrant/main.go
+++ b/internal/generated/snippets/privilegedaccessmanager/apiv1/Client/RevokeGrant/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/privilegedaccessmanager/apiv1/Client/SearchEntitlements/main.go
+++ b/internal/generated/snippets/privilegedaccessmanager/apiv1/Client/SearchEntitlements/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/privilegedaccessmanager/apiv1/Client/SearchGrants/main.go
+++ b/internal/generated/snippets/privilegedaccessmanager/apiv1/Client/SearchGrants/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/privilegedaccessmanager/apiv1/Client/UpdateEntitlement/main.go
+++ b/internal/generated/snippets/privilegedaccessmanager/apiv1/Client/UpdateEntitlement/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/pubsublite/apiv1/AdminClient/CancelOperation/main.go
+++ b/internal/generated/snippets/pubsublite/apiv1/AdminClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/pubsublite/apiv1/AdminClient/CreateReservation/main.go
+++ b/internal/generated/snippets/pubsublite/apiv1/AdminClient/CreateReservation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/pubsublite/apiv1/AdminClient/CreateSubscription/main.go
+++ b/internal/generated/snippets/pubsublite/apiv1/AdminClient/CreateSubscription/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/pubsublite/apiv1/AdminClient/CreateTopic/main.go
+++ b/internal/generated/snippets/pubsublite/apiv1/AdminClient/CreateTopic/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/pubsublite/apiv1/AdminClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/pubsublite/apiv1/AdminClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/pubsublite/apiv1/AdminClient/DeleteReservation/main.go
+++ b/internal/generated/snippets/pubsublite/apiv1/AdminClient/DeleteReservation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/pubsublite/apiv1/AdminClient/DeleteSubscription/main.go
+++ b/internal/generated/snippets/pubsublite/apiv1/AdminClient/DeleteSubscription/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/pubsublite/apiv1/AdminClient/DeleteTopic/main.go
+++ b/internal/generated/snippets/pubsublite/apiv1/AdminClient/DeleteTopic/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/pubsublite/apiv1/AdminClient/GetOperation/main.go
+++ b/internal/generated/snippets/pubsublite/apiv1/AdminClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/pubsublite/apiv1/AdminClient/GetReservation/main.go
+++ b/internal/generated/snippets/pubsublite/apiv1/AdminClient/GetReservation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/pubsublite/apiv1/AdminClient/GetSubscription/main.go
+++ b/internal/generated/snippets/pubsublite/apiv1/AdminClient/GetSubscription/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/pubsublite/apiv1/AdminClient/GetTopic/main.go
+++ b/internal/generated/snippets/pubsublite/apiv1/AdminClient/GetTopic/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/pubsublite/apiv1/AdminClient/GetTopicPartitions/main.go
+++ b/internal/generated/snippets/pubsublite/apiv1/AdminClient/GetTopicPartitions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/pubsublite/apiv1/AdminClient/ListOperations/main.go
+++ b/internal/generated/snippets/pubsublite/apiv1/AdminClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/pubsublite/apiv1/AdminClient/ListReservationTopics/main.go
+++ b/internal/generated/snippets/pubsublite/apiv1/AdminClient/ListReservationTopics/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/pubsublite/apiv1/AdminClient/ListReservations/main.go
+++ b/internal/generated/snippets/pubsublite/apiv1/AdminClient/ListReservations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/pubsublite/apiv1/AdminClient/ListSubscriptions/main.go
+++ b/internal/generated/snippets/pubsublite/apiv1/AdminClient/ListSubscriptions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/pubsublite/apiv1/AdminClient/ListTopicSubscriptions/main.go
+++ b/internal/generated/snippets/pubsublite/apiv1/AdminClient/ListTopicSubscriptions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/pubsublite/apiv1/AdminClient/ListTopics/main.go
+++ b/internal/generated/snippets/pubsublite/apiv1/AdminClient/ListTopics/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/pubsublite/apiv1/AdminClient/SeekSubscription/main.go
+++ b/internal/generated/snippets/pubsublite/apiv1/AdminClient/SeekSubscription/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/pubsublite/apiv1/AdminClient/UpdateReservation/main.go
+++ b/internal/generated/snippets/pubsublite/apiv1/AdminClient/UpdateReservation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/pubsublite/apiv1/AdminClient/UpdateSubscription/main.go
+++ b/internal/generated/snippets/pubsublite/apiv1/AdminClient/UpdateSubscription/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/pubsublite/apiv1/AdminClient/UpdateTopic/main.go
+++ b/internal/generated/snippets/pubsublite/apiv1/AdminClient/UpdateTopic/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/pubsublite/apiv1/CursorClient/CancelOperation/main.go
+++ b/internal/generated/snippets/pubsublite/apiv1/CursorClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/pubsublite/apiv1/CursorClient/CommitCursor/main.go
+++ b/internal/generated/snippets/pubsublite/apiv1/CursorClient/CommitCursor/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/pubsublite/apiv1/CursorClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/pubsublite/apiv1/CursorClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/pubsublite/apiv1/CursorClient/GetOperation/main.go
+++ b/internal/generated/snippets/pubsublite/apiv1/CursorClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/pubsublite/apiv1/CursorClient/ListOperations/main.go
+++ b/internal/generated/snippets/pubsublite/apiv1/CursorClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/pubsublite/apiv1/CursorClient/ListPartitionCursors/main.go
+++ b/internal/generated/snippets/pubsublite/apiv1/CursorClient/ListPartitionCursors/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/pubsublite/apiv1/CursorClient/StreamingCommitCursor/main.go
+++ b/internal/generated/snippets/pubsublite/apiv1/CursorClient/StreamingCommitCursor/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/pubsublite/apiv1/PartitionAssignmentClient/AssignPartitions/main.go
+++ b/internal/generated/snippets/pubsublite/apiv1/PartitionAssignmentClient/AssignPartitions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/pubsublite/apiv1/PartitionAssignmentClient/CancelOperation/main.go
+++ b/internal/generated/snippets/pubsublite/apiv1/PartitionAssignmentClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/pubsublite/apiv1/PartitionAssignmentClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/pubsublite/apiv1/PartitionAssignmentClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/pubsublite/apiv1/PartitionAssignmentClient/GetOperation/main.go
+++ b/internal/generated/snippets/pubsublite/apiv1/PartitionAssignmentClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/pubsublite/apiv1/PartitionAssignmentClient/ListOperations/main.go
+++ b/internal/generated/snippets/pubsublite/apiv1/PartitionAssignmentClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/pubsublite/apiv1/PublisherClient/CancelOperation/main.go
+++ b/internal/generated/snippets/pubsublite/apiv1/PublisherClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/pubsublite/apiv1/PublisherClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/pubsublite/apiv1/PublisherClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/pubsublite/apiv1/PublisherClient/GetOperation/main.go
+++ b/internal/generated/snippets/pubsublite/apiv1/PublisherClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/pubsublite/apiv1/PublisherClient/ListOperations/main.go
+++ b/internal/generated/snippets/pubsublite/apiv1/PublisherClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/pubsublite/apiv1/PublisherClient/Publish/main.go
+++ b/internal/generated/snippets/pubsublite/apiv1/PublisherClient/Publish/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/pubsublite/apiv1/SubscriberClient/CancelOperation/main.go
+++ b/internal/generated/snippets/pubsublite/apiv1/SubscriberClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/pubsublite/apiv1/SubscriberClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/pubsublite/apiv1/SubscriberClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/pubsublite/apiv1/SubscriberClient/GetOperation/main.go
+++ b/internal/generated/snippets/pubsublite/apiv1/SubscriberClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/pubsublite/apiv1/SubscriberClient/ListOperations/main.go
+++ b/internal/generated/snippets/pubsublite/apiv1/SubscriberClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/pubsublite/apiv1/SubscriberClient/Subscribe/main.go
+++ b/internal/generated/snippets/pubsublite/apiv1/SubscriberClient/Subscribe/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/pubsublite/apiv1/TopicStatsClient/CancelOperation/main.go
+++ b/internal/generated/snippets/pubsublite/apiv1/TopicStatsClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/pubsublite/apiv1/TopicStatsClient/ComputeHeadCursor/main.go
+++ b/internal/generated/snippets/pubsublite/apiv1/TopicStatsClient/ComputeHeadCursor/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/pubsublite/apiv1/TopicStatsClient/ComputeMessageStats/main.go
+++ b/internal/generated/snippets/pubsublite/apiv1/TopicStatsClient/ComputeMessageStats/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/pubsublite/apiv1/TopicStatsClient/ComputeTimeCursor/main.go
+++ b/internal/generated/snippets/pubsublite/apiv1/TopicStatsClient/ComputeTimeCursor/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/pubsublite/apiv1/TopicStatsClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/pubsublite/apiv1/TopicStatsClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/pubsublite/apiv1/TopicStatsClient/GetOperation/main.go
+++ b/internal/generated/snippets/pubsublite/apiv1/TopicStatsClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/pubsublite/apiv1/TopicStatsClient/ListOperations/main.go
+++ b/internal/generated/snippets/pubsublite/apiv1/TopicStatsClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/rapidmigrationassessment/apiv1/Client/CancelOperation/main.go
+++ b/internal/generated/snippets/rapidmigrationassessment/apiv1/Client/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/rapidmigrationassessment/apiv1/Client/CreateAnnotation/main.go
+++ b/internal/generated/snippets/rapidmigrationassessment/apiv1/Client/CreateAnnotation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/rapidmigrationassessment/apiv1/Client/CreateCollector/main.go
+++ b/internal/generated/snippets/rapidmigrationassessment/apiv1/Client/CreateCollector/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/rapidmigrationassessment/apiv1/Client/DeleteCollector/main.go
+++ b/internal/generated/snippets/rapidmigrationassessment/apiv1/Client/DeleteCollector/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/rapidmigrationassessment/apiv1/Client/DeleteOperation/main.go
+++ b/internal/generated/snippets/rapidmigrationassessment/apiv1/Client/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/rapidmigrationassessment/apiv1/Client/GetAnnotation/main.go
+++ b/internal/generated/snippets/rapidmigrationassessment/apiv1/Client/GetAnnotation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/rapidmigrationassessment/apiv1/Client/GetCollector/main.go
+++ b/internal/generated/snippets/rapidmigrationassessment/apiv1/Client/GetCollector/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/rapidmigrationassessment/apiv1/Client/GetLocation/main.go
+++ b/internal/generated/snippets/rapidmigrationassessment/apiv1/Client/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/rapidmigrationassessment/apiv1/Client/GetOperation/main.go
+++ b/internal/generated/snippets/rapidmigrationassessment/apiv1/Client/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/rapidmigrationassessment/apiv1/Client/ListCollectors/main.go
+++ b/internal/generated/snippets/rapidmigrationassessment/apiv1/Client/ListCollectors/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/rapidmigrationassessment/apiv1/Client/ListLocations/main.go
+++ b/internal/generated/snippets/rapidmigrationassessment/apiv1/Client/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/rapidmigrationassessment/apiv1/Client/ListOperations/main.go
+++ b/internal/generated/snippets/rapidmigrationassessment/apiv1/Client/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/rapidmigrationassessment/apiv1/Client/PauseCollector/main.go
+++ b/internal/generated/snippets/rapidmigrationassessment/apiv1/Client/PauseCollector/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/rapidmigrationassessment/apiv1/Client/RegisterCollector/main.go
+++ b/internal/generated/snippets/rapidmigrationassessment/apiv1/Client/RegisterCollector/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/rapidmigrationassessment/apiv1/Client/ResumeCollector/main.go
+++ b/internal/generated/snippets/rapidmigrationassessment/apiv1/Client/ResumeCollector/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/rapidmigrationassessment/apiv1/Client/UpdateCollector/main.go
+++ b/internal/generated/snippets/rapidmigrationassessment/apiv1/Client/UpdateCollector/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/recaptchaenterprise/apiv1/Client/AddIpOverride/main.go
+++ b/internal/generated/snippets/recaptchaenterprise/apiv1/Client/AddIpOverride/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/recaptchaenterprise/apiv1/Client/AnnotateAssessment/main.go
+++ b/internal/generated/snippets/recaptchaenterprise/apiv1/Client/AnnotateAssessment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/recaptchaenterprise/apiv1/Client/CreateAssessment/main.go
+++ b/internal/generated/snippets/recaptchaenterprise/apiv1/Client/CreateAssessment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/recaptchaenterprise/apiv1/Client/CreateFirewallPolicy/main.go
+++ b/internal/generated/snippets/recaptchaenterprise/apiv1/Client/CreateFirewallPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/recaptchaenterprise/apiv1/Client/CreateKey/main.go
+++ b/internal/generated/snippets/recaptchaenterprise/apiv1/Client/CreateKey/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/recaptchaenterprise/apiv1/Client/DeleteFirewallPolicy/main.go
+++ b/internal/generated/snippets/recaptchaenterprise/apiv1/Client/DeleteFirewallPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/recaptchaenterprise/apiv1/Client/DeleteKey/main.go
+++ b/internal/generated/snippets/recaptchaenterprise/apiv1/Client/DeleteKey/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/recaptchaenterprise/apiv1/Client/GetFirewallPolicy/main.go
+++ b/internal/generated/snippets/recaptchaenterprise/apiv1/Client/GetFirewallPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/recaptchaenterprise/apiv1/Client/GetKey/main.go
+++ b/internal/generated/snippets/recaptchaenterprise/apiv1/Client/GetKey/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/recaptchaenterprise/apiv1/Client/GetMetrics/main.go
+++ b/internal/generated/snippets/recaptchaenterprise/apiv1/Client/GetMetrics/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/recaptchaenterprise/apiv1/Client/ListFirewallPolicies/main.go
+++ b/internal/generated/snippets/recaptchaenterprise/apiv1/Client/ListFirewallPolicies/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/recaptchaenterprise/apiv1/Client/ListIpOverrides/main.go
+++ b/internal/generated/snippets/recaptchaenterprise/apiv1/Client/ListIpOverrides/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/recaptchaenterprise/apiv1/Client/ListKeys/main.go
+++ b/internal/generated/snippets/recaptchaenterprise/apiv1/Client/ListKeys/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/recaptchaenterprise/apiv1/Client/ListRelatedAccountGroupMemberships/main.go
+++ b/internal/generated/snippets/recaptchaenterprise/apiv1/Client/ListRelatedAccountGroupMemberships/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/recaptchaenterprise/apiv1/Client/ListRelatedAccountGroups/main.go
+++ b/internal/generated/snippets/recaptchaenterprise/apiv1/Client/ListRelatedAccountGroups/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/recaptchaenterprise/apiv1/Client/MigrateKey/main.go
+++ b/internal/generated/snippets/recaptchaenterprise/apiv1/Client/MigrateKey/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/recaptchaenterprise/apiv1/Client/RemoveIpOverride/main.go
+++ b/internal/generated/snippets/recaptchaenterprise/apiv1/Client/RemoveIpOverride/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/recaptchaenterprise/apiv1/Client/ReorderFirewallPolicies/main.go
+++ b/internal/generated/snippets/recaptchaenterprise/apiv1/Client/ReorderFirewallPolicies/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/recaptchaenterprise/apiv1/Client/RetrieveLegacySecretKey/main.go
+++ b/internal/generated/snippets/recaptchaenterprise/apiv1/Client/RetrieveLegacySecretKey/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/recaptchaenterprise/apiv1/Client/SearchRelatedAccountGroupMemberships/main.go
+++ b/internal/generated/snippets/recaptchaenterprise/apiv1/Client/SearchRelatedAccountGroupMemberships/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/recaptchaenterprise/apiv1/Client/UpdateFirewallPolicy/main.go
+++ b/internal/generated/snippets/recaptchaenterprise/apiv1/Client/UpdateFirewallPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/recaptchaenterprise/apiv1/Client/UpdateKey/main.go
+++ b/internal/generated/snippets/recaptchaenterprise/apiv1/Client/UpdateKey/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/recaptchaenterprise/apiv1beta1/RecaptchaEnterpriseServiceV1Beta1Client/AnnotateAssessment/main.go
+++ b/internal/generated/snippets/recaptchaenterprise/apiv1beta1/RecaptchaEnterpriseServiceV1Beta1Client/AnnotateAssessment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/recaptchaenterprise/apiv1beta1/RecaptchaEnterpriseServiceV1Beta1Client/CreateAssessment/main.go
+++ b/internal/generated/snippets/recaptchaenterprise/apiv1beta1/RecaptchaEnterpriseServiceV1Beta1Client/CreateAssessment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/recommendationengine/apiv1beta1/CatalogClient/CreateCatalogItem/main.go
+++ b/internal/generated/snippets/recommendationengine/apiv1beta1/CatalogClient/CreateCatalogItem/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/recommendationengine/apiv1beta1/CatalogClient/DeleteCatalogItem/main.go
+++ b/internal/generated/snippets/recommendationengine/apiv1beta1/CatalogClient/DeleteCatalogItem/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/recommendationengine/apiv1beta1/CatalogClient/GetCatalogItem/main.go
+++ b/internal/generated/snippets/recommendationengine/apiv1beta1/CatalogClient/GetCatalogItem/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/recommendationengine/apiv1beta1/CatalogClient/ImportCatalogItems/main.go
+++ b/internal/generated/snippets/recommendationengine/apiv1beta1/CatalogClient/ImportCatalogItems/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/recommendationengine/apiv1beta1/CatalogClient/ListCatalogItems/main.go
+++ b/internal/generated/snippets/recommendationengine/apiv1beta1/CatalogClient/ListCatalogItems/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/recommendationengine/apiv1beta1/CatalogClient/UpdateCatalogItem/main.go
+++ b/internal/generated/snippets/recommendationengine/apiv1beta1/CatalogClient/UpdateCatalogItem/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/recommendationengine/apiv1beta1/PredictionApiKeyRegistryClient/CreatePredictionApiKeyRegistration/main.go
+++ b/internal/generated/snippets/recommendationengine/apiv1beta1/PredictionApiKeyRegistryClient/CreatePredictionApiKeyRegistration/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/recommendationengine/apiv1beta1/PredictionApiKeyRegistryClient/DeletePredictionApiKeyRegistration/main.go
+++ b/internal/generated/snippets/recommendationengine/apiv1beta1/PredictionApiKeyRegistryClient/DeletePredictionApiKeyRegistration/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/recommendationengine/apiv1beta1/PredictionApiKeyRegistryClient/ListPredictionApiKeyRegistrations/main.go
+++ b/internal/generated/snippets/recommendationengine/apiv1beta1/PredictionApiKeyRegistryClient/ListPredictionApiKeyRegistrations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/recommendationengine/apiv1beta1/PredictionClient/Predict/main.go
+++ b/internal/generated/snippets/recommendationengine/apiv1beta1/PredictionClient/Predict/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/recommendationengine/apiv1beta1/UserEventClient/CollectUserEvent/main.go
+++ b/internal/generated/snippets/recommendationengine/apiv1beta1/UserEventClient/CollectUserEvent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/recommendationengine/apiv1beta1/UserEventClient/ImportUserEvents/main.go
+++ b/internal/generated/snippets/recommendationengine/apiv1beta1/UserEventClient/ImportUserEvents/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/recommendationengine/apiv1beta1/UserEventClient/ListUserEvents/main.go
+++ b/internal/generated/snippets/recommendationengine/apiv1beta1/UserEventClient/ListUserEvents/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/recommendationengine/apiv1beta1/UserEventClient/PurgeUserEvents/main.go
+++ b/internal/generated/snippets/recommendationengine/apiv1beta1/UserEventClient/PurgeUserEvents/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/recommendationengine/apiv1beta1/UserEventClient/WriteUserEvent/main.go
+++ b/internal/generated/snippets/recommendationengine/apiv1beta1/UserEventClient/WriteUserEvent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/recommender/apiv1/Client/GetInsight/main.go
+++ b/internal/generated/snippets/recommender/apiv1/Client/GetInsight/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/recommender/apiv1/Client/GetInsightTypeConfig/main.go
+++ b/internal/generated/snippets/recommender/apiv1/Client/GetInsightTypeConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/recommender/apiv1/Client/GetRecommendation/main.go
+++ b/internal/generated/snippets/recommender/apiv1/Client/GetRecommendation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/recommender/apiv1/Client/GetRecommenderConfig/main.go
+++ b/internal/generated/snippets/recommender/apiv1/Client/GetRecommenderConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/recommender/apiv1/Client/ListInsights/main.go
+++ b/internal/generated/snippets/recommender/apiv1/Client/ListInsights/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/recommender/apiv1/Client/ListRecommendations/main.go
+++ b/internal/generated/snippets/recommender/apiv1/Client/ListRecommendations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/recommender/apiv1/Client/MarkInsightAccepted/main.go
+++ b/internal/generated/snippets/recommender/apiv1/Client/MarkInsightAccepted/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/recommender/apiv1/Client/MarkRecommendationClaimed/main.go
+++ b/internal/generated/snippets/recommender/apiv1/Client/MarkRecommendationClaimed/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/recommender/apiv1/Client/MarkRecommendationDismissed/main.go
+++ b/internal/generated/snippets/recommender/apiv1/Client/MarkRecommendationDismissed/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/recommender/apiv1/Client/MarkRecommendationFailed/main.go
+++ b/internal/generated/snippets/recommender/apiv1/Client/MarkRecommendationFailed/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/recommender/apiv1/Client/MarkRecommendationSucceeded/main.go
+++ b/internal/generated/snippets/recommender/apiv1/Client/MarkRecommendationSucceeded/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/recommender/apiv1/Client/UpdateInsightTypeConfig/main.go
+++ b/internal/generated/snippets/recommender/apiv1/Client/UpdateInsightTypeConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/recommender/apiv1/Client/UpdateRecommenderConfig/main.go
+++ b/internal/generated/snippets/recommender/apiv1/Client/UpdateRecommenderConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/recommender/apiv1beta1/Client/GetInsight/main.go
+++ b/internal/generated/snippets/recommender/apiv1beta1/Client/GetInsight/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/recommender/apiv1beta1/Client/GetInsightTypeConfig/main.go
+++ b/internal/generated/snippets/recommender/apiv1beta1/Client/GetInsightTypeConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/recommender/apiv1beta1/Client/GetRecommendation/main.go
+++ b/internal/generated/snippets/recommender/apiv1beta1/Client/GetRecommendation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/recommender/apiv1beta1/Client/GetRecommenderConfig/main.go
+++ b/internal/generated/snippets/recommender/apiv1beta1/Client/GetRecommenderConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/recommender/apiv1beta1/Client/ListInsightTypes/main.go
+++ b/internal/generated/snippets/recommender/apiv1beta1/Client/ListInsightTypes/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/recommender/apiv1beta1/Client/ListInsights/main.go
+++ b/internal/generated/snippets/recommender/apiv1beta1/Client/ListInsights/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/recommender/apiv1beta1/Client/ListRecommendations/main.go
+++ b/internal/generated/snippets/recommender/apiv1beta1/Client/ListRecommendations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/recommender/apiv1beta1/Client/ListRecommenders/main.go
+++ b/internal/generated/snippets/recommender/apiv1beta1/Client/ListRecommenders/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/recommender/apiv1beta1/Client/MarkInsightAccepted/main.go
+++ b/internal/generated/snippets/recommender/apiv1beta1/Client/MarkInsightAccepted/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/recommender/apiv1beta1/Client/MarkRecommendationClaimed/main.go
+++ b/internal/generated/snippets/recommender/apiv1beta1/Client/MarkRecommendationClaimed/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/recommender/apiv1beta1/Client/MarkRecommendationFailed/main.go
+++ b/internal/generated/snippets/recommender/apiv1beta1/Client/MarkRecommendationFailed/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/recommender/apiv1beta1/Client/MarkRecommendationSucceeded/main.go
+++ b/internal/generated/snippets/recommender/apiv1beta1/Client/MarkRecommendationSucceeded/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/recommender/apiv1beta1/Client/UpdateInsightTypeConfig/main.go
+++ b/internal/generated/snippets/recommender/apiv1beta1/Client/UpdateInsightTypeConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/recommender/apiv1beta1/Client/UpdateRecommenderConfig/main.go
+++ b/internal/generated/snippets/recommender/apiv1beta1/Client/UpdateRecommenderConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/redis/apiv1/CloudRedisClient/CancelOperation/main.go
+++ b/internal/generated/snippets/redis/apiv1/CloudRedisClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/redis/apiv1/CloudRedisClient/CreateInstance/main.go
+++ b/internal/generated/snippets/redis/apiv1/CloudRedisClient/CreateInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/redis/apiv1/CloudRedisClient/DeleteInstance/main.go
+++ b/internal/generated/snippets/redis/apiv1/CloudRedisClient/DeleteInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/redis/apiv1/CloudRedisClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/redis/apiv1/CloudRedisClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/redis/apiv1/CloudRedisClient/ExportInstance/main.go
+++ b/internal/generated/snippets/redis/apiv1/CloudRedisClient/ExportInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/redis/apiv1/CloudRedisClient/FailoverInstance/main.go
+++ b/internal/generated/snippets/redis/apiv1/CloudRedisClient/FailoverInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/redis/apiv1/CloudRedisClient/GetInstance/main.go
+++ b/internal/generated/snippets/redis/apiv1/CloudRedisClient/GetInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/redis/apiv1/CloudRedisClient/GetInstanceAuthString/main.go
+++ b/internal/generated/snippets/redis/apiv1/CloudRedisClient/GetInstanceAuthString/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/redis/apiv1/CloudRedisClient/GetLocation/main.go
+++ b/internal/generated/snippets/redis/apiv1/CloudRedisClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/redis/apiv1/CloudRedisClient/GetOperation/main.go
+++ b/internal/generated/snippets/redis/apiv1/CloudRedisClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/redis/apiv1/CloudRedisClient/ImportInstance/main.go
+++ b/internal/generated/snippets/redis/apiv1/CloudRedisClient/ImportInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/redis/apiv1/CloudRedisClient/ListInstances/main.go
+++ b/internal/generated/snippets/redis/apiv1/CloudRedisClient/ListInstances/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/redis/apiv1/CloudRedisClient/ListLocations/main.go
+++ b/internal/generated/snippets/redis/apiv1/CloudRedisClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/redis/apiv1/CloudRedisClient/ListOperations/main.go
+++ b/internal/generated/snippets/redis/apiv1/CloudRedisClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/redis/apiv1/CloudRedisClient/RescheduleMaintenance/main.go
+++ b/internal/generated/snippets/redis/apiv1/CloudRedisClient/RescheduleMaintenance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/redis/apiv1/CloudRedisClient/UpdateInstance/main.go
+++ b/internal/generated/snippets/redis/apiv1/CloudRedisClient/UpdateInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/redis/apiv1/CloudRedisClient/UpgradeInstance/main.go
+++ b/internal/generated/snippets/redis/apiv1/CloudRedisClient/UpgradeInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/redis/apiv1beta1/CloudRedisClient/CreateInstance/main.go
+++ b/internal/generated/snippets/redis/apiv1beta1/CloudRedisClient/CreateInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/redis/apiv1beta1/CloudRedisClient/DeleteInstance/main.go
+++ b/internal/generated/snippets/redis/apiv1beta1/CloudRedisClient/DeleteInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/redis/apiv1beta1/CloudRedisClient/ExportInstance/main.go
+++ b/internal/generated/snippets/redis/apiv1beta1/CloudRedisClient/ExportInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/redis/apiv1beta1/CloudRedisClient/FailoverInstance/main.go
+++ b/internal/generated/snippets/redis/apiv1beta1/CloudRedisClient/FailoverInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/redis/apiv1beta1/CloudRedisClient/GetInstance/main.go
+++ b/internal/generated/snippets/redis/apiv1beta1/CloudRedisClient/GetInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/redis/apiv1beta1/CloudRedisClient/GetInstanceAuthString/main.go
+++ b/internal/generated/snippets/redis/apiv1beta1/CloudRedisClient/GetInstanceAuthString/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/redis/apiv1beta1/CloudRedisClient/ImportInstance/main.go
+++ b/internal/generated/snippets/redis/apiv1beta1/CloudRedisClient/ImportInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/redis/apiv1beta1/CloudRedisClient/ListInstances/main.go
+++ b/internal/generated/snippets/redis/apiv1beta1/CloudRedisClient/ListInstances/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/redis/apiv1beta1/CloudRedisClient/RescheduleMaintenance/main.go
+++ b/internal/generated/snippets/redis/apiv1beta1/CloudRedisClient/RescheduleMaintenance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/redis/apiv1beta1/CloudRedisClient/UpdateInstance/main.go
+++ b/internal/generated/snippets/redis/apiv1beta1/CloudRedisClient/UpdateInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/redis/apiv1beta1/CloudRedisClient/UpgradeInstance/main.go
+++ b/internal/generated/snippets/redis/apiv1beta1/CloudRedisClient/UpgradeInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/redis/cluster/apiv1/CloudRedisClusterClient/BackupCluster/main.go
+++ b/internal/generated/snippets/redis/cluster/apiv1/CloudRedisClusterClient/BackupCluster/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/redis/cluster/apiv1/CloudRedisClusterClient/CancelOperation/main.go
+++ b/internal/generated/snippets/redis/cluster/apiv1/CloudRedisClusterClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/redis/cluster/apiv1/CloudRedisClusterClient/CreateCluster/main.go
+++ b/internal/generated/snippets/redis/cluster/apiv1/CloudRedisClusterClient/CreateCluster/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/redis/cluster/apiv1/CloudRedisClusterClient/DeleteBackup/main.go
+++ b/internal/generated/snippets/redis/cluster/apiv1/CloudRedisClusterClient/DeleteBackup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/redis/cluster/apiv1/CloudRedisClusterClient/DeleteCluster/main.go
+++ b/internal/generated/snippets/redis/cluster/apiv1/CloudRedisClusterClient/DeleteCluster/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/redis/cluster/apiv1/CloudRedisClusterClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/redis/cluster/apiv1/CloudRedisClusterClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/redis/cluster/apiv1/CloudRedisClusterClient/ExportBackup/main.go
+++ b/internal/generated/snippets/redis/cluster/apiv1/CloudRedisClusterClient/ExportBackup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/redis/cluster/apiv1/CloudRedisClusterClient/GetBackup/main.go
+++ b/internal/generated/snippets/redis/cluster/apiv1/CloudRedisClusterClient/GetBackup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/redis/cluster/apiv1/CloudRedisClusterClient/GetBackupCollection/main.go
+++ b/internal/generated/snippets/redis/cluster/apiv1/CloudRedisClusterClient/GetBackupCollection/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/redis/cluster/apiv1/CloudRedisClusterClient/GetCluster/main.go
+++ b/internal/generated/snippets/redis/cluster/apiv1/CloudRedisClusterClient/GetCluster/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/redis/cluster/apiv1/CloudRedisClusterClient/GetClusterCertificateAuthority/main.go
+++ b/internal/generated/snippets/redis/cluster/apiv1/CloudRedisClusterClient/GetClusterCertificateAuthority/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/redis/cluster/apiv1/CloudRedisClusterClient/GetLocation/main.go
+++ b/internal/generated/snippets/redis/cluster/apiv1/CloudRedisClusterClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/redis/cluster/apiv1/CloudRedisClusterClient/GetOperation/main.go
+++ b/internal/generated/snippets/redis/cluster/apiv1/CloudRedisClusterClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/redis/cluster/apiv1/CloudRedisClusterClient/ListBackupCollections/main.go
+++ b/internal/generated/snippets/redis/cluster/apiv1/CloudRedisClusterClient/ListBackupCollections/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/redis/cluster/apiv1/CloudRedisClusterClient/ListBackups/main.go
+++ b/internal/generated/snippets/redis/cluster/apiv1/CloudRedisClusterClient/ListBackups/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/redis/cluster/apiv1/CloudRedisClusterClient/ListClusters/main.go
+++ b/internal/generated/snippets/redis/cluster/apiv1/CloudRedisClusterClient/ListClusters/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/redis/cluster/apiv1/CloudRedisClusterClient/ListLocations/main.go
+++ b/internal/generated/snippets/redis/cluster/apiv1/CloudRedisClusterClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/redis/cluster/apiv1/CloudRedisClusterClient/ListOperations/main.go
+++ b/internal/generated/snippets/redis/cluster/apiv1/CloudRedisClusterClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/redis/cluster/apiv1/CloudRedisClusterClient/RescheduleClusterMaintenance/main.go
+++ b/internal/generated/snippets/redis/cluster/apiv1/CloudRedisClusterClient/RescheduleClusterMaintenance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/redis/cluster/apiv1/CloudRedisClusterClient/UpdateCluster/main.go
+++ b/internal/generated/snippets/redis/cluster/apiv1/CloudRedisClusterClient/UpdateCluster/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/resourcemanager/apiv2/FoldersClient/CreateFolder/main.go
+++ b/internal/generated/snippets/resourcemanager/apiv2/FoldersClient/CreateFolder/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/resourcemanager/apiv2/FoldersClient/DeleteFolder/main.go
+++ b/internal/generated/snippets/resourcemanager/apiv2/FoldersClient/DeleteFolder/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/resourcemanager/apiv2/FoldersClient/GetFolder/main.go
+++ b/internal/generated/snippets/resourcemanager/apiv2/FoldersClient/GetFolder/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/resourcemanager/apiv2/FoldersClient/GetIamPolicy/main.go
+++ b/internal/generated/snippets/resourcemanager/apiv2/FoldersClient/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/resourcemanager/apiv2/FoldersClient/ListFolders/main.go
+++ b/internal/generated/snippets/resourcemanager/apiv2/FoldersClient/ListFolders/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/resourcemanager/apiv2/FoldersClient/MoveFolder/main.go
+++ b/internal/generated/snippets/resourcemanager/apiv2/FoldersClient/MoveFolder/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/resourcemanager/apiv2/FoldersClient/SearchFolders/main.go
+++ b/internal/generated/snippets/resourcemanager/apiv2/FoldersClient/SearchFolders/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/resourcemanager/apiv2/FoldersClient/SetIamPolicy/main.go
+++ b/internal/generated/snippets/resourcemanager/apiv2/FoldersClient/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/resourcemanager/apiv2/FoldersClient/TestIamPermissions/main.go
+++ b/internal/generated/snippets/resourcemanager/apiv2/FoldersClient/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/resourcemanager/apiv2/FoldersClient/UndeleteFolder/main.go
+++ b/internal/generated/snippets/resourcemanager/apiv2/FoldersClient/UndeleteFolder/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/resourcemanager/apiv2/FoldersClient/UpdateFolder/main.go
+++ b/internal/generated/snippets/resourcemanager/apiv2/FoldersClient/UpdateFolder/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/resourcemanager/apiv3/FoldersClient/CreateFolder/main.go
+++ b/internal/generated/snippets/resourcemanager/apiv3/FoldersClient/CreateFolder/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/resourcemanager/apiv3/FoldersClient/DeleteFolder/main.go
+++ b/internal/generated/snippets/resourcemanager/apiv3/FoldersClient/DeleteFolder/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/resourcemanager/apiv3/FoldersClient/GetFolder/main.go
+++ b/internal/generated/snippets/resourcemanager/apiv3/FoldersClient/GetFolder/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/resourcemanager/apiv3/FoldersClient/GetIamPolicy/main.go
+++ b/internal/generated/snippets/resourcemanager/apiv3/FoldersClient/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/resourcemanager/apiv3/FoldersClient/GetOperation/main.go
+++ b/internal/generated/snippets/resourcemanager/apiv3/FoldersClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/resourcemanager/apiv3/FoldersClient/ListFolders/main.go
+++ b/internal/generated/snippets/resourcemanager/apiv3/FoldersClient/ListFolders/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/resourcemanager/apiv3/FoldersClient/MoveFolder/main.go
+++ b/internal/generated/snippets/resourcemanager/apiv3/FoldersClient/MoveFolder/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/resourcemanager/apiv3/FoldersClient/SearchFolders/main.go
+++ b/internal/generated/snippets/resourcemanager/apiv3/FoldersClient/SearchFolders/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/resourcemanager/apiv3/FoldersClient/SetIamPolicy/main.go
+++ b/internal/generated/snippets/resourcemanager/apiv3/FoldersClient/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/resourcemanager/apiv3/FoldersClient/TestIamPermissions/main.go
+++ b/internal/generated/snippets/resourcemanager/apiv3/FoldersClient/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/resourcemanager/apiv3/FoldersClient/UndeleteFolder/main.go
+++ b/internal/generated/snippets/resourcemanager/apiv3/FoldersClient/UndeleteFolder/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/resourcemanager/apiv3/FoldersClient/UpdateFolder/main.go
+++ b/internal/generated/snippets/resourcemanager/apiv3/FoldersClient/UpdateFolder/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/resourcemanager/apiv3/OrganizationsClient/GetIamPolicy/main.go
+++ b/internal/generated/snippets/resourcemanager/apiv3/OrganizationsClient/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/resourcemanager/apiv3/OrganizationsClient/GetOperation/main.go
+++ b/internal/generated/snippets/resourcemanager/apiv3/OrganizationsClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/resourcemanager/apiv3/OrganizationsClient/GetOrganization/main.go
+++ b/internal/generated/snippets/resourcemanager/apiv3/OrganizationsClient/GetOrganization/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/resourcemanager/apiv3/OrganizationsClient/SearchOrganizations/main.go
+++ b/internal/generated/snippets/resourcemanager/apiv3/OrganizationsClient/SearchOrganizations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/resourcemanager/apiv3/OrganizationsClient/SetIamPolicy/main.go
+++ b/internal/generated/snippets/resourcemanager/apiv3/OrganizationsClient/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/resourcemanager/apiv3/OrganizationsClient/TestIamPermissions/main.go
+++ b/internal/generated/snippets/resourcemanager/apiv3/OrganizationsClient/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/resourcemanager/apiv3/ProjectsClient/CreateProject/main.go
+++ b/internal/generated/snippets/resourcemanager/apiv3/ProjectsClient/CreateProject/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/resourcemanager/apiv3/ProjectsClient/DeleteProject/main.go
+++ b/internal/generated/snippets/resourcemanager/apiv3/ProjectsClient/DeleteProject/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/resourcemanager/apiv3/ProjectsClient/GetIamPolicy/main.go
+++ b/internal/generated/snippets/resourcemanager/apiv3/ProjectsClient/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/resourcemanager/apiv3/ProjectsClient/GetOperation/main.go
+++ b/internal/generated/snippets/resourcemanager/apiv3/ProjectsClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/resourcemanager/apiv3/ProjectsClient/GetProject/main.go
+++ b/internal/generated/snippets/resourcemanager/apiv3/ProjectsClient/GetProject/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/resourcemanager/apiv3/ProjectsClient/ListProjects/main.go
+++ b/internal/generated/snippets/resourcemanager/apiv3/ProjectsClient/ListProjects/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/resourcemanager/apiv3/ProjectsClient/MoveProject/main.go
+++ b/internal/generated/snippets/resourcemanager/apiv3/ProjectsClient/MoveProject/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/resourcemanager/apiv3/ProjectsClient/SearchProjects/main.go
+++ b/internal/generated/snippets/resourcemanager/apiv3/ProjectsClient/SearchProjects/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/resourcemanager/apiv3/ProjectsClient/SetIamPolicy/main.go
+++ b/internal/generated/snippets/resourcemanager/apiv3/ProjectsClient/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/resourcemanager/apiv3/ProjectsClient/TestIamPermissions/main.go
+++ b/internal/generated/snippets/resourcemanager/apiv3/ProjectsClient/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/resourcemanager/apiv3/ProjectsClient/UndeleteProject/main.go
+++ b/internal/generated/snippets/resourcemanager/apiv3/ProjectsClient/UndeleteProject/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/resourcemanager/apiv3/ProjectsClient/UpdateProject/main.go
+++ b/internal/generated/snippets/resourcemanager/apiv3/ProjectsClient/UpdateProject/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/resourcemanager/apiv3/TagBindingsClient/CreateTagBinding/main.go
+++ b/internal/generated/snippets/resourcemanager/apiv3/TagBindingsClient/CreateTagBinding/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/resourcemanager/apiv3/TagBindingsClient/DeleteTagBinding/main.go
+++ b/internal/generated/snippets/resourcemanager/apiv3/TagBindingsClient/DeleteTagBinding/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/resourcemanager/apiv3/TagBindingsClient/GetOperation/main.go
+++ b/internal/generated/snippets/resourcemanager/apiv3/TagBindingsClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/resourcemanager/apiv3/TagBindingsClient/ListEffectiveTags/main.go
+++ b/internal/generated/snippets/resourcemanager/apiv3/TagBindingsClient/ListEffectiveTags/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/resourcemanager/apiv3/TagBindingsClient/ListTagBindings/main.go
+++ b/internal/generated/snippets/resourcemanager/apiv3/TagBindingsClient/ListTagBindings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/resourcemanager/apiv3/TagHoldsClient/CreateTagHold/main.go
+++ b/internal/generated/snippets/resourcemanager/apiv3/TagHoldsClient/CreateTagHold/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/resourcemanager/apiv3/TagHoldsClient/DeleteTagHold/main.go
+++ b/internal/generated/snippets/resourcemanager/apiv3/TagHoldsClient/DeleteTagHold/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/resourcemanager/apiv3/TagHoldsClient/GetOperation/main.go
+++ b/internal/generated/snippets/resourcemanager/apiv3/TagHoldsClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/resourcemanager/apiv3/TagHoldsClient/ListTagHolds/main.go
+++ b/internal/generated/snippets/resourcemanager/apiv3/TagHoldsClient/ListTagHolds/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/resourcemanager/apiv3/TagKeysClient/CreateTagKey/main.go
+++ b/internal/generated/snippets/resourcemanager/apiv3/TagKeysClient/CreateTagKey/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/resourcemanager/apiv3/TagKeysClient/DeleteTagKey/main.go
+++ b/internal/generated/snippets/resourcemanager/apiv3/TagKeysClient/DeleteTagKey/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/resourcemanager/apiv3/TagKeysClient/GetIamPolicy/main.go
+++ b/internal/generated/snippets/resourcemanager/apiv3/TagKeysClient/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/resourcemanager/apiv3/TagKeysClient/GetNamespacedTagKey/main.go
+++ b/internal/generated/snippets/resourcemanager/apiv3/TagKeysClient/GetNamespacedTagKey/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/resourcemanager/apiv3/TagKeysClient/GetOperation/main.go
+++ b/internal/generated/snippets/resourcemanager/apiv3/TagKeysClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/resourcemanager/apiv3/TagKeysClient/GetTagKey/main.go
+++ b/internal/generated/snippets/resourcemanager/apiv3/TagKeysClient/GetTagKey/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/resourcemanager/apiv3/TagKeysClient/ListTagKeys/main.go
+++ b/internal/generated/snippets/resourcemanager/apiv3/TagKeysClient/ListTagKeys/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/resourcemanager/apiv3/TagKeysClient/SetIamPolicy/main.go
+++ b/internal/generated/snippets/resourcemanager/apiv3/TagKeysClient/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/resourcemanager/apiv3/TagKeysClient/TestIamPermissions/main.go
+++ b/internal/generated/snippets/resourcemanager/apiv3/TagKeysClient/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/resourcemanager/apiv3/TagKeysClient/UpdateTagKey/main.go
+++ b/internal/generated/snippets/resourcemanager/apiv3/TagKeysClient/UpdateTagKey/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/resourcemanager/apiv3/TagValuesClient/CreateTagValue/main.go
+++ b/internal/generated/snippets/resourcemanager/apiv3/TagValuesClient/CreateTagValue/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/resourcemanager/apiv3/TagValuesClient/DeleteTagValue/main.go
+++ b/internal/generated/snippets/resourcemanager/apiv3/TagValuesClient/DeleteTagValue/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/resourcemanager/apiv3/TagValuesClient/GetIamPolicy/main.go
+++ b/internal/generated/snippets/resourcemanager/apiv3/TagValuesClient/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/resourcemanager/apiv3/TagValuesClient/GetNamespacedTagValue/main.go
+++ b/internal/generated/snippets/resourcemanager/apiv3/TagValuesClient/GetNamespacedTagValue/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/resourcemanager/apiv3/TagValuesClient/GetOperation/main.go
+++ b/internal/generated/snippets/resourcemanager/apiv3/TagValuesClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/resourcemanager/apiv3/TagValuesClient/GetTagValue/main.go
+++ b/internal/generated/snippets/resourcemanager/apiv3/TagValuesClient/GetTagValue/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/resourcemanager/apiv3/TagValuesClient/ListTagValues/main.go
+++ b/internal/generated/snippets/resourcemanager/apiv3/TagValuesClient/ListTagValues/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/resourcemanager/apiv3/TagValuesClient/SetIamPolicy/main.go
+++ b/internal/generated/snippets/resourcemanager/apiv3/TagValuesClient/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/resourcemanager/apiv3/TagValuesClient/TestIamPermissions/main.go
+++ b/internal/generated/snippets/resourcemanager/apiv3/TagValuesClient/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/resourcemanager/apiv3/TagValuesClient/UpdateTagValue/main.go
+++ b/internal/generated/snippets/resourcemanager/apiv3/TagValuesClient/UpdateTagValue/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/AnalyticsClient/ExportAnalyticsMetrics/main.go
+++ b/internal/generated/snippets/retail/apiv2/AnalyticsClient/ExportAnalyticsMetrics/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/AnalyticsClient/GetOperation/main.go
+++ b/internal/generated/snippets/retail/apiv2/AnalyticsClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/AnalyticsClient/ListOperations/main.go
+++ b/internal/generated/snippets/retail/apiv2/AnalyticsClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/CatalogClient/AddCatalogAttribute/main.go
+++ b/internal/generated/snippets/retail/apiv2/CatalogClient/AddCatalogAttribute/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/CatalogClient/GetAttributesConfig/main.go
+++ b/internal/generated/snippets/retail/apiv2/CatalogClient/GetAttributesConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/CatalogClient/GetCompletionConfig/main.go
+++ b/internal/generated/snippets/retail/apiv2/CatalogClient/GetCompletionConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/CatalogClient/GetDefaultBranch/main.go
+++ b/internal/generated/snippets/retail/apiv2/CatalogClient/GetDefaultBranch/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/CatalogClient/GetOperation/main.go
+++ b/internal/generated/snippets/retail/apiv2/CatalogClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/CatalogClient/ListCatalogs/main.go
+++ b/internal/generated/snippets/retail/apiv2/CatalogClient/ListCatalogs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/CatalogClient/ListOperations/main.go
+++ b/internal/generated/snippets/retail/apiv2/CatalogClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/CatalogClient/RemoveCatalogAttribute/main.go
+++ b/internal/generated/snippets/retail/apiv2/CatalogClient/RemoveCatalogAttribute/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/CatalogClient/ReplaceCatalogAttribute/main.go
+++ b/internal/generated/snippets/retail/apiv2/CatalogClient/ReplaceCatalogAttribute/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/CatalogClient/SetDefaultBranch/main.go
+++ b/internal/generated/snippets/retail/apiv2/CatalogClient/SetDefaultBranch/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/CatalogClient/UpdateAttributesConfig/main.go
+++ b/internal/generated/snippets/retail/apiv2/CatalogClient/UpdateAttributesConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/CatalogClient/UpdateCatalog/main.go
+++ b/internal/generated/snippets/retail/apiv2/CatalogClient/UpdateCatalog/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/CatalogClient/UpdateCompletionConfig/main.go
+++ b/internal/generated/snippets/retail/apiv2/CatalogClient/UpdateCompletionConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/CompletionClient/CompleteQuery/main.go
+++ b/internal/generated/snippets/retail/apiv2/CompletionClient/CompleteQuery/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/CompletionClient/GetOperation/main.go
+++ b/internal/generated/snippets/retail/apiv2/CompletionClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/CompletionClient/ImportCompletionData/main.go
+++ b/internal/generated/snippets/retail/apiv2/CompletionClient/ImportCompletionData/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/CompletionClient/ListOperations/main.go
+++ b/internal/generated/snippets/retail/apiv2/CompletionClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/ControlClient/CreateControl/main.go
+++ b/internal/generated/snippets/retail/apiv2/ControlClient/CreateControl/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/ControlClient/DeleteControl/main.go
+++ b/internal/generated/snippets/retail/apiv2/ControlClient/DeleteControl/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/ControlClient/GetControl/main.go
+++ b/internal/generated/snippets/retail/apiv2/ControlClient/GetControl/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/ControlClient/GetOperation/main.go
+++ b/internal/generated/snippets/retail/apiv2/ControlClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/ControlClient/ListControls/main.go
+++ b/internal/generated/snippets/retail/apiv2/ControlClient/ListControls/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/ControlClient/ListOperations/main.go
+++ b/internal/generated/snippets/retail/apiv2/ControlClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/ControlClient/UpdateControl/main.go
+++ b/internal/generated/snippets/retail/apiv2/ControlClient/UpdateControl/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/ConversationalSearchClient/GetOperation/main.go
+++ b/internal/generated/snippets/retail/apiv2/ConversationalSearchClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/ConversationalSearchClient/ListOperations/main.go
+++ b/internal/generated/snippets/retail/apiv2/ConversationalSearchClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/GenerativeQuestionClient/BatchUpdateGenerativeQuestionConfigs/main.go
+++ b/internal/generated/snippets/retail/apiv2/GenerativeQuestionClient/BatchUpdateGenerativeQuestionConfigs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/GenerativeQuestionClient/GetGenerativeQuestionsFeatureConfig/main.go
+++ b/internal/generated/snippets/retail/apiv2/GenerativeQuestionClient/GetGenerativeQuestionsFeatureConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/GenerativeQuestionClient/GetOperation/main.go
+++ b/internal/generated/snippets/retail/apiv2/GenerativeQuestionClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/GenerativeQuestionClient/ListGenerativeQuestionConfigs/main.go
+++ b/internal/generated/snippets/retail/apiv2/GenerativeQuestionClient/ListGenerativeQuestionConfigs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/GenerativeQuestionClient/ListOperations/main.go
+++ b/internal/generated/snippets/retail/apiv2/GenerativeQuestionClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/GenerativeQuestionClient/UpdateGenerativeQuestionConfig/main.go
+++ b/internal/generated/snippets/retail/apiv2/GenerativeQuestionClient/UpdateGenerativeQuestionConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/GenerativeQuestionClient/UpdateGenerativeQuestionsFeatureConfig/main.go
+++ b/internal/generated/snippets/retail/apiv2/GenerativeQuestionClient/UpdateGenerativeQuestionsFeatureConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/ModelClient/CreateModel/main.go
+++ b/internal/generated/snippets/retail/apiv2/ModelClient/CreateModel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/ModelClient/DeleteModel/main.go
+++ b/internal/generated/snippets/retail/apiv2/ModelClient/DeleteModel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/ModelClient/GetModel/main.go
+++ b/internal/generated/snippets/retail/apiv2/ModelClient/GetModel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/ModelClient/GetOperation/main.go
+++ b/internal/generated/snippets/retail/apiv2/ModelClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/ModelClient/ListModels/main.go
+++ b/internal/generated/snippets/retail/apiv2/ModelClient/ListModels/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/ModelClient/ListOperations/main.go
+++ b/internal/generated/snippets/retail/apiv2/ModelClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/ModelClient/PauseModel/main.go
+++ b/internal/generated/snippets/retail/apiv2/ModelClient/PauseModel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/ModelClient/ResumeModel/main.go
+++ b/internal/generated/snippets/retail/apiv2/ModelClient/ResumeModel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/ModelClient/TuneModel/main.go
+++ b/internal/generated/snippets/retail/apiv2/ModelClient/TuneModel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/ModelClient/UpdateModel/main.go
+++ b/internal/generated/snippets/retail/apiv2/ModelClient/UpdateModel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/PredictionClient/GetOperation/main.go
+++ b/internal/generated/snippets/retail/apiv2/PredictionClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/PredictionClient/ListOperations/main.go
+++ b/internal/generated/snippets/retail/apiv2/PredictionClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/PredictionClient/Predict/main.go
+++ b/internal/generated/snippets/retail/apiv2/PredictionClient/Predict/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/ProductClient/AddFulfillmentPlaces/main.go
+++ b/internal/generated/snippets/retail/apiv2/ProductClient/AddFulfillmentPlaces/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/ProductClient/AddLocalInventories/main.go
+++ b/internal/generated/snippets/retail/apiv2/ProductClient/AddLocalInventories/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/ProductClient/CreateProduct/main.go
+++ b/internal/generated/snippets/retail/apiv2/ProductClient/CreateProduct/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/ProductClient/DeleteProduct/main.go
+++ b/internal/generated/snippets/retail/apiv2/ProductClient/DeleteProduct/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/ProductClient/GetOperation/main.go
+++ b/internal/generated/snippets/retail/apiv2/ProductClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/ProductClient/GetProduct/main.go
+++ b/internal/generated/snippets/retail/apiv2/ProductClient/GetProduct/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/ProductClient/ImportProducts/main.go
+++ b/internal/generated/snippets/retail/apiv2/ProductClient/ImportProducts/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/ProductClient/ListOperations/main.go
+++ b/internal/generated/snippets/retail/apiv2/ProductClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/ProductClient/ListProducts/main.go
+++ b/internal/generated/snippets/retail/apiv2/ProductClient/ListProducts/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/ProductClient/PurgeProducts/main.go
+++ b/internal/generated/snippets/retail/apiv2/ProductClient/PurgeProducts/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/ProductClient/RemoveFulfillmentPlaces/main.go
+++ b/internal/generated/snippets/retail/apiv2/ProductClient/RemoveFulfillmentPlaces/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/ProductClient/RemoveLocalInventories/main.go
+++ b/internal/generated/snippets/retail/apiv2/ProductClient/RemoveLocalInventories/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/ProductClient/SetInventory/main.go
+++ b/internal/generated/snippets/retail/apiv2/ProductClient/SetInventory/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/ProductClient/UpdateProduct/main.go
+++ b/internal/generated/snippets/retail/apiv2/ProductClient/UpdateProduct/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/SearchClient/GetOperation/main.go
+++ b/internal/generated/snippets/retail/apiv2/SearchClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/SearchClient/ListOperations/main.go
+++ b/internal/generated/snippets/retail/apiv2/SearchClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/SearchClient/Search/main.go
+++ b/internal/generated/snippets/retail/apiv2/SearchClient/Search/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/ServingConfigClient/AddControl/main.go
+++ b/internal/generated/snippets/retail/apiv2/ServingConfigClient/AddControl/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/ServingConfigClient/CreateServingConfig/main.go
+++ b/internal/generated/snippets/retail/apiv2/ServingConfigClient/CreateServingConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/ServingConfigClient/DeleteServingConfig/main.go
+++ b/internal/generated/snippets/retail/apiv2/ServingConfigClient/DeleteServingConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/ServingConfigClient/GetOperation/main.go
+++ b/internal/generated/snippets/retail/apiv2/ServingConfigClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/ServingConfigClient/GetServingConfig/main.go
+++ b/internal/generated/snippets/retail/apiv2/ServingConfigClient/GetServingConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/ServingConfigClient/ListOperations/main.go
+++ b/internal/generated/snippets/retail/apiv2/ServingConfigClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/ServingConfigClient/ListServingConfigs/main.go
+++ b/internal/generated/snippets/retail/apiv2/ServingConfigClient/ListServingConfigs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/ServingConfigClient/RemoveControl/main.go
+++ b/internal/generated/snippets/retail/apiv2/ServingConfigClient/RemoveControl/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/ServingConfigClient/UpdateServingConfig/main.go
+++ b/internal/generated/snippets/retail/apiv2/ServingConfigClient/UpdateServingConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/UserEventClient/CollectUserEvent/main.go
+++ b/internal/generated/snippets/retail/apiv2/UserEventClient/CollectUserEvent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/UserEventClient/GetOperation/main.go
+++ b/internal/generated/snippets/retail/apiv2/UserEventClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/UserEventClient/ImportUserEvents/main.go
+++ b/internal/generated/snippets/retail/apiv2/UserEventClient/ImportUserEvents/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/UserEventClient/ListOperations/main.go
+++ b/internal/generated/snippets/retail/apiv2/UserEventClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/UserEventClient/PurgeUserEvents/main.go
+++ b/internal/generated/snippets/retail/apiv2/UserEventClient/PurgeUserEvents/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/UserEventClient/RejoinUserEvents/main.go
+++ b/internal/generated/snippets/retail/apiv2/UserEventClient/RejoinUserEvents/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2/UserEventClient/WriteUserEvent/main.go
+++ b/internal/generated/snippets/retail/apiv2/UserEventClient/WriteUserEvent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/AnalyticsClient/ExportAnalyticsMetrics/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/AnalyticsClient/ExportAnalyticsMetrics/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/AnalyticsClient/GetOperation/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/AnalyticsClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/AnalyticsClient/ListOperations/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/AnalyticsClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/BranchClient/GetBranch/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/BranchClient/GetBranch/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/BranchClient/GetOperation/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/BranchClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/BranchClient/ListBranches/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/BranchClient/ListBranches/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/BranchClient/ListOperations/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/BranchClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/CatalogClient/AddCatalogAttribute/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/CatalogClient/AddCatalogAttribute/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/CatalogClient/BatchRemoveCatalogAttributes/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/CatalogClient/BatchRemoveCatalogAttributes/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/CatalogClient/GetAttributesConfig/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/CatalogClient/GetAttributesConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/CatalogClient/GetCompletionConfig/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/CatalogClient/GetCompletionConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/CatalogClient/GetDefaultBranch/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/CatalogClient/GetDefaultBranch/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/CatalogClient/GetOperation/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/CatalogClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/CatalogClient/ListCatalogs/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/CatalogClient/ListCatalogs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/CatalogClient/ListOperations/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/CatalogClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/CatalogClient/RemoveCatalogAttribute/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/CatalogClient/RemoveCatalogAttribute/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/CatalogClient/ReplaceCatalogAttribute/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/CatalogClient/ReplaceCatalogAttribute/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/CatalogClient/SetDefaultBranch/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/CatalogClient/SetDefaultBranch/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/CatalogClient/UpdateAttributesConfig/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/CatalogClient/UpdateAttributesConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/CatalogClient/UpdateCatalog/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/CatalogClient/UpdateCatalog/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/CatalogClient/UpdateCompletionConfig/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/CatalogClient/UpdateCompletionConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/CompletionClient/CompleteQuery/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/CompletionClient/CompleteQuery/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/CompletionClient/GetOperation/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/CompletionClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/CompletionClient/ImportCompletionData/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/CompletionClient/ImportCompletionData/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/CompletionClient/ListOperations/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/CompletionClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/ControlClient/CreateControl/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/ControlClient/CreateControl/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/ControlClient/DeleteControl/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/ControlClient/DeleteControl/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/ControlClient/GetControl/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/ControlClient/GetControl/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/ControlClient/GetOperation/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/ControlClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/ControlClient/ListControls/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/ControlClient/ListControls/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/ControlClient/ListOperations/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/ControlClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/ControlClient/UpdateControl/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/ControlClient/UpdateControl/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/ConversationalSearchClient/GetOperation/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/ConversationalSearchClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/ConversationalSearchClient/ListOperations/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/ConversationalSearchClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/GenerativeQuestionClient/BatchUpdateGenerativeQuestionConfigs/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/GenerativeQuestionClient/BatchUpdateGenerativeQuestionConfigs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/GenerativeQuestionClient/GetGenerativeQuestionsFeatureConfig/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/GenerativeQuestionClient/GetGenerativeQuestionsFeatureConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/GenerativeQuestionClient/GetOperation/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/GenerativeQuestionClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/GenerativeQuestionClient/ListGenerativeQuestionConfigs/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/GenerativeQuestionClient/ListGenerativeQuestionConfigs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/GenerativeQuestionClient/ListOperations/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/GenerativeQuestionClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/GenerativeQuestionClient/UpdateGenerativeQuestionConfig/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/GenerativeQuestionClient/UpdateGenerativeQuestionConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/GenerativeQuestionClient/UpdateGenerativeQuestionsFeatureConfig/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/GenerativeQuestionClient/UpdateGenerativeQuestionsFeatureConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/MerchantCenterAccountLinkClient/CreateMerchantCenterAccountLink/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/MerchantCenterAccountLinkClient/CreateMerchantCenterAccountLink/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/MerchantCenterAccountLinkClient/DeleteMerchantCenterAccountLink/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/MerchantCenterAccountLinkClient/DeleteMerchantCenterAccountLink/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/MerchantCenterAccountLinkClient/GetOperation/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/MerchantCenterAccountLinkClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/MerchantCenterAccountLinkClient/ListMerchantCenterAccountLinks/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/MerchantCenterAccountLinkClient/ListMerchantCenterAccountLinks/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/MerchantCenterAccountLinkClient/ListOperations/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/MerchantCenterAccountLinkClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/ModelClient/CreateModel/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/ModelClient/CreateModel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/ModelClient/DeleteModel/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/ModelClient/DeleteModel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/ModelClient/GetModel/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/ModelClient/GetModel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/ModelClient/GetOperation/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/ModelClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/ModelClient/ListModels/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/ModelClient/ListModels/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/ModelClient/ListOperations/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/ModelClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/ModelClient/PauseModel/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/ModelClient/PauseModel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/ModelClient/ResumeModel/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/ModelClient/ResumeModel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/ModelClient/TuneModel/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/ModelClient/TuneModel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/ModelClient/UpdateModel/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/ModelClient/UpdateModel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/PredictionClient/GetOperation/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/PredictionClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/PredictionClient/ListOperations/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/PredictionClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/PredictionClient/Predict/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/PredictionClient/Predict/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/ProductClient/AddFulfillmentPlaces/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/ProductClient/AddFulfillmentPlaces/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/ProductClient/AddLocalInventories/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/ProductClient/AddLocalInventories/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/ProductClient/CreateProduct/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/ProductClient/CreateProduct/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/ProductClient/DeleteProduct/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/ProductClient/DeleteProduct/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/ProductClient/ExportProducts/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/ProductClient/ExportProducts/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/ProductClient/GetOperation/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/ProductClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/ProductClient/GetProduct/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/ProductClient/GetProduct/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/ProductClient/ImportProducts/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/ProductClient/ImportProducts/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/ProductClient/ListOperations/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/ProductClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/ProductClient/ListProducts/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/ProductClient/ListProducts/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/ProductClient/PurgeProducts/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/ProductClient/PurgeProducts/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/ProductClient/RemoveFulfillmentPlaces/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/ProductClient/RemoveFulfillmentPlaces/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/ProductClient/RemoveLocalInventories/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/ProductClient/RemoveLocalInventories/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/ProductClient/SetInventory/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/ProductClient/SetInventory/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/ProductClient/UpdateProduct/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/ProductClient/UpdateProduct/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/ProjectClient/AcceptTerms/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/ProjectClient/AcceptTerms/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/ProjectClient/EnrollSolution/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/ProjectClient/EnrollSolution/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/ProjectClient/GetAlertConfig/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/ProjectClient/GetAlertConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/ProjectClient/GetLoggingConfig/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/ProjectClient/GetLoggingConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/ProjectClient/GetOperation/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/ProjectClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/ProjectClient/GetProject/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/ProjectClient/GetProject/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/ProjectClient/ListEnrolledSolutions/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/ProjectClient/ListEnrolledSolutions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/ProjectClient/ListOperations/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/ProjectClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/ProjectClient/UpdateAlertConfig/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/ProjectClient/UpdateAlertConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/ProjectClient/UpdateLoggingConfig/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/ProjectClient/UpdateLoggingConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/SearchClient/GetOperation/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/SearchClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/SearchClient/ListOperations/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/SearchClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/SearchClient/Search/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/SearchClient/Search/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/ServingConfigClient/AddControl/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/ServingConfigClient/AddControl/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/ServingConfigClient/CreateServingConfig/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/ServingConfigClient/CreateServingConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/ServingConfigClient/DeleteServingConfig/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/ServingConfigClient/DeleteServingConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/ServingConfigClient/GetOperation/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/ServingConfigClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/ServingConfigClient/GetServingConfig/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/ServingConfigClient/GetServingConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/ServingConfigClient/ListOperations/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/ServingConfigClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/ServingConfigClient/ListServingConfigs/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/ServingConfigClient/ListServingConfigs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/ServingConfigClient/RemoveControl/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/ServingConfigClient/RemoveControl/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/ServingConfigClient/UpdateServingConfig/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/ServingConfigClient/UpdateServingConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/UserEventClient/CollectUserEvent/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/UserEventClient/CollectUserEvent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/UserEventClient/ExportUserEvents/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/UserEventClient/ExportUserEvents/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/UserEventClient/GetOperation/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/UserEventClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/UserEventClient/ImportUserEvents/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/UserEventClient/ImportUserEvents/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/UserEventClient/ListOperations/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/UserEventClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/UserEventClient/PurgeUserEvents/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/UserEventClient/PurgeUserEvents/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/UserEventClient/RejoinUserEvents/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/UserEventClient/RejoinUserEvents/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2alpha/UserEventClient/WriteUserEvent/main.go
+++ b/internal/generated/snippets/retail/apiv2alpha/UserEventClient/WriteUserEvent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/AnalyticsClient/ExportAnalyticsMetrics/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/AnalyticsClient/ExportAnalyticsMetrics/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/AnalyticsClient/GetOperation/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/AnalyticsClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/AnalyticsClient/ListOperations/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/AnalyticsClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/CatalogClient/AddCatalogAttribute/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/CatalogClient/AddCatalogAttribute/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/CatalogClient/BatchRemoveCatalogAttributes/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/CatalogClient/BatchRemoveCatalogAttributes/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/CatalogClient/GetAttributesConfig/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/CatalogClient/GetAttributesConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/CatalogClient/GetCompletionConfig/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/CatalogClient/GetCompletionConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/CatalogClient/GetDefaultBranch/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/CatalogClient/GetDefaultBranch/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/CatalogClient/GetOperation/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/CatalogClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/CatalogClient/ListCatalogs/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/CatalogClient/ListCatalogs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/CatalogClient/ListOperations/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/CatalogClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/CatalogClient/RemoveCatalogAttribute/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/CatalogClient/RemoveCatalogAttribute/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/CatalogClient/ReplaceCatalogAttribute/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/CatalogClient/ReplaceCatalogAttribute/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/CatalogClient/SetDefaultBranch/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/CatalogClient/SetDefaultBranch/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/CatalogClient/UpdateAttributesConfig/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/CatalogClient/UpdateAttributesConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/CatalogClient/UpdateCatalog/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/CatalogClient/UpdateCatalog/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/CatalogClient/UpdateCompletionConfig/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/CatalogClient/UpdateCompletionConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/CompletionClient/CompleteQuery/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/CompletionClient/CompleteQuery/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/CompletionClient/GetOperation/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/CompletionClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/CompletionClient/ImportCompletionData/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/CompletionClient/ImportCompletionData/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/CompletionClient/ListOperations/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/CompletionClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/ControlClient/CreateControl/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/ControlClient/CreateControl/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/ControlClient/DeleteControl/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/ControlClient/DeleteControl/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/ControlClient/GetControl/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/ControlClient/GetControl/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/ControlClient/GetOperation/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/ControlClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/ControlClient/ListControls/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/ControlClient/ListControls/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/ControlClient/ListOperations/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/ControlClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/ControlClient/UpdateControl/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/ControlClient/UpdateControl/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/ConversationalSearchClient/GetOperation/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/ConversationalSearchClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/ConversationalSearchClient/ListOperations/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/ConversationalSearchClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/GenerativeQuestionClient/BatchUpdateGenerativeQuestionConfigs/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/GenerativeQuestionClient/BatchUpdateGenerativeQuestionConfigs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/GenerativeQuestionClient/GetGenerativeQuestionsFeatureConfig/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/GenerativeQuestionClient/GetGenerativeQuestionsFeatureConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/GenerativeQuestionClient/GetOperation/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/GenerativeQuestionClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/GenerativeQuestionClient/ListGenerativeQuestionConfigs/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/GenerativeQuestionClient/ListGenerativeQuestionConfigs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/GenerativeQuestionClient/ListOperations/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/GenerativeQuestionClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/GenerativeQuestionClient/UpdateGenerativeQuestionConfig/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/GenerativeQuestionClient/UpdateGenerativeQuestionConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/GenerativeQuestionClient/UpdateGenerativeQuestionsFeatureConfig/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/GenerativeQuestionClient/UpdateGenerativeQuestionsFeatureConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/ModelClient/CreateModel/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/ModelClient/CreateModel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/ModelClient/DeleteModel/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/ModelClient/DeleteModel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/ModelClient/GetModel/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/ModelClient/GetModel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/ModelClient/GetOperation/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/ModelClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/ModelClient/ListModels/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/ModelClient/ListModels/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/ModelClient/ListOperations/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/ModelClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/ModelClient/PauseModel/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/ModelClient/PauseModel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/ModelClient/ResumeModel/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/ModelClient/ResumeModel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/ModelClient/TuneModel/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/ModelClient/TuneModel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/ModelClient/UpdateModel/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/ModelClient/UpdateModel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/PredictionClient/GetOperation/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/PredictionClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/PredictionClient/ListOperations/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/PredictionClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/PredictionClient/Predict/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/PredictionClient/Predict/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/ProductClient/AddFulfillmentPlaces/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/ProductClient/AddFulfillmentPlaces/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/ProductClient/AddLocalInventories/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/ProductClient/AddLocalInventories/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/ProductClient/CreateProduct/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/ProductClient/CreateProduct/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/ProductClient/DeleteProduct/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/ProductClient/DeleteProduct/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/ProductClient/ExportProducts/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/ProductClient/ExportProducts/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/ProductClient/GetOperation/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/ProductClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/ProductClient/GetProduct/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/ProductClient/GetProduct/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/ProductClient/ImportProducts/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/ProductClient/ImportProducts/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/ProductClient/ListOperations/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/ProductClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/ProductClient/ListProducts/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/ProductClient/ListProducts/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/ProductClient/PurgeProducts/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/ProductClient/PurgeProducts/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/ProductClient/RemoveFulfillmentPlaces/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/ProductClient/RemoveFulfillmentPlaces/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/ProductClient/RemoveLocalInventories/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/ProductClient/RemoveLocalInventories/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/ProductClient/SetInventory/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/ProductClient/SetInventory/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/ProductClient/UpdateProduct/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/ProductClient/UpdateProduct/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/ProjectClient/GetAlertConfig/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/ProjectClient/GetAlertConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/ProjectClient/GetOperation/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/ProjectClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/ProjectClient/ListOperations/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/ProjectClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/ProjectClient/UpdateAlertConfig/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/ProjectClient/UpdateAlertConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/SearchClient/GetOperation/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/SearchClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/SearchClient/ListOperations/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/SearchClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/SearchClient/Search/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/SearchClient/Search/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/ServingConfigClient/AddControl/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/ServingConfigClient/AddControl/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/ServingConfigClient/CreateServingConfig/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/ServingConfigClient/CreateServingConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/ServingConfigClient/DeleteServingConfig/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/ServingConfigClient/DeleteServingConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/ServingConfigClient/GetOperation/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/ServingConfigClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/ServingConfigClient/GetServingConfig/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/ServingConfigClient/GetServingConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/ServingConfigClient/ListOperations/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/ServingConfigClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/ServingConfigClient/ListServingConfigs/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/ServingConfigClient/ListServingConfigs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/ServingConfigClient/RemoveControl/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/ServingConfigClient/RemoveControl/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/ServingConfigClient/UpdateServingConfig/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/ServingConfigClient/UpdateServingConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/UserEventClient/CollectUserEvent/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/UserEventClient/CollectUserEvent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/UserEventClient/ExportUserEvents/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/UserEventClient/ExportUserEvents/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/UserEventClient/GetOperation/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/UserEventClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/UserEventClient/ImportUserEvents/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/UserEventClient/ImportUserEvents/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/UserEventClient/ListOperations/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/UserEventClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/UserEventClient/PurgeUserEvents/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/UserEventClient/PurgeUserEvents/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/UserEventClient/RejoinUserEvents/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/UserEventClient/RejoinUserEvents/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/retail/apiv2beta/UserEventClient/WriteUserEvent/main.go
+++ b/internal/generated/snippets/retail/apiv2beta/UserEventClient/WriteUserEvent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasDeploymentsClient/CreateRelease/main.go
+++ b/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasDeploymentsClient/CreateRelease/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasDeploymentsClient/CreateSaas/main.go
+++ b/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasDeploymentsClient/CreateSaas/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasDeploymentsClient/CreateTenant/main.go
+++ b/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasDeploymentsClient/CreateTenant/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasDeploymentsClient/CreateUnit/main.go
+++ b/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasDeploymentsClient/CreateUnit/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasDeploymentsClient/CreateUnitKind/main.go
+++ b/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasDeploymentsClient/CreateUnitKind/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasDeploymentsClient/CreateUnitOperation/main.go
+++ b/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasDeploymentsClient/CreateUnitOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasDeploymentsClient/DeleteRelease/main.go
+++ b/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasDeploymentsClient/DeleteRelease/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasDeploymentsClient/DeleteSaas/main.go
+++ b/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasDeploymentsClient/DeleteSaas/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasDeploymentsClient/DeleteTenant/main.go
+++ b/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasDeploymentsClient/DeleteTenant/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasDeploymentsClient/DeleteUnit/main.go
+++ b/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasDeploymentsClient/DeleteUnit/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasDeploymentsClient/DeleteUnitKind/main.go
+++ b/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasDeploymentsClient/DeleteUnitKind/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasDeploymentsClient/DeleteUnitOperation/main.go
+++ b/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasDeploymentsClient/DeleteUnitOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasDeploymentsClient/GetLocation/main.go
+++ b/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasDeploymentsClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasDeploymentsClient/GetRelease/main.go
+++ b/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasDeploymentsClient/GetRelease/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasDeploymentsClient/GetSaas/main.go
+++ b/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasDeploymentsClient/GetSaas/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasDeploymentsClient/GetTenant/main.go
+++ b/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasDeploymentsClient/GetTenant/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasDeploymentsClient/GetUnit/main.go
+++ b/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasDeploymentsClient/GetUnit/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasDeploymentsClient/GetUnitKind/main.go
+++ b/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasDeploymentsClient/GetUnitKind/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasDeploymentsClient/GetUnitOperation/main.go
+++ b/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasDeploymentsClient/GetUnitOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasDeploymentsClient/ListLocations/main.go
+++ b/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasDeploymentsClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasDeploymentsClient/ListReleases/main.go
+++ b/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasDeploymentsClient/ListReleases/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasDeploymentsClient/ListSaas/main.go
+++ b/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasDeploymentsClient/ListSaas/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasDeploymentsClient/ListTenants/main.go
+++ b/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasDeploymentsClient/ListTenants/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasDeploymentsClient/ListUnitKinds/main.go
+++ b/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasDeploymentsClient/ListUnitKinds/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasDeploymentsClient/ListUnitOperations/main.go
+++ b/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasDeploymentsClient/ListUnitOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasDeploymentsClient/ListUnits/main.go
+++ b/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasDeploymentsClient/ListUnits/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasDeploymentsClient/UpdateRelease/main.go
+++ b/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasDeploymentsClient/UpdateRelease/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasDeploymentsClient/UpdateSaas/main.go
+++ b/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasDeploymentsClient/UpdateSaas/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasDeploymentsClient/UpdateTenant/main.go
+++ b/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasDeploymentsClient/UpdateTenant/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasDeploymentsClient/UpdateUnit/main.go
+++ b/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasDeploymentsClient/UpdateUnit/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasDeploymentsClient/UpdateUnitKind/main.go
+++ b/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasDeploymentsClient/UpdateUnitKind/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasDeploymentsClient/UpdateUnitOperation/main.go
+++ b/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasDeploymentsClient/UpdateUnitOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasRolloutsClient/CreateRollout/main.go
+++ b/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasRolloutsClient/CreateRollout/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasRolloutsClient/CreateRolloutKind/main.go
+++ b/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasRolloutsClient/CreateRolloutKind/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasRolloutsClient/DeleteRollout/main.go
+++ b/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasRolloutsClient/DeleteRollout/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasRolloutsClient/DeleteRolloutKind/main.go
+++ b/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasRolloutsClient/DeleteRolloutKind/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasRolloutsClient/GetLocation/main.go
+++ b/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasRolloutsClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasRolloutsClient/GetRollout/main.go
+++ b/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasRolloutsClient/GetRollout/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasRolloutsClient/GetRolloutKind/main.go
+++ b/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasRolloutsClient/GetRolloutKind/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasRolloutsClient/ListLocations/main.go
+++ b/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasRolloutsClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasRolloutsClient/ListRolloutKinds/main.go
+++ b/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasRolloutsClient/ListRolloutKinds/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasRolloutsClient/ListRollouts/main.go
+++ b/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasRolloutsClient/ListRollouts/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasRolloutsClient/UpdateRollout/main.go
+++ b/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasRolloutsClient/UpdateRollout/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasRolloutsClient/UpdateRolloutKind/main.go
+++ b/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/SaasRolloutsClient/UpdateRolloutKind/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/scheduler/apiv1/CloudSchedulerClient/CreateJob/main.go
+++ b/internal/generated/snippets/scheduler/apiv1/CloudSchedulerClient/CreateJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/scheduler/apiv1/CloudSchedulerClient/DeleteJob/main.go
+++ b/internal/generated/snippets/scheduler/apiv1/CloudSchedulerClient/DeleteJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/scheduler/apiv1/CloudSchedulerClient/GetJob/main.go
+++ b/internal/generated/snippets/scheduler/apiv1/CloudSchedulerClient/GetJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/scheduler/apiv1/CloudSchedulerClient/GetLocation/main.go
+++ b/internal/generated/snippets/scheduler/apiv1/CloudSchedulerClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/scheduler/apiv1/CloudSchedulerClient/ListJobs/main.go
+++ b/internal/generated/snippets/scheduler/apiv1/CloudSchedulerClient/ListJobs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/scheduler/apiv1/CloudSchedulerClient/ListLocations/main.go
+++ b/internal/generated/snippets/scheduler/apiv1/CloudSchedulerClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/scheduler/apiv1/CloudSchedulerClient/PauseJob/main.go
+++ b/internal/generated/snippets/scheduler/apiv1/CloudSchedulerClient/PauseJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/scheduler/apiv1/CloudSchedulerClient/ResumeJob/main.go
+++ b/internal/generated/snippets/scheduler/apiv1/CloudSchedulerClient/ResumeJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/scheduler/apiv1/CloudSchedulerClient/RunJob/main.go
+++ b/internal/generated/snippets/scheduler/apiv1/CloudSchedulerClient/RunJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/scheduler/apiv1/CloudSchedulerClient/UpdateJob/main.go
+++ b/internal/generated/snippets/scheduler/apiv1/CloudSchedulerClient/UpdateJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/scheduler/apiv1beta1/CloudSchedulerClient/CreateJob/main.go
+++ b/internal/generated/snippets/scheduler/apiv1beta1/CloudSchedulerClient/CreateJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/scheduler/apiv1beta1/CloudSchedulerClient/DeleteJob/main.go
+++ b/internal/generated/snippets/scheduler/apiv1beta1/CloudSchedulerClient/DeleteJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/scheduler/apiv1beta1/CloudSchedulerClient/GetJob/main.go
+++ b/internal/generated/snippets/scheduler/apiv1beta1/CloudSchedulerClient/GetJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/scheduler/apiv1beta1/CloudSchedulerClient/GetLocation/main.go
+++ b/internal/generated/snippets/scheduler/apiv1beta1/CloudSchedulerClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/scheduler/apiv1beta1/CloudSchedulerClient/ListJobs/main.go
+++ b/internal/generated/snippets/scheduler/apiv1beta1/CloudSchedulerClient/ListJobs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/scheduler/apiv1beta1/CloudSchedulerClient/ListLocations/main.go
+++ b/internal/generated/snippets/scheduler/apiv1beta1/CloudSchedulerClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/scheduler/apiv1beta1/CloudSchedulerClient/PauseJob/main.go
+++ b/internal/generated/snippets/scheduler/apiv1beta1/CloudSchedulerClient/PauseJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/scheduler/apiv1beta1/CloudSchedulerClient/ResumeJob/main.go
+++ b/internal/generated/snippets/scheduler/apiv1beta1/CloudSchedulerClient/ResumeJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/scheduler/apiv1beta1/CloudSchedulerClient/RunJob/main.go
+++ b/internal/generated/snippets/scheduler/apiv1beta1/CloudSchedulerClient/RunJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/scheduler/apiv1beta1/CloudSchedulerClient/UpdateJob/main.go
+++ b/internal/generated/snippets/scheduler/apiv1beta1/CloudSchedulerClient/UpdateJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/secretmanager/apiv1/Client/AccessSecretVersion/main.go
+++ b/internal/generated/snippets/secretmanager/apiv1/Client/AccessSecretVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/secretmanager/apiv1/Client/AddSecretVersion/main.go
+++ b/internal/generated/snippets/secretmanager/apiv1/Client/AddSecretVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/secretmanager/apiv1/Client/CreateSecret/main.go
+++ b/internal/generated/snippets/secretmanager/apiv1/Client/CreateSecret/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/secretmanager/apiv1/Client/DeleteSecret/main.go
+++ b/internal/generated/snippets/secretmanager/apiv1/Client/DeleteSecret/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/secretmanager/apiv1/Client/DestroySecretVersion/main.go
+++ b/internal/generated/snippets/secretmanager/apiv1/Client/DestroySecretVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/secretmanager/apiv1/Client/DisableSecretVersion/main.go
+++ b/internal/generated/snippets/secretmanager/apiv1/Client/DisableSecretVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/secretmanager/apiv1/Client/EnableSecretVersion/main.go
+++ b/internal/generated/snippets/secretmanager/apiv1/Client/EnableSecretVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/secretmanager/apiv1/Client/GetIamPolicy/main.go
+++ b/internal/generated/snippets/secretmanager/apiv1/Client/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/secretmanager/apiv1/Client/GetLocation/main.go
+++ b/internal/generated/snippets/secretmanager/apiv1/Client/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/secretmanager/apiv1/Client/GetSecret/main.go
+++ b/internal/generated/snippets/secretmanager/apiv1/Client/GetSecret/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/secretmanager/apiv1/Client/GetSecretVersion/main.go
+++ b/internal/generated/snippets/secretmanager/apiv1/Client/GetSecretVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/secretmanager/apiv1/Client/ListLocations/main.go
+++ b/internal/generated/snippets/secretmanager/apiv1/Client/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/secretmanager/apiv1/Client/ListSecretVersions/main.go
+++ b/internal/generated/snippets/secretmanager/apiv1/Client/ListSecretVersions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/secretmanager/apiv1/Client/ListSecrets/main.go
+++ b/internal/generated/snippets/secretmanager/apiv1/Client/ListSecrets/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/secretmanager/apiv1/Client/SetIamPolicy/main.go
+++ b/internal/generated/snippets/secretmanager/apiv1/Client/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/secretmanager/apiv1/Client/TestIamPermissions/main.go
+++ b/internal/generated/snippets/secretmanager/apiv1/Client/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/secretmanager/apiv1/Client/UpdateSecret/main.go
+++ b/internal/generated/snippets/secretmanager/apiv1/Client/UpdateSecret/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/secretmanager/apiv1beta2/Client/AccessSecretVersion/main.go
+++ b/internal/generated/snippets/secretmanager/apiv1beta2/Client/AccessSecretVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/secretmanager/apiv1beta2/Client/AddSecretVersion/main.go
+++ b/internal/generated/snippets/secretmanager/apiv1beta2/Client/AddSecretVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/secretmanager/apiv1beta2/Client/CreateSecret/main.go
+++ b/internal/generated/snippets/secretmanager/apiv1beta2/Client/CreateSecret/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/secretmanager/apiv1beta2/Client/DeleteSecret/main.go
+++ b/internal/generated/snippets/secretmanager/apiv1beta2/Client/DeleteSecret/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/secretmanager/apiv1beta2/Client/DestroySecretVersion/main.go
+++ b/internal/generated/snippets/secretmanager/apiv1beta2/Client/DestroySecretVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/secretmanager/apiv1beta2/Client/DisableSecretVersion/main.go
+++ b/internal/generated/snippets/secretmanager/apiv1beta2/Client/DisableSecretVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/secretmanager/apiv1beta2/Client/EnableSecretVersion/main.go
+++ b/internal/generated/snippets/secretmanager/apiv1beta2/Client/EnableSecretVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/secretmanager/apiv1beta2/Client/GetIamPolicy/main.go
+++ b/internal/generated/snippets/secretmanager/apiv1beta2/Client/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/secretmanager/apiv1beta2/Client/GetLocation/main.go
+++ b/internal/generated/snippets/secretmanager/apiv1beta2/Client/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/secretmanager/apiv1beta2/Client/GetSecret/main.go
+++ b/internal/generated/snippets/secretmanager/apiv1beta2/Client/GetSecret/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/secretmanager/apiv1beta2/Client/GetSecretVersion/main.go
+++ b/internal/generated/snippets/secretmanager/apiv1beta2/Client/GetSecretVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/secretmanager/apiv1beta2/Client/ListLocations/main.go
+++ b/internal/generated/snippets/secretmanager/apiv1beta2/Client/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/secretmanager/apiv1beta2/Client/ListSecretVersions/main.go
+++ b/internal/generated/snippets/secretmanager/apiv1beta2/Client/ListSecretVersions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/secretmanager/apiv1beta2/Client/ListSecrets/main.go
+++ b/internal/generated/snippets/secretmanager/apiv1beta2/Client/ListSecrets/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/secretmanager/apiv1beta2/Client/SetIamPolicy/main.go
+++ b/internal/generated/snippets/secretmanager/apiv1beta2/Client/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/secretmanager/apiv1beta2/Client/TestIamPermissions/main.go
+++ b/internal/generated/snippets/secretmanager/apiv1beta2/Client/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/secretmanager/apiv1beta2/Client/UpdateSecret/main.go
+++ b/internal/generated/snippets/secretmanager/apiv1beta2/Client/UpdateSecret/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securesourcemanager/apiv1/Client/BatchCreatePullRequestComments/main.go
+++ b/internal/generated/snippets/securesourcemanager/apiv1/Client/BatchCreatePullRequestComments/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securesourcemanager/apiv1/Client/CancelOperation/main.go
+++ b/internal/generated/snippets/securesourcemanager/apiv1/Client/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securesourcemanager/apiv1/Client/CloseIssue/main.go
+++ b/internal/generated/snippets/securesourcemanager/apiv1/Client/CloseIssue/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securesourcemanager/apiv1/Client/ClosePullRequest/main.go
+++ b/internal/generated/snippets/securesourcemanager/apiv1/Client/ClosePullRequest/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securesourcemanager/apiv1/Client/CreateBranchRule/main.go
+++ b/internal/generated/snippets/securesourcemanager/apiv1/Client/CreateBranchRule/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securesourcemanager/apiv1/Client/CreateHook/main.go
+++ b/internal/generated/snippets/securesourcemanager/apiv1/Client/CreateHook/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securesourcemanager/apiv1/Client/CreateInstance/main.go
+++ b/internal/generated/snippets/securesourcemanager/apiv1/Client/CreateInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securesourcemanager/apiv1/Client/CreateIssue/main.go
+++ b/internal/generated/snippets/securesourcemanager/apiv1/Client/CreateIssue/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securesourcemanager/apiv1/Client/CreateIssueComment/main.go
+++ b/internal/generated/snippets/securesourcemanager/apiv1/Client/CreateIssueComment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securesourcemanager/apiv1/Client/CreatePullRequest/main.go
+++ b/internal/generated/snippets/securesourcemanager/apiv1/Client/CreatePullRequest/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securesourcemanager/apiv1/Client/CreatePullRequestComment/main.go
+++ b/internal/generated/snippets/securesourcemanager/apiv1/Client/CreatePullRequestComment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securesourcemanager/apiv1/Client/CreateRepository/main.go
+++ b/internal/generated/snippets/securesourcemanager/apiv1/Client/CreateRepository/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securesourcemanager/apiv1/Client/DeleteBranchRule/main.go
+++ b/internal/generated/snippets/securesourcemanager/apiv1/Client/DeleteBranchRule/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securesourcemanager/apiv1/Client/DeleteHook/main.go
+++ b/internal/generated/snippets/securesourcemanager/apiv1/Client/DeleteHook/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securesourcemanager/apiv1/Client/DeleteInstance/main.go
+++ b/internal/generated/snippets/securesourcemanager/apiv1/Client/DeleteInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securesourcemanager/apiv1/Client/DeleteIssue/main.go
+++ b/internal/generated/snippets/securesourcemanager/apiv1/Client/DeleteIssue/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securesourcemanager/apiv1/Client/DeleteIssueComment/main.go
+++ b/internal/generated/snippets/securesourcemanager/apiv1/Client/DeleteIssueComment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securesourcemanager/apiv1/Client/DeleteOperation/main.go
+++ b/internal/generated/snippets/securesourcemanager/apiv1/Client/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securesourcemanager/apiv1/Client/DeletePullRequestComment/main.go
+++ b/internal/generated/snippets/securesourcemanager/apiv1/Client/DeletePullRequestComment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securesourcemanager/apiv1/Client/DeleteRepository/main.go
+++ b/internal/generated/snippets/securesourcemanager/apiv1/Client/DeleteRepository/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securesourcemanager/apiv1/Client/FetchBlob/main.go
+++ b/internal/generated/snippets/securesourcemanager/apiv1/Client/FetchBlob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securesourcemanager/apiv1/Client/FetchTree/main.go
+++ b/internal/generated/snippets/securesourcemanager/apiv1/Client/FetchTree/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securesourcemanager/apiv1/Client/GetBranchRule/main.go
+++ b/internal/generated/snippets/securesourcemanager/apiv1/Client/GetBranchRule/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securesourcemanager/apiv1/Client/GetHook/main.go
+++ b/internal/generated/snippets/securesourcemanager/apiv1/Client/GetHook/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securesourcemanager/apiv1/Client/GetIamPolicy/main.go
+++ b/internal/generated/snippets/securesourcemanager/apiv1/Client/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securesourcemanager/apiv1/Client/GetIamPolicyRepo/main.go
+++ b/internal/generated/snippets/securesourcemanager/apiv1/Client/GetIamPolicyRepo/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securesourcemanager/apiv1/Client/GetInstance/main.go
+++ b/internal/generated/snippets/securesourcemanager/apiv1/Client/GetInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securesourcemanager/apiv1/Client/GetIssue/main.go
+++ b/internal/generated/snippets/securesourcemanager/apiv1/Client/GetIssue/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securesourcemanager/apiv1/Client/GetIssueComment/main.go
+++ b/internal/generated/snippets/securesourcemanager/apiv1/Client/GetIssueComment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securesourcemanager/apiv1/Client/GetLocation/main.go
+++ b/internal/generated/snippets/securesourcemanager/apiv1/Client/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securesourcemanager/apiv1/Client/GetOperation/main.go
+++ b/internal/generated/snippets/securesourcemanager/apiv1/Client/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securesourcemanager/apiv1/Client/GetPullRequest/main.go
+++ b/internal/generated/snippets/securesourcemanager/apiv1/Client/GetPullRequest/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securesourcemanager/apiv1/Client/GetPullRequestComment/main.go
+++ b/internal/generated/snippets/securesourcemanager/apiv1/Client/GetPullRequestComment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securesourcemanager/apiv1/Client/GetRepository/main.go
+++ b/internal/generated/snippets/securesourcemanager/apiv1/Client/GetRepository/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securesourcemanager/apiv1/Client/ListBranchRules/main.go
+++ b/internal/generated/snippets/securesourcemanager/apiv1/Client/ListBranchRules/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securesourcemanager/apiv1/Client/ListHooks/main.go
+++ b/internal/generated/snippets/securesourcemanager/apiv1/Client/ListHooks/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securesourcemanager/apiv1/Client/ListInstances/main.go
+++ b/internal/generated/snippets/securesourcemanager/apiv1/Client/ListInstances/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securesourcemanager/apiv1/Client/ListIssueComments/main.go
+++ b/internal/generated/snippets/securesourcemanager/apiv1/Client/ListIssueComments/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securesourcemanager/apiv1/Client/ListIssues/main.go
+++ b/internal/generated/snippets/securesourcemanager/apiv1/Client/ListIssues/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securesourcemanager/apiv1/Client/ListLocations/main.go
+++ b/internal/generated/snippets/securesourcemanager/apiv1/Client/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securesourcemanager/apiv1/Client/ListOperations/main.go
+++ b/internal/generated/snippets/securesourcemanager/apiv1/Client/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securesourcemanager/apiv1/Client/ListPullRequestComments/main.go
+++ b/internal/generated/snippets/securesourcemanager/apiv1/Client/ListPullRequestComments/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securesourcemanager/apiv1/Client/ListPullRequestFileDiffs/main.go
+++ b/internal/generated/snippets/securesourcemanager/apiv1/Client/ListPullRequestFileDiffs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securesourcemanager/apiv1/Client/ListPullRequests/main.go
+++ b/internal/generated/snippets/securesourcemanager/apiv1/Client/ListPullRequests/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securesourcemanager/apiv1/Client/ListRepositories/main.go
+++ b/internal/generated/snippets/securesourcemanager/apiv1/Client/ListRepositories/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securesourcemanager/apiv1/Client/MergePullRequest/main.go
+++ b/internal/generated/snippets/securesourcemanager/apiv1/Client/MergePullRequest/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securesourcemanager/apiv1/Client/OpenIssue/main.go
+++ b/internal/generated/snippets/securesourcemanager/apiv1/Client/OpenIssue/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securesourcemanager/apiv1/Client/OpenPullRequest/main.go
+++ b/internal/generated/snippets/securesourcemanager/apiv1/Client/OpenPullRequest/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securesourcemanager/apiv1/Client/ResolvePullRequestComments/main.go
+++ b/internal/generated/snippets/securesourcemanager/apiv1/Client/ResolvePullRequestComments/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securesourcemanager/apiv1/Client/SetIamPolicy/main.go
+++ b/internal/generated/snippets/securesourcemanager/apiv1/Client/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securesourcemanager/apiv1/Client/SetIamPolicyRepo/main.go
+++ b/internal/generated/snippets/securesourcemanager/apiv1/Client/SetIamPolicyRepo/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securesourcemanager/apiv1/Client/TestIamPermissions/main.go
+++ b/internal/generated/snippets/securesourcemanager/apiv1/Client/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securesourcemanager/apiv1/Client/TestIamPermissionsRepo/main.go
+++ b/internal/generated/snippets/securesourcemanager/apiv1/Client/TestIamPermissionsRepo/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securesourcemanager/apiv1/Client/UnresolvePullRequestComments/main.go
+++ b/internal/generated/snippets/securesourcemanager/apiv1/Client/UnresolvePullRequestComments/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securesourcemanager/apiv1/Client/UpdateBranchRule/main.go
+++ b/internal/generated/snippets/securesourcemanager/apiv1/Client/UpdateBranchRule/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securesourcemanager/apiv1/Client/UpdateHook/main.go
+++ b/internal/generated/snippets/securesourcemanager/apiv1/Client/UpdateHook/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securesourcemanager/apiv1/Client/UpdateIssue/main.go
+++ b/internal/generated/snippets/securesourcemanager/apiv1/Client/UpdateIssue/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securesourcemanager/apiv1/Client/UpdateIssueComment/main.go
+++ b/internal/generated/snippets/securesourcemanager/apiv1/Client/UpdateIssueComment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securesourcemanager/apiv1/Client/UpdatePullRequest/main.go
+++ b/internal/generated/snippets/securesourcemanager/apiv1/Client/UpdatePullRequest/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securesourcemanager/apiv1/Client/UpdatePullRequestComment/main.go
+++ b/internal/generated/snippets/securesourcemanager/apiv1/Client/UpdatePullRequestComment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securesourcemanager/apiv1/Client/UpdateRepository/main.go
+++ b/internal/generated/snippets/securesourcemanager/apiv1/Client/UpdateRepository/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/security/privateca/apiv1/CertificateAuthorityClient/ActivateCertificateAuthority/main.go
+++ b/internal/generated/snippets/security/privateca/apiv1/CertificateAuthorityClient/ActivateCertificateAuthority/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/security/privateca/apiv1/CertificateAuthorityClient/CancelOperation/main.go
+++ b/internal/generated/snippets/security/privateca/apiv1/CertificateAuthorityClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/security/privateca/apiv1/CertificateAuthorityClient/CreateCaPool/main.go
+++ b/internal/generated/snippets/security/privateca/apiv1/CertificateAuthorityClient/CreateCaPool/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/security/privateca/apiv1/CertificateAuthorityClient/CreateCertificate/main.go
+++ b/internal/generated/snippets/security/privateca/apiv1/CertificateAuthorityClient/CreateCertificate/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/security/privateca/apiv1/CertificateAuthorityClient/CreateCertificateAuthority/main.go
+++ b/internal/generated/snippets/security/privateca/apiv1/CertificateAuthorityClient/CreateCertificateAuthority/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/security/privateca/apiv1/CertificateAuthorityClient/CreateCertificateTemplate/main.go
+++ b/internal/generated/snippets/security/privateca/apiv1/CertificateAuthorityClient/CreateCertificateTemplate/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/security/privateca/apiv1/CertificateAuthorityClient/DeleteCaPool/main.go
+++ b/internal/generated/snippets/security/privateca/apiv1/CertificateAuthorityClient/DeleteCaPool/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/security/privateca/apiv1/CertificateAuthorityClient/DeleteCertificateAuthority/main.go
+++ b/internal/generated/snippets/security/privateca/apiv1/CertificateAuthorityClient/DeleteCertificateAuthority/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/security/privateca/apiv1/CertificateAuthorityClient/DeleteCertificateTemplate/main.go
+++ b/internal/generated/snippets/security/privateca/apiv1/CertificateAuthorityClient/DeleteCertificateTemplate/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/security/privateca/apiv1/CertificateAuthorityClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/security/privateca/apiv1/CertificateAuthorityClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/security/privateca/apiv1/CertificateAuthorityClient/DisableCertificateAuthority/main.go
+++ b/internal/generated/snippets/security/privateca/apiv1/CertificateAuthorityClient/DisableCertificateAuthority/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/security/privateca/apiv1/CertificateAuthorityClient/EnableCertificateAuthority/main.go
+++ b/internal/generated/snippets/security/privateca/apiv1/CertificateAuthorityClient/EnableCertificateAuthority/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/security/privateca/apiv1/CertificateAuthorityClient/FetchCaCerts/main.go
+++ b/internal/generated/snippets/security/privateca/apiv1/CertificateAuthorityClient/FetchCaCerts/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/security/privateca/apiv1/CertificateAuthorityClient/FetchCertificateAuthorityCsr/main.go
+++ b/internal/generated/snippets/security/privateca/apiv1/CertificateAuthorityClient/FetchCertificateAuthorityCsr/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/security/privateca/apiv1/CertificateAuthorityClient/GetCaPool/main.go
+++ b/internal/generated/snippets/security/privateca/apiv1/CertificateAuthorityClient/GetCaPool/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/security/privateca/apiv1/CertificateAuthorityClient/GetCertificate/main.go
+++ b/internal/generated/snippets/security/privateca/apiv1/CertificateAuthorityClient/GetCertificate/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/security/privateca/apiv1/CertificateAuthorityClient/GetCertificateAuthority/main.go
+++ b/internal/generated/snippets/security/privateca/apiv1/CertificateAuthorityClient/GetCertificateAuthority/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/security/privateca/apiv1/CertificateAuthorityClient/GetCertificateRevocationList/main.go
+++ b/internal/generated/snippets/security/privateca/apiv1/CertificateAuthorityClient/GetCertificateRevocationList/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/security/privateca/apiv1/CertificateAuthorityClient/GetCertificateTemplate/main.go
+++ b/internal/generated/snippets/security/privateca/apiv1/CertificateAuthorityClient/GetCertificateTemplate/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/security/privateca/apiv1/CertificateAuthorityClient/GetIamPolicy/main.go
+++ b/internal/generated/snippets/security/privateca/apiv1/CertificateAuthorityClient/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/security/privateca/apiv1/CertificateAuthorityClient/GetLocation/main.go
+++ b/internal/generated/snippets/security/privateca/apiv1/CertificateAuthorityClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/security/privateca/apiv1/CertificateAuthorityClient/GetOperation/main.go
+++ b/internal/generated/snippets/security/privateca/apiv1/CertificateAuthorityClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/security/privateca/apiv1/CertificateAuthorityClient/ListCaPools/main.go
+++ b/internal/generated/snippets/security/privateca/apiv1/CertificateAuthorityClient/ListCaPools/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/security/privateca/apiv1/CertificateAuthorityClient/ListCertificateAuthorities/main.go
+++ b/internal/generated/snippets/security/privateca/apiv1/CertificateAuthorityClient/ListCertificateAuthorities/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/security/privateca/apiv1/CertificateAuthorityClient/ListCertificateRevocationLists/main.go
+++ b/internal/generated/snippets/security/privateca/apiv1/CertificateAuthorityClient/ListCertificateRevocationLists/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/security/privateca/apiv1/CertificateAuthorityClient/ListCertificateTemplates/main.go
+++ b/internal/generated/snippets/security/privateca/apiv1/CertificateAuthorityClient/ListCertificateTemplates/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/security/privateca/apiv1/CertificateAuthorityClient/ListCertificates/main.go
+++ b/internal/generated/snippets/security/privateca/apiv1/CertificateAuthorityClient/ListCertificates/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/security/privateca/apiv1/CertificateAuthorityClient/ListLocations/main.go
+++ b/internal/generated/snippets/security/privateca/apiv1/CertificateAuthorityClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/security/privateca/apiv1/CertificateAuthorityClient/ListOperations/main.go
+++ b/internal/generated/snippets/security/privateca/apiv1/CertificateAuthorityClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/security/privateca/apiv1/CertificateAuthorityClient/RevokeCertificate/main.go
+++ b/internal/generated/snippets/security/privateca/apiv1/CertificateAuthorityClient/RevokeCertificate/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/security/privateca/apiv1/CertificateAuthorityClient/SetIamPolicy/main.go
+++ b/internal/generated/snippets/security/privateca/apiv1/CertificateAuthorityClient/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/security/privateca/apiv1/CertificateAuthorityClient/TestIamPermissions/main.go
+++ b/internal/generated/snippets/security/privateca/apiv1/CertificateAuthorityClient/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/security/privateca/apiv1/CertificateAuthorityClient/UndeleteCertificateAuthority/main.go
+++ b/internal/generated/snippets/security/privateca/apiv1/CertificateAuthorityClient/UndeleteCertificateAuthority/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/security/privateca/apiv1/CertificateAuthorityClient/UpdateCaPool/main.go
+++ b/internal/generated/snippets/security/privateca/apiv1/CertificateAuthorityClient/UpdateCaPool/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/security/privateca/apiv1/CertificateAuthorityClient/UpdateCertificate/main.go
+++ b/internal/generated/snippets/security/privateca/apiv1/CertificateAuthorityClient/UpdateCertificate/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/security/privateca/apiv1/CertificateAuthorityClient/UpdateCertificateAuthority/main.go
+++ b/internal/generated/snippets/security/privateca/apiv1/CertificateAuthorityClient/UpdateCertificateAuthority/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/security/privateca/apiv1/CertificateAuthorityClient/UpdateCertificateRevocationList/main.go
+++ b/internal/generated/snippets/security/privateca/apiv1/CertificateAuthorityClient/UpdateCertificateRevocationList/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/security/privateca/apiv1/CertificateAuthorityClient/UpdateCertificateTemplate/main.go
+++ b/internal/generated/snippets/security/privateca/apiv1/CertificateAuthorityClient/UpdateCertificateTemplate/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/security/publicca/apiv1/PublicCertificateAuthorityClient/CreateExternalAccountKey/main.go
+++ b/internal/generated/snippets/security/publicca/apiv1/PublicCertificateAuthorityClient/CreateExternalAccountKey/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/security/publicca/apiv1beta1/PublicCertificateAuthorityClient/CreateExternalAccountKey/main.go
+++ b/internal/generated/snippets/security/publicca/apiv1beta1/PublicCertificateAuthorityClient/CreateExternalAccountKey/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1/Client/BatchCreateResourceValueConfigs/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1/Client/BatchCreateResourceValueConfigs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1/Client/BulkMuteFindings/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1/Client/BulkMuteFindings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1/Client/CancelOperation/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1/Client/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1/Client/CreateBigQueryExport/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1/Client/CreateBigQueryExport/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1/Client/CreateEventThreatDetectionCustomModule/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1/Client/CreateEventThreatDetectionCustomModule/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1/Client/CreateFinding/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1/Client/CreateFinding/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1/Client/CreateMuteConfig/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1/Client/CreateMuteConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1/Client/CreateNotificationConfig/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1/Client/CreateNotificationConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1/Client/CreateSecurityHealthAnalyticsCustomModule/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1/Client/CreateSecurityHealthAnalyticsCustomModule/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1/Client/CreateSource/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1/Client/CreateSource/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1/Client/DeleteBigQueryExport/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1/Client/DeleteBigQueryExport/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1/Client/DeleteEventThreatDetectionCustomModule/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1/Client/DeleteEventThreatDetectionCustomModule/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1/Client/DeleteMuteConfig/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1/Client/DeleteMuteConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1/Client/DeleteNotificationConfig/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1/Client/DeleteNotificationConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1/Client/DeleteOperation/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1/Client/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1/Client/DeleteResourceValueConfig/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1/Client/DeleteResourceValueConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1/Client/DeleteSecurityHealthAnalyticsCustomModule/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1/Client/DeleteSecurityHealthAnalyticsCustomModule/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1/Client/GetBigQueryExport/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1/Client/GetBigQueryExport/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1/Client/GetEffectiveEventThreatDetectionCustomModule/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1/Client/GetEffectiveEventThreatDetectionCustomModule/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1/Client/GetEffectiveSecurityHealthAnalyticsCustomModule/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1/Client/GetEffectiveSecurityHealthAnalyticsCustomModule/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1/Client/GetEventThreatDetectionCustomModule/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1/Client/GetEventThreatDetectionCustomModule/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1/Client/GetIamPolicy/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1/Client/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1/Client/GetMuteConfig/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1/Client/GetMuteConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1/Client/GetNotificationConfig/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1/Client/GetNotificationConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1/Client/GetOperation/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1/Client/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1/Client/GetOrganizationSettings/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1/Client/GetOrganizationSettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1/Client/GetResourceValueConfig/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1/Client/GetResourceValueConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1/Client/GetSecurityHealthAnalyticsCustomModule/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1/Client/GetSecurityHealthAnalyticsCustomModule/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1/Client/GetSimulation/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1/Client/GetSimulation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1/Client/GetSource/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1/Client/GetSource/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1/Client/GetValuedResource/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1/Client/GetValuedResource/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1/Client/GroupAssets/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1/Client/GroupAssets/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1/Client/GroupFindings/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1/Client/GroupFindings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1/Client/ListAssets/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1/Client/ListAssets/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1/Client/ListAttackPaths/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1/Client/ListAttackPaths/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1/Client/ListBigQueryExports/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1/Client/ListBigQueryExports/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1/Client/ListDescendantEventThreatDetectionCustomModules/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1/Client/ListDescendantEventThreatDetectionCustomModules/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1/Client/ListDescendantSecurityHealthAnalyticsCustomModules/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1/Client/ListDescendantSecurityHealthAnalyticsCustomModules/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1/Client/ListEffectiveEventThreatDetectionCustomModules/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1/Client/ListEffectiveEventThreatDetectionCustomModules/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1/Client/ListEffectiveSecurityHealthAnalyticsCustomModules/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1/Client/ListEffectiveSecurityHealthAnalyticsCustomModules/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1/Client/ListEventThreatDetectionCustomModules/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1/Client/ListEventThreatDetectionCustomModules/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1/Client/ListFindings/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1/Client/ListFindings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1/Client/ListMuteConfigs/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1/Client/ListMuteConfigs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1/Client/ListNotificationConfigs/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1/Client/ListNotificationConfigs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1/Client/ListOperations/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1/Client/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1/Client/ListResourceValueConfigs/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1/Client/ListResourceValueConfigs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1/Client/ListSecurityHealthAnalyticsCustomModules/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1/Client/ListSecurityHealthAnalyticsCustomModules/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1/Client/ListSources/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1/Client/ListSources/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1/Client/ListValuedResources/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1/Client/ListValuedResources/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1/Client/RunAssetDiscovery/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1/Client/RunAssetDiscovery/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1/Client/SetFindingState/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1/Client/SetFindingState/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1/Client/SetIamPolicy/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1/Client/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1/Client/SetMute/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1/Client/SetMute/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1/Client/SimulateSecurityHealthAnalyticsCustomModule/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1/Client/SimulateSecurityHealthAnalyticsCustomModule/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1/Client/TestIamPermissions/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1/Client/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1/Client/UpdateBigQueryExport/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1/Client/UpdateBigQueryExport/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1/Client/UpdateEventThreatDetectionCustomModule/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1/Client/UpdateEventThreatDetectionCustomModule/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1/Client/UpdateExternalSystem/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1/Client/UpdateExternalSystem/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1/Client/UpdateFinding/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1/Client/UpdateFinding/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1/Client/UpdateMuteConfig/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1/Client/UpdateMuteConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1/Client/UpdateNotificationConfig/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1/Client/UpdateNotificationConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1/Client/UpdateOrganizationSettings/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1/Client/UpdateOrganizationSettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1/Client/UpdateResourceValueConfig/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1/Client/UpdateResourceValueConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1/Client/UpdateSecurityHealthAnalyticsCustomModule/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1/Client/UpdateSecurityHealthAnalyticsCustomModule/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1/Client/UpdateSecurityMarks/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1/Client/UpdateSecurityMarks/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1/Client/UpdateSource/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1/Client/UpdateSource/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1/Client/ValidateEventThreatDetectionCustomModule/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1/Client/ValidateEventThreatDetectionCustomModule/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1beta1/Client/CreateFinding/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1beta1/Client/CreateFinding/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1beta1/Client/CreateSource/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1beta1/Client/CreateSource/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1beta1/Client/GetIamPolicy/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1beta1/Client/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1beta1/Client/GetOrganizationSettings/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1beta1/Client/GetOrganizationSettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1beta1/Client/GetSource/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1beta1/Client/GetSource/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1beta1/Client/GroupAssets/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1beta1/Client/GroupAssets/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1beta1/Client/GroupFindings/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1beta1/Client/GroupFindings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1beta1/Client/ListAssets/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1beta1/Client/ListAssets/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1beta1/Client/ListFindings/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1beta1/Client/ListFindings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1beta1/Client/ListSources/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1beta1/Client/ListSources/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1beta1/Client/RunAssetDiscovery/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1beta1/Client/RunAssetDiscovery/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1beta1/Client/SetFindingState/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1beta1/Client/SetFindingState/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1beta1/Client/SetIamPolicy/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1beta1/Client/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1beta1/Client/TestIamPermissions/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1beta1/Client/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1beta1/Client/UpdateFinding/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1beta1/Client/UpdateFinding/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1beta1/Client/UpdateOrganizationSettings/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1beta1/Client/UpdateOrganizationSettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1beta1/Client/UpdateSecurityMarks/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1beta1/Client/UpdateSecurityMarks/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1beta1/Client/UpdateSource/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1beta1/Client/UpdateSource/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1p1beta1/Client/CreateFinding/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1p1beta1/Client/CreateFinding/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1p1beta1/Client/CreateNotificationConfig/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1p1beta1/Client/CreateNotificationConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1p1beta1/Client/CreateSource/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1p1beta1/Client/CreateSource/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1p1beta1/Client/DeleteNotificationConfig/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1p1beta1/Client/DeleteNotificationConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1p1beta1/Client/GetIamPolicy/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1p1beta1/Client/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1p1beta1/Client/GetNotificationConfig/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1p1beta1/Client/GetNotificationConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1p1beta1/Client/GetOrganizationSettings/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1p1beta1/Client/GetOrganizationSettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1p1beta1/Client/GetSource/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1p1beta1/Client/GetSource/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1p1beta1/Client/GroupAssets/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1p1beta1/Client/GroupAssets/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1p1beta1/Client/GroupFindings/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1p1beta1/Client/GroupFindings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1p1beta1/Client/ListAssets/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1p1beta1/Client/ListAssets/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1p1beta1/Client/ListFindings/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1p1beta1/Client/ListFindings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1p1beta1/Client/ListNotificationConfigs/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1p1beta1/Client/ListNotificationConfigs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1p1beta1/Client/ListSources/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1p1beta1/Client/ListSources/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1p1beta1/Client/RunAssetDiscovery/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1p1beta1/Client/RunAssetDiscovery/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1p1beta1/Client/SetFindingState/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1p1beta1/Client/SetFindingState/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1p1beta1/Client/SetIamPolicy/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1p1beta1/Client/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1p1beta1/Client/TestIamPermissions/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1p1beta1/Client/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1p1beta1/Client/UpdateFinding/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1p1beta1/Client/UpdateFinding/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1p1beta1/Client/UpdateNotificationConfig/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1p1beta1/Client/UpdateNotificationConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1p1beta1/Client/UpdateOrganizationSettings/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1p1beta1/Client/UpdateOrganizationSettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1p1beta1/Client/UpdateSecurityMarks/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1p1beta1/Client/UpdateSecurityMarks/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv1p1beta1/Client/UpdateSource/main.go
+++ b/internal/generated/snippets/securitycenter/apiv1p1beta1/Client/UpdateSource/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv2/Client/BatchCreateResourceValueConfigs/main.go
+++ b/internal/generated/snippets/securitycenter/apiv2/Client/BatchCreateResourceValueConfigs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv2/Client/BulkMuteFindings/main.go
+++ b/internal/generated/snippets/securitycenter/apiv2/Client/BulkMuteFindings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv2/Client/CancelOperation/main.go
+++ b/internal/generated/snippets/securitycenter/apiv2/Client/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv2/Client/CreateBigQueryExport/main.go
+++ b/internal/generated/snippets/securitycenter/apiv2/Client/CreateBigQueryExport/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv2/Client/CreateFinding/main.go
+++ b/internal/generated/snippets/securitycenter/apiv2/Client/CreateFinding/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv2/Client/CreateMuteConfig/main.go
+++ b/internal/generated/snippets/securitycenter/apiv2/Client/CreateMuteConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv2/Client/CreateNotificationConfig/main.go
+++ b/internal/generated/snippets/securitycenter/apiv2/Client/CreateNotificationConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv2/Client/CreateSource/main.go
+++ b/internal/generated/snippets/securitycenter/apiv2/Client/CreateSource/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv2/Client/DeleteBigQueryExport/main.go
+++ b/internal/generated/snippets/securitycenter/apiv2/Client/DeleteBigQueryExport/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv2/Client/DeleteMuteConfig/main.go
+++ b/internal/generated/snippets/securitycenter/apiv2/Client/DeleteMuteConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv2/Client/DeleteNotificationConfig/main.go
+++ b/internal/generated/snippets/securitycenter/apiv2/Client/DeleteNotificationConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv2/Client/DeleteOperation/main.go
+++ b/internal/generated/snippets/securitycenter/apiv2/Client/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv2/Client/DeleteResourceValueConfig/main.go
+++ b/internal/generated/snippets/securitycenter/apiv2/Client/DeleteResourceValueConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv2/Client/GetBigQueryExport/main.go
+++ b/internal/generated/snippets/securitycenter/apiv2/Client/GetBigQueryExport/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv2/Client/GetIamPolicy/main.go
+++ b/internal/generated/snippets/securitycenter/apiv2/Client/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv2/Client/GetMuteConfig/main.go
+++ b/internal/generated/snippets/securitycenter/apiv2/Client/GetMuteConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv2/Client/GetNotificationConfig/main.go
+++ b/internal/generated/snippets/securitycenter/apiv2/Client/GetNotificationConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv2/Client/GetOperation/main.go
+++ b/internal/generated/snippets/securitycenter/apiv2/Client/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv2/Client/GetResourceValueConfig/main.go
+++ b/internal/generated/snippets/securitycenter/apiv2/Client/GetResourceValueConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv2/Client/GetSimulation/main.go
+++ b/internal/generated/snippets/securitycenter/apiv2/Client/GetSimulation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv2/Client/GetSource/main.go
+++ b/internal/generated/snippets/securitycenter/apiv2/Client/GetSource/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv2/Client/GetValuedResource/main.go
+++ b/internal/generated/snippets/securitycenter/apiv2/Client/GetValuedResource/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv2/Client/GroupFindings/main.go
+++ b/internal/generated/snippets/securitycenter/apiv2/Client/GroupFindings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv2/Client/ListAttackPaths/main.go
+++ b/internal/generated/snippets/securitycenter/apiv2/Client/ListAttackPaths/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv2/Client/ListBigQueryExports/main.go
+++ b/internal/generated/snippets/securitycenter/apiv2/Client/ListBigQueryExports/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv2/Client/ListFindings/main.go
+++ b/internal/generated/snippets/securitycenter/apiv2/Client/ListFindings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv2/Client/ListMuteConfigs/main.go
+++ b/internal/generated/snippets/securitycenter/apiv2/Client/ListMuteConfigs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv2/Client/ListNotificationConfigs/main.go
+++ b/internal/generated/snippets/securitycenter/apiv2/Client/ListNotificationConfigs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv2/Client/ListOperations/main.go
+++ b/internal/generated/snippets/securitycenter/apiv2/Client/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv2/Client/ListResourceValueConfigs/main.go
+++ b/internal/generated/snippets/securitycenter/apiv2/Client/ListResourceValueConfigs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv2/Client/ListSources/main.go
+++ b/internal/generated/snippets/securitycenter/apiv2/Client/ListSources/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv2/Client/ListValuedResources/main.go
+++ b/internal/generated/snippets/securitycenter/apiv2/Client/ListValuedResources/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv2/Client/SetFindingState/main.go
+++ b/internal/generated/snippets/securitycenter/apiv2/Client/SetFindingState/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv2/Client/SetIamPolicy/main.go
+++ b/internal/generated/snippets/securitycenter/apiv2/Client/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv2/Client/SetMute/main.go
+++ b/internal/generated/snippets/securitycenter/apiv2/Client/SetMute/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv2/Client/TestIamPermissions/main.go
+++ b/internal/generated/snippets/securitycenter/apiv2/Client/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv2/Client/UpdateBigQueryExport/main.go
+++ b/internal/generated/snippets/securitycenter/apiv2/Client/UpdateBigQueryExport/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv2/Client/UpdateExternalSystem/main.go
+++ b/internal/generated/snippets/securitycenter/apiv2/Client/UpdateExternalSystem/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv2/Client/UpdateFinding/main.go
+++ b/internal/generated/snippets/securitycenter/apiv2/Client/UpdateFinding/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv2/Client/UpdateMuteConfig/main.go
+++ b/internal/generated/snippets/securitycenter/apiv2/Client/UpdateMuteConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv2/Client/UpdateNotificationConfig/main.go
+++ b/internal/generated/snippets/securitycenter/apiv2/Client/UpdateNotificationConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv2/Client/UpdateResourceValueConfig/main.go
+++ b/internal/generated/snippets/securitycenter/apiv2/Client/UpdateResourceValueConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv2/Client/UpdateSecurityMarks/main.go
+++ b/internal/generated/snippets/securitycenter/apiv2/Client/UpdateSecurityMarks/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/apiv2/Client/UpdateSource/main.go
+++ b/internal/generated/snippets/securitycenter/apiv2/Client/UpdateSource/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/settings/apiv1beta1/SecurityCenterSettingsClient/BatchCalculateEffectiveSettings/main.go
+++ b/internal/generated/snippets/securitycenter/settings/apiv1beta1/SecurityCenterSettingsClient/BatchCalculateEffectiveSettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/settings/apiv1beta1/SecurityCenterSettingsClient/BatchGetSettings/main.go
+++ b/internal/generated/snippets/securitycenter/settings/apiv1beta1/SecurityCenterSettingsClient/BatchGetSettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/settings/apiv1beta1/SecurityCenterSettingsClient/CalculateEffectiveComponentSettings/main.go
+++ b/internal/generated/snippets/securitycenter/settings/apiv1beta1/SecurityCenterSettingsClient/CalculateEffectiveComponentSettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/settings/apiv1beta1/SecurityCenterSettingsClient/CalculateEffectiveSettings/main.go
+++ b/internal/generated/snippets/securitycenter/settings/apiv1beta1/SecurityCenterSettingsClient/CalculateEffectiveSettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/settings/apiv1beta1/SecurityCenterSettingsClient/GetComponentSettings/main.go
+++ b/internal/generated/snippets/securitycenter/settings/apiv1beta1/SecurityCenterSettingsClient/GetComponentSettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/settings/apiv1beta1/SecurityCenterSettingsClient/GetServiceAccount/main.go
+++ b/internal/generated/snippets/securitycenter/settings/apiv1beta1/SecurityCenterSettingsClient/GetServiceAccount/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/settings/apiv1beta1/SecurityCenterSettingsClient/GetSettings/main.go
+++ b/internal/generated/snippets/securitycenter/settings/apiv1beta1/SecurityCenterSettingsClient/GetSettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/settings/apiv1beta1/SecurityCenterSettingsClient/ListComponents/main.go
+++ b/internal/generated/snippets/securitycenter/settings/apiv1beta1/SecurityCenterSettingsClient/ListComponents/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/settings/apiv1beta1/SecurityCenterSettingsClient/ListDetectors/main.go
+++ b/internal/generated/snippets/securitycenter/settings/apiv1beta1/SecurityCenterSettingsClient/ListDetectors/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/settings/apiv1beta1/SecurityCenterSettingsClient/ResetComponentSettings/main.go
+++ b/internal/generated/snippets/securitycenter/settings/apiv1beta1/SecurityCenterSettingsClient/ResetComponentSettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/settings/apiv1beta1/SecurityCenterSettingsClient/ResetSettings/main.go
+++ b/internal/generated/snippets/securitycenter/settings/apiv1beta1/SecurityCenterSettingsClient/ResetSettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/settings/apiv1beta1/SecurityCenterSettingsClient/UpdateComponentSettings/main.go
+++ b/internal/generated/snippets/securitycenter/settings/apiv1beta1/SecurityCenterSettingsClient/UpdateComponentSettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycenter/settings/apiv1beta1/SecurityCenterSettingsClient/UpdateSettings/main.go
+++ b/internal/generated/snippets/securitycenter/settings/apiv1beta1/SecurityCenterSettingsClient/UpdateSettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycentermanagement/apiv1/Client/CreateEventThreatDetectionCustomModule/main.go
+++ b/internal/generated/snippets/securitycentermanagement/apiv1/Client/CreateEventThreatDetectionCustomModule/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycentermanagement/apiv1/Client/CreateSecurityHealthAnalyticsCustomModule/main.go
+++ b/internal/generated/snippets/securitycentermanagement/apiv1/Client/CreateSecurityHealthAnalyticsCustomModule/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycentermanagement/apiv1/Client/DeleteEventThreatDetectionCustomModule/main.go
+++ b/internal/generated/snippets/securitycentermanagement/apiv1/Client/DeleteEventThreatDetectionCustomModule/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycentermanagement/apiv1/Client/DeleteSecurityHealthAnalyticsCustomModule/main.go
+++ b/internal/generated/snippets/securitycentermanagement/apiv1/Client/DeleteSecurityHealthAnalyticsCustomModule/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycentermanagement/apiv1/Client/GetEffectiveEventThreatDetectionCustomModule/main.go
+++ b/internal/generated/snippets/securitycentermanagement/apiv1/Client/GetEffectiveEventThreatDetectionCustomModule/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycentermanagement/apiv1/Client/GetEffectiveSecurityHealthAnalyticsCustomModule/main.go
+++ b/internal/generated/snippets/securitycentermanagement/apiv1/Client/GetEffectiveSecurityHealthAnalyticsCustomModule/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycentermanagement/apiv1/Client/GetEventThreatDetectionCustomModule/main.go
+++ b/internal/generated/snippets/securitycentermanagement/apiv1/Client/GetEventThreatDetectionCustomModule/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycentermanagement/apiv1/Client/GetLocation/main.go
+++ b/internal/generated/snippets/securitycentermanagement/apiv1/Client/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycentermanagement/apiv1/Client/GetSecurityCenterService/main.go
+++ b/internal/generated/snippets/securitycentermanagement/apiv1/Client/GetSecurityCenterService/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycentermanagement/apiv1/Client/GetSecurityHealthAnalyticsCustomModule/main.go
+++ b/internal/generated/snippets/securitycentermanagement/apiv1/Client/GetSecurityHealthAnalyticsCustomModule/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycentermanagement/apiv1/Client/ListDescendantEventThreatDetectionCustomModules/main.go
+++ b/internal/generated/snippets/securitycentermanagement/apiv1/Client/ListDescendantEventThreatDetectionCustomModules/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycentermanagement/apiv1/Client/ListDescendantSecurityHealthAnalyticsCustomModules/main.go
+++ b/internal/generated/snippets/securitycentermanagement/apiv1/Client/ListDescendantSecurityHealthAnalyticsCustomModules/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycentermanagement/apiv1/Client/ListEffectiveEventThreatDetectionCustomModules/main.go
+++ b/internal/generated/snippets/securitycentermanagement/apiv1/Client/ListEffectiveEventThreatDetectionCustomModules/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycentermanagement/apiv1/Client/ListEffectiveSecurityHealthAnalyticsCustomModules/main.go
+++ b/internal/generated/snippets/securitycentermanagement/apiv1/Client/ListEffectiveSecurityHealthAnalyticsCustomModules/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycentermanagement/apiv1/Client/ListEventThreatDetectionCustomModules/main.go
+++ b/internal/generated/snippets/securitycentermanagement/apiv1/Client/ListEventThreatDetectionCustomModules/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycentermanagement/apiv1/Client/ListLocations/main.go
+++ b/internal/generated/snippets/securitycentermanagement/apiv1/Client/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycentermanagement/apiv1/Client/ListSecurityCenterServices/main.go
+++ b/internal/generated/snippets/securitycentermanagement/apiv1/Client/ListSecurityCenterServices/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycentermanagement/apiv1/Client/ListSecurityHealthAnalyticsCustomModules/main.go
+++ b/internal/generated/snippets/securitycentermanagement/apiv1/Client/ListSecurityHealthAnalyticsCustomModules/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycentermanagement/apiv1/Client/SimulateSecurityHealthAnalyticsCustomModule/main.go
+++ b/internal/generated/snippets/securitycentermanagement/apiv1/Client/SimulateSecurityHealthAnalyticsCustomModule/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycentermanagement/apiv1/Client/UpdateEventThreatDetectionCustomModule/main.go
+++ b/internal/generated/snippets/securitycentermanagement/apiv1/Client/UpdateEventThreatDetectionCustomModule/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycentermanagement/apiv1/Client/UpdateSecurityCenterService/main.go
+++ b/internal/generated/snippets/securitycentermanagement/apiv1/Client/UpdateSecurityCenterService/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycentermanagement/apiv1/Client/UpdateSecurityHealthAnalyticsCustomModule/main.go
+++ b/internal/generated/snippets/securitycentermanagement/apiv1/Client/UpdateSecurityHealthAnalyticsCustomModule/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securitycentermanagement/apiv1/Client/ValidateEventThreatDetectionCustomModule/main.go
+++ b/internal/generated/snippets/securitycentermanagement/apiv1/Client/ValidateEventThreatDetectionCustomModule/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securityposture/apiv1/Client/CancelOperation/main.go
+++ b/internal/generated/snippets/securityposture/apiv1/Client/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securityposture/apiv1/Client/CreatePosture/main.go
+++ b/internal/generated/snippets/securityposture/apiv1/Client/CreatePosture/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securityposture/apiv1/Client/CreatePostureDeployment/main.go
+++ b/internal/generated/snippets/securityposture/apiv1/Client/CreatePostureDeployment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securityposture/apiv1/Client/DeleteOperation/main.go
+++ b/internal/generated/snippets/securityposture/apiv1/Client/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securityposture/apiv1/Client/DeletePosture/main.go
+++ b/internal/generated/snippets/securityposture/apiv1/Client/DeletePosture/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securityposture/apiv1/Client/DeletePostureDeployment/main.go
+++ b/internal/generated/snippets/securityposture/apiv1/Client/DeletePostureDeployment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securityposture/apiv1/Client/ExtractPosture/main.go
+++ b/internal/generated/snippets/securityposture/apiv1/Client/ExtractPosture/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securityposture/apiv1/Client/GetLocation/main.go
+++ b/internal/generated/snippets/securityposture/apiv1/Client/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securityposture/apiv1/Client/GetOperation/main.go
+++ b/internal/generated/snippets/securityposture/apiv1/Client/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securityposture/apiv1/Client/GetPosture/main.go
+++ b/internal/generated/snippets/securityposture/apiv1/Client/GetPosture/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securityposture/apiv1/Client/GetPostureDeployment/main.go
+++ b/internal/generated/snippets/securityposture/apiv1/Client/GetPostureDeployment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securityposture/apiv1/Client/GetPostureTemplate/main.go
+++ b/internal/generated/snippets/securityposture/apiv1/Client/GetPostureTemplate/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securityposture/apiv1/Client/ListLocations/main.go
+++ b/internal/generated/snippets/securityposture/apiv1/Client/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securityposture/apiv1/Client/ListOperations/main.go
+++ b/internal/generated/snippets/securityposture/apiv1/Client/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securityposture/apiv1/Client/ListPostureDeployments/main.go
+++ b/internal/generated/snippets/securityposture/apiv1/Client/ListPostureDeployments/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securityposture/apiv1/Client/ListPostureRevisions/main.go
+++ b/internal/generated/snippets/securityposture/apiv1/Client/ListPostureRevisions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securityposture/apiv1/Client/ListPostureTemplates/main.go
+++ b/internal/generated/snippets/securityposture/apiv1/Client/ListPostureTemplates/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securityposture/apiv1/Client/ListPostures/main.go
+++ b/internal/generated/snippets/securityposture/apiv1/Client/ListPostures/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securityposture/apiv1/Client/UpdatePosture/main.go
+++ b/internal/generated/snippets/securityposture/apiv1/Client/UpdatePosture/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/securityposture/apiv1/Client/UpdatePostureDeployment/main.go
+++ b/internal/generated/snippets/securityposture/apiv1/Client/UpdatePostureDeployment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/servicecontrol/apiv1/QuotaControllerClient/AllocateQuota/main.go
+++ b/internal/generated/snippets/servicecontrol/apiv1/QuotaControllerClient/AllocateQuota/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/servicecontrol/apiv1/ServiceControllerClient/Check/main.go
+++ b/internal/generated/snippets/servicecontrol/apiv1/ServiceControllerClient/Check/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/servicecontrol/apiv1/ServiceControllerClient/Report/main.go
+++ b/internal/generated/snippets/servicecontrol/apiv1/ServiceControllerClient/Report/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/servicedirectory/apiv1/LookupClient/GetLocation/main.go
+++ b/internal/generated/snippets/servicedirectory/apiv1/LookupClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/servicedirectory/apiv1/LookupClient/ListLocations/main.go
+++ b/internal/generated/snippets/servicedirectory/apiv1/LookupClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/servicedirectory/apiv1/LookupClient/ResolveService/main.go
+++ b/internal/generated/snippets/servicedirectory/apiv1/LookupClient/ResolveService/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/servicedirectory/apiv1/RegistrationClient/CreateEndpoint/main.go
+++ b/internal/generated/snippets/servicedirectory/apiv1/RegistrationClient/CreateEndpoint/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/servicedirectory/apiv1/RegistrationClient/CreateNamespace/main.go
+++ b/internal/generated/snippets/servicedirectory/apiv1/RegistrationClient/CreateNamespace/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/servicedirectory/apiv1/RegistrationClient/CreateService/main.go
+++ b/internal/generated/snippets/servicedirectory/apiv1/RegistrationClient/CreateService/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/servicedirectory/apiv1/RegistrationClient/DeleteEndpoint/main.go
+++ b/internal/generated/snippets/servicedirectory/apiv1/RegistrationClient/DeleteEndpoint/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/servicedirectory/apiv1/RegistrationClient/DeleteNamespace/main.go
+++ b/internal/generated/snippets/servicedirectory/apiv1/RegistrationClient/DeleteNamespace/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/servicedirectory/apiv1/RegistrationClient/DeleteService/main.go
+++ b/internal/generated/snippets/servicedirectory/apiv1/RegistrationClient/DeleteService/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/servicedirectory/apiv1/RegistrationClient/GetEndpoint/main.go
+++ b/internal/generated/snippets/servicedirectory/apiv1/RegistrationClient/GetEndpoint/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/servicedirectory/apiv1/RegistrationClient/GetIamPolicy/main.go
+++ b/internal/generated/snippets/servicedirectory/apiv1/RegistrationClient/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/servicedirectory/apiv1/RegistrationClient/GetLocation/main.go
+++ b/internal/generated/snippets/servicedirectory/apiv1/RegistrationClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/servicedirectory/apiv1/RegistrationClient/GetNamespace/main.go
+++ b/internal/generated/snippets/servicedirectory/apiv1/RegistrationClient/GetNamespace/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/servicedirectory/apiv1/RegistrationClient/GetService/main.go
+++ b/internal/generated/snippets/servicedirectory/apiv1/RegistrationClient/GetService/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/servicedirectory/apiv1/RegistrationClient/ListEndpoints/main.go
+++ b/internal/generated/snippets/servicedirectory/apiv1/RegistrationClient/ListEndpoints/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/servicedirectory/apiv1/RegistrationClient/ListLocations/main.go
+++ b/internal/generated/snippets/servicedirectory/apiv1/RegistrationClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/servicedirectory/apiv1/RegistrationClient/ListNamespaces/main.go
+++ b/internal/generated/snippets/servicedirectory/apiv1/RegistrationClient/ListNamespaces/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/servicedirectory/apiv1/RegistrationClient/ListServices/main.go
+++ b/internal/generated/snippets/servicedirectory/apiv1/RegistrationClient/ListServices/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/servicedirectory/apiv1/RegistrationClient/SetIamPolicy/main.go
+++ b/internal/generated/snippets/servicedirectory/apiv1/RegistrationClient/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/servicedirectory/apiv1/RegistrationClient/TestIamPermissions/main.go
+++ b/internal/generated/snippets/servicedirectory/apiv1/RegistrationClient/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/servicedirectory/apiv1/RegistrationClient/UpdateEndpoint/main.go
+++ b/internal/generated/snippets/servicedirectory/apiv1/RegistrationClient/UpdateEndpoint/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/servicedirectory/apiv1/RegistrationClient/UpdateNamespace/main.go
+++ b/internal/generated/snippets/servicedirectory/apiv1/RegistrationClient/UpdateNamespace/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/servicedirectory/apiv1/RegistrationClient/UpdateService/main.go
+++ b/internal/generated/snippets/servicedirectory/apiv1/RegistrationClient/UpdateService/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/servicedirectory/apiv1beta1/LookupClient/GetLocation/main.go
+++ b/internal/generated/snippets/servicedirectory/apiv1beta1/LookupClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/servicedirectory/apiv1beta1/LookupClient/ListLocations/main.go
+++ b/internal/generated/snippets/servicedirectory/apiv1beta1/LookupClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/servicedirectory/apiv1beta1/LookupClient/ResolveService/main.go
+++ b/internal/generated/snippets/servicedirectory/apiv1beta1/LookupClient/ResolveService/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/servicedirectory/apiv1beta1/RegistrationClient/CreateEndpoint/main.go
+++ b/internal/generated/snippets/servicedirectory/apiv1beta1/RegistrationClient/CreateEndpoint/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/servicedirectory/apiv1beta1/RegistrationClient/CreateNamespace/main.go
+++ b/internal/generated/snippets/servicedirectory/apiv1beta1/RegistrationClient/CreateNamespace/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/servicedirectory/apiv1beta1/RegistrationClient/CreateService/main.go
+++ b/internal/generated/snippets/servicedirectory/apiv1beta1/RegistrationClient/CreateService/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/servicedirectory/apiv1beta1/RegistrationClient/DeleteEndpoint/main.go
+++ b/internal/generated/snippets/servicedirectory/apiv1beta1/RegistrationClient/DeleteEndpoint/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/servicedirectory/apiv1beta1/RegistrationClient/DeleteNamespace/main.go
+++ b/internal/generated/snippets/servicedirectory/apiv1beta1/RegistrationClient/DeleteNamespace/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/servicedirectory/apiv1beta1/RegistrationClient/DeleteService/main.go
+++ b/internal/generated/snippets/servicedirectory/apiv1beta1/RegistrationClient/DeleteService/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/servicedirectory/apiv1beta1/RegistrationClient/GetEndpoint/main.go
+++ b/internal/generated/snippets/servicedirectory/apiv1beta1/RegistrationClient/GetEndpoint/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/servicedirectory/apiv1beta1/RegistrationClient/GetIamPolicy/main.go
+++ b/internal/generated/snippets/servicedirectory/apiv1beta1/RegistrationClient/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/servicedirectory/apiv1beta1/RegistrationClient/GetLocation/main.go
+++ b/internal/generated/snippets/servicedirectory/apiv1beta1/RegistrationClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/servicedirectory/apiv1beta1/RegistrationClient/GetNamespace/main.go
+++ b/internal/generated/snippets/servicedirectory/apiv1beta1/RegistrationClient/GetNamespace/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/servicedirectory/apiv1beta1/RegistrationClient/GetService/main.go
+++ b/internal/generated/snippets/servicedirectory/apiv1beta1/RegistrationClient/GetService/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/servicedirectory/apiv1beta1/RegistrationClient/ListEndpoints/main.go
+++ b/internal/generated/snippets/servicedirectory/apiv1beta1/RegistrationClient/ListEndpoints/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/servicedirectory/apiv1beta1/RegistrationClient/ListLocations/main.go
+++ b/internal/generated/snippets/servicedirectory/apiv1beta1/RegistrationClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/servicedirectory/apiv1beta1/RegistrationClient/ListNamespaces/main.go
+++ b/internal/generated/snippets/servicedirectory/apiv1beta1/RegistrationClient/ListNamespaces/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/servicedirectory/apiv1beta1/RegistrationClient/ListServices/main.go
+++ b/internal/generated/snippets/servicedirectory/apiv1beta1/RegistrationClient/ListServices/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/servicedirectory/apiv1beta1/RegistrationClient/SetIamPolicy/main.go
+++ b/internal/generated/snippets/servicedirectory/apiv1beta1/RegistrationClient/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/servicedirectory/apiv1beta1/RegistrationClient/TestIamPermissions/main.go
+++ b/internal/generated/snippets/servicedirectory/apiv1beta1/RegistrationClient/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/servicedirectory/apiv1beta1/RegistrationClient/UpdateEndpoint/main.go
+++ b/internal/generated/snippets/servicedirectory/apiv1beta1/RegistrationClient/UpdateEndpoint/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/servicedirectory/apiv1beta1/RegistrationClient/UpdateNamespace/main.go
+++ b/internal/generated/snippets/servicedirectory/apiv1beta1/RegistrationClient/UpdateNamespace/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/servicedirectory/apiv1beta1/RegistrationClient/UpdateService/main.go
+++ b/internal/generated/snippets/servicedirectory/apiv1beta1/RegistrationClient/UpdateService/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/servicehealth/apiv1/Client/GetEvent/main.go
+++ b/internal/generated/snippets/servicehealth/apiv1/Client/GetEvent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/servicehealth/apiv1/Client/GetLocation/main.go
+++ b/internal/generated/snippets/servicehealth/apiv1/Client/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/servicehealth/apiv1/Client/GetOrganizationEvent/main.go
+++ b/internal/generated/snippets/servicehealth/apiv1/Client/GetOrganizationEvent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/servicehealth/apiv1/Client/GetOrganizationImpact/main.go
+++ b/internal/generated/snippets/servicehealth/apiv1/Client/GetOrganizationImpact/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/servicehealth/apiv1/Client/ListEvents/main.go
+++ b/internal/generated/snippets/servicehealth/apiv1/Client/ListEvents/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/servicehealth/apiv1/Client/ListLocations/main.go
+++ b/internal/generated/snippets/servicehealth/apiv1/Client/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/servicehealth/apiv1/Client/ListOrganizationEvents/main.go
+++ b/internal/generated/snippets/servicehealth/apiv1/Client/ListOrganizationEvents/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/servicehealth/apiv1/Client/ListOrganizationImpacts/main.go
+++ b/internal/generated/snippets/servicehealth/apiv1/Client/ListOrganizationImpacts/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/servicemanagement/apiv1/ServiceManagerClient/CreateService/main.go
+++ b/internal/generated/snippets/servicemanagement/apiv1/ServiceManagerClient/CreateService/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/servicemanagement/apiv1/ServiceManagerClient/CreateServiceConfig/main.go
+++ b/internal/generated/snippets/servicemanagement/apiv1/ServiceManagerClient/CreateServiceConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/servicemanagement/apiv1/ServiceManagerClient/CreateServiceRollout/main.go
+++ b/internal/generated/snippets/servicemanagement/apiv1/ServiceManagerClient/CreateServiceRollout/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/servicemanagement/apiv1/ServiceManagerClient/DeleteService/main.go
+++ b/internal/generated/snippets/servicemanagement/apiv1/ServiceManagerClient/DeleteService/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/servicemanagement/apiv1/ServiceManagerClient/GenerateConfigReport/main.go
+++ b/internal/generated/snippets/servicemanagement/apiv1/ServiceManagerClient/GenerateConfigReport/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/servicemanagement/apiv1/ServiceManagerClient/GetIamPolicy/main.go
+++ b/internal/generated/snippets/servicemanagement/apiv1/ServiceManagerClient/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/servicemanagement/apiv1/ServiceManagerClient/GetService/main.go
+++ b/internal/generated/snippets/servicemanagement/apiv1/ServiceManagerClient/GetService/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/servicemanagement/apiv1/ServiceManagerClient/GetServiceConfig/main.go
+++ b/internal/generated/snippets/servicemanagement/apiv1/ServiceManagerClient/GetServiceConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/servicemanagement/apiv1/ServiceManagerClient/GetServiceRollout/main.go
+++ b/internal/generated/snippets/servicemanagement/apiv1/ServiceManagerClient/GetServiceRollout/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/servicemanagement/apiv1/ServiceManagerClient/ListOperations/main.go
+++ b/internal/generated/snippets/servicemanagement/apiv1/ServiceManagerClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/servicemanagement/apiv1/ServiceManagerClient/ListServiceConfigs/main.go
+++ b/internal/generated/snippets/servicemanagement/apiv1/ServiceManagerClient/ListServiceConfigs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/servicemanagement/apiv1/ServiceManagerClient/ListServiceRollouts/main.go
+++ b/internal/generated/snippets/servicemanagement/apiv1/ServiceManagerClient/ListServiceRollouts/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/servicemanagement/apiv1/ServiceManagerClient/ListServices/main.go
+++ b/internal/generated/snippets/servicemanagement/apiv1/ServiceManagerClient/ListServices/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/servicemanagement/apiv1/ServiceManagerClient/SetIamPolicy/main.go
+++ b/internal/generated/snippets/servicemanagement/apiv1/ServiceManagerClient/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/servicemanagement/apiv1/ServiceManagerClient/SubmitConfigSource/main.go
+++ b/internal/generated/snippets/servicemanagement/apiv1/ServiceManagerClient/SubmitConfigSource/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/servicemanagement/apiv1/ServiceManagerClient/TestIamPermissions/main.go
+++ b/internal/generated/snippets/servicemanagement/apiv1/ServiceManagerClient/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/servicemanagement/apiv1/ServiceManagerClient/UndeleteService/main.go
+++ b/internal/generated/snippets/servicemanagement/apiv1/ServiceManagerClient/UndeleteService/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/serviceusage/apiv1/Client/BatchEnableServices/main.go
+++ b/internal/generated/snippets/serviceusage/apiv1/Client/BatchEnableServices/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/serviceusage/apiv1/Client/BatchGetServices/main.go
+++ b/internal/generated/snippets/serviceusage/apiv1/Client/BatchGetServices/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/serviceusage/apiv1/Client/DisableService/main.go
+++ b/internal/generated/snippets/serviceusage/apiv1/Client/DisableService/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/serviceusage/apiv1/Client/EnableService/main.go
+++ b/internal/generated/snippets/serviceusage/apiv1/Client/EnableService/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/serviceusage/apiv1/Client/GetOperation/main.go
+++ b/internal/generated/snippets/serviceusage/apiv1/Client/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/serviceusage/apiv1/Client/GetService/main.go
+++ b/internal/generated/snippets/serviceusage/apiv1/Client/GetService/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/serviceusage/apiv1/Client/ListOperations/main.go
+++ b/internal/generated/snippets/serviceusage/apiv1/Client/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/serviceusage/apiv1/Client/ListServices/main.go
+++ b/internal/generated/snippets/serviceusage/apiv1/Client/ListServices/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shell/apiv1/CloudShellClient/AddPublicKey/main.go
+++ b/internal/generated/snippets/shell/apiv1/CloudShellClient/AddPublicKey/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shell/apiv1/CloudShellClient/AuthorizeEnvironment/main.go
+++ b/internal/generated/snippets/shell/apiv1/CloudShellClient/AuthorizeEnvironment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shell/apiv1/CloudShellClient/GetEnvironment/main.go
+++ b/internal/generated/snippets/shell/apiv1/CloudShellClient/GetEnvironment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shell/apiv1/CloudShellClient/RemovePublicKey/main.go
+++ b/internal/generated/snippets/shell/apiv1/CloudShellClient/RemovePublicKey/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shell/apiv1/CloudShellClient/StartEnvironment/main.go
+++ b/internal/generated/snippets/shell/apiv1/CloudShellClient/StartEnvironment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/css/apiv1/AccountLabelsClient/CreateAccountLabel/main.go
+++ b/internal/generated/snippets/shopping/css/apiv1/AccountLabelsClient/CreateAccountLabel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/css/apiv1/AccountLabelsClient/DeleteAccountLabel/main.go
+++ b/internal/generated/snippets/shopping/css/apiv1/AccountLabelsClient/DeleteAccountLabel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/css/apiv1/AccountLabelsClient/ListAccountLabels/main.go
+++ b/internal/generated/snippets/shopping/css/apiv1/AccountLabelsClient/ListAccountLabels/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/css/apiv1/AccountLabelsClient/UpdateAccountLabel/main.go
+++ b/internal/generated/snippets/shopping/css/apiv1/AccountLabelsClient/UpdateAccountLabel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/css/apiv1/AccountsClient/GetAccount/main.go
+++ b/internal/generated/snippets/shopping/css/apiv1/AccountsClient/GetAccount/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/css/apiv1/AccountsClient/ListChildAccounts/main.go
+++ b/internal/generated/snippets/shopping/css/apiv1/AccountsClient/ListChildAccounts/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/css/apiv1/AccountsClient/UpdateLabels/main.go
+++ b/internal/generated/snippets/shopping/css/apiv1/AccountsClient/UpdateLabels/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/css/apiv1/CssProductInputsClient/DeleteCssProductInput/main.go
+++ b/internal/generated/snippets/shopping/css/apiv1/CssProductInputsClient/DeleteCssProductInput/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/css/apiv1/CssProductInputsClient/InsertCssProductInput/main.go
+++ b/internal/generated/snippets/shopping/css/apiv1/CssProductInputsClient/InsertCssProductInput/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/css/apiv1/CssProductInputsClient/UpdateCssProductInput/main.go
+++ b/internal/generated/snippets/shopping/css/apiv1/CssProductInputsClient/UpdateCssProductInput/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/css/apiv1/CssProductsClient/GetCssProduct/main.go
+++ b/internal/generated/snippets/shopping/css/apiv1/CssProductsClient/GetCssProduct/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/css/apiv1/CssProductsClient/ListCssProducts/main.go
+++ b/internal/generated/snippets/shopping/css/apiv1/CssProductsClient/ListCssProducts/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/css/apiv1/QuotaClient/ListQuotaGroups/main.go
+++ b/internal/generated/snippets/shopping/css/apiv1/QuotaClient/ListQuotaGroups/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1/AccountIssueClient/ListAccountIssues/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1/AccountIssueClient/ListAccountIssues/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1/AccountRelationshipsClient/GetAccountRelationship/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1/AccountRelationshipsClient/GetAccountRelationship/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1/AccountRelationshipsClient/ListAccountRelationships/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1/AccountRelationshipsClient/ListAccountRelationships/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1/AccountRelationshipsClient/UpdateAccountRelationship/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1/AccountRelationshipsClient/UpdateAccountRelationship/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1/AccountServicesClient/ApproveAccountService/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1/AccountServicesClient/ApproveAccountService/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1/AccountServicesClient/GetAccountService/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1/AccountServicesClient/GetAccountService/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1/AccountServicesClient/ListAccountServices/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1/AccountServicesClient/ListAccountServices/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1/AccountServicesClient/ProposeAccountService/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1/AccountServicesClient/ProposeAccountService/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1/AccountServicesClient/RejectAccountService/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1/AccountServicesClient/RejectAccountService/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1/AutofeedSettingsClient/GetAutofeedSettings/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1/AutofeedSettingsClient/GetAutofeedSettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1/AutofeedSettingsClient/UpdateAutofeedSettings/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1/AutofeedSettingsClient/UpdateAutofeedSettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1/AutomaticImprovementsClient/GetAutomaticImprovements/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1/AutomaticImprovementsClient/GetAutomaticImprovements/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1/AutomaticImprovementsClient/UpdateAutomaticImprovements/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1/AutomaticImprovementsClient/UpdateAutomaticImprovements/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1/BusinessIdentityClient/GetBusinessIdentity/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1/BusinessIdentityClient/GetBusinessIdentity/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1/BusinessIdentityClient/UpdateBusinessIdentity/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1/BusinessIdentityClient/UpdateBusinessIdentity/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1/BusinessInfoClient/GetBusinessInfo/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1/BusinessInfoClient/GetBusinessInfo/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1/BusinessInfoClient/UpdateBusinessInfo/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1/BusinessInfoClient/UpdateBusinessInfo/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1/CheckoutSettingsClient/CreateCheckoutSettings/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1/CheckoutSettingsClient/CreateCheckoutSettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1/CheckoutSettingsClient/DeleteCheckoutSettings/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1/CheckoutSettingsClient/DeleteCheckoutSettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1/CheckoutSettingsClient/GetCheckoutSettings/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1/CheckoutSettingsClient/GetCheckoutSettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1/CheckoutSettingsClient/UpdateCheckoutSettings/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1/CheckoutSettingsClient/UpdateCheckoutSettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1/Client/CreateAndConfigureAccount/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1/Client/CreateAndConfigureAccount/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1/Client/DeleteAccount/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1/Client/DeleteAccount/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1/Client/GetAccount/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1/Client/GetAccount/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1/Client/ListAccounts/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1/Client/ListAccounts/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1/Client/ListSubAccounts/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1/Client/ListSubAccounts/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1/Client/UpdateAccount/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1/Client/UpdateAccount/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1/DeveloperRegistrationClient/GetAccountForGcpRegistration/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1/DeveloperRegistrationClient/GetAccountForGcpRegistration/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1/DeveloperRegistrationClient/GetDeveloperRegistration/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1/DeveloperRegistrationClient/GetDeveloperRegistration/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1/DeveloperRegistrationClient/RegisterGcp/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1/DeveloperRegistrationClient/RegisterGcp/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1/DeveloperRegistrationClient/UnregisterGcp/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1/DeveloperRegistrationClient/UnregisterGcp/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1/EmailPreferencesClient/GetEmailPreferences/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1/EmailPreferencesClient/GetEmailPreferences/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1/EmailPreferencesClient/UpdateEmailPreferences/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1/EmailPreferencesClient/UpdateEmailPreferences/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1/GbpAccountsClient/LinkGbpAccount/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1/GbpAccountsClient/LinkGbpAccount/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1/GbpAccountsClient/ListGbpAccounts/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1/GbpAccountsClient/ListGbpAccounts/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1/HomepageClient/ClaimHomepage/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1/HomepageClient/ClaimHomepage/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1/HomepageClient/GetHomepage/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1/HomepageClient/GetHomepage/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1/HomepageClient/UnclaimHomepage/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1/HomepageClient/UnclaimHomepage/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1/HomepageClient/UpdateHomepage/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1/HomepageClient/UpdateHomepage/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1/LfpProvidersClient/FindLfpProviders/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1/LfpProvidersClient/FindLfpProviders/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1/LfpProvidersClient/LinkLfpProvider/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1/LfpProvidersClient/LinkLfpProvider/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1/OmnichannelSettingsClient/CreateOmnichannelSetting/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1/OmnichannelSettingsClient/CreateOmnichannelSetting/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1/OmnichannelSettingsClient/GetOmnichannelSetting/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1/OmnichannelSettingsClient/GetOmnichannelSetting/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1/OmnichannelSettingsClient/ListOmnichannelSettings/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1/OmnichannelSettingsClient/ListOmnichannelSettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1/OmnichannelSettingsClient/RequestInventoryVerification/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1/OmnichannelSettingsClient/RequestInventoryVerification/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1/OmnichannelSettingsClient/UpdateOmnichannelSetting/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1/OmnichannelSettingsClient/UpdateOmnichannelSetting/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1/OnlineReturnPolicyClient/CreateOnlineReturnPolicy/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1/OnlineReturnPolicyClient/CreateOnlineReturnPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1/OnlineReturnPolicyClient/DeleteOnlineReturnPolicy/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1/OnlineReturnPolicyClient/DeleteOnlineReturnPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1/OnlineReturnPolicyClient/GetOnlineReturnPolicy/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1/OnlineReturnPolicyClient/GetOnlineReturnPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1/OnlineReturnPolicyClient/ListOnlineReturnPolicies/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1/OnlineReturnPolicyClient/ListOnlineReturnPolicies/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1/ProgramsClient/DisableProgram/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1/ProgramsClient/DisableProgram/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1/ProgramsClient/EnableProgram/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1/ProgramsClient/EnableProgram/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1/ProgramsClient/GetProgram/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1/ProgramsClient/GetProgram/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1/ProgramsClient/ListPrograms/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1/ProgramsClient/ListPrograms/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1/RegionsClient/BatchCreateRegions/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1/RegionsClient/BatchCreateRegions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1/RegionsClient/BatchDeleteRegions/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1/RegionsClient/BatchDeleteRegions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1/RegionsClient/BatchUpdateRegions/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1/RegionsClient/BatchUpdateRegions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1/RegionsClient/CreateRegion/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1/RegionsClient/CreateRegion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1/RegionsClient/DeleteRegion/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1/RegionsClient/DeleteRegion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1/RegionsClient/GetRegion/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1/RegionsClient/GetRegion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1/RegionsClient/ListRegions/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1/RegionsClient/ListRegions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1/RegionsClient/UpdateRegion/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1/RegionsClient/UpdateRegion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1/ShippingSettingsClient/GetShippingSettings/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1/ShippingSettingsClient/GetShippingSettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1/ShippingSettingsClient/InsertShippingSettings/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1/ShippingSettingsClient/InsertShippingSettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1/TermsOfServiceAgreementStateClient/GetTermsOfServiceAgreementState/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1/TermsOfServiceAgreementStateClient/GetTermsOfServiceAgreementState/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1/TermsOfServiceAgreementStateClient/RetrieveForApplicationTermsOfServiceAgreementState/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1/TermsOfServiceAgreementStateClient/RetrieveForApplicationTermsOfServiceAgreementState/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1/TermsOfServiceClient/AcceptTermsOfService/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1/TermsOfServiceClient/AcceptTermsOfService/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1/TermsOfServiceClient/GetTermsOfService/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1/TermsOfServiceClient/GetTermsOfService/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1/TermsOfServiceClient/RetrieveLatestTermsOfService/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1/TermsOfServiceClient/RetrieveLatestTermsOfService/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1/UserClient/CreateUser/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1/UserClient/CreateUser/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1/UserClient/DeleteUser/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1/UserClient/DeleteUser/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1/UserClient/GetUser/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1/UserClient/GetUser/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1/UserClient/ListUsers/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1/UserClient/ListUsers/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1/UserClient/UpdateUser/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1/UserClient/UpdateUser/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1/UserClient/VerifySelf/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1/UserClient/VerifySelf/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/AccountIssueClient/ListAccountIssues/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/AccountIssueClient/ListAccountIssues/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/AccountTaxClient/GetAccountTax/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/AccountTaxClient/GetAccountTax/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/AccountTaxClient/ListAccountTax/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/AccountTaxClient/ListAccountTax/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/AccountTaxClient/UpdateAccountTax/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/AccountTaxClient/UpdateAccountTax/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/AutofeedSettingsClient/GetAutofeedSettings/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/AutofeedSettingsClient/GetAutofeedSettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/AutofeedSettingsClient/UpdateAutofeedSettings/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/AutofeedSettingsClient/UpdateAutofeedSettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/AutomaticImprovementsClient/GetAutomaticImprovements/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/AutomaticImprovementsClient/GetAutomaticImprovements/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/AutomaticImprovementsClient/UpdateAutomaticImprovements/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/AutomaticImprovementsClient/UpdateAutomaticImprovements/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/BusinessIdentityClient/GetBusinessIdentity/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/BusinessIdentityClient/GetBusinessIdentity/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/BusinessIdentityClient/UpdateBusinessIdentity/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/BusinessIdentityClient/UpdateBusinessIdentity/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/BusinessInfoClient/GetBusinessInfo/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/BusinessInfoClient/GetBusinessInfo/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/BusinessInfoClient/UpdateBusinessInfo/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/BusinessInfoClient/UpdateBusinessInfo/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/CheckoutSettingsClient/CreateCheckoutSettings/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/CheckoutSettingsClient/CreateCheckoutSettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/CheckoutSettingsClient/DeleteCheckoutSettings/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/CheckoutSettingsClient/DeleteCheckoutSettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/CheckoutSettingsClient/GetCheckoutSettings/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/CheckoutSettingsClient/GetCheckoutSettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/CheckoutSettingsClient/UpdateCheckoutSettings/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/CheckoutSettingsClient/UpdateCheckoutSettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/Client/CreateAndConfigureAccount/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/Client/CreateAndConfigureAccount/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/Client/DeleteAccount/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/Client/DeleteAccount/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/Client/GetAccount/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/Client/GetAccount/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/Client/ListAccounts/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/Client/ListAccounts/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/Client/ListSubAccounts/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/Client/ListSubAccounts/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/Client/UpdateAccount/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/Client/UpdateAccount/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/EmailPreferencesClient/GetEmailPreferences/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/EmailPreferencesClient/GetEmailPreferences/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/EmailPreferencesClient/UpdateEmailPreferences/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/EmailPreferencesClient/UpdateEmailPreferences/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/GbpAccountsClient/LinkGbpAccount/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/GbpAccountsClient/LinkGbpAccount/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/GbpAccountsClient/ListGbpAccounts/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/GbpAccountsClient/ListGbpAccounts/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/HomepageClient/ClaimHomepage/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/HomepageClient/ClaimHomepage/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/HomepageClient/GetHomepage/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/HomepageClient/GetHomepage/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/HomepageClient/UnclaimHomepage/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/HomepageClient/UnclaimHomepage/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/HomepageClient/UpdateHomepage/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/HomepageClient/UpdateHomepage/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/LfpProvidersClient/FindLfpProviders/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/LfpProvidersClient/FindLfpProviders/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/LfpProvidersClient/LinkLfpProvider/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/LfpProvidersClient/LinkLfpProvider/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/OmnichannelSettingsClient/CreateOmnichannelSetting/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/OmnichannelSettingsClient/CreateOmnichannelSetting/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/OmnichannelSettingsClient/GetOmnichannelSetting/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/OmnichannelSettingsClient/GetOmnichannelSetting/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/OmnichannelSettingsClient/ListOmnichannelSettings/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/OmnichannelSettingsClient/ListOmnichannelSettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/OmnichannelSettingsClient/RequestInventoryVerification/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/OmnichannelSettingsClient/RequestInventoryVerification/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/OmnichannelSettingsClient/UpdateOmnichannelSetting/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/OmnichannelSettingsClient/UpdateOmnichannelSetting/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/OnlineReturnPolicyClient/CreateOnlineReturnPolicy/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/OnlineReturnPolicyClient/CreateOnlineReturnPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/OnlineReturnPolicyClient/DeleteOnlineReturnPolicy/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/OnlineReturnPolicyClient/DeleteOnlineReturnPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/OnlineReturnPolicyClient/GetOnlineReturnPolicy/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/OnlineReturnPolicyClient/GetOnlineReturnPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/OnlineReturnPolicyClient/ListOnlineReturnPolicies/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/OnlineReturnPolicyClient/ListOnlineReturnPolicies/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/OnlineReturnPolicyClient/UpdateOnlineReturnPolicy/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/OnlineReturnPolicyClient/UpdateOnlineReturnPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/ProgramsClient/DisableProgram/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/ProgramsClient/DisableProgram/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/ProgramsClient/EnableProgram/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/ProgramsClient/EnableProgram/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/ProgramsClient/GetProgram/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/ProgramsClient/GetProgram/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/ProgramsClient/ListPrograms/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/ProgramsClient/ListPrograms/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/RegionsClient/CreateRegion/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/RegionsClient/CreateRegion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/RegionsClient/DeleteRegion/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/RegionsClient/DeleteRegion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/RegionsClient/GetRegion/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/RegionsClient/GetRegion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/RegionsClient/ListRegions/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/RegionsClient/ListRegions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/RegionsClient/UpdateRegion/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/RegionsClient/UpdateRegion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/ShippingSettingsClient/GetShippingSettings/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/ShippingSettingsClient/GetShippingSettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/ShippingSettingsClient/InsertShippingSettings/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/ShippingSettingsClient/InsertShippingSettings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/TermsOfServiceAgreementStateClient/GetTermsOfServiceAgreementState/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/TermsOfServiceAgreementStateClient/GetTermsOfServiceAgreementState/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/TermsOfServiceAgreementStateClient/RetrieveForApplicationTermsOfServiceAgreementState/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/TermsOfServiceAgreementStateClient/RetrieveForApplicationTermsOfServiceAgreementState/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/TermsOfServiceClient/AcceptTermsOfService/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/TermsOfServiceClient/AcceptTermsOfService/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/TermsOfServiceClient/GetTermsOfService/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/TermsOfServiceClient/GetTermsOfService/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/TermsOfServiceClient/RetrieveLatestTermsOfService/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/TermsOfServiceClient/RetrieveLatestTermsOfService/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/UserClient/CreateUser/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/UserClient/CreateUser/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/UserClient/DeleteUser/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/UserClient/DeleteUser/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/UserClient/GetUser/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/UserClient/GetUser/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/UserClient/ListUsers/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/UserClient/ListUsers/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/UserClient/UpdateUser/main.go
+++ b/internal/generated/snippets/shopping/merchant/accounts/apiv1beta/UserClient/UpdateUser/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/conversions/apiv1/ConversionSourcesClient/CreateConversionSource/main.go
+++ b/internal/generated/snippets/shopping/merchant/conversions/apiv1/ConversionSourcesClient/CreateConversionSource/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/conversions/apiv1/ConversionSourcesClient/DeleteConversionSource/main.go
+++ b/internal/generated/snippets/shopping/merchant/conversions/apiv1/ConversionSourcesClient/DeleteConversionSource/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/conversions/apiv1/ConversionSourcesClient/GetConversionSource/main.go
+++ b/internal/generated/snippets/shopping/merchant/conversions/apiv1/ConversionSourcesClient/GetConversionSource/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/conversions/apiv1/ConversionSourcesClient/ListConversionSources/main.go
+++ b/internal/generated/snippets/shopping/merchant/conversions/apiv1/ConversionSourcesClient/ListConversionSources/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/conversions/apiv1/ConversionSourcesClient/UndeleteConversionSource/main.go
+++ b/internal/generated/snippets/shopping/merchant/conversions/apiv1/ConversionSourcesClient/UndeleteConversionSource/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/conversions/apiv1/ConversionSourcesClient/UpdateConversionSource/main.go
+++ b/internal/generated/snippets/shopping/merchant/conversions/apiv1/ConversionSourcesClient/UpdateConversionSource/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/conversions/apiv1beta/ConversionSourcesClient/CreateConversionSource/main.go
+++ b/internal/generated/snippets/shopping/merchant/conversions/apiv1beta/ConversionSourcesClient/CreateConversionSource/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/conversions/apiv1beta/ConversionSourcesClient/DeleteConversionSource/main.go
+++ b/internal/generated/snippets/shopping/merchant/conversions/apiv1beta/ConversionSourcesClient/DeleteConversionSource/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/conversions/apiv1beta/ConversionSourcesClient/GetConversionSource/main.go
+++ b/internal/generated/snippets/shopping/merchant/conversions/apiv1beta/ConversionSourcesClient/GetConversionSource/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/conversions/apiv1beta/ConversionSourcesClient/ListConversionSources/main.go
+++ b/internal/generated/snippets/shopping/merchant/conversions/apiv1beta/ConversionSourcesClient/ListConversionSources/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/conversions/apiv1beta/ConversionSourcesClient/UndeleteConversionSource/main.go
+++ b/internal/generated/snippets/shopping/merchant/conversions/apiv1beta/ConversionSourcesClient/UndeleteConversionSource/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/conversions/apiv1beta/ConversionSourcesClient/UpdateConversionSource/main.go
+++ b/internal/generated/snippets/shopping/merchant/conversions/apiv1beta/ConversionSourcesClient/UpdateConversionSource/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/datasources/apiv1/Client/CreateDataSource/main.go
+++ b/internal/generated/snippets/shopping/merchant/datasources/apiv1/Client/CreateDataSource/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/datasources/apiv1/Client/DeleteDataSource/main.go
+++ b/internal/generated/snippets/shopping/merchant/datasources/apiv1/Client/DeleteDataSource/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/datasources/apiv1/Client/FetchDataSource/main.go
+++ b/internal/generated/snippets/shopping/merchant/datasources/apiv1/Client/FetchDataSource/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/datasources/apiv1/Client/GetDataSource/main.go
+++ b/internal/generated/snippets/shopping/merchant/datasources/apiv1/Client/GetDataSource/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/datasources/apiv1/Client/ListDataSources/main.go
+++ b/internal/generated/snippets/shopping/merchant/datasources/apiv1/Client/ListDataSources/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/datasources/apiv1/Client/UpdateDataSource/main.go
+++ b/internal/generated/snippets/shopping/merchant/datasources/apiv1/Client/UpdateDataSource/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/datasources/apiv1/FileUploadsClient/GetFileUpload/main.go
+++ b/internal/generated/snippets/shopping/merchant/datasources/apiv1/FileUploadsClient/GetFileUpload/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/datasources/apiv1beta/Client/CreateDataSource/main.go
+++ b/internal/generated/snippets/shopping/merchant/datasources/apiv1beta/Client/CreateDataSource/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/datasources/apiv1beta/Client/DeleteDataSource/main.go
+++ b/internal/generated/snippets/shopping/merchant/datasources/apiv1beta/Client/DeleteDataSource/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/datasources/apiv1beta/Client/FetchDataSource/main.go
+++ b/internal/generated/snippets/shopping/merchant/datasources/apiv1beta/Client/FetchDataSource/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/datasources/apiv1beta/Client/GetDataSource/main.go
+++ b/internal/generated/snippets/shopping/merchant/datasources/apiv1beta/Client/GetDataSource/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/datasources/apiv1beta/Client/ListDataSources/main.go
+++ b/internal/generated/snippets/shopping/merchant/datasources/apiv1beta/Client/ListDataSources/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/datasources/apiv1beta/Client/UpdateDataSource/main.go
+++ b/internal/generated/snippets/shopping/merchant/datasources/apiv1beta/Client/UpdateDataSource/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/datasources/apiv1beta/FileUploadsClient/GetFileUpload/main.go
+++ b/internal/generated/snippets/shopping/merchant/datasources/apiv1beta/FileUploadsClient/GetFileUpload/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/inventories/apiv1/LocalInventoryClient/DeleteLocalInventory/main.go
+++ b/internal/generated/snippets/shopping/merchant/inventories/apiv1/LocalInventoryClient/DeleteLocalInventory/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/inventories/apiv1/LocalInventoryClient/InsertLocalInventory/main.go
+++ b/internal/generated/snippets/shopping/merchant/inventories/apiv1/LocalInventoryClient/InsertLocalInventory/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/inventories/apiv1/LocalInventoryClient/ListLocalInventories/main.go
+++ b/internal/generated/snippets/shopping/merchant/inventories/apiv1/LocalInventoryClient/ListLocalInventories/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/inventories/apiv1/RegionalInventoryClient/DeleteRegionalInventory/main.go
+++ b/internal/generated/snippets/shopping/merchant/inventories/apiv1/RegionalInventoryClient/DeleteRegionalInventory/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/inventories/apiv1/RegionalInventoryClient/InsertRegionalInventory/main.go
+++ b/internal/generated/snippets/shopping/merchant/inventories/apiv1/RegionalInventoryClient/InsertRegionalInventory/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/inventories/apiv1/RegionalInventoryClient/ListRegionalInventories/main.go
+++ b/internal/generated/snippets/shopping/merchant/inventories/apiv1/RegionalInventoryClient/ListRegionalInventories/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/inventories/apiv1beta/LocalInventoryClient/DeleteLocalInventory/main.go
+++ b/internal/generated/snippets/shopping/merchant/inventories/apiv1beta/LocalInventoryClient/DeleteLocalInventory/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/inventories/apiv1beta/LocalInventoryClient/InsertLocalInventory/main.go
+++ b/internal/generated/snippets/shopping/merchant/inventories/apiv1beta/LocalInventoryClient/InsertLocalInventory/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/inventories/apiv1beta/LocalInventoryClient/ListLocalInventories/main.go
+++ b/internal/generated/snippets/shopping/merchant/inventories/apiv1beta/LocalInventoryClient/ListLocalInventories/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/inventories/apiv1beta/RegionalInventoryClient/DeleteRegionalInventory/main.go
+++ b/internal/generated/snippets/shopping/merchant/inventories/apiv1beta/RegionalInventoryClient/DeleteRegionalInventory/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/inventories/apiv1beta/RegionalInventoryClient/InsertRegionalInventory/main.go
+++ b/internal/generated/snippets/shopping/merchant/inventories/apiv1beta/RegionalInventoryClient/InsertRegionalInventory/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/inventories/apiv1beta/RegionalInventoryClient/ListRegionalInventories/main.go
+++ b/internal/generated/snippets/shopping/merchant/inventories/apiv1beta/RegionalInventoryClient/ListRegionalInventories/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/issueresolution/apiv1/AggregateProductStatusesClient/ListAggregateProductStatuses/main.go
+++ b/internal/generated/snippets/shopping/merchant/issueresolution/apiv1/AggregateProductStatusesClient/ListAggregateProductStatuses/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/issueresolution/apiv1/Client/RenderAccountIssues/main.go
+++ b/internal/generated/snippets/shopping/merchant/issueresolution/apiv1/Client/RenderAccountIssues/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/issueresolution/apiv1/Client/RenderProductIssues/main.go
+++ b/internal/generated/snippets/shopping/merchant/issueresolution/apiv1/Client/RenderProductIssues/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/issueresolution/apiv1/Client/TriggerAction/main.go
+++ b/internal/generated/snippets/shopping/merchant/issueresolution/apiv1/Client/TriggerAction/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/issueresolution/apiv1beta/AggregateProductStatusesClient/ListAggregateProductStatuses/main.go
+++ b/internal/generated/snippets/shopping/merchant/issueresolution/apiv1beta/AggregateProductStatusesClient/ListAggregateProductStatuses/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/issueresolution/apiv1beta/Client/RenderAccountIssues/main.go
+++ b/internal/generated/snippets/shopping/merchant/issueresolution/apiv1beta/Client/RenderAccountIssues/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/issueresolution/apiv1beta/Client/RenderProductIssues/main.go
+++ b/internal/generated/snippets/shopping/merchant/issueresolution/apiv1beta/Client/RenderProductIssues/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/issueresolution/apiv1beta/Client/TriggerAction/main.go
+++ b/internal/generated/snippets/shopping/merchant/issueresolution/apiv1beta/Client/TriggerAction/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/lfp/apiv1/LfpInventoryClient/InsertLfpInventory/main.go
+++ b/internal/generated/snippets/shopping/merchant/lfp/apiv1/LfpInventoryClient/InsertLfpInventory/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/lfp/apiv1/LfpMerchantStateClient/GetLfpMerchantState/main.go
+++ b/internal/generated/snippets/shopping/merchant/lfp/apiv1/LfpMerchantStateClient/GetLfpMerchantState/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/lfp/apiv1/LfpSaleClient/InsertLfpSale/main.go
+++ b/internal/generated/snippets/shopping/merchant/lfp/apiv1/LfpSaleClient/InsertLfpSale/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/lfp/apiv1/LfpStoreClient/DeleteLfpStore/main.go
+++ b/internal/generated/snippets/shopping/merchant/lfp/apiv1/LfpStoreClient/DeleteLfpStore/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/lfp/apiv1/LfpStoreClient/GetLfpStore/main.go
+++ b/internal/generated/snippets/shopping/merchant/lfp/apiv1/LfpStoreClient/GetLfpStore/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/lfp/apiv1/LfpStoreClient/InsertLfpStore/main.go
+++ b/internal/generated/snippets/shopping/merchant/lfp/apiv1/LfpStoreClient/InsertLfpStore/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/lfp/apiv1/LfpStoreClient/ListLfpStores/main.go
+++ b/internal/generated/snippets/shopping/merchant/lfp/apiv1/LfpStoreClient/ListLfpStores/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/lfp/apiv1beta/LfpInventoryClient/InsertLfpInventory/main.go
+++ b/internal/generated/snippets/shopping/merchant/lfp/apiv1beta/LfpInventoryClient/InsertLfpInventory/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/lfp/apiv1beta/LfpMerchantStateClient/GetLfpMerchantState/main.go
+++ b/internal/generated/snippets/shopping/merchant/lfp/apiv1beta/LfpMerchantStateClient/GetLfpMerchantState/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/lfp/apiv1beta/LfpSaleClient/InsertLfpSale/main.go
+++ b/internal/generated/snippets/shopping/merchant/lfp/apiv1beta/LfpSaleClient/InsertLfpSale/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/lfp/apiv1beta/LfpStoreClient/DeleteLfpStore/main.go
+++ b/internal/generated/snippets/shopping/merchant/lfp/apiv1beta/LfpStoreClient/DeleteLfpStore/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/lfp/apiv1beta/LfpStoreClient/GetLfpStore/main.go
+++ b/internal/generated/snippets/shopping/merchant/lfp/apiv1beta/LfpStoreClient/GetLfpStore/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/lfp/apiv1beta/LfpStoreClient/InsertLfpStore/main.go
+++ b/internal/generated/snippets/shopping/merchant/lfp/apiv1beta/LfpStoreClient/InsertLfpStore/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/lfp/apiv1beta/LfpStoreClient/ListLfpStores/main.go
+++ b/internal/generated/snippets/shopping/merchant/lfp/apiv1beta/LfpStoreClient/ListLfpStores/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/notifications/apiv1/NotificationsApiClient/CreateNotificationSubscription/main.go
+++ b/internal/generated/snippets/shopping/merchant/notifications/apiv1/NotificationsApiClient/CreateNotificationSubscription/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/notifications/apiv1/NotificationsApiClient/DeleteNotificationSubscription/main.go
+++ b/internal/generated/snippets/shopping/merchant/notifications/apiv1/NotificationsApiClient/DeleteNotificationSubscription/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/notifications/apiv1/NotificationsApiClient/GetNotificationSubscription/main.go
+++ b/internal/generated/snippets/shopping/merchant/notifications/apiv1/NotificationsApiClient/GetNotificationSubscription/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/notifications/apiv1/NotificationsApiClient/GetNotificationSubscriptionHealthMetrics/main.go
+++ b/internal/generated/snippets/shopping/merchant/notifications/apiv1/NotificationsApiClient/GetNotificationSubscriptionHealthMetrics/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/notifications/apiv1/NotificationsApiClient/ListNotificationSubscriptions/main.go
+++ b/internal/generated/snippets/shopping/merchant/notifications/apiv1/NotificationsApiClient/ListNotificationSubscriptions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/notifications/apiv1/NotificationsApiClient/UpdateNotificationSubscription/main.go
+++ b/internal/generated/snippets/shopping/merchant/notifications/apiv1/NotificationsApiClient/UpdateNotificationSubscription/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/notifications/apiv1beta/NotificationsApiClient/CreateNotificationSubscription/main.go
+++ b/internal/generated/snippets/shopping/merchant/notifications/apiv1beta/NotificationsApiClient/CreateNotificationSubscription/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/notifications/apiv1beta/NotificationsApiClient/DeleteNotificationSubscription/main.go
+++ b/internal/generated/snippets/shopping/merchant/notifications/apiv1beta/NotificationsApiClient/DeleteNotificationSubscription/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/notifications/apiv1beta/NotificationsApiClient/GetNotificationSubscription/main.go
+++ b/internal/generated/snippets/shopping/merchant/notifications/apiv1beta/NotificationsApiClient/GetNotificationSubscription/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/notifications/apiv1beta/NotificationsApiClient/ListNotificationSubscriptions/main.go
+++ b/internal/generated/snippets/shopping/merchant/notifications/apiv1beta/NotificationsApiClient/ListNotificationSubscriptions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/notifications/apiv1beta/NotificationsApiClient/UpdateNotificationSubscription/main.go
+++ b/internal/generated/snippets/shopping/merchant/notifications/apiv1beta/NotificationsApiClient/UpdateNotificationSubscription/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/ordertracking/apiv1/OrderTrackingSignalsClient/CreateOrderTrackingSignal/main.go
+++ b/internal/generated/snippets/shopping/merchant/ordertracking/apiv1/OrderTrackingSignalsClient/CreateOrderTrackingSignal/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/ordertracking/apiv1beta/OrderTrackingSignalsClient/CreateOrderTrackingSignal/main.go
+++ b/internal/generated/snippets/shopping/merchant/ordertracking/apiv1beta/OrderTrackingSignalsClient/CreateOrderTrackingSignal/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/products/apiv1/Client/GetProduct/main.go
+++ b/internal/generated/snippets/shopping/merchant/products/apiv1/Client/GetProduct/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/products/apiv1/Client/ListProducts/main.go
+++ b/internal/generated/snippets/shopping/merchant/products/apiv1/Client/ListProducts/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/products/apiv1/ProductInputsClient/DeleteProductInput/main.go
+++ b/internal/generated/snippets/shopping/merchant/products/apiv1/ProductInputsClient/DeleteProductInput/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/products/apiv1/ProductInputsClient/InsertProductInput/main.go
+++ b/internal/generated/snippets/shopping/merchant/products/apiv1/ProductInputsClient/InsertProductInput/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/products/apiv1/ProductInputsClient/UpdateProductInput/main.go
+++ b/internal/generated/snippets/shopping/merchant/products/apiv1/ProductInputsClient/UpdateProductInput/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/products/apiv1beta/Client/GetProduct/main.go
+++ b/internal/generated/snippets/shopping/merchant/products/apiv1beta/Client/GetProduct/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/products/apiv1beta/Client/ListProducts/main.go
+++ b/internal/generated/snippets/shopping/merchant/products/apiv1beta/Client/ListProducts/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/products/apiv1beta/ProductInputsClient/DeleteProductInput/main.go
+++ b/internal/generated/snippets/shopping/merchant/products/apiv1beta/ProductInputsClient/DeleteProductInput/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/products/apiv1beta/ProductInputsClient/InsertProductInput/main.go
+++ b/internal/generated/snippets/shopping/merchant/products/apiv1beta/ProductInputsClient/InsertProductInput/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/products/apiv1beta/ProductInputsClient/UpdateProductInput/main.go
+++ b/internal/generated/snippets/shopping/merchant/products/apiv1beta/ProductInputsClient/UpdateProductInput/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/productstudio/apiv1alpha/ImageClient/GenerateProductImageBackground/main.go
+++ b/internal/generated/snippets/shopping/merchant/productstudio/apiv1alpha/ImageClient/GenerateProductImageBackground/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/productstudio/apiv1alpha/ImageClient/RemoveProductImageBackground/main.go
+++ b/internal/generated/snippets/shopping/merchant/productstudio/apiv1alpha/ImageClient/RemoveProductImageBackground/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/productstudio/apiv1alpha/ImageClient/UpscaleProductImage/main.go
+++ b/internal/generated/snippets/shopping/merchant/productstudio/apiv1alpha/ImageClient/UpscaleProductImage/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/productstudio/apiv1alpha/TextSuggestionsClient/GenerateProductTextSuggestions/main.go
+++ b/internal/generated/snippets/shopping/merchant/productstudio/apiv1alpha/TextSuggestionsClient/GenerateProductTextSuggestions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/promotions/apiv1/Client/GetPromotion/main.go
+++ b/internal/generated/snippets/shopping/merchant/promotions/apiv1/Client/GetPromotion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/promotions/apiv1/Client/InsertPromotion/main.go
+++ b/internal/generated/snippets/shopping/merchant/promotions/apiv1/Client/InsertPromotion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/promotions/apiv1/Client/ListPromotions/main.go
+++ b/internal/generated/snippets/shopping/merchant/promotions/apiv1/Client/ListPromotions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/promotions/apiv1beta/Client/GetPromotion/main.go
+++ b/internal/generated/snippets/shopping/merchant/promotions/apiv1beta/Client/GetPromotion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/promotions/apiv1beta/Client/InsertPromotion/main.go
+++ b/internal/generated/snippets/shopping/merchant/promotions/apiv1beta/Client/InsertPromotion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/promotions/apiv1beta/Client/ListPromotions/main.go
+++ b/internal/generated/snippets/shopping/merchant/promotions/apiv1beta/Client/ListPromotions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/quota/apiv1/AccountLimitsClient/GetAccountLimit/main.go
+++ b/internal/generated/snippets/shopping/merchant/quota/apiv1/AccountLimitsClient/GetAccountLimit/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/quota/apiv1/AccountLimitsClient/ListAccountLimits/main.go
+++ b/internal/generated/snippets/shopping/merchant/quota/apiv1/AccountLimitsClient/ListAccountLimits/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/quota/apiv1/Client/ListQuotaGroups/main.go
+++ b/internal/generated/snippets/shopping/merchant/quota/apiv1/Client/ListQuotaGroups/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/quota/apiv1beta/Client/ListQuotaGroups/main.go
+++ b/internal/generated/snippets/shopping/merchant/quota/apiv1beta/Client/ListQuotaGroups/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/reports/apiv1/ReportClient/Search/main.go
+++ b/internal/generated/snippets/shopping/merchant/reports/apiv1/ReportClient/Search/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/reports/apiv1beta/ReportClient/Search/main.go
+++ b/internal/generated/snippets/shopping/merchant/reports/apiv1beta/ReportClient/Search/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/reviews/apiv1beta/MerchantReviewsClient/DeleteMerchantReview/main.go
+++ b/internal/generated/snippets/shopping/merchant/reviews/apiv1beta/MerchantReviewsClient/DeleteMerchantReview/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/reviews/apiv1beta/MerchantReviewsClient/GetMerchantReview/main.go
+++ b/internal/generated/snippets/shopping/merchant/reviews/apiv1beta/MerchantReviewsClient/GetMerchantReview/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/reviews/apiv1beta/MerchantReviewsClient/InsertMerchantReview/main.go
+++ b/internal/generated/snippets/shopping/merchant/reviews/apiv1beta/MerchantReviewsClient/InsertMerchantReview/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/reviews/apiv1beta/MerchantReviewsClient/ListMerchantReviews/main.go
+++ b/internal/generated/snippets/shopping/merchant/reviews/apiv1beta/MerchantReviewsClient/ListMerchantReviews/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/reviews/apiv1beta/ProductReviewsClient/DeleteProductReview/main.go
+++ b/internal/generated/snippets/shopping/merchant/reviews/apiv1beta/ProductReviewsClient/DeleteProductReview/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/reviews/apiv1beta/ProductReviewsClient/GetProductReview/main.go
+++ b/internal/generated/snippets/shopping/merchant/reviews/apiv1beta/ProductReviewsClient/GetProductReview/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/reviews/apiv1beta/ProductReviewsClient/InsertProductReview/main.go
+++ b/internal/generated/snippets/shopping/merchant/reviews/apiv1beta/ProductReviewsClient/InsertProductReview/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/shopping/merchant/reviews/apiv1beta/ProductReviewsClient/ListProductReviews/main.go
+++ b/internal/generated/snippets/shopping/merchant/reviews/apiv1beta/ProductReviewsClient/ListProductReviews/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/storage/control/apiv2/StorageControlClient/CreateAnywhereCache/main.go
+++ b/internal/generated/snippets/storage/control/apiv2/StorageControlClient/CreateAnywhereCache/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/storage/control/apiv2/StorageControlClient/CreateFolder/main.go
+++ b/internal/generated/snippets/storage/control/apiv2/StorageControlClient/CreateFolder/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/storage/control/apiv2/StorageControlClient/CreateManagedFolder/main.go
+++ b/internal/generated/snippets/storage/control/apiv2/StorageControlClient/CreateManagedFolder/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/storage/control/apiv2/StorageControlClient/DeleteFolder/main.go
+++ b/internal/generated/snippets/storage/control/apiv2/StorageControlClient/DeleteFolder/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/storage/control/apiv2/StorageControlClient/DeleteManagedFolder/main.go
+++ b/internal/generated/snippets/storage/control/apiv2/StorageControlClient/DeleteManagedFolder/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/storage/control/apiv2/StorageControlClient/DisableAnywhereCache/main.go
+++ b/internal/generated/snippets/storage/control/apiv2/StorageControlClient/DisableAnywhereCache/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/storage/control/apiv2/StorageControlClient/GetAnywhereCache/main.go
+++ b/internal/generated/snippets/storage/control/apiv2/StorageControlClient/GetAnywhereCache/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/storage/control/apiv2/StorageControlClient/GetFolder/main.go
+++ b/internal/generated/snippets/storage/control/apiv2/StorageControlClient/GetFolder/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/storage/control/apiv2/StorageControlClient/GetFolderIntelligenceConfig/main.go
+++ b/internal/generated/snippets/storage/control/apiv2/StorageControlClient/GetFolderIntelligenceConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/storage/control/apiv2/StorageControlClient/GetIamPolicy/main.go
+++ b/internal/generated/snippets/storage/control/apiv2/StorageControlClient/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/storage/control/apiv2/StorageControlClient/GetManagedFolder/main.go
+++ b/internal/generated/snippets/storage/control/apiv2/StorageControlClient/GetManagedFolder/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/storage/control/apiv2/StorageControlClient/GetOrganizationIntelligenceConfig/main.go
+++ b/internal/generated/snippets/storage/control/apiv2/StorageControlClient/GetOrganizationIntelligenceConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/storage/control/apiv2/StorageControlClient/GetProjectIntelligenceConfig/main.go
+++ b/internal/generated/snippets/storage/control/apiv2/StorageControlClient/GetProjectIntelligenceConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/storage/control/apiv2/StorageControlClient/GetStorageLayout/main.go
+++ b/internal/generated/snippets/storage/control/apiv2/StorageControlClient/GetStorageLayout/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/storage/control/apiv2/StorageControlClient/ListAnywhereCaches/main.go
+++ b/internal/generated/snippets/storage/control/apiv2/StorageControlClient/ListAnywhereCaches/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/storage/control/apiv2/StorageControlClient/ListFolders/main.go
+++ b/internal/generated/snippets/storage/control/apiv2/StorageControlClient/ListFolders/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/storage/control/apiv2/StorageControlClient/ListManagedFolders/main.go
+++ b/internal/generated/snippets/storage/control/apiv2/StorageControlClient/ListManagedFolders/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/storage/control/apiv2/StorageControlClient/PauseAnywhereCache/main.go
+++ b/internal/generated/snippets/storage/control/apiv2/StorageControlClient/PauseAnywhereCache/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/storage/control/apiv2/StorageControlClient/RenameFolder/main.go
+++ b/internal/generated/snippets/storage/control/apiv2/StorageControlClient/RenameFolder/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/storage/control/apiv2/StorageControlClient/ResumeAnywhereCache/main.go
+++ b/internal/generated/snippets/storage/control/apiv2/StorageControlClient/ResumeAnywhereCache/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/storage/control/apiv2/StorageControlClient/SetIamPolicy/main.go
+++ b/internal/generated/snippets/storage/control/apiv2/StorageControlClient/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/storage/control/apiv2/StorageControlClient/TestIamPermissions/main.go
+++ b/internal/generated/snippets/storage/control/apiv2/StorageControlClient/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/storage/control/apiv2/StorageControlClient/UpdateAnywhereCache/main.go
+++ b/internal/generated/snippets/storage/control/apiv2/StorageControlClient/UpdateAnywhereCache/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/storage/control/apiv2/StorageControlClient/UpdateFolderIntelligenceConfig/main.go
+++ b/internal/generated/snippets/storage/control/apiv2/StorageControlClient/UpdateFolderIntelligenceConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/storage/control/apiv2/StorageControlClient/UpdateOrganizationIntelligenceConfig/main.go
+++ b/internal/generated/snippets/storage/control/apiv2/StorageControlClient/UpdateOrganizationIntelligenceConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/storage/control/apiv2/StorageControlClient/UpdateProjectIntelligenceConfig/main.go
+++ b/internal/generated/snippets/storage/control/apiv2/StorageControlClient/UpdateProjectIntelligenceConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/storagebatchoperations/apiv1/Client/CancelJob/main.go
+++ b/internal/generated/snippets/storagebatchoperations/apiv1/Client/CancelJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/storagebatchoperations/apiv1/Client/CancelOperation/main.go
+++ b/internal/generated/snippets/storagebatchoperations/apiv1/Client/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/storagebatchoperations/apiv1/Client/CreateJob/main.go
+++ b/internal/generated/snippets/storagebatchoperations/apiv1/Client/CreateJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/storagebatchoperations/apiv1/Client/DeleteJob/main.go
+++ b/internal/generated/snippets/storagebatchoperations/apiv1/Client/DeleteJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/storagebatchoperations/apiv1/Client/DeleteOperation/main.go
+++ b/internal/generated/snippets/storagebatchoperations/apiv1/Client/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/storagebatchoperations/apiv1/Client/GetJob/main.go
+++ b/internal/generated/snippets/storagebatchoperations/apiv1/Client/GetJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/storagebatchoperations/apiv1/Client/GetLocation/main.go
+++ b/internal/generated/snippets/storagebatchoperations/apiv1/Client/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/storagebatchoperations/apiv1/Client/GetOperation/main.go
+++ b/internal/generated/snippets/storagebatchoperations/apiv1/Client/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/storagebatchoperations/apiv1/Client/ListJobs/main.go
+++ b/internal/generated/snippets/storagebatchoperations/apiv1/Client/ListJobs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/storagebatchoperations/apiv1/Client/ListLocations/main.go
+++ b/internal/generated/snippets/storagebatchoperations/apiv1/Client/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/storagebatchoperations/apiv1/Client/ListOperations/main.go
+++ b/internal/generated/snippets/storagebatchoperations/apiv1/Client/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/storageinsights/apiv1/Client/CancelOperation/main.go
+++ b/internal/generated/snippets/storageinsights/apiv1/Client/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/storageinsights/apiv1/Client/CreateDatasetConfig/main.go
+++ b/internal/generated/snippets/storageinsights/apiv1/Client/CreateDatasetConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/storageinsights/apiv1/Client/CreateReportConfig/main.go
+++ b/internal/generated/snippets/storageinsights/apiv1/Client/CreateReportConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/storageinsights/apiv1/Client/DeleteDatasetConfig/main.go
+++ b/internal/generated/snippets/storageinsights/apiv1/Client/DeleteDatasetConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/storageinsights/apiv1/Client/DeleteOperation/main.go
+++ b/internal/generated/snippets/storageinsights/apiv1/Client/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/storageinsights/apiv1/Client/DeleteReportConfig/main.go
+++ b/internal/generated/snippets/storageinsights/apiv1/Client/DeleteReportConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/storageinsights/apiv1/Client/GetDatasetConfig/main.go
+++ b/internal/generated/snippets/storageinsights/apiv1/Client/GetDatasetConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/storageinsights/apiv1/Client/GetLocation/main.go
+++ b/internal/generated/snippets/storageinsights/apiv1/Client/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/storageinsights/apiv1/Client/GetOperation/main.go
+++ b/internal/generated/snippets/storageinsights/apiv1/Client/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/storageinsights/apiv1/Client/GetReportConfig/main.go
+++ b/internal/generated/snippets/storageinsights/apiv1/Client/GetReportConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/storageinsights/apiv1/Client/GetReportDetail/main.go
+++ b/internal/generated/snippets/storageinsights/apiv1/Client/GetReportDetail/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/storageinsights/apiv1/Client/LinkDataset/main.go
+++ b/internal/generated/snippets/storageinsights/apiv1/Client/LinkDataset/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/storageinsights/apiv1/Client/ListDatasetConfigs/main.go
+++ b/internal/generated/snippets/storageinsights/apiv1/Client/ListDatasetConfigs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/storageinsights/apiv1/Client/ListLocations/main.go
+++ b/internal/generated/snippets/storageinsights/apiv1/Client/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/storageinsights/apiv1/Client/ListOperations/main.go
+++ b/internal/generated/snippets/storageinsights/apiv1/Client/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/storageinsights/apiv1/Client/ListReportConfigs/main.go
+++ b/internal/generated/snippets/storageinsights/apiv1/Client/ListReportConfigs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/storageinsights/apiv1/Client/ListReportDetails/main.go
+++ b/internal/generated/snippets/storageinsights/apiv1/Client/ListReportDetails/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/storageinsights/apiv1/Client/UnlinkDataset/main.go
+++ b/internal/generated/snippets/storageinsights/apiv1/Client/UnlinkDataset/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/storageinsights/apiv1/Client/UpdateDatasetConfig/main.go
+++ b/internal/generated/snippets/storageinsights/apiv1/Client/UpdateDatasetConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/storageinsights/apiv1/Client/UpdateReportConfig/main.go
+++ b/internal/generated/snippets/storageinsights/apiv1/Client/UpdateReportConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/storagetransfer/apiv1/Client/CancelOperation/main.go
+++ b/internal/generated/snippets/storagetransfer/apiv1/Client/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/storagetransfer/apiv1/Client/CreateAgentPool/main.go
+++ b/internal/generated/snippets/storagetransfer/apiv1/Client/CreateAgentPool/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/storagetransfer/apiv1/Client/CreateTransferJob/main.go
+++ b/internal/generated/snippets/storagetransfer/apiv1/Client/CreateTransferJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/storagetransfer/apiv1/Client/DeleteAgentPool/main.go
+++ b/internal/generated/snippets/storagetransfer/apiv1/Client/DeleteAgentPool/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/storagetransfer/apiv1/Client/DeleteTransferJob/main.go
+++ b/internal/generated/snippets/storagetransfer/apiv1/Client/DeleteTransferJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/storagetransfer/apiv1/Client/GetAgentPool/main.go
+++ b/internal/generated/snippets/storagetransfer/apiv1/Client/GetAgentPool/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/storagetransfer/apiv1/Client/GetGoogleServiceAccount/main.go
+++ b/internal/generated/snippets/storagetransfer/apiv1/Client/GetGoogleServiceAccount/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/storagetransfer/apiv1/Client/GetOperation/main.go
+++ b/internal/generated/snippets/storagetransfer/apiv1/Client/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/storagetransfer/apiv1/Client/GetTransferJob/main.go
+++ b/internal/generated/snippets/storagetransfer/apiv1/Client/GetTransferJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/storagetransfer/apiv1/Client/ListAgentPools/main.go
+++ b/internal/generated/snippets/storagetransfer/apiv1/Client/ListAgentPools/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/storagetransfer/apiv1/Client/ListOperations/main.go
+++ b/internal/generated/snippets/storagetransfer/apiv1/Client/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/storagetransfer/apiv1/Client/ListTransferJobs/main.go
+++ b/internal/generated/snippets/storagetransfer/apiv1/Client/ListTransferJobs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/storagetransfer/apiv1/Client/PauseTransferOperation/main.go
+++ b/internal/generated/snippets/storagetransfer/apiv1/Client/PauseTransferOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/storagetransfer/apiv1/Client/ResumeTransferOperation/main.go
+++ b/internal/generated/snippets/storagetransfer/apiv1/Client/ResumeTransferOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/storagetransfer/apiv1/Client/RunTransferJob/main.go
+++ b/internal/generated/snippets/storagetransfer/apiv1/Client/RunTransferJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/storagetransfer/apiv1/Client/UpdateAgentPool/main.go
+++ b/internal/generated/snippets/storagetransfer/apiv1/Client/UpdateAgentPool/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/storagetransfer/apiv1/Client/UpdateTransferJob/main.go
+++ b/internal/generated/snippets/storagetransfer/apiv1/Client/UpdateTransferJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/streetview/publish/apiv1/StreetViewPublishClient/BatchDeletePhotos/main.go
+++ b/internal/generated/snippets/streetview/publish/apiv1/StreetViewPublishClient/BatchDeletePhotos/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/streetview/publish/apiv1/StreetViewPublishClient/BatchGetPhotos/main.go
+++ b/internal/generated/snippets/streetview/publish/apiv1/StreetViewPublishClient/BatchGetPhotos/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/streetview/publish/apiv1/StreetViewPublishClient/BatchUpdatePhotos/main.go
+++ b/internal/generated/snippets/streetview/publish/apiv1/StreetViewPublishClient/BatchUpdatePhotos/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/streetview/publish/apiv1/StreetViewPublishClient/CreatePhoto/main.go
+++ b/internal/generated/snippets/streetview/publish/apiv1/StreetViewPublishClient/CreatePhoto/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/streetview/publish/apiv1/StreetViewPublishClient/CreatePhotoSequence/main.go
+++ b/internal/generated/snippets/streetview/publish/apiv1/StreetViewPublishClient/CreatePhotoSequence/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/streetview/publish/apiv1/StreetViewPublishClient/DeletePhoto/main.go
+++ b/internal/generated/snippets/streetview/publish/apiv1/StreetViewPublishClient/DeletePhoto/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/streetview/publish/apiv1/StreetViewPublishClient/DeletePhotoSequence/main.go
+++ b/internal/generated/snippets/streetview/publish/apiv1/StreetViewPublishClient/DeletePhotoSequence/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/streetview/publish/apiv1/StreetViewPublishClient/GetPhoto/main.go
+++ b/internal/generated/snippets/streetview/publish/apiv1/StreetViewPublishClient/GetPhoto/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/streetview/publish/apiv1/StreetViewPublishClient/GetPhotoSequence/main.go
+++ b/internal/generated/snippets/streetview/publish/apiv1/StreetViewPublishClient/GetPhotoSequence/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/streetview/publish/apiv1/StreetViewPublishClient/ListPhotoSequences/main.go
+++ b/internal/generated/snippets/streetview/publish/apiv1/StreetViewPublishClient/ListPhotoSequences/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/streetview/publish/apiv1/StreetViewPublishClient/ListPhotos/main.go
+++ b/internal/generated/snippets/streetview/publish/apiv1/StreetViewPublishClient/ListPhotos/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/streetview/publish/apiv1/StreetViewPublishClient/StartPhotoSequenceUpload/main.go
+++ b/internal/generated/snippets/streetview/publish/apiv1/StreetViewPublishClient/StartPhotoSequenceUpload/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/streetview/publish/apiv1/StreetViewPublishClient/StartUpload/main.go
+++ b/internal/generated/snippets/streetview/publish/apiv1/StreetViewPublishClient/StartUpload/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/streetview/publish/apiv1/StreetViewPublishClient/UpdatePhoto/main.go
+++ b/internal/generated/snippets/streetview/publish/apiv1/StreetViewPublishClient/UpdatePhoto/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/support/apiv2/CaseAttachmentClient/ListAttachments/main.go
+++ b/internal/generated/snippets/support/apiv2/CaseAttachmentClient/ListAttachments/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/support/apiv2/CaseClient/CloseCase/main.go
+++ b/internal/generated/snippets/support/apiv2/CaseClient/CloseCase/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/support/apiv2/CaseClient/CreateCase/main.go
+++ b/internal/generated/snippets/support/apiv2/CaseClient/CreateCase/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/support/apiv2/CaseClient/EscalateCase/main.go
+++ b/internal/generated/snippets/support/apiv2/CaseClient/EscalateCase/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/support/apiv2/CaseClient/GetCase/main.go
+++ b/internal/generated/snippets/support/apiv2/CaseClient/GetCase/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/support/apiv2/CaseClient/ListCases/main.go
+++ b/internal/generated/snippets/support/apiv2/CaseClient/ListCases/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/support/apiv2/CaseClient/SearchCaseClassifications/main.go
+++ b/internal/generated/snippets/support/apiv2/CaseClient/SearchCaseClassifications/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/support/apiv2/CaseClient/SearchCases/main.go
+++ b/internal/generated/snippets/support/apiv2/CaseClient/SearchCases/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/support/apiv2/CaseClient/UpdateCase/main.go
+++ b/internal/generated/snippets/support/apiv2/CaseClient/UpdateCase/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/support/apiv2/CommentClient/CreateComment/main.go
+++ b/internal/generated/snippets/support/apiv2/CommentClient/CreateComment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/support/apiv2/CommentClient/ListComments/main.go
+++ b/internal/generated/snippets/support/apiv2/CommentClient/ListComments/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/support/apiv2beta/CaseAttachmentClient/GetAttachment/main.go
+++ b/internal/generated/snippets/support/apiv2beta/CaseAttachmentClient/GetAttachment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/support/apiv2beta/CaseAttachmentClient/ListAttachments/main.go
+++ b/internal/generated/snippets/support/apiv2beta/CaseAttachmentClient/ListAttachments/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/support/apiv2beta/CaseClient/CloseCase/main.go
+++ b/internal/generated/snippets/support/apiv2beta/CaseClient/CloseCase/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/support/apiv2beta/CaseClient/CreateCase/main.go
+++ b/internal/generated/snippets/support/apiv2beta/CaseClient/CreateCase/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/support/apiv2beta/CaseClient/EscalateCase/main.go
+++ b/internal/generated/snippets/support/apiv2beta/CaseClient/EscalateCase/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/support/apiv2beta/CaseClient/GetCase/main.go
+++ b/internal/generated/snippets/support/apiv2beta/CaseClient/GetCase/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/support/apiv2beta/CaseClient/ListCases/main.go
+++ b/internal/generated/snippets/support/apiv2beta/CaseClient/ListCases/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/support/apiv2beta/CaseClient/SearchCaseClassifications/main.go
+++ b/internal/generated/snippets/support/apiv2beta/CaseClient/SearchCaseClassifications/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/support/apiv2beta/CaseClient/SearchCases/main.go
+++ b/internal/generated/snippets/support/apiv2beta/CaseClient/SearchCases/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/support/apiv2beta/CaseClient/UpdateCase/main.go
+++ b/internal/generated/snippets/support/apiv2beta/CaseClient/UpdateCase/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/support/apiv2beta/CommentClient/CreateComment/main.go
+++ b/internal/generated/snippets/support/apiv2beta/CommentClient/CreateComment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/support/apiv2beta/CommentClient/GetComment/main.go
+++ b/internal/generated/snippets/support/apiv2beta/CommentClient/GetComment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/support/apiv2beta/CommentClient/ListComments/main.go
+++ b/internal/generated/snippets/support/apiv2beta/CommentClient/ListComments/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/support/apiv2beta/FeedClient/ShowFeed/main.go
+++ b/internal/generated/snippets/support/apiv2beta/FeedClient/ShowFeed/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/talent/apiv4/CompanyClient/CreateCompany/main.go
+++ b/internal/generated/snippets/talent/apiv4/CompanyClient/CreateCompany/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/talent/apiv4/CompanyClient/DeleteCompany/main.go
+++ b/internal/generated/snippets/talent/apiv4/CompanyClient/DeleteCompany/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/talent/apiv4/CompanyClient/GetCompany/main.go
+++ b/internal/generated/snippets/talent/apiv4/CompanyClient/GetCompany/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/talent/apiv4/CompanyClient/GetOperation/main.go
+++ b/internal/generated/snippets/talent/apiv4/CompanyClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/talent/apiv4/CompanyClient/ListCompanies/main.go
+++ b/internal/generated/snippets/talent/apiv4/CompanyClient/ListCompanies/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/talent/apiv4/CompanyClient/UpdateCompany/main.go
+++ b/internal/generated/snippets/talent/apiv4/CompanyClient/UpdateCompany/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/talent/apiv4/CompletionClient/CompleteQuery/main.go
+++ b/internal/generated/snippets/talent/apiv4/CompletionClient/CompleteQuery/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/talent/apiv4/CompletionClient/GetOperation/main.go
+++ b/internal/generated/snippets/talent/apiv4/CompletionClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/talent/apiv4/EventClient/CreateClientEvent/main.go
+++ b/internal/generated/snippets/talent/apiv4/EventClient/CreateClientEvent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/talent/apiv4/EventClient/GetOperation/main.go
+++ b/internal/generated/snippets/talent/apiv4/EventClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/talent/apiv4/JobClient/BatchCreateJobs/main.go
+++ b/internal/generated/snippets/talent/apiv4/JobClient/BatchCreateJobs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/talent/apiv4/JobClient/BatchDeleteJobs/main.go
+++ b/internal/generated/snippets/talent/apiv4/JobClient/BatchDeleteJobs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/talent/apiv4/JobClient/BatchUpdateJobs/main.go
+++ b/internal/generated/snippets/talent/apiv4/JobClient/BatchUpdateJobs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/talent/apiv4/JobClient/CreateJob/main.go
+++ b/internal/generated/snippets/talent/apiv4/JobClient/CreateJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/talent/apiv4/JobClient/DeleteJob/main.go
+++ b/internal/generated/snippets/talent/apiv4/JobClient/DeleteJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/talent/apiv4/JobClient/GetJob/main.go
+++ b/internal/generated/snippets/talent/apiv4/JobClient/GetJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/talent/apiv4/JobClient/GetOperation/main.go
+++ b/internal/generated/snippets/talent/apiv4/JobClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/talent/apiv4/JobClient/ListJobs/main.go
+++ b/internal/generated/snippets/talent/apiv4/JobClient/ListJobs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/talent/apiv4/JobClient/SearchJobs/main.go
+++ b/internal/generated/snippets/talent/apiv4/JobClient/SearchJobs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/talent/apiv4/JobClient/SearchJobsForAlert/main.go
+++ b/internal/generated/snippets/talent/apiv4/JobClient/SearchJobsForAlert/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/talent/apiv4/JobClient/UpdateJob/main.go
+++ b/internal/generated/snippets/talent/apiv4/JobClient/UpdateJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/talent/apiv4/TenantClient/CreateTenant/main.go
+++ b/internal/generated/snippets/talent/apiv4/TenantClient/CreateTenant/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/talent/apiv4/TenantClient/DeleteTenant/main.go
+++ b/internal/generated/snippets/talent/apiv4/TenantClient/DeleteTenant/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/talent/apiv4/TenantClient/GetOperation/main.go
+++ b/internal/generated/snippets/talent/apiv4/TenantClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/talent/apiv4/TenantClient/GetTenant/main.go
+++ b/internal/generated/snippets/talent/apiv4/TenantClient/GetTenant/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/talent/apiv4/TenantClient/ListTenants/main.go
+++ b/internal/generated/snippets/talent/apiv4/TenantClient/ListTenants/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/talent/apiv4/TenantClient/UpdateTenant/main.go
+++ b/internal/generated/snippets/talent/apiv4/TenantClient/UpdateTenant/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/talent/apiv4beta1/CompanyClient/CreateCompany/main.go
+++ b/internal/generated/snippets/talent/apiv4beta1/CompanyClient/CreateCompany/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/talent/apiv4beta1/CompanyClient/DeleteCompany/main.go
+++ b/internal/generated/snippets/talent/apiv4beta1/CompanyClient/DeleteCompany/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/talent/apiv4beta1/CompanyClient/GetCompany/main.go
+++ b/internal/generated/snippets/talent/apiv4beta1/CompanyClient/GetCompany/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/talent/apiv4beta1/CompanyClient/GetOperation/main.go
+++ b/internal/generated/snippets/talent/apiv4beta1/CompanyClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/talent/apiv4beta1/CompanyClient/ListCompanies/main.go
+++ b/internal/generated/snippets/talent/apiv4beta1/CompanyClient/ListCompanies/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/talent/apiv4beta1/CompanyClient/UpdateCompany/main.go
+++ b/internal/generated/snippets/talent/apiv4beta1/CompanyClient/UpdateCompany/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/talent/apiv4beta1/CompletionClient/CompleteQuery/main.go
+++ b/internal/generated/snippets/talent/apiv4beta1/CompletionClient/CompleteQuery/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/talent/apiv4beta1/CompletionClient/GetOperation/main.go
+++ b/internal/generated/snippets/talent/apiv4beta1/CompletionClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/talent/apiv4beta1/EventClient/CreateClientEvent/main.go
+++ b/internal/generated/snippets/talent/apiv4beta1/EventClient/CreateClientEvent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/talent/apiv4beta1/EventClient/GetOperation/main.go
+++ b/internal/generated/snippets/talent/apiv4beta1/EventClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/talent/apiv4beta1/JobClient/BatchCreateJobs/main.go
+++ b/internal/generated/snippets/talent/apiv4beta1/JobClient/BatchCreateJobs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/talent/apiv4beta1/JobClient/BatchDeleteJobs/main.go
+++ b/internal/generated/snippets/talent/apiv4beta1/JobClient/BatchDeleteJobs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/talent/apiv4beta1/JobClient/BatchUpdateJobs/main.go
+++ b/internal/generated/snippets/talent/apiv4beta1/JobClient/BatchUpdateJobs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/talent/apiv4beta1/JobClient/CreateJob/main.go
+++ b/internal/generated/snippets/talent/apiv4beta1/JobClient/CreateJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/talent/apiv4beta1/JobClient/DeleteJob/main.go
+++ b/internal/generated/snippets/talent/apiv4beta1/JobClient/DeleteJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/talent/apiv4beta1/JobClient/GetJob/main.go
+++ b/internal/generated/snippets/talent/apiv4beta1/JobClient/GetJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/talent/apiv4beta1/JobClient/GetOperation/main.go
+++ b/internal/generated/snippets/talent/apiv4beta1/JobClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/talent/apiv4beta1/JobClient/ListJobs/main.go
+++ b/internal/generated/snippets/talent/apiv4beta1/JobClient/ListJobs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/talent/apiv4beta1/JobClient/SearchJobs/main.go
+++ b/internal/generated/snippets/talent/apiv4beta1/JobClient/SearchJobs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/talent/apiv4beta1/JobClient/SearchJobsForAlert/main.go
+++ b/internal/generated/snippets/talent/apiv4beta1/JobClient/SearchJobsForAlert/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/talent/apiv4beta1/JobClient/UpdateJob/main.go
+++ b/internal/generated/snippets/talent/apiv4beta1/JobClient/UpdateJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/talent/apiv4beta1/TenantClient/CreateTenant/main.go
+++ b/internal/generated/snippets/talent/apiv4beta1/TenantClient/CreateTenant/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/talent/apiv4beta1/TenantClient/DeleteTenant/main.go
+++ b/internal/generated/snippets/talent/apiv4beta1/TenantClient/DeleteTenant/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/talent/apiv4beta1/TenantClient/GetOperation/main.go
+++ b/internal/generated/snippets/talent/apiv4beta1/TenantClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/talent/apiv4beta1/TenantClient/GetTenant/main.go
+++ b/internal/generated/snippets/talent/apiv4beta1/TenantClient/GetTenant/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/talent/apiv4beta1/TenantClient/ListTenants/main.go
+++ b/internal/generated/snippets/talent/apiv4beta1/TenantClient/ListTenants/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/talent/apiv4beta1/TenantClient/UpdateTenant/main.go
+++ b/internal/generated/snippets/talent/apiv4beta1/TenantClient/UpdateTenant/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/telcoautomation/apiv1/Client/ApplyDeployment/main.go
+++ b/internal/generated/snippets/telcoautomation/apiv1/Client/ApplyDeployment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/telcoautomation/apiv1/Client/ApplyHydratedDeployment/main.go
+++ b/internal/generated/snippets/telcoautomation/apiv1/Client/ApplyHydratedDeployment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/telcoautomation/apiv1/Client/ApproveBlueprint/main.go
+++ b/internal/generated/snippets/telcoautomation/apiv1/Client/ApproveBlueprint/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/telcoautomation/apiv1/Client/CancelOperation/main.go
+++ b/internal/generated/snippets/telcoautomation/apiv1/Client/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/telcoautomation/apiv1/Client/ComputeDeploymentStatus/main.go
+++ b/internal/generated/snippets/telcoautomation/apiv1/Client/ComputeDeploymentStatus/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/telcoautomation/apiv1/Client/CreateBlueprint/main.go
+++ b/internal/generated/snippets/telcoautomation/apiv1/Client/CreateBlueprint/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/telcoautomation/apiv1/Client/CreateDeployment/main.go
+++ b/internal/generated/snippets/telcoautomation/apiv1/Client/CreateDeployment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/telcoautomation/apiv1/Client/CreateEdgeSlm/main.go
+++ b/internal/generated/snippets/telcoautomation/apiv1/Client/CreateEdgeSlm/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/telcoautomation/apiv1/Client/CreateOrchestrationCluster/main.go
+++ b/internal/generated/snippets/telcoautomation/apiv1/Client/CreateOrchestrationCluster/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/telcoautomation/apiv1/Client/DeleteBlueprint/main.go
+++ b/internal/generated/snippets/telcoautomation/apiv1/Client/DeleteBlueprint/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/telcoautomation/apiv1/Client/DeleteEdgeSlm/main.go
+++ b/internal/generated/snippets/telcoautomation/apiv1/Client/DeleteEdgeSlm/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/telcoautomation/apiv1/Client/DeleteOperation/main.go
+++ b/internal/generated/snippets/telcoautomation/apiv1/Client/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/telcoautomation/apiv1/Client/DeleteOrchestrationCluster/main.go
+++ b/internal/generated/snippets/telcoautomation/apiv1/Client/DeleteOrchestrationCluster/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/telcoautomation/apiv1/Client/DiscardBlueprintChanges/main.go
+++ b/internal/generated/snippets/telcoautomation/apiv1/Client/DiscardBlueprintChanges/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/telcoautomation/apiv1/Client/DiscardDeploymentChanges/main.go
+++ b/internal/generated/snippets/telcoautomation/apiv1/Client/DiscardDeploymentChanges/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/telcoautomation/apiv1/Client/GetBlueprint/main.go
+++ b/internal/generated/snippets/telcoautomation/apiv1/Client/GetBlueprint/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/telcoautomation/apiv1/Client/GetDeployment/main.go
+++ b/internal/generated/snippets/telcoautomation/apiv1/Client/GetDeployment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/telcoautomation/apiv1/Client/GetEdgeSlm/main.go
+++ b/internal/generated/snippets/telcoautomation/apiv1/Client/GetEdgeSlm/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/telcoautomation/apiv1/Client/GetHydratedDeployment/main.go
+++ b/internal/generated/snippets/telcoautomation/apiv1/Client/GetHydratedDeployment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/telcoautomation/apiv1/Client/GetLocation/main.go
+++ b/internal/generated/snippets/telcoautomation/apiv1/Client/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/telcoautomation/apiv1/Client/GetOperation/main.go
+++ b/internal/generated/snippets/telcoautomation/apiv1/Client/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/telcoautomation/apiv1/Client/GetOrchestrationCluster/main.go
+++ b/internal/generated/snippets/telcoautomation/apiv1/Client/GetOrchestrationCluster/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/telcoautomation/apiv1/Client/GetPublicBlueprint/main.go
+++ b/internal/generated/snippets/telcoautomation/apiv1/Client/GetPublicBlueprint/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/telcoautomation/apiv1/Client/ListBlueprintRevisions/main.go
+++ b/internal/generated/snippets/telcoautomation/apiv1/Client/ListBlueprintRevisions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/telcoautomation/apiv1/Client/ListBlueprints/main.go
+++ b/internal/generated/snippets/telcoautomation/apiv1/Client/ListBlueprints/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/telcoautomation/apiv1/Client/ListDeploymentRevisions/main.go
+++ b/internal/generated/snippets/telcoautomation/apiv1/Client/ListDeploymentRevisions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/telcoautomation/apiv1/Client/ListDeployments/main.go
+++ b/internal/generated/snippets/telcoautomation/apiv1/Client/ListDeployments/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/telcoautomation/apiv1/Client/ListEdgeSlms/main.go
+++ b/internal/generated/snippets/telcoautomation/apiv1/Client/ListEdgeSlms/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/telcoautomation/apiv1/Client/ListHydratedDeployments/main.go
+++ b/internal/generated/snippets/telcoautomation/apiv1/Client/ListHydratedDeployments/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/telcoautomation/apiv1/Client/ListLocations/main.go
+++ b/internal/generated/snippets/telcoautomation/apiv1/Client/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/telcoautomation/apiv1/Client/ListOperations/main.go
+++ b/internal/generated/snippets/telcoautomation/apiv1/Client/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/telcoautomation/apiv1/Client/ListOrchestrationClusters/main.go
+++ b/internal/generated/snippets/telcoautomation/apiv1/Client/ListOrchestrationClusters/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/telcoautomation/apiv1/Client/ListPublicBlueprints/main.go
+++ b/internal/generated/snippets/telcoautomation/apiv1/Client/ListPublicBlueprints/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/telcoautomation/apiv1/Client/ProposeBlueprint/main.go
+++ b/internal/generated/snippets/telcoautomation/apiv1/Client/ProposeBlueprint/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/telcoautomation/apiv1/Client/RejectBlueprint/main.go
+++ b/internal/generated/snippets/telcoautomation/apiv1/Client/RejectBlueprint/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/telcoautomation/apiv1/Client/RemoveDeployment/main.go
+++ b/internal/generated/snippets/telcoautomation/apiv1/Client/RemoveDeployment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/telcoautomation/apiv1/Client/RollbackDeployment/main.go
+++ b/internal/generated/snippets/telcoautomation/apiv1/Client/RollbackDeployment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/telcoautomation/apiv1/Client/SearchBlueprintRevisions/main.go
+++ b/internal/generated/snippets/telcoautomation/apiv1/Client/SearchBlueprintRevisions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/telcoautomation/apiv1/Client/SearchDeploymentRevisions/main.go
+++ b/internal/generated/snippets/telcoautomation/apiv1/Client/SearchDeploymentRevisions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/telcoautomation/apiv1/Client/UpdateBlueprint/main.go
+++ b/internal/generated/snippets/telcoautomation/apiv1/Client/UpdateBlueprint/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/telcoautomation/apiv1/Client/UpdateDeployment/main.go
+++ b/internal/generated/snippets/telcoautomation/apiv1/Client/UpdateDeployment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/telcoautomation/apiv1/Client/UpdateHydratedDeployment/main.go
+++ b/internal/generated/snippets/telcoautomation/apiv1/Client/UpdateHydratedDeployment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/texttospeech/apiv1/Client/GetOperation/main.go
+++ b/internal/generated/snippets/texttospeech/apiv1/Client/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/texttospeech/apiv1/Client/ListOperations/main.go
+++ b/internal/generated/snippets/texttospeech/apiv1/Client/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/texttospeech/apiv1/Client/ListVoices/main.go
+++ b/internal/generated/snippets/texttospeech/apiv1/Client/ListVoices/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/texttospeech/apiv1/Client/StreamingSynthesize/main.go
+++ b/internal/generated/snippets/texttospeech/apiv1/Client/StreamingSynthesize/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/texttospeech/apiv1/Client/SynthesizeSpeech/main.go
+++ b/internal/generated/snippets/texttospeech/apiv1/Client/SynthesizeSpeech/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/texttospeech/apiv1/TextToSpeechLongAudioSynthesizeClient/GetOperation/main.go
+++ b/internal/generated/snippets/texttospeech/apiv1/TextToSpeechLongAudioSynthesizeClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/texttospeech/apiv1/TextToSpeechLongAudioSynthesizeClient/ListOperations/main.go
+++ b/internal/generated/snippets/texttospeech/apiv1/TextToSpeechLongAudioSynthesizeClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/texttospeech/apiv1/TextToSpeechLongAudioSynthesizeClient/SynthesizeLongAudio/main.go
+++ b/internal/generated/snippets/texttospeech/apiv1/TextToSpeechLongAudioSynthesizeClient/SynthesizeLongAudio/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/tpu/apiv1/Client/CancelOperation/main.go
+++ b/internal/generated/snippets/tpu/apiv1/Client/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/tpu/apiv1/Client/CreateNode/main.go
+++ b/internal/generated/snippets/tpu/apiv1/Client/CreateNode/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/tpu/apiv1/Client/DeleteNode/main.go
+++ b/internal/generated/snippets/tpu/apiv1/Client/DeleteNode/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/tpu/apiv1/Client/DeleteOperation/main.go
+++ b/internal/generated/snippets/tpu/apiv1/Client/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/tpu/apiv1/Client/GetAcceleratorType/main.go
+++ b/internal/generated/snippets/tpu/apiv1/Client/GetAcceleratorType/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/tpu/apiv1/Client/GetLocation/main.go
+++ b/internal/generated/snippets/tpu/apiv1/Client/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/tpu/apiv1/Client/GetNode/main.go
+++ b/internal/generated/snippets/tpu/apiv1/Client/GetNode/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/tpu/apiv1/Client/GetOperation/main.go
+++ b/internal/generated/snippets/tpu/apiv1/Client/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/tpu/apiv1/Client/GetTensorFlowVersion/main.go
+++ b/internal/generated/snippets/tpu/apiv1/Client/GetTensorFlowVersion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/tpu/apiv1/Client/ListAcceleratorTypes/main.go
+++ b/internal/generated/snippets/tpu/apiv1/Client/ListAcceleratorTypes/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/tpu/apiv1/Client/ListLocations/main.go
+++ b/internal/generated/snippets/tpu/apiv1/Client/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/tpu/apiv1/Client/ListNodes/main.go
+++ b/internal/generated/snippets/tpu/apiv1/Client/ListNodes/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/tpu/apiv1/Client/ListOperations/main.go
+++ b/internal/generated/snippets/tpu/apiv1/Client/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/tpu/apiv1/Client/ListTensorFlowVersions/main.go
+++ b/internal/generated/snippets/tpu/apiv1/Client/ListTensorFlowVersions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/tpu/apiv1/Client/ReimageNode/main.go
+++ b/internal/generated/snippets/tpu/apiv1/Client/ReimageNode/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/tpu/apiv1/Client/StartNode/main.go
+++ b/internal/generated/snippets/tpu/apiv1/Client/StartNode/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/tpu/apiv1/Client/StopNode/main.go
+++ b/internal/generated/snippets/tpu/apiv1/Client/StopNode/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/trace/apiv1/Client/GetTrace/main.go
+++ b/internal/generated/snippets/trace/apiv1/Client/GetTrace/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/trace/apiv1/Client/ListTraces/main.go
+++ b/internal/generated/snippets/trace/apiv1/Client/ListTraces/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/trace/apiv1/Client/PatchTraces/main.go
+++ b/internal/generated/snippets/trace/apiv1/Client/PatchTraces/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/trace/apiv2/Client/BatchWriteSpans/main.go
+++ b/internal/generated/snippets/trace/apiv2/Client/BatchWriteSpans/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/trace/apiv2/Client/CreateSpan/main.go
+++ b/internal/generated/snippets/trace/apiv2/Client/CreateSpan/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/translate/apiv3/TranslationClient/AdaptiveMtTranslate/main.go
+++ b/internal/generated/snippets/translate/apiv3/TranslationClient/AdaptiveMtTranslate/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/translate/apiv3/TranslationClient/BatchTranslateDocument/main.go
+++ b/internal/generated/snippets/translate/apiv3/TranslationClient/BatchTranslateDocument/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/translate/apiv3/TranslationClient/BatchTranslateText/main.go
+++ b/internal/generated/snippets/translate/apiv3/TranslationClient/BatchTranslateText/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/translate/apiv3/TranslationClient/CancelOperation/main.go
+++ b/internal/generated/snippets/translate/apiv3/TranslationClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/translate/apiv3/TranslationClient/CreateAdaptiveMtDataset/main.go
+++ b/internal/generated/snippets/translate/apiv3/TranslationClient/CreateAdaptiveMtDataset/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/translate/apiv3/TranslationClient/CreateDataset/main.go
+++ b/internal/generated/snippets/translate/apiv3/TranslationClient/CreateDataset/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/translate/apiv3/TranslationClient/CreateGlossary/main.go
+++ b/internal/generated/snippets/translate/apiv3/TranslationClient/CreateGlossary/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/translate/apiv3/TranslationClient/CreateGlossaryEntry/main.go
+++ b/internal/generated/snippets/translate/apiv3/TranslationClient/CreateGlossaryEntry/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/translate/apiv3/TranslationClient/CreateModel/main.go
+++ b/internal/generated/snippets/translate/apiv3/TranslationClient/CreateModel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/translate/apiv3/TranslationClient/DeleteAdaptiveMtDataset/main.go
+++ b/internal/generated/snippets/translate/apiv3/TranslationClient/DeleteAdaptiveMtDataset/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/translate/apiv3/TranslationClient/DeleteAdaptiveMtFile/main.go
+++ b/internal/generated/snippets/translate/apiv3/TranslationClient/DeleteAdaptiveMtFile/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/translate/apiv3/TranslationClient/DeleteDataset/main.go
+++ b/internal/generated/snippets/translate/apiv3/TranslationClient/DeleteDataset/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/translate/apiv3/TranslationClient/DeleteGlossary/main.go
+++ b/internal/generated/snippets/translate/apiv3/TranslationClient/DeleteGlossary/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/translate/apiv3/TranslationClient/DeleteGlossaryEntry/main.go
+++ b/internal/generated/snippets/translate/apiv3/TranslationClient/DeleteGlossaryEntry/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/translate/apiv3/TranslationClient/DeleteModel/main.go
+++ b/internal/generated/snippets/translate/apiv3/TranslationClient/DeleteModel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/translate/apiv3/TranslationClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/translate/apiv3/TranslationClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/translate/apiv3/TranslationClient/DetectLanguage/main.go
+++ b/internal/generated/snippets/translate/apiv3/TranslationClient/DetectLanguage/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/translate/apiv3/TranslationClient/ExportData/main.go
+++ b/internal/generated/snippets/translate/apiv3/TranslationClient/ExportData/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/translate/apiv3/TranslationClient/GetAdaptiveMtDataset/main.go
+++ b/internal/generated/snippets/translate/apiv3/TranslationClient/GetAdaptiveMtDataset/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/translate/apiv3/TranslationClient/GetAdaptiveMtFile/main.go
+++ b/internal/generated/snippets/translate/apiv3/TranslationClient/GetAdaptiveMtFile/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/translate/apiv3/TranslationClient/GetDataset/main.go
+++ b/internal/generated/snippets/translate/apiv3/TranslationClient/GetDataset/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/translate/apiv3/TranslationClient/GetGlossary/main.go
+++ b/internal/generated/snippets/translate/apiv3/TranslationClient/GetGlossary/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/translate/apiv3/TranslationClient/GetGlossaryEntry/main.go
+++ b/internal/generated/snippets/translate/apiv3/TranslationClient/GetGlossaryEntry/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/translate/apiv3/TranslationClient/GetLocation/main.go
+++ b/internal/generated/snippets/translate/apiv3/TranslationClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/translate/apiv3/TranslationClient/GetModel/main.go
+++ b/internal/generated/snippets/translate/apiv3/TranslationClient/GetModel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/translate/apiv3/TranslationClient/GetOperation/main.go
+++ b/internal/generated/snippets/translate/apiv3/TranslationClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/translate/apiv3/TranslationClient/GetSupportedLanguages/main.go
+++ b/internal/generated/snippets/translate/apiv3/TranslationClient/GetSupportedLanguages/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/translate/apiv3/TranslationClient/ImportAdaptiveMtFile/main.go
+++ b/internal/generated/snippets/translate/apiv3/TranslationClient/ImportAdaptiveMtFile/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/translate/apiv3/TranslationClient/ImportData/main.go
+++ b/internal/generated/snippets/translate/apiv3/TranslationClient/ImportData/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/translate/apiv3/TranslationClient/ListAdaptiveMtDatasets/main.go
+++ b/internal/generated/snippets/translate/apiv3/TranslationClient/ListAdaptiveMtDatasets/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/translate/apiv3/TranslationClient/ListAdaptiveMtFiles/main.go
+++ b/internal/generated/snippets/translate/apiv3/TranslationClient/ListAdaptiveMtFiles/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/translate/apiv3/TranslationClient/ListAdaptiveMtSentences/main.go
+++ b/internal/generated/snippets/translate/apiv3/TranslationClient/ListAdaptiveMtSentences/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/translate/apiv3/TranslationClient/ListDatasets/main.go
+++ b/internal/generated/snippets/translate/apiv3/TranslationClient/ListDatasets/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/translate/apiv3/TranslationClient/ListExamples/main.go
+++ b/internal/generated/snippets/translate/apiv3/TranslationClient/ListExamples/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/translate/apiv3/TranslationClient/ListGlossaries/main.go
+++ b/internal/generated/snippets/translate/apiv3/TranslationClient/ListGlossaries/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/translate/apiv3/TranslationClient/ListGlossaryEntries/main.go
+++ b/internal/generated/snippets/translate/apiv3/TranslationClient/ListGlossaryEntries/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/translate/apiv3/TranslationClient/ListLocations/main.go
+++ b/internal/generated/snippets/translate/apiv3/TranslationClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/translate/apiv3/TranslationClient/ListModels/main.go
+++ b/internal/generated/snippets/translate/apiv3/TranslationClient/ListModels/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/translate/apiv3/TranslationClient/ListOperations/main.go
+++ b/internal/generated/snippets/translate/apiv3/TranslationClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/translate/apiv3/TranslationClient/RomanizeText/main.go
+++ b/internal/generated/snippets/translate/apiv3/TranslationClient/RomanizeText/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/translate/apiv3/TranslationClient/TranslateDocument/main.go
+++ b/internal/generated/snippets/translate/apiv3/TranslationClient/TranslateDocument/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/translate/apiv3/TranslationClient/TranslateText/main.go
+++ b/internal/generated/snippets/translate/apiv3/TranslationClient/TranslateText/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/translate/apiv3/TranslationClient/UpdateGlossary/main.go
+++ b/internal/generated/snippets/translate/apiv3/TranslationClient/UpdateGlossary/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/translate/apiv3/TranslationClient/UpdateGlossaryEntry/main.go
+++ b/internal/generated/snippets/translate/apiv3/TranslationClient/UpdateGlossaryEntry/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/translate/apiv3/TranslationClient/WaitOperation/main.go
+++ b/internal/generated/snippets/translate/apiv3/TranslationClient/WaitOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vectorsearch/apiv1beta/Client/CancelOperation/main.go
+++ b/internal/generated/snippets/vectorsearch/apiv1beta/Client/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vectorsearch/apiv1beta/Client/CreateCollection/main.go
+++ b/internal/generated/snippets/vectorsearch/apiv1beta/Client/CreateCollection/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vectorsearch/apiv1beta/Client/CreateIndex/main.go
+++ b/internal/generated/snippets/vectorsearch/apiv1beta/Client/CreateIndex/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vectorsearch/apiv1beta/Client/DeleteCollection/main.go
+++ b/internal/generated/snippets/vectorsearch/apiv1beta/Client/DeleteCollection/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vectorsearch/apiv1beta/Client/DeleteIndex/main.go
+++ b/internal/generated/snippets/vectorsearch/apiv1beta/Client/DeleteIndex/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vectorsearch/apiv1beta/Client/DeleteOperation/main.go
+++ b/internal/generated/snippets/vectorsearch/apiv1beta/Client/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vectorsearch/apiv1beta/Client/GetCollection/main.go
+++ b/internal/generated/snippets/vectorsearch/apiv1beta/Client/GetCollection/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vectorsearch/apiv1beta/Client/GetIndex/main.go
+++ b/internal/generated/snippets/vectorsearch/apiv1beta/Client/GetIndex/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vectorsearch/apiv1beta/Client/GetLocation/main.go
+++ b/internal/generated/snippets/vectorsearch/apiv1beta/Client/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vectorsearch/apiv1beta/Client/GetOperation/main.go
+++ b/internal/generated/snippets/vectorsearch/apiv1beta/Client/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vectorsearch/apiv1beta/Client/ImportDataObjects/main.go
+++ b/internal/generated/snippets/vectorsearch/apiv1beta/Client/ImportDataObjects/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vectorsearch/apiv1beta/Client/ListCollections/main.go
+++ b/internal/generated/snippets/vectorsearch/apiv1beta/Client/ListCollections/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vectorsearch/apiv1beta/Client/ListIndexes/main.go
+++ b/internal/generated/snippets/vectorsearch/apiv1beta/Client/ListIndexes/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vectorsearch/apiv1beta/Client/ListLocations/main.go
+++ b/internal/generated/snippets/vectorsearch/apiv1beta/Client/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vectorsearch/apiv1beta/Client/ListOperations/main.go
+++ b/internal/generated/snippets/vectorsearch/apiv1beta/Client/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vectorsearch/apiv1beta/Client/UpdateCollection/main.go
+++ b/internal/generated/snippets/vectorsearch/apiv1beta/Client/UpdateCollection/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vectorsearch/apiv1beta/DataObjectClient/BatchCreateDataObjects/main.go
+++ b/internal/generated/snippets/vectorsearch/apiv1beta/DataObjectClient/BatchCreateDataObjects/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vectorsearch/apiv1beta/DataObjectClient/BatchDeleteDataObjects/main.go
+++ b/internal/generated/snippets/vectorsearch/apiv1beta/DataObjectClient/BatchDeleteDataObjects/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vectorsearch/apiv1beta/DataObjectClient/BatchUpdateDataObjects/main.go
+++ b/internal/generated/snippets/vectorsearch/apiv1beta/DataObjectClient/BatchUpdateDataObjects/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vectorsearch/apiv1beta/DataObjectClient/CancelOperation/main.go
+++ b/internal/generated/snippets/vectorsearch/apiv1beta/DataObjectClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vectorsearch/apiv1beta/DataObjectClient/CreateDataObject/main.go
+++ b/internal/generated/snippets/vectorsearch/apiv1beta/DataObjectClient/CreateDataObject/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vectorsearch/apiv1beta/DataObjectClient/DeleteDataObject/main.go
+++ b/internal/generated/snippets/vectorsearch/apiv1beta/DataObjectClient/DeleteDataObject/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vectorsearch/apiv1beta/DataObjectClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/vectorsearch/apiv1beta/DataObjectClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vectorsearch/apiv1beta/DataObjectClient/GetDataObject/main.go
+++ b/internal/generated/snippets/vectorsearch/apiv1beta/DataObjectClient/GetDataObject/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vectorsearch/apiv1beta/DataObjectClient/GetLocation/main.go
+++ b/internal/generated/snippets/vectorsearch/apiv1beta/DataObjectClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vectorsearch/apiv1beta/DataObjectClient/GetOperation/main.go
+++ b/internal/generated/snippets/vectorsearch/apiv1beta/DataObjectClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vectorsearch/apiv1beta/DataObjectClient/ListLocations/main.go
+++ b/internal/generated/snippets/vectorsearch/apiv1beta/DataObjectClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vectorsearch/apiv1beta/DataObjectClient/ListOperations/main.go
+++ b/internal/generated/snippets/vectorsearch/apiv1beta/DataObjectClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vectorsearch/apiv1beta/DataObjectClient/UpdateDataObject/main.go
+++ b/internal/generated/snippets/vectorsearch/apiv1beta/DataObjectClient/UpdateDataObject/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vectorsearch/apiv1beta/DataObjectSearchClient/AggregateDataObjects/main.go
+++ b/internal/generated/snippets/vectorsearch/apiv1beta/DataObjectSearchClient/AggregateDataObjects/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vectorsearch/apiv1beta/DataObjectSearchClient/BatchSearchDataObjects/main.go
+++ b/internal/generated/snippets/vectorsearch/apiv1beta/DataObjectSearchClient/BatchSearchDataObjects/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vectorsearch/apiv1beta/DataObjectSearchClient/CancelOperation/main.go
+++ b/internal/generated/snippets/vectorsearch/apiv1beta/DataObjectSearchClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vectorsearch/apiv1beta/DataObjectSearchClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/vectorsearch/apiv1beta/DataObjectSearchClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vectorsearch/apiv1beta/DataObjectSearchClient/GetLocation/main.go
+++ b/internal/generated/snippets/vectorsearch/apiv1beta/DataObjectSearchClient/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vectorsearch/apiv1beta/DataObjectSearchClient/GetOperation/main.go
+++ b/internal/generated/snippets/vectorsearch/apiv1beta/DataObjectSearchClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vectorsearch/apiv1beta/DataObjectSearchClient/ListLocations/main.go
+++ b/internal/generated/snippets/vectorsearch/apiv1beta/DataObjectSearchClient/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vectorsearch/apiv1beta/DataObjectSearchClient/ListOperations/main.go
+++ b/internal/generated/snippets/vectorsearch/apiv1beta/DataObjectSearchClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vectorsearch/apiv1beta/DataObjectSearchClient/QueryDataObjects/main.go
+++ b/internal/generated/snippets/vectorsearch/apiv1beta/DataObjectSearchClient/QueryDataObjects/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vectorsearch/apiv1beta/DataObjectSearchClient/SearchDataObjects/main.go
+++ b/internal/generated/snippets/vectorsearch/apiv1beta/DataObjectSearchClient/SearchDataObjects/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/livestream/apiv1/Client/CancelOperation/main.go
+++ b/internal/generated/snippets/video/livestream/apiv1/Client/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/livestream/apiv1/Client/CreateAsset/main.go
+++ b/internal/generated/snippets/video/livestream/apiv1/Client/CreateAsset/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/livestream/apiv1/Client/CreateChannel/main.go
+++ b/internal/generated/snippets/video/livestream/apiv1/Client/CreateChannel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/livestream/apiv1/Client/CreateClip/main.go
+++ b/internal/generated/snippets/video/livestream/apiv1/Client/CreateClip/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/livestream/apiv1/Client/CreateDvrSession/main.go
+++ b/internal/generated/snippets/video/livestream/apiv1/Client/CreateDvrSession/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/livestream/apiv1/Client/CreateEvent/main.go
+++ b/internal/generated/snippets/video/livestream/apiv1/Client/CreateEvent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/livestream/apiv1/Client/CreateInput/main.go
+++ b/internal/generated/snippets/video/livestream/apiv1/Client/CreateInput/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/livestream/apiv1/Client/DeleteAsset/main.go
+++ b/internal/generated/snippets/video/livestream/apiv1/Client/DeleteAsset/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/livestream/apiv1/Client/DeleteChannel/main.go
+++ b/internal/generated/snippets/video/livestream/apiv1/Client/DeleteChannel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/livestream/apiv1/Client/DeleteClip/main.go
+++ b/internal/generated/snippets/video/livestream/apiv1/Client/DeleteClip/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/livestream/apiv1/Client/DeleteDvrSession/main.go
+++ b/internal/generated/snippets/video/livestream/apiv1/Client/DeleteDvrSession/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/livestream/apiv1/Client/DeleteEvent/main.go
+++ b/internal/generated/snippets/video/livestream/apiv1/Client/DeleteEvent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/livestream/apiv1/Client/DeleteInput/main.go
+++ b/internal/generated/snippets/video/livestream/apiv1/Client/DeleteInput/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/livestream/apiv1/Client/DeleteOperation/main.go
+++ b/internal/generated/snippets/video/livestream/apiv1/Client/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/livestream/apiv1/Client/GetAsset/main.go
+++ b/internal/generated/snippets/video/livestream/apiv1/Client/GetAsset/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/livestream/apiv1/Client/GetChannel/main.go
+++ b/internal/generated/snippets/video/livestream/apiv1/Client/GetChannel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/livestream/apiv1/Client/GetClip/main.go
+++ b/internal/generated/snippets/video/livestream/apiv1/Client/GetClip/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/livestream/apiv1/Client/GetDvrSession/main.go
+++ b/internal/generated/snippets/video/livestream/apiv1/Client/GetDvrSession/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/livestream/apiv1/Client/GetEvent/main.go
+++ b/internal/generated/snippets/video/livestream/apiv1/Client/GetEvent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/livestream/apiv1/Client/GetInput/main.go
+++ b/internal/generated/snippets/video/livestream/apiv1/Client/GetInput/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/livestream/apiv1/Client/GetLocation/main.go
+++ b/internal/generated/snippets/video/livestream/apiv1/Client/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/livestream/apiv1/Client/GetOperation/main.go
+++ b/internal/generated/snippets/video/livestream/apiv1/Client/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/livestream/apiv1/Client/GetPool/main.go
+++ b/internal/generated/snippets/video/livestream/apiv1/Client/GetPool/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/livestream/apiv1/Client/ListAssets/main.go
+++ b/internal/generated/snippets/video/livestream/apiv1/Client/ListAssets/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/livestream/apiv1/Client/ListChannels/main.go
+++ b/internal/generated/snippets/video/livestream/apiv1/Client/ListChannels/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/livestream/apiv1/Client/ListClips/main.go
+++ b/internal/generated/snippets/video/livestream/apiv1/Client/ListClips/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/livestream/apiv1/Client/ListDvrSessions/main.go
+++ b/internal/generated/snippets/video/livestream/apiv1/Client/ListDvrSessions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/livestream/apiv1/Client/ListEvents/main.go
+++ b/internal/generated/snippets/video/livestream/apiv1/Client/ListEvents/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/livestream/apiv1/Client/ListInputs/main.go
+++ b/internal/generated/snippets/video/livestream/apiv1/Client/ListInputs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/livestream/apiv1/Client/ListLocations/main.go
+++ b/internal/generated/snippets/video/livestream/apiv1/Client/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/livestream/apiv1/Client/ListOperations/main.go
+++ b/internal/generated/snippets/video/livestream/apiv1/Client/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/livestream/apiv1/Client/PreviewInput/main.go
+++ b/internal/generated/snippets/video/livestream/apiv1/Client/PreviewInput/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/livestream/apiv1/Client/StartChannel/main.go
+++ b/internal/generated/snippets/video/livestream/apiv1/Client/StartChannel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/livestream/apiv1/Client/StartDistribution/main.go
+++ b/internal/generated/snippets/video/livestream/apiv1/Client/StartDistribution/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/livestream/apiv1/Client/StopChannel/main.go
+++ b/internal/generated/snippets/video/livestream/apiv1/Client/StopChannel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/livestream/apiv1/Client/StopDistribution/main.go
+++ b/internal/generated/snippets/video/livestream/apiv1/Client/StopDistribution/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/livestream/apiv1/Client/UpdateChannel/main.go
+++ b/internal/generated/snippets/video/livestream/apiv1/Client/UpdateChannel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/livestream/apiv1/Client/UpdateDvrSession/main.go
+++ b/internal/generated/snippets/video/livestream/apiv1/Client/UpdateDvrSession/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/livestream/apiv1/Client/UpdateInput/main.go
+++ b/internal/generated/snippets/video/livestream/apiv1/Client/UpdateInput/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/livestream/apiv1/Client/UpdatePool/main.go
+++ b/internal/generated/snippets/video/livestream/apiv1/Client/UpdatePool/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/stitcher/apiv1/VideoStitcherClient/CancelOperation/main.go
+++ b/internal/generated/snippets/video/stitcher/apiv1/VideoStitcherClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/stitcher/apiv1/VideoStitcherClient/CreateCdnKey/main.go
+++ b/internal/generated/snippets/video/stitcher/apiv1/VideoStitcherClient/CreateCdnKey/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/stitcher/apiv1/VideoStitcherClient/CreateLiveConfig/main.go
+++ b/internal/generated/snippets/video/stitcher/apiv1/VideoStitcherClient/CreateLiveConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/stitcher/apiv1/VideoStitcherClient/CreateLiveSession/main.go
+++ b/internal/generated/snippets/video/stitcher/apiv1/VideoStitcherClient/CreateLiveSession/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/stitcher/apiv1/VideoStitcherClient/CreateSlate/main.go
+++ b/internal/generated/snippets/video/stitcher/apiv1/VideoStitcherClient/CreateSlate/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/stitcher/apiv1/VideoStitcherClient/CreateVodConfig/main.go
+++ b/internal/generated/snippets/video/stitcher/apiv1/VideoStitcherClient/CreateVodConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/stitcher/apiv1/VideoStitcherClient/CreateVodSession/main.go
+++ b/internal/generated/snippets/video/stitcher/apiv1/VideoStitcherClient/CreateVodSession/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/stitcher/apiv1/VideoStitcherClient/DeleteCdnKey/main.go
+++ b/internal/generated/snippets/video/stitcher/apiv1/VideoStitcherClient/DeleteCdnKey/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/stitcher/apiv1/VideoStitcherClient/DeleteLiveConfig/main.go
+++ b/internal/generated/snippets/video/stitcher/apiv1/VideoStitcherClient/DeleteLiveConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/stitcher/apiv1/VideoStitcherClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/video/stitcher/apiv1/VideoStitcherClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/stitcher/apiv1/VideoStitcherClient/DeleteSlate/main.go
+++ b/internal/generated/snippets/video/stitcher/apiv1/VideoStitcherClient/DeleteSlate/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/stitcher/apiv1/VideoStitcherClient/DeleteVodConfig/main.go
+++ b/internal/generated/snippets/video/stitcher/apiv1/VideoStitcherClient/DeleteVodConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/stitcher/apiv1/VideoStitcherClient/GetCdnKey/main.go
+++ b/internal/generated/snippets/video/stitcher/apiv1/VideoStitcherClient/GetCdnKey/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/stitcher/apiv1/VideoStitcherClient/GetLiveAdTagDetail/main.go
+++ b/internal/generated/snippets/video/stitcher/apiv1/VideoStitcherClient/GetLiveAdTagDetail/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/stitcher/apiv1/VideoStitcherClient/GetLiveConfig/main.go
+++ b/internal/generated/snippets/video/stitcher/apiv1/VideoStitcherClient/GetLiveConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/stitcher/apiv1/VideoStitcherClient/GetLiveSession/main.go
+++ b/internal/generated/snippets/video/stitcher/apiv1/VideoStitcherClient/GetLiveSession/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/stitcher/apiv1/VideoStitcherClient/GetOperation/main.go
+++ b/internal/generated/snippets/video/stitcher/apiv1/VideoStitcherClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/stitcher/apiv1/VideoStitcherClient/GetSlate/main.go
+++ b/internal/generated/snippets/video/stitcher/apiv1/VideoStitcherClient/GetSlate/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/stitcher/apiv1/VideoStitcherClient/GetVodAdTagDetail/main.go
+++ b/internal/generated/snippets/video/stitcher/apiv1/VideoStitcherClient/GetVodAdTagDetail/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/stitcher/apiv1/VideoStitcherClient/GetVodConfig/main.go
+++ b/internal/generated/snippets/video/stitcher/apiv1/VideoStitcherClient/GetVodConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/stitcher/apiv1/VideoStitcherClient/GetVodSession/main.go
+++ b/internal/generated/snippets/video/stitcher/apiv1/VideoStitcherClient/GetVodSession/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/stitcher/apiv1/VideoStitcherClient/GetVodStitchDetail/main.go
+++ b/internal/generated/snippets/video/stitcher/apiv1/VideoStitcherClient/GetVodStitchDetail/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/stitcher/apiv1/VideoStitcherClient/ListCdnKeys/main.go
+++ b/internal/generated/snippets/video/stitcher/apiv1/VideoStitcherClient/ListCdnKeys/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/stitcher/apiv1/VideoStitcherClient/ListLiveAdTagDetails/main.go
+++ b/internal/generated/snippets/video/stitcher/apiv1/VideoStitcherClient/ListLiveAdTagDetails/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/stitcher/apiv1/VideoStitcherClient/ListLiveConfigs/main.go
+++ b/internal/generated/snippets/video/stitcher/apiv1/VideoStitcherClient/ListLiveConfigs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/stitcher/apiv1/VideoStitcherClient/ListOperations/main.go
+++ b/internal/generated/snippets/video/stitcher/apiv1/VideoStitcherClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/stitcher/apiv1/VideoStitcherClient/ListSlates/main.go
+++ b/internal/generated/snippets/video/stitcher/apiv1/VideoStitcherClient/ListSlates/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/stitcher/apiv1/VideoStitcherClient/ListVodAdTagDetails/main.go
+++ b/internal/generated/snippets/video/stitcher/apiv1/VideoStitcherClient/ListVodAdTagDetails/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/stitcher/apiv1/VideoStitcherClient/ListVodConfigs/main.go
+++ b/internal/generated/snippets/video/stitcher/apiv1/VideoStitcherClient/ListVodConfigs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/stitcher/apiv1/VideoStitcherClient/ListVodStitchDetails/main.go
+++ b/internal/generated/snippets/video/stitcher/apiv1/VideoStitcherClient/ListVodStitchDetails/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/stitcher/apiv1/VideoStitcherClient/UpdateCdnKey/main.go
+++ b/internal/generated/snippets/video/stitcher/apiv1/VideoStitcherClient/UpdateCdnKey/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/stitcher/apiv1/VideoStitcherClient/UpdateLiveConfig/main.go
+++ b/internal/generated/snippets/video/stitcher/apiv1/VideoStitcherClient/UpdateLiveConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/stitcher/apiv1/VideoStitcherClient/UpdateSlate/main.go
+++ b/internal/generated/snippets/video/stitcher/apiv1/VideoStitcherClient/UpdateSlate/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/stitcher/apiv1/VideoStitcherClient/UpdateVodConfig/main.go
+++ b/internal/generated/snippets/video/stitcher/apiv1/VideoStitcherClient/UpdateVodConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/transcoder/apiv1/Client/CreateJob/main.go
+++ b/internal/generated/snippets/video/transcoder/apiv1/Client/CreateJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/transcoder/apiv1/Client/CreateJobTemplate/main.go
+++ b/internal/generated/snippets/video/transcoder/apiv1/Client/CreateJobTemplate/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/transcoder/apiv1/Client/DeleteJob/main.go
+++ b/internal/generated/snippets/video/transcoder/apiv1/Client/DeleteJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/transcoder/apiv1/Client/DeleteJobTemplate/main.go
+++ b/internal/generated/snippets/video/transcoder/apiv1/Client/DeleteJobTemplate/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/transcoder/apiv1/Client/GetJob/main.go
+++ b/internal/generated/snippets/video/transcoder/apiv1/Client/GetJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/transcoder/apiv1/Client/GetJobTemplate/main.go
+++ b/internal/generated/snippets/video/transcoder/apiv1/Client/GetJobTemplate/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/transcoder/apiv1/Client/ListJobTemplates/main.go
+++ b/internal/generated/snippets/video/transcoder/apiv1/Client/ListJobTemplates/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/video/transcoder/apiv1/Client/ListJobs/main.go
+++ b/internal/generated/snippets/video/transcoder/apiv1/Client/ListJobs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/videointelligence/apiv1/Client/AnnotateVideo/main.go
+++ b/internal/generated/snippets/videointelligence/apiv1/Client/AnnotateVideo/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/videointelligence/apiv1beta2/Client/AnnotateVideo/main.go
+++ b/internal/generated/snippets/videointelligence/apiv1beta2/Client/AnnotateVideo/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/videointelligence/apiv1p3beta1/Client/AnnotateVideo/main.go
+++ b/internal/generated/snippets/videointelligence/apiv1p3beta1/Client/AnnotateVideo/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/videointelligence/apiv1p3beta1/StreamingVideoIntelligenceClient/StreamingAnnotateVideo/main.go
+++ b/internal/generated/snippets/videointelligence/apiv1p3beta1/StreamingVideoIntelligenceClient/StreamingAnnotateVideo/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vision/apiv1/ImageAnnotatorClient/AsyncBatchAnnotateFiles/main.go
+++ b/internal/generated/snippets/vision/apiv1/ImageAnnotatorClient/AsyncBatchAnnotateFiles/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vision/apiv1/ImageAnnotatorClient/AsyncBatchAnnotateImages/main.go
+++ b/internal/generated/snippets/vision/apiv1/ImageAnnotatorClient/AsyncBatchAnnotateImages/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vision/apiv1/ImageAnnotatorClient/BatchAnnotateFiles/main.go
+++ b/internal/generated/snippets/vision/apiv1/ImageAnnotatorClient/BatchAnnotateFiles/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vision/apiv1/ImageAnnotatorClient/BatchAnnotateImages/main.go
+++ b/internal/generated/snippets/vision/apiv1/ImageAnnotatorClient/BatchAnnotateImages/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vision/apiv1/ImageAnnotatorClient/GetOperation/main.go
+++ b/internal/generated/snippets/vision/apiv1/ImageAnnotatorClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vision/apiv1/ProductSearchClient/AddProductToProductSet/main.go
+++ b/internal/generated/snippets/vision/apiv1/ProductSearchClient/AddProductToProductSet/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vision/apiv1/ProductSearchClient/CreateProduct/main.go
+++ b/internal/generated/snippets/vision/apiv1/ProductSearchClient/CreateProduct/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vision/apiv1/ProductSearchClient/CreateProductSet/main.go
+++ b/internal/generated/snippets/vision/apiv1/ProductSearchClient/CreateProductSet/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vision/apiv1/ProductSearchClient/CreateReferenceImage/main.go
+++ b/internal/generated/snippets/vision/apiv1/ProductSearchClient/CreateReferenceImage/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vision/apiv1/ProductSearchClient/DeleteProduct/main.go
+++ b/internal/generated/snippets/vision/apiv1/ProductSearchClient/DeleteProduct/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vision/apiv1/ProductSearchClient/DeleteProductSet/main.go
+++ b/internal/generated/snippets/vision/apiv1/ProductSearchClient/DeleteProductSet/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vision/apiv1/ProductSearchClient/DeleteReferenceImage/main.go
+++ b/internal/generated/snippets/vision/apiv1/ProductSearchClient/DeleteReferenceImage/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vision/apiv1/ProductSearchClient/GetOperation/main.go
+++ b/internal/generated/snippets/vision/apiv1/ProductSearchClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vision/apiv1/ProductSearchClient/GetProduct/main.go
+++ b/internal/generated/snippets/vision/apiv1/ProductSearchClient/GetProduct/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vision/apiv1/ProductSearchClient/GetProductSet/main.go
+++ b/internal/generated/snippets/vision/apiv1/ProductSearchClient/GetProductSet/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vision/apiv1/ProductSearchClient/GetReferenceImage/main.go
+++ b/internal/generated/snippets/vision/apiv1/ProductSearchClient/GetReferenceImage/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vision/apiv1/ProductSearchClient/ImportProductSets/main.go
+++ b/internal/generated/snippets/vision/apiv1/ProductSearchClient/ImportProductSets/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vision/apiv1/ProductSearchClient/ListProductSets/main.go
+++ b/internal/generated/snippets/vision/apiv1/ProductSearchClient/ListProductSets/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vision/apiv1/ProductSearchClient/ListProducts/main.go
+++ b/internal/generated/snippets/vision/apiv1/ProductSearchClient/ListProducts/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vision/apiv1/ProductSearchClient/ListProductsInProductSet/main.go
+++ b/internal/generated/snippets/vision/apiv1/ProductSearchClient/ListProductsInProductSet/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vision/apiv1/ProductSearchClient/ListReferenceImages/main.go
+++ b/internal/generated/snippets/vision/apiv1/ProductSearchClient/ListReferenceImages/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vision/apiv1/ProductSearchClient/PurgeProducts/main.go
+++ b/internal/generated/snippets/vision/apiv1/ProductSearchClient/PurgeProducts/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vision/apiv1/ProductSearchClient/RemoveProductFromProductSet/main.go
+++ b/internal/generated/snippets/vision/apiv1/ProductSearchClient/RemoveProductFromProductSet/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vision/apiv1/ProductSearchClient/UpdateProduct/main.go
+++ b/internal/generated/snippets/vision/apiv1/ProductSearchClient/UpdateProduct/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vision/apiv1/ProductSearchClient/UpdateProductSet/main.go
+++ b/internal/generated/snippets/vision/apiv1/ProductSearchClient/UpdateProductSet/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vision/apiv1p1beta1/ImageAnnotatorClient/BatchAnnotateImages/main.go
+++ b/internal/generated/snippets/vision/apiv1p1beta1/ImageAnnotatorClient/BatchAnnotateImages/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/AppPlatformClient/AddApplicationStreamInput/main.go
+++ b/internal/generated/snippets/visionai/apiv1/AppPlatformClient/AddApplicationStreamInput/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/AppPlatformClient/CancelOperation/main.go
+++ b/internal/generated/snippets/visionai/apiv1/AppPlatformClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/AppPlatformClient/CreateApplication/main.go
+++ b/internal/generated/snippets/visionai/apiv1/AppPlatformClient/CreateApplication/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/AppPlatformClient/CreateApplicationInstances/main.go
+++ b/internal/generated/snippets/visionai/apiv1/AppPlatformClient/CreateApplicationInstances/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/AppPlatformClient/CreateDraft/main.go
+++ b/internal/generated/snippets/visionai/apiv1/AppPlatformClient/CreateDraft/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/AppPlatformClient/CreateProcessor/main.go
+++ b/internal/generated/snippets/visionai/apiv1/AppPlatformClient/CreateProcessor/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/AppPlatformClient/DeleteApplication/main.go
+++ b/internal/generated/snippets/visionai/apiv1/AppPlatformClient/DeleteApplication/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/AppPlatformClient/DeleteApplicationInstances/main.go
+++ b/internal/generated/snippets/visionai/apiv1/AppPlatformClient/DeleteApplicationInstances/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/AppPlatformClient/DeleteDraft/main.go
+++ b/internal/generated/snippets/visionai/apiv1/AppPlatformClient/DeleteDraft/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/AppPlatformClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/visionai/apiv1/AppPlatformClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/AppPlatformClient/DeleteProcessor/main.go
+++ b/internal/generated/snippets/visionai/apiv1/AppPlatformClient/DeleteProcessor/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/AppPlatformClient/DeployApplication/main.go
+++ b/internal/generated/snippets/visionai/apiv1/AppPlatformClient/DeployApplication/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/AppPlatformClient/GetApplication/main.go
+++ b/internal/generated/snippets/visionai/apiv1/AppPlatformClient/GetApplication/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/AppPlatformClient/GetDraft/main.go
+++ b/internal/generated/snippets/visionai/apiv1/AppPlatformClient/GetDraft/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/AppPlatformClient/GetInstance/main.go
+++ b/internal/generated/snippets/visionai/apiv1/AppPlatformClient/GetInstance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/AppPlatformClient/GetOperation/main.go
+++ b/internal/generated/snippets/visionai/apiv1/AppPlatformClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/AppPlatformClient/GetProcessor/main.go
+++ b/internal/generated/snippets/visionai/apiv1/AppPlatformClient/GetProcessor/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/AppPlatformClient/ListApplications/main.go
+++ b/internal/generated/snippets/visionai/apiv1/AppPlatformClient/ListApplications/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/AppPlatformClient/ListDrafts/main.go
+++ b/internal/generated/snippets/visionai/apiv1/AppPlatformClient/ListDrafts/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/AppPlatformClient/ListInstances/main.go
+++ b/internal/generated/snippets/visionai/apiv1/AppPlatformClient/ListInstances/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/AppPlatformClient/ListOperations/main.go
+++ b/internal/generated/snippets/visionai/apiv1/AppPlatformClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/AppPlatformClient/ListPrebuiltProcessors/main.go
+++ b/internal/generated/snippets/visionai/apiv1/AppPlatformClient/ListPrebuiltProcessors/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/AppPlatformClient/ListProcessors/main.go
+++ b/internal/generated/snippets/visionai/apiv1/AppPlatformClient/ListProcessors/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/AppPlatformClient/RemoveApplicationStreamInput/main.go
+++ b/internal/generated/snippets/visionai/apiv1/AppPlatformClient/RemoveApplicationStreamInput/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/AppPlatformClient/UndeployApplication/main.go
+++ b/internal/generated/snippets/visionai/apiv1/AppPlatformClient/UndeployApplication/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/AppPlatformClient/UpdateApplication/main.go
+++ b/internal/generated/snippets/visionai/apiv1/AppPlatformClient/UpdateApplication/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/AppPlatformClient/UpdateApplicationInstances/main.go
+++ b/internal/generated/snippets/visionai/apiv1/AppPlatformClient/UpdateApplicationInstances/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/AppPlatformClient/UpdateApplicationStreamInput/main.go
+++ b/internal/generated/snippets/visionai/apiv1/AppPlatformClient/UpdateApplicationStreamInput/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/AppPlatformClient/UpdateDraft/main.go
+++ b/internal/generated/snippets/visionai/apiv1/AppPlatformClient/UpdateDraft/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/AppPlatformClient/UpdateProcessor/main.go
+++ b/internal/generated/snippets/visionai/apiv1/AppPlatformClient/UpdateProcessor/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/HealthCheckClient/CancelOperation/main.go
+++ b/internal/generated/snippets/visionai/apiv1/HealthCheckClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/HealthCheckClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/visionai/apiv1/HealthCheckClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/HealthCheckClient/GetOperation/main.go
+++ b/internal/generated/snippets/visionai/apiv1/HealthCheckClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/HealthCheckClient/HealthCheck/main.go
+++ b/internal/generated/snippets/visionai/apiv1/HealthCheckClient/HealthCheck/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/HealthCheckClient/ListOperations/main.go
+++ b/internal/generated/snippets/visionai/apiv1/HealthCheckClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/LiveVideoAnalyticsClient/BatchRunProcess/main.go
+++ b/internal/generated/snippets/visionai/apiv1/LiveVideoAnalyticsClient/BatchRunProcess/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/LiveVideoAnalyticsClient/CancelOperation/main.go
+++ b/internal/generated/snippets/visionai/apiv1/LiveVideoAnalyticsClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/LiveVideoAnalyticsClient/CreateAnalysis/main.go
+++ b/internal/generated/snippets/visionai/apiv1/LiveVideoAnalyticsClient/CreateAnalysis/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/LiveVideoAnalyticsClient/CreateOperator/main.go
+++ b/internal/generated/snippets/visionai/apiv1/LiveVideoAnalyticsClient/CreateOperator/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/LiveVideoAnalyticsClient/CreateProcess/main.go
+++ b/internal/generated/snippets/visionai/apiv1/LiveVideoAnalyticsClient/CreateProcess/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/LiveVideoAnalyticsClient/DeleteAnalysis/main.go
+++ b/internal/generated/snippets/visionai/apiv1/LiveVideoAnalyticsClient/DeleteAnalysis/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/LiveVideoAnalyticsClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/visionai/apiv1/LiveVideoAnalyticsClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/LiveVideoAnalyticsClient/DeleteOperator/main.go
+++ b/internal/generated/snippets/visionai/apiv1/LiveVideoAnalyticsClient/DeleteOperator/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/LiveVideoAnalyticsClient/DeleteProcess/main.go
+++ b/internal/generated/snippets/visionai/apiv1/LiveVideoAnalyticsClient/DeleteProcess/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/LiveVideoAnalyticsClient/GetAnalysis/main.go
+++ b/internal/generated/snippets/visionai/apiv1/LiveVideoAnalyticsClient/GetAnalysis/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/LiveVideoAnalyticsClient/GetOperation/main.go
+++ b/internal/generated/snippets/visionai/apiv1/LiveVideoAnalyticsClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/LiveVideoAnalyticsClient/GetOperator/main.go
+++ b/internal/generated/snippets/visionai/apiv1/LiveVideoAnalyticsClient/GetOperator/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/LiveVideoAnalyticsClient/GetProcess/main.go
+++ b/internal/generated/snippets/visionai/apiv1/LiveVideoAnalyticsClient/GetProcess/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/LiveVideoAnalyticsClient/ListAnalyses/main.go
+++ b/internal/generated/snippets/visionai/apiv1/LiveVideoAnalyticsClient/ListAnalyses/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/LiveVideoAnalyticsClient/ListOperations/main.go
+++ b/internal/generated/snippets/visionai/apiv1/LiveVideoAnalyticsClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/LiveVideoAnalyticsClient/ListOperators/main.go
+++ b/internal/generated/snippets/visionai/apiv1/LiveVideoAnalyticsClient/ListOperators/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/LiveVideoAnalyticsClient/ListProcesses/main.go
+++ b/internal/generated/snippets/visionai/apiv1/LiveVideoAnalyticsClient/ListProcesses/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/LiveVideoAnalyticsClient/ListPublicOperators/main.go
+++ b/internal/generated/snippets/visionai/apiv1/LiveVideoAnalyticsClient/ListPublicOperators/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/LiveVideoAnalyticsClient/ResolveOperatorInfo/main.go
+++ b/internal/generated/snippets/visionai/apiv1/LiveVideoAnalyticsClient/ResolveOperatorInfo/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/LiveVideoAnalyticsClient/UpdateAnalysis/main.go
+++ b/internal/generated/snippets/visionai/apiv1/LiveVideoAnalyticsClient/UpdateAnalysis/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/LiveVideoAnalyticsClient/UpdateOperator/main.go
+++ b/internal/generated/snippets/visionai/apiv1/LiveVideoAnalyticsClient/UpdateOperator/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/LiveVideoAnalyticsClient/UpdateProcess/main.go
+++ b/internal/generated/snippets/visionai/apiv1/LiveVideoAnalyticsClient/UpdateProcess/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/StreamingClient/AcquireLease/main.go
+++ b/internal/generated/snippets/visionai/apiv1/StreamingClient/AcquireLease/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/StreamingClient/CancelOperation/main.go
+++ b/internal/generated/snippets/visionai/apiv1/StreamingClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/StreamingClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/visionai/apiv1/StreamingClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/StreamingClient/GetOperation/main.go
+++ b/internal/generated/snippets/visionai/apiv1/StreamingClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/StreamingClient/ListOperations/main.go
+++ b/internal/generated/snippets/visionai/apiv1/StreamingClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/StreamingClient/ReceiveEvents/main.go
+++ b/internal/generated/snippets/visionai/apiv1/StreamingClient/ReceiveEvents/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/StreamingClient/ReceivePackets/main.go
+++ b/internal/generated/snippets/visionai/apiv1/StreamingClient/ReceivePackets/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/StreamingClient/ReleaseLease/main.go
+++ b/internal/generated/snippets/visionai/apiv1/StreamingClient/ReleaseLease/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/StreamingClient/RenewLease/main.go
+++ b/internal/generated/snippets/visionai/apiv1/StreamingClient/RenewLease/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/StreamingClient/SendPackets/main.go
+++ b/internal/generated/snippets/visionai/apiv1/StreamingClient/SendPackets/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/StreamsClient/CancelOperation/main.go
+++ b/internal/generated/snippets/visionai/apiv1/StreamsClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/StreamsClient/CreateCluster/main.go
+++ b/internal/generated/snippets/visionai/apiv1/StreamsClient/CreateCluster/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/StreamsClient/CreateEvent/main.go
+++ b/internal/generated/snippets/visionai/apiv1/StreamsClient/CreateEvent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/StreamsClient/CreateSeries/main.go
+++ b/internal/generated/snippets/visionai/apiv1/StreamsClient/CreateSeries/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/StreamsClient/CreateStream/main.go
+++ b/internal/generated/snippets/visionai/apiv1/StreamsClient/CreateStream/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/StreamsClient/DeleteCluster/main.go
+++ b/internal/generated/snippets/visionai/apiv1/StreamsClient/DeleteCluster/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/StreamsClient/DeleteEvent/main.go
+++ b/internal/generated/snippets/visionai/apiv1/StreamsClient/DeleteEvent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/StreamsClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/visionai/apiv1/StreamsClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/StreamsClient/DeleteSeries/main.go
+++ b/internal/generated/snippets/visionai/apiv1/StreamsClient/DeleteSeries/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/StreamsClient/DeleteStream/main.go
+++ b/internal/generated/snippets/visionai/apiv1/StreamsClient/DeleteStream/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/StreamsClient/GenerateStreamHlsToken/main.go
+++ b/internal/generated/snippets/visionai/apiv1/StreamsClient/GenerateStreamHlsToken/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/StreamsClient/GetCluster/main.go
+++ b/internal/generated/snippets/visionai/apiv1/StreamsClient/GetCluster/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/StreamsClient/GetEvent/main.go
+++ b/internal/generated/snippets/visionai/apiv1/StreamsClient/GetEvent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/StreamsClient/GetOperation/main.go
+++ b/internal/generated/snippets/visionai/apiv1/StreamsClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/StreamsClient/GetSeries/main.go
+++ b/internal/generated/snippets/visionai/apiv1/StreamsClient/GetSeries/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/StreamsClient/GetStream/main.go
+++ b/internal/generated/snippets/visionai/apiv1/StreamsClient/GetStream/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/StreamsClient/GetStreamThumbnail/main.go
+++ b/internal/generated/snippets/visionai/apiv1/StreamsClient/GetStreamThumbnail/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/StreamsClient/ListClusters/main.go
+++ b/internal/generated/snippets/visionai/apiv1/StreamsClient/ListClusters/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/StreamsClient/ListEvents/main.go
+++ b/internal/generated/snippets/visionai/apiv1/StreamsClient/ListEvents/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/StreamsClient/ListOperations/main.go
+++ b/internal/generated/snippets/visionai/apiv1/StreamsClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/StreamsClient/ListSeries/main.go
+++ b/internal/generated/snippets/visionai/apiv1/StreamsClient/ListSeries/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/StreamsClient/ListStreams/main.go
+++ b/internal/generated/snippets/visionai/apiv1/StreamsClient/ListStreams/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/StreamsClient/MaterializeChannel/main.go
+++ b/internal/generated/snippets/visionai/apiv1/StreamsClient/MaterializeChannel/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/StreamsClient/UpdateCluster/main.go
+++ b/internal/generated/snippets/visionai/apiv1/StreamsClient/UpdateCluster/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/StreamsClient/UpdateEvent/main.go
+++ b/internal/generated/snippets/visionai/apiv1/StreamsClient/UpdateEvent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/StreamsClient/UpdateSeries/main.go
+++ b/internal/generated/snippets/visionai/apiv1/StreamsClient/UpdateSeries/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/StreamsClient/UpdateStream/main.go
+++ b/internal/generated/snippets/visionai/apiv1/StreamsClient/UpdateStream/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/WarehouseClient/AddCollectionItem/main.go
+++ b/internal/generated/snippets/visionai/apiv1/WarehouseClient/AddCollectionItem/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/WarehouseClient/AnalyzeAsset/main.go
+++ b/internal/generated/snippets/visionai/apiv1/WarehouseClient/AnalyzeAsset/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/WarehouseClient/AnalyzeCorpus/main.go
+++ b/internal/generated/snippets/visionai/apiv1/WarehouseClient/AnalyzeCorpus/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/WarehouseClient/CancelOperation/main.go
+++ b/internal/generated/snippets/visionai/apiv1/WarehouseClient/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/WarehouseClient/ClipAsset/main.go
+++ b/internal/generated/snippets/visionai/apiv1/WarehouseClient/ClipAsset/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/WarehouseClient/CreateAnnotation/main.go
+++ b/internal/generated/snippets/visionai/apiv1/WarehouseClient/CreateAnnotation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/WarehouseClient/CreateAsset/main.go
+++ b/internal/generated/snippets/visionai/apiv1/WarehouseClient/CreateAsset/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/WarehouseClient/CreateCollection/main.go
+++ b/internal/generated/snippets/visionai/apiv1/WarehouseClient/CreateCollection/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/WarehouseClient/CreateCorpus/main.go
+++ b/internal/generated/snippets/visionai/apiv1/WarehouseClient/CreateCorpus/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/WarehouseClient/CreateDataSchema/main.go
+++ b/internal/generated/snippets/visionai/apiv1/WarehouseClient/CreateDataSchema/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/WarehouseClient/CreateIndex/main.go
+++ b/internal/generated/snippets/visionai/apiv1/WarehouseClient/CreateIndex/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/WarehouseClient/CreateIndexEndpoint/main.go
+++ b/internal/generated/snippets/visionai/apiv1/WarehouseClient/CreateIndexEndpoint/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/WarehouseClient/CreateSearchConfig/main.go
+++ b/internal/generated/snippets/visionai/apiv1/WarehouseClient/CreateSearchConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/WarehouseClient/CreateSearchHypernym/main.go
+++ b/internal/generated/snippets/visionai/apiv1/WarehouseClient/CreateSearchHypernym/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/WarehouseClient/DeleteAnnotation/main.go
+++ b/internal/generated/snippets/visionai/apiv1/WarehouseClient/DeleteAnnotation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/WarehouseClient/DeleteAsset/main.go
+++ b/internal/generated/snippets/visionai/apiv1/WarehouseClient/DeleteAsset/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/WarehouseClient/DeleteCollection/main.go
+++ b/internal/generated/snippets/visionai/apiv1/WarehouseClient/DeleteCollection/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/WarehouseClient/DeleteCorpus/main.go
+++ b/internal/generated/snippets/visionai/apiv1/WarehouseClient/DeleteCorpus/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/WarehouseClient/DeleteDataSchema/main.go
+++ b/internal/generated/snippets/visionai/apiv1/WarehouseClient/DeleteDataSchema/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/WarehouseClient/DeleteIndex/main.go
+++ b/internal/generated/snippets/visionai/apiv1/WarehouseClient/DeleteIndex/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/WarehouseClient/DeleteIndexEndpoint/main.go
+++ b/internal/generated/snippets/visionai/apiv1/WarehouseClient/DeleteIndexEndpoint/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/WarehouseClient/DeleteOperation/main.go
+++ b/internal/generated/snippets/visionai/apiv1/WarehouseClient/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/WarehouseClient/DeleteSearchConfig/main.go
+++ b/internal/generated/snippets/visionai/apiv1/WarehouseClient/DeleteSearchConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/WarehouseClient/DeleteSearchHypernym/main.go
+++ b/internal/generated/snippets/visionai/apiv1/WarehouseClient/DeleteSearchHypernym/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/WarehouseClient/DeployIndex/main.go
+++ b/internal/generated/snippets/visionai/apiv1/WarehouseClient/DeployIndex/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/WarehouseClient/GenerateHlsUri/main.go
+++ b/internal/generated/snippets/visionai/apiv1/WarehouseClient/GenerateHlsUri/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/WarehouseClient/GenerateRetrievalUrl/main.go
+++ b/internal/generated/snippets/visionai/apiv1/WarehouseClient/GenerateRetrievalUrl/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/WarehouseClient/GetAnnotation/main.go
+++ b/internal/generated/snippets/visionai/apiv1/WarehouseClient/GetAnnotation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/WarehouseClient/GetAsset/main.go
+++ b/internal/generated/snippets/visionai/apiv1/WarehouseClient/GetAsset/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/WarehouseClient/GetCollection/main.go
+++ b/internal/generated/snippets/visionai/apiv1/WarehouseClient/GetCollection/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/WarehouseClient/GetCorpus/main.go
+++ b/internal/generated/snippets/visionai/apiv1/WarehouseClient/GetCorpus/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/WarehouseClient/GetDataSchema/main.go
+++ b/internal/generated/snippets/visionai/apiv1/WarehouseClient/GetDataSchema/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/WarehouseClient/GetIndex/main.go
+++ b/internal/generated/snippets/visionai/apiv1/WarehouseClient/GetIndex/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/WarehouseClient/GetIndexEndpoint/main.go
+++ b/internal/generated/snippets/visionai/apiv1/WarehouseClient/GetIndexEndpoint/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/WarehouseClient/GetOperation/main.go
+++ b/internal/generated/snippets/visionai/apiv1/WarehouseClient/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/WarehouseClient/GetSearchConfig/main.go
+++ b/internal/generated/snippets/visionai/apiv1/WarehouseClient/GetSearchConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/WarehouseClient/GetSearchHypernym/main.go
+++ b/internal/generated/snippets/visionai/apiv1/WarehouseClient/GetSearchHypernym/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/WarehouseClient/ImportAssets/main.go
+++ b/internal/generated/snippets/visionai/apiv1/WarehouseClient/ImportAssets/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/WarehouseClient/IndexAsset/main.go
+++ b/internal/generated/snippets/visionai/apiv1/WarehouseClient/IndexAsset/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/WarehouseClient/IngestAsset/main.go
+++ b/internal/generated/snippets/visionai/apiv1/WarehouseClient/IngestAsset/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/WarehouseClient/ListAnnotations/main.go
+++ b/internal/generated/snippets/visionai/apiv1/WarehouseClient/ListAnnotations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/WarehouseClient/ListAssets/main.go
+++ b/internal/generated/snippets/visionai/apiv1/WarehouseClient/ListAssets/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/WarehouseClient/ListCollections/main.go
+++ b/internal/generated/snippets/visionai/apiv1/WarehouseClient/ListCollections/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/WarehouseClient/ListCorpora/main.go
+++ b/internal/generated/snippets/visionai/apiv1/WarehouseClient/ListCorpora/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/WarehouseClient/ListDataSchemas/main.go
+++ b/internal/generated/snippets/visionai/apiv1/WarehouseClient/ListDataSchemas/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/WarehouseClient/ListIndexEndpoints/main.go
+++ b/internal/generated/snippets/visionai/apiv1/WarehouseClient/ListIndexEndpoints/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/WarehouseClient/ListIndexes/main.go
+++ b/internal/generated/snippets/visionai/apiv1/WarehouseClient/ListIndexes/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/WarehouseClient/ListOperations/main.go
+++ b/internal/generated/snippets/visionai/apiv1/WarehouseClient/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/WarehouseClient/ListSearchConfigs/main.go
+++ b/internal/generated/snippets/visionai/apiv1/WarehouseClient/ListSearchConfigs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/WarehouseClient/ListSearchHypernyms/main.go
+++ b/internal/generated/snippets/visionai/apiv1/WarehouseClient/ListSearchHypernyms/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/WarehouseClient/RemoveCollectionItem/main.go
+++ b/internal/generated/snippets/visionai/apiv1/WarehouseClient/RemoveCollectionItem/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/WarehouseClient/RemoveIndexAsset/main.go
+++ b/internal/generated/snippets/visionai/apiv1/WarehouseClient/RemoveIndexAsset/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/WarehouseClient/SearchAssets/main.go
+++ b/internal/generated/snippets/visionai/apiv1/WarehouseClient/SearchAssets/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/WarehouseClient/SearchIndexEndpoint/main.go
+++ b/internal/generated/snippets/visionai/apiv1/WarehouseClient/SearchIndexEndpoint/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/WarehouseClient/UndeployIndex/main.go
+++ b/internal/generated/snippets/visionai/apiv1/WarehouseClient/UndeployIndex/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/WarehouseClient/UpdateAnnotation/main.go
+++ b/internal/generated/snippets/visionai/apiv1/WarehouseClient/UpdateAnnotation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/WarehouseClient/UpdateAsset/main.go
+++ b/internal/generated/snippets/visionai/apiv1/WarehouseClient/UpdateAsset/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/WarehouseClient/UpdateCollection/main.go
+++ b/internal/generated/snippets/visionai/apiv1/WarehouseClient/UpdateCollection/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/WarehouseClient/UpdateCorpus/main.go
+++ b/internal/generated/snippets/visionai/apiv1/WarehouseClient/UpdateCorpus/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/WarehouseClient/UpdateDataSchema/main.go
+++ b/internal/generated/snippets/visionai/apiv1/WarehouseClient/UpdateDataSchema/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/WarehouseClient/UpdateIndex/main.go
+++ b/internal/generated/snippets/visionai/apiv1/WarehouseClient/UpdateIndex/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/WarehouseClient/UpdateIndexEndpoint/main.go
+++ b/internal/generated/snippets/visionai/apiv1/WarehouseClient/UpdateIndexEndpoint/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/WarehouseClient/UpdateSearchConfig/main.go
+++ b/internal/generated/snippets/visionai/apiv1/WarehouseClient/UpdateSearchConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/WarehouseClient/UpdateSearchHypernym/main.go
+++ b/internal/generated/snippets/visionai/apiv1/WarehouseClient/UpdateSearchHypernym/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/WarehouseClient/UploadAsset/main.go
+++ b/internal/generated/snippets/visionai/apiv1/WarehouseClient/UploadAsset/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/WarehouseClient/ViewCollectionItems/main.go
+++ b/internal/generated/snippets/visionai/apiv1/WarehouseClient/ViewCollectionItems/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/visionai/apiv1/WarehouseClient/ViewIndexedAssets/main.go
+++ b/internal/generated/snippets/visionai/apiv1/WarehouseClient/ViewIndexedAssets/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmmigration/apiv1/Client/AddGroupMigration/main.go
+++ b/internal/generated/snippets/vmmigration/apiv1/Client/AddGroupMigration/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmmigration/apiv1/Client/CancelCloneJob/main.go
+++ b/internal/generated/snippets/vmmigration/apiv1/Client/CancelCloneJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmmigration/apiv1/Client/CancelCutoverJob/main.go
+++ b/internal/generated/snippets/vmmigration/apiv1/Client/CancelCutoverJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmmigration/apiv1/Client/CancelDiskMigrationJob/main.go
+++ b/internal/generated/snippets/vmmigration/apiv1/Client/CancelDiskMigrationJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmmigration/apiv1/Client/CancelImageImportJob/main.go
+++ b/internal/generated/snippets/vmmigration/apiv1/Client/CancelImageImportJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmmigration/apiv1/Client/CancelOperation/main.go
+++ b/internal/generated/snippets/vmmigration/apiv1/Client/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmmigration/apiv1/Client/CreateCloneJob/main.go
+++ b/internal/generated/snippets/vmmigration/apiv1/Client/CreateCloneJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmmigration/apiv1/Client/CreateCutoverJob/main.go
+++ b/internal/generated/snippets/vmmigration/apiv1/Client/CreateCutoverJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmmigration/apiv1/Client/CreateDatacenterConnector/main.go
+++ b/internal/generated/snippets/vmmigration/apiv1/Client/CreateDatacenterConnector/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmmigration/apiv1/Client/CreateDiskMigrationJob/main.go
+++ b/internal/generated/snippets/vmmigration/apiv1/Client/CreateDiskMigrationJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmmigration/apiv1/Client/CreateGroup/main.go
+++ b/internal/generated/snippets/vmmigration/apiv1/Client/CreateGroup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmmigration/apiv1/Client/CreateImageImport/main.go
+++ b/internal/generated/snippets/vmmigration/apiv1/Client/CreateImageImport/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmmigration/apiv1/Client/CreateMigratingVm/main.go
+++ b/internal/generated/snippets/vmmigration/apiv1/Client/CreateMigratingVm/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmmigration/apiv1/Client/CreateSource/main.go
+++ b/internal/generated/snippets/vmmigration/apiv1/Client/CreateSource/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmmigration/apiv1/Client/CreateTargetProject/main.go
+++ b/internal/generated/snippets/vmmigration/apiv1/Client/CreateTargetProject/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmmigration/apiv1/Client/CreateUtilizationReport/main.go
+++ b/internal/generated/snippets/vmmigration/apiv1/Client/CreateUtilizationReport/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmmigration/apiv1/Client/DeleteDatacenterConnector/main.go
+++ b/internal/generated/snippets/vmmigration/apiv1/Client/DeleteDatacenterConnector/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmmigration/apiv1/Client/DeleteDiskMigrationJob/main.go
+++ b/internal/generated/snippets/vmmigration/apiv1/Client/DeleteDiskMigrationJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmmigration/apiv1/Client/DeleteGroup/main.go
+++ b/internal/generated/snippets/vmmigration/apiv1/Client/DeleteGroup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmmigration/apiv1/Client/DeleteImageImport/main.go
+++ b/internal/generated/snippets/vmmigration/apiv1/Client/DeleteImageImport/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmmigration/apiv1/Client/DeleteMigratingVm/main.go
+++ b/internal/generated/snippets/vmmigration/apiv1/Client/DeleteMigratingVm/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmmigration/apiv1/Client/DeleteOperation/main.go
+++ b/internal/generated/snippets/vmmigration/apiv1/Client/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmmigration/apiv1/Client/DeleteSource/main.go
+++ b/internal/generated/snippets/vmmigration/apiv1/Client/DeleteSource/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmmigration/apiv1/Client/DeleteTargetProject/main.go
+++ b/internal/generated/snippets/vmmigration/apiv1/Client/DeleteTargetProject/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmmigration/apiv1/Client/DeleteUtilizationReport/main.go
+++ b/internal/generated/snippets/vmmigration/apiv1/Client/DeleteUtilizationReport/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmmigration/apiv1/Client/ExtendMigration/main.go
+++ b/internal/generated/snippets/vmmigration/apiv1/Client/ExtendMigration/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmmigration/apiv1/Client/FetchInventory/main.go
+++ b/internal/generated/snippets/vmmigration/apiv1/Client/FetchInventory/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmmigration/apiv1/Client/FetchStorageInventory/main.go
+++ b/internal/generated/snippets/vmmigration/apiv1/Client/FetchStorageInventory/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmmigration/apiv1/Client/FinalizeMigration/main.go
+++ b/internal/generated/snippets/vmmigration/apiv1/Client/FinalizeMigration/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmmigration/apiv1/Client/GetCloneJob/main.go
+++ b/internal/generated/snippets/vmmigration/apiv1/Client/GetCloneJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmmigration/apiv1/Client/GetCutoverJob/main.go
+++ b/internal/generated/snippets/vmmigration/apiv1/Client/GetCutoverJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmmigration/apiv1/Client/GetDatacenterConnector/main.go
+++ b/internal/generated/snippets/vmmigration/apiv1/Client/GetDatacenterConnector/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmmigration/apiv1/Client/GetDiskMigrationJob/main.go
+++ b/internal/generated/snippets/vmmigration/apiv1/Client/GetDiskMigrationJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmmigration/apiv1/Client/GetGroup/main.go
+++ b/internal/generated/snippets/vmmigration/apiv1/Client/GetGroup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmmigration/apiv1/Client/GetImageImport/main.go
+++ b/internal/generated/snippets/vmmigration/apiv1/Client/GetImageImport/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmmigration/apiv1/Client/GetImageImportJob/main.go
+++ b/internal/generated/snippets/vmmigration/apiv1/Client/GetImageImportJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmmigration/apiv1/Client/GetLocation/main.go
+++ b/internal/generated/snippets/vmmigration/apiv1/Client/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmmigration/apiv1/Client/GetMigratingVm/main.go
+++ b/internal/generated/snippets/vmmigration/apiv1/Client/GetMigratingVm/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmmigration/apiv1/Client/GetOperation/main.go
+++ b/internal/generated/snippets/vmmigration/apiv1/Client/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmmigration/apiv1/Client/GetReplicationCycle/main.go
+++ b/internal/generated/snippets/vmmigration/apiv1/Client/GetReplicationCycle/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmmigration/apiv1/Client/GetSource/main.go
+++ b/internal/generated/snippets/vmmigration/apiv1/Client/GetSource/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmmigration/apiv1/Client/GetTargetProject/main.go
+++ b/internal/generated/snippets/vmmigration/apiv1/Client/GetTargetProject/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmmigration/apiv1/Client/GetUtilizationReport/main.go
+++ b/internal/generated/snippets/vmmigration/apiv1/Client/GetUtilizationReport/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmmigration/apiv1/Client/ListCloneJobs/main.go
+++ b/internal/generated/snippets/vmmigration/apiv1/Client/ListCloneJobs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmmigration/apiv1/Client/ListCutoverJobs/main.go
+++ b/internal/generated/snippets/vmmigration/apiv1/Client/ListCutoverJobs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmmigration/apiv1/Client/ListDatacenterConnectors/main.go
+++ b/internal/generated/snippets/vmmigration/apiv1/Client/ListDatacenterConnectors/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmmigration/apiv1/Client/ListDiskMigrationJobs/main.go
+++ b/internal/generated/snippets/vmmigration/apiv1/Client/ListDiskMigrationJobs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmmigration/apiv1/Client/ListGroups/main.go
+++ b/internal/generated/snippets/vmmigration/apiv1/Client/ListGroups/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmmigration/apiv1/Client/ListImageImportJobs/main.go
+++ b/internal/generated/snippets/vmmigration/apiv1/Client/ListImageImportJobs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmmigration/apiv1/Client/ListImageImports/main.go
+++ b/internal/generated/snippets/vmmigration/apiv1/Client/ListImageImports/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmmigration/apiv1/Client/ListLocations/main.go
+++ b/internal/generated/snippets/vmmigration/apiv1/Client/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmmigration/apiv1/Client/ListMigratingVms/main.go
+++ b/internal/generated/snippets/vmmigration/apiv1/Client/ListMigratingVms/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmmigration/apiv1/Client/ListOperations/main.go
+++ b/internal/generated/snippets/vmmigration/apiv1/Client/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmmigration/apiv1/Client/ListReplicationCycles/main.go
+++ b/internal/generated/snippets/vmmigration/apiv1/Client/ListReplicationCycles/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmmigration/apiv1/Client/ListSources/main.go
+++ b/internal/generated/snippets/vmmigration/apiv1/Client/ListSources/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmmigration/apiv1/Client/ListTargetProjects/main.go
+++ b/internal/generated/snippets/vmmigration/apiv1/Client/ListTargetProjects/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmmigration/apiv1/Client/ListUtilizationReports/main.go
+++ b/internal/generated/snippets/vmmigration/apiv1/Client/ListUtilizationReports/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmmigration/apiv1/Client/PauseMigration/main.go
+++ b/internal/generated/snippets/vmmigration/apiv1/Client/PauseMigration/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmmigration/apiv1/Client/RemoveGroupMigration/main.go
+++ b/internal/generated/snippets/vmmigration/apiv1/Client/RemoveGroupMigration/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmmigration/apiv1/Client/ResumeMigration/main.go
+++ b/internal/generated/snippets/vmmigration/apiv1/Client/ResumeMigration/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmmigration/apiv1/Client/RunDiskMigrationJob/main.go
+++ b/internal/generated/snippets/vmmigration/apiv1/Client/RunDiskMigrationJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmmigration/apiv1/Client/StartMigration/main.go
+++ b/internal/generated/snippets/vmmigration/apiv1/Client/StartMigration/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmmigration/apiv1/Client/UpdateDiskMigrationJob/main.go
+++ b/internal/generated/snippets/vmmigration/apiv1/Client/UpdateDiskMigrationJob/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmmigration/apiv1/Client/UpdateGroup/main.go
+++ b/internal/generated/snippets/vmmigration/apiv1/Client/UpdateGroup/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmmigration/apiv1/Client/UpdateMigratingVm/main.go
+++ b/internal/generated/snippets/vmmigration/apiv1/Client/UpdateMigratingVm/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmmigration/apiv1/Client/UpdateSource/main.go
+++ b/internal/generated/snippets/vmmigration/apiv1/Client/UpdateSource/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmmigration/apiv1/Client/UpdateTargetProject/main.go
+++ b/internal/generated/snippets/vmmigration/apiv1/Client/UpdateTargetProject/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmmigration/apiv1/Client/UpgradeAppliance/main.go
+++ b/internal/generated/snippets/vmmigration/apiv1/Client/UpgradeAppliance/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/CreateCluster/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/CreateCluster/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/CreateExternalAccessRule/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/CreateExternalAccessRule/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/CreateExternalAddress/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/CreateExternalAddress/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/CreateHcxActivationKey/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/CreateHcxActivationKey/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/CreateLoggingServer/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/CreateLoggingServer/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/CreateManagementDnsZoneBinding/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/CreateManagementDnsZoneBinding/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/CreateNetworkPeering/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/CreateNetworkPeering/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/CreateNetworkPolicy/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/CreateNetworkPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/CreatePrivateCloud/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/CreatePrivateCloud/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/CreatePrivateConnection/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/CreatePrivateConnection/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/CreateVmwareEngineNetwork/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/CreateVmwareEngineNetwork/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/DeleteCluster/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/DeleteCluster/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/DeleteExternalAccessRule/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/DeleteExternalAccessRule/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/DeleteExternalAddress/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/DeleteExternalAddress/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/DeleteLoggingServer/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/DeleteLoggingServer/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/DeleteManagementDnsZoneBinding/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/DeleteManagementDnsZoneBinding/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/DeleteNetworkPeering/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/DeleteNetworkPeering/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/DeleteNetworkPolicy/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/DeleteNetworkPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/DeleteOperation/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/DeletePrivateCloud/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/DeletePrivateCloud/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/DeletePrivateConnection/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/DeletePrivateConnection/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/DeleteVmwareEngineNetwork/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/DeleteVmwareEngineNetwork/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/FetchNetworkPolicyExternalAddresses/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/FetchNetworkPolicyExternalAddresses/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/GetCluster/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/GetCluster/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/GetDnsBindPermission/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/GetDnsBindPermission/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/GetDnsForwarding/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/GetDnsForwarding/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/GetExternalAccessRule/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/GetExternalAccessRule/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/GetExternalAddress/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/GetExternalAddress/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/GetHcxActivationKey/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/GetHcxActivationKey/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/GetIamPolicy/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/GetLocation/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/GetLoggingServer/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/GetLoggingServer/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/GetManagementDnsZoneBinding/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/GetManagementDnsZoneBinding/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/GetNetworkPeering/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/GetNetworkPeering/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/GetNetworkPolicy/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/GetNetworkPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/GetNode/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/GetNode/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/GetNodeType/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/GetNodeType/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/GetOperation/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/GetPrivateCloud/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/GetPrivateCloud/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/GetPrivateConnection/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/GetPrivateConnection/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/GetSubnet/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/GetSubnet/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/GetVmwareEngineNetwork/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/GetVmwareEngineNetwork/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/GrantDnsBindPermission/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/GrantDnsBindPermission/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/ListClusters/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/ListClusters/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/ListExternalAccessRules/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/ListExternalAccessRules/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/ListExternalAddresses/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/ListExternalAddresses/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/ListHcxActivationKeys/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/ListHcxActivationKeys/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/ListLocations/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/ListLoggingServers/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/ListLoggingServers/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/ListManagementDnsZoneBindings/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/ListManagementDnsZoneBindings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/ListNetworkPeerings/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/ListNetworkPeerings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/ListNetworkPolicies/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/ListNetworkPolicies/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/ListNodeTypes/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/ListNodeTypes/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/ListNodes/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/ListNodes/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/ListOperations/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/ListPeeringRoutes/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/ListPeeringRoutes/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/ListPrivateClouds/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/ListPrivateClouds/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/ListPrivateConnectionPeeringRoutes/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/ListPrivateConnectionPeeringRoutes/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/ListPrivateConnections/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/ListPrivateConnections/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/ListSubnets/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/ListSubnets/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/ListVmwareEngineNetworks/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/ListVmwareEngineNetworks/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/RepairManagementDnsZoneBinding/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/RepairManagementDnsZoneBinding/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/ResetNsxCredentials/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/ResetNsxCredentials/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/ResetVcenterCredentials/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/ResetVcenterCredentials/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/RevokeDnsBindPermission/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/RevokeDnsBindPermission/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/SetIamPolicy/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/ShowNsxCredentials/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/ShowNsxCredentials/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/ShowVcenterCredentials/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/ShowVcenterCredentials/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/TestIamPermissions/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/UndeletePrivateCloud/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/UndeletePrivateCloud/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/UpdateCluster/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/UpdateCluster/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/UpdateDnsForwarding/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/UpdateDnsForwarding/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/UpdateExternalAccessRule/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/UpdateExternalAccessRule/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/UpdateExternalAddress/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/UpdateExternalAddress/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/UpdateLoggingServer/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/UpdateLoggingServer/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/UpdateManagementDnsZoneBinding/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/UpdateManagementDnsZoneBinding/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/UpdateNetworkPeering/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/UpdateNetworkPeering/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/UpdateNetworkPolicy/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/UpdateNetworkPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/UpdatePrivateCloud/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/UpdatePrivateCloud/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/UpdatePrivateConnection/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/UpdatePrivateConnection/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/UpdateSubnet/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/UpdateSubnet/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vmwareengine/apiv1/Client/UpdateVmwareEngineNetwork/main.go
+++ b/internal/generated/snippets/vmwareengine/apiv1/Client/UpdateVmwareEngineNetwork/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vpcaccess/apiv1/Client/CreateConnector/main.go
+++ b/internal/generated/snippets/vpcaccess/apiv1/Client/CreateConnector/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vpcaccess/apiv1/Client/DeleteConnector/main.go
+++ b/internal/generated/snippets/vpcaccess/apiv1/Client/DeleteConnector/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vpcaccess/apiv1/Client/GetConnector/main.go
+++ b/internal/generated/snippets/vpcaccess/apiv1/Client/GetConnector/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vpcaccess/apiv1/Client/GetOperation/main.go
+++ b/internal/generated/snippets/vpcaccess/apiv1/Client/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vpcaccess/apiv1/Client/ListConnectors/main.go
+++ b/internal/generated/snippets/vpcaccess/apiv1/Client/ListConnectors/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vpcaccess/apiv1/Client/ListLocations/main.go
+++ b/internal/generated/snippets/vpcaccess/apiv1/Client/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/vpcaccess/apiv1/Client/ListOperations/main.go
+++ b/internal/generated/snippets/vpcaccess/apiv1/Client/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/webrisk/apiv1/Client/CancelOperation/main.go
+++ b/internal/generated/snippets/webrisk/apiv1/Client/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/webrisk/apiv1/Client/ComputeThreatListDiff/main.go
+++ b/internal/generated/snippets/webrisk/apiv1/Client/ComputeThreatListDiff/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/webrisk/apiv1/Client/CreateSubmission/main.go
+++ b/internal/generated/snippets/webrisk/apiv1/Client/CreateSubmission/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/webrisk/apiv1/Client/DeleteOperation/main.go
+++ b/internal/generated/snippets/webrisk/apiv1/Client/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/webrisk/apiv1/Client/GetOperation/main.go
+++ b/internal/generated/snippets/webrisk/apiv1/Client/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/webrisk/apiv1/Client/ListOperations/main.go
+++ b/internal/generated/snippets/webrisk/apiv1/Client/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/webrisk/apiv1/Client/SearchHashes/main.go
+++ b/internal/generated/snippets/webrisk/apiv1/Client/SearchHashes/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/webrisk/apiv1/Client/SearchUris/main.go
+++ b/internal/generated/snippets/webrisk/apiv1/Client/SearchUris/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/webrisk/apiv1/Client/SubmitUri/main.go
+++ b/internal/generated/snippets/webrisk/apiv1/Client/SubmitUri/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/webrisk/apiv1beta1/WebRiskServiceV1Beta1Client/ComputeThreatListDiff/main.go
+++ b/internal/generated/snippets/webrisk/apiv1beta1/WebRiskServiceV1Beta1Client/ComputeThreatListDiff/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/webrisk/apiv1beta1/WebRiskServiceV1Beta1Client/SearchHashes/main.go
+++ b/internal/generated/snippets/webrisk/apiv1beta1/WebRiskServiceV1Beta1Client/SearchHashes/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/webrisk/apiv1beta1/WebRiskServiceV1Beta1Client/SearchUris/main.go
+++ b/internal/generated/snippets/webrisk/apiv1beta1/WebRiskServiceV1Beta1Client/SearchUris/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/websecurityscanner/apiv1/Client/CreateScanConfig/main.go
+++ b/internal/generated/snippets/websecurityscanner/apiv1/Client/CreateScanConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/websecurityscanner/apiv1/Client/DeleteScanConfig/main.go
+++ b/internal/generated/snippets/websecurityscanner/apiv1/Client/DeleteScanConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/websecurityscanner/apiv1/Client/GetFinding/main.go
+++ b/internal/generated/snippets/websecurityscanner/apiv1/Client/GetFinding/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/websecurityscanner/apiv1/Client/GetScanConfig/main.go
+++ b/internal/generated/snippets/websecurityscanner/apiv1/Client/GetScanConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/websecurityscanner/apiv1/Client/GetScanRun/main.go
+++ b/internal/generated/snippets/websecurityscanner/apiv1/Client/GetScanRun/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/websecurityscanner/apiv1/Client/ListCrawledUrls/main.go
+++ b/internal/generated/snippets/websecurityscanner/apiv1/Client/ListCrawledUrls/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/websecurityscanner/apiv1/Client/ListFindingTypeStats/main.go
+++ b/internal/generated/snippets/websecurityscanner/apiv1/Client/ListFindingTypeStats/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/websecurityscanner/apiv1/Client/ListFindings/main.go
+++ b/internal/generated/snippets/websecurityscanner/apiv1/Client/ListFindings/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/websecurityscanner/apiv1/Client/ListScanConfigs/main.go
+++ b/internal/generated/snippets/websecurityscanner/apiv1/Client/ListScanConfigs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/websecurityscanner/apiv1/Client/ListScanRuns/main.go
+++ b/internal/generated/snippets/websecurityscanner/apiv1/Client/ListScanRuns/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/websecurityscanner/apiv1/Client/StartScanRun/main.go
+++ b/internal/generated/snippets/websecurityscanner/apiv1/Client/StartScanRun/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/websecurityscanner/apiv1/Client/StopScanRun/main.go
+++ b/internal/generated/snippets/websecurityscanner/apiv1/Client/StopScanRun/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/websecurityscanner/apiv1/Client/UpdateScanConfig/main.go
+++ b/internal/generated/snippets/websecurityscanner/apiv1/Client/UpdateScanConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workflows/apiv1/Client/CreateWorkflow/main.go
+++ b/internal/generated/snippets/workflows/apiv1/Client/CreateWorkflow/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workflows/apiv1/Client/DeleteOperation/main.go
+++ b/internal/generated/snippets/workflows/apiv1/Client/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workflows/apiv1/Client/DeleteWorkflow/main.go
+++ b/internal/generated/snippets/workflows/apiv1/Client/DeleteWorkflow/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workflows/apiv1/Client/GetLocation/main.go
+++ b/internal/generated/snippets/workflows/apiv1/Client/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workflows/apiv1/Client/GetOperation/main.go
+++ b/internal/generated/snippets/workflows/apiv1/Client/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workflows/apiv1/Client/GetWorkflow/main.go
+++ b/internal/generated/snippets/workflows/apiv1/Client/GetWorkflow/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workflows/apiv1/Client/ListLocations/main.go
+++ b/internal/generated/snippets/workflows/apiv1/Client/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workflows/apiv1/Client/ListOperations/main.go
+++ b/internal/generated/snippets/workflows/apiv1/Client/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workflows/apiv1/Client/ListWorkflowRevisions/main.go
+++ b/internal/generated/snippets/workflows/apiv1/Client/ListWorkflowRevisions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workflows/apiv1/Client/ListWorkflows/main.go
+++ b/internal/generated/snippets/workflows/apiv1/Client/ListWorkflows/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workflows/apiv1/Client/UpdateWorkflow/main.go
+++ b/internal/generated/snippets/workflows/apiv1/Client/UpdateWorkflow/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workflows/apiv1beta/Client/CreateWorkflow/main.go
+++ b/internal/generated/snippets/workflows/apiv1beta/Client/CreateWorkflow/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workflows/apiv1beta/Client/DeleteOperation/main.go
+++ b/internal/generated/snippets/workflows/apiv1beta/Client/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workflows/apiv1beta/Client/DeleteWorkflow/main.go
+++ b/internal/generated/snippets/workflows/apiv1beta/Client/DeleteWorkflow/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workflows/apiv1beta/Client/GetLocation/main.go
+++ b/internal/generated/snippets/workflows/apiv1beta/Client/GetLocation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workflows/apiv1beta/Client/GetOperation/main.go
+++ b/internal/generated/snippets/workflows/apiv1beta/Client/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workflows/apiv1beta/Client/GetWorkflow/main.go
+++ b/internal/generated/snippets/workflows/apiv1beta/Client/GetWorkflow/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workflows/apiv1beta/Client/ListLocations/main.go
+++ b/internal/generated/snippets/workflows/apiv1beta/Client/ListLocations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workflows/apiv1beta/Client/ListOperations/main.go
+++ b/internal/generated/snippets/workflows/apiv1beta/Client/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workflows/apiv1beta/Client/ListWorkflows/main.go
+++ b/internal/generated/snippets/workflows/apiv1beta/Client/ListWorkflows/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workflows/apiv1beta/Client/UpdateWorkflow/main.go
+++ b/internal/generated/snippets/workflows/apiv1beta/Client/UpdateWorkflow/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workflows/executions/apiv1/Client/CancelExecution/main.go
+++ b/internal/generated/snippets/workflows/executions/apiv1/Client/CancelExecution/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workflows/executions/apiv1/Client/CreateExecution/main.go
+++ b/internal/generated/snippets/workflows/executions/apiv1/Client/CreateExecution/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workflows/executions/apiv1/Client/GetExecution/main.go
+++ b/internal/generated/snippets/workflows/executions/apiv1/Client/GetExecution/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workflows/executions/apiv1/Client/ListExecutions/main.go
+++ b/internal/generated/snippets/workflows/executions/apiv1/Client/ListExecutions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workflows/executions/apiv1beta/Client/CancelExecution/main.go
+++ b/internal/generated/snippets/workflows/executions/apiv1beta/Client/CancelExecution/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workflows/executions/apiv1beta/Client/CreateExecution/main.go
+++ b/internal/generated/snippets/workflows/executions/apiv1beta/Client/CreateExecution/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workflows/executions/apiv1beta/Client/GetExecution/main.go
+++ b/internal/generated/snippets/workflows/executions/apiv1beta/Client/GetExecution/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workflows/executions/apiv1beta/Client/ListExecutions/main.go
+++ b/internal/generated/snippets/workflows/executions/apiv1beta/Client/ListExecutions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workstations/apiv1/Client/CancelOperation/main.go
+++ b/internal/generated/snippets/workstations/apiv1/Client/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workstations/apiv1/Client/CreateWorkstation/main.go
+++ b/internal/generated/snippets/workstations/apiv1/Client/CreateWorkstation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workstations/apiv1/Client/CreateWorkstationCluster/main.go
+++ b/internal/generated/snippets/workstations/apiv1/Client/CreateWorkstationCluster/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workstations/apiv1/Client/CreateWorkstationConfig/main.go
+++ b/internal/generated/snippets/workstations/apiv1/Client/CreateWorkstationConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workstations/apiv1/Client/DeleteOperation/main.go
+++ b/internal/generated/snippets/workstations/apiv1/Client/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workstations/apiv1/Client/DeleteWorkstation/main.go
+++ b/internal/generated/snippets/workstations/apiv1/Client/DeleteWorkstation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workstations/apiv1/Client/DeleteWorkstationCluster/main.go
+++ b/internal/generated/snippets/workstations/apiv1/Client/DeleteWorkstationCluster/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workstations/apiv1/Client/DeleteWorkstationConfig/main.go
+++ b/internal/generated/snippets/workstations/apiv1/Client/DeleteWorkstationConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workstations/apiv1/Client/GenerateAccessToken/main.go
+++ b/internal/generated/snippets/workstations/apiv1/Client/GenerateAccessToken/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workstations/apiv1/Client/GetIamPolicy/main.go
+++ b/internal/generated/snippets/workstations/apiv1/Client/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workstations/apiv1/Client/GetOperation/main.go
+++ b/internal/generated/snippets/workstations/apiv1/Client/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workstations/apiv1/Client/GetWorkstation/main.go
+++ b/internal/generated/snippets/workstations/apiv1/Client/GetWorkstation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workstations/apiv1/Client/GetWorkstationCluster/main.go
+++ b/internal/generated/snippets/workstations/apiv1/Client/GetWorkstationCluster/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workstations/apiv1/Client/GetWorkstationConfig/main.go
+++ b/internal/generated/snippets/workstations/apiv1/Client/GetWorkstationConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workstations/apiv1/Client/ListOperations/main.go
+++ b/internal/generated/snippets/workstations/apiv1/Client/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workstations/apiv1/Client/ListUsableWorkstationConfigs/main.go
+++ b/internal/generated/snippets/workstations/apiv1/Client/ListUsableWorkstationConfigs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workstations/apiv1/Client/ListUsableWorkstations/main.go
+++ b/internal/generated/snippets/workstations/apiv1/Client/ListUsableWorkstations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workstations/apiv1/Client/ListWorkstationClusters/main.go
+++ b/internal/generated/snippets/workstations/apiv1/Client/ListWorkstationClusters/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workstations/apiv1/Client/ListWorkstationConfigs/main.go
+++ b/internal/generated/snippets/workstations/apiv1/Client/ListWorkstationConfigs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workstations/apiv1/Client/ListWorkstations/main.go
+++ b/internal/generated/snippets/workstations/apiv1/Client/ListWorkstations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workstations/apiv1/Client/SetIamPolicy/main.go
+++ b/internal/generated/snippets/workstations/apiv1/Client/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workstations/apiv1/Client/StartWorkstation/main.go
+++ b/internal/generated/snippets/workstations/apiv1/Client/StartWorkstation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workstations/apiv1/Client/StopWorkstation/main.go
+++ b/internal/generated/snippets/workstations/apiv1/Client/StopWorkstation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workstations/apiv1/Client/TestIamPermissions/main.go
+++ b/internal/generated/snippets/workstations/apiv1/Client/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workstations/apiv1/Client/UpdateWorkstation/main.go
+++ b/internal/generated/snippets/workstations/apiv1/Client/UpdateWorkstation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workstations/apiv1/Client/UpdateWorkstationCluster/main.go
+++ b/internal/generated/snippets/workstations/apiv1/Client/UpdateWorkstationCluster/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workstations/apiv1/Client/UpdateWorkstationConfig/main.go
+++ b/internal/generated/snippets/workstations/apiv1/Client/UpdateWorkstationConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workstations/apiv1beta/Client/CancelOperation/main.go
+++ b/internal/generated/snippets/workstations/apiv1beta/Client/CancelOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workstations/apiv1beta/Client/CreateWorkstation/main.go
+++ b/internal/generated/snippets/workstations/apiv1beta/Client/CreateWorkstation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workstations/apiv1beta/Client/CreateWorkstationCluster/main.go
+++ b/internal/generated/snippets/workstations/apiv1beta/Client/CreateWorkstationCluster/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workstations/apiv1beta/Client/CreateWorkstationConfig/main.go
+++ b/internal/generated/snippets/workstations/apiv1beta/Client/CreateWorkstationConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workstations/apiv1beta/Client/DeleteOperation/main.go
+++ b/internal/generated/snippets/workstations/apiv1beta/Client/DeleteOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workstations/apiv1beta/Client/DeleteWorkstation/main.go
+++ b/internal/generated/snippets/workstations/apiv1beta/Client/DeleteWorkstation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workstations/apiv1beta/Client/DeleteWorkstationCluster/main.go
+++ b/internal/generated/snippets/workstations/apiv1beta/Client/DeleteWorkstationCluster/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workstations/apiv1beta/Client/DeleteWorkstationConfig/main.go
+++ b/internal/generated/snippets/workstations/apiv1beta/Client/DeleteWorkstationConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workstations/apiv1beta/Client/GenerateAccessToken/main.go
+++ b/internal/generated/snippets/workstations/apiv1beta/Client/GenerateAccessToken/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workstations/apiv1beta/Client/GetIamPolicy/main.go
+++ b/internal/generated/snippets/workstations/apiv1beta/Client/GetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workstations/apiv1beta/Client/GetOperation/main.go
+++ b/internal/generated/snippets/workstations/apiv1beta/Client/GetOperation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workstations/apiv1beta/Client/GetWorkstation/main.go
+++ b/internal/generated/snippets/workstations/apiv1beta/Client/GetWorkstation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workstations/apiv1beta/Client/GetWorkstationCluster/main.go
+++ b/internal/generated/snippets/workstations/apiv1beta/Client/GetWorkstationCluster/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workstations/apiv1beta/Client/GetWorkstationConfig/main.go
+++ b/internal/generated/snippets/workstations/apiv1beta/Client/GetWorkstationConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workstations/apiv1beta/Client/ListOperations/main.go
+++ b/internal/generated/snippets/workstations/apiv1beta/Client/ListOperations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workstations/apiv1beta/Client/ListUsableWorkstationConfigs/main.go
+++ b/internal/generated/snippets/workstations/apiv1beta/Client/ListUsableWorkstationConfigs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workstations/apiv1beta/Client/ListUsableWorkstations/main.go
+++ b/internal/generated/snippets/workstations/apiv1beta/Client/ListUsableWorkstations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workstations/apiv1beta/Client/ListWorkstationClusters/main.go
+++ b/internal/generated/snippets/workstations/apiv1beta/Client/ListWorkstationClusters/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workstations/apiv1beta/Client/ListWorkstationConfigs/main.go
+++ b/internal/generated/snippets/workstations/apiv1beta/Client/ListWorkstationConfigs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workstations/apiv1beta/Client/ListWorkstations/main.go
+++ b/internal/generated/snippets/workstations/apiv1beta/Client/ListWorkstations/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workstations/apiv1beta/Client/SetIamPolicy/main.go
+++ b/internal/generated/snippets/workstations/apiv1beta/Client/SetIamPolicy/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workstations/apiv1beta/Client/StartWorkstation/main.go
+++ b/internal/generated/snippets/workstations/apiv1beta/Client/StartWorkstation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workstations/apiv1beta/Client/StopWorkstation/main.go
+++ b/internal/generated/snippets/workstations/apiv1beta/Client/StopWorkstation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workstations/apiv1beta/Client/TestIamPermissions/main.go
+++ b/internal/generated/snippets/workstations/apiv1beta/Client/TestIamPermissions/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workstations/apiv1beta/Client/UpdateWorkstation/main.go
+++ b/internal/generated/snippets/workstations/apiv1beta/Client/UpdateWorkstation/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workstations/apiv1beta/Client/UpdateWorkstationCluster/main.go
+++ b/internal/generated/snippets/workstations/apiv1beta/Client/UpdateWorkstationCluster/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generated/snippets/workstations/apiv1beta/Client/UpdateWorkstationConfig/main.go
+++ b/internal/generated/snippets/workstations/apiv1beta/Client/UpdateWorkstationConfig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iot/apiv1/auxiliary.go
+++ b/iot/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iot/apiv1/auxiliary_go123.go
+++ b/iot/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iot/apiv1/device_manager_client.go
+++ b/iot/apiv1/device_manager_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iot/apiv1/device_manager_client_example_go123_test.go
+++ b/iot/apiv1/device_manager_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iot/apiv1/device_manager_client_example_test.go
+++ b/iot/apiv1/device_manager_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iot/apiv1/doc.go
+++ b/iot/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iot/apiv1/helpers.go
+++ b/iot/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/language/apiv1/auxiliary.go
+++ b/language/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/language/apiv1/auxiliary_go123.go
+++ b/language/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/language/apiv1/doc.go
+++ b/language/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/language/apiv1/helpers.go
+++ b/language/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/language/apiv1/language_client.go
+++ b/language/apiv1/language_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/language/apiv1/language_client_example_go123_test.go
+++ b/language/apiv1/language_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/language/apiv1/language_client_example_test.go
+++ b/language/apiv1/language_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/language/apiv1beta2/auxiliary.go
+++ b/language/apiv1beta2/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/language/apiv1beta2/auxiliary_go123.go
+++ b/language/apiv1beta2/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/language/apiv1beta2/doc.go
+++ b/language/apiv1beta2/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/language/apiv1beta2/helpers.go
+++ b/language/apiv1beta2/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/language/apiv1beta2/language_client.go
+++ b/language/apiv1beta2/language_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/language/apiv1beta2/language_client_example_go123_test.go
+++ b/language/apiv1beta2/language_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/language/apiv1beta2/language_client_example_test.go
+++ b/language/apiv1beta2/language_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/language/apiv2/auxiliary.go
+++ b/language/apiv2/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/language/apiv2/auxiliary_go123.go
+++ b/language/apiv2/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/language/apiv2/doc.go
+++ b/language/apiv2/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/language/apiv2/helpers.go
+++ b/language/apiv2/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/language/apiv2/language_client.go
+++ b/language/apiv2/language_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/language/apiv2/language_client_example_go123_test.go
+++ b/language/apiv2/language_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/language/apiv2/language_client_example_test.go
+++ b/language/apiv2/language_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/licensemanager/apiv1/auxiliary.go
+++ b/licensemanager/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/licensemanager/apiv1/auxiliary_go123.go
+++ b/licensemanager/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/licensemanager/apiv1/doc.go
+++ b/licensemanager/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/licensemanager/apiv1/helpers.go
+++ b/licensemanager/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/licensemanager/apiv1/license_manager_client.go
+++ b/licensemanager/apiv1/license_manager_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/licensemanager/apiv1/license_manager_client_example_go123_test.go
+++ b/licensemanager/apiv1/license_manager_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/licensemanager/apiv1/license_manager_client_example_test.go
+++ b/licensemanager/apiv1/license_manager_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lifesciences/apiv2beta/auxiliary.go
+++ b/lifesciences/apiv2beta/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lifesciences/apiv2beta/auxiliary_go123.go
+++ b/lifesciences/apiv2beta/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lifesciences/apiv2beta/doc.go
+++ b/lifesciences/apiv2beta/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lifesciences/apiv2beta/helpers.go
+++ b/lifesciences/apiv2beta/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lifesciences/apiv2beta/workflows_service_v2_beta_client.go
+++ b/lifesciences/apiv2beta/workflows_service_v2_beta_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lifesciences/apiv2beta/workflows_service_v2_beta_client_example_go123_test.go
+++ b/lifesciences/apiv2beta/workflows_service_v2_beta_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lifesciences/apiv2beta/workflows_service_v2_beta_client_example_test.go
+++ b/lifesciences/apiv2beta/workflows_service_v2_beta_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/locationfinder/apiv1/auxiliary.go
+++ b/locationfinder/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/locationfinder/apiv1/auxiliary_go123.go
+++ b/locationfinder/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/locationfinder/apiv1/cloud_location_finder_client.go
+++ b/locationfinder/apiv1/cloud_location_finder_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/locationfinder/apiv1/cloud_location_finder_client_example_go123_test.go
+++ b/locationfinder/apiv1/cloud_location_finder_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/locationfinder/apiv1/cloud_location_finder_client_example_test.go
+++ b/locationfinder/apiv1/cloud_location_finder_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/locationfinder/apiv1/doc.go
+++ b/locationfinder/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/locationfinder/apiv1/helpers.go
+++ b/locationfinder/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/logging/apiv2/auxiliary.go
+++ b/logging/apiv2/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/logging/apiv2/auxiliary_go123.go
+++ b/logging/apiv2/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/logging/apiv2/config_client.go
+++ b/logging/apiv2/config_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/logging/apiv2/config_client_example_go123_test.go
+++ b/logging/apiv2/config_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/logging/apiv2/config_client_example_test.go
+++ b/logging/apiv2/config_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/logging/apiv2/doc.go
+++ b/logging/apiv2/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/logging/apiv2/helpers.go
+++ b/logging/apiv2/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/logging/apiv2/logging_client.go
+++ b/logging/apiv2/logging_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/logging/apiv2/logging_client_example_go123_test.go
+++ b/logging/apiv2/logging_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/logging/apiv2/logging_client_example_test.go
+++ b/logging/apiv2/logging_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/logging/apiv2/metrics_client.go
+++ b/logging/apiv2/metrics_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/logging/apiv2/metrics_client_example_go123_test.go
+++ b/logging/apiv2/metrics_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/logging/apiv2/metrics_client_example_test.go
+++ b/logging/apiv2/metrics_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/longrunning/autogen/auxiliary.go
+++ b/longrunning/autogen/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/longrunning/autogen/auxiliary_go123.go
+++ b/longrunning/autogen/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/longrunning/autogen/doc.go
+++ b/longrunning/autogen/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/longrunning/autogen/helpers.go
+++ b/longrunning/autogen/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/longrunning/autogen/operations_client.go
+++ b/longrunning/autogen/operations_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/longrunning/autogen/operations_client_example_go123_test.go
+++ b/longrunning/autogen/operations_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/longrunning/autogen/operations_client_example_test.go
+++ b/longrunning/autogen/operations_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lustre/apiv1/auxiliary.go
+++ b/lustre/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lustre/apiv1/auxiliary_go123.go
+++ b/lustre/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lustre/apiv1/doc.go
+++ b/lustre/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lustre/apiv1/helpers.go
+++ b/lustre/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lustre/apiv1/lustre_client.go
+++ b/lustre/apiv1/lustre_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lustre/apiv1/lustre_client_example_go123_test.go
+++ b/lustre/apiv1/lustre_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lustre/apiv1/lustre_client_example_test.go
+++ b/lustre/apiv1/lustre_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/maintenance/api/apiv1/auxiliary.go
+++ b/maintenance/api/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/maintenance/api/apiv1/auxiliary_go123.go
+++ b/maintenance/api/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/maintenance/api/apiv1/doc.go
+++ b/maintenance/api/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/maintenance/api/apiv1/helpers.go
+++ b/maintenance/api/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/maintenance/api/apiv1/maintenance_client.go
+++ b/maintenance/api/apiv1/maintenance_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/maintenance/api/apiv1/maintenance_client_example_go123_test.go
+++ b/maintenance/api/apiv1/maintenance_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/maintenance/api/apiv1/maintenance_client_example_test.go
+++ b/maintenance/api/apiv1/maintenance_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/maintenance/api/apiv1beta/auxiliary.go
+++ b/maintenance/api/apiv1beta/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/maintenance/api/apiv1beta/auxiliary_go123.go
+++ b/maintenance/api/apiv1beta/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/maintenance/api/apiv1beta/doc.go
+++ b/maintenance/api/apiv1beta/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/maintenance/api/apiv1beta/helpers.go
+++ b/maintenance/api/apiv1beta/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/maintenance/api/apiv1beta/maintenance_client.go
+++ b/maintenance/api/apiv1beta/maintenance_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/maintenance/api/apiv1beta/maintenance_client_example_go123_test.go
+++ b/maintenance/api/apiv1beta/maintenance_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/maintenance/api/apiv1beta/maintenance_client_example_test.go
+++ b/maintenance/api/apiv1beta/maintenance_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/managedidentities/apiv1/auxiliary.go
+++ b/managedidentities/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/managedidentities/apiv1/auxiliary_go123.go
+++ b/managedidentities/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/managedidentities/apiv1/doc.go
+++ b/managedidentities/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/managedidentities/apiv1/helpers.go
+++ b/managedidentities/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/managedidentities/apiv1/managed_identities_client.go
+++ b/managedidentities/apiv1/managed_identities_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/managedidentities/apiv1/managed_identities_client_example_go123_test.go
+++ b/managedidentities/apiv1/managed_identities_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/managedidentities/apiv1/managed_identities_client_example_test.go
+++ b/managedidentities/apiv1/managed_identities_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/managedkafka/apiv1/auxiliary.go
+++ b/managedkafka/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/managedkafka/apiv1/auxiliary_go123.go
+++ b/managedkafka/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/managedkafka/apiv1/doc.go
+++ b/managedkafka/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/managedkafka/apiv1/helpers.go
+++ b/managedkafka/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/managedkafka/apiv1/managed_kafka_client.go
+++ b/managedkafka/apiv1/managed_kafka_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/managedkafka/apiv1/managed_kafka_client_example_go123_test.go
+++ b/managedkafka/apiv1/managed_kafka_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/managedkafka/apiv1/managed_kafka_client_example_test.go
+++ b/managedkafka/apiv1/managed_kafka_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/managedkafka/apiv1/managed_kafka_connect_client.go
+++ b/managedkafka/apiv1/managed_kafka_connect_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/managedkafka/apiv1/managed_kafka_connect_client_example_go123_test.go
+++ b/managedkafka/apiv1/managed_kafka_connect_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/managedkafka/apiv1/managed_kafka_connect_client_example_test.go
+++ b/managedkafka/apiv1/managed_kafka_connect_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/managedkafka/schemaregistry/apiv1/auxiliary.go
+++ b/managedkafka/schemaregistry/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/managedkafka/schemaregistry/apiv1/auxiliary_go123.go
+++ b/managedkafka/schemaregistry/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/managedkafka/schemaregistry/apiv1/doc.go
+++ b/managedkafka/schemaregistry/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/managedkafka/schemaregistry/apiv1/helpers.go
+++ b/managedkafka/schemaregistry/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/managedkafka/schemaregistry/apiv1/managed_schema_registry_client.go
+++ b/managedkafka/schemaregistry/apiv1/managed_schema_registry_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/managedkafka/schemaregistry/apiv1/managed_schema_registry_client_example_go123_test.go
+++ b/managedkafka/schemaregistry/apiv1/managed_schema_registry_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/managedkafka/schemaregistry/apiv1/managed_schema_registry_client_example_test.go
+++ b/managedkafka/schemaregistry/apiv1/managed_schema_registry_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/maps/addressvalidation/apiv1/address_validation_client.go
+++ b/maps/addressvalidation/apiv1/address_validation_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/maps/addressvalidation/apiv1/address_validation_client_example_go123_test.go
+++ b/maps/addressvalidation/apiv1/address_validation_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/maps/addressvalidation/apiv1/address_validation_client_example_test.go
+++ b/maps/addressvalidation/apiv1/address_validation_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/maps/addressvalidation/apiv1/auxiliary.go
+++ b/maps/addressvalidation/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/maps/addressvalidation/apiv1/auxiliary_go123.go
+++ b/maps/addressvalidation/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/maps/addressvalidation/apiv1/doc.go
+++ b/maps/addressvalidation/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/maps/addressvalidation/apiv1/helpers.go
+++ b/maps/addressvalidation/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/maps/areainsights/apiv1/area_insights_client.go
+++ b/maps/areainsights/apiv1/area_insights_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/maps/areainsights/apiv1/area_insights_client_example_go123_test.go
+++ b/maps/areainsights/apiv1/area_insights_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/maps/areainsights/apiv1/area_insights_client_example_test.go
+++ b/maps/areainsights/apiv1/area_insights_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/maps/areainsights/apiv1/auxiliary.go
+++ b/maps/areainsights/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/maps/areainsights/apiv1/auxiliary_go123.go
+++ b/maps/areainsights/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/maps/areainsights/apiv1/doc.go
+++ b/maps/areainsights/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/maps/areainsights/apiv1/helpers.go
+++ b/maps/areainsights/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/maps/fleetengine/apiv1/auxiliary.go
+++ b/maps/fleetengine/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/maps/fleetengine/apiv1/auxiliary_go123.go
+++ b/maps/fleetengine/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/maps/fleetengine/apiv1/doc.go
+++ b/maps/fleetengine/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/maps/fleetengine/apiv1/helpers.go
+++ b/maps/fleetengine/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/maps/fleetengine/apiv1/trip_client.go
+++ b/maps/fleetengine/apiv1/trip_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/maps/fleetengine/apiv1/trip_client_example_go123_test.go
+++ b/maps/fleetengine/apiv1/trip_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/maps/fleetengine/apiv1/trip_client_example_test.go
+++ b/maps/fleetengine/apiv1/trip_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/maps/fleetengine/apiv1/vehicle_client.go
+++ b/maps/fleetengine/apiv1/vehicle_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/maps/fleetengine/apiv1/vehicle_client_example_go123_test.go
+++ b/maps/fleetengine/apiv1/vehicle_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/maps/fleetengine/apiv1/vehicle_client_example_test.go
+++ b/maps/fleetengine/apiv1/vehicle_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/maps/fleetengine/delivery/apiv1/auxiliary.go
+++ b/maps/fleetengine/delivery/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/maps/fleetengine/delivery/apiv1/auxiliary_go123.go
+++ b/maps/fleetengine/delivery/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/maps/fleetengine/delivery/apiv1/delivery_client.go
+++ b/maps/fleetengine/delivery/apiv1/delivery_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/maps/fleetengine/delivery/apiv1/delivery_client_example_go123_test.go
+++ b/maps/fleetengine/delivery/apiv1/delivery_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/maps/fleetengine/delivery/apiv1/delivery_client_example_test.go
+++ b/maps/fleetengine/delivery/apiv1/delivery_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/maps/fleetengine/delivery/apiv1/doc.go
+++ b/maps/fleetengine/delivery/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/maps/fleetengine/delivery/apiv1/helpers.go
+++ b/maps/fleetengine/delivery/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/maps/places/apiv1/auxiliary.go
+++ b/maps/places/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/maps/places/apiv1/auxiliary_go123.go
+++ b/maps/places/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/maps/places/apiv1/doc.go
+++ b/maps/places/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/maps/places/apiv1/helpers.go
+++ b/maps/places/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/maps/places/apiv1/places_client.go
+++ b/maps/places/apiv1/places_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/maps/places/apiv1/places_client_example_go123_test.go
+++ b/maps/places/apiv1/places_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/maps/places/apiv1/places_client_example_test.go
+++ b/maps/places/apiv1/places_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/maps/routeoptimization/apiv1/auxiliary.go
+++ b/maps/routeoptimization/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/maps/routeoptimization/apiv1/auxiliary_go123.go
+++ b/maps/routeoptimization/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/maps/routeoptimization/apiv1/doc.go
+++ b/maps/routeoptimization/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/maps/routeoptimization/apiv1/helpers.go
+++ b/maps/routeoptimization/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/maps/routeoptimization/apiv1/route_optimization_client.go
+++ b/maps/routeoptimization/apiv1/route_optimization_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/maps/routeoptimization/apiv1/route_optimization_client_example_go123_test.go
+++ b/maps/routeoptimization/apiv1/route_optimization_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/maps/routeoptimization/apiv1/route_optimization_client_example_test.go
+++ b/maps/routeoptimization/apiv1/route_optimization_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/maps/routing/apiv2/auxiliary.go
+++ b/maps/routing/apiv2/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/maps/routing/apiv2/auxiliary_go123.go
+++ b/maps/routing/apiv2/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/maps/routing/apiv2/doc.go
+++ b/maps/routing/apiv2/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/maps/routing/apiv2/helpers.go
+++ b/maps/routing/apiv2/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/maps/routing/apiv2/routes_client.go
+++ b/maps/routing/apiv2/routes_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/maps/routing/apiv2/routes_client_example_go123_test.go
+++ b/maps/routing/apiv2/routes_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/maps/routing/apiv2/routes_client_example_test.go
+++ b/maps/routing/apiv2/routes_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/maps/solar/apiv1/auxiliary.go
+++ b/maps/solar/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/maps/solar/apiv1/auxiliary_go123.go
+++ b/maps/solar/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/maps/solar/apiv1/doc.go
+++ b/maps/solar/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/maps/solar/apiv1/helpers.go
+++ b/maps/solar/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/maps/solar/apiv1/solar_client.go
+++ b/maps/solar/apiv1/solar_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/maps/solar/apiv1/solar_client_example_go123_test.go
+++ b/maps/solar/apiv1/solar_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/maps/solar/apiv1/solar_client_example_test.go
+++ b/maps/solar/apiv1/solar_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mediatranslation/apiv1beta1/auxiliary.go
+++ b/mediatranslation/apiv1beta1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mediatranslation/apiv1beta1/auxiliary_go123.go
+++ b/mediatranslation/apiv1beta1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mediatranslation/apiv1beta1/doc.go
+++ b/mediatranslation/apiv1beta1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mediatranslation/apiv1beta1/helpers.go
+++ b/mediatranslation/apiv1beta1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mediatranslation/apiv1beta1/speech_translation_client.go
+++ b/mediatranslation/apiv1beta1/speech_translation_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mediatranslation/apiv1beta1/speech_translation_client_example_go123_test.go
+++ b/mediatranslation/apiv1beta1/speech_translation_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mediatranslation/apiv1beta1/speech_translation_client_example_test.go
+++ b/mediatranslation/apiv1beta1/speech_translation_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/memcache/apiv1/auxiliary.go
+++ b/memcache/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/memcache/apiv1/auxiliary_go123.go
+++ b/memcache/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/memcache/apiv1/cloud_memcache_client.go
+++ b/memcache/apiv1/cloud_memcache_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/memcache/apiv1/cloud_memcache_client_example_go123_test.go
+++ b/memcache/apiv1/cloud_memcache_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/memcache/apiv1/cloud_memcache_client_example_test.go
+++ b/memcache/apiv1/cloud_memcache_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/memcache/apiv1/doc.go
+++ b/memcache/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/memcache/apiv1/helpers.go
+++ b/memcache/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/memcache/apiv1beta2/auxiliary.go
+++ b/memcache/apiv1beta2/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/memcache/apiv1beta2/auxiliary_go123.go
+++ b/memcache/apiv1beta2/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/memcache/apiv1beta2/cloud_memcache_client.go
+++ b/memcache/apiv1beta2/cloud_memcache_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/memcache/apiv1beta2/cloud_memcache_client_example_go123_test.go
+++ b/memcache/apiv1beta2/cloud_memcache_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/memcache/apiv1beta2/cloud_memcache_client_example_test.go
+++ b/memcache/apiv1beta2/cloud_memcache_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/memcache/apiv1beta2/doc.go
+++ b/memcache/apiv1beta2/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/memcache/apiv1beta2/helpers.go
+++ b/memcache/apiv1beta2/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/memorystore/apiv1/auxiliary.go
+++ b/memorystore/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/memorystore/apiv1/auxiliary_go123.go
+++ b/memorystore/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/memorystore/apiv1/doc.go
+++ b/memorystore/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/memorystore/apiv1/helpers.go
+++ b/memorystore/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/memorystore/apiv1/memorystore_client.go
+++ b/memorystore/apiv1/memorystore_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/memorystore/apiv1/memorystore_client_example_go123_test.go
+++ b/memorystore/apiv1/memorystore_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/memorystore/apiv1/memorystore_client_example_test.go
+++ b/memorystore/apiv1/memorystore_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/memorystore/apiv1beta/auxiliary.go
+++ b/memorystore/apiv1beta/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/memorystore/apiv1beta/auxiliary_go123.go
+++ b/memorystore/apiv1beta/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/memorystore/apiv1beta/doc.go
+++ b/memorystore/apiv1beta/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/memorystore/apiv1beta/helpers.go
+++ b/memorystore/apiv1beta/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/memorystore/apiv1beta/memorystore_client.go
+++ b/memorystore/apiv1beta/memorystore_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/memorystore/apiv1beta/memorystore_client_example_go123_test.go
+++ b/memorystore/apiv1beta/memorystore_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/memorystore/apiv1beta/memorystore_client_example_test.go
+++ b/memorystore/apiv1beta/memorystore_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/metastore/apiv1/auxiliary.go
+++ b/metastore/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/metastore/apiv1/auxiliary_go123.go
+++ b/metastore/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/metastore/apiv1/dataproc_metastore_client.go
+++ b/metastore/apiv1/dataproc_metastore_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/metastore/apiv1/dataproc_metastore_client_example_go123_test.go
+++ b/metastore/apiv1/dataproc_metastore_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/metastore/apiv1/dataproc_metastore_client_example_test.go
+++ b/metastore/apiv1/dataproc_metastore_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/metastore/apiv1/dataproc_metastore_federation_client.go
+++ b/metastore/apiv1/dataproc_metastore_federation_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/metastore/apiv1/dataproc_metastore_federation_client_example_go123_test.go
+++ b/metastore/apiv1/dataproc_metastore_federation_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/metastore/apiv1/dataproc_metastore_federation_client_example_test.go
+++ b/metastore/apiv1/dataproc_metastore_federation_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/metastore/apiv1/doc.go
+++ b/metastore/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/metastore/apiv1/helpers.go
+++ b/metastore/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/metastore/apiv1alpha/auxiliary.go
+++ b/metastore/apiv1alpha/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/metastore/apiv1alpha/auxiliary_go123.go
+++ b/metastore/apiv1alpha/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/metastore/apiv1alpha/dataproc_metastore_client.go
+++ b/metastore/apiv1alpha/dataproc_metastore_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/metastore/apiv1alpha/dataproc_metastore_client_example_go123_test.go
+++ b/metastore/apiv1alpha/dataproc_metastore_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/metastore/apiv1alpha/dataproc_metastore_client_example_test.go
+++ b/metastore/apiv1alpha/dataproc_metastore_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/metastore/apiv1alpha/dataproc_metastore_federation_client.go
+++ b/metastore/apiv1alpha/dataproc_metastore_federation_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/metastore/apiv1alpha/dataproc_metastore_federation_client_example_go123_test.go
+++ b/metastore/apiv1alpha/dataproc_metastore_federation_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/metastore/apiv1alpha/dataproc_metastore_federation_client_example_test.go
+++ b/metastore/apiv1alpha/dataproc_metastore_federation_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/metastore/apiv1alpha/doc.go
+++ b/metastore/apiv1alpha/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/metastore/apiv1alpha/helpers.go
+++ b/metastore/apiv1alpha/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/metastore/apiv1beta/auxiliary.go
+++ b/metastore/apiv1beta/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/metastore/apiv1beta/auxiliary_go123.go
+++ b/metastore/apiv1beta/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/metastore/apiv1beta/dataproc_metastore_client.go
+++ b/metastore/apiv1beta/dataproc_metastore_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/metastore/apiv1beta/dataproc_metastore_client_example_go123_test.go
+++ b/metastore/apiv1beta/dataproc_metastore_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/metastore/apiv1beta/dataproc_metastore_client_example_test.go
+++ b/metastore/apiv1beta/dataproc_metastore_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/metastore/apiv1beta/dataproc_metastore_federation_client.go
+++ b/metastore/apiv1beta/dataproc_metastore_federation_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/metastore/apiv1beta/dataproc_metastore_federation_client_example_go123_test.go
+++ b/metastore/apiv1beta/dataproc_metastore_federation_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/metastore/apiv1beta/dataproc_metastore_federation_client_example_test.go
+++ b/metastore/apiv1beta/dataproc_metastore_federation_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/metastore/apiv1beta/doc.go
+++ b/metastore/apiv1beta/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/metastore/apiv1beta/helpers.go
+++ b/metastore/apiv1beta/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/migrationcenter/apiv1/auxiliary.go
+++ b/migrationcenter/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/migrationcenter/apiv1/auxiliary_go123.go
+++ b/migrationcenter/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/migrationcenter/apiv1/doc.go
+++ b/migrationcenter/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/migrationcenter/apiv1/helpers.go
+++ b/migrationcenter/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/migrationcenter/apiv1/migration_center_client.go
+++ b/migrationcenter/apiv1/migration_center_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/migrationcenter/apiv1/migration_center_client_example_go123_test.go
+++ b/migrationcenter/apiv1/migration_center_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/migrationcenter/apiv1/migration_center_client_example_test.go
+++ b/migrationcenter/apiv1/migration_center_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/modelarmor/apiv1/auxiliary.go
+++ b/modelarmor/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/modelarmor/apiv1/auxiliary_go123.go
+++ b/modelarmor/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/modelarmor/apiv1/doc.go
+++ b/modelarmor/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/modelarmor/apiv1/helpers.go
+++ b/modelarmor/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/modelarmor/apiv1/model_armor_client.go
+++ b/modelarmor/apiv1/model_armor_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/modelarmor/apiv1/model_armor_client_example_go123_test.go
+++ b/modelarmor/apiv1/model_armor_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/modelarmor/apiv1/model_armor_client_example_test.go
+++ b/modelarmor/apiv1/model_armor_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/modelarmor/apiv1beta/auxiliary.go
+++ b/modelarmor/apiv1beta/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/modelarmor/apiv1beta/auxiliary_go123.go
+++ b/modelarmor/apiv1beta/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/modelarmor/apiv1beta/doc.go
+++ b/modelarmor/apiv1beta/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/modelarmor/apiv1beta/helpers.go
+++ b/modelarmor/apiv1beta/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/modelarmor/apiv1beta/model_armor_client.go
+++ b/modelarmor/apiv1beta/model_armor_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/modelarmor/apiv1beta/model_armor_client_example_go123_test.go
+++ b/modelarmor/apiv1beta/model_armor_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/modelarmor/apiv1beta/model_armor_client_example_test.go
+++ b/modelarmor/apiv1beta/model_armor_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/monitoring/apiv3/v2/alert_policy_client.go
+++ b/monitoring/apiv3/v2/alert_policy_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/monitoring/apiv3/v2/alert_policy_client_example_go123_test.go
+++ b/monitoring/apiv3/v2/alert_policy_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/monitoring/apiv3/v2/alert_policy_client_example_test.go
+++ b/monitoring/apiv3/v2/alert_policy_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/monitoring/apiv3/v2/auxiliary.go
+++ b/monitoring/apiv3/v2/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/monitoring/apiv3/v2/auxiliary_go123.go
+++ b/monitoring/apiv3/v2/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/monitoring/apiv3/v2/doc.go
+++ b/monitoring/apiv3/v2/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/monitoring/apiv3/v2/group_client.go
+++ b/monitoring/apiv3/v2/group_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/monitoring/apiv3/v2/group_client_example_go123_test.go
+++ b/monitoring/apiv3/v2/group_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/monitoring/apiv3/v2/group_client_example_test.go
+++ b/monitoring/apiv3/v2/group_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/monitoring/apiv3/v2/helpers.go
+++ b/monitoring/apiv3/v2/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/monitoring/apiv3/v2/metric_client.go
+++ b/monitoring/apiv3/v2/metric_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/monitoring/apiv3/v2/metric_client_example_go123_test.go
+++ b/monitoring/apiv3/v2/metric_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/monitoring/apiv3/v2/metric_client_example_test.go
+++ b/monitoring/apiv3/v2/metric_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/monitoring/apiv3/v2/notification_channel_client.go
+++ b/monitoring/apiv3/v2/notification_channel_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/monitoring/apiv3/v2/notification_channel_client_example_go123_test.go
+++ b/monitoring/apiv3/v2/notification_channel_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/monitoring/apiv3/v2/notification_channel_client_example_test.go
+++ b/monitoring/apiv3/v2/notification_channel_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/monitoring/apiv3/v2/query_client.go
+++ b/monitoring/apiv3/v2/query_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/monitoring/apiv3/v2/query_client_example_go123_test.go
+++ b/monitoring/apiv3/v2/query_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/monitoring/apiv3/v2/query_client_example_test.go
+++ b/monitoring/apiv3/v2/query_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/monitoring/apiv3/v2/service_monitoring_client.go
+++ b/monitoring/apiv3/v2/service_monitoring_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/monitoring/apiv3/v2/service_monitoring_client_example_go123_test.go
+++ b/monitoring/apiv3/v2/service_monitoring_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/monitoring/apiv3/v2/service_monitoring_client_example_test.go
+++ b/monitoring/apiv3/v2/service_monitoring_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/monitoring/apiv3/v2/snooze_client.go
+++ b/monitoring/apiv3/v2/snooze_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/monitoring/apiv3/v2/snooze_client_example_go123_test.go
+++ b/monitoring/apiv3/v2/snooze_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/monitoring/apiv3/v2/snooze_client_example_test.go
+++ b/monitoring/apiv3/v2/snooze_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/monitoring/apiv3/v2/uptime_check_client.go
+++ b/monitoring/apiv3/v2/uptime_check_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/monitoring/apiv3/v2/uptime_check_client_example_go123_test.go
+++ b/monitoring/apiv3/v2/uptime_check_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/monitoring/apiv3/v2/uptime_check_client_example_test.go
+++ b/monitoring/apiv3/v2/uptime_check_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/monitoring/dashboard/apiv1/auxiliary.go
+++ b/monitoring/dashboard/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/monitoring/dashboard/apiv1/auxiliary_go123.go
+++ b/monitoring/dashboard/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/monitoring/dashboard/apiv1/dashboards_client.go
+++ b/monitoring/dashboard/apiv1/dashboards_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/monitoring/dashboard/apiv1/dashboards_client_example_go123_test.go
+++ b/monitoring/dashboard/apiv1/dashboards_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/monitoring/dashboard/apiv1/dashboards_client_example_test.go
+++ b/monitoring/dashboard/apiv1/dashboards_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/monitoring/dashboard/apiv1/doc.go
+++ b/monitoring/dashboard/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/monitoring/dashboard/apiv1/helpers.go
+++ b/monitoring/dashboard/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/monitoring/metricsscope/apiv1/auxiliary.go
+++ b/monitoring/metricsscope/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/monitoring/metricsscope/apiv1/auxiliary_go123.go
+++ b/monitoring/metricsscope/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/monitoring/metricsscope/apiv1/doc.go
+++ b/monitoring/metricsscope/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/monitoring/metricsscope/apiv1/helpers.go
+++ b/monitoring/metricsscope/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/monitoring/metricsscope/apiv1/metrics_scopes_client.go
+++ b/monitoring/metricsscope/apiv1/metrics_scopes_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/monitoring/metricsscope/apiv1/metrics_scopes_client_example_go123_test.go
+++ b/monitoring/metricsscope/apiv1/metrics_scopes_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/monitoring/metricsscope/apiv1/metrics_scopes_client_example_test.go
+++ b/monitoring/metricsscope/apiv1/metrics_scopes_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/networkconnectivity/apiv1/auxiliary.go
+++ b/networkconnectivity/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/networkconnectivity/apiv1/auxiliary_go123.go
+++ b/networkconnectivity/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/networkconnectivity/apiv1/cross_network_automation_client.go
+++ b/networkconnectivity/apiv1/cross_network_automation_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/networkconnectivity/apiv1/cross_network_automation_client_example_go123_test.go
+++ b/networkconnectivity/apiv1/cross_network_automation_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/networkconnectivity/apiv1/cross_network_automation_client_example_test.go
+++ b/networkconnectivity/apiv1/cross_network_automation_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/networkconnectivity/apiv1/data_transfer_client.go
+++ b/networkconnectivity/apiv1/data_transfer_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/networkconnectivity/apiv1/data_transfer_client_example_go123_test.go
+++ b/networkconnectivity/apiv1/data_transfer_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/networkconnectivity/apiv1/data_transfer_client_example_test.go
+++ b/networkconnectivity/apiv1/data_transfer_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/networkconnectivity/apiv1/doc.go
+++ b/networkconnectivity/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/networkconnectivity/apiv1/helpers.go
+++ b/networkconnectivity/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/networkconnectivity/apiv1/hub_client.go
+++ b/networkconnectivity/apiv1/hub_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/networkconnectivity/apiv1/hub_client_example_go123_test.go
+++ b/networkconnectivity/apiv1/hub_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/networkconnectivity/apiv1/hub_client_example_test.go
+++ b/networkconnectivity/apiv1/hub_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/networkconnectivity/apiv1/internal_range_client.go
+++ b/networkconnectivity/apiv1/internal_range_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/networkconnectivity/apiv1/internal_range_client_example_go123_test.go
+++ b/networkconnectivity/apiv1/internal_range_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/networkconnectivity/apiv1/internal_range_client_example_test.go
+++ b/networkconnectivity/apiv1/internal_range_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/networkconnectivity/apiv1/policy_based_routing_client.go
+++ b/networkconnectivity/apiv1/policy_based_routing_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/networkconnectivity/apiv1/policy_based_routing_client_example_go123_test.go
+++ b/networkconnectivity/apiv1/policy_based_routing_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/networkconnectivity/apiv1/policy_based_routing_client_example_test.go
+++ b/networkconnectivity/apiv1/policy_based_routing_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/networkconnectivity/apiv1alpha1/auxiliary.go
+++ b/networkconnectivity/apiv1alpha1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/networkconnectivity/apiv1alpha1/auxiliary_go123.go
+++ b/networkconnectivity/apiv1alpha1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/networkconnectivity/apiv1alpha1/doc.go
+++ b/networkconnectivity/apiv1alpha1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/networkconnectivity/apiv1alpha1/helpers.go
+++ b/networkconnectivity/apiv1alpha1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/networkconnectivity/apiv1alpha1/hub_client.go
+++ b/networkconnectivity/apiv1alpha1/hub_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/networkconnectivity/apiv1alpha1/hub_client_example_go123_test.go
+++ b/networkconnectivity/apiv1alpha1/hub_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/networkconnectivity/apiv1alpha1/hub_client_example_test.go
+++ b/networkconnectivity/apiv1alpha1/hub_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/networkmanagement/apiv1/auxiliary.go
+++ b/networkmanagement/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/networkmanagement/apiv1/auxiliary_go123.go
+++ b/networkmanagement/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/networkmanagement/apiv1/doc.go
+++ b/networkmanagement/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/networkmanagement/apiv1/helpers.go
+++ b/networkmanagement/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/networkmanagement/apiv1/organization_vpc_flow_logs_client.go
+++ b/networkmanagement/apiv1/organization_vpc_flow_logs_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/networkmanagement/apiv1/organization_vpc_flow_logs_client_example_go123_test.go
+++ b/networkmanagement/apiv1/organization_vpc_flow_logs_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/networkmanagement/apiv1/organization_vpc_flow_logs_client_example_test.go
+++ b/networkmanagement/apiv1/organization_vpc_flow_logs_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/networkmanagement/apiv1/reachability_client.go
+++ b/networkmanagement/apiv1/reachability_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/networkmanagement/apiv1/reachability_client_example_go123_test.go
+++ b/networkmanagement/apiv1/reachability_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/networkmanagement/apiv1/reachability_client_example_test.go
+++ b/networkmanagement/apiv1/reachability_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/networkmanagement/apiv1/vpc_flow_logs_client.go
+++ b/networkmanagement/apiv1/vpc_flow_logs_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/networkmanagement/apiv1/vpc_flow_logs_client_example_go123_test.go
+++ b/networkmanagement/apiv1/vpc_flow_logs_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/networkmanagement/apiv1/vpc_flow_logs_client_example_test.go
+++ b/networkmanagement/apiv1/vpc_flow_logs_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/networksecurity/apiv1beta1/auxiliary.go
+++ b/networksecurity/apiv1beta1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/networksecurity/apiv1beta1/auxiliary_go123.go
+++ b/networksecurity/apiv1beta1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/networksecurity/apiv1beta1/dns_threat_detector_client.go
+++ b/networksecurity/apiv1beta1/dns_threat_detector_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/networksecurity/apiv1beta1/dns_threat_detector_client_example_go123_test.go
+++ b/networksecurity/apiv1beta1/dns_threat_detector_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/networksecurity/apiv1beta1/dns_threat_detector_client_example_test.go
+++ b/networksecurity/apiv1beta1/dns_threat_detector_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/networksecurity/apiv1beta1/doc.go
+++ b/networksecurity/apiv1beta1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/networksecurity/apiv1beta1/helpers.go
+++ b/networksecurity/apiv1beta1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/networksecurity/apiv1beta1/network_security_client.go
+++ b/networksecurity/apiv1beta1/network_security_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/networksecurity/apiv1beta1/network_security_client_example_go123_test.go
+++ b/networksecurity/apiv1beta1/network_security_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/networksecurity/apiv1beta1/network_security_client_example_test.go
+++ b/networksecurity/apiv1beta1/network_security_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/networkservices/apiv1/auxiliary.go
+++ b/networkservices/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/networkservices/apiv1/auxiliary_go123.go
+++ b/networkservices/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/networkservices/apiv1/dep_client.go
+++ b/networkservices/apiv1/dep_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/networkservices/apiv1/dep_client_example_go123_test.go
+++ b/networkservices/apiv1/dep_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/networkservices/apiv1/dep_client_example_test.go
+++ b/networkservices/apiv1/dep_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/networkservices/apiv1/doc.go
+++ b/networkservices/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/networkservices/apiv1/helpers.go
+++ b/networkservices/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/networkservices/apiv1/network_services_client.go
+++ b/networkservices/apiv1/network_services_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/networkservices/apiv1/network_services_client_example_go123_test.go
+++ b/networkservices/apiv1/network_services_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/networkservices/apiv1/network_services_client_example_test.go
+++ b/networkservices/apiv1/network_services_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/notebooks/apiv1/auxiliary.go
+++ b/notebooks/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/notebooks/apiv1/auxiliary_go123.go
+++ b/notebooks/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/notebooks/apiv1/doc.go
+++ b/notebooks/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/notebooks/apiv1/helpers.go
+++ b/notebooks/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/notebooks/apiv1/managed_notebook_client.go
+++ b/notebooks/apiv1/managed_notebook_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/notebooks/apiv1/managed_notebook_client_example_go123_test.go
+++ b/notebooks/apiv1/managed_notebook_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/notebooks/apiv1/managed_notebook_client_example_test.go
+++ b/notebooks/apiv1/managed_notebook_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/notebooks/apiv1/notebook_client.go
+++ b/notebooks/apiv1/notebook_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/notebooks/apiv1/notebook_client_example_go123_test.go
+++ b/notebooks/apiv1/notebook_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/notebooks/apiv1/notebook_client_example_test.go
+++ b/notebooks/apiv1/notebook_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/notebooks/apiv1beta1/auxiliary.go
+++ b/notebooks/apiv1beta1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/notebooks/apiv1beta1/auxiliary_go123.go
+++ b/notebooks/apiv1beta1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/notebooks/apiv1beta1/doc.go
+++ b/notebooks/apiv1beta1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/notebooks/apiv1beta1/helpers.go
+++ b/notebooks/apiv1beta1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/notebooks/apiv1beta1/notebook_client.go
+++ b/notebooks/apiv1beta1/notebook_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/notebooks/apiv1beta1/notebook_client_example_go123_test.go
+++ b/notebooks/apiv1beta1/notebook_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/notebooks/apiv1beta1/notebook_client_example_test.go
+++ b/notebooks/apiv1beta1/notebook_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/notebooks/apiv2/auxiliary.go
+++ b/notebooks/apiv2/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/notebooks/apiv2/auxiliary_go123.go
+++ b/notebooks/apiv2/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/notebooks/apiv2/doc.go
+++ b/notebooks/apiv2/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/notebooks/apiv2/helpers.go
+++ b/notebooks/apiv2/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/notebooks/apiv2/notebook_client.go
+++ b/notebooks/apiv2/notebook_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/notebooks/apiv2/notebook_client_example_go123_test.go
+++ b/notebooks/apiv2/notebook_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/notebooks/apiv2/notebook_client_example_test.go
+++ b/notebooks/apiv2/notebook_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/optimization/apiv1/auxiliary.go
+++ b/optimization/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/optimization/apiv1/auxiliary_go123.go
+++ b/optimization/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/optimization/apiv1/doc.go
+++ b/optimization/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/optimization/apiv1/fleet_routing_client.go
+++ b/optimization/apiv1/fleet_routing_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/optimization/apiv1/fleet_routing_client_example_go123_test.go
+++ b/optimization/apiv1/fleet_routing_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/optimization/apiv1/fleet_routing_client_example_test.go
+++ b/optimization/apiv1/fleet_routing_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/optimization/apiv1/helpers.go
+++ b/optimization/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/oracledatabase/apiv1/auxiliary.go
+++ b/oracledatabase/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/oracledatabase/apiv1/auxiliary_go123.go
+++ b/oracledatabase/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/oracledatabase/apiv1/doc.go
+++ b/oracledatabase/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/oracledatabase/apiv1/helpers.go
+++ b/oracledatabase/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/oracledatabase/apiv1/oracle_database_client.go
+++ b/oracledatabase/apiv1/oracle_database_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/oracledatabase/apiv1/oracle_database_client_example_go123_test.go
+++ b/oracledatabase/apiv1/oracle_database_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/oracledatabase/apiv1/oracle_database_client_example_test.go
+++ b/oracledatabase/apiv1/oracle_database_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/orchestration/airflow/service/apiv1/auxiliary.go
+++ b/orchestration/airflow/service/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/orchestration/airflow/service/apiv1/auxiliary_go123.go
+++ b/orchestration/airflow/service/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/orchestration/airflow/service/apiv1/doc.go
+++ b/orchestration/airflow/service/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/orchestration/airflow/service/apiv1/environments_client.go
+++ b/orchestration/airflow/service/apiv1/environments_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/orchestration/airflow/service/apiv1/environments_client_example_go123_test.go
+++ b/orchestration/airflow/service/apiv1/environments_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/orchestration/airflow/service/apiv1/environments_client_example_test.go
+++ b/orchestration/airflow/service/apiv1/environments_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/orchestration/airflow/service/apiv1/helpers.go
+++ b/orchestration/airflow/service/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/orchestration/airflow/service/apiv1/image_versions_client.go
+++ b/orchestration/airflow/service/apiv1/image_versions_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/orchestration/airflow/service/apiv1/image_versions_client_example_go123_test.go
+++ b/orchestration/airflow/service/apiv1/image_versions_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/orchestration/airflow/service/apiv1/image_versions_client_example_test.go
+++ b/orchestration/airflow/service/apiv1/image_versions_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/orgpolicy/apiv2/auxiliary.go
+++ b/orgpolicy/apiv2/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/orgpolicy/apiv2/auxiliary_go123.go
+++ b/orgpolicy/apiv2/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/orgpolicy/apiv2/doc.go
+++ b/orgpolicy/apiv2/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/orgpolicy/apiv2/helpers.go
+++ b/orgpolicy/apiv2/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/orgpolicy/apiv2/org_policy_client.go
+++ b/orgpolicy/apiv2/org_policy_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/orgpolicy/apiv2/org_policy_client_example_go123_test.go
+++ b/orgpolicy/apiv2/org_policy_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/orgpolicy/apiv2/org_policy_client_example_test.go
+++ b/orgpolicy/apiv2/org_policy_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/osconfig/agentendpoint/apiv1/agent_endpoint_client.go
+++ b/osconfig/agentendpoint/apiv1/agent_endpoint_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/osconfig/agentendpoint/apiv1/agent_endpoint_client_example_go123_test.go
+++ b/osconfig/agentendpoint/apiv1/agent_endpoint_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/osconfig/agentendpoint/apiv1/agent_endpoint_client_example_test.go
+++ b/osconfig/agentendpoint/apiv1/agent_endpoint_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/osconfig/agentendpoint/apiv1/auxiliary.go
+++ b/osconfig/agentendpoint/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/osconfig/agentendpoint/apiv1/auxiliary_go123.go
+++ b/osconfig/agentendpoint/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/osconfig/agentendpoint/apiv1/doc.go
+++ b/osconfig/agentendpoint/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/osconfig/agentendpoint/apiv1/helpers.go
+++ b/osconfig/agentendpoint/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/osconfig/agentendpoint/apiv1beta/agent_endpoint_client.go
+++ b/osconfig/agentendpoint/apiv1beta/agent_endpoint_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/osconfig/agentendpoint/apiv1beta/agent_endpoint_client_example_go123_test.go
+++ b/osconfig/agentendpoint/apiv1beta/agent_endpoint_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/osconfig/agentendpoint/apiv1beta/agent_endpoint_client_example_test.go
+++ b/osconfig/agentendpoint/apiv1beta/agent_endpoint_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/osconfig/agentendpoint/apiv1beta/auxiliary.go
+++ b/osconfig/agentendpoint/apiv1beta/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/osconfig/agentendpoint/apiv1beta/auxiliary_go123.go
+++ b/osconfig/agentendpoint/apiv1beta/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/osconfig/agentendpoint/apiv1beta/doc.go
+++ b/osconfig/agentendpoint/apiv1beta/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/osconfig/agentendpoint/apiv1beta/helpers.go
+++ b/osconfig/agentendpoint/apiv1beta/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/osconfig/apiv1/auxiliary.go
+++ b/osconfig/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/osconfig/apiv1/auxiliary_go123.go
+++ b/osconfig/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/osconfig/apiv1/doc.go
+++ b/osconfig/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/osconfig/apiv1/helpers.go
+++ b/osconfig/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/osconfig/apiv1/os_config_client.go
+++ b/osconfig/apiv1/os_config_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/osconfig/apiv1/os_config_client_example_go123_test.go
+++ b/osconfig/apiv1/os_config_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/osconfig/apiv1/os_config_client_example_test.go
+++ b/osconfig/apiv1/os_config_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/osconfig/apiv1/os_config_zonal_client.go
+++ b/osconfig/apiv1/os_config_zonal_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/osconfig/apiv1/os_config_zonal_client_example_go123_test.go
+++ b/osconfig/apiv1/os_config_zonal_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/osconfig/apiv1/os_config_zonal_client_example_test.go
+++ b/osconfig/apiv1/os_config_zonal_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/osconfig/apiv1alpha/auxiliary.go
+++ b/osconfig/apiv1alpha/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/osconfig/apiv1alpha/auxiliary_go123.go
+++ b/osconfig/apiv1alpha/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/osconfig/apiv1alpha/doc.go
+++ b/osconfig/apiv1alpha/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/osconfig/apiv1alpha/helpers.go
+++ b/osconfig/apiv1alpha/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/osconfig/apiv1alpha/os_config_zonal_client.go
+++ b/osconfig/apiv1alpha/os_config_zonal_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/osconfig/apiv1alpha/os_config_zonal_client_example_go123_test.go
+++ b/osconfig/apiv1alpha/os_config_zonal_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/osconfig/apiv1alpha/os_config_zonal_client_example_test.go
+++ b/osconfig/apiv1alpha/os_config_zonal_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/osconfig/apiv1beta/auxiliary.go
+++ b/osconfig/apiv1beta/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/osconfig/apiv1beta/auxiliary_go123.go
+++ b/osconfig/apiv1beta/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/osconfig/apiv1beta/doc.go
+++ b/osconfig/apiv1beta/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/osconfig/apiv1beta/helpers.go
+++ b/osconfig/apiv1beta/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/osconfig/apiv1beta/os_config_client.go
+++ b/osconfig/apiv1beta/os_config_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/osconfig/apiv1beta/os_config_client_example_go123_test.go
+++ b/osconfig/apiv1beta/os_config_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/osconfig/apiv1beta/os_config_client_example_test.go
+++ b/osconfig/apiv1beta/os_config_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/oslogin/apiv1/auxiliary.go
+++ b/oslogin/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/oslogin/apiv1/auxiliary_go123.go
+++ b/oslogin/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/oslogin/apiv1/doc.go
+++ b/oslogin/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/oslogin/apiv1/helpers.go
+++ b/oslogin/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/oslogin/apiv1/os_login_client.go
+++ b/oslogin/apiv1/os_login_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/oslogin/apiv1/os_login_client_example_go123_test.go
+++ b/oslogin/apiv1/os_login_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/oslogin/apiv1/os_login_client_example_test.go
+++ b/oslogin/apiv1/os_login_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/oslogin/apiv1beta/auxiliary.go
+++ b/oslogin/apiv1beta/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/oslogin/apiv1beta/auxiliary_go123.go
+++ b/oslogin/apiv1beta/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/oslogin/apiv1beta/doc.go
+++ b/oslogin/apiv1beta/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/oslogin/apiv1beta/helpers.go
+++ b/oslogin/apiv1beta/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/oslogin/apiv1beta/os_login_client.go
+++ b/oslogin/apiv1beta/os_login_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/oslogin/apiv1beta/os_login_client_example_go123_test.go
+++ b/oslogin/apiv1beta/os_login_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/oslogin/apiv1beta/os_login_client_example_test.go
+++ b/oslogin/apiv1beta/os_login_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/parallelstore/apiv1/auxiliary.go
+++ b/parallelstore/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/parallelstore/apiv1/auxiliary_go123.go
+++ b/parallelstore/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/parallelstore/apiv1/doc.go
+++ b/parallelstore/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/parallelstore/apiv1/helpers.go
+++ b/parallelstore/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/parallelstore/apiv1/parallelstore_client.go
+++ b/parallelstore/apiv1/parallelstore_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/parallelstore/apiv1/parallelstore_client_example_go123_test.go
+++ b/parallelstore/apiv1/parallelstore_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/parallelstore/apiv1/parallelstore_client_example_test.go
+++ b/parallelstore/apiv1/parallelstore_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/parallelstore/apiv1beta/auxiliary.go
+++ b/parallelstore/apiv1beta/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/parallelstore/apiv1beta/auxiliary_go123.go
+++ b/parallelstore/apiv1beta/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/parallelstore/apiv1beta/doc.go
+++ b/parallelstore/apiv1beta/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/parallelstore/apiv1beta/helpers.go
+++ b/parallelstore/apiv1beta/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/parallelstore/apiv1beta/parallelstore_client.go
+++ b/parallelstore/apiv1beta/parallelstore_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/parallelstore/apiv1beta/parallelstore_client_example_go123_test.go
+++ b/parallelstore/apiv1beta/parallelstore_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/parallelstore/apiv1beta/parallelstore_client_example_test.go
+++ b/parallelstore/apiv1beta/parallelstore_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/parametermanager/apiv1/auxiliary.go
+++ b/parametermanager/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/parametermanager/apiv1/auxiliary_go123.go
+++ b/parametermanager/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/parametermanager/apiv1/doc.go
+++ b/parametermanager/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/parametermanager/apiv1/helpers.go
+++ b/parametermanager/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/parametermanager/apiv1/parameter_manager_client.go
+++ b/parametermanager/apiv1/parameter_manager_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/parametermanager/apiv1/parameter_manager_client_example_go123_test.go
+++ b/parametermanager/apiv1/parameter_manager_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/parametermanager/apiv1/parameter_manager_client_example_test.go
+++ b/parametermanager/apiv1/parameter_manager_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/phishingprotection/apiv1beta1/auxiliary.go
+++ b/phishingprotection/apiv1beta1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/phishingprotection/apiv1beta1/auxiliary_go123.go
+++ b/phishingprotection/apiv1beta1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/phishingprotection/apiv1beta1/doc.go
+++ b/phishingprotection/apiv1beta1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/phishingprotection/apiv1beta1/helpers.go
+++ b/phishingprotection/apiv1beta1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/phishingprotection/apiv1beta1/phishing_protection_service_v1_beta1_client.go
+++ b/phishingprotection/apiv1beta1/phishing_protection_service_v1_beta1_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/phishingprotection/apiv1beta1/phishing_protection_service_v1_beta1_client_example_go123_test.go
+++ b/phishingprotection/apiv1beta1/phishing_protection_service_v1_beta1_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/phishingprotection/apiv1beta1/phishing_protection_service_v1_beta1_client_example_test.go
+++ b/phishingprotection/apiv1beta1/phishing_protection_service_v1_beta1_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/policysimulator/apiv1/auxiliary.go
+++ b/policysimulator/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/policysimulator/apiv1/auxiliary_go123.go
+++ b/policysimulator/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/policysimulator/apiv1/doc.go
+++ b/policysimulator/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/policysimulator/apiv1/helpers.go
+++ b/policysimulator/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/policysimulator/apiv1/org_policy_violations_preview_client.go
+++ b/policysimulator/apiv1/org_policy_violations_preview_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/policysimulator/apiv1/org_policy_violations_preview_client_example_go123_test.go
+++ b/policysimulator/apiv1/org_policy_violations_preview_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/policysimulator/apiv1/org_policy_violations_preview_client_example_test.go
+++ b/policysimulator/apiv1/org_policy_violations_preview_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/policysimulator/apiv1/simulator_client.go
+++ b/policysimulator/apiv1/simulator_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/policysimulator/apiv1/simulator_client_example_go123_test.go
+++ b/policysimulator/apiv1/simulator_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/policysimulator/apiv1/simulator_client_example_test.go
+++ b/policysimulator/apiv1/simulator_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/policytroubleshooter/apiv1/auxiliary.go
+++ b/policytroubleshooter/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/policytroubleshooter/apiv1/auxiliary_go123.go
+++ b/policytroubleshooter/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/policytroubleshooter/apiv1/doc.go
+++ b/policytroubleshooter/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/policytroubleshooter/apiv1/helpers.go
+++ b/policytroubleshooter/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/policytroubleshooter/apiv1/iam_checker_client.go
+++ b/policytroubleshooter/apiv1/iam_checker_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/policytroubleshooter/apiv1/iam_checker_client_example_go123_test.go
+++ b/policytroubleshooter/apiv1/iam_checker_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/policytroubleshooter/apiv1/iam_checker_client_example_test.go
+++ b/policytroubleshooter/apiv1/iam_checker_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/policytroubleshooter/iam/apiv3/auxiliary.go
+++ b/policytroubleshooter/iam/apiv3/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/policytroubleshooter/iam/apiv3/auxiliary_go123.go
+++ b/policytroubleshooter/iam/apiv3/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/policytroubleshooter/iam/apiv3/doc.go
+++ b/policytroubleshooter/iam/apiv3/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/policytroubleshooter/iam/apiv3/helpers.go
+++ b/policytroubleshooter/iam/apiv3/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/policytroubleshooter/iam/apiv3/policy_troubleshooter_client.go
+++ b/policytroubleshooter/iam/apiv3/policy_troubleshooter_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/policytroubleshooter/iam/apiv3/policy_troubleshooter_client_example_go123_test.go
+++ b/policytroubleshooter/iam/apiv3/policy_troubleshooter_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/policytroubleshooter/iam/apiv3/policy_troubleshooter_client_example_test.go
+++ b/policytroubleshooter/iam/apiv3/policy_troubleshooter_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/privatecatalog/apiv1beta1/auxiliary.go
+++ b/privatecatalog/apiv1beta1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/privatecatalog/apiv1beta1/auxiliary_go123.go
+++ b/privatecatalog/apiv1beta1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/privatecatalog/apiv1beta1/doc.go
+++ b/privatecatalog/apiv1beta1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/privatecatalog/apiv1beta1/helpers.go
+++ b/privatecatalog/apiv1beta1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/privatecatalog/apiv1beta1/private_catalog_client.go
+++ b/privatecatalog/apiv1beta1/private_catalog_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/privatecatalog/apiv1beta1/private_catalog_client_example_go123_test.go
+++ b/privatecatalog/apiv1beta1/private_catalog_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/privatecatalog/apiv1beta1/private_catalog_client_example_test.go
+++ b/privatecatalog/apiv1beta1/private_catalog_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/privilegedaccessmanager/apiv1/auxiliary.go
+++ b/privilegedaccessmanager/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/privilegedaccessmanager/apiv1/auxiliary_go123.go
+++ b/privilegedaccessmanager/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/privilegedaccessmanager/apiv1/doc.go
+++ b/privilegedaccessmanager/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/privilegedaccessmanager/apiv1/helpers.go
+++ b/privilegedaccessmanager/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/privilegedaccessmanager/apiv1/privileged_access_manager_client.go
+++ b/privilegedaccessmanager/apiv1/privileged_access_manager_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/privilegedaccessmanager/apiv1/privileged_access_manager_client_example_go123_test.go
+++ b/privilegedaccessmanager/apiv1/privileged_access_manager_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/privilegedaccessmanager/apiv1/privileged_access_manager_client_example_test.go
+++ b/privilegedaccessmanager/apiv1/privileged_access_manager_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pubsublite/apiv1/admin_client.go
+++ b/pubsublite/apiv1/admin_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pubsublite/apiv1/admin_client_example_go123_test.go
+++ b/pubsublite/apiv1/admin_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pubsublite/apiv1/admin_client_example_test.go
+++ b/pubsublite/apiv1/admin_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pubsublite/apiv1/auxiliary.go
+++ b/pubsublite/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pubsublite/apiv1/auxiliary_go123.go
+++ b/pubsublite/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pubsublite/apiv1/cursor_client.go
+++ b/pubsublite/apiv1/cursor_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pubsublite/apiv1/cursor_client_example_go123_test.go
+++ b/pubsublite/apiv1/cursor_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pubsublite/apiv1/cursor_client_example_test.go
+++ b/pubsublite/apiv1/cursor_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pubsublite/apiv1/doc.go
+++ b/pubsublite/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pubsublite/apiv1/helpers.go
+++ b/pubsublite/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pubsublite/apiv1/partition_assignment_client.go
+++ b/pubsublite/apiv1/partition_assignment_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pubsublite/apiv1/partition_assignment_client_example_go123_test.go
+++ b/pubsublite/apiv1/partition_assignment_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pubsublite/apiv1/partition_assignment_client_example_test.go
+++ b/pubsublite/apiv1/partition_assignment_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pubsublite/apiv1/publisher_client.go
+++ b/pubsublite/apiv1/publisher_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pubsublite/apiv1/publisher_client_example_go123_test.go
+++ b/pubsublite/apiv1/publisher_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pubsublite/apiv1/publisher_client_example_test.go
+++ b/pubsublite/apiv1/publisher_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pubsublite/apiv1/subscriber_client.go
+++ b/pubsublite/apiv1/subscriber_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pubsublite/apiv1/subscriber_client_example_go123_test.go
+++ b/pubsublite/apiv1/subscriber_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pubsublite/apiv1/subscriber_client_example_test.go
+++ b/pubsublite/apiv1/subscriber_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pubsublite/apiv1/topic_stats_client.go
+++ b/pubsublite/apiv1/topic_stats_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pubsublite/apiv1/topic_stats_client_example_go123_test.go
+++ b/pubsublite/apiv1/topic_stats_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pubsublite/apiv1/topic_stats_client_example_test.go
+++ b/pubsublite/apiv1/topic_stats_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rapidmigrationassessment/apiv1/auxiliary.go
+++ b/rapidmigrationassessment/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rapidmigrationassessment/apiv1/auxiliary_go123.go
+++ b/rapidmigrationassessment/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rapidmigrationassessment/apiv1/doc.go
+++ b/rapidmigrationassessment/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rapidmigrationassessment/apiv1/helpers.go
+++ b/rapidmigrationassessment/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rapidmigrationassessment/apiv1/rapid_migration_assessment_client.go
+++ b/rapidmigrationassessment/apiv1/rapid_migration_assessment_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rapidmigrationassessment/apiv1/rapid_migration_assessment_client_example_go123_test.go
+++ b/rapidmigrationassessment/apiv1/rapid_migration_assessment_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rapidmigrationassessment/apiv1/rapid_migration_assessment_client_example_test.go
+++ b/rapidmigrationassessment/apiv1/rapid_migration_assessment_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/recaptchaenterprise/apiv1/auxiliary.go
+++ b/recaptchaenterprise/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/recaptchaenterprise/apiv1/auxiliary_go123.go
+++ b/recaptchaenterprise/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/recaptchaenterprise/apiv1/doc.go
+++ b/recaptchaenterprise/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/recaptchaenterprise/apiv1/helpers.go
+++ b/recaptchaenterprise/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/recaptchaenterprise/apiv1/recaptcha_enterprise_client.go
+++ b/recaptchaenterprise/apiv1/recaptcha_enterprise_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/recaptchaenterprise/apiv1/recaptcha_enterprise_client_example_go123_test.go
+++ b/recaptchaenterprise/apiv1/recaptcha_enterprise_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/recaptchaenterprise/apiv1/recaptcha_enterprise_client_example_test.go
+++ b/recaptchaenterprise/apiv1/recaptcha_enterprise_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/recaptchaenterprise/apiv1beta1/auxiliary.go
+++ b/recaptchaenterprise/apiv1beta1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/recaptchaenterprise/apiv1beta1/auxiliary_go123.go
+++ b/recaptchaenterprise/apiv1beta1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/recaptchaenterprise/apiv1beta1/doc.go
+++ b/recaptchaenterprise/apiv1beta1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/recaptchaenterprise/apiv1beta1/helpers.go
+++ b/recaptchaenterprise/apiv1beta1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/recaptchaenterprise/apiv1beta1/recaptcha_enterprise_service_v1_beta1_client.go
+++ b/recaptchaenterprise/apiv1beta1/recaptcha_enterprise_service_v1_beta1_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/recaptchaenterprise/apiv1beta1/recaptcha_enterprise_service_v1_beta1_client_example_go123_test.go
+++ b/recaptchaenterprise/apiv1beta1/recaptcha_enterprise_service_v1_beta1_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/recaptchaenterprise/apiv1beta1/recaptcha_enterprise_service_v1_beta1_client_example_test.go
+++ b/recaptchaenterprise/apiv1beta1/recaptcha_enterprise_service_v1_beta1_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/recommendationengine/apiv1beta1/auxiliary.go
+++ b/recommendationengine/apiv1beta1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/recommendationengine/apiv1beta1/auxiliary_go123.go
+++ b/recommendationengine/apiv1beta1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/recommendationengine/apiv1beta1/catalog_client.go
+++ b/recommendationengine/apiv1beta1/catalog_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/recommendationengine/apiv1beta1/catalog_client_example_go123_test.go
+++ b/recommendationengine/apiv1beta1/catalog_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/recommendationengine/apiv1beta1/catalog_client_example_test.go
+++ b/recommendationengine/apiv1beta1/catalog_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/recommendationengine/apiv1beta1/doc.go
+++ b/recommendationengine/apiv1beta1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/recommendationengine/apiv1beta1/helpers.go
+++ b/recommendationengine/apiv1beta1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/recommendationengine/apiv1beta1/prediction_api_key_registry_client.go
+++ b/recommendationengine/apiv1beta1/prediction_api_key_registry_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/recommendationengine/apiv1beta1/prediction_api_key_registry_client_example_go123_test.go
+++ b/recommendationengine/apiv1beta1/prediction_api_key_registry_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/recommendationengine/apiv1beta1/prediction_api_key_registry_client_example_test.go
+++ b/recommendationengine/apiv1beta1/prediction_api_key_registry_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/recommendationengine/apiv1beta1/prediction_client.go
+++ b/recommendationengine/apiv1beta1/prediction_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/recommendationengine/apiv1beta1/prediction_client_example_go123_test.go
+++ b/recommendationengine/apiv1beta1/prediction_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/recommendationengine/apiv1beta1/prediction_client_example_test.go
+++ b/recommendationengine/apiv1beta1/prediction_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/recommendationengine/apiv1beta1/user_event_client.go
+++ b/recommendationengine/apiv1beta1/user_event_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/recommendationengine/apiv1beta1/user_event_client_example_go123_test.go
+++ b/recommendationengine/apiv1beta1/user_event_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/recommendationengine/apiv1beta1/user_event_client_example_test.go
+++ b/recommendationengine/apiv1beta1/user_event_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/recommender/apiv1/auxiliary.go
+++ b/recommender/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/recommender/apiv1/auxiliary_go123.go
+++ b/recommender/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/recommender/apiv1/doc.go
+++ b/recommender/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/recommender/apiv1/helpers.go
+++ b/recommender/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/recommender/apiv1/recommender_client.go
+++ b/recommender/apiv1/recommender_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/recommender/apiv1/recommender_client_example_go123_test.go
+++ b/recommender/apiv1/recommender_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/recommender/apiv1/recommender_client_example_test.go
+++ b/recommender/apiv1/recommender_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/recommender/apiv1beta1/auxiliary.go
+++ b/recommender/apiv1beta1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/recommender/apiv1beta1/auxiliary_go123.go
+++ b/recommender/apiv1beta1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/recommender/apiv1beta1/doc.go
+++ b/recommender/apiv1beta1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/recommender/apiv1beta1/helpers.go
+++ b/recommender/apiv1beta1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/recommender/apiv1beta1/recommender_client.go
+++ b/recommender/apiv1beta1/recommender_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/recommender/apiv1beta1/recommender_client_example_go123_test.go
+++ b/recommender/apiv1beta1/recommender_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/recommender/apiv1beta1/recommender_client_example_test.go
+++ b/recommender/apiv1beta1/recommender_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/redis/apiv1/auxiliary.go
+++ b/redis/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/redis/apiv1/auxiliary_go123.go
+++ b/redis/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/redis/apiv1/cloud_redis_client.go
+++ b/redis/apiv1/cloud_redis_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/redis/apiv1/cloud_redis_client_example_go123_test.go
+++ b/redis/apiv1/cloud_redis_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/redis/apiv1/cloud_redis_client_example_test.go
+++ b/redis/apiv1/cloud_redis_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/redis/apiv1/doc.go
+++ b/redis/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/redis/apiv1/helpers.go
+++ b/redis/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/redis/apiv1beta1/auxiliary.go
+++ b/redis/apiv1beta1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/redis/apiv1beta1/auxiliary_go123.go
+++ b/redis/apiv1beta1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/redis/apiv1beta1/cloud_redis_client.go
+++ b/redis/apiv1beta1/cloud_redis_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/redis/apiv1beta1/cloud_redis_client_example_go123_test.go
+++ b/redis/apiv1beta1/cloud_redis_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/redis/apiv1beta1/cloud_redis_client_example_test.go
+++ b/redis/apiv1beta1/cloud_redis_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/redis/apiv1beta1/doc.go
+++ b/redis/apiv1beta1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/redis/apiv1beta1/helpers.go
+++ b/redis/apiv1beta1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/redis/cluster/apiv1/auxiliary.go
+++ b/redis/cluster/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/redis/cluster/apiv1/auxiliary_go123.go
+++ b/redis/cluster/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/redis/cluster/apiv1/cloud_redis_cluster_client.go
+++ b/redis/cluster/apiv1/cloud_redis_cluster_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/redis/cluster/apiv1/cloud_redis_cluster_client_example_go123_test.go
+++ b/redis/cluster/apiv1/cloud_redis_cluster_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/redis/cluster/apiv1/cloud_redis_cluster_client_example_test.go
+++ b/redis/cluster/apiv1/cloud_redis_cluster_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/redis/cluster/apiv1/doc.go
+++ b/redis/cluster/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/redis/cluster/apiv1/helpers.go
+++ b/redis/cluster/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/resourcemanager/apiv2/auxiliary.go
+++ b/resourcemanager/apiv2/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/resourcemanager/apiv2/auxiliary_go123.go
+++ b/resourcemanager/apiv2/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/resourcemanager/apiv2/doc.go
+++ b/resourcemanager/apiv2/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/resourcemanager/apiv2/folders_client.go
+++ b/resourcemanager/apiv2/folders_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/resourcemanager/apiv2/folders_client_example_go123_test.go
+++ b/resourcemanager/apiv2/folders_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/resourcemanager/apiv2/folders_client_example_test.go
+++ b/resourcemanager/apiv2/folders_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/resourcemanager/apiv2/helpers.go
+++ b/resourcemanager/apiv2/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/resourcemanager/apiv3/auxiliary.go
+++ b/resourcemanager/apiv3/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/resourcemanager/apiv3/auxiliary_go123.go
+++ b/resourcemanager/apiv3/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/resourcemanager/apiv3/doc.go
+++ b/resourcemanager/apiv3/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/resourcemanager/apiv3/folders_client.go
+++ b/resourcemanager/apiv3/folders_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/resourcemanager/apiv3/folders_client_example_go123_test.go
+++ b/resourcemanager/apiv3/folders_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/resourcemanager/apiv3/folders_client_example_test.go
+++ b/resourcemanager/apiv3/folders_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/resourcemanager/apiv3/helpers.go
+++ b/resourcemanager/apiv3/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/resourcemanager/apiv3/organizations_client.go
+++ b/resourcemanager/apiv3/organizations_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/resourcemanager/apiv3/organizations_client_example_go123_test.go
+++ b/resourcemanager/apiv3/organizations_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/resourcemanager/apiv3/organizations_client_example_test.go
+++ b/resourcemanager/apiv3/organizations_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/resourcemanager/apiv3/projects_client.go
+++ b/resourcemanager/apiv3/projects_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/resourcemanager/apiv3/projects_client_example_go123_test.go
+++ b/resourcemanager/apiv3/projects_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/resourcemanager/apiv3/projects_client_example_test.go
+++ b/resourcemanager/apiv3/projects_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/resourcemanager/apiv3/tag_bindings_client.go
+++ b/resourcemanager/apiv3/tag_bindings_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/resourcemanager/apiv3/tag_bindings_client_example_go123_test.go
+++ b/resourcemanager/apiv3/tag_bindings_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/resourcemanager/apiv3/tag_bindings_client_example_test.go
+++ b/resourcemanager/apiv3/tag_bindings_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/resourcemanager/apiv3/tag_holds_client.go
+++ b/resourcemanager/apiv3/tag_holds_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/resourcemanager/apiv3/tag_holds_client_example_go123_test.go
+++ b/resourcemanager/apiv3/tag_holds_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/resourcemanager/apiv3/tag_holds_client_example_test.go
+++ b/resourcemanager/apiv3/tag_holds_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/resourcemanager/apiv3/tag_keys_client.go
+++ b/resourcemanager/apiv3/tag_keys_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/resourcemanager/apiv3/tag_keys_client_example_go123_test.go
+++ b/resourcemanager/apiv3/tag_keys_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/resourcemanager/apiv3/tag_keys_client_example_test.go
+++ b/resourcemanager/apiv3/tag_keys_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/resourcemanager/apiv3/tag_values_client.go
+++ b/resourcemanager/apiv3/tag_values_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/resourcemanager/apiv3/tag_values_client_example_go123_test.go
+++ b/resourcemanager/apiv3/tag_values_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/resourcemanager/apiv3/tag_values_client_example_test.go
+++ b/resourcemanager/apiv3/tag_values_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2/analytics_client.go
+++ b/retail/apiv2/analytics_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2/analytics_client_example_go123_test.go
+++ b/retail/apiv2/analytics_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2/analytics_client_example_test.go
+++ b/retail/apiv2/analytics_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2/auxiliary.go
+++ b/retail/apiv2/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2/auxiliary_go123.go
+++ b/retail/apiv2/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2/catalog_client.go
+++ b/retail/apiv2/catalog_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2/catalog_client_example_go123_test.go
+++ b/retail/apiv2/catalog_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2/catalog_client_example_test.go
+++ b/retail/apiv2/catalog_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2/completion_client.go
+++ b/retail/apiv2/completion_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2/completion_client_example_go123_test.go
+++ b/retail/apiv2/completion_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2/completion_client_example_test.go
+++ b/retail/apiv2/completion_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2/control_client.go
+++ b/retail/apiv2/control_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2/control_client_example_go123_test.go
+++ b/retail/apiv2/control_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2/control_client_example_test.go
+++ b/retail/apiv2/control_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2/conversational_search_client.go
+++ b/retail/apiv2/conversational_search_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2/conversational_search_client_example_go123_test.go
+++ b/retail/apiv2/conversational_search_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2/conversational_search_client_example_test.go
+++ b/retail/apiv2/conversational_search_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2/doc.go
+++ b/retail/apiv2/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2/generative_question_client.go
+++ b/retail/apiv2/generative_question_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2/generative_question_client_example_go123_test.go
+++ b/retail/apiv2/generative_question_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2/generative_question_client_example_test.go
+++ b/retail/apiv2/generative_question_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2/helpers.go
+++ b/retail/apiv2/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2/model_client.go
+++ b/retail/apiv2/model_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2/model_client_example_go123_test.go
+++ b/retail/apiv2/model_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2/model_client_example_test.go
+++ b/retail/apiv2/model_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2/prediction_client.go
+++ b/retail/apiv2/prediction_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2/prediction_client_example_go123_test.go
+++ b/retail/apiv2/prediction_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2/prediction_client_example_test.go
+++ b/retail/apiv2/prediction_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2/product_client.go
+++ b/retail/apiv2/product_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2/product_client_example_go123_test.go
+++ b/retail/apiv2/product_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2/product_client_example_test.go
+++ b/retail/apiv2/product_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2/search_client.go
+++ b/retail/apiv2/search_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2/search_client_example_go123_test.go
+++ b/retail/apiv2/search_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2/search_client_example_test.go
+++ b/retail/apiv2/search_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2/serving_config_client.go
+++ b/retail/apiv2/serving_config_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2/serving_config_client_example_go123_test.go
+++ b/retail/apiv2/serving_config_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2/serving_config_client_example_test.go
+++ b/retail/apiv2/serving_config_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2/user_event_client.go
+++ b/retail/apiv2/user_event_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2/user_event_client_example_go123_test.go
+++ b/retail/apiv2/user_event_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2/user_event_client_example_test.go
+++ b/retail/apiv2/user_event_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2alpha/analytics_client.go
+++ b/retail/apiv2alpha/analytics_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2alpha/analytics_client_example_go123_test.go
+++ b/retail/apiv2alpha/analytics_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2alpha/analytics_client_example_test.go
+++ b/retail/apiv2alpha/analytics_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2alpha/auxiliary.go
+++ b/retail/apiv2alpha/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2alpha/auxiliary_go123.go
+++ b/retail/apiv2alpha/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2alpha/branch_client.go
+++ b/retail/apiv2alpha/branch_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2alpha/branch_client_example_go123_test.go
+++ b/retail/apiv2alpha/branch_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2alpha/branch_client_example_test.go
+++ b/retail/apiv2alpha/branch_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2alpha/catalog_client.go
+++ b/retail/apiv2alpha/catalog_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2alpha/catalog_client_example_go123_test.go
+++ b/retail/apiv2alpha/catalog_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2alpha/catalog_client_example_test.go
+++ b/retail/apiv2alpha/catalog_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2alpha/completion_client.go
+++ b/retail/apiv2alpha/completion_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2alpha/completion_client_example_go123_test.go
+++ b/retail/apiv2alpha/completion_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2alpha/completion_client_example_test.go
+++ b/retail/apiv2alpha/completion_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2alpha/control_client.go
+++ b/retail/apiv2alpha/control_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2alpha/control_client_example_go123_test.go
+++ b/retail/apiv2alpha/control_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2alpha/control_client_example_test.go
+++ b/retail/apiv2alpha/control_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2alpha/conversational_search_client.go
+++ b/retail/apiv2alpha/conversational_search_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2alpha/conversational_search_client_example_go123_test.go
+++ b/retail/apiv2alpha/conversational_search_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2alpha/conversational_search_client_example_test.go
+++ b/retail/apiv2alpha/conversational_search_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2alpha/doc.go
+++ b/retail/apiv2alpha/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2alpha/generative_question_client.go
+++ b/retail/apiv2alpha/generative_question_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2alpha/generative_question_client_example_go123_test.go
+++ b/retail/apiv2alpha/generative_question_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2alpha/generative_question_client_example_test.go
+++ b/retail/apiv2alpha/generative_question_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2alpha/helpers.go
+++ b/retail/apiv2alpha/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2alpha/merchant_center_account_link_client.go
+++ b/retail/apiv2alpha/merchant_center_account_link_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2alpha/merchant_center_account_link_client_example_go123_test.go
+++ b/retail/apiv2alpha/merchant_center_account_link_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2alpha/merchant_center_account_link_client_example_test.go
+++ b/retail/apiv2alpha/merchant_center_account_link_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2alpha/model_client.go
+++ b/retail/apiv2alpha/model_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2alpha/model_client_example_go123_test.go
+++ b/retail/apiv2alpha/model_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2alpha/model_client_example_test.go
+++ b/retail/apiv2alpha/model_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2alpha/prediction_client.go
+++ b/retail/apiv2alpha/prediction_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2alpha/prediction_client_example_go123_test.go
+++ b/retail/apiv2alpha/prediction_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2alpha/prediction_client_example_test.go
+++ b/retail/apiv2alpha/prediction_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2alpha/product_client.go
+++ b/retail/apiv2alpha/product_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2alpha/product_client_example_go123_test.go
+++ b/retail/apiv2alpha/product_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2alpha/product_client_example_test.go
+++ b/retail/apiv2alpha/product_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2alpha/project_client.go
+++ b/retail/apiv2alpha/project_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2alpha/project_client_example_go123_test.go
+++ b/retail/apiv2alpha/project_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2alpha/project_client_example_test.go
+++ b/retail/apiv2alpha/project_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2alpha/search_client.go
+++ b/retail/apiv2alpha/search_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2alpha/search_client_example_go123_test.go
+++ b/retail/apiv2alpha/search_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2alpha/search_client_example_test.go
+++ b/retail/apiv2alpha/search_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2alpha/serving_config_client.go
+++ b/retail/apiv2alpha/serving_config_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2alpha/serving_config_client_example_go123_test.go
+++ b/retail/apiv2alpha/serving_config_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2alpha/serving_config_client_example_test.go
+++ b/retail/apiv2alpha/serving_config_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2alpha/user_event_client.go
+++ b/retail/apiv2alpha/user_event_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2alpha/user_event_client_example_go123_test.go
+++ b/retail/apiv2alpha/user_event_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2alpha/user_event_client_example_test.go
+++ b/retail/apiv2alpha/user_event_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2beta/analytics_client.go
+++ b/retail/apiv2beta/analytics_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2beta/analytics_client_example_go123_test.go
+++ b/retail/apiv2beta/analytics_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2beta/analytics_client_example_test.go
+++ b/retail/apiv2beta/analytics_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2beta/auxiliary.go
+++ b/retail/apiv2beta/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2beta/auxiliary_go123.go
+++ b/retail/apiv2beta/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2beta/catalog_client.go
+++ b/retail/apiv2beta/catalog_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2beta/catalog_client_example_go123_test.go
+++ b/retail/apiv2beta/catalog_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2beta/catalog_client_example_test.go
+++ b/retail/apiv2beta/catalog_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2beta/completion_client.go
+++ b/retail/apiv2beta/completion_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2beta/completion_client_example_go123_test.go
+++ b/retail/apiv2beta/completion_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2beta/completion_client_example_test.go
+++ b/retail/apiv2beta/completion_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2beta/control_client.go
+++ b/retail/apiv2beta/control_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2beta/control_client_example_go123_test.go
+++ b/retail/apiv2beta/control_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2beta/control_client_example_test.go
+++ b/retail/apiv2beta/control_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2beta/conversational_search_client.go
+++ b/retail/apiv2beta/conversational_search_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2beta/conversational_search_client_example_go123_test.go
+++ b/retail/apiv2beta/conversational_search_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2beta/conversational_search_client_example_test.go
+++ b/retail/apiv2beta/conversational_search_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2beta/doc.go
+++ b/retail/apiv2beta/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2beta/generative_question_client.go
+++ b/retail/apiv2beta/generative_question_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2beta/generative_question_client_example_go123_test.go
+++ b/retail/apiv2beta/generative_question_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2beta/generative_question_client_example_test.go
+++ b/retail/apiv2beta/generative_question_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2beta/helpers.go
+++ b/retail/apiv2beta/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2beta/model_client.go
+++ b/retail/apiv2beta/model_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2beta/model_client_example_go123_test.go
+++ b/retail/apiv2beta/model_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2beta/model_client_example_test.go
+++ b/retail/apiv2beta/model_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2beta/prediction_client.go
+++ b/retail/apiv2beta/prediction_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2beta/prediction_client_example_go123_test.go
+++ b/retail/apiv2beta/prediction_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2beta/prediction_client_example_test.go
+++ b/retail/apiv2beta/prediction_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2beta/product_client.go
+++ b/retail/apiv2beta/product_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2beta/product_client_example_go123_test.go
+++ b/retail/apiv2beta/product_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2beta/product_client_example_test.go
+++ b/retail/apiv2beta/product_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2beta/project_client.go
+++ b/retail/apiv2beta/project_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2beta/project_client_example_go123_test.go
+++ b/retail/apiv2beta/project_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2beta/project_client_example_test.go
+++ b/retail/apiv2beta/project_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2beta/search_client.go
+++ b/retail/apiv2beta/search_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2beta/search_client_example_go123_test.go
+++ b/retail/apiv2beta/search_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2beta/search_client_example_test.go
+++ b/retail/apiv2beta/search_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2beta/serving_config_client.go
+++ b/retail/apiv2beta/serving_config_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2beta/serving_config_client_example_go123_test.go
+++ b/retail/apiv2beta/serving_config_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2beta/serving_config_client_example_test.go
+++ b/retail/apiv2beta/serving_config_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2beta/user_event_client.go
+++ b/retail/apiv2beta/user_event_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2beta/user_event_client_example_go123_test.go
+++ b/retail/apiv2beta/user_event_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/retail/apiv2beta/user_event_client_example_test.go
+++ b/retail/apiv2beta/user_event_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/saasplatform/saasservicemgmt/apiv1beta1/auxiliary.go
+++ b/saasplatform/saasservicemgmt/apiv1beta1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/saasplatform/saasservicemgmt/apiv1beta1/auxiliary_go123.go
+++ b/saasplatform/saasservicemgmt/apiv1beta1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/saasplatform/saasservicemgmt/apiv1beta1/doc.go
+++ b/saasplatform/saasservicemgmt/apiv1beta1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/saasplatform/saasservicemgmt/apiv1beta1/helpers.go
+++ b/saasplatform/saasservicemgmt/apiv1beta1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/saasplatform/saasservicemgmt/apiv1beta1/saas_deployments_client.go
+++ b/saasplatform/saasservicemgmt/apiv1beta1/saas_deployments_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/saasplatform/saasservicemgmt/apiv1beta1/saas_deployments_client_example_go123_test.go
+++ b/saasplatform/saasservicemgmt/apiv1beta1/saas_deployments_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/saasplatform/saasservicemgmt/apiv1beta1/saas_deployments_client_example_test.go
+++ b/saasplatform/saasservicemgmt/apiv1beta1/saas_deployments_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/saasplatform/saasservicemgmt/apiv1beta1/saas_rollouts_client.go
+++ b/saasplatform/saasservicemgmt/apiv1beta1/saas_rollouts_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/saasplatform/saasservicemgmt/apiv1beta1/saas_rollouts_client_example_go123_test.go
+++ b/saasplatform/saasservicemgmt/apiv1beta1/saas_rollouts_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/saasplatform/saasservicemgmt/apiv1beta1/saas_rollouts_client_example_test.go
+++ b/saasplatform/saasservicemgmt/apiv1beta1/saas_rollouts_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/scheduler/apiv1/auxiliary.go
+++ b/scheduler/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/scheduler/apiv1/auxiliary_go123.go
+++ b/scheduler/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/scheduler/apiv1/cloud_scheduler_client.go
+++ b/scheduler/apiv1/cloud_scheduler_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/scheduler/apiv1/cloud_scheduler_client_example_go123_test.go
+++ b/scheduler/apiv1/cloud_scheduler_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/scheduler/apiv1/cloud_scheduler_client_example_test.go
+++ b/scheduler/apiv1/cloud_scheduler_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/scheduler/apiv1/doc.go
+++ b/scheduler/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/scheduler/apiv1/helpers.go
+++ b/scheduler/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/scheduler/apiv1beta1/auxiliary.go
+++ b/scheduler/apiv1beta1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/scheduler/apiv1beta1/auxiliary_go123.go
+++ b/scheduler/apiv1beta1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/scheduler/apiv1beta1/cloud_scheduler_client.go
+++ b/scheduler/apiv1beta1/cloud_scheduler_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/scheduler/apiv1beta1/cloud_scheduler_client_example_go123_test.go
+++ b/scheduler/apiv1beta1/cloud_scheduler_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/scheduler/apiv1beta1/cloud_scheduler_client_example_test.go
+++ b/scheduler/apiv1beta1/cloud_scheduler_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/scheduler/apiv1beta1/doc.go
+++ b/scheduler/apiv1beta1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/scheduler/apiv1beta1/helpers.go
+++ b/scheduler/apiv1beta1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/secretmanager/apiv1/auxiliary.go
+++ b/secretmanager/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/secretmanager/apiv1/auxiliary_go123.go
+++ b/secretmanager/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/secretmanager/apiv1/doc.go
+++ b/secretmanager/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/secretmanager/apiv1/helpers.go
+++ b/secretmanager/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/secretmanager/apiv1/secret_manager_client.go
+++ b/secretmanager/apiv1/secret_manager_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/secretmanager/apiv1/secret_manager_client_example_go123_test.go
+++ b/secretmanager/apiv1/secret_manager_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/secretmanager/apiv1/secret_manager_client_example_test.go
+++ b/secretmanager/apiv1/secret_manager_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/secretmanager/apiv1beta2/auxiliary.go
+++ b/secretmanager/apiv1beta2/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/secretmanager/apiv1beta2/auxiliary_go123.go
+++ b/secretmanager/apiv1beta2/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/secretmanager/apiv1beta2/doc.go
+++ b/secretmanager/apiv1beta2/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/secretmanager/apiv1beta2/helpers.go
+++ b/secretmanager/apiv1beta2/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/secretmanager/apiv1beta2/secret_manager_client.go
+++ b/secretmanager/apiv1beta2/secret_manager_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/secretmanager/apiv1beta2/secret_manager_client_example_go123_test.go
+++ b/secretmanager/apiv1beta2/secret_manager_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/secretmanager/apiv1beta2/secret_manager_client_example_test.go
+++ b/secretmanager/apiv1beta2/secret_manager_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/securesourcemanager/apiv1/auxiliary.go
+++ b/securesourcemanager/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/securesourcemanager/apiv1/auxiliary_go123.go
+++ b/securesourcemanager/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/securesourcemanager/apiv1/doc.go
+++ b/securesourcemanager/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/securesourcemanager/apiv1/helpers.go
+++ b/securesourcemanager/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/securesourcemanager/apiv1/secure_source_manager_client.go
+++ b/securesourcemanager/apiv1/secure_source_manager_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/securesourcemanager/apiv1/secure_source_manager_client_example_go123_test.go
+++ b/securesourcemanager/apiv1/secure_source_manager_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/securesourcemanager/apiv1/secure_source_manager_client_example_test.go
+++ b/securesourcemanager/apiv1/secure_source_manager_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/security/privateca/apiv1/auxiliary.go
+++ b/security/privateca/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/security/privateca/apiv1/auxiliary_go123.go
+++ b/security/privateca/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/security/privateca/apiv1/certificate_authority_client.go
+++ b/security/privateca/apiv1/certificate_authority_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/security/privateca/apiv1/certificate_authority_client_example_go123_test.go
+++ b/security/privateca/apiv1/certificate_authority_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/security/privateca/apiv1/certificate_authority_client_example_test.go
+++ b/security/privateca/apiv1/certificate_authority_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/security/privateca/apiv1/doc.go
+++ b/security/privateca/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/security/privateca/apiv1/helpers.go
+++ b/security/privateca/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/security/publicca/apiv1/auxiliary.go
+++ b/security/publicca/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/security/publicca/apiv1/auxiliary_go123.go
+++ b/security/publicca/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/security/publicca/apiv1/doc.go
+++ b/security/publicca/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/security/publicca/apiv1/helpers.go
+++ b/security/publicca/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/security/publicca/apiv1/public_certificate_authority_client.go
+++ b/security/publicca/apiv1/public_certificate_authority_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/security/publicca/apiv1/public_certificate_authority_client_example_go123_test.go
+++ b/security/publicca/apiv1/public_certificate_authority_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/security/publicca/apiv1/public_certificate_authority_client_example_test.go
+++ b/security/publicca/apiv1/public_certificate_authority_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/security/publicca/apiv1beta1/auxiliary.go
+++ b/security/publicca/apiv1beta1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/security/publicca/apiv1beta1/auxiliary_go123.go
+++ b/security/publicca/apiv1beta1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/security/publicca/apiv1beta1/doc.go
+++ b/security/publicca/apiv1beta1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/security/publicca/apiv1beta1/helpers.go
+++ b/security/publicca/apiv1beta1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/security/publicca/apiv1beta1/public_certificate_authority_client.go
+++ b/security/publicca/apiv1beta1/public_certificate_authority_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/security/publicca/apiv1beta1/public_certificate_authority_client_example_go123_test.go
+++ b/security/publicca/apiv1beta1/public_certificate_authority_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/security/publicca/apiv1beta1/public_certificate_authority_client_example_test.go
+++ b/security/publicca/apiv1beta1/public_certificate_authority_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/securitycenter/apiv1/auxiliary.go
+++ b/securitycenter/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/securitycenter/apiv1/auxiliary_go123.go
+++ b/securitycenter/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/securitycenter/apiv1/doc.go
+++ b/securitycenter/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/securitycenter/apiv1/helpers.go
+++ b/securitycenter/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/securitycenter/apiv1/security_center_client.go
+++ b/securitycenter/apiv1/security_center_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/securitycenter/apiv1/security_center_client_example_go123_test.go
+++ b/securitycenter/apiv1/security_center_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/securitycenter/apiv1/security_center_client_example_test.go
+++ b/securitycenter/apiv1/security_center_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/securitycenter/apiv1beta1/auxiliary.go
+++ b/securitycenter/apiv1beta1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/securitycenter/apiv1beta1/auxiliary_go123.go
+++ b/securitycenter/apiv1beta1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/securitycenter/apiv1beta1/doc.go
+++ b/securitycenter/apiv1beta1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/securitycenter/apiv1beta1/helpers.go
+++ b/securitycenter/apiv1beta1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/securitycenter/apiv1beta1/security_center_client.go
+++ b/securitycenter/apiv1beta1/security_center_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/securitycenter/apiv1beta1/security_center_client_example_go123_test.go
+++ b/securitycenter/apiv1beta1/security_center_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/securitycenter/apiv1beta1/security_center_client_example_test.go
+++ b/securitycenter/apiv1beta1/security_center_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/securitycenter/apiv1p1beta1/auxiliary.go
+++ b/securitycenter/apiv1p1beta1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/securitycenter/apiv1p1beta1/auxiliary_go123.go
+++ b/securitycenter/apiv1p1beta1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/securitycenter/apiv1p1beta1/doc.go
+++ b/securitycenter/apiv1p1beta1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/securitycenter/apiv1p1beta1/helpers.go
+++ b/securitycenter/apiv1p1beta1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/securitycenter/apiv1p1beta1/security_center_client.go
+++ b/securitycenter/apiv1p1beta1/security_center_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/securitycenter/apiv1p1beta1/security_center_client_example_go123_test.go
+++ b/securitycenter/apiv1p1beta1/security_center_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/securitycenter/apiv1p1beta1/security_center_client_example_test.go
+++ b/securitycenter/apiv1p1beta1/security_center_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/securitycenter/apiv2/auxiliary.go
+++ b/securitycenter/apiv2/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/securitycenter/apiv2/auxiliary_go123.go
+++ b/securitycenter/apiv2/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/securitycenter/apiv2/doc.go
+++ b/securitycenter/apiv2/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/securitycenter/apiv2/helpers.go
+++ b/securitycenter/apiv2/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/securitycenter/apiv2/security_center_client.go
+++ b/securitycenter/apiv2/security_center_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/securitycenter/apiv2/security_center_client_example_go123_test.go
+++ b/securitycenter/apiv2/security_center_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/securitycenter/apiv2/security_center_client_example_test.go
+++ b/securitycenter/apiv2/security_center_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/securitycenter/settings/apiv1beta1/auxiliary.go
+++ b/securitycenter/settings/apiv1beta1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/securitycenter/settings/apiv1beta1/auxiliary_go123.go
+++ b/securitycenter/settings/apiv1beta1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/securitycenter/settings/apiv1beta1/doc.go
+++ b/securitycenter/settings/apiv1beta1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/securitycenter/settings/apiv1beta1/helpers.go
+++ b/securitycenter/settings/apiv1beta1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/securitycenter/settings/apiv1beta1/security_center_settings_client.go
+++ b/securitycenter/settings/apiv1beta1/security_center_settings_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/securitycenter/settings/apiv1beta1/security_center_settings_client_example_go123_test.go
+++ b/securitycenter/settings/apiv1beta1/security_center_settings_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/securitycenter/settings/apiv1beta1/security_center_settings_client_example_test.go
+++ b/securitycenter/settings/apiv1beta1/security_center_settings_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/securitycentermanagement/apiv1/auxiliary.go
+++ b/securitycentermanagement/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/securitycentermanagement/apiv1/auxiliary_go123.go
+++ b/securitycentermanagement/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/securitycentermanagement/apiv1/doc.go
+++ b/securitycentermanagement/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/securitycentermanagement/apiv1/helpers.go
+++ b/securitycentermanagement/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/securitycentermanagement/apiv1/security_center_management_client.go
+++ b/securitycentermanagement/apiv1/security_center_management_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/securitycentermanagement/apiv1/security_center_management_client_example_go123_test.go
+++ b/securitycentermanagement/apiv1/security_center_management_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/securitycentermanagement/apiv1/security_center_management_client_example_test.go
+++ b/securitycentermanagement/apiv1/security_center_management_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/securityposture/apiv1/auxiliary.go
+++ b/securityposture/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/securityposture/apiv1/auxiliary_go123.go
+++ b/securityposture/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/securityposture/apiv1/doc.go
+++ b/securityposture/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/securityposture/apiv1/helpers.go
+++ b/securityposture/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/securityposture/apiv1/security_posture_client.go
+++ b/securityposture/apiv1/security_posture_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/securityposture/apiv1/security_posture_client_example_go123_test.go
+++ b/securityposture/apiv1/security_posture_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/securityposture/apiv1/security_posture_client_example_test.go
+++ b/securityposture/apiv1/security_posture_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/servicecontrol/apiv1/auxiliary.go
+++ b/servicecontrol/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/servicecontrol/apiv1/auxiliary_go123.go
+++ b/servicecontrol/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/servicecontrol/apiv1/doc.go
+++ b/servicecontrol/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/servicecontrol/apiv1/helpers.go
+++ b/servicecontrol/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/servicecontrol/apiv1/quota_controller_client.go
+++ b/servicecontrol/apiv1/quota_controller_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/servicecontrol/apiv1/quota_controller_client_example_go123_test.go
+++ b/servicecontrol/apiv1/quota_controller_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/servicecontrol/apiv1/quota_controller_client_example_test.go
+++ b/servicecontrol/apiv1/quota_controller_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/servicecontrol/apiv1/service_controller_client.go
+++ b/servicecontrol/apiv1/service_controller_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/servicecontrol/apiv1/service_controller_client_example_go123_test.go
+++ b/servicecontrol/apiv1/service_controller_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/servicecontrol/apiv1/service_controller_client_example_test.go
+++ b/servicecontrol/apiv1/service_controller_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/servicedirectory/apiv1/auxiliary.go
+++ b/servicedirectory/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/servicedirectory/apiv1/auxiliary_go123.go
+++ b/servicedirectory/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/servicedirectory/apiv1/doc.go
+++ b/servicedirectory/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/servicedirectory/apiv1/helpers.go
+++ b/servicedirectory/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/servicedirectory/apiv1/lookup_client.go
+++ b/servicedirectory/apiv1/lookup_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/servicedirectory/apiv1/lookup_client_example_go123_test.go
+++ b/servicedirectory/apiv1/lookup_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/servicedirectory/apiv1/lookup_client_example_test.go
+++ b/servicedirectory/apiv1/lookup_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/servicedirectory/apiv1/registration_client.go
+++ b/servicedirectory/apiv1/registration_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/servicedirectory/apiv1/registration_client_example_go123_test.go
+++ b/servicedirectory/apiv1/registration_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/servicedirectory/apiv1/registration_client_example_test.go
+++ b/servicedirectory/apiv1/registration_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/servicedirectory/apiv1beta1/auxiliary.go
+++ b/servicedirectory/apiv1beta1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/servicedirectory/apiv1beta1/auxiliary_go123.go
+++ b/servicedirectory/apiv1beta1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/servicedirectory/apiv1beta1/doc.go
+++ b/servicedirectory/apiv1beta1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/servicedirectory/apiv1beta1/helpers.go
+++ b/servicedirectory/apiv1beta1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/servicedirectory/apiv1beta1/lookup_client.go
+++ b/servicedirectory/apiv1beta1/lookup_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/servicedirectory/apiv1beta1/lookup_client_example_go123_test.go
+++ b/servicedirectory/apiv1beta1/lookup_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/servicedirectory/apiv1beta1/lookup_client_example_test.go
+++ b/servicedirectory/apiv1beta1/lookup_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/servicedirectory/apiv1beta1/registration_client.go
+++ b/servicedirectory/apiv1beta1/registration_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/servicedirectory/apiv1beta1/registration_client_example_go123_test.go
+++ b/servicedirectory/apiv1beta1/registration_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/servicedirectory/apiv1beta1/registration_client_example_test.go
+++ b/servicedirectory/apiv1beta1/registration_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/servicehealth/apiv1/auxiliary.go
+++ b/servicehealth/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/servicehealth/apiv1/auxiliary_go123.go
+++ b/servicehealth/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/servicehealth/apiv1/doc.go
+++ b/servicehealth/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/servicehealth/apiv1/helpers.go
+++ b/servicehealth/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/servicehealth/apiv1/service_health_client.go
+++ b/servicehealth/apiv1/service_health_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/servicehealth/apiv1/service_health_client_example_go123_test.go
+++ b/servicehealth/apiv1/service_health_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/servicehealth/apiv1/service_health_client_example_test.go
+++ b/servicehealth/apiv1/service_health_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/servicemanagement/apiv1/auxiliary.go
+++ b/servicemanagement/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/servicemanagement/apiv1/auxiliary_go123.go
+++ b/servicemanagement/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/servicemanagement/apiv1/doc.go
+++ b/servicemanagement/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/servicemanagement/apiv1/helpers.go
+++ b/servicemanagement/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/servicemanagement/apiv1/service_manager_client.go
+++ b/servicemanagement/apiv1/service_manager_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/servicemanagement/apiv1/service_manager_client_example_go123_test.go
+++ b/servicemanagement/apiv1/service_manager_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/servicemanagement/apiv1/service_manager_client_example_test.go
+++ b/servicemanagement/apiv1/service_manager_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/serviceusage/apiv1/auxiliary.go
+++ b/serviceusage/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/serviceusage/apiv1/auxiliary_go123.go
+++ b/serviceusage/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/serviceusage/apiv1/doc.go
+++ b/serviceusage/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/serviceusage/apiv1/helpers.go
+++ b/serviceusage/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/serviceusage/apiv1/service_usage_client.go
+++ b/serviceusage/apiv1/service_usage_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/serviceusage/apiv1/service_usage_client_example_go123_test.go
+++ b/serviceusage/apiv1/service_usage_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/serviceusage/apiv1/service_usage_client_example_test.go
+++ b/serviceusage/apiv1/service_usage_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shell/apiv1/auxiliary.go
+++ b/shell/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shell/apiv1/auxiliary_go123.go
+++ b/shell/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shell/apiv1/cloud_shell_client.go
+++ b/shell/apiv1/cloud_shell_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shell/apiv1/cloud_shell_client_example_go123_test.go
+++ b/shell/apiv1/cloud_shell_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shell/apiv1/cloud_shell_client_example_test.go
+++ b/shell/apiv1/cloud_shell_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shell/apiv1/doc.go
+++ b/shell/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shell/apiv1/helpers.go
+++ b/shell/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/css/apiv1/account_labels_client.go
+++ b/shopping/css/apiv1/account_labels_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/css/apiv1/account_labels_client_example_go123_test.go
+++ b/shopping/css/apiv1/account_labels_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/css/apiv1/account_labels_client_example_test.go
+++ b/shopping/css/apiv1/account_labels_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/css/apiv1/accounts_client.go
+++ b/shopping/css/apiv1/accounts_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/css/apiv1/accounts_client_example_go123_test.go
+++ b/shopping/css/apiv1/accounts_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/css/apiv1/accounts_client_example_test.go
+++ b/shopping/css/apiv1/accounts_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/css/apiv1/auxiliary.go
+++ b/shopping/css/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/css/apiv1/auxiliary_go123.go
+++ b/shopping/css/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/css/apiv1/css_product_inputs_client.go
+++ b/shopping/css/apiv1/css_product_inputs_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/css/apiv1/css_product_inputs_client_example_go123_test.go
+++ b/shopping/css/apiv1/css_product_inputs_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/css/apiv1/css_product_inputs_client_example_test.go
+++ b/shopping/css/apiv1/css_product_inputs_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/css/apiv1/css_products_client.go
+++ b/shopping/css/apiv1/css_products_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/css/apiv1/css_products_client_example_go123_test.go
+++ b/shopping/css/apiv1/css_products_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/css/apiv1/css_products_client_example_test.go
+++ b/shopping/css/apiv1/css_products_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/css/apiv1/doc.go
+++ b/shopping/css/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/css/apiv1/helpers.go
+++ b/shopping/css/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/css/apiv1/quota_client.go
+++ b/shopping/css/apiv1/quota_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/css/apiv1/quota_client_example_go123_test.go
+++ b/shopping/css/apiv1/quota_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/css/apiv1/quota_client_example_test.go
+++ b/shopping/css/apiv1/quota_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1/account_issue_client.go
+++ b/shopping/merchant/accounts/apiv1/account_issue_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1/account_issue_client_example_go123_test.go
+++ b/shopping/merchant/accounts/apiv1/account_issue_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1/account_issue_client_example_test.go
+++ b/shopping/merchant/accounts/apiv1/account_issue_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1/account_relationships_client.go
+++ b/shopping/merchant/accounts/apiv1/account_relationships_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1/account_relationships_client_example_go123_test.go
+++ b/shopping/merchant/accounts/apiv1/account_relationships_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1/account_relationships_client_example_test.go
+++ b/shopping/merchant/accounts/apiv1/account_relationships_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1/account_services_client.go
+++ b/shopping/merchant/accounts/apiv1/account_services_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1/account_services_client_example_go123_test.go
+++ b/shopping/merchant/accounts/apiv1/account_services_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1/account_services_client_example_test.go
+++ b/shopping/merchant/accounts/apiv1/account_services_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1/accounts_client.go
+++ b/shopping/merchant/accounts/apiv1/accounts_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1/accounts_client_example_go123_test.go
+++ b/shopping/merchant/accounts/apiv1/accounts_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1/accounts_client_example_test.go
+++ b/shopping/merchant/accounts/apiv1/accounts_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1/autofeed_settings_client.go
+++ b/shopping/merchant/accounts/apiv1/autofeed_settings_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1/autofeed_settings_client_example_go123_test.go
+++ b/shopping/merchant/accounts/apiv1/autofeed_settings_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1/autofeed_settings_client_example_test.go
+++ b/shopping/merchant/accounts/apiv1/autofeed_settings_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1/automatic_improvements_client.go
+++ b/shopping/merchant/accounts/apiv1/automatic_improvements_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1/automatic_improvements_client_example_go123_test.go
+++ b/shopping/merchant/accounts/apiv1/automatic_improvements_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1/automatic_improvements_client_example_test.go
+++ b/shopping/merchant/accounts/apiv1/automatic_improvements_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1/auxiliary.go
+++ b/shopping/merchant/accounts/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1/auxiliary_go123.go
+++ b/shopping/merchant/accounts/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1/business_identity_client.go
+++ b/shopping/merchant/accounts/apiv1/business_identity_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1/business_identity_client_example_go123_test.go
+++ b/shopping/merchant/accounts/apiv1/business_identity_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1/business_identity_client_example_test.go
+++ b/shopping/merchant/accounts/apiv1/business_identity_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1/business_info_client.go
+++ b/shopping/merchant/accounts/apiv1/business_info_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1/business_info_client_example_go123_test.go
+++ b/shopping/merchant/accounts/apiv1/business_info_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1/business_info_client_example_test.go
+++ b/shopping/merchant/accounts/apiv1/business_info_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1/checkout_settings_client.go
+++ b/shopping/merchant/accounts/apiv1/checkout_settings_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1/checkout_settings_client_example_go123_test.go
+++ b/shopping/merchant/accounts/apiv1/checkout_settings_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1/checkout_settings_client_example_test.go
+++ b/shopping/merchant/accounts/apiv1/checkout_settings_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1/developer_registration_client.go
+++ b/shopping/merchant/accounts/apiv1/developer_registration_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1/developer_registration_client_example_go123_test.go
+++ b/shopping/merchant/accounts/apiv1/developer_registration_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1/developer_registration_client_example_test.go
+++ b/shopping/merchant/accounts/apiv1/developer_registration_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1/doc.go
+++ b/shopping/merchant/accounts/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1/email_preferences_client.go
+++ b/shopping/merchant/accounts/apiv1/email_preferences_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1/email_preferences_client_example_go123_test.go
+++ b/shopping/merchant/accounts/apiv1/email_preferences_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1/email_preferences_client_example_test.go
+++ b/shopping/merchant/accounts/apiv1/email_preferences_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1/gbp_accounts_client.go
+++ b/shopping/merchant/accounts/apiv1/gbp_accounts_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1/gbp_accounts_client_example_go123_test.go
+++ b/shopping/merchant/accounts/apiv1/gbp_accounts_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1/gbp_accounts_client_example_test.go
+++ b/shopping/merchant/accounts/apiv1/gbp_accounts_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1/helpers.go
+++ b/shopping/merchant/accounts/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1/homepage_client.go
+++ b/shopping/merchant/accounts/apiv1/homepage_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1/homepage_client_example_go123_test.go
+++ b/shopping/merchant/accounts/apiv1/homepage_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1/homepage_client_example_test.go
+++ b/shopping/merchant/accounts/apiv1/homepage_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1/lfp_providers_client.go
+++ b/shopping/merchant/accounts/apiv1/lfp_providers_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1/lfp_providers_client_example_go123_test.go
+++ b/shopping/merchant/accounts/apiv1/lfp_providers_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1/lfp_providers_client_example_test.go
+++ b/shopping/merchant/accounts/apiv1/lfp_providers_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1/omnichannel_settings_client.go
+++ b/shopping/merchant/accounts/apiv1/omnichannel_settings_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1/omnichannel_settings_client_example_go123_test.go
+++ b/shopping/merchant/accounts/apiv1/omnichannel_settings_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1/omnichannel_settings_client_example_test.go
+++ b/shopping/merchant/accounts/apiv1/omnichannel_settings_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1/online_return_policy_client.go
+++ b/shopping/merchant/accounts/apiv1/online_return_policy_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1/online_return_policy_client_example_go123_test.go
+++ b/shopping/merchant/accounts/apiv1/online_return_policy_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1/online_return_policy_client_example_test.go
+++ b/shopping/merchant/accounts/apiv1/online_return_policy_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1/programs_client.go
+++ b/shopping/merchant/accounts/apiv1/programs_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1/programs_client_example_go123_test.go
+++ b/shopping/merchant/accounts/apiv1/programs_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1/programs_client_example_test.go
+++ b/shopping/merchant/accounts/apiv1/programs_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1/regions_client.go
+++ b/shopping/merchant/accounts/apiv1/regions_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1/regions_client_example_go123_test.go
+++ b/shopping/merchant/accounts/apiv1/regions_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1/regions_client_example_test.go
+++ b/shopping/merchant/accounts/apiv1/regions_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1/shipping_settings_client.go
+++ b/shopping/merchant/accounts/apiv1/shipping_settings_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1/shipping_settings_client_example_go123_test.go
+++ b/shopping/merchant/accounts/apiv1/shipping_settings_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1/shipping_settings_client_example_test.go
+++ b/shopping/merchant/accounts/apiv1/shipping_settings_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1/terms_of_service_agreement_state_client.go
+++ b/shopping/merchant/accounts/apiv1/terms_of_service_agreement_state_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1/terms_of_service_agreement_state_client_example_go123_test.go
+++ b/shopping/merchant/accounts/apiv1/terms_of_service_agreement_state_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1/terms_of_service_agreement_state_client_example_test.go
+++ b/shopping/merchant/accounts/apiv1/terms_of_service_agreement_state_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1/terms_of_service_client.go
+++ b/shopping/merchant/accounts/apiv1/terms_of_service_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1/terms_of_service_client_example_go123_test.go
+++ b/shopping/merchant/accounts/apiv1/terms_of_service_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1/terms_of_service_client_example_test.go
+++ b/shopping/merchant/accounts/apiv1/terms_of_service_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1/user_client.go
+++ b/shopping/merchant/accounts/apiv1/user_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1/user_client_example_go123_test.go
+++ b/shopping/merchant/accounts/apiv1/user_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1/user_client_example_test.go
+++ b/shopping/merchant/accounts/apiv1/user_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1beta/account_issue_client.go
+++ b/shopping/merchant/accounts/apiv1beta/account_issue_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1beta/account_issue_client_example_go123_test.go
+++ b/shopping/merchant/accounts/apiv1beta/account_issue_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1beta/account_issue_client_example_test.go
+++ b/shopping/merchant/accounts/apiv1beta/account_issue_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1beta/account_tax_client.go
+++ b/shopping/merchant/accounts/apiv1beta/account_tax_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1beta/account_tax_client_example_go123_test.go
+++ b/shopping/merchant/accounts/apiv1beta/account_tax_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1beta/account_tax_client_example_test.go
+++ b/shopping/merchant/accounts/apiv1beta/account_tax_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1beta/accounts_client.go
+++ b/shopping/merchant/accounts/apiv1beta/accounts_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1beta/accounts_client_example_go123_test.go
+++ b/shopping/merchant/accounts/apiv1beta/accounts_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1beta/accounts_client_example_test.go
+++ b/shopping/merchant/accounts/apiv1beta/accounts_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1beta/autofeed_settings_client.go
+++ b/shopping/merchant/accounts/apiv1beta/autofeed_settings_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1beta/autofeed_settings_client_example_go123_test.go
+++ b/shopping/merchant/accounts/apiv1beta/autofeed_settings_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1beta/autofeed_settings_client_example_test.go
+++ b/shopping/merchant/accounts/apiv1beta/autofeed_settings_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1beta/automatic_improvements_client.go
+++ b/shopping/merchant/accounts/apiv1beta/automatic_improvements_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1beta/automatic_improvements_client_example_go123_test.go
+++ b/shopping/merchant/accounts/apiv1beta/automatic_improvements_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1beta/automatic_improvements_client_example_test.go
+++ b/shopping/merchant/accounts/apiv1beta/automatic_improvements_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1beta/auxiliary.go
+++ b/shopping/merchant/accounts/apiv1beta/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1beta/auxiliary_go123.go
+++ b/shopping/merchant/accounts/apiv1beta/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1beta/business_identity_client.go
+++ b/shopping/merchant/accounts/apiv1beta/business_identity_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1beta/business_identity_client_example_go123_test.go
+++ b/shopping/merchant/accounts/apiv1beta/business_identity_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1beta/business_identity_client_example_test.go
+++ b/shopping/merchant/accounts/apiv1beta/business_identity_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1beta/business_info_client.go
+++ b/shopping/merchant/accounts/apiv1beta/business_info_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1beta/business_info_client_example_go123_test.go
+++ b/shopping/merchant/accounts/apiv1beta/business_info_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1beta/business_info_client_example_test.go
+++ b/shopping/merchant/accounts/apiv1beta/business_info_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1beta/checkout_settings_client.go
+++ b/shopping/merchant/accounts/apiv1beta/checkout_settings_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1beta/checkout_settings_client_example_go123_test.go
+++ b/shopping/merchant/accounts/apiv1beta/checkout_settings_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1beta/checkout_settings_client_example_test.go
+++ b/shopping/merchant/accounts/apiv1beta/checkout_settings_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1beta/doc.go
+++ b/shopping/merchant/accounts/apiv1beta/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1beta/email_preferences_client.go
+++ b/shopping/merchant/accounts/apiv1beta/email_preferences_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1beta/email_preferences_client_example_go123_test.go
+++ b/shopping/merchant/accounts/apiv1beta/email_preferences_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1beta/email_preferences_client_example_test.go
+++ b/shopping/merchant/accounts/apiv1beta/email_preferences_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1beta/gbp_accounts_client.go
+++ b/shopping/merchant/accounts/apiv1beta/gbp_accounts_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1beta/gbp_accounts_client_example_go123_test.go
+++ b/shopping/merchant/accounts/apiv1beta/gbp_accounts_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1beta/gbp_accounts_client_example_test.go
+++ b/shopping/merchant/accounts/apiv1beta/gbp_accounts_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1beta/helpers.go
+++ b/shopping/merchant/accounts/apiv1beta/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1beta/homepage_client.go
+++ b/shopping/merchant/accounts/apiv1beta/homepage_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1beta/homepage_client_example_go123_test.go
+++ b/shopping/merchant/accounts/apiv1beta/homepage_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1beta/homepage_client_example_test.go
+++ b/shopping/merchant/accounts/apiv1beta/homepage_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1beta/lfp_providers_client.go
+++ b/shopping/merchant/accounts/apiv1beta/lfp_providers_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1beta/lfp_providers_client_example_go123_test.go
+++ b/shopping/merchant/accounts/apiv1beta/lfp_providers_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1beta/lfp_providers_client_example_test.go
+++ b/shopping/merchant/accounts/apiv1beta/lfp_providers_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1beta/omnichannel_settings_client.go
+++ b/shopping/merchant/accounts/apiv1beta/omnichannel_settings_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1beta/omnichannel_settings_client_example_go123_test.go
+++ b/shopping/merchant/accounts/apiv1beta/omnichannel_settings_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1beta/omnichannel_settings_client_example_test.go
+++ b/shopping/merchant/accounts/apiv1beta/omnichannel_settings_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1beta/online_return_policy_client.go
+++ b/shopping/merchant/accounts/apiv1beta/online_return_policy_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1beta/online_return_policy_client_example_go123_test.go
+++ b/shopping/merchant/accounts/apiv1beta/online_return_policy_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1beta/online_return_policy_client_example_test.go
+++ b/shopping/merchant/accounts/apiv1beta/online_return_policy_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1beta/programs_client.go
+++ b/shopping/merchant/accounts/apiv1beta/programs_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1beta/programs_client_example_go123_test.go
+++ b/shopping/merchant/accounts/apiv1beta/programs_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1beta/programs_client_example_test.go
+++ b/shopping/merchant/accounts/apiv1beta/programs_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1beta/regions_client.go
+++ b/shopping/merchant/accounts/apiv1beta/regions_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1beta/regions_client_example_go123_test.go
+++ b/shopping/merchant/accounts/apiv1beta/regions_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1beta/regions_client_example_test.go
+++ b/shopping/merchant/accounts/apiv1beta/regions_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1beta/shipping_settings_client.go
+++ b/shopping/merchant/accounts/apiv1beta/shipping_settings_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1beta/shipping_settings_client_example_go123_test.go
+++ b/shopping/merchant/accounts/apiv1beta/shipping_settings_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1beta/shipping_settings_client_example_test.go
+++ b/shopping/merchant/accounts/apiv1beta/shipping_settings_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1beta/terms_of_service_agreement_state_client.go
+++ b/shopping/merchant/accounts/apiv1beta/terms_of_service_agreement_state_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1beta/terms_of_service_agreement_state_client_example_go123_test.go
+++ b/shopping/merchant/accounts/apiv1beta/terms_of_service_agreement_state_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1beta/terms_of_service_agreement_state_client_example_test.go
+++ b/shopping/merchant/accounts/apiv1beta/terms_of_service_agreement_state_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1beta/terms_of_service_client.go
+++ b/shopping/merchant/accounts/apiv1beta/terms_of_service_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1beta/terms_of_service_client_example_go123_test.go
+++ b/shopping/merchant/accounts/apiv1beta/terms_of_service_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1beta/terms_of_service_client_example_test.go
+++ b/shopping/merchant/accounts/apiv1beta/terms_of_service_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1beta/user_client.go
+++ b/shopping/merchant/accounts/apiv1beta/user_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1beta/user_client_example_go123_test.go
+++ b/shopping/merchant/accounts/apiv1beta/user_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/accounts/apiv1beta/user_client_example_test.go
+++ b/shopping/merchant/accounts/apiv1beta/user_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/conversions/apiv1/auxiliary.go
+++ b/shopping/merchant/conversions/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/conversions/apiv1/auxiliary_go123.go
+++ b/shopping/merchant/conversions/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/conversions/apiv1/conversion_sources_client.go
+++ b/shopping/merchant/conversions/apiv1/conversion_sources_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/conversions/apiv1/conversion_sources_client_example_go123_test.go
+++ b/shopping/merchant/conversions/apiv1/conversion_sources_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/conversions/apiv1/conversion_sources_client_example_test.go
+++ b/shopping/merchant/conversions/apiv1/conversion_sources_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/conversions/apiv1/doc.go
+++ b/shopping/merchant/conversions/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/conversions/apiv1/helpers.go
+++ b/shopping/merchant/conversions/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/conversions/apiv1beta/auxiliary.go
+++ b/shopping/merchant/conversions/apiv1beta/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/conversions/apiv1beta/auxiliary_go123.go
+++ b/shopping/merchant/conversions/apiv1beta/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/conversions/apiv1beta/conversion_sources_client.go
+++ b/shopping/merchant/conversions/apiv1beta/conversion_sources_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/conversions/apiv1beta/conversion_sources_client_example_go123_test.go
+++ b/shopping/merchant/conversions/apiv1beta/conversion_sources_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/conversions/apiv1beta/conversion_sources_client_example_test.go
+++ b/shopping/merchant/conversions/apiv1beta/conversion_sources_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/conversions/apiv1beta/doc.go
+++ b/shopping/merchant/conversions/apiv1beta/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/conversions/apiv1beta/helpers.go
+++ b/shopping/merchant/conversions/apiv1beta/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/datasources/apiv1/auxiliary.go
+++ b/shopping/merchant/datasources/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/datasources/apiv1/auxiliary_go123.go
+++ b/shopping/merchant/datasources/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/datasources/apiv1/data_sources_client.go
+++ b/shopping/merchant/datasources/apiv1/data_sources_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/datasources/apiv1/data_sources_client_example_go123_test.go
+++ b/shopping/merchant/datasources/apiv1/data_sources_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/datasources/apiv1/data_sources_client_example_test.go
+++ b/shopping/merchant/datasources/apiv1/data_sources_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/datasources/apiv1/doc.go
+++ b/shopping/merchant/datasources/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/datasources/apiv1/file_uploads_client.go
+++ b/shopping/merchant/datasources/apiv1/file_uploads_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/datasources/apiv1/file_uploads_client_example_go123_test.go
+++ b/shopping/merchant/datasources/apiv1/file_uploads_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/datasources/apiv1/file_uploads_client_example_test.go
+++ b/shopping/merchant/datasources/apiv1/file_uploads_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/datasources/apiv1/helpers.go
+++ b/shopping/merchant/datasources/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/datasources/apiv1beta/auxiliary.go
+++ b/shopping/merchant/datasources/apiv1beta/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/datasources/apiv1beta/auxiliary_go123.go
+++ b/shopping/merchant/datasources/apiv1beta/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/datasources/apiv1beta/data_sources_client.go
+++ b/shopping/merchant/datasources/apiv1beta/data_sources_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/datasources/apiv1beta/data_sources_client_example_go123_test.go
+++ b/shopping/merchant/datasources/apiv1beta/data_sources_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/datasources/apiv1beta/data_sources_client_example_test.go
+++ b/shopping/merchant/datasources/apiv1beta/data_sources_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/datasources/apiv1beta/doc.go
+++ b/shopping/merchant/datasources/apiv1beta/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/datasources/apiv1beta/file_uploads_client.go
+++ b/shopping/merchant/datasources/apiv1beta/file_uploads_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/datasources/apiv1beta/file_uploads_client_example_go123_test.go
+++ b/shopping/merchant/datasources/apiv1beta/file_uploads_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/datasources/apiv1beta/file_uploads_client_example_test.go
+++ b/shopping/merchant/datasources/apiv1beta/file_uploads_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/datasources/apiv1beta/helpers.go
+++ b/shopping/merchant/datasources/apiv1beta/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/inventories/apiv1/auxiliary.go
+++ b/shopping/merchant/inventories/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/inventories/apiv1/auxiliary_go123.go
+++ b/shopping/merchant/inventories/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/inventories/apiv1/doc.go
+++ b/shopping/merchant/inventories/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/inventories/apiv1/helpers.go
+++ b/shopping/merchant/inventories/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/inventories/apiv1/local_inventory_client.go
+++ b/shopping/merchant/inventories/apiv1/local_inventory_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/inventories/apiv1/local_inventory_client_example_go123_test.go
+++ b/shopping/merchant/inventories/apiv1/local_inventory_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/inventories/apiv1/local_inventory_client_example_test.go
+++ b/shopping/merchant/inventories/apiv1/local_inventory_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/inventories/apiv1/regional_inventory_client.go
+++ b/shopping/merchant/inventories/apiv1/regional_inventory_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/inventories/apiv1/regional_inventory_client_example_go123_test.go
+++ b/shopping/merchant/inventories/apiv1/regional_inventory_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/inventories/apiv1/regional_inventory_client_example_test.go
+++ b/shopping/merchant/inventories/apiv1/regional_inventory_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/inventories/apiv1beta/auxiliary.go
+++ b/shopping/merchant/inventories/apiv1beta/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/inventories/apiv1beta/auxiliary_go123.go
+++ b/shopping/merchant/inventories/apiv1beta/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/inventories/apiv1beta/doc.go
+++ b/shopping/merchant/inventories/apiv1beta/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/inventories/apiv1beta/helpers.go
+++ b/shopping/merchant/inventories/apiv1beta/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/inventories/apiv1beta/local_inventory_client.go
+++ b/shopping/merchant/inventories/apiv1beta/local_inventory_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/inventories/apiv1beta/local_inventory_client_example_go123_test.go
+++ b/shopping/merchant/inventories/apiv1beta/local_inventory_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/inventories/apiv1beta/local_inventory_client_example_test.go
+++ b/shopping/merchant/inventories/apiv1beta/local_inventory_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/inventories/apiv1beta/regional_inventory_client.go
+++ b/shopping/merchant/inventories/apiv1beta/regional_inventory_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/inventories/apiv1beta/regional_inventory_client_example_go123_test.go
+++ b/shopping/merchant/inventories/apiv1beta/regional_inventory_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/inventories/apiv1beta/regional_inventory_client_example_test.go
+++ b/shopping/merchant/inventories/apiv1beta/regional_inventory_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/issueresolution/apiv1/aggregate_product_statuses_client.go
+++ b/shopping/merchant/issueresolution/apiv1/aggregate_product_statuses_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/issueresolution/apiv1/aggregate_product_statuses_client_example_go123_test.go
+++ b/shopping/merchant/issueresolution/apiv1/aggregate_product_statuses_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/issueresolution/apiv1/aggregate_product_statuses_client_example_test.go
+++ b/shopping/merchant/issueresolution/apiv1/aggregate_product_statuses_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/issueresolution/apiv1/auxiliary.go
+++ b/shopping/merchant/issueresolution/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/issueresolution/apiv1/auxiliary_go123.go
+++ b/shopping/merchant/issueresolution/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/issueresolution/apiv1/doc.go
+++ b/shopping/merchant/issueresolution/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/issueresolution/apiv1/helpers.go
+++ b/shopping/merchant/issueresolution/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/issueresolution/apiv1/issue_resolution_client.go
+++ b/shopping/merchant/issueresolution/apiv1/issue_resolution_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/issueresolution/apiv1/issue_resolution_client_example_go123_test.go
+++ b/shopping/merchant/issueresolution/apiv1/issue_resolution_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/issueresolution/apiv1/issue_resolution_client_example_test.go
+++ b/shopping/merchant/issueresolution/apiv1/issue_resolution_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/issueresolution/apiv1beta/aggregate_product_statuses_client.go
+++ b/shopping/merchant/issueresolution/apiv1beta/aggregate_product_statuses_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/issueresolution/apiv1beta/aggregate_product_statuses_client_example_go123_test.go
+++ b/shopping/merchant/issueresolution/apiv1beta/aggregate_product_statuses_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/issueresolution/apiv1beta/aggregate_product_statuses_client_example_test.go
+++ b/shopping/merchant/issueresolution/apiv1beta/aggregate_product_statuses_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/issueresolution/apiv1beta/auxiliary.go
+++ b/shopping/merchant/issueresolution/apiv1beta/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/issueresolution/apiv1beta/auxiliary_go123.go
+++ b/shopping/merchant/issueresolution/apiv1beta/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/issueresolution/apiv1beta/doc.go
+++ b/shopping/merchant/issueresolution/apiv1beta/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/issueresolution/apiv1beta/helpers.go
+++ b/shopping/merchant/issueresolution/apiv1beta/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/issueresolution/apiv1beta/issue_resolution_client.go
+++ b/shopping/merchant/issueresolution/apiv1beta/issue_resolution_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/issueresolution/apiv1beta/issue_resolution_client_example_go123_test.go
+++ b/shopping/merchant/issueresolution/apiv1beta/issue_resolution_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/issueresolution/apiv1beta/issue_resolution_client_example_test.go
+++ b/shopping/merchant/issueresolution/apiv1beta/issue_resolution_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/lfp/apiv1/auxiliary.go
+++ b/shopping/merchant/lfp/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/lfp/apiv1/auxiliary_go123.go
+++ b/shopping/merchant/lfp/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/lfp/apiv1/doc.go
+++ b/shopping/merchant/lfp/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/lfp/apiv1/helpers.go
+++ b/shopping/merchant/lfp/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/lfp/apiv1/lfp_inventory_client.go
+++ b/shopping/merchant/lfp/apiv1/lfp_inventory_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/lfp/apiv1/lfp_inventory_client_example_go123_test.go
+++ b/shopping/merchant/lfp/apiv1/lfp_inventory_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/lfp/apiv1/lfp_inventory_client_example_test.go
+++ b/shopping/merchant/lfp/apiv1/lfp_inventory_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/lfp/apiv1/lfp_merchant_state_client.go
+++ b/shopping/merchant/lfp/apiv1/lfp_merchant_state_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/lfp/apiv1/lfp_merchant_state_client_example_go123_test.go
+++ b/shopping/merchant/lfp/apiv1/lfp_merchant_state_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/lfp/apiv1/lfp_merchant_state_client_example_test.go
+++ b/shopping/merchant/lfp/apiv1/lfp_merchant_state_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/lfp/apiv1/lfp_sale_client.go
+++ b/shopping/merchant/lfp/apiv1/lfp_sale_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/lfp/apiv1/lfp_sale_client_example_go123_test.go
+++ b/shopping/merchant/lfp/apiv1/lfp_sale_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/lfp/apiv1/lfp_sale_client_example_test.go
+++ b/shopping/merchant/lfp/apiv1/lfp_sale_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/lfp/apiv1/lfp_store_client.go
+++ b/shopping/merchant/lfp/apiv1/lfp_store_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/lfp/apiv1/lfp_store_client_example_go123_test.go
+++ b/shopping/merchant/lfp/apiv1/lfp_store_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/lfp/apiv1/lfp_store_client_example_test.go
+++ b/shopping/merchant/lfp/apiv1/lfp_store_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/lfp/apiv1beta/auxiliary.go
+++ b/shopping/merchant/lfp/apiv1beta/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/lfp/apiv1beta/auxiliary_go123.go
+++ b/shopping/merchant/lfp/apiv1beta/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/lfp/apiv1beta/doc.go
+++ b/shopping/merchant/lfp/apiv1beta/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/lfp/apiv1beta/helpers.go
+++ b/shopping/merchant/lfp/apiv1beta/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/lfp/apiv1beta/lfp_inventory_client.go
+++ b/shopping/merchant/lfp/apiv1beta/lfp_inventory_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/lfp/apiv1beta/lfp_inventory_client_example_go123_test.go
+++ b/shopping/merchant/lfp/apiv1beta/lfp_inventory_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/lfp/apiv1beta/lfp_inventory_client_example_test.go
+++ b/shopping/merchant/lfp/apiv1beta/lfp_inventory_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/lfp/apiv1beta/lfp_merchant_state_client.go
+++ b/shopping/merchant/lfp/apiv1beta/lfp_merchant_state_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/lfp/apiv1beta/lfp_merchant_state_client_example_go123_test.go
+++ b/shopping/merchant/lfp/apiv1beta/lfp_merchant_state_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/lfp/apiv1beta/lfp_merchant_state_client_example_test.go
+++ b/shopping/merchant/lfp/apiv1beta/lfp_merchant_state_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/lfp/apiv1beta/lfp_sale_client.go
+++ b/shopping/merchant/lfp/apiv1beta/lfp_sale_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/lfp/apiv1beta/lfp_sale_client_example_go123_test.go
+++ b/shopping/merchant/lfp/apiv1beta/lfp_sale_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/lfp/apiv1beta/lfp_sale_client_example_test.go
+++ b/shopping/merchant/lfp/apiv1beta/lfp_sale_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/lfp/apiv1beta/lfp_store_client.go
+++ b/shopping/merchant/lfp/apiv1beta/lfp_store_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/lfp/apiv1beta/lfp_store_client_example_go123_test.go
+++ b/shopping/merchant/lfp/apiv1beta/lfp_store_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/lfp/apiv1beta/lfp_store_client_example_test.go
+++ b/shopping/merchant/lfp/apiv1beta/lfp_store_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/notifications/apiv1/auxiliary.go
+++ b/shopping/merchant/notifications/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/notifications/apiv1/auxiliary_go123.go
+++ b/shopping/merchant/notifications/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/notifications/apiv1/doc.go
+++ b/shopping/merchant/notifications/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/notifications/apiv1/helpers.go
+++ b/shopping/merchant/notifications/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/notifications/apiv1/notifications_api_client.go
+++ b/shopping/merchant/notifications/apiv1/notifications_api_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/notifications/apiv1/notifications_api_client_example_go123_test.go
+++ b/shopping/merchant/notifications/apiv1/notifications_api_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/notifications/apiv1/notifications_api_client_example_test.go
+++ b/shopping/merchant/notifications/apiv1/notifications_api_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/notifications/apiv1beta/auxiliary.go
+++ b/shopping/merchant/notifications/apiv1beta/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/notifications/apiv1beta/auxiliary_go123.go
+++ b/shopping/merchant/notifications/apiv1beta/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/notifications/apiv1beta/doc.go
+++ b/shopping/merchant/notifications/apiv1beta/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/notifications/apiv1beta/helpers.go
+++ b/shopping/merchant/notifications/apiv1beta/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/notifications/apiv1beta/notifications_api_client.go
+++ b/shopping/merchant/notifications/apiv1beta/notifications_api_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/notifications/apiv1beta/notifications_api_client_example_go123_test.go
+++ b/shopping/merchant/notifications/apiv1beta/notifications_api_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/notifications/apiv1beta/notifications_api_client_example_test.go
+++ b/shopping/merchant/notifications/apiv1beta/notifications_api_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/ordertracking/apiv1/auxiliary.go
+++ b/shopping/merchant/ordertracking/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/ordertracking/apiv1/auxiliary_go123.go
+++ b/shopping/merchant/ordertracking/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/ordertracking/apiv1/doc.go
+++ b/shopping/merchant/ordertracking/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/ordertracking/apiv1/helpers.go
+++ b/shopping/merchant/ordertracking/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/ordertracking/apiv1/order_tracking_signals_client.go
+++ b/shopping/merchant/ordertracking/apiv1/order_tracking_signals_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/ordertracking/apiv1/order_tracking_signals_client_example_go123_test.go
+++ b/shopping/merchant/ordertracking/apiv1/order_tracking_signals_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/ordertracking/apiv1/order_tracking_signals_client_example_test.go
+++ b/shopping/merchant/ordertracking/apiv1/order_tracking_signals_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/ordertracking/apiv1beta/auxiliary.go
+++ b/shopping/merchant/ordertracking/apiv1beta/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/ordertracking/apiv1beta/auxiliary_go123.go
+++ b/shopping/merchant/ordertracking/apiv1beta/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/ordertracking/apiv1beta/doc.go
+++ b/shopping/merchant/ordertracking/apiv1beta/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/ordertracking/apiv1beta/helpers.go
+++ b/shopping/merchant/ordertracking/apiv1beta/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/ordertracking/apiv1beta/order_tracking_signals_client.go
+++ b/shopping/merchant/ordertracking/apiv1beta/order_tracking_signals_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/ordertracking/apiv1beta/order_tracking_signals_client_example_go123_test.go
+++ b/shopping/merchant/ordertracking/apiv1beta/order_tracking_signals_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/ordertracking/apiv1beta/order_tracking_signals_client_example_test.go
+++ b/shopping/merchant/ordertracking/apiv1beta/order_tracking_signals_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/products/apiv1/auxiliary.go
+++ b/shopping/merchant/products/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/products/apiv1/auxiliary_go123.go
+++ b/shopping/merchant/products/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/products/apiv1/doc.go
+++ b/shopping/merchant/products/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/products/apiv1/helpers.go
+++ b/shopping/merchant/products/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/products/apiv1/product_inputs_client.go
+++ b/shopping/merchant/products/apiv1/product_inputs_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/products/apiv1/product_inputs_client_example_go123_test.go
+++ b/shopping/merchant/products/apiv1/product_inputs_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/products/apiv1/product_inputs_client_example_test.go
+++ b/shopping/merchant/products/apiv1/product_inputs_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/products/apiv1/products_client.go
+++ b/shopping/merchant/products/apiv1/products_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/products/apiv1/products_client_example_go123_test.go
+++ b/shopping/merchant/products/apiv1/products_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/products/apiv1/products_client_example_test.go
+++ b/shopping/merchant/products/apiv1/products_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/products/apiv1beta/auxiliary.go
+++ b/shopping/merchant/products/apiv1beta/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/products/apiv1beta/auxiliary_go123.go
+++ b/shopping/merchant/products/apiv1beta/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/products/apiv1beta/doc.go
+++ b/shopping/merchant/products/apiv1beta/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/products/apiv1beta/helpers.go
+++ b/shopping/merchant/products/apiv1beta/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/products/apiv1beta/product_inputs_client.go
+++ b/shopping/merchant/products/apiv1beta/product_inputs_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/products/apiv1beta/product_inputs_client_example_go123_test.go
+++ b/shopping/merchant/products/apiv1beta/product_inputs_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/products/apiv1beta/product_inputs_client_example_test.go
+++ b/shopping/merchant/products/apiv1beta/product_inputs_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/products/apiv1beta/products_client.go
+++ b/shopping/merchant/products/apiv1beta/products_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/products/apiv1beta/products_client_example_go123_test.go
+++ b/shopping/merchant/products/apiv1beta/products_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/products/apiv1beta/products_client_example_test.go
+++ b/shopping/merchant/products/apiv1beta/products_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/productstudio/apiv1alpha/auxiliary.go
+++ b/shopping/merchant/productstudio/apiv1alpha/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/productstudio/apiv1alpha/auxiliary_go123.go
+++ b/shopping/merchant/productstudio/apiv1alpha/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/productstudio/apiv1alpha/doc.go
+++ b/shopping/merchant/productstudio/apiv1alpha/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/productstudio/apiv1alpha/helpers.go
+++ b/shopping/merchant/productstudio/apiv1alpha/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/productstudio/apiv1alpha/image_client.go
+++ b/shopping/merchant/productstudio/apiv1alpha/image_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/productstudio/apiv1alpha/image_client_example_go123_test.go
+++ b/shopping/merchant/productstudio/apiv1alpha/image_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/productstudio/apiv1alpha/image_client_example_test.go
+++ b/shopping/merchant/productstudio/apiv1alpha/image_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/productstudio/apiv1alpha/text_suggestions_client.go
+++ b/shopping/merchant/productstudio/apiv1alpha/text_suggestions_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/productstudio/apiv1alpha/text_suggestions_client_example_go123_test.go
+++ b/shopping/merchant/productstudio/apiv1alpha/text_suggestions_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/productstudio/apiv1alpha/text_suggestions_client_example_test.go
+++ b/shopping/merchant/productstudio/apiv1alpha/text_suggestions_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/promotions/apiv1/auxiliary.go
+++ b/shopping/merchant/promotions/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/promotions/apiv1/auxiliary_go123.go
+++ b/shopping/merchant/promotions/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/promotions/apiv1/doc.go
+++ b/shopping/merchant/promotions/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/promotions/apiv1/helpers.go
+++ b/shopping/merchant/promotions/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/promotions/apiv1/promotions_client.go
+++ b/shopping/merchant/promotions/apiv1/promotions_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/promotions/apiv1/promotions_client_example_go123_test.go
+++ b/shopping/merchant/promotions/apiv1/promotions_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/promotions/apiv1/promotions_client_example_test.go
+++ b/shopping/merchant/promotions/apiv1/promotions_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/promotions/apiv1beta/auxiliary.go
+++ b/shopping/merchant/promotions/apiv1beta/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/promotions/apiv1beta/auxiliary_go123.go
+++ b/shopping/merchant/promotions/apiv1beta/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/promotions/apiv1beta/doc.go
+++ b/shopping/merchant/promotions/apiv1beta/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/promotions/apiv1beta/helpers.go
+++ b/shopping/merchant/promotions/apiv1beta/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/promotions/apiv1beta/promotions_client.go
+++ b/shopping/merchant/promotions/apiv1beta/promotions_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/promotions/apiv1beta/promotions_client_example_go123_test.go
+++ b/shopping/merchant/promotions/apiv1beta/promotions_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/promotions/apiv1beta/promotions_client_example_test.go
+++ b/shopping/merchant/promotions/apiv1beta/promotions_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/quota/apiv1/account_limits_client.go
+++ b/shopping/merchant/quota/apiv1/account_limits_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/quota/apiv1/account_limits_client_example_go123_test.go
+++ b/shopping/merchant/quota/apiv1/account_limits_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/quota/apiv1/account_limits_client_example_test.go
+++ b/shopping/merchant/quota/apiv1/account_limits_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/quota/apiv1/auxiliary.go
+++ b/shopping/merchant/quota/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/quota/apiv1/auxiliary_go123.go
+++ b/shopping/merchant/quota/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/quota/apiv1/doc.go
+++ b/shopping/merchant/quota/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/quota/apiv1/helpers.go
+++ b/shopping/merchant/quota/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/quota/apiv1/quota_client.go
+++ b/shopping/merchant/quota/apiv1/quota_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/quota/apiv1/quota_client_example_go123_test.go
+++ b/shopping/merchant/quota/apiv1/quota_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/quota/apiv1/quota_client_example_test.go
+++ b/shopping/merchant/quota/apiv1/quota_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/quota/apiv1beta/auxiliary.go
+++ b/shopping/merchant/quota/apiv1beta/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/quota/apiv1beta/auxiliary_go123.go
+++ b/shopping/merchant/quota/apiv1beta/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/quota/apiv1beta/doc.go
+++ b/shopping/merchant/quota/apiv1beta/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/quota/apiv1beta/helpers.go
+++ b/shopping/merchant/quota/apiv1beta/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/quota/apiv1beta/quota_client.go
+++ b/shopping/merchant/quota/apiv1beta/quota_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/quota/apiv1beta/quota_client_example_go123_test.go
+++ b/shopping/merchant/quota/apiv1beta/quota_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/quota/apiv1beta/quota_client_example_test.go
+++ b/shopping/merchant/quota/apiv1beta/quota_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/reports/apiv1/auxiliary.go
+++ b/shopping/merchant/reports/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/reports/apiv1/auxiliary_go123.go
+++ b/shopping/merchant/reports/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/reports/apiv1/doc.go
+++ b/shopping/merchant/reports/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/reports/apiv1/helpers.go
+++ b/shopping/merchant/reports/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/reports/apiv1/report_client.go
+++ b/shopping/merchant/reports/apiv1/report_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/reports/apiv1/report_client_example_go123_test.go
+++ b/shopping/merchant/reports/apiv1/report_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/reports/apiv1/report_client_example_test.go
+++ b/shopping/merchant/reports/apiv1/report_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/reports/apiv1beta/auxiliary.go
+++ b/shopping/merchant/reports/apiv1beta/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/reports/apiv1beta/auxiliary_go123.go
+++ b/shopping/merchant/reports/apiv1beta/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/reports/apiv1beta/doc.go
+++ b/shopping/merchant/reports/apiv1beta/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/reports/apiv1beta/helpers.go
+++ b/shopping/merchant/reports/apiv1beta/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/reports/apiv1beta/report_client.go
+++ b/shopping/merchant/reports/apiv1beta/report_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/reports/apiv1beta/report_client_example_go123_test.go
+++ b/shopping/merchant/reports/apiv1beta/report_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/reports/apiv1beta/report_client_example_test.go
+++ b/shopping/merchant/reports/apiv1beta/report_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/reviews/apiv1beta/auxiliary.go
+++ b/shopping/merchant/reviews/apiv1beta/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/reviews/apiv1beta/auxiliary_go123.go
+++ b/shopping/merchant/reviews/apiv1beta/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/reviews/apiv1beta/doc.go
+++ b/shopping/merchant/reviews/apiv1beta/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/reviews/apiv1beta/helpers.go
+++ b/shopping/merchant/reviews/apiv1beta/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/reviews/apiv1beta/merchant_reviews_client.go
+++ b/shopping/merchant/reviews/apiv1beta/merchant_reviews_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/reviews/apiv1beta/merchant_reviews_client_example_go123_test.go
+++ b/shopping/merchant/reviews/apiv1beta/merchant_reviews_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/reviews/apiv1beta/merchant_reviews_client_example_test.go
+++ b/shopping/merchant/reviews/apiv1beta/merchant_reviews_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/reviews/apiv1beta/product_reviews_client.go
+++ b/shopping/merchant/reviews/apiv1beta/product_reviews_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/reviews/apiv1beta/product_reviews_client_example_go123_test.go
+++ b/shopping/merchant/reviews/apiv1beta/product_reviews_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shopping/merchant/reviews/apiv1beta/product_reviews_client_example_test.go
+++ b/shopping/merchant/reviews/apiv1beta/product_reviews_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/storage/control/apiv2/auxiliary.go
+++ b/storage/control/apiv2/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/storage/control/apiv2/auxiliary_go123.go
+++ b/storage/control/apiv2/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/storage/control/apiv2/doc.go
+++ b/storage/control/apiv2/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/storage/control/apiv2/helpers.go
+++ b/storage/control/apiv2/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/storage/control/apiv2/storage_control_client.go
+++ b/storage/control/apiv2/storage_control_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/storage/control/apiv2/storage_control_client_example_go123_test.go
+++ b/storage/control/apiv2/storage_control_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/storage/control/apiv2/storage_control_client_example_test.go
+++ b/storage/control/apiv2/storage_control_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/storage/internal/apiv2/auxiliary.go
+++ b/storage/internal/apiv2/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/storage/internal/apiv2/auxiliary_go123.go
+++ b/storage/internal/apiv2/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/storage/internal/apiv2/doc.go
+++ b/storage/internal/apiv2/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/storage/internal/apiv2/helpers.go
+++ b/storage/internal/apiv2/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/storage/internal/apiv2/storage_client.go
+++ b/storage/internal/apiv2/storage_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/storage/internal/apiv2/storage_client_example_go123_test.go
+++ b/storage/internal/apiv2/storage_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/storage/internal/apiv2/storage_client_example_test.go
+++ b/storage/internal/apiv2/storage_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/storagebatchoperations/apiv1/auxiliary.go
+++ b/storagebatchoperations/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/storagebatchoperations/apiv1/auxiliary_go123.go
+++ b/storagebatchoperations/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/storagebatchoperations/apiv1/doc.go
+++ b/storagebatchoperations/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/storagebatchoperations/apiv1/helpers.go
+++ b/storagebatchoperations/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/storagebatchoperations/apiv1/storage_batch_operations_client.go
+++ b/storagebatchoperations/apiv1/storage_batch_operations_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/storagebatchoperations/apiv1/storage_batch_operations_client_example_go123_test.go
+++ b/storagebatchoperations/apiv1/storage_batch_operations_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/storagebatchoperations/apiv1/storage_batch_operations_client_example_test.go
+++ b/storagebatchoperations/apiv1/storage_batch_operations_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/storageinsights/apiv1/auxiliary.go
+++ b/storageinsights/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/storageinsights/apiv1/auxiliary_go123.go
+++ b/storageinsights/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/storageinsights/apiv1/doc.go
+++ b/storageinsights/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/storageinsights/apiv1/helpers.go
+++ b/storageinsights/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/storageinsights/apiv1/storage_insights_client.go
+++ b/storageinsights/apiv1/storage_insights_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/storageinsights/apiv1/storage_insights_client_example_go123_test.go
+++ b/storageinsights/apiv1/storage_insights_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/storageinsights/apiv1/storage_insights_client_example_test.go
+++ b/storageinsights/apiv1/storage_insights_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/storagetransfer/apiv1/auxiliary.go
+++ b/storagetransfer/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/storagetransfer/apiv1/auxiliary_go123.go
+++ b/storagetransfer/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/storagetransfer/apiv1/doc.go
+++ b/storagetransfer/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/storagetransfer/apiv1/helpers.go
+++ b/storagetransfer/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/storagetransfer/apiv1/storage_transfer_client.go
+++ b/storagetransfer/apiv1/storage_transfer_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/storagetransfer/apiv1/storage_transfer_client_example_go123_test.go
+++ b/storagetransfer/apiv1/storage_transfer_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/storagetransfer/apiv1/storage_transfer_client_example_test.go
+++ b/storagetransfer/apiv1/storage_transfer_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/streetview/publish/apiv1/auxiliary.go
+++ b/streetview/publish/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/streetview/publish/apiv1/auxiliary_go123.go
+++ b/streetview/publish/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/streetview/publish/apiv1/doc.go
+++ b/streetview/publish/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/streetview/publish/apiv1/helpers.go
+++ b/streetview/publish/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/streetview/publish/apiv1/street_view_publish_client.go
+++ b/streetview/publish/apiv1/street_view_publish_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/streetview/publish/apiv1/street_view_publish_client_example_go123_test.go
+++ b/streetview/publish/apiv1/street_view_publish_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/streetview/publish/apiv1/street_view_publish_client_example_test.go
+++ b/streetview/publish/apiv1/street_view_publish_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/support/apiv2/auxiliary.go
+++ b/support/apiv2/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/support/apiv2/auxiliary_go123.go
+++ b/support/apiv2/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/support/apiv2/case_attachment_client.go
+++ b/support/apiv2/case_attachment_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/support/apiv2/case_attachment_client_example_go123_test.go
+++ b/support/apiv2/case_attachment_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/support/apiv2/case_attachment_client_example_test.go
+++ b/support/apiv2/case_attachment_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/support/apiv2/case_client.go
+++ b/support/apiv2/case_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/support/apiv2/case_client_example_go123_test.go
+++ b/support/apiv2/case_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/support/apiv2/case_client_example_test.go
+++ b/support/apiv2/case_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/support/apiv2/comment_client.go
+++ b/support/apiv2/comment_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/support/apiv2/comment_client_example_go123_test.go
+++ b/support/apiv2/comment_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/support/apiv2/comment_client_example_test.go
+++ b/support/apiv2/comment_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/support/apiv2/doc.go
+++ b/support/apiv2/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/support/apiv2/helpers.go
+++ b/support/apiv2/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/support/apiv2beta/auxiliary.go
+++ b/support/apiv2beta/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/support/apiv2beta/auxiliary_go123.go
+++ b/support/apiv2beta/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/support/apiv2beta/case_attachment_client.go
+++ b/support/apiv2beta/case_attachment_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/support/apiv2beta/case_attachment_client_example_go123_test.go
+++ b/support/apiv2beta/case_attachment_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/support/apiv2beta/case_attachment_client_example_test.go
+++ b/support/apiv2beta/case_attachment_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/support/apiv2beta/case_client.go
+++ b/support/apiv2beta/case_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/support/apiv2beta/case_client_example_go123_test.go
+++ b/support/apiv2beta/case_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/support/apiv2beta/case_client_example_test.go
+++ b/support/apiv2beta/case_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/support/apiv2beta/comment_client.go
+++ b/support/apiv2beta/comment_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/support/apiv2beta/comment_client_example_go123_test.go
+++ b/support/apiv2beta/comment_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/support/apiv2beta/comment_client_example_test.go
+++ b/support/apiv2beta/comment_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/support/apiv2beta/doc.go
+++ b/support/apiv2beta/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/support/apiv2beta/feed_client.go
+++ b/support/apiv2beta/feed_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/support/apiv2beta/feed_client_example_go123_test.go
+++ b/support/apiv2beta/feed_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/support/apiv2beta/feed_client_example_test.go
+++ b/support/apiv2beta/feed_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/support/apiv2beta/helpers.go
+++ b/support/apiv2beta/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/talent/apiv4/auxiliary.go
+++ b/talent/apiv4/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/talent/apiv4/auxiliary_go123.go
+++ b/talent/apiv4/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/talent/apiv4/company_client.go
+++ b/talent/apiv4/company_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/talent/apiv4/company_client_example_go123_test.go
+++ b/talent/apiv4/company_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/talent/apiv4/company_client_example_test.go
+++ b/talent/apiv4/company_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/talent/apiv4/completion_client.go
+++ b/talent/apiv4/completion_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/talent/apiv4/completion_client_example_go123_test.go
+++ b/talent/apiv4/completion_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/talent/apiv4/completion_client_example_test.go
+++ b/talent/apiv4/completion_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/talent/apiv4/doc.go
+++ b/talent/apiv4/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/talent/apiv4/event_client.go
+++ b/talent/apiv4/event_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/talent/apiv4/event_client_example_go123_test.go
+++ b/talent/apiv4/event_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/talent/apiv4/event_client_example_test.go
+++ b/talent/apiv4/event_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/talent/apiv4/helpers.go
+++ b/talent/apiv4/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/talent/apiv4/job_client.go
+++ b/talent/apiv4/job_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/talent/apiv4/job_client_example_go123_test.go
+++ b/talent/apiv4/job_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/talent/apiv4/job_client_example_test.go
+++ b/talent/apiv4/job_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/talent/apiv4/tenant_client.go
+++ b/talent/apiv4/tenant_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/talent/apiv4/tenant_client_example_go123_test.go
+++ b/talent/apiv4/tenant_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/talent/apiv4/tenant_client_example_test.go
+++ b/talent/apiv4/tenant_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/talent/apiv4beta1/auxiliary.go
+++ b/talent/apiv4beta1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/talent/apiv4beta1/auxiliary_go123.go
+++ b/talent/apiv4beta1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/talent/apiv4beta1/company_client.go
+++ b/talent/apiv4beta1/company_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/talent/apiv4beta1/company_client_example_go123_test.go
+++ b/talent/apiv4beta1/company_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/talent/apiv4beta1/company_client_example_test.go
+++ b/talent/apiv4beta1/company_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/talent/apiv4beta1/completion_client.go
+++ b/talent/apiv4beta1/completion_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/talent/apiv4beta1/completion_client_example_go123_test.go
+++ b/talent/apiv4beta1/completion_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/talent/apiv4beta1/completion_client_example_test.go
+++ b/talent/apiv4beta1/completion_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/talent/apiv4beta1/doc.go
+++ b/talent/apiv4beta1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/talent/apiv4beta1/event_client.go
+++ b/talent/apiv4beta1/event_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/talent/apiv4beta1/event_client_example_go123_test.go
+++ b/talent/apiv4beta1/event_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/talent/apiv4beta1/event_client_example_test.go
+++ b/talent/apiv4beta1/event_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/talent/apiv4beta1/helpers.go
+++ b/talent/apiv4beta1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/talent/apiv4beta1/job_client.go
+++ b/talent/apiv4beta1/job_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/talent/apiv4beta1/job_client_example_go123_test.go
+++ b/talent/apiv4beta1/job_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/talent/apiv4beta1/job_client_example_test.go
+++ b/talent/apiv4beta1/job_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/talent/apiv4beta1/tenant_client.go
+++ b/talent/apiv4beta1/tenant_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/talent/apiv4beta1/tenant_client_example_go123_test.go
+++ b/talent/apiv4beta1/tenant_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/talent/apiv4beta1/tenant_client_example_test.go
+++ b/talent/apiv4beta1/tenant_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/telcoautomation/apiv1/auxiliary.go
+++ b/telcoautomation/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/telcoautomation/apiv1/auxiliary_go123.go
+++ b/telcoautomation/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/telcoautomation/apiv1/doc.go
+++ b/telcoautomation/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/telcoautomation/apiv1/helpers.go
+++ b/telcoautomation/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/telcoautomation/apiv1/telco_automation_client.go
+++ b/telcoautomation/apiv1/telco_automation_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/telcoautomation/apiv1/telco_automation_client_example_go123_test.go
+++ b/telcoautomation/apiv1/telco_automation_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/telcoautomation/apiv1/telco_automation_client_example_test.go
+++ b/telcoautomation/apiv1/telco_automation_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/texttospeech/apiv1/auxiliary.go
+++ b/texttospeech/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/texttospeech/apiv1/auxiliary_go123.go
+++ b/texttospeech/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/texttospeech/apiv1/doc.go
+++ b/texttospeech/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/texttospeech/apiv1/helpers.go
+++ b/texttospeech/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/texttospeech/apiv1/text_to_speech_client.go
+++ b/texttospeech/apiv1/text_to_speech_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/texttospeech/apiv1/text_to_speech_client_example_go123_test.go
+++ b/texttospeech/apiv1/text_to_speech_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/texttospeech/apiv1/text_to_speech_client_example_test.go
+++ b/texttospeech/apiv1/text_to_speech_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/texttospeech/apiv1/text_to_speech_long_audio_synthesize_client.go
+++ b/texttospeech/apiv1/text_to_speech_long_audio_synthesize_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/texttospeech/apiv1/text_to_speech_long_audio_synthesize_client_example_go123_test.go
+++ b/texttospeech/apiv1/text_to_speech_long_audio_synthesize_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/texttospeech/apiv1/text_to_speech_long_audio_synthesize_client_example_test.go
+++ b/texttospeech/apiv1/text_to_speech_long_audio_synthesize_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tpu/apiv1/auxiliary.go
+++ b/tpu/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tpu/apiv1/auxiliary_go123.go
+++ b/tpu/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tpu/apiv1/doc.go
+++ b/tpu/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tpu/apiv1/helpers.go
+++ b/tpu/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tpu/apiv1/tpu_client.go
+++ b/tpu/apiv1/tpu_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tpu/apiv1/tpu_client_example_go123_test.go
+++ b/tpu/apiv1/tpu_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tpu/apiv1/tpu_client_example_test.go
+++ b/tpu/apiv1/tpu_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/trace/apiv1/auxiliary.go
+++ b/trace/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/trace/apiv1/auxiliary_go123.go
+++ b/trace/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/trace/apiv1/doc.go
+++ b/trace/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/trace/apiv1/helpers.go
+++ b/trace/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/trace/apiv1/trace_client.go
+++ b/trace/apiv1/trace_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/trace/apiv1/trace_client_example_go123_test.go
+++ b/trace/apiv1/trace_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/trace/apiv1/trace_client_example_test.go
+++ b/trace/apiv1/trace_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/trace/apiv2/auxiliary.go
+++ b/trace/apiv2/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/trace/apiv2/auxiliary_go123.go
+++ b/trace/apiv2/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/trace/apiv2/doc.go
+++ b/trace/apiv2/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/trace/apiv2/helpers.go
+++ b/trace/apiv2/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/trace/apiv2/trace_client.go
+++ b/trace/apiv2/trace_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/trace/apiv2/trace_client_example_go123_test.go
+++ b/trace/apiv2/trace_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/trace/apiv2/trace_client_example_test.go
+++ b/trace/apiv2/trace_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/translate/apiv3/auxiliary.go
+++ b/translate/apiv3/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/translate/apiv3/auxiliary_go123.go
+++ b/translate/apiv3/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/translate/apiv3/doc.go
+++ b/translate/apiv3/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/translate/apiv3/helpers.go
+++ b/translate/apiv3/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/translate/apiv3/translation_client.go
+++ b/translate/apiv3/translation_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/translate/apiv3/translation_client_example_go123_test.go
+++ b/translate/apiv3/translation_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/translate/apiv3/translation_client_example_test.go
+++ b/translate/apiv3/translation_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vectorsearch/apiv1beta/auxiliary.go
+++ b/vectorsearch/apiv1beta/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vectorsearch/apiv1beta/auxiliary_go123.go
+++ b/vectorsearch/apiv1beta/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vectorsearch/apiv1beta/data_object_client.go
+++ b/vectorsearch/apiv1beta/data_object_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vectorsearch/apiv1beta/data_object_client_example_go123_test.go
+++ b/vectorsearch/apiv1beta/data_object_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vectorsearch/apiv1beta/data_object_client_example_test.go
+++ b/vectorsearch/apiv1beta/data_object_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vectorsearch/apiv1beta/data_object_search_client.go
+++ b/vectorsearch/apiv1beta/data_object_search_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vectorsearch/apiv1beta/data_object_search_client_example_go123_test.go
+++ b/vectorsearch/apiv1beta/data_object_search_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vectorsearch/apiv1beta/data_object_search_client_example_test.go
+++ b/vectorsearch/apiv1beta/data_object_search_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vectorsearch/apiv1beta/doc.go
+++ b/vectorsearch/apiv1beta/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vectorsearch/apiv1beta/helpers.go
+++ b/vectorsearch/apiv1beta/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vectorsearch/apiv1beta/vector_search_client.go
+++ b/vectorsearch/apiv1beta/vector_search_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vectorsearch/apiv1beta/vector_search_client_example_go123_test.go
+++ b/vectorsearch/apiv1beta/vector_search_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vectorsearch/apiv1beta/vector_search_client_example_test.go
+++ b/vectorsearch/apiv1beta/vector_search_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/video/livestream/apiv1/auxiliary.go
+++ b/video/livestream/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/video/livestream/apiv1/auxiliary_go123.go
+++ b/video/livestream/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/video/livestream/apiv1/doc.go
+++ b/video/livestream/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/video/livestream/apiv1/helpers.go
+++ b/video/livestream/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/video/livestream/apiv1/livestream_client.go
+++ b/video/livestream/apiv1/livestream_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/video/livestream/apiv1/livestream_client_example_go123_test.go
+++ b/video/livestream/apiv1/livestream_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/video/livestream/apiv1/livestream_client_example_test.go
+++ b/video/livestream/apiv1/livestream_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/video/stitcher/apiv1/auxiliary.go
+++ b/video/stitcher/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/video/stitcher/apiv1/auxiliary_go123.go
+++ b/video/stitcher/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/video/stitcher/apiv1/doc.go
+++ b/video/stitcher/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/video/stitcher/apiv1/helpers.go
+++ b/video/stitcher/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/video/stitcher/apiv1/video_stitcher_client.go
+++ b/video/stitcher/apiv1/video_stitcher_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/video/stitcher/apiv1/video_stitcher_client_example_go123_test.go
+++ b/video/stitcher/apiv1/video_stitcher_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/video/stitcher/apiv1/video_stitcher_client_example_test.go
+++ b/video/stitcher/apiv1/video_stitcher_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/video/transcoder/apiv1/auxiliary.go
+++ b/video/transcoder/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/video/transcoder/apiv1/auxiliary_go123.go
+++ b/video/transcoder/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/video/transcoder/apiv1/doc.go
+++ b/video/transcoder/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/video/transcoder/apiv1/helpers.go
+++ b/video/transcoder/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/video/transcoder/apiv1/transcoder_client.go
+++ b/video/transcoder/apiv1/transcoder_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/video/transcoder/apiv1/transcoder_client_example_go123_test.go
+++ b/video/transcoder/apiv1/transcoder_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/video/transcoder/apiv1/transcoder_client_example_test.go
+++ b/video/transcoder/apiv1/transcoder_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/videointelligence/apiv1/auxiliary.go
+++ b/videointelligence/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/videointelligence/apiv1/auxiliary_go123.go
+++ b/videointelligence/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/videointelligence/apiv1/doc.go
+++ b/videointelligence/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/videointelligence/apiv1/helpers.go
+++ b/videointelligence/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/videointelligence/apiv1/video_intelligence_client.go
+++ b/videointelligence/apiv1/video_intelligence_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/videointelligence/apiv1/video_intelligence_client_example_go123_test.go
+++ b/videointelligence/apiv1/video_intelligence_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/videointelligence/apiv1/video_intelligence_client_example_test.go
+++ b/videointelligence/apiv1/video_intelligence_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/videointelligence/apiv1beta2/auxiliary.go
+++ b/videointelligence/apiv1beta2/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/videointelligence/apiv1beta2/auxiliary_go123.go
+++ b/videointelligence/apiv1beta2/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/videointelligence/apiv1beta2/doc.go
+++ b/videointelligence/apiv1beta2/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/videointelligence/apiv1beta2/helpers.go
+++ b/videointelligence/apiv1beta2/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/videointelligence/apiv1beta2/video_intelligence_client.go
+++ b/videointelligence/apiv1beta2/video_intelligence_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/videointelligence/apiv1beta2/video_intelligence_client_example_go123_test.go
+++ b/videointelligence/apiv1beta2/video_intelligence_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/videointelligence/apiv1beta2/video_intelligence_client_example_test.go
+++ b/videointelligence/apiv1beta2/video_intelligence_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/videointelligence/apiv1p3beta1/auxiliary.go
+++ b/videointelligence/apiv1p3beta1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/videointelligence/apiv1p3beta1/auxiliary_go123.go
+++ b/videointelligence/apiv1p3beta1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/videointelligence/apiv1p3beta1/doc.go
+++ b/videointelligence/apiv1p3beta1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/videointelligence/apiv1p3beta1/helpers.go
+++ b/videointelligence/apiv1p3beta1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/videointelligence/apiv1p3beta1/streaming_video_intelligence_client.go
+++ b/videointelligence/apiv1p3beta1/streaming_video_intelligence_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/videointelligence/apiv1p3beta1/streaming_video_intelligence_client_example_go123_test.go
+++ b/videointelligence/apiv1p3beta1/streaming_video_intelligence_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/videointelligence/apiv1p3beta1/streaming_video_intelligence_client_example_test.go
+++ b/videointelligence/apiv1p3beta1/streaming_video_intelligence_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/videointelligence/apiv1p3beta1/video_intelligence_client.go
+++ b/videointelligence/apiv1p3beta1/video_intelligence_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/videointelligence/apiv1p3beta1/video_intelligence_client_example_go123_test.go
+++ b/videointelligence/apiv1p3beta1/video_intelligence_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/videointelligence/apiv1p3beta1/video_intelligence_client_example_test.go
+++ b/videointelligence/apiv1p3beta1/video_intelligence_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vision/apiv1/auxiliary.go
+++ b/vision/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vision/apiv1/auxiliary_go123.go
+++ b/vision/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vision/apiv1/doc.go
+++ b/vision/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vision/apiv1/helpers.go
+++ b/vision/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vision/apiv1/image_annotator_client.go
+++ b/vision/apiv1/image_annotator_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vision/apiv1/image_annotator_client_example_go123_test.go
+++ b/vision/apiv1/image_annotator_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vision/apiv1/image_annotator_client_example_test.go
+++ b/vision/apiv1/image_annotator_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vision/apiv1/product_search_client.go
+++ b/vision/apiv1/product_search_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vision/apiv1/product_search_client_example_go123_test.go
+++ b/vision/apiv1/product_search_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vision/apiv1/product_search_client_example_test.go
+++ b/vision/apiv1/product_search_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vision/apiv1p1beta1/auxiliary.go
+++ b/vision/apiv1p1beta1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vision/apiv1p1beta1/auxiliary_go123.go
+++ b/vision/apiv1p1beta1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vision/apiv1p1beta1/doc.go
+++ b/vision/apiv1p1beta1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vision/apiv1p1beta1/helpers.go
+++ b/vision/apiv1p1beta1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vision/apiv1p1beta1/image_annotator_client.go
+++ b/vision/apiv1p1beta1/image_annotator_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vision/apiv1p1beta1/image_annotator_client_example_go123_test.go
+++ b/vision/apiv1p1beta1/image_annotator_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vision/apiv1p1beta1/image_annotator_client_example_test.go
+++ b/vision/apiv1p1beta1/image_annotator_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/visionai/apiv1/app_platform_client.go
+++ b/visionai/apiv1/app_platform_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/visionai/apiv1/app_platform_client_example_go123_test.go
+++ b/visionai/apiv1/app_platform_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/visionai/apiv1/app_platform_client_example_test.go
+++ b/visionai/apiv1/app_platform_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/visionai/apiv1/auxiliary.go
+++ b/visionai/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/visionai/apiv1/auxiliary_go123.go
+++ b/visionai/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/visionai/apiv1/doc.go
+++ b/visionai/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/visionai/apiv1/health_check_client.go
+++ b/visionai/apiv1/health_check_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/visionai/apiv1/health_check_client_example_go123_test.go
+++ b/visionai/apiv1/health_check_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/visionai/apiv1/health_check_client_example_test.go
+++ b/visionai/apiv1/health_check_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/visionai/apiv1/helpers.go
+++ b/visionai/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/visionai/apiv1/live_video_analytics_client.go
+++ b/visionai/apiv1/live_video_analytics_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/visionai/apiv1/live_video_analytics_client_example_go123_test.go
+++ b/visionai/apiv1/live_video_analytics_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/visionai/apiv1/live_video_analytics_client_example_test.go
+++ b/visionai/apiv1/live_video_analytics_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/visionai/apiv1/streaming_client.go
+++ b/visionai/apiv1/streaming_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/visionai/apiv1/streaming_client_example_go123_test.go
+++ b/visionai/apiv1/streaming_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/visionai/apiv1/streaming_client_example_test.go
+++ b/visionai/apiv1/streaming_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/visionai/apiv1/streams_client.go
+++ b/visionai/apiv1/streams_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/visionai/apiv1/streams_client_example_go123_test.go
+++ b/visionai/apiv1/streams_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/visionai/apiv1/streams_client_example_test.go
+++ b/visionai/apiv1/streams_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/visionai/apiv1/warehouse_client.go
+++ b/visionai/apiv1/warehouse_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/visionai/apiv1/warehouse_client_example_go123_test.go
+++ b/visionai/apiv1/warehouse_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/visionai/apiv1/warehouse_client_example_test.go
+++ b/visionai/apiv1/warehouse_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vmmigration/apiv1/auxiliary.go
+++ b/vmmigration/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vmmigration/apiv1/auxiliary_go123.go
+++ b/vmmigration/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vmmigration/apiv1/doc.go
+++ b/vmmigration/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vmmigration/apiv1/helpers.go
+++ b/vmmigration/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vmmigration/apiv1/vm_migration_client.go
+++ b/vmmigration/apiv1/vm_migration_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vmmigration/apiv1/vm_migration_client_example_go123_test.go
+++ b/vmmigration/apiv1/vm_migration_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vmmigration/apiv1/vm_migration_client_example_test.go
+++ b/vmmigration/apiv1/vm_migration_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vmwareengine/apiv1/auxiliary.go
+++ b/vmwareengine/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vmwareengine/apiv1/auxiliary_go123.go
+++ b/vmwareengine/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vmwareengine/apiv1/doc.go
+++ b/vmwareengine/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vmwareengine/apiv1/helpers.go
+++ b/vmwareengine/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vmwareengine/apiv1/vmware_engine_client.go
+++ b/vmwareengine/apiv1/vmware_engine_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vmwareengine/apiv1/vmware_engine_client_example_go123_test.go
+++ b/vmwareengine/apiv1/vmware_engine_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vmwareengine/apiv1/vmware_engine_client_example_test.go
+++ b/vmwareengine/apiv1/vmware_engine_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vpcaccess/apiv1/auxiliary.go
+++ b/vpcaccess/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vpcaccess/apiv1/auxiliary_go123.go
+++ b/vpcaccess/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vpcaccess/apiv1/doc.go
+++ b/vpcaccess/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vpcaccess/apiv1/helpers.go
+++ b/vpcaccess/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vpcaccess/apiv1/vpc_access_client.go
+++ b/vpcaccess/apiv1/vpc_access_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vpcaccess/apiv1/vpc_access_client_example_go123_test.go
+++ b/vpcaccess/apiv1/vpc_access_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vpcaccess/apiv1/vpc_access_client_example_test.go
+++ b/vpcaccess/apiv1/vpc_access_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/webrisk/apiv1/auxiliary.go
+++ b/webrisk/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/webrisk/apiv1/auxiliary_go123.go
+++ b/webrisk/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/webrisk/apiv1/doc.go
+++ b/webrisk/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/webrisk/apiv1/helpers.go
+++ b/webrisk/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/webrisk/apiv1/web_risk_client.go
+++ b/webrisk/apiv1/web_risk_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/webrisk/apiv1/web_risk_client_example_go123_test.go
+++ b/webrisk/apiv1/web_risk_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/webrisk/apiv1/web_risk_client_example_test.go
+++ b/webrisk/apiv1/web_risk_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/webrisk/apiv1beta1/auxiliary.go
+++ b/webrisk/apiv1beta1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/webrisk/apiv1beta1/auxiliary_go123.go
+++ b/webrisk/apiv1beta1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/webrisk/apiv1beta1/doc.go
+++ b/webrisk/apiv1beta1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/webrisk/apiv1beta1/helpers.go
+++ b/webrisk/apiv1beta1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/webrisk/apiv1beta1/web_risk_service_v1_beta1_client.go
+++ b/webrisk/apiv1beta1/web_risk_service_v1_beta1_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/webrisk/apiv1beta1/web_risk_service_v1_beta1_client_example_go123_test.go
+++ b/webrisk/apiv1beta1/web_risk_service_v1_beta1_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/webrisk/apiv1beta1/web_risk_service_v1_beta1_client_example_test.go
+++ b/webrisk/apiv1beta1/web_risk_service_v1_beta1_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/websecurityscanner/apiv1/auxiliary.go
+++ b/websecurityscanner/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/websecurityscanner/apiv1/auxiliary_go123.go
+++ b/websecurityscanner/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/websecurityscanner/apiv1/doc.go
+++ b/websecurityscanner/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/websecurityscanner/apiv1/helpers.go
+++ b/websecurityscanner/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/websecurityscanner/apiv1/web_security_scanner_client.go
+++ b/websecurityscanner/apiv1/web_security_scanner_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/websecurityscanner/apiv1/web_security_scanner_client_example_go123_test.go
+++ b/websecurityscanner/apiv1/web_security_scanner_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/websecurityscanner/apiv1/web_security_scanner_client_example_test.go
+++ b/websecurityscanner/apiv1/web_security_scanner_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/workflows/apiv1/auxiliary.go
+++ b/workflows/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/workflows/apiv1/auxiliary_go123.go
+++ b/workflows/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/workflows/apiv1/doc.go
+++ b/workflows/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/workflows/apiv1/helpers.go
+++ b/workflows/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/workflows/apiv1/workflows_client.go
+++ b/workflows/apiv1/workflows_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/workflows/apiv1/workflows_client_example_go123_test.go
+++ b/workflows/apiv1/workflows_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/workflows/apiv1/workflows_client_example_test.go
+++ b/workflows/apiv1/workflows_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/workflows/apiv1beta/auxiliary.go
+++ b/workflows/apiv1beta/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/workflows/apiv1beta/auxiliary_go123.go
+++ b/workflows/apiv1beta/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/workflows/apiv1beta/doc.go
+++ b/workflows/apiv1beta/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/workflows/apiv1beta/helpers.go
+++ b/workflows/apiv1beta/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/workflows/apiv1beta/workflows_client.go
+++ b/workflows/apiv1beta/workflows_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/workflows/apiv1beta/workflows_client_example_go123_test.go
+++ b/workflows/apiv1beta/workflows_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/workflows/apiv1beta/workflows_client_example_test.go
+++ b/workflows/apiv1beta/workflows_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/workflows/executions/apiv1/auxiliary.go
+++ b/workflows/executions/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/workflows/executions/apiv1/auxiliary_go123.go
+++ b/workflows/executions/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/workflows/executions/apiv1/doc.go
+++ b/workflows/executions/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/workflows/executions/apiv1/executions_client.go
+++ b/workflows/executions/apiv1/executions_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/workflows/executions/apiv1/executions_client_example_go123_test.go
+++ b/workflows/executions/apiv1/executions_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/workflows/executions/apiv1/executions_client_example_test.go
+++ b/workflows/executions/apiv1/executions_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/workflows/executions/apiv1/helpers.go
+++ b/workflows/executions/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/workflows/executions/apiv1beta/auxiliary.go
+++ b/workflows/executions/apiv1beta/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/workflows/executions/apiv1beta/auxiliary_go123.go
+++ b/workflows/executions/apiv1beta/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/workflows/executions/apiv1beta/doc.go
+++ b/workflows/executions/apiv1beta/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/workflows/executions/apiv1beta/executions_client.go
+++ b/workflows/executions/apiv1beta/executions_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/workflows/executions/apiv1beta/executions_client_example_go123_test.go
+++ b/workflows/executions/apiv1beta/executions_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/workflows/executions/apiv1beta/executions_client_example_test.go
+++ b/workflows/executions/apiv1beta/executions_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/workflows/executions/apiv1beta/helpers.go
+++ b/workflows/executions/apiv1beta/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/workstations/apiv1/auxiliary.go
+++ b/workstations/apiv1/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/workstations/apiv1/auxiliary_go123.go
+++ b/workstations/apiv1/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/workstations/apiv1/doc.go
+++ b/workstations/apiv1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/workstations/apiv1/helpers.go
+++ b/workstations/apiv1/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/workstations/apiv1/workstations_client.go
+++ b/workstations/apiv1/workstations_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/workstations/apiv1/workstations_client_example_go123_test.go
+++ b/workstations/apiv1/workstations_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/workstations/apiv1/workstations_client_example_test.go
+++ b/workstations/apiv1/workstations_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/workstations/apiv1beta/auxiliary.go
+++ b/workstations/apiv1beta/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/workstations/apiv1beta/auxiliary_go123.go
+++ b/workstations/apiv1beta/auxiliary_go123.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/workstations/apiv1beta/doc.go
+++ b/workstations/apiv1beta/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/workstations/apiv1beta/helpers.go
+++ b/workstations/apiv1beta/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/workstations/apiv1beta/workstations_client.go
+++ b/workstations/apiv1beta/workstations_client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/workstations/apiv1beta/workstations_client_example_go123_test.go
+++ b/workstations/apiv1beta/workstations_client_example_go123_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/workstations/apiv1beta/workstations_client_example_test.go
+++ b/workstations/apiv1beta/workstations_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
update image to us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go@sha256:d2dee66d7c8c1d673fac26280164ea24015b79491b7f9d6ba369e6a98ab3420c

created with `go run github.com/googleapis/librarian/cmd/legacylibrarian@main update-image`