### PR TITLE
chore(spanner): replace `interface{}` with `any` for statement Params

### DIFF
--- a/spanner/statement.go
+++ b/spanner/statement.go
@@ -40,12 +40,12 @@ import (
 // Spanner types.
 type Statement struct {
 	SQL    string
-	Params map[string]interface{}
+	Params map[string]any
 }
 
 // NewStatement returns a Statement with the given SQL and an empty Params map.
 func NewStatement(sql string) Statement {
-	return Statement{SQL: sql, Params: map[string]interface{}{}}
+	return Statement{SQL: sql, Params: map[string]any{}}
 }
 
 // convertParams converts a statement's parameters into proto Param and

--- a/spanner/statement_test.go
+++ b/spanner/statement_test.go
@@ -33,7 +33,7 @@ import (
 func TestConvertParams(t *testing.T) {
 	st := Statement{
 		SQL:    "SELECT id from t_foo WHERE col = @var",
-		Params: map[string]interface{}{"var": nil},
+		Params: map[string]any{"var": nil},
 	}
 	var (
 		t1, _ = time.Parse(time.RFC3339Nano, "2016-11-15T15:04:05.999999999Z")
@@ -61,7 +61,7 @@ func TestConvertParams(t *testing.T) {
 	)
 
 	for _, test := range []struct {
-		val       interface{}
+		val       any
 		wantField *proto3.Value
 		wantType  *sppb.Type
 	}{


### PR DESCRIPTION
This change is a minor quality of life change mixed with some modernisation.

Using `any` over `interface{}` is generally considered the preferred syntax in modern Go.
When creating `Params` on `Statement` gopls will suggest `map[string]interface{}{}` which will then have to be changed to `map[string]any{}` manually (or with `go fix`).

I kept the change small to minimize review time, but with the recent `go fix` changes in 1.26 i would suggest running that to catch everything.

So this PR will make that part the spanner package a smidge more enjoyable to work with as well as modernise the code a bit.