### PR TITLE
feat(firestore): return native Go types from AggregationQuery.Get()

### DIFF
--- a/firestore/query.go
+++ b/firestore/query.go
@@ -1749,7 +1749,11 @@ func (a *AggregationQuery) GetResponse(ctx context.Context) (aro *AggregationRes
 			f := res.Result.AggregateFields
 
 			for k, v := range f {
-				resp[k] = v
+				converted, err := createFromProtoValue(v, a.query.c)
+				if err != nil {
+					return nil, err
+				}
+				resp[k] = converted
 			}
 		}
 		aro.ExplainMetrics = fromExplainMetricsProto(res.GetExplainMetrics())

--- a/firestore/query_test.go
+++ b/firestore/query_test.go
@@ -1464,9 +1464,12 @@ func TestAggregationQuery(t *testing.T) {
 		t.Errorf("aggregation query key not found")
 	}
 
-	cv := count.(*pb.Value)
-	if cv.GetIntegerValue() != 1 {
-		t.Errorf("got: %v\nwant: %v\n; result: %v\n", cv.GetIntegerValue(), 1, count)
+	cv, ok := count.(int64)
+	if !ok {
+		t.Fatalf("expected int64, got %T", count)
+	}
+	if cv != 1 {
+		t.Errorf("got: %v, want: %v", cv, 1)
 	}
 }
 


### PR DESCRIPTION
Fix AggregationQuery.Get() to return native Go types (int64, float64, nil) instead of *firestorepb.Value proto types. This resolves inconsistent behavior between the Firestore emulator and production, where users had to write type switches to handle both cases.

Fixes #13646