### PR TITLE
fix(pubsublite): reduce pscompat BufferedByteLimit

### DIFF
--- a/pubsublite/internal/wire/settings_test.go
+++ b/pubsublite/internal/wire/settings_test.go
@@ -38,7 +38,7 @@ func TestValidatePublishSettings(t *testing.T) {
 				// These have no max bounds, check large values.
 				settings.DelayThreshold = 24 * time.Hour
 				settings.Timeout = 24 * time.Hour
-				settings.BufferedByteLimit = 1e10
+				settings.BufferedByteLimit = 1e9
 			},
 			wantErr: false,
 		},
@@ -133,7 +133,7 @@ func TestValidateReceiveSettings(t *testing.T) {
 				settings.Partitions = []int{5, 3, 9, 1, 4, 0}
 				// These have no max bounds, check large values.
 				settings.MaxOutstandingMessages = 100000
-				settings.MaxOutstandingBytes = 1e10
+				settings.MaxOutstandingBytes = 1e9
 				settings.Timeout = 24 * time.Hour
 			},
 			wantErr: false,

--- a/pubsublite/pscompat/settings.go
+++ b/pubsublite/pscompat/settings.go
@@ -122,7 +122,7 @@ var DefaultPublishSettings = PublishSettings{
 	CountThreshold:    100,
 	ByteThreshold:     1e6,
 	Timeout:           7 * 24 * time.Hour,
-	BufferedByteLimit: 1e10,
+	BufferedByteLimit: 1e9,
 	EnableIdempotence: true,
 }
 


### PR DESCRIPTION
Reduced default BufferedByteLimit in pscompat layer to ensure compatibility with 32-bit architectures. This prevents compilation errors and potential OOM issues on memory-constrained systems (10 GB default is too high).

Users requiring extremely large buffers on 64-bit systems can still override these settings manually.

Note: Pub/Sub Lite has been deprecated and is scheduled to be shut down in [June 2026](https://docs.cloud.google.com/pubsub/lite/docs).

Fixes #14237