### PR TITLE
chore: librarian release pull request: 20260211T232929Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -5680,7 +5680,7 @@ libraries:
       - internal/generated/snippets/shopping/
     tag_format: '{id}/v{version}'
   - id: spanner
-    version: 1.87.0
+    version: 1.88.0
     last_generated_commit: 9eea40c74d97622bb0aa406dd313409a376cc73b
     apis:
       - path: google/spanner/adapter/v1

--- a/internal/generated/snippets/spanner/adapter/apiv1/snippet_metadata.google.spanner.adapter.v1.json
+++ b/internal/generated/snippets/spanner/adapter/apiv1/snippet_metadata.google.spanner.adapter.v1.json
@@ -1,7 +1,7 @@
 {
   "clientLibrary": {
     "name": "cloud.google.com/go/spanner/adapter/apiv1",
-    "version": "1.87.0",
+    "version": "1.88.0",
     "language": "GO",
     "apis": [
       {

--- a/internal/generated/snippets/spanner/admin/database/apiv1/snippet_metadata.google.spanner.admin.database.v1.json
+++ b/internal/generated/snippets/spanner/admin/database/apiv1/snippet_metadata.google.spanner.admin.database.v1.json
@@ -1,7 +1,7 @@
 {
   "clientLibrary": {
     "name": "cloud.google.com/go/spanner/admin/database/apiv1",
-    "version": "1.87.0",
+    "version": "1.88.0",
     "language": "GO",
     "apis": [
       {

--- a/internal/generated/snippets/spanner/admin/instance/apiv1/snippet_metadata.google.spanner.admin.instance.v1.json
+++ b/internal/generated/snippets/spanner/admin/instance/apiv1/snippet_metadata.google.spanner.admin.instance.v1.json
@@ -1,7 +1,7 @@
 {
   "clientLibrary": {
     "name": "cloud.google.com/go/spanner/admin/instance/apiv1",
-    "version": "1.87.0",
+    "version": "1.88.0",
     "language": "GO",
     "apis": [
       {

--- a/internal/generated/snippets/spanner/apiv1/snippet_metadata.google.spanner.v1.json
+++ b/internal/generated/snippets/spanner/apiv1/snippet_metadata.google.spanner.v1.json
@@ -1,7 +1,7 @@
 {
   "clientLibrary": {
     "name": "cloud.google.com/go/spanner/apiv1",
-    "version": "1.87.0",
+    "version": "1.88.0",
     "language": "GO",
     "apis": [
       {

--- a/internal/generated/snippets/spanner/executor/apiv1/snippet_metadata.google.spanner.executor.v1.json
+++ b/internal/generated/snippets/spanner/executor/apiv1/snippet_metadata.google.spanner.executor.v1.json
@@ -1,7 +1,7 @@
 {
   "clientLibrary": {
     "name": "cloud.google.com/go/spanner/executor/apiv1",
-    "version": "1.87.0",
+    "version": "1.88.0",
     "language": "GO",
     "apis": [
       {

--- a/spanner/CHANGES.md
+++ b/spanner/CHANGES.md
@@ -1,5 +1,36 @@
 # Changes
 
+## [1.88.0](https://github.com/googleapis/google-cloud-go/releases/tag/spanner%2Fv1.88.0) (2026-02-11)
+
+### Features
+
+* Adding Send and Ack Mutation Support for Cloud Spanner Queue (#13616) ([1cf600d](https://github.com/googleapis/google-cloud-go/commit/1cf600d68b604984ffcf475d495b5e4e9eee8e68))
+* Exposing total CPU related fields in AutoscalingConfig ([db65e79](https://github.com/googleapis/google-cloud-go/commit/db65e7927e54b21a39a54f685810495d2885cb33))
+* PGNumeric implements Scanner and Valuer (#13722) ([85bc9db](https://github.com/googleapis/google-cloud-go/commit/85bc9dbfb75d6f30d9c7564b448fc0a17fa3b252))
+* add ClientContext support (#13775) ([e85d706](https://github.com/googleapis/google-cloud-go/commit/e85d706143ce0ffedd4c6a7485d13f512673f8ed))
+* add Secure Parameters to the ClientContext ([80379ed](https://github.com/googleapis/google-cloud-go/commit/80379edb1c47cd7c2d928d18762029cfe28420c0))
+* add a ClientContext field to Spanner requests ([80379ed](https://github.com/googleapis/google-cloud-go/commit/80379edb1c47cd7c2d928d18762029cfe28420c0))
+* include cache updates into the ResultSet response ([6f31019](https://github.com/googleapis/google-cloud-go/commit/6f310199e136b133bb4fadaa353e264e809db6d7))
+* support struct literal (#13766) ([b4a6f4c](https://github.com/googleapis/google-cloud-go/commit/b4a6f4c5810408daa67bb6ee7ad02d07786faff8))
+
+### Bug Fixes
+
+* decode PG JSONB array to PGJsonB struct (#13602) ([d72d0f4](https://github.com/googleapis/google-cloud-go/commit/d72d0f458c517a7c8ddf5f62ff4a92651f2b4bb4))
+* disable config logging by default (#13478) ([ad19592](https://github.com/googleapis/google-cloud-go/commit/ad19592ed7ba9effe23f9df664aca07f967a65c0))
+
+### Performance Improvements
+
+* only create sessions if multiplexed sessions are disabled (#13477) ([e44e58f](https://github.com/googleapis/google-cloud-go/commit/e44e58f608c9b25125e0412919bea5de90596dd9))
+
+### Documentation
+
+* A comment for field `commit_timestamp` in message `.google.spanner.v1.BatchWriteResponse` is changed ([6f31019](https://github.com/googleapis/google-cloud-go/commit/6f310199e136b133bb4fadaa353e264e809db6d7))
+* A comment for field `param_types` in message `.google.spanner.v1.PartitionQueryRequest` is changed ([6f31019](https://github.com/googleapis/google-cloud-go/commit/6f310199e136b133bb4fadaa353e264e809db6d7))
+* A comment for field `params` in message `.google.spanner.v1.PartitionQueryRequest` is changed ([6f31019](https://github.com/googleapis/google-cloud-go/commit/6f310199e136b133bb4fadaa353e264e809db6d7))
+* A comment for field `transaction_tag` in message `.google.spanner.v1.RequestOptions` is changed ([6f31019](https://github.com/googleapis/google-cloud-go/commit/6f310199e136b133bb4fadaa353e264e809db6d7))
+* Update client side metrics and permission issues in README  (#13491) ([ab56892](https://github.com/googleapis/google-cloud-go/commit/ab56892e7bc1ba960289097c9b7909bf77d26a87))
+* Update high_priority_cpu_utilization_percent in AutoscalingConfig to be Optional and clarify its behavior when not specified ([db65e79](https://github.com/googleapis/google-cloud-go/commit/db65e7927e54b21a39a54f685810495d2885cb33))
+
 ## [1.87.0](https://github.com/googleapis/google-cloud-go/releases/tag/spanner%2Fv1.87.0) (2025-12-10)
 
 ### Features

--- a/spanner/internal/version.go
+++ b/spanner/internal/version.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "1.87.0"
+const Version = "1.88.0"


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v1.0.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go@sha256:19bb93e8f1f916c61b597db2bad65dc432f79baaabb210499d7d0e4ad1dffe29
<details><summary>spanner: 1.88.0</summary>

## [1.88.0](https://github.com/googleapis/google-cloud-go/compare/spanner/v1.87.0...spanner/v1.88.0) (2026-02-11)

### Features

* Adding Send and Ack Mutation Support for Cloud Spanner Queue (#13616) ([1cf600d6](https://github.com/googleapis/google-cloud-go/commit/1cf600d6))

* include cache updates into the ResultSet response (PiperOrigin-RevId: 865546011) ([6f310199](https://github.com/googleapis/google-cloud-go/commit/6f310199))

* add a ClientContext field to Spanner requests (PiperOrigin-RevId: 853323071) ([80379edb](https://github.com/googleapis/google-cloud-go/commit/80379edb))

* add Secure Parameters to the ClientContext (PiperOrigin-RevId: 853323071) ([80379edb](https://github.com/googleapis/google-cloud-go/commit/80379edb))

* PGNumeric implements Scanner and Valuer (#13722) ([85bc9dbf](https://github.com/googleapis/google-cloud-go/commit/85bc9dbf))

* support struct literal (#13766) ([b4a6f4c5](https://github.com/googleapis/google-cloud-go/commit/b4a6f4c5))

* Exposing total CPU related fields in AutoscalingConfig (PiperOrigin-RevId: 845819318) ([db65e792](https://github.com/googleapis/google-cloud-go/commit/db65e792))

* add ClientContext support (#13775) ([e85d7061](https://github.com/googleapis/google-cloud-go/commit/e85d7061))

### Bug Fixes

* disable config logging by default (#13478) ([ad19592e](https://github.com/googleapis/google-cloud-go/commit/ad19592e))

* decode PG JSONB array to PGJsonB struct (#13602) ([d72d0f45](https://github.com/googleapis/google-cloud-go/commit/d72d0f45))

### Performance Improvements

* only create sessions if multiplexed sessions are disabled (#13477) ([e44e58f6](https://github.com/googleapis/google-cloud-go/commit/e44e58f6))

### Documentation

* A comment for field `param_types` in message `.google.spanner.v1.PartitionQueryRequest` is changed (PiperOrigin-RevId: 865546011) ([6f310199](https://github.com/googleapis/google-cloud-go/commit/6f310199))

* A comment for field `transaction_tag` in message `.google.spanner.v1.RequestOptions` is changed (PiperOrigin-RevId: 865546011) ([6f310199](https://github.com/googleapis/google-cloud-go/commit/6f310199))

* A comment for field `commit_timestamp` in message `.google.spanner.v1.BatchWriteResponse` is changed (PiperOrigin-RevId: 865546011) ([6f310199](https://github.com/googleapis/google-cloud-go/commit/6f310199))

* A comment for field `params` in message `.google.spanner.v1.PartitionQueryRequest` is changed (PiperOrigin-RevId: 865546011) ([6f310199](https://github.com/googleapis/google-cloud-go/commit/6f310199))

* Update client side metrics and permission issues in README  (#13491) ([ab56892e](https://github.com/googleapis/google-cloud-go/commit/ab56892e))

* Update high_priority_cpu_utilization_percent in AutoscalingConfig to be Optional and clarify its behavior when not specified (PiperOrigin-RevId: 845819318) ([db65e792](https://github.com/googleapis/google-cloud-go/commit/db65e792))

</details>