### PR TITLE
chore: update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,26 +1,26 @@
 # Default owner for all directories not owned by others
-# The cloud-sdk-go-eng team are the effective repo maintainers, but automatic
+# The cloud-sdk-go-team team are the effective repo maintainers, but automatic
 # generation/releasing PRs are in the purview of the librarian team.
-*                       @googleapis/cloud-sdk-librarian-team @googleapis/cloud-sdk-go-eng
+*                       @googleapis/cloud-sdk-librarian-team @googleapis/cloud-sdk-go-team
 
-/ai/                    @googleapis/go-vertexai @googleapis/cloud-sdk-go-eng @googleapis/cloud-sdk-librarian-team
-/aiplatform/            @googleapis/go-vertexai @googleapis/cloud-sdk-go-eng @googleapis/cloud-sdk-librarian-team
-/bigtable/              @googleapis/cloud-native-db-dpes @googleapis/api-bigtable-partners @googleapis/api-bigtable @googleapis/cloud-sdk-go-eng @googleapis/cloud-sdk-librarian-team
-/bigtable/cmd/cbt       @igorbernstein2 @googleapis/cloud-native-db-dpes @googleapis/api-bigtable-partners @googleapis/api-bigtable @googleapis/cloud-sdk-go-eng @googleapis/cloud-sdk-librarian-team
-/bigtable/cmd/emulator  @igorbernstein2 @googleapis/cloud-native-db-dpes @googleapis/api-bigtable-partners @googleapis/api-bigtable @googleapis/cloud-sdk-go-eng @googleapis/cloud-sdk-librarian-team
-/bigtable/bttest        @igorbernstein2 @googleapis/cloud-native-db-dpes @googleapis/api-bigtable-partners @googleapis/api-bigtable @googleapis/cloud-sdk-go-eng @googleapis/cloud-sdk-librarian-team
-/datastore/             @googleapis/cloud-native-db-dpes @googleapis/api-firestore-partners @googleapis/cloud-sdk-go-eng @googleapis/cloud-sdk-librarian-team
-/firestore/             @googleapis/cloud-native-db-dpes @googleapis/api-firestore-partners @googleapis/cloud-sdk-go-eng @googleapis/cloud-sdk-librarian-team
-/pubsub/                @googleapis/api-pubsub @googleapis/cloud-sdk-go-eng @googleapis/cloud-sdk-librarian-team @googleapis/cloud-native-db-dpes
-/pubsublite/            @googleapis/api-pubsub @googleapis/cloud-sdk-go-eng @googleapis/cloud-sdk-librarian-team
-/spanner/               @googleapis/spanner-client-libraries-go @googleapis/cloud-sdk-go-eng @googleapis/cloud-sdk-librarian-team
-/storage/               @googleapis/gcs-sdk-team @googleapis/cloud-sdk-go-eng @googleapis/cloud-sdk-librarian-team
-/httpreplay/            @googleapis/gcs-sdk-team @googleapis/cloud-sdk-go-eng @googleapis/cloud-sdk-librarian-team
-/errorreporting/        @googleapis/cloud-sdk-go-eng @googleapis/cloud-sdk-librarian-team
-/logging/               @googleapis/cloud-sdk-go-eng @googleapis/cloud-sdk-librarian-team
-/profiler/              @googleapis/api-profiler @googleapis/cloud-sdk-go-eng @googleapis/cloud-sdk-librarian-team
-/vertexai/              @googleapis/go-vertexai @googleapis/cloud-sdk-go-eng @googleapis/cloud-sdk-librarian-team
-/internal/protoveneer/  @googleapis/cloud-sdk-go-eng @googleapis/cloud-sdk-librarian-team @jba
+/ai/                    @googleapis/go-vertexai @googleapis/cloud-sdk-go-team @googleapis/cloud-sdk-librarian-team
+/aiplatform/            @googleapis/go-vertexai @googleapis/cloud-sdk-go-team @googleapis/cloud-sdk-librarian-team
+/bigtable/              @googleapis/cloud-native-db-dpes @googleapis/api-bigtable-partners @googleapis/api-bigtable @googleapis/cloud-sdk-go-team @googleapis/cloud-sdk-librarian-team
+/bigtable/cmd/cbt       @igorbernstein2 @googleapis/cloud-native-db-dpes @googleapis/api-bigtable-partners @googleapis/api-bigtable @googleapis/cloud-sdk-go-team @googleapis/cloud-sdk-librarian-team
+/bigtable/cmd/emulator  @igorbernstein2 @googleapis/cloud-native-db-dpes @googleapis/api-bigtable-partners @googleapis/api-bigtable @googleapis/cloud-sdk-go-team @googleapis/cloud-sdk-librarian-team
+/bigtable/bttest        @igorbernstein2 @googleapis/cloud-native-db-dpes @googleapis/api-bigtable-partners @googleapis/api-bigtable @googleapis/cloud-sdk-go-team @googleapis/cloud-sdk-librarian-team
+/datastore/             @googleapis/cloud-native-db-dpes @googleapis/api-firestore-partners @googleapis/cloud-sdk-go-team @googleapis/cloud-sdk-librarian-team
+/firestore/             @googleapis/cloud-native-db-dpes @googleapis/api-firestore-partners @googleapis/cloud-sdk-go-team @googleapis/cloud-sdk-librarian-team
+/pubsub/                @googleapis/api-pubsub @googleapis/cloud-sdk-go-team @googleapis/cloud-sdk-librarian-team @googleapis/cloud-native-db-dpes
+/pubsublite/            @googleapis/api-pubsub @googleapis/cloud-sdk-go-team @googleapis/cloud-sdk-librarian-team
+/spanner/               @googleapis/spanner-client-libraries-go @googleapis/cloud-sdk-go-team @googleapis/cloud-sdk-librarian-team
+/storage/               @googleapis/gcs-sdk-team @googleapis/cloud-sdk-go-team @googleapis/cloud-sdk-librarian-team
+/httpreplay/            @googleapis/gcs-sdk-team @googleapis/cloud-sdk-go-team @googleapis/cloud-sdk-librarian-team
+/errorreporting/        @googleapis/cloud-sdk-go-team @googleapis/cloud-sdk-librarian-team
+/logging/               @googleapis/cloud-sdk-go-team @googleapis/cloud-sdk-librarian-team
+/profiler/              @googleapis/api-profiler @googleapis/cloud-sdk-go-team @googleapis/cloud-sdk-librarian-team
+/vertexai/              @googleapis/go-vertexai @googleapis/cloud-sdk-go-team @googleapis/cloud-sdk-librarian-team
+/internal/protoveneer/  @googleapis/cloud-sdk-go-team @googleapis/cloud-sdk-librarian-team @jba
 
 
 # We mark the librarian state file as unowned to avoid gatekeeping librarian operations on 


### PR DESCRIPTION
Handle the rename for cloud-sdk-go-eng -> cloud-sdk-go-team

It appears the repo permissions were updated without doing the CODEOWNERS update(s)