### PR TITLE
chore(spanner): add gcp resource name span attribute

### DIFF
--- a/spanner/ot_metrics.go
+++ b/spanner/ot_metrics.go
@@ -67,6 +67,7 @@ func createOpenTelemetryConfig(ctx context.Context, mp metric.MeterProvider, log
 				attribute.String("gcp.client.version", internal.Version),
 				attribute.String("gcp.client.repo", gcpClientRepo),
 				attribute.String("gcp.client.artifact", gcpClientArtifact),
+				attribute.String("gcp.resource.name", GcpResourceNamePrefix+db),
 			),
 		},
 	}

--- a/spanner/test/opentelemetry/test/ot_traces_test.go
+++ b/spanner/test/opentelemetry/test/ot_traces_test.go
@@ -130,6 +130,7 @@ func TestSpannerTracesWithOpenTelemetry(t *testing.T) {
 		"cloud.region":        "global",
 		"gcp.client.version":  internal.Version,
 		"gcp.client.repo":     "googleapis/google-cloud-go",
+		"gcp.resource.name":   spanner.GcpResourceNamePrefix + "projects/[PROJECT]/instances/[INSTANCE]/databases/[DATABASE]",
 		"gcp.client.artifact": "cloud.google.com/go/spanner",
 		"transaction.tag":     transactionTag,
 	}

--- a/spanner/trace.go
+++ b/spanner/trace.go
@@ -31,6 +31,8 @@ const (
 	defaultTracerName = "cloud.google.com/go/spanner"
 	gcpClientRepo     = "googleapis/google-cloud-go"
 	gcpClientArtifact = "cloud.google.com/go/spanner"
+	// GcpResourceNamePrefix is the prefix for Spanner GCP resource names span attribute.
+	GcpResourceNamePrefix = "//spanner.googleapis.com/"
 )
 
 func tracer() trace.Tracer {


### PR DESCRIPTION
Adding a new span attribute called gcp.resource.name which contains an identifier to a particular spanner instance and database in the following format:

//spanner.googleapis.com/projects/{project}/instances/{instance_id}/databases/{database_id}
Example:

//spanner.googleapis.com/projects/my_project/instances/my_instance/databases/my_database
