### PR TITLE
chore: librarian release pull request: 20260213T162929Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -726,7 +726,7 @@ libraries:
       - ^auditmanager/apiv1/auditmanagerpb/.*$
     tag_format: '{id}/v{version}'
   - id: auth
-    version: 0.18.1
+    version: 0.18.2
     last_generated_commit: 31b413bc4feb03f6849c718048c2b9998561b5fa
     apis: []
     source_roots:

--- a/auth/CHANGES.md
+++ b/auth/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+## [0.18.2](https://github.com/googleapis/google-cloud-go/releases/tag/auth%2Fv0.18.2) (2026-02-13)
+
+### Bug Fixes
+
+* fixes gdch credentials logic (#13741) ([f82cda5](https://github.com/googleapis/google-cloud-go/commit/f82cda58bd9885b7b8a9d8b15126f5a1e0add0dc))
+
 ## [0.18.1](https://github.com/googleapis/google-cloud-go/releases/tag/auth%2Fv0.18.1) (2026-01-21)
 
 ### Bug Fixes

--- a/auth/internal/version.go
+++ b/auth/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "0.18.1"
+const Version = "0.18.2"


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.8.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go@sha256:19bb93e8f1f916c61b597db2bad65dc432f79baaabb210499d7d0e4ad1dffe29
<details><summary>auth: 0.18.2</summary>

## [0.18.2](https://github.com/googleapis/google-cloud-go/compare/auth/v0.18.1...auth/v0.18.2) (2026-02-13)

### Bug Fixes

* fixes gdch credentials logic (#13741) ([f82cda58](https://github.com/googleapis/google-cloud-go/commit/f82cda58))

</details>