### PR TITLE
test(bigtable): switch error match to regexp

### DIFF
--- a/bigtable/integration_test.go
+++ b/bigtable/integration_test.go
@@ -400,7 +400,7 @@ func TestIntegration_Aggregates(t *testing.T) {
 		t.Fatalf("Expected UpdateFamily to fail, but it didn't")
 	}
 	wantErrorPattern := "Immutable fields 'value_type.aggregate_type.*' cannot be updated"
-	if !regexp.MatchString(wantErrorPattern, err.Error()) {
+	if matched, _ := !regexp.MatchString(wantErrorPattern, err.Error()); !matched {
 		t.Errorf("Wrong error. Expected to match %q but was %v", wantErrorPattern, err)
 	}
 }


### PR DESCRIPTION
Test error string matching is too specific, this changes to a simple regexp match