### PR TITLE
test(bigtable): skip flaky TestIntegration_AdminEncryptionInfo test

### DIFF
--- a/bigtable/integration_test.go
+++ b/bigtable/integration_test.go
@@ -2336,6 +2336,7 @@ func TestIntegration_AdminCreateInstance(t *testing.T) {
 }
 
 func TestIntegration_AdminEncryptionInfo(t *testing.T) {
+	t.Skip("flaky - https://github.com/googleapis/google-cloud-go/issues/11268")
 	if instanceToCreate == "" {
 		t.Skip("instanceToCreate not set, skipping instance creation testing")
 	}


### PR DESCRIPTION
This test is extremely flaky, and responsible for more than 50% of the recent nightly flakes.  Marking this test as skipped until this can be addressed.

Related: https://github.com/googleapis/google-cloud-go/issues/11268