### PR TITLE
chore: librarian release pull request: 20260204T133510Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -4803,7 +4803,7 @@ libraries:
       - internal/generated/snippets/retail/
     tag_format: '{id}/v{version}'
   - id: root-module
-    version: 0.123.0
+    version: 0.124.0
     last_generated_commit: 3990e05b25dcaf7ba8d6baa4255d9b012a3a6a4f
     apis: []
     source_roots:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,18 @@
 
 
 
+## [0.124.0](https://github.com/googleapis/google-cloud-go/releases/tag/v0.124.0) (2026-02-04)
+
+### Features
+
+* populate release_exclude_paths for snippets (#12942) ([b25be45](https://github.com/googleapis/google-cloud-go/commit/b25be45eb7bf565b491586749de00ed9aa0fbdab))
+
+### Bug Fixes
+
+* be more conservative about removing OwlBot lines (#13106) ([7663fdc](https://github.com/googleapis/google-cloud-go/commit/7663fdce3663478cf9fe02f265c4abdb27775b61))
+* match input directories more carefully in OwlBot (#13057) ([f9efee1](https://github.com/googleapis/google-cloud-go/commit/f9efee1c2f3e7a1cf3ab9d8cd3c2fd5cd2a53325))
+* write state.yaml with the same code as librarian CLI (#12955) ([0464d0b](https://github.com/googleapis/google-cloud-go/commit/0464d0beed74e91c158f08672f8742d453a62320))
+
 ## [0.123.0](https://github.com/googleapis/google-cloud-go/compare/v0.122.0...v0.123.0) (2025-09-18)
 
 

--- a/internal/version.go
+++ b/internal/version.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "0.123.0"
+const Version = "0.124.0"


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.8.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go@sha256:01189c9771ac4150742aed38eb52e19a008018889066002742034b7f82db070f
<details><summary>root-module: 0.124.0</summary>

## [0.124.0](https://github.com/googleapis/google-cloud-go/compare/v0.123.0...v0.124.0) (2026-02-04)

### Features

* populate release_exclude_paths for snippets (#12942) ([b25be45e](https://github.com/googleapis/google-cloud-go/commit/b25be45e))

### Bug Fixes

* write state.yaml with the same code as librarian CLI (#12955) ([0464d0be](https://github.com/googleapis/google-cloud-go/commit/0464d0be))

* be more conservative about removing OwlBot lines (#13106) ([7663fdce](https://github.com/googleapis/google-cloud-go/commit/7663fdce))

* match input directories more carefully in OwlBot (#13057) ([f9efee1c](https://github.com/googleapis/google-cloud-go/commit/f9efee1c))

</details>