### PR TITLE
chore(internal/kokoro): presubmits track preview branch

### DIFF
--- a/internal/kokoro/presubmit.sh
+++ b/internal/kokoro/presubmit.sh
@@ -42,7 +42,7 @@ if [[ $KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH_google_cloud_go == "preview" ]];
   # This seems to be necessary in order to run git commands in this directory
   # even though we have a similar command above.
   git config --global --add safe.directory "$(pwd)"
-  git branch preview origin/preview
+  git branch -f preview origin/preview
 fi
 git clone . $GOCLOUD_HOME
 cd $GOCLOUD_HOME


### PR DESCRIPTION
Explicitly track `preview` branch in presubmits when the Pull Request targets the `preview` branch.

Our presubmits (for some reason) do a local clone of the kokoro cloned google-cloud-go repository, but into a different directory. This only clones the _working copy's_ branches, not the remote's branches, which means the local clone does not have an `origin/preview` to reference in change detection. So, we explicitly create a `preview` branch tracking `origin/preview` in the Kokoro provided working copy so that the local clone has its own `origin/preview` referring back to the Kokoro provided clone's `preview`.

Testing shows that the local clone is missing most branches: 
<img width="386" height="157" alt="image" src="https://github.com/user-attachments/assets/4eb4d370-869b-4bd6-ad01-970c49623bae" />

When we add it, we can see that the `git diff` change detection call works and assigns the appropriate changed directories:
<img width="952" height="593" alt="image" src="https://github.com/user-attachments/assets/2d311646-d9f9-403d-bef6-6b63f08855a7" />

Note: Putting this in main b.c it may be useful for future reference and there is no reason it can't be put in main with a condition guarding it. Makes synching this file easier as well.