### PR TITLE
chore(internal/kokoro): ref pr target branch in change detect

### DIFF
--- a/pubsub/doc.go
+++ b/pubsub/doc.go
@@ -170,7 +170,5 @@ and use a client as usual:
 	defer client.Close()
 
 Deprecated: Please use cloud.google.com/go/pubsub/v2.
-
-Test comment to elicit a test run.
 */
 package pubsub // import "cloud.google.com/go/pubsub"


### PR DESCRIPTION
Parameterizes the base branch used in our presubmit "significant change" detection rather than hardcoding to `main`. This allows us to more accurately run tests for the forthcoming `preview` branch.

I saw this being used in the [Java Apiary repo](https://github.com/googleapis/google-api-java-client-services/blob/5ec85f7c634fe76113844dc9066a5eb75d4ac794/.kokoro/test.sh#L31) after I read the Kokoro docs.