### PR TITLE
chore: librarian release pull request: 20260319T051547Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -4598,7 +4598,7 @@ libraries:
       - internal/generated/snippets/pubsub/
     tag_format: '{id}/v{version}'
   - id: pubsub/v2
-    version: 2.4.0
+    version: 3.0.0
     last_generated_commit: 6df3ecf4fd43b64826de6a477d1a535ec18b0d7c
     apis:
       - path: google/pubsub/v1

--- a/internal/generated/snippets/pubsub/v2/apiv1/snippet_metadata.google.pubsub.v1.json
+++ b/internal/generated/snippets/pubsub/v2/apiv1/snippet_metadata.google.pubsub.v1.json
@@ -1,7 +1,7 @@
 {
   "clientLibrary": {
     "name": "cloud.google.com/go/pubsub/v2/apiv1",
-    "version": "2.4.0",
+    "version": "3.0.0",
     "language": "GO",
     "apis": [
       {

--- a/pubsub/v2/CHANGES.md
+++ b/pubsub/v2/CHANGES.md
@@ -1,5 +1,13 @@
 # Changes
 
+## [3.0.0](https://github.com/googleapis/google-cloud-go/releases/tag/pubsub%2Fv3.0.0) (2026-03-19)
+
+### Features
+
+* Add BigtableConfig type ([177550d](https://github.com/googleapis/google-cloud-go/commit/177550d454fe98dcd1cd6645bf9b4c51eef7a419))
+* add keep alive support (#13457) ([aeffa93](https://github.com/googleapis/google-cloud-go/commit/aeffa932f86ee8b221bc8f71faef7876791054db))
+* introduce per stream flow control (#13642) ([9bb9541](https://github.com/googleapis/google-cloud-go/commit/9bb9541773cde3a934eb0ab15032d777468cba9c))
+
 ## [2.4.0](https://github.com/googleapis/google-cloud-go/releases/tag/pubsub%2Fv2.4.0) (2026-02-04)
 
 ### Features

--- a/pubsub/v2/internal/version.go
+++ b/pubsub/v2/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "2.4.0"
+const Version = "3.0.0"


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.8.3
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go@sha256:19bb93e8f1f916c61b597db2bad65dc432f79baaabb210499d7d0e4ad1dffe29
<details><summary>pubsub/v2: v3.0.0</summary>

## [v3.0.0](https://github.com/googleapis/google-cloud-go/compare/pubsub/v2.4.0...pubsub/v3.0.0) (2026-03-19)

### Features

* Add BigtableConfig type (PiperOrigin-RevId: 878685355) ([177550d4](https://github.com/googleapis/google-cloud-go/commit/177550d4))

* introduce per stream flow control (#13642) ([9bb95417](https://github.com/googleapis/google-cloud-go/commit/9bb95417))

* add keep alive support (#13457) ([aeffa932](https://github.com/googleapis/google-cloud-go/commit/aeffa932))

</details>