### PR TITLE
chore: librarian release pull request: 20260204T143905Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -4494,7 +4494,7 @@ libraries:
       - internal/generated/snippets/pubsub/
     tag_format: '{id}/v{version}'
   - id: pubsub/v2
-    version: 2.3.0
+    version: 2.4.0
     last_generated_commit: 94aa4f5ae672addf00e7970ecc47699e34989e90
     apis:
       - path: google/pubsub/v1

--- a/internal/generated/snippets/pubsub/v2/apiv1/snippet_metadata.google.pubsub.v1.json
+++ b/internal/generated/snippets/pubsub/v2/apiv1/snippet_metadata.google.pubsub.v1.json
@@ -1,7 +1,7 @@
 {
   "clientLibrary": {
     "name": "cloud.google.com/go/pubsub/v2/apiv1",
-    "version": "2.3.0",
+    "version": "2.4.0",
     "language": "GO",
     "apis": [
       {

--- a/pubsub/v2/CHANGES.md
+++ b/pubsub/v2/CHANGES.md
@@ -1,5 +1,25 @@
 # Changes
 
+## [2.4.0](https://github.com/googleapis/google-cloud-go/releases/tag/pubsub%2Fv2.4.0) (2026-02-04)
+
+### Features
+
+* Add AIInference MessageTransform type ([80379ed](https://github.com/googleapis/google-cloud-go/commit/80379edb1c47cd7c2d928d18762029cfe28420c0))
+* fix concurrent map write (#13530) ([50a9c4a](https://github.com/googleapis/google-cloud-go/commit/50a9c4ac16a68db30c9c7ea71bbc2792237f8840))
+* update image to us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go@sha256:ec5a10e927e3b3cdc457b23974879644572ab204864f353b19bf35d0af227678 (#13305) ([04e111b](https://github.com/googleapis/google-cloud-go/commit/04e111b595b4b7f18673102f6dc8a2cd322a025f))
+
+### Bug Fixes
+
+* return AckWithResult after NackImmediately shutdown mode (#13458) ([e94436c](https://github.com/googleapis/google-cloud-go/commit/e94436cdc351bba0b91af0501c43a3090251e465))
+
+### Documentation
+
+* A comment for field `analytics_hub_subscription_info` in message `.google.pubsub.v1.Subscription` is updated ([80379ed](https://github.com/googleapis/google-cloud-go/commit/80379edb1c47cd7c2d928d18762029cfe28420c0))
+* A comment for field `subscription` in message `.google.pubsub.v1.CreateSnapshotRequest` is updated ([80379ed](https://github.com/googleapis/google-cloud-go/commit/80379edb1c47cd7c2d928d18762029cfe28420c0))
+* A comment for field `topic` in message `.google.pubsub.v1.Subscription` is updated ([80379ed](https://github.com/googleapis/google-cloud-go/commit/80379edb1c47cd7c2d928d18762029cfe28420c0))
+* Add the IDENTIFIER field behavior annotation to fields of Cloud Pub/Sub methods that represent a specific identity and need to be sourced with additional care ([21c9dbf](https://github.com/googleapis/google-cloud-go/commit/21c9dbfbf9061b29b1c64e5ca24273ec97078f25))
+* add tags documentation links to Pub/Sub resource tags fields ([db65e79](https://github.com/googleapis/google-cloud-go/commit/db65e7927e54b21a39a54f685810495d2885cb33))
+
 ## [2.3.0](https://github.com/googleapis/google-cloud-go/releases/tag/pubsub%2Fv2.3.0) (2025-10-22)
 
 ### Features

--- a/pubsub/v2/internal/version.go
+++ b/pubsub/v2/internal/version.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "2.3.0"
+const Version = "2.4.0"


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.8.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go@sha256:01189c9771ac4150742aed38eb52e19a008018889066002742034b7f82db070f
<details><summary>pubsub/v2: 2.4.0</summary>

## [2.4.0](https://github.com/googleapis/google-cloud-go/compare/pubsub/v2.3.0...pubsub/v2.4.0) (2026-02-04)

### Features

* update image to us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go@sha256:ec5a10e927e3b3cdc457b23974879644572ab204864f353b19bf35d0af227678 (#13305) ([04e111b5](https://github.com/googleapis/google-cloud-go/commit/04e111b5))

* fix concurrent map write (#13530) ([50a9c4ac](https://github.com/googleapis/google-cloud-go/commit/50a9c4ac))

* Add AIInference MessageTransform type (PiperOrigin-RevId: 853856321) ([80379edb](https://github.com/googleapis/google-cloud-go/commit/80379edb))

### Bug Fixes

* return AckWithResult after NackImmediately shutdown mode (#13458) ([e94436cd](https://github.com/googleapis/google-cloud-go/commit/e94436cd))

### Documentation

* Add the IDENTIFIER field behavior annotation to fields of Cloud Pub/Sub methods that represent a specific identity and need to be sourced with additional care (PiperOrigin-RevId: 840763233) ([21c9dbfb](https://github.com/googleapis/google-cloud-go/commit/21c9dbfb))

* A comment for field `subscription` in message `.google.pubsub.v1.CreateSnapshotRequest` is updated (PiperOrigin-RevId: 853856321) ([80379edb](https://github.com/googleapis/google-cloud-go/commit/80379edb))

* A comment for field `topic` in message `.google.pubsub.v1.Subscription` is updated (PiperOrigin-RevId: 853856321) ([80379edb](https://github.com/googleapis/google-cloud-go/commit/80379edb))

* A comment for field `analytics_hub_subscription_info` in message `.google.pubsub.v1.Subscription` is updated (PiperOrigin-RevId: 853856321) ([80379edb](https://github.com/googleapis/google-cloud-go/commit/80379edb))

* add tags documentation links to Pub/Sub resource tags fields (PiperOrigin-RevId: 845891076) ([db65e792](https://github.com/googleapis/google-cloud-go/commit/db65e792))

</details>