### PR TITLE
chore(pubsub): add v1 deprecation notice in more places

### DIFF
--- a/pubsub/MIGRATING.md
+++ b/pubsub/MIGRATING.md
@@ -6,7 +6,7 @@ Note: The code snippets in this guide are meant to be a quick way of comparing t
 
 In line with Google's [OSS Library Breaking Change Policy](https://opensource.google/documentation/policies/library-breaking-change), support for the Go PubSub client library v1 version will continue until December 31st, 2026. This includes continued bug fixes and security patches for v1 version, but no new features would be introduced. We encourage all users to migrate to the Go PubSub client library v2 version before support expires for the earlier v1 version.
 
-Note: We had previously set the end of support date to July 31st, 2026. This was extended in February to December 31st instead.
+Note: The end of support date has been extended to December 31st, 2026 from the previously announced July 31st, 2026.
 
 ## New imports
 

--- a/pubsub/doc.go
+++ b/pubsub/doc.go
@@ -17,7 +17,7 @@ Package pubsub provides an easy way to publish and receive Google Cloud Pub/Sub
 messages, hiding the details of the underlying server RPCs.
 
 This package is **deprecated**. All users should use cloud.google.com/go/pubsub/v2 instead.
-This version will supported with bug fixes until the deprecation date of December 31st 2026.
+This version will be supported with bug fixes and security patches until the deprecation date of December 31st, 2026.
 For more information about migrating, see https://github.com/googleapis/google-cloud-go/blob/main/pubsub/MIGRATING.md
 
 Pub/Sub is a many-to-many, asynchronous messaging system that decouples senders

--- a/pubsub/go.mod
+++ b/pubsub/go.mod
@@ -1,5 +1,5 @@
 // Deprecated: use cloud.google.com/go/pubsub/v2 instead.
-// This version will be supported until December 31st, 2026.
+// This version will be supported with bug fixes and security patches until December 31st, 2026.
 // For migration, see https://github.com/googleapis/google-cloud-go/blob/main/pubsub/MIGRATING.md
 module cloud.google.com/go/pubsub
 


### PR DESCRIPTION
This PR pushes the end of support for pubsub v1 (aka cloud.google.com/go/pubsub) to December 31st, 2026.

This also marks the deprecation in more places, including at the [module level](https://go.dev/ref/mod#go-mod-file-module-deprecation). Previously, this was only marked at the package level
