### PR TITLE
test(spanner/test/opentelemetry/test): update otelgrpc invocation

### DIFF
--- a/spanner/test/opentelemetry/test/ot_traces_test.go
+++ b/spanner/test/opentelemetry/test/ot_traces_test.go
@@ -50,7 +50,7 @@ func TestSpannerTracesWithOpenTelemetry(t *testing.T) {
 		SessionPoolConfig: spanner.SessionPoolConfig{
 			MinOpened: minOpened,
 		},
-	}, option.WithGRPCDialOption(grpc.WithStreamInterceptor(otelgrpc.StreamClientInterceptor(otelgrpc.WithTracerProvider(te.tp)))))
+	}, option.WithGRPCDialOption(grpc.WithStatsHandler(otelgrpc.NewClientHandler(otelgrpc.WithTracerProvider(te.tp)))))
 	defer teardown()
 
 	waitFor(t, func() error {


### PR DESCRIPTION
This PR is minimal and updates a deprecated call signature causing build failures in TestSpannerTracesWithOpenTelemetry.

Fixes: https://github.com/googleapis/google-cloud-go/issues/13760