### PR TITLE
chore(preview): sync shared files, fix sync.sh

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,13 +5,13 @@
 
 /ai/                    @googleapis/vertexai-team @googleapis/cloud-sdk-go-team @googleapis/cloud-sdk-librarian-team
 /aiplatform/            @googleapis/vertexai-team @googleapis/cloud-sdk-go-team @googleapis/cloud-sdk-librarian-team
-/bigtable/              @googleapis/cloud-native-db-dpes @googleapis/bigtable-team @googleapis/cloud-sdk-go-team @googleapis/cloud-sdk-librarian-team
-/bigtable/cmd/cbt       @igorbernstein2 @googleapis/cloud-native-db-dpes @googleapis/bigtable-team @googleapis/cloud-sdk-go-team @googleapis/cloud-sdk-librarian-team
-/bigtable/cmd/emulator  @igorbernstein2 @googleapis/cloud-native-db-dpes @googleapis/bigtable-team @googleapis/cloud-sdk-go-team @googleapis/cloud-sdk-librarian-team
-/bigtable/bttest        @igorbernstein2 @googleapis/cloud-native-db-dpes @googleapis/bigtable-team @googleapis/cloud-sdk-go-team @googleapis/cloud-sdk-librarian-team
-/datastore/             @googleapis/cloud-native-db-dpes @googleapis/cloud-sdk-go-team @googleapis/cloud-sdk-librarian-team
-/firestore/             @googleapis/cloud-native-db-dpes @googleapis/cloud-sdk-go-team @googleapis/cloud-sdk-librarian-team
-/pubsub/                @googleapis/pubsub-team @googleapis/cloud-sdk-go-team @googleapis/cloud-sdk-librarian-team @googleapis/cloud-native-db-dpes
+/bigtable/              @googleapis/bigtable-team @googleapis/cloud-sdk-go-team @googleapis/cloud-sdk-librarian-team
+/bigtable/cmd/cbt       @googleapis/bigtable-team @googleapis/cloud-sdk-go-team @googleapis/cloud-sdk-librarian-team
+/bigtable/cmd/emulator  @googleapis/bigtable-team @googleapis/cloud-sdk-go-team @googleapis/cloud-sdk-librarian-team
+/bigtable/bttest        @googleapis/bigtable-team @googleapis/cloud-sdk-go-team @googleapis/cloud-sdk-librarian-team
+/datastore/             @googleapis/cloud-sdk-go-team @googleapis/cloud-sdk-librarian-team
+/firestore/             @googleapis/cloud-sdk-go-team @googleapis/cloud-sdk-librarian-team
+/pubsub/                @googleapis/pubsub-team @googleapis/cloud-sdk-go-team @googleapis/cloud-sdk-librarian-team
 /pubsublite/            @googleapis/pubsub-team @googleapis/cloud-sdk-go-team @googleapis/cloud-sdk-librarian-team
 /spanner/               @googleapis/spanner-team @googleapis/cloud-sdk-go-team @googleapis/cloud-sdk-librarian-team
 /storage/               @googleapis/gcs-team @googleapis/cloud-sdk-go-team @googleapis/cloud-sdk-librarian-team
@@ -20,7 +20,7 @@
 /logging/               @googleapis/cloud-sdk-go-team @googleapis/cloud-sdk-librarian-team
 /profiler/              @googleapis/cloud-profiler-team @googleapis/cloud-sdk-go-team @googleapis/cloud-sdk-librarian-team
 /vertexai/              @googleapis/vertexai-team @googleapis/cloud-sdk-go-team @googleapis/cloud-sdk-librarian-team
-/internal/protoveneer/  @googleapis/cloud-sdk-go-team @googleapis/cloud-sdk-librarian-team @jba
+/internal/protoveneer/  @googleapis/cloud-sdk-go-team @googleapis/cloud-sdk-librarian-team
 
 
 # We mark the librarian state file as unowned to avoid gatekeeping librarian operations on 

--- a/sync.sh
+++ b/sync.sh
@@ -23,5 +23,3 @@ git checkout main -- \
     LICENSE \
     README.md \
     SECURITY.md
-
-sed -i '1c\'"$(git show origin/main:.librarian/state.yaml | head -n 1)" .librarian/state.yaml


### PR DESCRIPTION
Updates shared files based on contents of `main` at https://github.com/googleapis/google-cloud-go/commit/7dd4948dde25b811cbf2679a011a7a24dd2e6220. Only `CODEOWNERS` has changed since last sync.

Removes librarian image tag sync - this should be done with an `update-image` command.