### PR TITLE
chore: disable major version upgrade of pubsub

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -26,6 +26,11 @@
                 "^github.com/cloudprober/cloudprober"
             ],
             "enabled": false
+        },
+        {
+          "matchPackageNames": ["cloud.google.com/go/pubsub"],
+          "matchUpdateTypes": ["major"],
+          "enabled": false
         }
     ],
     "vulnerabilityAlerts": {


### PR DESCRIPTION
https://github.com/googleapis/google-cloud-go/pull/13644 wants to update the pubsub packages from v1 -> v2

This PR disables them so we don't take on these changes.