### PR TITLE
chore: release vertexai@v0.17.0

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -6274,7 +6274,7 @@ libraries:
       - ^vectorsearch/apiv1/vectorsearchpb/.*$
     tag_format: '{id}/v{version}'
   - id: vertexai
-    version: 0.16.0
+    version: 0.17.0
     last_generated_commit: e8365a7f88fabe8717cb8322b8ce784b03b6daea
     apis: []
     source_roots:

--- a/vertexai/CHANGES.md
+++ b/vertexai/CHANGES.md
@@ -1,5 +1,7 @@
 # Changes
 
+## [0.17.0](https://github.com/googleapis/google-cloud-go/releases/tag/vertexai%2Fv0.17.0) (2026-03-17)
+
 ## [0.16.0](https://github.com/googleapis/google-cloud-go/releases/tag/vertexai%2Fv0.16.0) (2026-03-13)
 
 ### Features

--- a/vertexai/internal/version.go
+++ b/vertexai/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "0.16.0"
+const Version = "0.17.0"


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.8.3
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go@sha256:19bb93e8f1f916c61b597db2bad65dc432f79baaabb210499d7d0e4ad1dffe29
<details><summary>vertexai: v0.17.0</summary>

## [v0.17.0](https://github.com/googleapis/google-cloud-go/compare/vertexai/v0.16.0...vertexai/v0.17.0) (2026-03-17)

</details>