### PR TITLE
fix(spanner/spannertest): Support UUID as a base data type

### DIFF
--- a/spanner/spannertest/funcs.go
+++ b/spanner/spannertest/funcs.go
@@ -25,6 +25,7 @@ import (
 
 	"cloud.google.com/go/civil"
 	"cloud.google.com/go/spanner/spansql"
+	"github.com/google/uuid"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -212,6 +213,8 @@ func convert(val interface{}, tp spansql.Type) (interface{}, error) {
 		res, convertErr, err = convertToTimestamp(val)
 	case spansql.Numeric:
 	case spansql.JSON:
+	case spansql.UUID:
+		res, convertErr, err = convertToUUID(val)
 	}
 	if err != nil {
 		return nil, err
@@ -310,6 +313,20 @@ func convertToTimestamp(val interface{}) (res time.Time, convertErr error, err e
 		return res, nil, nil
 	}
 	return time.Time{}, nil, status.Errorf(codes.Unimplemented, "unsupported conversion for %v to TIMESTAMP", val)
+}
+
+func convertToUUID(val any) (res uuid.UUID, convertErr error, err error) {
+	switch v := val.(type) {
+	case uuid.UUID:
+		return v, nil, nil
+	case string:
+		res, err := uuid.Parse(v)
+		if err != nil {
+			return uuid.UUID{}, status.Errorf(codes.InvalidArgument, "invalid value for UUID: %q", v), nil
+		}
+		return res, nil, nil
+	}
+	return uuid.UUID{}, nil, status.Errorf(codes.Unimplemented, "unsupported conversion for %v to UUID", val)
 }
 
 type aggregateFunc struct {

--- a/spanner/spannertest/funcs.go
+++ b/spanner/spannertest/funcs.go
@@ -315,16 +315,16 @@ func convertToTimestamp(val interface{}) (res time.Time, convertErr error, err e
 	return time.Time{}, nil, status.Errorf(codes.Unimplemented, "unsupported conversion for %v to TIMESTAMP", val)
 }
 
-func convertToUUID(val any) (res uuid.UUID, convertErr error, err error) {
+func convertToUUID(val interface{}) (res uuid.UUID, convertErr error, err error) {
 	switch v := val.(type) {
 	case uuid.UUID:
 		return v, nil, nil
 	case string:
-		res, err := uuid.Parse(v)
-		if err != nil {
+		id, parseErr := uuid.Parse(v)
+		if parseErr != nil {
 			return uuid.UUID{}, status.Errorf(codes.InvalidArgument, "invalid value for UUID: %q", v), nil
 		}
-		return res, nil, nil
+		return id, nil, nil
 	}
 	return uuid.UUID{}, nil, status.Errorf(codes.Unimplemented, "unsupported conversion for %v to UUID", val)
 }

--- a/spanner/spansql/parser.go
+++ b/spanner/spansql/parser.go
@@ -3404,6 +3404,7 @@ var baseTypes = map[string]TypeBase{
 	"PROTO":     Proto, // for use in CAST
 	"ENUM":      Enum,  // for use in CAST
 	"TOKENLIST": Tokenlist,
+	"UUID":      UUID,
 }
 
 func (p *parser) parseBaseType() (Type, *parseError) {

--- a/spanner/spansql/parser_test.go
+++ b/spanner/spansql/parser_test.go
@@ -2703,54 +2703,54 @@ func TestParseDML(t *testing.T) {
 			DELETE FROM FooBar WHERE Name = "foo"; -- This is another comment.
 		-- This is an isolated comment.
 		`, &DML{
-			Filename: "filename",
-			List: []DMLStmt{
-				&Update{
-					Table: "FooBar",
-					Items: []UpdateItem{
-						{Column: "Name", Value: StringLiteral("foo")},
+				Filename: "filename",
+				List: []DMLStmt{
+					&Update{
+						Table: "FooBar",
+						Items: []UpdateItem{
+							{Column: "Name", Value: StringLiteral("foo")},
+						},
+						Where: ComparisonOp{Op: 4, LHS: ID("ID"), RHS: IntegerLiteral(0), RHS2: nil},
 					},
-					Where: ComparisonOp{Op: 4, LHS: ID("ID"), RHS: IntegerLiteral(0), RHS2: nil},
-				},
-				&Update{
-					Table: "FooBar",
-					Items: []UpdateItem{
-						{Column: "Name", Value: StringLiteral("foo")},
+					&Update{
+						Table: "FooBar",
+						Items: []UpdateItem{
+							{Column: "Name", Value: StringLiteral("foo")},
+						},
+						Where: ComparisonOp{Op: 4, LHS: ID("ID"), RHS: IntegerLiteral(0), RHS2: nil},
 					},
-					Where: ComparisonOp{Op: 4, LHS: ID("ID"), RHS: IntegerLiteral(0), RHS2: nil},
+					&Insert{
+						Table:   "FooBar",
+						Columns: []ID{"ID", "Name"},
+						Input:   Values{[]Expr{IntegerLiteral(0), StringLiteral("foo")}},
+					},
+					&Delete{
+						Table: "FooBar",
+						Where: ComparisonOp{Op: 4, LHS: ID("Name"), RHS: StringLiteral("foo"), RHS2: nil},
+					},
 				},
-				&Insert{
-					Table:   "FooBar",
-					Columns: []ID{"ID", "Name"},
-					Input:   Values{[]Expr{IntegerLiteral(0), StringLiteral("foo")}},
+				Comments: []*Comment{
+					{
+						Marker: "#", Start: line(2), End: line(2),
+						Text: []string{"This is a comment."},
+					},
+					{
+						Marker: "/*", Start: line(3), End: line(4),
+						Text:     []string{" This is a", "\t\t\t\t\t\t\t\t\t        * multiline comment."},
+						Isolated: false,
+					},
+					{
+						Marker: "--", Start: line(7), End: line(7),
+						Text:     []string{"This is another comment."},
+						Isolated: false,
+					},
+					{
+						Marker: "--", Start: line(8), End: line(8),
+						Text:     []string{"This is an isolated comment."},
+						Isolated: true,
+					},
 				},
-				&Delete{
-					Table: "FooBar",
-					Where: ComparisonOp{Op: 4, LHS: ID("Name"), RHS: StringLiteral("foo"), RHS2: nil},
-				},
-			},
-			Comments: []*Comment{
-				{
-					Marker: "#", Start: line(2), End: line(2),
-					Text: []string{"This is a comment."},
-				},
-				{
-					Marker: "/*", Start: line(3), End: line(4),
-					Text:     []string{" This is a", "\t\t\t\t\t\t\t\t\t        * multiline comment."},
-					Isolated: false,
-				},
-				{
-					Marker: "--", Start: line(7), End: line(7),
-					Text:     []string{"This is another comment."},
-					Isolated: false,
-				},
-				{
-					Marker: "--", Start: line(8), End: line(8),
-					Text:     []string{"This is an isolated comment."},
-					Isolated: true,
-				},
-			},
-		}},
+			}},
 		// No trailing comma:
 		{`Update FooBar SET Name = "foo" WHERE ID = 0`, &DML{
 			Filename: "filename", List: []DMLStmt{

--- a/spanner/spansql/parser_test.go
+++ b/spanner/spansql/parser_test.go
@@ -2702,52 +2702,55 @@ func TestParseDML(t *testing.T) {
 			INSERT FooBar (ID, Name) VALUES (0, 'foo');
 			DELETE FROM FooBar WHERE Name = "foo"; -- This is another comment.
 		-- This is an isolated comment.
-		`, &DML{Filename: "filename", List: []DMLStmt{
-			&Update{
-				Table: "FooBar",
-				Items: []UpdateItem{
-					{Column: "Name", Value: StringLiteral("foo")},
+		`, &DML{
+			Filename: "filename",
+			List: []DMLStmt{
+				&Update{
+					Table: "FooBar",
+					Items: []UpdateItem{
+						{Column: "Name", Value: StringLiteral("foo")},
+					},
+					Where: ComparisonOp{Op: 4, LHS: ID("ID"), RHS: IntegerLiteral(0), RHS2: nil},
 				},
-				Where: ComparisonOp{Op: 4, LHS: ID("ID"), RHS: IntegerLiteral(0), RHS2: nil},
-			},
-			&Update{
-				Table: "FooBar",
-				Items: []UpdateItem{
-					{Column: "Name", Value: StringLiteral("foo")},
+				&Update{
+					Table: "FooBar",
+					Items: []UpdateItem{
+						{Column: "Name", Value: StringLiteral("foo")},
+					},
+					Where: ComparisonOp{Op: 4, LHS: ID("ID"), RHS: IntegerLiteral(0), RHS2: nil},
 				},
-				Where: ComparisonOp{Op: 4, LHS: ID("ID"), RHS: IntegerLiteral(0), RHS2: nil},
+				&Insert{
+					Table:   "FooBar",
+					Columns: []ID{"ID", "Name"},
+					Input:   Values{[]Expr{IntegerLiteral(0), StringLiteral("foo")}},
+				},
+				&Delete{
+					Table: "FooBar",
+					Where: ComparisonOp{Op: 4, LHS: ID("Name"), RHS: StringLiteral("foo"), RHS2: nil},
+				},
 			},
-			&Insert{
-				Table:   "FooBar",
-				Columns: []ID{"ID", "Name"},
-				Input:   Values{[]Expr{IntegerLiteral(0), StringLiteral("foo")}},
-			},
-			&Delete{
-				Table: "FooBar",
-				Where: ComparisonOp{Op: 4, LHS: ID("Name"), RHS: StringLiteral("foo"), RHS2: nil},
-			},
-		}, Comments: []*Comment{
-			{
-				Marker: "#", Start: line(2), End: line(2),
-				Text: []string{"This is a comment."},
-			},
-			{
-				Marker: "/*", Start: line(3), End: line(4),
-				Text:     []string{" This is a", "\t\t\t\t\t\t\t\t\t        * multiline comment."},
-				Isolated: false,
-			},
-			{
-				Marker: "--", Start: line(7), End: line(7),
-				Text:     []string{"This is another comment."},
-				Isolated: false,
-			},
-			{
-				Marker: "--", Start: line(8), End: line(8),
-				Text:     []string{"This is an isolated comment."},
-				Isolated: true,
+			Comments: []*Comment{
+				{
+					Marker: "#", Start: line(2), End: line(2),
+					Text: []string{"This is a comment."},
+				},
+				{
+					Marker: "/*", Start: line(3), End: line(4),
+					Text:     []string{" This is a", "\t\t\t\t\t\t\t\t\t        * multiline comment."},
+					Isolated: false,
+				},
+				{
+					Marker: "--", Start: line(7), End: line(7),
+					Text:     []string{"This is another comment."},
+					Isolated: false,
+				},
+				{
+					Marker: "--", Start: line(8), End: line(8),
+					Text:     []string{"This is an isolated comment."},
+					Isolated: true,
+				},
 			},
 		}},
-		},
 		// No trailing comma:
 		{`Update FooBar SET Name = "foo" WHERE ID = 0`, &DML{
 			Filename: "filename", List: []DMLStmt{

--- a/spanner/spansql/parser_test.go
+++ b/spanner/spansql/parser_test.go
@@ -2610,6 +2610,26 @@ func TestParseDDL(t *testing.T) {
 				},
 			},
 		},
+		{
+			`CREATE TABLE tname (id UUID) PRIMARY KEY (id)`,
+			&DDL{
+				Filename: "filename",
+				List: []DDLStmt{
+					&CreateTable{
+						Name: "tname",
+						Columns: []ColumnDef{
+							{
+								Name:     "id",
+								Type:     Type{Base: UUID},
+								Position: line(1),
+							},
+						},
+						PrimaryKey: []KeyPart{{Column: "id"}},
+						Position:   line(1),
+					},
+				},
+			},
+		},
 	}
 	for _, test := range tests {
 		got, err := ParseDDL("filename", test.in)
@@ -2683,50 +2703,50 @@ func TestParseDML(t *testing.T) {
 			DELETE FROM FooBar WHERE Name = "foo"; -- This is another comment.
 		-- This is an isolated comment.
 		`, &DML{Filename: "filename", List: []DMLStmt{
-				&Update{
-					Table: "FooBar",
-					Items: []UpdateItem{
-						{Column: "Name", Value: StringLiteral("foo")},
-					},
-					Where: ComparisonOp{Op: 4, LHS: ID("ID"), RHS: IntegerLiteral(0), RHS2: nil},
+			&Update{
+				Table: "FooBar",
+				Items: []UpdateItem{
+					{Column: "Name", Value: StringLiteral("foo")},
 				},
-				&Update{
-					Table: "FooBar",
-					Items: []UpdateItem{
-						{Column: "Name", Value: StringLiteral("foo")},
-					},
-					Where: ComparisonOp{Op: 4, LHS: ID("ID"), RHS: IntegerLiteral(0), RHS2: nil},
+				Where: ComparisonOp{Op: 4, LHS: ID("ID"), RHS: IntegerLiteral(0), RHS2: nil},
+			},
+			&Update{
+				Table: "FooBar",
+				Items: []UpdateItem{
+					{Column: "Name", Value: StringLiteral("foo")},
 				},
-				&Insert{
-					Table:   "FooBar",
-					Columns: []ID{"ID", "Name"},
-					Input:   Values{[]Expr{IntegerLiteral(0), StringLiteral("foo")}},
-				},
-				&Delete{
-					Table: "FooBar",
-					Where: ComparisonOp{Op: 4, LHS: ID("Name"), RHS: StringLiteral("foo"), RHS2: nil},
-				},
-			}, Comments: []*Comment{
-				{
-					Marker: "#", Start: line(2), End: line(2),
-					Text: []string{"This is a comment."},
-				},
-				{
-					Marker: "/*", Start: line(3), End: line(4),
-					Text:     []string{" This is a", "\t\t\t\t\t\t\t\t\t        * multiline comment."},
-					Isolated: false,
-				},
-				{
-					Marker: "--", Start: line(7), End: line(7),
-					Text:     []string{"This is another comment."},
-					Isolated: false,
-				},
-				{
-					Marker: "--", Start: line(8), End: line(8),
-					Text:     []string{"This is an isolated comment."},
-					Isolated: true,
-				},
-			}},
+				Where: ComparisonOp{Op: 4, LHS: ID("ID"), RHS: IntegerLiteral(0), RHS2: nil},
+			},
+			&Insert{
+				Table:   "FooBar",
+				Columns: []ID{"ID", "Name"},
+				Input:   Values{[]Expr{IntegerLiteral(0), StringLiteral("foo")}},
+			},
+			&Delete{
+				Table: "FooBar",
+				Where: ComparisonOp{Op: 4, LHS: ID("Name"), RHS: StringLiteral("foo"), RHS2: nil},
+			},
+		}, Comments: []*Comment{
+			{
+				Marker: "#", Start: line(2), End: line(2),
+				Text: []string{"This is a comment."},
+			},
+			{
+				Marker: "/*", Start: line(3), End: line(4),
+				Text:     []string{" This is a", "\t\t\t\t\t\t\t\t\t        * multiline comment."},
+				Isolated: false,
+			},
+			{
+				Marker: "--", Start: line(7), End: line(7),
+				Text:     []string{"This is another comment."},
+				Isolated: false,
+			},
+			{
+				Marker: "--", Start: line(8), End: line(8),
+				Text:     []string{"This is an isolated comment."},
+				Isolated: true,
+			},
+		}},
 		},
 		// No trailing comma:
 		{`Update FooBar SET Name = "foo" WHERE ID = 0`, &DML{

--- a/spanner/spansql/sql.go
+++ b/spanner/spansql/sql.go
@@ -814,6 +814,8 @@ func (tb TypeBase) SQL() string {
 		return "ENUM"
 	case Tokenlist:
 		return "TOKENLIST"
+	case UUID:
+		return "UUID"
 	}
 
 	panic("unknown TypeBase")

--- a/spanner/spansql/sql_test.go
+++ b/spanner/spansql/sql_test.go
@@ -95,6 +95,7 @@ func TestSQL(t *testing.T) {
 					{Name: "Cn", Type: Type{Base: JSON}, Position: line(15)},
 					{Name: "Co", Type: Type{Base: Int64}, Default: IntegerLiteral(1), Position: line(16)},
 					{Name: "Cp", Type: Type{Base: Proto, ProtoRef: "a.b.c"}, Position: line(17)},
+					{Name: "Cq", Type: Type{Base: UUID}, Position: line(18)},
 				},
 				PrimaryKey: []KeyPart{
 					{Column: "Ca"},
@@ -119,6 +120,7 @@ func TestSQL(t *testing.T) {
   Cn JSON,
   Co INT64 DEFAULT (1),
   Cp ` + "`a.b.c`" + `,
+  Cq UUID,
 ) PRIMARY KEY(Ca, Cb DESC)`,
 			reparseDDL,
 		},

--- a/spanner/spansql/types.go
+++ b/spanner/spansql/types.go
@@ -594,6 +594,7 @@ const (
 	Proto
 	Enum // Enum used in CAST expressions
 	Tokenlist
+	UUID
 )
 
 type PrivilegeType int


### PR DESCRIPTION
Fixes: https://github.com/googleapis/google-cloud-go/issues/14506
Currently if we have this ddl statement
```
CREATE TABLE tname (id UUID) PRIMARY KEY (id)
```
and we run it through `spansql` like this:
```
out, _ := spansql.ParseDDL("", ddl)
ddl = out.List[0].SQL()
```
we end up with
```
CREATE TABLE tname (
  id `UUID`,
) PRIMARY KEY(id)
```
which can no longer be run against the database as the UUID data type has been mangled.

This change proposes to add UUID as a base type so that it can be recognised and retained through parsing.