### PR TITLE
chore: relax ownership of the internal/generated/snippets paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -31,4 +31,4 @@
 # tracking granular ownership in the snippets directories, and to avoid chasing
 # code owners approvals for things like snippet metadata versioning bumps which
 # happen naturally as part of release activities.
-/internal/generated/snippets/*
+/internal/generated/snippets/


### PR DESCRIPTION
This PR removes code owners mappings for the snippets paths, mostly to reduce friction for maintainers and committers.