### PR TITLE
chore: enable vulnerability remediation via renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -28,6 +28,10 @@
             "enabled": false
         }
     ],
+    "vulnerabilityAlerts": {
+        "enabled": true,
+        "vulnerabilityFixStrategy": "lowest"
+    },
     "force": {
         "constraints": {
             "go": "1.24"


### PR DESCRIPTION
This PR adds some additional vulnerability configuration to renovate, so it can be responsibility for making automated changes to dependencies when vulns happen.

Once this is verified to work as expected, we can disable the complementary functionality in dependabot.

ref: https://github.com/googleapis/google-cloud-go/issues/13629