### PR TITLE
test(bigquery): relax TestIntegration_QueryStatistics

### DIFF
--- a/bigquery/integration_test.go
+++ b/bigquery/integration_test.go
@@ -1513,7 +1513,7 @@ func TestIntegration_QueryStatistics(t *testing.T) {
 	}
 
 	if status.Statistics.TotalSlotDuration < 0 {
-		t.Errorf("expected positive total slot duration, %s reported", status.Statistics.TotalSlotDuration.String())
+		t.Errorf("expected non-negative total slot duration, %s reported", status.Statistics.TotalSlotDuration.String())
 	}
 
 	if status.Statistics.NumChildJobs != 0 {


### PR DESCRIPTION
relax test to only fire on negative slot values


Fixes: https://github.com/googleapis/google-cloud-go/issues/14013