### PR TITLE
test(storage): Fix a write integration test.

### DIFF
--- a/storage/integration_test.go
+++ b/storage/integration_test.go
@@ -4200,8 +4200,8 @@ func TestIntegration_WriterAppendEdgeCases(t *testing.T) {
 			t.Fatalf("w2.Close: %v", err)
 		}
 
-		// If we add yet another takeover writer to finalize the object, tw should
-		// return an error on flush.
+		// If we add yet another takeover writer to finalize the object, that should
+		// succeed.
 		tw2, _, err := obj.Generation(w2.Attrs().Generation).NewWriterFromAppendableObject(ctx, &AppendableWriterOpts{
 			FinalizeOnClose: true,
 		})
@@ -4211,12 +4211,16 @@ func TestIntegration_WriterAppendEdgeCases(t *testing.T) {
 		if err := tw2.Close(); err != nil {
 			t.Fatalf("tw2.Close: %v", err)
 		}
+
+		// `tw` should always fail to flush. Because `w2` overwrote the original
+		// object generation, `tw` might see either a fence error or a NOT_FOUND
+		// error.
 		_, err = tw.Write([]byte("abcde"))
 		if err == nil {
 			_, err = tw.Flush()
 		}
-		if code := status.Code(err); !(code == codes.FailedPrecondition || code == codes.Aborted) {
-			t.Errorf("tw.Write or tw.Flush: got error %v, want FailedPrecondition or Aborted", err)
+		if code := status.Code(err); !(code == codes.FailedPrecondition || code == codes.Aborted || code == codes.NotFound) {
+			t.Errorf("tw.Write or tw.Flush: got error %v, want FailedPrecondition, Aborted, or NotFound", err)
 		}
 	})
 }


### PR DESCRIPTION
The writer integration edge cases test included an unnecessary deletion. It also was a little bit brittle to specific implementation details of when flushes are implicitly scheduled on both the client and server side.