### PR TITLE
chore: librarian update image pull request: 20260206T212728Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,4 +1,4 @@
-image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go@sha256:f9f9065a893591ad505df3384f409e9d404132d8c83b5d4bcbb8ae1650553b3b
+image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go@sha256:19bb93e8f1f916c61b597db2bad65dc432f79baaabb210499d7d0e4ad1dffe29
 libraries:
   - id: accessapproval
     version: 1.8.8

--- a/bigquery/v2/apiv2/dataset_client.go
+++ b/bigquery/v2/apiv2/dataset_client.go
@@ -62,7 +62,6 @@ func defaultDatasetGRPCClientOptions() []option.ClientOption {
 		internaloption.WithDefaultAudience("https://bigquery.googleapis.com/"),
 		internaloption.WithDefaultScopes(DefaultAuthScopes()...),
 		internaloption.EnableJwtWithScope(),
-		internaloption.AllowHardBoundTokens("MTLS_S2A"),
 		internaloption.EnableNewAuthLibrary(),
 		option.WithGRPCDialOption(grpc.WithDefaultCallOptions(
 			grpc.MaxCallRecvMsgSize(math.MaxInt32))),

--- a/bigquery/v2/apiv2/job_client.go
+++ b/bigquery/v2/apiv2/job_client.go
@@ -62,7 +62,6 @@ func defaultJobGRPCClientOptions() []option.ClientOption {
 		internaloption.WithDefaultAudience("https://bigquery.googleapis.com/"),
 		internaloption.WithDefaultScopes(DefaultAuthScopes()...),
 		internaloption.EnableJwtWithScope(),
-		internaloption.AllowHardBoundTokens("MTLS_S2A"),
 		internaloption.EnableNewAuthLibrary(),
 		option.WithGRPCDialOption(grpc.WithDefaultCallOptions(
 			grpc.MaxCallRecvMsgSize(math.MaxInt32))),

--- a/bigquery/v2/apiv2/model_client.go
+++ b/bigquery/v2/apiv2/model_client.go
@@ -59,7 +59,6 @@ func defaultModelGRPCClientOptions() []option.ClientOption {
 		internaloption.WithDefaultAudience("https://bigquery.googleapis.com/"),
 		internaloption.WithDefaultScopes(DefaultAuthScopes()...),
 		internaloption.EnableJwtWithScope(),
-		internaloption.AllowHardBoundTokens("MTLS_S2A"),
 		internaloption.EnableNewAuthLibrary(),
 		option.WithGRPCDialOption(grpc.WithDefaultCallOptions(
 			grpc.MaxCallRecvMsgSize(math.MaxInt32))),

--- a/bigquery/v2/apiv2/project_client.go
+++ b/bigquery/v2/apiv2/project_client.go
@@ -52,7 +52,6 @@ func defaultProjectGRPCClientOptions() []option.ClientOption {
 		internaloption.WithDefaultAudience("https://bigquery.googleapis.com/"),
 		internaloption.WithDefaultScopes(DefaultAuthScopes()...),
 		internaloption.EnableJwtWithScope(),
-		internaloption.AllowHardBoundTokens("MTLS_S2A"),
 		internaloption.EnableNewAuthLibrary(),
 		option.WithGRPCDialOption(grpc.WithDefaultCallOptions(
 			grpc.MaxCallRecvMsgSize(math.MaxInt32))),

--- a/bigquery/v2/apiv2/routine_client.go
+++ b/bigquery/v2/apiv2/routine_client.go
@@ -60,7 +60,6 @@ func defaultRoutineGRPCClientOptions() []option.ClientOption {
 		internaloption.WithDefaultAudience("https://bigquery.googleapis.com/"),
 		internaloption.WithDefaultScopes(DefaultAuthScopes()...),
 		internaloption.EnableJwtWithScope(),
-		internaloption.AllowHardBoundTokens("MTLS_S2A"),
 		internaloption.EnableNewAuthLibrary(),
 		option.WithGRPCDialOption(grpc.WithDefaultCallOptions(
 			grpc.MaxCallRecvMsgSize(math.MaxInt32))),

--- a/bigquery/v2/apiv2/row_access_policy_client.go
+++ b/bigquery/v2/apiv2/row_access_policy_client.go
@@ -60,7 +60,6 @@ func defaultRowAccessPolicyGRPCClientOptions() []option.ClientOption {
 		internaloption.WithDefaultAudience("https://bigquery.googleapis.com/"),
 		internaloption.WithDefaultScopes(DefaultAuthScopes()...),
 		internaloption.EnableJwtWithScope(),
-		internaloption.AllowHardBoundTokens("MTLS_S2A"),
 		internaloption.EnableNewAuthLibrary(),
 		option.WithGRPCDialOption(grpc.WithDefaultCallOptions(
 			grpc.MaxCallRecvMsgSize(math.MaxInt32))),

--- a/bigquery/v2/apiv2/table_client.go
+++ b/bigquery/v2/apiv2/table_client.go
@@ -61,7 +61,6 @@ func defaultTableGRPCClientOptions() []option.ClientOption {
 		internaloption.WithDefaultAudience("https://bigquery.googleapis.com/"),
 		internaloption.WithDefaultScopes(DefaultAuthScopes()...),
 		internaloption.EnableJwtWithScope(),
-		internaloption.AllowHardBoundTokens("MTLS_S2A"),
 		internaloption.EnableNewAuthLibrary(),
 		option.WithGRPCDialOption(grpc.WithDefaultCallOptions(
 			grpc.MaxCallRecvMsgSize(math.MaxInt32))),


### PR DESCRIPTION
feat: update image to us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go@sha256:19bb93e8f1f916c61b597db2bad65dc432f79baaabb210499d7d0e4ad1dffe29

This PR also demonstrates that feature enablement is being driven from https://github.com/googleapis/google-cloud-go/blob/main/.librarian/generator-input/repo-config.yaml as the MTLS feature is not enabled in bigquery/v2 there, thus removing the features from the generated code.  I'll add it back in a subsequent PR (this module is not currently being released).