### PR TITLE
chore: librarian release pull request: 20260225T213439Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -932,7 +932,7 @@ libraries:
       - internal/generated/snippets/beyondcorp/
     tag_format: '{id}/v{version}'
   - id: bigquery
-    version: 1.73.1
+    version: 1.74.0
     last_generated_commit: 9a477cd3c26a704130e2a2fb44a40281d9312e4c
     apis:
       - path: google/cloud/bigquery/analyticshub/v1

--- a/bigquery/CHANGES.md
+++ b/bigquery/CHANGES.md
@@ -3,6 +3,12 @@
 
 
 
+## [1.74.0](https://github.com/googleapis/google-cloud-go/releases/tag/bigquery%2Fv1.74.0) (2026-02-25)
+
+### Features
+
+* add TotalServicesSkuSlotMillis to QueryStatistics (#13808) ([d716a47](https://github.com/googleapis/google-cloud-go/commit/d716a472d52af217bdccbcd5e974bac70e7e256a))
+
 ## [1.73.1](https://github.com/googleapis/google-cloud-go/releases/tag/bigquery%2Fv1.73.1) (2026-02-05)
 
 ### Bug Fixes

--- a/bigquery/internal/version.go
+++ b/bigquery/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "1.73.1"
+const Version = "1.74.0"

--- a/internal/generated/snippets/bigquery/analyticshub/apiv1/snippet_metadata.google.cloud.bigquery.analyticshub.v1.json
+++ b/internal/generated/snippets/bigquery/analyticshub/apiv1/snippet_metadata.google.cloud.bigquery.analyticshub.v1.json
@@ -1,7 +1,7 @@
 {
   "clientLibrary": {
     "name": "cloud.google.com/go/bigquery/analyticshub/apiv1",
-    "version": "1.73.1",
+    "version": "1.74.0",
     "language": "GO",
     "apis": [
       {

--- a/internal/generated/snippets/bigquery/biglake/apiv1/snippet_metadata.google.cloud.bigquery.biglake.v1.json
+++ b/internal/generated/snippets/bigquery/biglake/apiv1/snippet_metadata.google.cloud.bigquery.biglake.v1.json
@@ -1,7 +1,7 @@
 {
   "clientLibrary": {
     "name": "cloud.google.com/go/bigquery/biglake/apiv1",
-    "version": "1.73.1",
+    "version": "1.74.0",
     "language": "GO",
     "apis": [
       {

--- a/internal/generated/snippets/bigquery/biglake/apiv1alpha1/snippet_metadata.google.cloud.bigquery.biglake.v1alpha1.json
+++ b/internal/generated/snippets/bigquery/biglake/apiv1alpha1/snippet_metadata.google.cloud.bigquery.biglake.v1alpha1.json
@@ -1,7 +1,7 @@
 {
   "clientLibrary": {
     "name": "cloud.google.com/go/bigquery/biglake/apiv1alpha1",
-    "version": "1.73.1",
+    "version": "1.74.0",
     "language": "GO",
     "apis": [
       {

--- a/internal/generated/snippets/bigquery/connection/apiv1/snippet_metadata.google.cloud.bigquery.connection.v1.json
+++ b/internal/generated/snippets/bigquery/connection/apiv1/snippet_metadata.google.cloud.bigquery.connection.v1.json
@@ -1,7 +1,7 @@
 {
   "clientLibrary": {
     "name": "cloud.google.com/go/bigquery/connection/apiv1",
-    "version": "1.73.1",
+    "version": "1.74.0",
     "language": "GO",
     "apis": [
       {

--- a/internal/generated/snippets/bigquery/connection/apiv1beta1/snippet_metadata.google.cloud.bigquery.connection.v1beta1.json
+++ b/internal/generated/snippets/bigquery/connection/apiv1beta1/snippet_metadata.google.cloud.bigquery.connection.v1beta1.json
@@ -1,7 +1,7 @@
 {
   "clientLibrary": {
     "name": "cloud.google.com/go/bigquery/connection/apiv1beta1",
-    "version": "1.73.1",
+    "version": "1.74.0",
     "language": "GO",
     "apis": [
       {

--- a/internal/generated/snippets/bigquery/dataexchange/apiv1beta1/snippet_metadata.google.cloud.bigquery.dataexchange.v1beta1.json
+++ b/internal/generated/snippets/bigquery/dataexchange/apiv1beta1/snippet_metadata.google.cloud.bigquery.dataexchange.v1beta1.json
@@ -1,7 +1,7 @@
 {
   "clientLibrary": {
     "name": "cloud.google.com/go/bigquery/dataexchange/apiv1beta1",
-    "version": "1.73.1",
+    "version": "1.74.0",
     "language": "GO",
     "apis": [
       {

--- a/internal/generated/snippets/bigquery/datapolicies/apiv1/snippet_metadata.google.cloud.bigquery.datapolicies.v1.json
+++ b/internal/generated/snippets/bigquery/datapolicies/apiv1/snippet_metadata.google.cloud.bigquery.datapolicies.v1.json
@@ -1,7 +1,7 @@
 {
   "clientLibrary": {
     "name": "cloud.google.com/go/bigquery/datapolicies/apiv1",
-    "version": "1.73.1",
+    "version": "1.74.0",
     "language": "GO",
     "apis": [
       {

--- a/internal/generated/snippets/bigquery/datapolicies/apiv1beta1/snippet_metadata.google.cloud.bigquery.datapolicies.v1beta1.json
+++ b/internal/generated/snippets/bigquery/datapolicies/apiv1beta1/snippet_metadata.google.cloud.bigquery.datapolicies.v1beta1.json
@@ -1,7 +1,7 @@
 {
   "clientLibrary": {
     "name": "cloud.google.com/go/bigquery/datapolicies/apiv1beta1",
-    "version": "1.73.1",
+    "version": "1.74.0",
     "language": "GO",
     "apis": [
       {

--- a/internal/generated/snippets/bigquery/datapolicies/apiv2/snippet_metadata.google.cloud.bigquery.datapolicies.v2.json
+++ b/internal/generated/snippets/bigquery/datapolicies/apiv2/snippet_metadata.google.cloud.bigquery.datapolicies.v2.json
@@ -1,7 +1,7 @@
 {
   "clientLibrary": {
     "name": "cloud.google.com/go/bigquery/datapolicies/apiv2",
-    "version": "1.73.1",
+    "version": "1.74.0",
     "language": "GO",
     "apis": [
       {

--- a/internal/generated/snippets/bigquery/datapolicies/apiv2beta1/snippet_metadata.google.cloud.bigquery.datapolicies.v2beta1.json
+++ b/internal/generated/snippets/bigquery/datapolicies/apiv2beta1/snippet_metadata.google.cloud.bigquery.datapolicies.v2beta1.json
@@ -1,7 +1,7 @@
 {
   "clientLibrary": {
     "name": "cloud.google.com/go/bigquery/datapolicies/apiv2beta1",
-    "version": "1.73.1",
+    "version": "1.74.0",
     "language": "GO",
     "apis": [
       {

--- a/internal/generated/snippets/bigquery/datatransfer/apiv1/snippet_metadata.google.cloud.bigquery.datatransfer.v1.json
+++ b/internal/generated/snippets/bigquery/datatransfer/apiv1/snippet_metadata.google.cloud.bigquery.datatransfer.v1.json
@@ -1,7 +1,7 @@
 {
   "clientLibrary": {
     "name": "cloud.google.com/go/bigquery/datatransfer/apiv1",
-    "version": "1.73.1",
+    "version": "1.74.0",
     "language": "GO",
     "apis": [
       {

--- a/internal/generated/snippets/bigquery/migration/apiv2/snippet_metadata.google.cloud.bigquery.migration.v2.json
+++ b/internal/generated/snippets/bigquery/migration/apiv2/snippet_metadata.google.cloud.bigquery.migration.v2.json
@@ -1,7 +1,7 @@
 {
   "clientLibrary": {
     "name": "cloud.google.com/go/bigquery/migration/apiv2",
-    "version": "1.73.1",
+    "version": "1.74.0",
     "language": "GO",
     "apis": [
       {

--- a/internal/generated/snippets/bigquery/migration/apiv2alpha/snippet_metadata.google.cloud.bigquery.migration.v2alpha.json
+++ b/internal/generated/snippets/bigquery/migration/apiv2alpha/snippet_metadata.google.cloud.bigquery.migration.v2alpha.json
@@ -1,7 +1,7 @@
 {
   "clientLibrary": {
     "name": "cloud.google.com/go/bigquery/migration/apiv2alpha",
-    "version": "1.73.1",
+    "version": "1.74.0",
     "language": "GO",
     "apis": [
       {

--- a/internal/generated/snippets/bigquery/reservation/apiv1/snippet_metadata.google.cloud.bigquery.reservation.v1.json
+++ b/internal/generated/snippets/bigquery/reservation/apiv1/snippet_metadata.google.cloud.bigquery.reservation.v1.json
@@ -1,7 +1,7 @@
 {
   "clientLibrary": {
     "name": "cloud.google.com/go/bigquery/reservation/apiv1",
-    "version": "1.73.1",
+    "version": "1.74.0",
     "language": "GO",
     "apis": [
       {

--- a/internal/generated/snippets/bigquery/storage/apiv1/snippet_metadata.google.cloud.bigquery.storage.v1.json
+++ b/internal/generated/snippets/bigquery/storage/apiv1/snippet_metadata.google.cloud.bigquery.storage.v1.json
@@ -1,7 +1,7 @@
 {
   "clientLibrary": {
     "name": "cloud.google.com/go/bigquery/storage/apiv1",
-    "version": "1.73.1",
+    "version": "1.74.0",
     "language": "GO",
     "apis": [
       {

--- a/internal/generated/snippets/bigquery/storage/apiv1alpha/snippet_metadata.google.cloud.bigquery.storage.v1alpha.json
+++ b/internal/generated/snippets/bigquery/storage/apiv1alpha/snippet_metadata.google.cloud.bigquery.storage.v1alpha.json
@@ -1,7 +1,7 @@
 {
   "clientLibrary": {
     "name": "cloud.google.com/go/bigquery/storage/apiv1alpha",
-    "version": "1.73.1",
+    "version": "1.74.0",
     "language": "GO",
     "apis": [
       {

--- a/internal/generated/snippets/bigquery/storage/apiv1beta/snippet_metadata.google.cloud.bigquery.storage.v1beta.json
+++ b/internal/generated/snippets/bigquery/storage/apiv1beta/snippet_metadata.google.cloud.bigquery.storage.v1beta.json
@@ -1,7 +1,7 @@
 {
   "clientLibrary": {
     "name": "cloud.google.com/go/bigquery/storage/apiv1beta",
-    "version": "1.73.1",
+    "version": "1.74.0",
     "language": "GO",
     "apis": [
       {

--- a/internal/generated/snippets/bigquery/storage/apiv1beta1/snippet_metadata.google.cloud.bigquery.storage.v1beta1.json
+++ b/internal/generated/snippets/bigquery/storage/apiv1beta1/snippet_metadata.google.cloud.bigquery.storage.v1beta1.json
@@ -1,7 +1,7 @@
 {
   "clientLibrary": {
     "name": "cloud.google.com/go/bigquery/storage/apiv1beta1",
-    "version": "1.73.1",
+    "version": "1.74.0",
     "language": "GO",
     "apis": [
       {

--- a/internal/generated/snippets/bigquery/storage/apiv1beta2/snippet_metadata.google.cloud.bigquery.storage.v1beta2.json
+++ b/internal/generated/snippets/bigquery/storage/apiv1beta2/snippet_metadata.google.cloud.bigquery.storage.v1beta2.json
@@ -1,7 +1,7 @@
 {
   "clientLibrary": {
     "name": "cloud.google.com/go/bigquery/storage/apiv1beta2",
-    "version": "1.73.1",
+    "version": "1.74.0",
     "language": "GO",
     "apis": [
       {


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.8.3
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go@sha256:19bb93e8f1f916c61b597db2bad65dc432f79baaabb210499d7d0e4ad1dffe29
<details><summary>bigquery: v1.74.0</summary>

## [v1.74.0](https://github.com/googleapis/google-cloud-go/compare/bigquery/v1.73.1...bigquery/v1.74.0) (2026-02-25)

### Features

* add TotalServicesSkuSlotMillis to QueryStatistics (#13808) ([d716a472](https://github.com/googleapis/google-cloud-go/commit/d716a472))

</details>