### PR TITLE
fix(datastore): allow custom types in query filters and flaky test fix

### DIFF
--- a/datastore/integration_test.go
+++ b/datastore/integration_test.go
@@ -1419,6 +1419,7 @@ func TestIntegration_AggregationQueries(t *testing.T) {
 	defer client.Close()
 
 	beforeCreate := time.Now().Truncate(time.Millisecond)
+	time.Sleep(100 * time.Millisecond) // Ensure beforeCreate is strictly before Put
 
 	parent := NameKey("SQParent", keyPrefix+"AggregationQueries"+suffix, nil)
 	now := timeNow.Truncate(time.Millisecond).Unix()

--- a/datastore/query_test.go
+++ b/datastore/query_test.go
@@ -505,12 +505,14 @@ type pfToProtoTestCase struct {
 
 func TestPropertyFilterToProto(t *testing.T) {
 
+	type CustomType int
 	testCases := []pfToProtoTestCase{
 		{PropertyFilter{FieldName: "x", Operator: "=", Value: 4}, ""},
 		{PropertyFilter{FieldName: "x ", Operator: "=", Value: 4}, ""},
 		{PropertyFilter{FieldName: "", Operator: "=", Value: 4}, "datastore: empty query filter field name"},
 		{PropertyFilter{FieldName: "x", Operator: "==", Value: 4}, "datastore: invalid operator \"==\" in filter"},
 		{PropertyFilter{FieldName: "x", Operator: "==", Value: struct{ x string }{x: "sample"}}, "datastore: bad query filter value type: invalid Value type struct { x string }"},
+		{PropertyFilter{FieldName: "x", Operator: "=", Value: CustomType(4)}, ""},
 	}
 
 	successFilterFieldTestCases := append(filterTestCases, filterFieldTestCases...)


### PR DESCRIPTION
This PR addresses a behavior difference compared to the legacy appengine/datastore library where custom basic types (e.g., type Score int) worked in query filters. Previously, cloud.google.com/go/datastore rejected these custom types with invalid Value type.


Changes:
- Updated interfaceToProto in datastore/save.go to handle custom types via reflection, unwrapping them to their underlying basic types (Int, String, Bool, Float).
- This PR also fixes flaky test #11491

Fixes #3179  #11491