### PR TITLE
chore: librarian release pull request: 20260121T212954Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -691,7 +691,7 @@ libraries:
       - internal/generated/snippets/assuredworkloads/
     tag_format: '{id}/v{version}'
   - id: auth
-    version: 0.18.0
+    version: 0.18.1
     last_generated_commit: 31b413bc4feb03f6849c718048c2b9998561b5fa
     apis: []
     source_roots:

--- a/auth/CHANGES.md
+++ b/auth/CHANGES.md
@@ -1,5 +1,12 @@
 # Changes
 
+## [0.18.1](https://github.com/googleapis/google-cloud-go/releases/tag/auth%2Fv0.18.1) (2026-01-21)
+
+### Bug Fixes
+
+* add InternalOptions.TelemetryAttributes for internal client use (#13641) ([3876978](https://github.com/googleapis/google-cloud-go/commit/38769789755ed47d85e85dcd56596109de65f780))
+* remove singleton and restore normal usage of otelgrpc.clientHandler (#13522) ([673d4b0](https://github.com/googleapis/google-cloud-go/commit/673d4b05617f833aa433f7f6a350b5cb888ea20d))
+
 ## [0.18.0](https://github.com/googleapis/google-cloud-go/releases/tag/auth%2Fv0.18.0) (2025-12-15)
 
 ### Features

--- a/auth/internal/version.go
+++ b/auth/internal/version.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "0.18.0"
+const Version = "0.18.1"


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.8.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go@sha256:d2dee66d7c8c1d673fac26280164ea24015b79491b7f9d6ba369e6a98ab3420c
<details><summary>auth: 0.18.1</summary>

## [0.18.1](https://github.com/googleapis/google-cloud-go/compare/auth/v0.18.0...auth/v0.18.1) (2026-01-21)

### Bug Fixes

* add InternalOptions.TelemetryAttributes for internal client use (#13641) ([38769789](https://github.com/googleapis/google-cloud-go/commit/38769789))

* remove singleton and restore normal usage of otelgrpc.clientHandler (#13522) ([673d4b05](https://github.com/googleapis/google-cloud-go/commit/673d4b05))

</details>