### PR TITLE
chore: exclude go.einride.tech from renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -24,7 +24,7 @@
                 "^github.com/google/go-github/v",
                 "^github.com/apache/arrow/go/v",
                 "^github.com/cloudprober/cloudprober",
-                "^go.einride.tech/aip",
+                "^go.einride.tech/aip"
             ],
             "enabled": false
         },


### PR DESCRIPTION
Originally proposed in #9338 but deferred, we plan on removing this dependency in the medium-term future.