### PR TITLE
datastore: fix WithIgnoreFieldMismatch for nested slices

### DIFF
--- a/datastore/load.go
+++ b/datastore/load.go
@@ -78,13 +78,16 @@ func (l *propertyLoader) load(codec fields.List, structValue reflect.Value, p Pr
 	if !ok {
 		return l.loadOneElement(codec, structValue, p, prev)
 	}
+	var firstErr string
 	for _, val := range sl {
 		p.Value = val
 		if errStr := l.loadOneElement(codec, structValue, p, prev); errStr != "" {
-			return errStr
+			if firstErr == "" {
+				firstErr = errStr
+			}
 		}
 	}
-	return ""
+	return firstErr
 }
 
 // loadOneElement loads the value of Property p into structValue based on the provided


### PR DESCRIPTION
Fixes: #10822

This change ensures that propertyLoader.load continues iterating through slice elements even if individual elements encounter loading errors (like ErrFieldMismatch).

Previously, when loading a slice of structs, if one element caused an error (e.g. valid field mismatch), the loader would abort immediately. This prevented subsequent elements from being loaded, even if the user intended to ignore these mismatches using WithIgnoreFieldMismatch.

The fix captures the first error encountered but continues the loop to ensure all valid data is loaded. The error is returned at the end, preserving the existing error reporting behavior (which WithIgnoreFieldMismatch relies on).