### PR TITLE
chore: librarian release pull request: 20260310T073310Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -5889,7 +5889,7 @@ libraries:
       - internal/generated/snippets/speech/
     tag_format: '{id}/v{version}'
   - id: storage
-    version: 1.60.0
+    version: 1.61.0
     last_generated_commit: 9eea40c74d97622bb0aa406dd313409a376cc73b
     apis:
       - path: google/storage/control/v2

--- a/internal/generated/snippets/storage/control/apiv2/snippet_metadata.google.storage.control.v2.json
+++ b/internal/generated/snippets/storage/control/apiv2/snippet_metadata.google.storage.control.v2.json
@@ -1,7 +1,7 @@
 {
   "clientLibrary": {
     "name": "cloud.google.com/go/storage/control/apiv2",
-    "version": "1.60.0",
+    "version": "1.61.0",
     "language": "GO",
     "apis": [
       {

--- a/storage/CHANGES.md
+++ b/storage/CHANGES.md
@@ -1,6 +1,21 @@
 # Changes
 
 
+## [1.61.0](https://github.com/googleapis/google-cloud-go/releases/tag/storage%2Fv1.61.0) (2026-03-10)
+
+### Features
+
+* add a DeleteFolderRecursive API definition ([6f31019](https://github.com/googleapis/google-cloud-go/commit/6f310199e136b133bb4fadaa353e264e809db6d7))
+* add bucket encryption enforcement configuration (#13874) ([245c8d7](https://github.com/googleapis/google-cloud-go/commit/245c8d7638756f3ec7c55b32b8a0f924814e8547))
+* add multistream options to MRD (#13758) ([4557675](https://github.com/googleapis/google-cloud-go/commit/4557675e058e042c614a46b55c1b2346d378204b))
+* add multistream support to MRD (#13792) ([ffa7268](https://github.com/googleapis/google-cloud-go/commit/ffa7268c6195f11f404b0c976b3c7c836df26294))
+
+### Bug Fixes
+
+* Fix TM download dir corner case (#14142) ([87cdcc9](https://github.com/googleapis/google-cloud-go/commit/87cdcc9f756881f90337d222fe3707234d1a2c71))
+* Omit auto checksum in final request when MD5 is given (#14024) ([d404777](https://github.com/googleapis/google-cloud-go/commit/d40477749f0d54c88dd92fd992c9401732ef8d50))
+* optimize gRPC writer with zero-copy and lazy allocation (#13481) ([df64147](https://github.com/googleapis/google-cloud-go/commit/df64147605e961803c7ea839bc080ffd1b814ac9))
+
 ## [1.60.0](https://github.com/googleapis/google-cloud-go/releases/tag/storage%2Fv1.60.0) (2026-02-10)
 
 ### Features

--- a/storage/internal/version.go
+++ b/storage/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "1.60.0"
+const Version = "1.61.0"


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.8.3
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go@sha256:19bb93e8f1f916c61b597db2bad65dc432f79baaabb210499d7d0e4ad1dffe29
<details><summary>storage: v1.61.0</summary>

## [v1.61.0](https://github.com/googleapis/google-cloud-go/compare/storage/v1.60.0...storage/v1.61.0) (2026-03-10)

### Features

* add bucket encryption enforcement configuration (#13874) ([245c8d76](https://github.com/googleapis/google-cloud-go/commit/245c8d76))

* add multistream options to MRD (#13758) ([4557675e](https://github.com/googleapis/google-cloud-go/commit/4557675e))

* add a DeleteFolderRecursive API definition (PiperOrigin-RevId: 866471251) ([6f310199](https://github.com/googleapis/google-cloud-go/commit/6f310199))

* add multistream support to MRD (#13792) ([ffa7268c](https://github.com/googleapis/google-cloud-go/commit/ffa7268c))

### Bug Fixes

* Fix TM download dir corner case (#14142) ([87cdcc9f](https://github.com/googleapis/google-cloud-go/commit/87cdcc9f))

* Omit auto checksum in final request when MD5 is given (#14024) ([d4047774](https://github.com/googleapis/google-cloud-go/commit/d4047774))

* optimize gRPC writer with zero-copy and lazy allocation (#13481) ([df641476](https://github.com/googleapis/google-cloud-go/commit/df641476))

</details>