### PR TITLE
test(pubsub/v2): reduced flow controller test limits for 32 bit systems

### DIFF
--- a/pubsub/flow_controller_test.go
+++ b/pubsub/flow_controller_test.go
@@ -226,13 +226,13 @@ func TestFlowControllerUnboundedBytes(t *testing.T) {
 	ctx := context.Background()
 	fc := newFlowController(fcSettings(2, 0, FlowControlSignalError))
 
-	// Successfully acquire 4GB.
-	if err := fc.acquire(ctx, 4e9); err != nil {
+	// Successfully acquire 2GB.
+	if err := fc.acquire(ctx, 2e9); err != nil {
 		t.Errorf("got %v, wanted no error", err)
 	}
 
-	// Successfully acquired 4GB bytes.
-	if err := fc.acquire(ctx, 4e9); err != nil {
+	// Successfully acquired 2GB bytes.
+	if err := fc.acquire(ctx, 2e9); err != nil {
 		t.Errorf("got %v, wanted no error", err)
 	}
 

--- a/pubsub/v2/flow_controller_test.go
+++ b/pubsub/v2/flow_controller_test.go
@@ -226,13 +226,13 @@ func TestFlowControllerUnboundedBytes(t *testing.T) {
 	ctx := context.Background()
 	fc := newFlowController(fcSettings(2, 0, FlowControlSignalError))
 
-	// Successfully acquire 4GB.
-	if err := fc.acquire(ctx, 4e9); err != nil {
+	// Successfully acquire 2GB.
+	if err := fc.acquire(ctx, 2e9); err != nil {
 		t.Errorf("got %v, wanted no error", err)
 	}
 
-	// Successfully acquired 4GB bytes.
-	if err := fc.acquire(ctx, 4e9); err != nil {
+	// Successfully acquired 2GB bytes.
+	if err := fc.acquire(ctx, 2e9); err != nil {
 		t.Errorf("got %v, wanted no error", err)
 	}
 


### PR DESCRIPTION
Reduces the flow controller test limits from 4GB -> 2GB, retaining the intent, but making this pass for 32 bit systems.

The alternative would be to convert flow_controller to take an int64 explicitly instead, but since the test is rather trivial, I prefer to keep this as-is.

Fixes #14235