### PR TITLE
chore(preview): upgrade towards go 1.26

### DIFF
--- a/.github/workflows/vet.sh
+++ b/.github/workflows/vet.sh
@@ -79,7 +79,7 @@ golint ./... 2>&1 | (
 ) |
   tee /dev/stderr | (! read)
 
-staticcheck -go 1.24 ./... 2>&1 | (
+staticcheck -go 1.25 ./... 2>&1 | (
   grep -v SA1019 |
     grep -v internal/btree/btree.go |
     grep -v httpreplay/internal/proxy/debug.go |

--- a/.github/workflows/vet.yml
+++ b/.github/workflows/vet.yml
@@ -19,7 +19,7 @@ jobs:
     - uses: actions/checkout@v6
     - uses: actions/setup-go@v6
       with:
-        go-version: '1.25.x'
+        go-version: '1.26.x'
     - name: Install tools
       run: |
         go install golang.org/x/lint/golint@latest && \

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ Our libraries are compatible with the two most recent major Go
 releases, the same [policy](https://go.dev/doc/devel/release#policy) the Go
 programming language follows. This means the currently supported versions are:
 
-- Go 1.24
 - Go 1.25
+- Go 1.26
 
 ## Authentication
 

--- a/compute/go.mod
+++ b/compute/go.mod
@@ -1,6 +1,6 @@
 module cloud.google.com/go/compute
 
-go 1.24.0
+go 1.25.0
 
 require (
 	cloud.google.com/go v0.123.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module cloud.google.com/go
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/google/go-cmp v0.7.0


### PR DESCRIPTION
Capture changes from https://github.com/googleapis/google-cloud-go/commit/05f8554c1d63ed5a79d0b5c94acf479a34441347.