### PR TITLE
chore: librarian release pull request: 20260311T074420Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -5889,7 +5889,7 @@ libraries:
       - internal/generated/snippets/speech/
     tag_format: '{id}/v{version}'
   - id: storage
-    version: 1.61.0
+    version: 1.61.1
     last_generated_commit: 9eea40c74d97622bb0aa406dd313409a376cc73b
     apis:
       - path: google/storage/control/v2

--- a/internal/generated/snippets/storage/control/apiv2/snippet_metadata.google.storage.control.v2.json
+++ b/internal/generated/snippets/storage/control/apiv2/snippet_metadata.google.storage.control.v2.json
@@ -1,7 +1,7 @@
 {
   "clientLibrary": {
     "name": "cloud.google.com/go/storage/control/apiv2",
-    "version": "1.61.0",
+    "version": "1.61.1",
     "language": "GO",
     "apis": [
       {

--- a/storage/CHANGES.md
+++ b/storage/CHANGES.md
@@ -1,6 +1,8 @@
 # Changes
 
 
+## [1.61.1](https://github.com/googleapis/google-cloud-go/releases/tag/storage%2Fv1.61.1) (2026-03-11)
+
 ## [1.61.0](https://github.com/googleapis/google-cloud-go/releases/tag/storage%2Fv1.61.0) (2026-03-10)
 
 ### Features

--- a/storage/internal/version.go
+++ b/storage/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "1.61.0"
+const Version = "1.61.1"


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.8.3
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go@sha256:19bb93e8f1f916c61b597db2bad65dc432f79baaabb210499d7d0e4ad1dffe29
<details><summary>storage: v1.61.1</summary>

## [v1.61.1](https://github.com/googleapis/google-cloud-go/compare/storage/v1.61.0...storage/v1.61.1) (2026-03-11)

</details>