### PR TITLE
fix(datastore): emulator connection scheme and add nil key filter

### DIFF
--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -21,6 +21,7 @@ import (
 	"log"
 	"os"
 	"reflect"
+	"regexp"
 	"time"
 
 	pb "cloud.google.com/go/datastore/apiv1/datastorepb"
@@ -66,6 +67,7 @@ const DefaultDatabaseID = ""
 var (
 	gtransportDialPoolFn = gtransport.DialPool
 	detectProjectIDFn    = detectProjectID
+	schemeRegexp         = regexp.MustCompile("^(http://|https://|passthrough:///)")
 )
 
 // Client is a client for reading and writing data in a datastore dataset.
@@ -106,8 +108,9 @@ func NewClientWithDatabase(ctx context.Context, projectID, databaseID string, op
 	// https://cloud.google.com/datastore/docs/tools/datastore-emulator
 	// If the emulator is available, dial it without passing any credentials.
 	if addr := os.Getenv("DATASTORE_EMULATOR_HOST"); addr != "" {
+		addr = schemeRegexp.ReplaceAllString(addr, "")
 		o = []option.ClientOption{
-			option.WithEndpoint(addr),
+			option.WithEndpoint("passthrough:///" + addr),
 			option.WithoutAuthentication(),
 			option.WithGRPCDialOption(grpc.WithTransportCredentials(insecure.NewCredentials())),
 		}

--- a/datastore/query.go
+++ b/datastore/query.go
@@ -112,7 +112,7 @@ func (pf PropertyFilter) toProto() (*pb.Filter, error) {
 	if pf.FieldName == "" {
 		return nil, errors.New("datastore: empty query filter field name")
 	}
-	v, err := interfaceToProto(reflect.ValueOf(pf.Value).Interface(), false)
+	v, err := interfaceToProto(pf.Value, false)
 	if err != nil {
 		return nil, fmt.Errorf("datastore: bad query filter value type: %w", err)
 	}

--- a/datastore/query_test.go
+++ b/datastore/query_test.go
@@ -1045,3 +1045,40 @@ func TestValidateReadOptions(t *testing.T) {
 		}
 	}
 }
+func TestQueryFilterNil(t *testing.T) {
+	// Attempts to filter by a nil *Key
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Recovered from panic: %v", r)
+		}
+	}()
+
+	// Case 1: Untyped nil
+	t.Run("Untyped nil", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("Recovered from panic: %v", r)
+			}
+		}()
+		q1 := NewQuery("Entity").Filter("Parent =", nil)
+		if q1.err != nil {
+			t.Logf("q1 error (untyped nil): %v", q1.err)
+		}
+		if _, err := q1.toProto(); err != nil {
+			t.Logf("q1.toProto() error: %v", err)
+		}
+	})
+
+	// Case 2: Typed nil *Key
+	t.Run("Typed nil *Key", func(t *testing.T) {
+		var k *Key = nil
+		q2 := NewQuery("Entity").Filter("Parent =", k)
+		if q2.err != nil {
+			t.Fatalf("q2 failed (typed nil *Key): %v", q2.err)
+		}
+		if _, err := q2.toProto(); err != nil {
+			t.Fatalf("q2.toProto() failed: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
1. Fixes emulator connection scheme (Issue #10964):
Aligns datastore client behavior with bigtable by using the passthrough:/// scheme for emulator connections.
Uses regex to robustly strip existing schemes (http://, https://, passthrough:///) from the DATASTORE_EMULATOR_HOST environment variable before prepending passthrough:///.
This ensures reliable connections to local emulators and avoids potential gRPC name resolution issues.

2. Fixes and tests nil key filtering (Issue #13499):
Fix: Removed a redundant reflect.ValueOf(pf.Value).Interface() call in toProto which caused a panic when pf.Value was an untyped nil. The value is now passed directly to interfaceToProto, which handles nil correctly.

Fixes #10964 Fixes #13499