### PR TITLE
feat(bigtable): make downscalling less aggressive

### DIFF
--- a/bigtable/internal/option/option.go
+++ b/bigtable/internal/option/option.go
@@ -233,27 +233,29 @@ func Debugf(logger *log.Logger, format string, v ...interface{}) {
 
 // DynamicChannelPoolConfig holds the parameters for dynamic channel pool scaling.
 type DynamicChannelPoolConfig struct {
-	Enabled              bool          // Whether dynamic scaling is enabled.
-	MinConns             int           // Minimum conns allowed
-	MaxConns             int           // Maximum conns allowed.
-	AvgLoadHighThreshold float64       // Average weighted load per connection to trigger scale-up.
-	AvgLoadLowThreshold  float64       // Average weighted load per connection to trigger scale-down.
-	MinScalingInterval   time.Duration // Minimum time between scaling operations (both up and down).
-	CheckInterval        time.Duration // How often to check if scaling is needed.
-	MaxRemoveConns       int           // Maximum number of connections to remove at once.
+	Enabled                          bool          // Whether dynamic scaling is enabled.
+	MinConns                         int           // Minimum conns allowed
+	MaxConns                         int           // Maximum conns allowed.
+	AvgLoadHighThreshold             float64       // Average weighted load per connection to trigger scale-up.
+	AvgLoadLowThreshold              float64       // Average weighted load per connection to trigger scale-down.
+	MinScalingInterval               time.Duration // Minimum time between scaling operations (both up and down).
+	CheckInterval                    time.Duration // How often to check if scaling is needed.
+	MaxRemoveConns                   int           // Maximum number of connections to remove at once.
+	ContinuousDownscaleRunsThreshold int           // Continous downscale signals for downscale to actually occur
 }
 
 // DefaultDynamicChannelPoolConfig is default settings for dynamic channel pool
 func DefaultDynamicChannelPoolConfig() DynamicChannelPoolConfig {
 	return DynamicChannelPoolConfig{
-		Enabled:              true, // Enabled by default
-		MinConns:             10,
-		MaxConns:             200,
-		AvgLoadHighThreshold: 50,
-		AvgLoadLowThreshold:  5,
-		MinScalingInterval:   1 * time.Minute,
-		CheckInterval:        30 * time.Second,
-		MaxRemoveConns:       2, // Only Cap for removals
+		Enabled:                          true, // Enabled by default
+		MinConns:                         10,
+		MaxConns:                         200,
+		AvgLoadHighThreshold:             50,
+		AvgLoadLowThreshold:              5,
+		MinScalingInterval:               1 * time.Minute,
+		CheckInterval:                    30 * time.Second,
+		MaxRemoveConns:                   2, // Only Cap for removals
+		ContinuousDownscaleRunsThreshold: 3,
 	}
 }
 

--- a/bigtable/internal/transport/dynamic_scale_monitor.go
+++ b/bigtable/internal/transport/dynamic_scale_monitor.go
@@ -24,8 +24,6 @@ import (
 	btopt "cloud.google.com/go/bigtable/internal/option"
 )
 
-const continuousDownscaleRunsThreshold = 3
-
 // DynamicScaleMonitor manages upscale and downscale of the connection pool.
 // Owner: It is owned by BigtableClient
 type DynamicScaleMonitor struct {
@@ -43,6 +41,10 @@ type DynamicScaleMonitor struct {
 
 // NewDynamicScaleMonitor creates a new DynamicScaleMonitor.
 func NewDynamicScaleMonitor(config btopt.DynamicChannelPoolConfig, pool *BigtableChannelPool) *DynamicScaleMonitor {
+	// Fallback to a default threshold of 3 if specified 0.
+	if config.ContinuousDownscaleRunsThreshold == 0 {
+		config.ContinuousDownscaleRunsThreshold = 3
+	}
 
 	perConnTargetLoad := math.Floor(config.AvgLoadLowThreshold+config.AvgLoadHighThreshold) / 2.0
 	if perConnTargetLoad < 1.0 {
@@ -118,9 +120,9 @@ func (dsm *DynamicScaleMonitor) evaluateAndScale() {
 	if currentAvgLoadPerConn <= dsm.config.AvgLoadLowThreshold {
 		dsm.continuousDownscaleRuns++
 
-		btopt.Debugf(dsm.pool.logger, "bigtable_connpool: Low load detected. Downscale streak: %d/%d\n", dsm.continuousDownscaleRuns, continuousDownscaleRunsThreshold)
+		btopt.Debugf(dsm.pool.logger, "bigtable_connpool: Low load detected. Downscale streak: %d/%d\n", dsm.continuousDownscaleRuns, dsm.config.ContinuousDownscaleRunsThreshold)
 
-		if dsm.continuousDownscaleRuns >= continuousDownscaleRunsThreshold {
+		if dsm.continuousDownscaleRuns >= dsm.config.ContinuousDownscaleRunsThreshold {
 			dsm.scaleDown(currentLoadSum, currentConnsCount)
 			dsm.continuousDownscaleRuns = 0
 		}
@@ -160,6 +162,11 @@ func ValidateDynamicConfig(config btopt.DynamicChannelPoolConfig, connPoolSize i
 	}
 	if config.MaxRemoveConns <= 0 {
 		return fmt.Errorf("bigtable_connpool: DynamicChannelPoolConfig.MaxRemoveConns must be positive")
+	}
+
+	// Validate the new config field
+	if config.ContinuousDownscaleRunsThreshold < 0 {
+		return fmt.Errorf("bigtable_connpool: DynamicChannelPoolConfig.ContinuousDownscaleRunsThreshold cannot be negative")
 	}
 	return nil
 }

--- a/bigtable/internal/transport/dynamic_scale_monitor_test.go
+++ b/bigtable/internal/transport/dynamic_scale_monitor_test.go
@@ -29,14 +29,15 @@ func TestDynamicChannelScaling(t *testing.T) {
 	dialFunc := func() (*BigtableConn, error) { return dialBigtableserver(addr) }
 
 	baseConfig := btopt.DynamicChannelPoolConfig{
-		Enabled:              true,
-		MinConns:             2,
-		MaxConns:             10,
-		AvgLoadHighThreshold: 10.0,             // Scale up if avg load >= 10
-		AvgLoadLowThreshold:  3.0,              // Scale down if avg load <= 3
-		MinScalingInterval:   0,                // Disable time throttling for most tests
-		CheckInterval:        10 * time.Second, // Not directly used by calling evaluateAndScale
-		MaxRemoveConns:       3,
+		Enabled:                          true,
+		MinConns:                         2,
+		MaxConns:                         10,
+		AvgLoadHighThreshold:             10.0,             // Scale up if avg load >= 10
+		AvgLoadLowThreshold:              3.0,              // Scale down if avg load <= 3
+		MinScalingInterval:               0,                // Disable time throttling for most tests
+		CheckInterval:                    10 * time.Second, // Not directly used by calling evaluateAndScale
+		MaxRemoveConns:                   3,
+		ContinuousDownscaleRunsThreshold: 3,
 	}
 	tests := []struct {
 		name          string
@@ -126,6 +127,15 @@ func TestDynamicChannelScaling(t *testing.T) {
 			// Total load = 20. Desired = ceil(20 / 6.5) = 4. Add 2.
 			wantSize:      4,
 			evaluateCalls: 1,
+		},
+		{
+			name:        "NoScaleDownWithEvaluations<ContinuousDownscaleRunsThreshold",
+			initialSize: 6,
+			setLoad: func(conns []*connEntry) {
+				setConnLoads(conns, 1, 0) // Avg load 1 < 3 (Low load)
+			},
+			wantSize:      6,
+			evaluateCalls: 2,
 		},
 	}
 


### PR DESCRIPTION
will only downscale if three consecutive runs happen.