### PR TITLE
fix(storage): ensure endpoint has a scheme before parsing in storage client

### DIFF
--- a/storage/http_client.go
+++ b/storage/http_client.go
@@ -119,6 +119,12 @@ func newHTTPStorageClient(ctx context.Context, opts ...storageOption) (storageCl
 	if err != nil {
 		return nil, fmt.Errorf("dialing: %w", err)
 	}
+
+	hc, ep, s.clientOption, err = ensureSchemeAndRedial(ctx, hc, ep, s.clientOption)
+	if err != nil {
+		return nil, err
+	}
+
 	// RawService should be created with the chosen endpoint to take account of user override.
 	rawService, err := raw.NewService(ctx, option.WithEndpoint(ep), option.WithHTTPClient(hc))
 	if err != nil {

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -206,6 +206,12 @@ func NewClient(ctx context.Context, opts ...option.ClientOption) (*Client, error
 	if err != nil {
 		return nil, fmt.Errorf("dialing: %w", err)
 	}
+
+	hc, ep, opts, err = ensureSchemeAndRedial(ctx, hc, ep, opts)
+	if err != nil {
+		return nil, err
+	}
+
 	// RawService should be created with the chosen endpoint to take account of user override.
 	// Preserve other user-supplied options as well.
 	opts = append(opts, option.WithEndpoint(ep), option.WithHTTPClient(hc))
@@ -232,6 +238,32 @@ func NewClient(ctx context.Context, opts ...option.ClientOption) (*Client, error
 		creds:   creds,
 		tc:      tc,
 	}, nil
+}
+
+// ensureSchemeAndRedial checks if the resolved endpoint has a scheme. If not, it
+// prepends https://, appends the storage path if missing, closes any idle connections
+// on the existing HTTP client, and redials with the corrected endpoint.
+func ensureSchemeAndRedial(ctx context.Context, hc *http.Client, ep string, opts []option.ClientOption) (*http.Client, string, []option.ClientOption, error) {
+	if !strings.Contains(ep, "://") {
+		ep = "https://" + ep
+		if !strings.Contains(ep, "/storage/v1") {
+			if !strings.HasSuffix(ep, "/") {
+				ep += "/"
+			}
+			ep += "storage/v1/"
+		}
+		// Clean up idle connections on the previous HTTP client before overwriting.
+		hc.CloseIdleConnections()
+		// Redial with the fixed endpoint so that the HTTP transport is
+		// correctly configured for HTTPS (including ALPN for HTTP/2).
+		opts = append(opts, option.WithEndpoint(ep))
+		var err error
+		hc, ep, err = htransport.NewClient(ctx, opts...)
+		if err != nil {
+			return nil, "", nil, fmt.Errorf("dialing with fixed endpoint: %w", err)
+		}
+	}
+	return hc, ep, opts, nil
 }
 
 // NewGRPCClient creates a new Storage client using the gRPC transport and API.

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -507,6 +507,32 @@ func TestSignedURL_EmulatorHost(t *testing.T) {
 	}
 }
 
+func TestSignedURL_SchemelessEndpoint(t *testing.T) {
+	ctx := context.Background()
+	ep := "storage.europe-west3.rep.googleapis.com"
+	client, err := NewClient(ctx, option.WithEndpoint(ep), option.WithoutAuthentication())
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	defer client.Close()
+
+	u, err := client.Bucket("my-bucket").SignedURL("my-object", &SignedURLOptions{
+		Method:         "GET",
+		Expires:        time.Now().Add(time.Hour),
+		GoogleAccessID: "xxx@xxx.com",
+		SignBytes: func(b []byte) ([]byte, error) {
+			return []byte("signed"), nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("SignedURL: %v", err)
+	}
+
+	if !strings.HasPrefix(u, "https://"+ep) {
+		t.Errorf("SignedURL %q does not start with expected endpoint %q", u, "https://"+ep)
+	}
+}
+
 func TestSignedURL_MissingOptions(t *testing.T) {
 	now, _ := time.Parse(time.RFC3339, "2002-10-01T00:00:00-05:00")
 	expires, _ := time.Parse(time.RFC3339, "2002-10-15T00:00:00-05:00")
@@ -2372,6 +2398,14 @@ func TestWithEndpoint(t *testing.T) {
 			WantScheme:          "http",
 		},
 		{
+			desc:                "With schemeless regional endpoint",
+			CustomEndpoint:      "storage.europe-west3.rep.googleapis.com",
+			StorageEmulatorHost: "",
+			WantRawBasePath:     "https://storage.europe-west3.rep.googleapis.com/storage/v1/",
+			WantXMLHost:         "storage.europe-west3.rep.googleapis.com",
+			WantScheme:          "https",
+		},
+		{
 			desc:                "Endpoint overrides emulator host when both are specified - https",
 			CustomEndpoint:      "https://fake.gcs.com:8080/storage/v1",
 			StorageEmulatorHost: "http://emu.com",
@@ -2490,16 +2524,22 @@ func TestOperationsWithEndpoint(t *testing.T) {
 			wantScheme:          "https",
 			wantHost:            "end",
 		},
+		{
+			desc:                "schemeless endpoint specified",
+			CustomEndpoint:      "storage.europe-west3.rep.googleapis.com",
+			StorageEmulatorHost: "",
+			wantScheme:          "https",
+			wantHost:            "storage.europe-west3.rep.googleapis.com",
+		},
 	}
 
 	for _, tc := range testCases {
 		ctx := context.Background()
 		t.Run(tc.desc, func(t *testing.T) {
+			t.Setenv("STORAGE_EMULATOR_HOST", tc.StorageEmulatorHost)
 			timeout := time.After(time.Second)
 			done := make(chan bool, 1)
 			go func() {
-				t.Setenv("STORAGE_EMULATOR_HOST", tc.StorageEmulatorHost)
-
 				c, err := NewClient(ctx, option.WithHTTPClient(hClient), option.WithEndpoint(tc.CustomEndpoint))
 				if err != nil {
 					t.Errorf("error creating client: %v", err)


### PR DESCRIPTION
Ensure that the endpoint provided via `option.WithEndpoint` has a scheme before it is parsed in `NewClient` and `newHTTPStorageClient`. This prevents empty `scheme` and `xmlHost` internal fields when a schemeless regional endpoint is used, which avoids transport-level issues and incorrect Signed URL generation.

Fixes #12695

---
*PR created automatically by Jules for task [18183255431142686154](https://jules.google.com/task/18183255431142686154) started by @cpriti-os*