### PR TITLE
fix(internal/librariangen): handle preview versions in snippet metadata

### DIFF
--- a/internal/librariangen/module/module.go
+++ b/internal/librariangen/module/module.go
@@ -34,6 +34,9 @@ import (
 var (
 	//go:embed _internal_version.go.txt
 	internalVersionTmpl string
+
+	// This regex finds a version string like "1.2.3" or "1.2.3-preview.1".
+	versionRegexp = regexp.MustCompile(`\d+\.\d+\.\d+(-preview\.[0-9]+)?`)
 )
 
 // GenerateInternalVersionFile creates an internal/version.go file for the module.
@@ -101,13 +104,9 @@ func UpdateSnippetsMetadata(lib *request.Library, sourceDir string, destDir stri
 		if strings.Contains(content, "$VERSION") {
 			newContent = strings.Replace(content, "$VERSION", version, 1)
 			oldVersion = "$VERSION"
-		} else {
-			// This regex finds a version string like "1.2.3".
-			re := regexp.MustCompile(`\d+\.\d+\.\d+`)
-			if foundVersion := re.FindString(content); foundVersion != "" {
-				newContent = strings.Replace(content, foundVersion, version, 1)
-				oldVersion = foundVersion
-			}
+		} else if foundVersion := versionRegexp.FindString(content); foundVersion != "" {
+			newContent = strings.Replace(content, foundVersion, version, 1)
+			oldVersion = foundVersion
 		}
 
 		if newContent == "" {

--- a/internal/librariangen/module/module_test.go
+++ b/internal/librariangen/module/module_test.go
@@ -132,6 +132,33 @@ func TestUpdateSnippetsMetadata(t *testing.T) {
 			},
 		},
 		{
+			name: "existing preview version",
+			lib: &request.Library{
+				ID:      "workflows",
+				Version: "5.6.7-preview.1",
+				APIs: []request.API{
+					{
+						Path: "google/cloud/workflows/v1",
+					},
+				},
+			},
+			moduleConfig: &config.ModuleConfig{
+				Name: "workflows",
+				APIs: []*config.APIConfig{
+					{
+						Path:         "google/cloud/workflows/v1",
+						ProtoPackage: "google.cloud.workflows.v1",
+					},
+				},
+			},
+			files: map[string]string{
+				"internal/generated/snippets/workflows/apiv1/snippet_metadata.google.cloud.workflows.v1.json": `{"clientLibrary":{"version":"1.2.3-preview.5"}}`,
+			},
+			want: map[string]string{
+				"internal/generated/snippets/workflows/apiv1/snippet_metadata.google.cloud.workflows.v1.json": `{"clientLibrary":{"version":"5.6.7-preview.1"}}`,
+			},
+		},
+		{
 			name: "file not found",
 			lib: &request.Library{
 				ID:      "secretmanager",


### PR DESCRIPTION
Adds support for preview version matching in snippet metadata update postprocessing. Otherwise it only matches the SemVer version core, like it does in below:

<img width="683" height="327" alt="image" src="https://github.com/user-attachments/assets/17ecdf65-0bc8-46a0-a837-e78805c1ec33" />
