### PR TITLE
chore(internal/kokoro): wrap variable in quotes

### DIFF
--- a/internal/kokoro/presubmit.sh
+++ b/internal/kokoro/presubmit.sh
@@ -90,7 +90,7 @@ runPresubmitTests() {
 SIGNIFICANT_CHANGES=$(git --no-pager diff --name-only origin/$KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH_google_cloud_go...$KOKORO_GIT_COMMIT_google_cloud_go |
   grep -Ev '(\.md$|^\.github|\.json$|\.yaml$)' | xargs dirname | sort -u || true)
 
-if [ -z $SIGNIFICANT_CHANGES ]; then
+if [ -z "$SIGNIFICANT_CHANGES" ]; then
   echo "No changes detected, skipping tests"
   exit 0
 fi


### PR DESCRIPTION
Wrap variable expansion in double quotes for `-z` length check to fix error regularly seen in kokoro:
`github/google-cloud-go/internal/kokoro/presubmit.sh: line 93: [: too many arguments`.

This happens when `$SIGNIFICANT_CHANGES` contains multiple, space separated values, which is often.

This is from a recent PR:
<img width="912" height="543" alt="image" src="https://github.com/user-attachments/assets/d0db59af-8bb5-4298-93a0-8cf6981704b0" />
