### PR TITLE
test(pubsub/v2): fix race by locking server timeout const at newIterator

### DIFF
--- a/pubsub/v2/iterator.go
+++ b/pubsub/v2/iterator.go
@@ -103,6 +103,7 @@ type messageIterator struct {
 	pingMu             sync.RWMutex
 	lastServerResponse time.Time
 	lastClientPing     time.Time
+	serverTimeout      time.Duration
 
 	// This mutex guards the structs related to lease extension.
 	mu          sync.Mutex
@@ -196,6 +197,7 @@ func newMessageIterator(subc *vkit.SubscriptionAdminClient, subName string, po *
 		pendingReceipts:     map[string]*AckResult{},
 		lastServerResponse:  time.Now(),
 		lastClientPing:      time.UnixMicro(0),
+		serverTimeout:       serverPingTimeoutDuration,
 	}
 	it.wg.Add(1)
 	go it.streamKeepAliveHandler()
@@ -911,9 +913,9 @@ func (it *messageIterator) streamKeepAliveHandler() {
 
 		select {
 		case <-it.pingTicker.C:
-			it.pingStream()
+			go it.pingStream()
 		case <-it.serverMonitorTicker.C:
-			it.checkServer()
+			go it.checkServer()
 		}
 	}
 }
@@ -931,7 +933,7 @@ func (it *messageIterator) checkServer() {
 	}
 
 	// if the lastPing happened within the timeout, we pass this check.
-	if time.Since(lastPing) < serverPingTimeoutDuration {
+	if time.Since(lastPing) < it.serverTimeout {
 		return
 	}
 


### PR DESCRIPTION
Keep alive support was added in #13457 which introduced called pingStream and checkServer functions as goroutines. This could cause a race condition on stream shutdown when the server timeout variable was read / written during test cleanup.

Fixes #14161 which isn't because of `TestPublisherID` specifically, but a race condition detected in the previous shutdown test during shutdown.

Fixes #14165 