### PR TITLE
chore(deps): run renovate on preview branch

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -41,5 +41,9 @@
         "constraints": {
             "go": "1.24"
         }
-    }
+    },
+    "baseBranchPatterns": [
+        "main",
+        "preview"
+    ]
 }


### PR DESCRIPTION
Enables renovatebot to send dependency updates to the `preview` branch as well.

https://docs.renovatebot.com/configuration-options/#basebranchpatterns