### PR TITLE
chore: format repo metadata

### DIFF
--- a/accessapproval/apiv1/.repo-metadata.json
+++ b/accessapproval/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "accessapproval",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/accessapproval/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Access Approval API",
-  "distribution_name": "cloud.google.com/go/accessapproval/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "accessapproval",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/accessapproval/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Access Approval API",
+    "distribution_name": "cloud.google.com/go/accessapproval/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/accesscontextmanager/apiv1/.repo-metadata.json
+++ b/accesscontextmanager/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "accesscontextmanager",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/accesscontextmanager/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Access Context Manager API",
-  "distribution_name": "cloud.google.com/go/accesscontextmanager/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "accesscontextmanager",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/accesscontextmanager/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Access Context Manager API",
+    "distribution_name": "cloud.google.com/go/accesscontextmanager/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/advisorynotifications/apiv1/.repo-metadata.json
+++ b/advisorynotifications/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "advisorynotifications",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/advisorynotifications/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Advisory Notifications API",
-  "distribution_name": "cloud.google.com/go/advisorynotifications/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "advisorynotifications",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/advisorynotifications/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Advisory Notifications API",
+    "distribution_name": "cloud.google.com/go/advisorynotifications/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/ai/generativelanguage/apiv1/.repo-metadata.json
+++ b/ai/generativelanguage/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "generativelanguage",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/ai/latest/generativelanguage/apiv1",
-  "client_library_type": "generated",
-  "description": "Generative Language API",
-  "distribution_name": "cloud.google.com/go/ai/generativelanguage/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "generativelanguage",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/ai/latest/generativelanguage/apiv1",
+    "client_library_type": "generated",
+    "description": "Generative Language API",
+    "distribution_name": "cloud.google.com/go/ai/generativelanguage/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/ai/generativelanguage/apiv1alpha/.repo-metadata.json
+++ b/ai/generativelanguage/apiv1alpha/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "generativelanguage",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/ai/latest/generativelanguage/apiv1alpha",
-  "client_library_type": "generated",
-  "description": "Generative Language API",
-  "distribution_name": "cloud.google.com/go/ai/generativelanguage/apiv1alpha",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "generativelanguage",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/ai/latest/generativelanguage/apiv1alpha",
+    "client_library_type": "generated",
+    "description": "Generative Language API",
+    "distribution_name": "cloud.google.com/go/ai/generativelanguage/apiv1alpha",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/ai/generativelanguage/apiv1beta/.repo-metadata.json
+++ b/ai/generativelanguage/apiv1beta/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "generativelanguage",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/ai/latest/generativelanguage/apiv1beta",
-  "client_library_type": "generated",
-  "description": "Generative Language API",
-  "distribution_name": "cloud.google.com/go/ai/generativelanguage/apiv1beta",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "generativelanguage",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/ai/latest/generativelanguage/apiv1beta",
+    "client_library_type": "generated",
+    "description": "Generative Language API",
+    "distribution_name": "cloud.google.com/go/ai/generativelanguage/apiv1beta",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/ai/generativelanguage/apiv1beta2/.repo-metadata.json
+++ b/ai/generativelanguage/apiv1beta2/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "generativelanguage",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/ai/latest/generativelanguage/apiv1beta2",
-  "client_library_type": "generated",
-  "description": "Generative Language API",
-  "distribution_name": "cloud.google.com/go/ai/generativelanguage/apiv1beta2",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "generativelanguage",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/ai/latest/generativelanguage/apiv1beta2",
+    "client_library_type": "generated",
+    "description": "Generative Language API",
+    "distribution_name": "cloud.google.com/go/ai/generativelanguage/apiv1beta2",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/aiplatform/apiv1/.repo-metadata.json
+++ b/aiplatform/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "aiplatform",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/aiplatform/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Vertex AI API",
-  "distribution_name": "cloud.google.com/go/aiplatform/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "aiplatform",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/aiplatform/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Vertex AI API",
+    "distribution_name": "cloud.google.com/go/aiplatform/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/aiplatform/apiv1beta1/.repo-metadata.json
+++ b/aiplatform/apiv1beta1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "aiplatform",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/aiplatform/latest/apiv1beta1",
-  "client_library_type": "generated",
-  "description": "Vertex AI API",
-  "distribution_name": "cloud.google.com/go/aiplatform/apiv1beta1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "aiplatform",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/aiplatform/latest/apiv1beta1",
+    "client_library_type": "generated",
+    "description": "Vertex AI API",
+    "distribution_name": "cloud.google.com/go/aiplatform/apiv1beta1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/alloydb/apiv1/.repo-metadata.json
+++ b/alloydb/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "alloydb",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/alloydb/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "AlloyDB API",
-  "distribution_name": "cloud.google.com/go/alloydb/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "alloydb",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/alloydb/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "AlloyDB API",
+    "distribution_name": "cloud.google.com/go/alloydb/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/alloydb/apiv1alpha/.repo-metadata.json
+++ b/alloydb/apiv1alpha/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "alloydb",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/alloydb/latest/apiv1alpha",
-  "client_library_type": "generated",
-  "description": "AlloyDB API",
-  "distribution_name": "cloud.google.com/go/alloydb/apiv1alpha",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "alloydb",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/alloydb/latest/apiv1alpha",
+    "client_library_type": "generated",
+    "description": "AlloyDB API",
+    "distribution_name": "cloud.google.com/go/alloydb/apiv1alpha",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/alloydb/apiv1beta/.repo-metadata.json
+++ b/alloydb/apiv1beta/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "alloydb",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/alloydb/latest/apiv1beta",
-  "client_library_type": "generated",
-  "description": "AlloyDB API",
-  "distribution_name": "cloud.google.com/go/alloydb/apiv1beta",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "alloydb",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/alloydb/latest/apiv1beta",
+    "client_library_type": "generated",
+    "description": "AlloyDB API",
+    "distribution_name": "cloud.google.com/go/alloydb/apiv1beta",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/analytics/admin/apiv1alpha/.repo-metadata.json
+++ b/analytics/admin/apiv1alpha/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "analyticsadmin",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/analytics/latest/admin/apiv1alpha",
-  "client_library_type": "generated",
-  "description": "Google Analytics Admin API",
-  "distribution_name": "cloud.google.com/go/analytics/admin/apiv1alpha",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "analyticsadmin",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/analytics/latest/admin/apiv1alpha",
+    "client_library_type": "generated",
+    "description": "Google Analytics Admin API",
+    "distribution_name": "cloud.google.com/go/analytics/admin/apiv1alpha",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/apigateway/apiv1/.repo-metadata.json
+++ b/apigateway/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "apigateway",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/apigateway/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "API Gateway API",
-  "distribution_name": "cloud.google.com/go/apigateway/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "apigateway",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/apigateway/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "API Gateway API",
+    "distribution_name": "cloud.google.com/go/apigateway/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/apigeeconnect/apiv1/.repo-metadata.json
+++ b/apigeeconnect/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "apigeeconnect",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/apigeeconnect/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Apigee Connect API",
-  "distribution_name": "cloud.google.com/go/apigeeconnect/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "apigeeconnect",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/apigeeconnect/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Apigee Connect API",
+    "distribution_name": "cloud.google.com/go/apigeeconnect/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/apigeeregistry/apiv1/.repo-metadata.json
+++ b/apigeeregistry/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "apigeeregistry",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/apigeeregistry/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Apigee Registry API",
-  "distribution_name": "cloud.google.com/go/apigeeregistry/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "apigeeregistry",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/apigeeregistry/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Apigee Registry API",
+    "distribution_name": "cloud.google.com/go/apigeeregistry/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/apihub/apiv1/.repo-metadata.json
+++ b/apihub/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "apihub",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/apihub/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "API hub API",
-  "distribution_name": "cloud.google.com/go/apihub/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "apihub",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/apihub/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "API hub API",
+    "distribution_name": "cloud.google.com/go/apihub/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/apikeys/apiv2/.repo-metadata.json
+++ b/apikeys/apiv2/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "apikeys",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/apikeys/latest/apiv2",
-  "client_library_type": "generated",
-  "description": "API Keys API",
-  "distribution_name": "cloud.google.com/go/apikeys/apiv2",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "apikeys",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/apikeys/latest/apiv2",
+    "client_library_type": "generated",
+    "description": "API Keys API",
+    "distribution_name": "cloud.google.com/go/apikeys/apiv2",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/apiregistry/apiv1/.repo-metadata.json
+++ b/apiregistry/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "cloudapiregistry",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/apiregistry/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Cloud API Registry API",
-  "distribution_name": "cloud.google.com/go/apiregistry/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "cloudapiregistry",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/apiregistry/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Cloud API Registry API",
+    "distribution_name": "cloud.google.com/go/apiregistry/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/apiregistry/apiv1beta/.repo-metadata.json
+++ b/apiregistry/apiv1beta/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "cloudapiregistry",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/apiregistry/latest/apiv1beta",
-  "client_library_type": "generated",
-  "description": "Cloud API Registry API",
-  "distribution_name": "cloud.google.com/go/apiregistry/apiv1beta",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "cloudapiregistry",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/apiregistry/latest/apiv1beta",
+    "client_library_type": "generated",
+    "description": "Cloud API Registry API",
+    "distribution_name": "cloud.google.com/go/apiregistry/apiv1beta",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/appengine/apiv1/.repo-metadata.json
+++ b/appengine/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "appengine",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/appengine/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "App Engine Admin API",
-  "distribution_name": "cloud.google.com/go/appengine/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "appengine",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/appengine/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "App Engine Admin API",
+    "distribution_name": "cloud.google.com/go/appengine/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/apphub/apiv1/.repo-metadata.json
+++ b/apphub/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "apphub",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/apphub/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "App Hub API",
-  "distribution_name": "cloud.google.com/go/apphub/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "apphub",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/apphub/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "App Hub API",
+    "distribution_name": "cloud.google.com/go/apphub/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/apps/events/subscriptions/apiv1/.repo-metadata.json
+++ b/apps/events/subscriptions/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "workspaceevents",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/apps/latest/events/subscriptions/apiv1",
-  "client_library_type": "generated",
-  "description": "Google Workspace Events API",
-  "distribution_name": "cloud.google.com/go/apps/events/subscriptions/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "workspaceevents",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/apps/latest/events/subscriptions/apiv1",
+    "client_library_type": "generated",
+    "description": "Google Workspace Events API",
+    "distribution_name": "cloud.google.com/go/apps/events/subscriptions/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/apps/events/subscriptions/apiv1beta/.repo-metadata.json
+++ b/apps/events/subscriptions/apiv1beta/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "workspaceevents",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/apps/latest/events/subscriptions/apiv1beta",
-  "client_library_type": "generated",
-  "description": "Google Workspace Events API",
-  "distribution_name": "cloud.google.com/go/apps/events/subscriptions/apiv1beta",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "workspaceevents",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/apps/latest/events/subscriptions/apiv1beta",
+    "client_library_type": "generated",
+    "description": "Google Workspace Events API",
+    "distribution_name": "cloud.google.com/go/apps/events/subscriptions/apiv1beta",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/apps/meet/apiv2/.repo-metadata.json
+++ b/apps/meet/apiv2/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "meet",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/apps/latest/meet/apiv2",
-  "client_library_type": "generated",
-  "description": "Google Meet API",
-  "distribution_name": "cloud.google.com/go/apps/meet/apiv2",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "meet",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/apps/latest/meet/apiv2",
+    "client_library_type": "generated",
+    "description": "Google Meet API",
+    "distribution_name": "cloud.google.com/go/apps/meet/apiv2",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/apps/meet/apiv2beta/.repo-metadata.json
+++ b/apps/meet/apiv2beta/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "meet",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/apps/latest/meet/apiv2beta",
-  "client_library_type": "generated",
-  "description": "Google Meet API",
-  "distribution_name": "cloud.google.com/go/apps/meet/apiv2beta",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "meet",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/apps/latest/meet/apiv2beta",
+    "client_library_type": "generated",
+    "description": "Google Meet API",
+    "distribution_name": "cloud.google.com/go/apps/meet/apiv2beta",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/area120/tables/apiv1alpha1/.repo-metadata.json
+++ b/area120/tables/apiv1alpha1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "area120tables",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/area120/latest/tables/apiv1alpha1",
-  "client_library_type": "generated",
-  "description": "Area120 Tables API",
-  "distribution_name": "cloud.google.com/go/area120/tables/apiv1alpha1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "area120tables",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/area120/latest/tables/apiv1alpha1",
+    "client_library_type": "generated",
+    "description": "Area120 Tables API",
+    "distribution_name": "cloud.google.com/go/area120/tables/apiv1alpha1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/artifactregistry/apiv1/.repo-metadata.json
+++ b/artifactregistry/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "artifactregistry",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/artifactregistry/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Artifact Registry API",
-  "distribution_name": "cloud.google.com/go/artifactregistry/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "artifactregistry",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/artifactregistry/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Artifact Registry API",
+    "distribution_name": "cloud.google.com/go/artifactregistry/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/artifactregistry/apiv1beta2/.repo-metadata.json
+++ b/artifactregistry/apiv1beta2/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "artifactregistry",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/artifactregistry/latest/apiv1beta2",
-  "client_library_type": "generated",
-  "description": "Artifact Registry API",
-  "distribution_name": "cloud.google.com/go/artifactregistry/apiv1beta2",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "artifactregistry",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/artifactregistry/latest/apiv1beta2",
+    "client_library_type": "generated",
+    "description": "Artifact Registry API",
+    "distribution_name": "cloud.google.com/go/artifactregistry/apiv1beta2",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/asset/apiv1/.repo-metadata.json
+++ b/asset/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "cloudasset",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/asset/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Cloud Asset API",
-  "distribution_name": "cloud.google.com/go/asset/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "cloudasset",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/asset/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Cloud Asset API",
+    "distribution_name": "cloud.google.com/go/asset/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/asset/apiv1p2beta1/.repo-metadata.json
+++ b/asset/apiv1p2beta1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "cloudasset",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/asset/latest/apiv1p2beta1",
-  "client_library_type": "generated",
-  "description": "Cloud Asset API",
-  "distribution_name": "cloud.google.com/go/asset/apiv1p2beta1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "cloudasset",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/asset/latest/apiv1p2beta1",
+    "client_library_type": "generated",
+    "description": "Cloud Asset API",
+    "distribution_name": "cloud.google.com/go/asset/apiv1p2beta1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/asset/apiv1p5beta1/.repo-metadata.json
+++ b/asset/apiv1p5beta1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "cloudasset",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/asset/latest/apiv1p5beta1",
-  "client_library_type": "generated",
-  "description": "Cloud Asset API",
-  "distribution_name": "cloud.google.com/go/asset/apiv1p5beta1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "cloudasset",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/asset/latest/apiv1p5beta1",
+    "client_library_type": "generated",
+    "description": "Cloud Asset API",
+    "distribution_name": "cloud.google.com/go/asset/apiv1p5beta1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/assuredworkloads/apiv1/.repo-metadata.json
+++ b/assuredworkloads/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "assuredworkloads",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/assuredworkloads/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Assured Workloads API",
-  "distribution_name": "cloud.google.com/go/assuredworkloads/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "assuredworkloads",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/assuredworkloads/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Assured Workloads API",
+    "distribution_name": "cloud.google.com/go/assuredworkloads/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/assuredworkloads/apiv1beta1/.repo-metadata.json
+++ b/assuredworkloads/apiv1beta1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "assuredworkloads",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/assuredworkloads/latest/apiv1beta1",
-  "client_library_type": "generated",
-  "description": "Assured Workloads API",
-  "distribution_name": "cloud.google.com/go/assuredworkloads/apiv1beta1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "assuredworkloads",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/assuredworkloads/latest/apiv1beta1",
+    "client_library_type": "generated",
+    "description": "Assured Workloads API",
+    "distribution_name": "cloud.google.com/go/assuredworkloads/apiv1beta1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/auditmanager/apiv1/.repo-metadata.json
+++ b/auditmanager/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "auditmanager",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/auditmanager/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Audit Manager API",
-  "distribution_name": "cloud.google.com/go/auditmanager/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "auditmanager",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/auditmanager/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Audit Manager API",
+    "distribution_name": "cloud.google.com/go/auditmanager/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/automl/apiv1/.repo-metadata.json
+++ b/automl/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "automl",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/automl/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Cloud AutoML API",
-  "distribution_name": "cloud.google.com/go/automl/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "automl",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/automl/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Cloud AutoML API",
+    "distribution_name": "cloud.google.com/go/automl/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/automl/apiv1beta1/.repo-metadata.json
+++ b/automl/apiv1beta1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "automl",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/automl/latest/apiv1beta1",
-  "client_library_type": "generated",
-  "description": "Cloud AutoML API",
-  "distribution_name": "cloud.google.com/go/automl/apiv1beta1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "automl",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/automl/latest/apiv1beta1",
+    "client_library_type": "generated",
+    "description": "Cloud AutoML API",
+    "distribution_name": "cloud.google.com/go/automl/apiv1beta1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/backupdr/apiv1/.repo-metadata.json
+++ b/backupdr/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "backupdr",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/backupdr/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Backup and DR Service API",
-  "distribution_name": "cloud.google.com/go/backupdr/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "backupdr",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/backupdr/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Backup and DR Service API",
+    "distribution_name": "cloud.google.com/go/backupdr/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/baremetalsolution/apiv2/.repo-metadata.json
+++ b/baremetalsolution/apiv2/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "baremetalsolution",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/baremetalsolution/latest/apiv2",
-  "client_library_type": "generated",
-  "description": "Bare Metal Solution API",
-  "distribution_name": "cloud.google.com/go/baremetalsolution/apiv2",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "baremetalsolution",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/baremetalsolution/latest/apiv2",
+    "client_library_type": "generated",
+    "description": "Bare Metal Solution API",
+    "distribution_name": "cloud.google.com/go/baremetalsolution/apiv2",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/batch/apiv1/.repo-metadata.json
+++ b/batch/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "batch",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/batch/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Batch API",
-  "distribution_name": "cloud.google.com/go/batch/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "batch",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/batch/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Batch API",
+    "distribution_name": "cloud.google.com/go/batch/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/beyondcorp/apiv1/.repo-metadata.json
+++ b/beyondcorp/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "beyondcorp",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/beyondcorp/latest/clientgateways/apiv1",
-  "client_library_type": "generated",
-  "description": "BeyondCorp API",
-  "distribution_name": "cloud.google.com/go/beyondcorp/clientgateways/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "beyondcorp",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/beyondcorp/latest/clientgateways/apiv1",
+    "client_library_type": "generated",
+    "description": "BeyondCorp API",
+    "distribution_name": "cloud.google.com/go/beyondcorp/clientgateways/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/beyondcorp/appconnections/apiv1/.repo-metadata.json
+++ b/beyondcorp/appconnections/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "beyondcorp",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/beyondcorp/latest/appconnections/apiv1",
-  "client_library_type": "generated",
-  "description": "BeyondCorp API",
-  "distribution_name": "cloud.google.com/go/beyondcorp/appconnections/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "beyondcorp",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/beyondcorp/latest/appconnections/apiv1",
+    "client_library_type": "generated",
+    "description": "BeyondCorp API",
+    "distribution_name": "cloud.google.com/go/beyondcorp/appconnections/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/beyondcorp/appconnectors/apiv1/.repo-metadata.json
+++ b/beyondcorp/appconnectors/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "beyondcorp",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/beyondcorp/latest/appconnectors/apiv1",
-  "client_library_type": "generated",
-  "description": "BeyondCorp API",
-  "distribution_name": "cloud.google.com/go/beyondcorp/appconnectors/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "beyondcorp",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/beyondcorp/latest/appconnectors/apiv1",
+    "client_library_type": "generated",
+    "description": "BeyondCorp API",
+    "distribution_name": "cloud.google.com/go/beyondcorp/appconnectors/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/beyondcorp/appgateways/apiv1/.repo-metadata.json
+++ b/beyondcorp/appgateways/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "beyondcorp",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/beyondcorp/latest/appgateways/apiv1",
-  "client_library_type": "generated",
-  "description": "BeyondCorp API",
-  "distribution_name": "cloud.google.com/go/beyondcorp/appgateways/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "beyondcorp",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/beyondcorp/latest/appgateways/apiv1",
+    "client_library_type": "generated",
+    "description": "BeyondCorp API",
+    "distribution_name": "cloud.google.com/go/beyondcorp/appgateways/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/beyondcorp/clientconnectorservices/apiv1/.repo-metadata.json
+++ b/beyondcorp/clientconnectorservices/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "beyondcorp",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/beyondcorp/latest/clientconnectorservices/apiv1",
-  "client_library_type": "generated",
-  "description": "BeyondCorp API",
-  "distribution_name": "cloud.google.com/go/beyondcorp/clientconnectorservices/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "beyondcorp",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/beyondcorp/latest/clientconnectorservices/apiv1",
+    "client_library_type": "generated",
+    "description": "BeyondCorp API",
+    "distribution_name": "cloud.google.com/go/beyondcorp/clientconnectorservices/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/beyondcorp/clientgateways/apiv1/.repo-metadata.json
+++ b/beyondcorp/clientgateways/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "beyondcorp",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/beyondcorp/latest/clientgateways/apiv1",
-  "client_library_type": "generated",
-  "description": "BeyondCorp API",
-  "distribution_name": "cloud.google.com/go/beyondcorp/clientgateways/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "beyondcorp",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/beyondcorp/latest/clientgateways/apiv1",
+    "client_library_type": "generated",
+    "description": "BeyondCorp API",
+    "distribution_name": "cloud.google.com/go/beyondcorp/clientgateways/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/bigquery/.repo-metadata.json
+++ b/bigquery/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "bigquery",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigquery/latest",
-  "client_library_type": "manual",
-  "description": "BigQuery",
-  "distribution_name": "cloud.google.com/go/bigquery",
-  "language": "go",
-  "library_type": "GAPIC_MANUAL",
-  "release_level": "stable"
+    "api_shortname": "bigquery",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigquery/latest",
+    "client_library_type": "manual",
+    "description": "BigQuery",
+    "distribution_name": "cloud.google.com/go/bigquery",
+    "language": "go",
+    "library_type": "GAPIC_MANUAL",
+    "release_level": "stable"
 }

--- a/bigquery/analyticshub/apiv1/.repo-metadata.json
+++ b/bigquery/analyticshub/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "analyticshub",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigquery/latest/analyticshub/apiv1",
-  "client_library_type": "generated",
-  "description": "Analytics Hub API",
-  "distribution_name": "cloud.google.com/go/bigquery/analyticshub/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "analyticshub",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigquery/latest/analyticshub/apiv1",
+    "client_library_type": "generated",
+    "description": "Analytics Hub API",
+    "distribution_name": "cloud.google.com/go/bigquery/analyticshub/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/bigquery/biglake/apiv1/.repo-metadata.json
+++ b/bigquery/biglake/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "biglake",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigquery/latest/biglake/apiv1",
-  "client_library_type": "generated",
-  "description": "BigLake API",
-  "distribution_name": "cloud.google.com/go/bigquery/biglake/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "biglake",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigquery/latest/biglake/apiv1",
+    "client_library_type": "generated",
+    "description": "BigLake API",
+    "distribution_name": "cloud.google.com/go/bigquery/biglake/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/bigquery/biglake/apiv1alpha1/.repo-metadata.json
+++ b/bigquery/biglake/apiv1alpha1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "biglake",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigquery/latest/biglake/apiv1alpha1",
-  "client_library_type": "generated",
-  "description": "BigLake API",
-  "distribution_name": "cloud.google.com/go/bigquery/biglake/apiv1alpha1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "biglake",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigquery/latest/biglake/apiv1alpha1",
+    "client_library_type": "generated",
+    "description": "BigLake API",
+    "distribution_name": "cloud.google.com/go/bigquery/biglake/apiv1alpha1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/bigquery/connection/apiv1/.repo-metadata.json
+++ b/bigquery/connection/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "bigqueryconnection",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigquery/latest/connection/apiv1",
-  "client_library_type": "generated",
-  "description": "BigQuery Connection API",
-  "distribution_name": "cloud.google.com/go/bigquery/connection/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "bigqueryconnection",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigquery/latest/connection/apiv1",
+    "client_library_type": "generated",
+    "description": "BigQuery Connection API",
+    "distribution_name": "cloud.google.com/go/bigquery/connection/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/bigquery/connection/apiv1beta1/.repo-metadata.json
+++ b/bigquery/connection/apiv1beta1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "bigqueryconnection",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigquery/latest/connection/apiv1beta1",
-  "client_library_type": "generated",
-  "description": "BigQuery Connection API",
-  "distribution_name": "cloud.google.com/go/bigquery/connection/apiv1beta1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "bigqueryconnection",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigquery/latest/connection/apiv1beta1",
+    "client_library_type": "generated",
+    "description": "BigQuery Connection API",
+    "distribution_name": "cloud.google.com/go/bigquery/connection/apiv1beta1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/bigquery/dataexchange/apiv1beta1/.repo-metadata.json
+++ b/bigquery/dataexchange/apiv1beta1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "analyticshub",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigquery/latest/dataexchange/apiv1beta1",
-  "client_library_type": "generated",
-  "description": "Analytics Hub API",
-  "distribution_name": "cloud.google.com/go/bigquery/dataexchange/apiv1beta1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "analyticshub",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigquery/latest/dataexchange/apiv1beta1",
+    "client_library_type": "generated",
+    "description": "Analytics Hub API",
+    "distribution_name": "cloud.google.com/go/bigquery/dataexchange/apiv1beta1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/bigquery/datapolicies/apiv1/.repo-metadata.json
+++ b/bigquery/datapolicies/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "bigquerydatapolicy",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigquery/latest/datapolicies/apiv1",
-  "client_library_type": "generated",
-  "description": "BigQuery Data Policy API",
-  "distribution_name": "cloud.google.com/go/bigquery/datapolicies/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "bigquerydatapolicy",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigquery/latest/datapolicies/apiv1",
+    "client_library_type": "generated",
+    "description": "BigQuery Data Policy API",
+    "distribution_name": "cloud.google.com/go/bigquery/datapolicies/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/bigquery/datapolicies/apiv1beta1/.repo-metadata.json
+++ b/bigquery/datapolicies/apiv1beta1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "bigquerydatapolicy",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigquery/latest/datapolicies/apiv1beta1",
-  "client_library_type": "generated",
-  "description": "BigQuery Data Policy API",
-  "distribution_name": "cloud.google.com/go/bigquery/datapolicies/apiv1beta1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "bigquerydatapolicy",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigquery/latest/datapolicies/apiv1beta1",
+    "client_library_type": "generated",
+    "description": "BigQuery Data Policy API",
+    "distribution_name": "cloud.google.com/go/bigquery/datapolicies/apiv1beta1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/bigquery/datapolicies/apiv2/.repo-metadata.json
+++ b/bigquery/datapolicies/apiv2/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "bigquerydatapolicy",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigquery/latest/datapolicies/apiv2",
-  "client_library_type": "generated",
-  "description": "BigQuery Data Policy API",
-  "distribution_name": "cloud.google.com/go/bigquery/datapolicies/apiv2",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "bigquerydatapolicy",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigquery/latest/datapolicies/apiv2",
+    "client_library_type": "generated",
+    "description": "BigQuery Data Policy API",
+    "distribution_name": "cloud.google.com/go/bigquery/datapolicies/apiv2",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/bigquery/datapolicies/apiv2beta1/.repo-metadata.json
+++ b/bigquery/datapolicies/apiv2beta1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "bigquerydatapolicy",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigquery/latest/datapolicies/apiv2beta1",
-  "client_library_type": "generated",
-  "description": "BigQuery Data Policy API",
-  "distribution_name": "cloud.google.com/go/bigquery/datapolicies/apiv2beta1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "bigquerydatapolicy",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigquery/latest/datapolicies/apiv2beta1",
+    "client_library_type": "generated",
+    "description": "BigQuery Data Policy API",
+    "distribution_name": "cloud.google.com/go/bigquery/datapolicies/apiv2beta1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/bigquery/datatransfer/apiv1/.repo-metadata.json
+++ b/bigquery/datatransfer/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "bigquerydatatransfer",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigquery/latest/datatransfer/apiv1",
-  "client_library_type": "generated",
-  "description": "BigQuery Data Transfer API",
-  "distribution_name": "cloud.google.com/go/bigquery/datatransfer/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "bigquerydatatransfer",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigquery/latest/datatransfer/apiv1",
+    "client_library_type": "generated",
+    "description": "BigQuery Data Transfer API",
+    "distribution_name": "cloud.google.com/go/bigquery/datatransfer/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/bigquery/migration/apiv2/.repo-metadata.json
+++ b/bigquery/migration/apiv2/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "bigquerymigration",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigquery/latest/migration/apiv2",
-  "client_library_type": "generated",
-  "description": "BigQuery Migration API",
-  "distribution_name": "cloud.google.com/go/bigquery/migration/apiv2",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "bigquerymigration",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigquery/latest/migration/apiv2",
+    "client_library_type": "generated",
+    "description": "BigQuery Migration API",
+    "distribution_name": "cloud.google.com/go/bigquery/migration/apiv2",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/bigquery/migration/apiv2alpha/.repo-metadata.json
+++ b/bigquery/migration/apiv2alpha/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "bigquerymigration",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigquery/latest/migration/apiv2alpha",
-  "client_library_type": "generated",
-  "description": "BigQuery Migration API",
-  "distribution_name": "cloud.google.com/go/bigquery/migration/apiv2alpha",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "bigquerymigration",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigquery/latest/migration/apiv2alpha",
+    "client_library_type": "generated",
+    "description": "BigQuery Migration API",
+    "distribution_name": "cloud.google.com/go/bigquery/migration/apiv2alpha",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/bigquery/reservation/apiv1/.repo-metadata.json
+++ b/bigquery/reservation/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "bigqueryreservation",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigquery/latest/reservation/apiv1",
-  "client_library_type": "generated",
-  "description": "BigQuery Reservation API",
-  "distribution_name": "cloud.google.com/go/bigquery/reservation/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "bigqueryreservation",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigquery/latest/reservation/apiv1",
+    "client_library_type": "generated",
+    "description": "BigQuery Reservation API",
+    "distribution_name": "cloud.google.com/go/bigquery/reservation/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/bigquery/storage/apiv1/.repo-metadata.json
+++ b/bigquery/storage/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "bigquerystorage",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigquery/latest/storage/apiv1",
-  "client_library_type": "generated",
-  "description": "BigQuery Storage API",
-  "distribution_name": "cloud.google.com/go/bigquery/storage/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "bigquerystorage",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigquery/latest/storage/apiv1",
+    "client_library_type": "generated",
+    "description": "BigQuery Storage API",
+    "distribution_name": "cloud.google.com/go/bigquery/storage/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/bigquery/storage/apiv1alpha/.repo-metadata.json
+++ b/bigquery/storage/apiv1alpha/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "bigquerystorage",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigquery/latest/storage/apiv1alpha",
-  "client_library_type": "generated",
-  "description": "BigQuery Storage API",
-  "distribution_name": "cloud.google.com/go/bigquery/storage/apiv1alpha",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "bigquerystorage",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigquery/latest/storage/apiv1alpha",
+    "client_library_type": "generated",
+    "description": "BigQuery Storage API",
+    "distribution_name": "cloud.google.com/go/bigquery/storage/apiv1alpha",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/bigquery/storage/apiv1beta/.repo-metadata.json
+++ b/bigquery/storage/apiv1beta/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "bigquerystorage",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigquery/latest/storage/apiv1beta",
-  "client_library_type": "generated",
-  "description": "BigQuery Storage API",
-  "distribution_name": "cloud.google.com/go/bigquery/storage/apiv1beta",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "bigquerystorage",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigquery/latest/storage/apiv1beta",
+    "client_library_type": "generated",
+    "description": "BigQuery Storage API",
+    "distribution_name": "cloud.google.com/go/bigquery/storage/apiv1beta",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/bigquery/storage/apiv1beta1/.repo-metadata.json
+++ b/bigquery/storage/apiv1beta1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "bigquerystorage",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigquery/latest/storage/apiv1beta1",
-  "client_library_type": "generated",
-  "description": "BigQuery Storage API",
-  "distribution_name": "cloud.google.com/go/bigquery/storage/apiv1beta1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "bigquerystorage",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigquery/latest/storage/apiv1beta1",
+    "client_library_type": "generated",
+    "description": "BigQuery Storage API",
+    "distribution_name": "cloud.google.com/go/bigquery/storage/apiv1beta1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/bigquery/storage/apiv1beta2/.repo-metadata.json
+++ b/bigquery/storage/apiv1beta2/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "bigquerystorage",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigquery/latest/storage/apiv1beta2",
-  "client_library_type": "generated",
-  "description": "BigQuery Storage API",
-  "distribution_name": "cloud.google.com/go/bigquery/storage/apiv1beta2",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "bigquerystorage",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigquery/latest/storage/apiv1beta2",
+    "client_library_type": "generated",
+    "description": "BigQuery Storage API",
+    "distribution_name": "cloud.google.com/go/bigquery/storage/apiv1beta2",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/bigquery/v2/apiv2/.repo-metadata.json
+++ b/bigquery/v2/apiv2/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "bigquery",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigquery/v2/latest/apiv2",
-  "client_library_type": "generated",
-  "description": "BigQuery API",
-  "distribution_name": "cloud.google.com/go/bigquery/v2/apiv2",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "bigquery",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigquery/v2/latest/apiv2",
+    "client_library_type": "generated",
+    "description": "BigQuery API",
+    "distribution_name": "cloud.google.com/go/bigquery/v2/apiv2",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/bigtable/.repo-metadata.json
+++ b/bigtable/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "bigtable",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigtable/latest",
-  "client_library_type": "manual",
-  "description": "Cloud BigTable",
-  "distribution_name": "cloud.google.com/go/bigtable",
-  "language": "go",
-  "library_type": "GAPIC_MANUAL",
-  "release_level": "stable"
+    "api_shortname": "bigtable",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigtable/latest",
+    "client_library_type": "manual",
+    "description": "Cloud BigTable",
+    "distribution_name": "cloud.google.com/go/bigtable",
+    "language": "go",
+    "library_type": "GAPIC_MANUAL",
+    "release_level": "stable"
 }

--- a/bigtable/admin/apiv2/.repo-metadata.json
+++ b/bigtable/admin/apiv2/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "bigtableadmin",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigtable/latest/admin/apiv2",
-  "client_library_type": "generated",
-  "description": "Cloud Bigtable Admin API",
-  "distribution_name": "cloud.google.com/go/bigtable/admin/apiv2",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "bigtableadmin",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigtable/latest/admin/apiv2",
+    "client_library_type": "generated",
+    "description": "Cloud Bigtable Admin API",
+    "distribution_name": "cloud.google.com/go/bigtable/admin/apiv2",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/bigtable/apiv2/.repo-metadata.json
+++ b/bigtable/apiv2/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "bigtable",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigtable/latest/apiv2",
-  "client_library_type": "generated",
-  "description": "Cloud Bigtable API",
-  "distribution_name": "cloud.google.com/go/bigtable/apiv2",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "bigtable",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/bigtable/latest/apiv2",
+    "client_library_type": "generated",
+    "description": "Cloud Bigtable API",
+    "distribution_name": "cloud.google.com/go/bigtable/apiv2",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/billing/apiv1/.repo-metadata.json
+++ b/billing/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "cloudbilling",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/billing/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Cloud Billing API",
-  "distribution_name": "cloud.google.com/go/billing/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "cloudbilling",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/billing/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Cloud Billing API",
+    "distribution_name": "cloud.google.com/go/billing/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/billing/apiv1beta1/.repo-metadata.json
+++ b/billing/apiv1beta1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "billingbudgets",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/billing/latest/budgets/apiv1beta1",
-  "client_library_type": "generated",
-  "description": "Cloud Billing Budget API",
-  "distribution_name": "cloud.google.com/go/billing/budgets/apiv1beta1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "billingbudgets",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/billing/latest/budgets/apiv1beta1",
+    "client_library_type": "generated",
+    "description": "Cloud Billing Budget API",
+    "distribution_name": "cloud.google.com/go/billing/budgets/apiv1beta1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/billing/budgets/apiv1/.repo-metadata.json
+++ b/billing/budgets/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "billingbudgets",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/billing/latest/budgets/apiv1",
-  "client_library_type": "generated",
-  "description": "Cloud Billing Budget API",
-  "distribution_name": "cloud.google.com/go/billing/budgets/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "billingbudgets",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/billing/latest/budgets/apiv1",
+    "client_library_type": "generated",
+    "description": "Cloud Billing Budget API",
+    "distribution_name": "cloud.google.com/go/billing/budgets/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/billing/budgets/apiv1beta1/.repo-metadata.json
+++ b/billing/budgets/apiv1beta1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "billingbudgets",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/billing/latest/budgets/apiv1beta1",
-  "client_library_type": "generated",
-  "description": "Cloud Billing Budget API",
-  "distribution_name": "cloud.google.com/go/billing/budgets/apiv1beta1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "billingbudgets",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/billing/latest/budgets/apiv1beta1",
+    "client_library_type": "generated",
+    "description": "Cloud Billing Budget API",
+    "distribution_name": "cloud.google.com/go/billing/budgets/apiv1beta1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/binaryauthorization/apiv1/.repo-metadata.json
+++ b/binaryauthorization/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "binaryauthorization",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/binaryauthorization/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Binary Authorization API",
-  "distribution_name": "cloud.google.com/go/binaryauthorization/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "binaryauthorization",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/binaryauthorization/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Binary Authorization API",
+    "distribution_name": "cloud.google.com/go/binaryauthorization/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/binaryauthorization/apiv1beta1/.repo-metadata.json
+++ b/binaryauthorization/apiv1beta1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "binaryauthorization",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/binaryauthorization/latest/apiv1beta1",
-  "client_library_type": "generated",
-  "description": "Binary Authorization API",
-  "distribution_name": "cloud.google.com/go/binaryauthorization/apiv1beta1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "binaryauthorization",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/binaryauthorization/latest/apiv1beta1",
+    "client_library_type": "generated",
+    "description": "Binary Authorization API",
+    "distribution_name": "cloud.google.com/go/binaryauthorization/apiv1beta1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/capacityplanner/apiv1beta/.repo-metadata.json
+++ b/capacityplanner/apiv1beta/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "capacityplanner",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/capacityplanner/latest/apiv1beta",
-  "client_library_type": "generated",
-  "description": "Capacity Planner API",
-  "distribution_name": "cloud.google.com/go/capacityplanner/apiv1beta",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "capacityplanner",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/capacityplanner/latest/apiv1beta",
+    "client_library_type": "generated",
+    "description": "Capacity Planner API",
+    "distribution_name": "cloud.google.com/go/capacityplanner/apiv1beta",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/certificatemanager/apiv1/.repo-metadata.json
+++ b/certificatemanager/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "certificatemanager",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/certificatemanager/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Certificate Manager API",
-  "distribution_name": "cloud.google.com/go/certificatemanager/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "certificatemanager",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/certificatemanager/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Certificate Manager API",
+    "distribution_name": "cloud.google.com/go/certificatemanager/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/ces/apiv1/.repo-metadata.json
+++ b/ces/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "ces",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/ces/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Gemini Enterprise for Customer Experience API",
-  "distribution_name": "cloud.google.com/go/ces/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "ces",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/ces/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Gemini Enterprise for Customer Experience API",
+    "distribution_name": "cloud.google.com/go/ces/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/ces/apiv1beta/.repo-metadata.json
+++ b/ces/apiv1beta/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "ces",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/ces/latest/apiv1beta",
-  "client_library_type": "generated",
-  "description": "Gemini Enterprise for Customer Experience API",
-  "distribution_name": "cloud.google.com/go/ces/apiv1beta",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "ces",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/ces/latest/apiv1beta",
+    "client_library_type": "generated",
+    "description": "Gemini Enterprise for Customer Experience API",
+    "distribution_name": "cloud.google.com/go/ces/apiv1beta",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/channel/apiv1/.repo-metadata.json
+++ b/channel/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "cloudchannel",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/channel/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Cloud Channel API",
-  "distribution_name": "cloud.google.com/go/channel/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "cloudchannel",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/channel/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Cloud Channel API",
+    "distribution_name": "cloud.google.com/go/channel/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/chat/apiv1/.repo-metadata.json
+++ b/chat/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "chat",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/chat/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Google Chat API",
-  "distribution_name": "cloud.google.com/go/chat/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "chat",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/chat/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Google Chat API",
+    "distribution_name": "cloud.google.com/go/chat/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/chronicle/apiv1/.repo-metadata.json
+++ b/chronicle/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "chronicle",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/chronicle/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Chronicle API",
-  "distribution_name": "cloud.google.com/go/chronicle/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "chronicle",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/chronicle/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Chronicle API",
+    "distribution_name": "cloud.google.com/go/chronicle/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/cloudbuild/apiv1/v2/.repo-metadata.json
+++ b/cloudbuild/apiv1/v2/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "cloudbuild",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/cloudbuild/latest/apiv1/v2",
-  "client_library_type": "generated",
-  "description": "Cloud Build API",
-  "distribution_name": "cloud.google.com/go/cloudbuild/apiv1/v2",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "cloudbuild",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/cloudbuild/latest/apiv1/v2",
+    "client_library_type": "generated",
+    "description": "Cloud Build API",
+    "distribution_name": "cloud.google.com/go/cloudbuild/apiv1/v2",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/cloudbuild/apiv2/.repo-metadata.json
+++ b/cloudbuild/apiv2/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "cloudbuild",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/cloudbuild/latest/apiv2",
-  "client_library_type": "generated",
-  "description": "Cloud Build API",
-  "distribution_name": "cloud.google.com/go/cloudbuild/apiv2",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "cloudbuild",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/cloudbuild/latest/apiv2",
+    "client_library_type": "generated",
+    "description": "Cloud Build API",
+    "distribution_name": "cloud.google.com/go/cloudbuild/apiv2",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/cloudcontrolspartner/apiv1/.repo-metadata.json
+++ b/cloudcontrolspartner/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "cloudcontrolspartner",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/cloudcontrolspartner/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Cloud Controls Partner API",
-  "distribution_name": "cloud.google.com/go/cloudcontrolspartner/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "cloudcontrolspartner",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/cloudcontrolspartner/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Cloud Controls Partner API",
+    "distribution_name": "cloud.google.com/go/cloudcontrolspartner/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/cloudcontrolspartner/apiv1beta/.repo-metadata.json
+++ b/cloudcontrolspartner/apiv1beta/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "cloudcontrolspartner",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/cloudcontrolspartner/latest/apiv1beta",
-  "client_library_type": "generated",
-  "description": "Cloud Controls Partner API",
-  "distribution_name": "cloud.google.com/go/cloudcontrolspartner/apiv1beta",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "cloudcontrolspartner",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/cloudcontrolspartner/latest/apiv1beta",
+    "client_library_type": "generated",
+    "description": "Cloud Controls Partner API",
+    "distribution_name": "cloud.google.com/go/cloudcontrolspartner/apiv1beta",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/clouddms/apiv1/.repo-metadata.json
+++ b/clouddms/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "datamigration",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/clouddms/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Database Migration API",
-  "distribution_name": "cloud.google.com/go/clouddms/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "datamigration",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/clouddms/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Database Migration API",
+    "distribution_name": "cloud.google.com/go/clouddms/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/cloudprofiler/apiv2/.repo-metadata.json
+++ b/cloudprofiler/apiv2/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "cloudprofiler",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/cloudprofiler/latest/apiv2",
-  "client_library_type": "generated",
-  "description": "Cloud Profiler API",
-  "distribution_name": "cloud.google.com/go/cloudprofiler/apiv2",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "cloudprofiler",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/cloudprofiler/latest/apiv2",
+    "client_library_type": "generated",
+    "description": "Cloud Profiler API",
+    "distribution_name": "cloud.google.com/go/cloudprofiler/apiv2",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/cloudquotas/apiv1/.repo-metadata.json
+++ b/cloudquotas/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "cloudquotas",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/cloudquotas/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Cloud Quotas API",
-  "distribution_name": "cloud.google.com/go/cloudquotas/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "cloudquotas",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/cloudquotas/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Cloud Quotas API",
+    "distribution_name": "cloud.google.com/go/cloudquotas/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/cloudquotas/apiv1beta/.repo-metadata.json
+++ b/cloudquotas/apiv1beta/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "cloudquotas",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/cloudquotas/latest/apiv1beta",
-  "client_library_type": "generated",
-  "description": "Cloud Quotas API",
-  "distribution_name": "cloud.google.com/go/cloudquotas/apiv1beta",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "cloudquotas",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/cloudquotas/latest/apiv1beta",
+    "client_library_type": "generated",
+    "description": "Cloud Quotas API",
+    "distribution_name": "cloud.google.com/go/cloudquotas/apiv1beta",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/cloudsecuritycompliance/apiv1/.repo-metadata.json
+++ b/cloudsecuritycompliance/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "cloudsecuritycompliance",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/cloudsecuritycompliance/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Cloud Security Compliance API",
-  "distribution_name": "cloud.google.com/go/cloudsecuritycompliance/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "cloudsecuritycompliance",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/cloudsecuritycompliance/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Cloud Security Compliance API",
+    "distribution_name": "cloud.google.com/go/cloudsecuritycompliance/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/cloudtasks/apiv2/.repo-metadata.json
+++ b/cloudtasks/apiv2/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "cloudtasks",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/cloudtasks/latest/apiv2",
-  "client_library_type": "generated",
-  "description": "Cloud Tasks API",
-  "distribution_name": "cloud.google.com/go/cloudtasks/apiv2",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "cloudtasks",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/cloudtasks/latest/apiv2",
+    "client_library_type": "generated",
+    "description": "Cloud Tasks API",
+    "distribution_name": "cloud.google.com/go/cloudtasks/apiv2",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/cloudtasks/apiv2beta2/.repo-metadata.json
+++ b/cloudtasks/apiv2beta2/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "cloudtasks",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/cloudtasks/latest/apiv2beta2",
-  "client_library_type": "generated",
-  "description": "Cloud Tasks API",
-  "distribution_name": "cloud.google.com/go/cloudtasks/apiv2beta2",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "cloudtasks",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/cloudtasks/latest/apiv2beta2",
+    "client_library_type": "generated",
+    "description": "Cloud Tasks API",
+    "distribution_name": "cloud.google.com/go/cloudtasks/apiv2beta2",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/cloudtasks/apiv2beta3/.repo-metadata.json
+++ b/cloudtasks/apiv2beta3/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "cloudtasks",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/cloudtasks/latest/apiv2beta3",
-  "client_library_type": "generated",
-  "description": "Cloud Tasks API",
-  "distribution_name": "cloud.google.com/go/cloudtasks/apiv2beta3",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "cloudtasks",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/cloudtasks/latest/apiv2beta3",
+    "client_library_type": "generated",
+    "description": "Cloud Tasks API",
+    "distribution_name": "cloud.google.com/go/cloudtasks/apiv2beta3",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/commerce/apiv1/.repo-metadata.json
+++ b/commerce/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "cloudcommerceconsumerprocurement",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/commerce/latest/consumer/procurement/apiv1",
-  "client_library_type": "generated",
-  "description": "Cloud Commerce Consumer Procurement API",
-  "distribution_name": "cloud.google.com/go/commerce/consumer/procurement/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "cloudcommerceconsumerprocurement",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/commerce/latest/consumer/procurement/apiv1",
+    "client_library_type": "generated",
+    "description": "Cloud Commerce Consumer Procurement API",
+    "distribution_name": "cloud.google.com/go/commerce/consumer/procurement/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/commerce/consumer/procurement/apiv1/.repo-metadata.json
+++ b/commerce/consumer/procurement/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "cloudcommerceconsumerprocurement",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/commerce/latest/consumer/procurement/apiv1",
-  "client_library_type": "generated",
-  "description": "Cloud Commerce Consumer Procurement API",
-  "distribution_name": "cloud.google.com/go/commerce/consumer/procurement/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "cloudcommerceconsumerprocurement",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/commerce/latest/consumer/procurement/apiv1",
+    "client_library_type": "generated",
+    "description": "Cloud Commerce Consumer Procurement API",
+    "distribution_name": "cloud.google.com/go/commerce/consumer/procurement/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/compute/apiv1/.repo-metadata.json
+++ b/compute/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "compute",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/compute/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Google Compute Engine API",
-  "distribution_name": "cloud.google.com/go/compute/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "compute",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/compute/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Google Compute Engine API",
+    "distribution_name": "cloud.google.com/go/compute/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/compute/apiv1beta/.repo-metadata.json
+++ b/compute/apiv1beta/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "compute",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/compute/latest/apiv1beta",
-  "client_library_type": "generated",
-  "description": "Google Compute Engine API",
-  "distribution_name": "cloud.google.com/go/compute/apiv1beta",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "compute",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/compute/latest/apiv1beta",
+    "client_library_type": "generated",
+    "description": "Google Compute Engine API",
+    "distribution_name": "cloud.google.com/go/compute/apiv1beta",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/compute/metadata/.repo-metadata.json
+++ b/compute/metadata/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "compute-metadata",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/compute/latest/metadata",
-  "client_library_type": "manual",
-  "description": "Service Metadata API",
-  "distribution_name": "cloud.google.com/go/compute/metadata",
-  "language": "go",
-  "library_type": "CORE",
-  "release_level": "stable"
+    "api_shortname": "compute-metadata",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/compute/latest/metadata",
+    "client_library_type": "manual",
+    "description": "Service Metadata API",
+    "distribution_name": "cloud.google.com/go/compute/metadata",
+    "language": "go",
+    "library_type": "CORE",
+    "release_level": "stable"
 }

--- a/confidentialcomputing/apiv1/.repo-metadata.json
+++ b/confidentialcomputing/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "confidentialcomputing",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/confidentialcomputing/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Confidential Computing API",
-  "distribution_name": "cloud.google.com/go/confidentialcomputing/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "confidentialcomputing",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/confidentialcomputing/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Confidential Computing API",
+    "distribution_name": "cloud.google.com/go/confidentialcomputing/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/confidentialcomputing/apiv1alpha1/.repo-metadata.json
+++ b/confidentialcomputing/apiv1alpha1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "confidentialcomputing",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/confidentialcomputing/latest/apiv1alpha1",
-  "client_library_type": "generated",
-  "description": "Confidential Computing API",
-  "distribution_name": "cloud.google.com/go/confidentialcomputing/apiv1alpha1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "confidentialcomputing",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/confidentialcomputing/latest/apiv1alpha1",
+    "client_library_type": "generated",
+    "description": "Confidential Computing API",
+    "distribution_name": "cloud.google.com/go/confidentialcomputing/apiv1alpha1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/config/apiv1/.repo-metadata.json
+++ b/config/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "config",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/config/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Infrastructure Manager API",
-  "distribution_name": "cloud.google.com/go/config/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "config",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/config/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Infrastructure Manager API",
+    "distribution_name": "cloud.google.com/go/config/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/configdelivery/apiv1/.repo-metadata.json
+++ b/configdelivery/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "configdelivery",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/configdelivery/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Config Delivery API",
-  "distribution_name": "cloud.google.com/go/configdelivery/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "configdelivery",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/configdelivery/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Config Delivery API",
+    "distribution_name": "cloud.google.com/go/configdelivery/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/configdelivery/apiv1beta/.repo-metadata.json
+++ b/configdelivery/apiv1beta/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "configdelivery",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/configdelivery/latest/apiv1beta",
-  "client_library_type": "generated",
-  "description": "Config Delivery API",
-  "distribution_name": "cloud.google.com/go/configdelivery/apiv1beta",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "configdelivery",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/configdelivery/latest/apiv1beta",
+    "client_library_type": "generated",
+    "description": "Config Delivery API",
+    "distribution_name": "cloud.google.com/go/configdelivery/apiv1beta",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/contactcenterinsights/apiv1/.repo-metadata.json
+++ b/contactcenterinsights/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "contactcenterinsights",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/contactcenterinsights/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Contact Center AI Insights API",
-  "distribution_name": "cloud.google.com/go/contactcenterinsights/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "contactcenterinsights",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/contactcenterinsights/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Contact Center AI Insights API",
+    "distribution_name": "cloud.google.com/go/contactcenterinsights/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/container/apiv1/.repo-metadata.json
+++ b/container/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "container",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/container/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Kubernetes Engine API",
-  "distribution_name": "cloud.google.com/go/container/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "container",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/container/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Kubernetes Engine API",
+    "distribution_name": "cloud.google.com/go/container/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/containeranalysis/apiv1beta1/.repo-metadata.json
+++ b/containeranalysis/apiv1beta1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "containeranalysis",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/containeranalysis/latest/apiv1beta1",
-  "client_library_type": "generated",
-  "description": "Container Analysis API",
-  "distribution_name": "cloud.google.com/go/containeranalysis/apiv1beta1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "containeranalysis",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/containeranalysis/latest/apiv1beta1",
+    "client_library_type": "generated",
+    "description": "Container Analysis API",
+    "distribution_name": "cloud.google.com/go/containeranalysis/apiv1beta1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/datacatalog/apiv1/.repo-metadata.json
+++ b/datacatalog/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "datacatalog",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/datacatalog/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Google Cloud Data Catalog API",
-  "distribution_name": "cloud.google.com/go/datacatalog/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "datacatalog",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/datacatalog/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Google Cloud Data Catalog API",
+    "distribution_name": "cloud.google.com/go/datacatalog/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/datacatalog/apiv1beta1/.repo-metadata.json
+++ b/datacatalog/apiv1beta1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "datacatalog",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/datacatalog/latest/apiv1beta1",
-  "client_library_type": "generated",
-  "description": "Google Cloud Data Catalog API",
-  "distribution_name": "cloud.google.com/go/datacatalog/apiv1beta1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "datacatalog",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/datacatalog/latest/apiv1beta1",
+    "client_library_type": "generated",
+    "description": "Google Cloud Data Catalog API",
+    "distribution_name": "cloud.google.com/go/datacatalog/apiv1beta1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/datacatalog/lineage/apiv1/.repo-metadata.json
+++ b/datacatalog/lineage/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "datalineage",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/datacatalog/latest/lineage/apiv1",
-  "client_library_type": "generated",
-  "description": "Data Lineage API",
-  "distribution_name": "cloud.google.com/go/datacatalog/lineage/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "datalineage",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/datacatalog/latest/lineage/apiv1",
+    "client_library_type": "generated",
+    "description": "Data Lineage API",
+    "distribution_name": "cloud.google.com/go/datacatalog/lineage/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/dataflow/apiv1beta3/.repo-metadata.json
+++ b/dataflow/apiv1beta3/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "dataflow",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/dataflow/latest/apiv1beta3",
-  "client_library_type": "generated",
-  "description": "Dataflow API",
-  "distribution_name": "cloud.google.com/go/dataflow/apiv1beta3",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "dataflow",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/dataflow/latest/apiv1beta3",
+    "client_library_type": "generated",
+    "description": "Dataflow API",
+    "distribution_name": "cloud.google.com/go/dataflow/apiv1beta3",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/dataform/apiv1/.repo-metadata.json
+++ b/dataform/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "dataform",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/dataform/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Dataform API",
-  "distribution_name": "cloud.google.com/go/dataform/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "dataform",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/dataform/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Dataform API",
+    "distribution_name": "cloud.google.com/go/dataform/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/dataform/apiv1beta1/.repo-metadata.json
+++ b/dataform/apiv1beta1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "dataform",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/dataform/latest/apiv1beta1",
-  "client_library_type": "generated",
-  "description": "Dataform API",
-  "distribution_name": "cloud.google.com/go/dataform/apiv1beta1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "dataform",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/dataform/latest/apiv1beta1",
+    "client_library_type": "generated",
+    "description": "Dataform API",
+    "distribution_name": "cloud.google.com/go/dataform/apiv1beta1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/datafusion/apiv1/.repo-metadata.json
+++ b/datafusion/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "datafusion",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/datafusion/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Cloud Data Fusion API",
-  "distribution_name": "cloud.google.com/go/datafusion/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "datafusion",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/datafusion/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Cloud Data Fusion API",
+    "distribution_name": "cloud.google.com/go/datafusion/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/datalabeling/apiv1beta1/.repo-metadata.json
+++ b/datalabeling/apiv1beta1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "datalabeling",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/datalabeling/latest/apiv1beta1",
-  "client_library_type": "generated",
-  "description": "Data Labeling API",
-  "distribution_name": "cloud.google.com/go/datalabeling/apiv1beta1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "datalabeling",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/datalabeling/latest/apiv1beta1",
+    "client_library_type": "generated",
+    "description": "Data Labeling API",
+    "distribution_name": "cloud.google.com/go/datalabeling/apiv1beta1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/datamanager/apiv1/.repo-metadata.json
+++ b/datamanager/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "datamanager",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/datamanager/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Data Manager API",
-  "distribution_name": "cloud.google.com/go/datamanager/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "datamanager",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/datamanager/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Data Manager API",
+    "distribution_name": "cloud.google.com/go/datamanager/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/dataplex/apiv1/.repo-metadata.json
+++ b/dataplex/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "dataplex",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/dataplex/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Cloud Dataplex API",
-  "distribution_name": "cloud.google.com/go/dataplex/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "dataplex",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/dataplex/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Cloud Dataplex API",
+    "distribution_name": "cloud.google.com/go/dataplex/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/dataproc/apiv1/.repo-metadata.json
+++ b/dataproc/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "dataproc",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/dataproc/v2/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Cloud Dataproc API",
-  "distribution_name": "cloud.google.com/go/dataproc/v2/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "dataproc",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/dataproc/v2/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Cloud Dataproc API",
+    "distribution_name": "cloud.google.com/go/dataproc/v2/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/dataqna/apiv1alpha/.repo-metadata.json
+++ b/dataqna/apiv1alpha/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "dataqna",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/dataqna/latest/apiv1alpha",
-  "client_library_type": "generated",
-  "description": "Data QnA API",
-  "distribution_name": "cloud.google.com/go/dataqna/apiv1alpha",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "dataqna",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/dataqna/latest/apiv1alpha",
+    "client_library_type": "generated",
+    "description": "Data QnA API",
+    "distribution_name": "cloud.google.com/go/dataqna/apiv1alpha",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/datastore/.repo-metadata.json
+++ b/datastore/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "datastore",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/datastore/latest",
-  "client_library_type": "manual",
-  "description": "Cloud Datastore",
-  "distribution_name": "cloud.google.com/go/datastore",
-  "language": "go",
-  "library_type": "GAPIC_MANUAL",
-  "release_level": "stable"
+    "api_shortname": "datastore",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/datastore/latest",
+    "client_library_type": "manual",
+    "description": "Cloud Datastore",
+    "distribution_name": "cloud.google.com/go/datastore",
+    "language": "go",
+    "library_type": "GAPIC_MANUAL",
+    "release_level": "stable"
 }

--- a/datastore/admin/apiv1/.repo-metadata.json
+++ b/datastore/admin/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "datastore",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/datastore/latest/admin/apiv1",
-  "client_library_type": "generated",
-  "description": "Cloud Datastore API",
-  "distribution_name": "cloud.google.com/go/datastore/admin/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "datastore",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/datastore/latest/admin/apiv1",
+    "client_library_type": "generated",
+    "description": "Cloud Datastore API",
+    "distribution_name": "cloud.google.com/go/datastore/admin/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/datastore/apiv1/.repo-metadata.json
+++ b/datastore/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "datastore",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/datastore/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Cloud Datastore API",
-  "distribution_name": "cloud.google.com/go/datastore/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "datastore",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/datastore/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Cloud Datastore API",
+    "distribution_name": "cloud.google.com/go/datastore/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/datastream/apiv1/.repo-metadata.json
+++ b/datastream/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "datastream",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/datastream/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Datastream API",
-  "distribution_name": "cloud.google.com/go/datastream/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "datastream",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/datastream/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Datastream API",
+    "distribution_name": "cloud.google.com/go/datastream/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/datastream/apiv1alpha1/.repo-metadata.json
+++ b/datastream/apiv1alpha1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "datastream",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/datastream/latest/apiv1alpha1",
-  "client_library_type": "generated",
-  "description": "Datastream API",
-  "distribution_name": "cloud.google.com/go/datastream/apiv1alpha1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "datastream",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/datastream/latest/apiv1alpha1",
+    "client_library_type": "generated",
+    "description": "Datastream API",
+    "distribution_name": "cloud.google.com/go/datastream/apiv1alpha1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/deploy/apiv1/.repo-metadata.json
+++ b/deploy/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "clouddeploy",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/deploy/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Cloud Deploy API",
-  "distribution_name": "cloud.google.com/go/deploy/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "clouddeploy",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/deploy/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Cloud Deploy API",
+    "distribution_name": "cloud.google.com/go/deploy/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/developerconnect/apiv1/.repo-metadata.json
+++ b/developerconnect/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "developerconnect",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/developerconnect/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Developer Connect API",
-  "distribution_name": "cloud.google.com/go/developerconnect/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "developerconnect",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/developerconnect/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Developer Connect API",
+    "distribution_name": "cloud.google.com/go/developerconnect/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/devicestreaming/apiv1/.repo-metadata.json
+++ b/devicestreaming/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "devicestreaming",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/devicestreaming/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Device Streaming API",
-  "distribution_name": "cloud.google.com/go/devicestreaming/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "devicestreaming",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/devicestreaming/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Device Streaming API",
+    "distribution_name": "cloud.google.com/go/devicestreaming/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/dialogflow/apiv2/.repo-metadata.json
+++ b/dialogflow/apiv2/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "dialogflow",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/dialogflow/latest/apiv2",
-  "client_library_type": "generated",
-  "description": "Dialogflow API",
-  "distribution_name": "cloud.google.com/go/dialogflow/apiv2",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "dialogflow",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/dialogflow/latest/apiv2",
+    "client_library_type": "generated",
+    "description": "Dialogflow API",
+    "distribution_name": "cloud.google.com/go/dialogflow/apiv2",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/dialogflow/apiv2beta1/.repo-metadata.json
+++ b/dialogflow/apiv2beta1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "dialogflow",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/dialogflow/latest/apiv2beta1",
-  "client_library_type": "generated",
-  "description": "Dialogflow API",
-  "distribution_name": "cloud.google.com/go/dialogflow/apiv2beta1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "dialogflow",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/dialogflow/latest/apiv2beta1",
+    "client_library_type": "generated",
+    "description": "Dialogflow API",
+    "distribution_name": "cloud.google.com/go/dialogflow/apiv2beta1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/dialogflow/apiv3/.repo-metadata.json
+++ b/dialogflow/apiv3/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "dialogflow",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/dialogflow/latest/cx/apiv3",
-  "client_library_type": "generated",
-  "description": "Dialogflow API",
-  "distribution_name": "cloud.google.com/go/dialogflow/cx/apiv3",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "dialogflow",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/dialogflow/latest/cx/apiv3",
+    "client_library_type": "generated",
+    "description": "Dialogflow API",
+    "distribution_name": "cloud.google.com/go/dialogflow/cx/apiv3",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/dialogflow/apiv3beta1/.repo-metadata.json
+++ b/dialogflow/apiv3beta1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "dialogflow",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/dialogflow/latest/cx/apiv3beta1",
-  "client_library_type": "generated",
-  "description": "Dialogflow API",
-  "distribution_name": "cloud.google.com/go/dialogflow/cx/apiv3beta1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "dialogflow",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/dialogflow/latest/cx/apiv3beta1",
+    "client_library_type": "generated",
+    "description": "Dialogflow API",
+    "distribution_name": "cloud.google.com/go/dialogflow/cx/apiv3beta1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/dialogflow/cx/apiv3/.repo-metadata.json
+++ b/dialogflow/cx/apiv3/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "dialogflow",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/dialogflow/latest/cx/apiv3",
-  "client_library_type": "generated",
-  "description": "Dialogflow API",
-  "distribution_name": "cloud.google.com/go/dialogflow/cx/apiv3",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "dialogflow",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/dialogflow/latest/cx/apiv3",
+    "client_library_type": "generated",
+    "description": "Dialogflow API",
+    "distribution_name": "cloud.google.com/go/dialogflow/cx/apiv3",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/dialogflow/cx/apiv3beta1/.repo-metadata.json
+++ b/dialogflow/cx/apiv3beta1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "dialogflow",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/dialogflow/latest/cx/apiv3beta1",
-  "client_library_type": "generated",
-  "description": "Dialogflow API",
-  "distribution_name": "cloud.google.com/go/dialogflow/cx/apiv3beta1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "dialogflow",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/dialogflow/latest/cx/apiv3beta1",
+    "client_library_type": "generated",
+    "description": "Dialogflow API",
+    "distribution_name": "cloud.google.com/go/dialogflow/cx/apiv3beta1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/discoveryengine/apiv1/.repo-metadata.json
+++ b/discoveryengine/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "discoveryengine",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/discoveryengine/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Discovery Engine API",
-  "distribution_name": "cloud.google.com/go/discoveryengine/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "discoveryengine",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/discoveryengine/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Discovery Engine API",
+    "distribution_name": "cloud.google.com/go/discoveryengine/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/discoveryengine/apiv1alpha/.repo-metadata.json
+++ b/discoveryengine/apiv1alpha/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "discoveryengine",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/discoveryengine/latest/apiv1alpha",
-  "client_library_type": "generated",
-  "description": "Discovery Engine API",
-  "distribution_name": "cloud.google.com/go/discoveryengine/apiv1alpha",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "discoveryengine",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/discoveryengine/latest/apiv1alpha",
+    "client_library_type": "generated",
+    "description": "Discovery Engine API",
+    "distribution_name": "cloud.google.com/go/discoveryengine/apiv1alpha",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/discoveryengine/apiv1beta/.repo-metadata.json
+++ b/discoveryengine/apiv1beta/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "discoveryengine",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/discoveryengine/latest/apiv1beta",
-  "client_library_type": "generated",
-  "description": "Discovery Engine API",
-  "distribution_name": "cloud.google.com/go/discoveryengine/apiv1beta",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "discoveryengine",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/discoveryengine/latest/apiv1beta",
+    "client_library_type": "generated",
+    "description": "Discovery Engine API",
+    "distribution_name": "cloud.google.com/go/discoveryengine/apiv1beta",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/dlp/apiv2/.repo-metadata.json
+++ b/dlp/apiv2/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "dlp",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/dlp/latest/apiv2",
-  "client_library_type": "generated",
-  "description": "Sensitive Data Protection (DLP)",
-  "distribution_name": "cloud.google.com/go/dlp/apiv2",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "dlp",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/dlp/latest/apiv2",
+    "client_library_type": "generated",
+    "description": "Sensitive Data Protection (DLP)",
+    "distribution_name": "cloud.google.com/go/dlp/apiv2",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/documentai/apiv1/.repo-metadata.json
+++ b/documentai/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "documentai",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/documentai/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Cloud Document AI API",
-  "distribution_name": "cloud.google.com/go/documentai/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "documentai",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/documentai/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Cloud Document AI API",
+    "distribution_name": "cloud.google.com/go/documentai/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/documentai/apiv1beta3/.repo-metadata.json
+++ b/documentai/apiv1beta3/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "documentai",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/documentai/latest/apiv1beta3",
-  "client_library_type": "generated",
-  "description": "Cloud Document AI API",
-  "distribution_name": "cloud.google.com/go/documentai/apiv1beta3",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "documentai",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/documentai/latest/apiv1beta3",
+    "client_library_type": "generated",
+    "description": "Cloud Document AI API",
+    "distribution_name": "cloud.google.com/go/documentai/apiv1beta3",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/domains/apiv1beta1/.repo-metadata.json
+++ b/domains/apiv1beta1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "domains",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/domains/latest/apiv1beta1",
-  "client_library_type": "generated",
-  "description": "Cloud Domains API",
-  "distribution_name": "cloud.google.com/go/domains/apiv1beta1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "domains",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/domains/latest/apiv1beta1",
+    "client_library_type": "generated",
+    "description": "Cloud Domains API",
+    "distribution_name": "cloud.google.com/go/domains/apiv1beta1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/edgecontainer/apiv1/.repo-metadata.json
+++ b/edgecontainer/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "edgecontainer",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/edgecontainer/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Distributed Cloud Edge Container API",
-  "distribution_name": "cloud.google.com/go/edgecontainer/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "edgecontainer",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/edgecontainer/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Distributed Cloud Edge Container API",
+    "distribution_name": "cloud.google.com/go/edgecontainer/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/edgenetwork/apiv1/.repo-metadata.json
+++ b/edgenetwork/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "edgenetwork",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/edgenetwork/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Distributed Cloud Edge Network API",
-  "distribution_name": "cloud.google.com/go/edgenetwork/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "edgenetwork",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/edgenetwork/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Distributed Cloud Edge Network API",
+    "distribution_name": "cloud.google.com/go/edgenetwork/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/errorreporting/.repo-metadata.json
+++ b/errorreporting/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "clouderrorreporting",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/errorreporting/latest",
-  "client_library_type": "manual",
-  "description": "Cloud Error Reporting API",
-  "distribution_name": "cloud.google.com/go/errorreporting",
-  "language": "go",
-  "library_type": "GAPIC_MANUAL",
-  "release_level": "preview"
+    "api_shortname": "clouderrorreporting",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/errorreporting/latest",
+    "client_library_type": "manual",
+    "description": "Cloud Error Reporting API",
+    "distribution_name": "cloud.google.com/go/errorreporting",
+    "language": "go",
+    "library_type": "GAPIC_MANUAL",
+    "release_level": "preview"
 }

--- a/errorreporting/apiv1beta1/.repo-metadata.json
+++ b/errorreporting/apiv1beta1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "clouderrorreporting",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/errorreporting/latest/apiv1beta1",
-  "client_library_type": "generated",
-  "description": "Error Reporting API",
-  "distribution_name": "cloud.google.com/go/errorreporting/apiv1beta1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "clouderrorreporting",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/errorreporting/latest/apiv1beta1",
+    "client_library_type": "generated",
+    "description": "Error Reporting API",
+    "distribution_name": "cloud.google.com/go/errorreporting/apiv1beta1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/essentialcontacts/apiv1/.repo-metadata.json
+++ b/essentialcontacts/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "essentialcontacts",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/essentialcontacts/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Essential Contacts API",
-  "distribution_name": "cloud.google.com/go/essentialcontacts/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "essentialcontacts",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/essentialcontacts/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Essential Contacts API",
+    "distribution_name": "cloud.google.com/go/essentialcontacts/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/eventarc/apiv1/.repo-metadata.json
+++ b/eventarc/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "eventarc",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/eventarc/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Eventarc API",
-  "distribution_name": "cloud.google.com/go/eventarc/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "eventarc",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/eventarc/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Eventarc API",
+    "distribution_name": "cloud.google.com/go/eventarc/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/eventarc/publishing/apiv1/.repo-metadata.json
+++ b/eventarc/publishing/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "eventarcpublishing",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/eventarc/latest/publishing/apiv1",
-  "client_library_type": "generated",
-  "description": "Eventarc Publishing API",
-  "distribution_name": "cloud.google.com/go/eventarc/publishing/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "eventarcpublishing",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/eventarc/latest/publishing/apiv1",
+    "client_library_type": "generated",
+    "description": "Eventarc Publishing API",
+    "distribution_name": "cloud.google.com/go/eventarc/publishing/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/filestore/apiv1/.repo-metadata.json
+++ b/filestore/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "file",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/filestore/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Cloud Filestore API",
-  "distribution_name": "cloud.google.com/go/filestore/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "file",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/filestore/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Cloud Filestore API",
+    "distribution_name": "cloud.google.com/go/filestore/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/financialservices/apiv1/.repo-metadata.json
+++ b/financialservices/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "financialservices",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/financialservices/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Financial Services API",
-  "distribution_name": "cloud.google.com/go/financialservices/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "financialservices",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/financialservices/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Financial Services API",
+    "distribution_name": "cloud.google.com/go/financialservices/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/firestore/.repo-metadata.json
+++ b/firestore/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "firestore",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/firestore/latest",
-  "client_library_type": "manual",
-  "description": "Cloud Firestore API",
-  "distribution_name": "cloud.google.com/go/firestore",
-  "language": "go",
-  "library_type": "GAPIC_MANUAL",
-  "release_level": "stable"
+    "api_shortname": "firestore",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/firestore/latest",
+    "client_library_type": "manual",
+    "description": "Cloud Firestore API",
+    "distribution_name": "cloud.google.com/go/firestore",
+    "language": "go",
+    "library_type": "GAPIC_MANUAL",
+    "release_level": "stable"
 }

--- a/firestore/apiv1/.repo-metadata.json
+++ b/firestore/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "firestore",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/firestore/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Cloud Firestore API",
-  "distribution_name": "cloud.google.com/go/firestore/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "firestore",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/firestore/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Cloud Firestore API",
+    "distribution_name": "cloud.google.com/go/firestore/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/firestore/apiv1/admin/.repo-metadata.json
+++ b/firestore/apiv1/admin/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "firestore",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/firestore/latest/apiv1/admin",
-  "client_library_type": "generated",
-  "description": "Cloud Firestore API",
-  "distribution_name": "cloud.google.com/go/firestore/apiv1/admin",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "firestore",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/firestore/latest/apiv1/admin",
+    "client_library_type": "generated",
+    "description": "Cloud Firestore API",
+    "distribution_name": "cloud.google.com/go/firestore/apiv1/admin",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/functions/apiv1/.repo-metadata.json
+++ b/functions/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "cloudfunctions",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/functions/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Cloud Functions API",
-  "distribution_name": "cloud.google.com/go/functions/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "cloudfunctions",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/functions/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Cloud Functions API",
+    "distribution_name": "cloud.google.com/go/functions/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/functions/apiv2/.repo-metadata.json
+++ b/functions/apiv2/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "cloudfunctions",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/functions/latest/apiv2",
-  "client_library_type": "generated",
-  "description": "Cloud Functions API",
-  "distribution_name": "cloud.google.com/go/functions/apiv2",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "cloudfunctions",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/functions/latest/apiv2",
+    "client_library_type": "generated",
+    "description": "Cloud Functions API",
+    "distribution_name": "cloud.google.com/go/functions/apiv2",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/functions/apiv2beta/.repo-metadata.json
+++ b/functions/apiv2beta/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "cloudfunctions",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/functions/latest/apiv2beta",
-  "client_library_type": "generated",
-  "description": "Cloud Functions API",
-  "distribution_name": "cloud.google.com/go/functions/apiv2beta",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "cloudfunctions",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/functions/latest/apiv2beta",
+    "client_library_type": "generated",
+    "description": "Cloud Functions API",
+    "distribution_name": "cloud.google.com/go/functions/apiv2beta",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/functions/metadata/.repo-metadata.json
+++ b/functions/metadata/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "firestore-metadata",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/functions/latest/metadata",
-  "client_library_type": "manual",
-  "description": "Cloud Functions",
-  "distribution_name": "cloud.google.com/go/functions/metadata",
-  "language": "go",
-  "library_type": "CORE",
-  "release_level": "preview"
+    "api_shortname": "firestore-metadata",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/functions/latest/metadata",
+    "client_library_type": "manual",
+    "description": "Cloud Functions",
+    "distribution_name": "cloud.google.com/go/functions/metadata",
+    "language": "go",
+    "library_type": "CORE",
+    "release_level": "preview"
 }

--- a/geminidataanalytics/apiv1beta/.repo-metadata.json
+++ b/geminidataanalytics/apiv1beta/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "geminidataanalytics",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/geminidataanalytics/latest/apiv1beta",
-  "client_library_type": "generated",
-  "description": "Data Analytics API with Gemini",
-  "distribution_name": "cloud.google.com/go/geminidataanalytics/apiv1beta",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "geminidataanalytics",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/geminidataanalytics/latest/apiv1beta",
+    "client_library_type": "generated",
+    "description": "Data Analytics API with Gemini",
+    "distribution_name": "cloud.google.com/go/geminidataanalytics/apiv1beta",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/gkebackup/apiv1/.repo-metadata.json
+++ b/gkebackup/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "gkebackup",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/gkebackup/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Backup for GKE API",
-  "distribution_name": "cloud.google.com/go/gkebackup/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "gkebackup",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/gkebackup/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Backup for GKE API",
+    "distribution_name": "cloud.google.com/go/gkebackup/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/gkeconnect/apiv1/.repo-metadata.json
+++ b/gkeconnect/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "connectgateway",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/gkeconnect/latest/gateway/apiv1",
-  "client_library_type": "generated",
-  "description": "Connect Gateway API",
-  "distribution_name": "cloud.google.com/go/gkeconnect/gateway/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "connectgateway",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/gkeconnect/latest/gateway/apiv1",
+    "client_library_type": "generated",
+    "description": "Connect Gateway API",
+    "distribution_name": "cloud.google.com/go/gkeconnect/gateway/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/gkeconnect/apiv1beta1/.repo-metadata.json
+++ b/gkeconnect/apiv1beta1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "connectgateway",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/gkeconnect/latest/gateway/apiv1beta1",
-  "client_library_type": "generated",
-  "description": "Connect Gateway API",
-  "distribution_name": "cloud.google.com/go/gkeconnect/gateway/apiv1beta1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "connectgateway",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/gkeconnect/latest/gateway/apiv1beta1",
+    "client_library_type": "generated",
+    "description": "Connect Gateway API",
+    "distribution_name": "cloud.google.com/go/gkeconnect/gateway/apiv1beta1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/gkeconnect/gateway/apiv1/.repo-metadata.json
+++ b/gkeconnect/gateway/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "connectgateway",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/gkeconnect/latest/gateway/apiv1",
-  "client_library_type": "generated",
-  "description": "Connect Gateway API",
-  "distribution_name": "cloud.google.com/go/gkeconnect/gateway/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "connectgateway",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/gkeconnect/latest/gateway/apiv1",
+    "client_library_type": "generated",
+    "description": "Connect Gateway API",
+    "distribution_name": "cloud.google.com/go/gkeconnect/gateway/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/gkeconnect/gateway/apiv1beta1/.repo-metadata.json
+++ b/gkeconnect/gateway/apiv1beta1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "connectgateway",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/gkeconnect/latest/gateway/apiv1beta1",
-  "client_library_type": "generated",
-  "description": "Connect Gateway API",
-  "distribution_name": "cloud.google.com/go/gkeconnect/gateway/apiv1beta1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "connectgateway",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/gkeconnect/latest/gateway/apiv1beta1",
+    "client_library_type": "generated",
+    "description": "Connect Gateway API",
+    "distribution_name": "cloud.google.com/go/gkeconnect/gateway/apiv1beta1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/gkehub/apiv1beta1/.repo-metadata.json
+++ b/gkehub/apiv1beta1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "gkehub",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/gkehub/latest/apiv1beta1",
-  "client_library_type": "generated",
-  "description": "GKE Hub API",
-  "distribution_name": "cloud.google.com/go/gkehub/apiv1beta1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "gkehub",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/gkehub/latest/apiv1beta1",
+    "client_library_type": "generated",
+    "description": "GKE Hub API",
+    "distribution_name": "cloud.google.com/go/gkehub/apiv1beta1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/gkemulticloud/apiv1/.repo-metadata.json
+++ b/gkemulticloud/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "gkemulticloud",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/gkemulticloud/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "GKE Multi-Cloud API",
-  "distribution_name": "cloud.google.com/go/gkemulticloud/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "gkemulticloud",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/gkemulticloud/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "GKE Multi-Cloud API",
+    "distribution_name": "cloud.google.com/go/gkemulticloud/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/gkerecommender/apiv1/.repo-metadata.json
+++ b/gkerecommender/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "gkerecommender",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/gkerecommender/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "GKE Recommender API",
-  "distribution_name": "cloud.google.com/go/gkerecommender/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "gkerecommender",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/gkerecommender/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "GKE Recommender API",
+    "distribution_name": "cloud.google.com/go/gkerecommender/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/gsuiteaddons/apiv1/.repo-metadata.json
+++ b/gsuiteaddons/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "gsuiteaddons",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/gsuiteaddons/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Google Workspace add-ons API",
-  "distribution_name": "cloud.google.com/go/gsuiteaddons/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "gsuiteaddons",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/gsuiteaddons/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Google Workspace add-ons API",
+    "distribution_name": "cloud.google.com/go/gsuiteaddons/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/hypercomputecluster/apiv1/.repo-metadata.json
+++ b/hypercomputecluster/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "hypercomputecluster",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/hypercomputecluster/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Cluster Director API",
-  "distribution_name": "cloud.google.com/go/hypercomputecluster/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "hypercomputecluster",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/hypercomputecluster/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Cluster Director API",
+    "distribution_name": "cloud.google.com/go/hypercomputecluster/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/hypercomputecluster/apiv1beta/.repo-metadata.json
+++ b/hypercomputecluster/apiv1beta/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "hypercomputecluster",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/hypercomputecluster/latest/apiv1beta",
-  "client_library_type": "generated",
-  "description": "Cluster Director API",
-  "distribution_name": "cloud.google.com/go/hypercomputecluster/apiv1beta",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "hypercomputecluster",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/hypercomputecluster/latest/apiv1beta",
+    "client_library_type": "generated",
+    "description": "Cluster Director API",
+    "distribution_name": "cloud.google.com/go/hypercomputecluster/apiv1beta",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/iam/.repo-metadata.json
+++ b/iam/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "iam",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/iam/latest",
-  "client_library_type": "manual",
-  "description": "Cloud IAM",
-  "distribution_name": "cloud.google.com/go/iam",
-  "language": "go",
-  "library_type": "CORE",
-  "release_level": "stable"
+    "api_shortname": "iam",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/iam/latest",
+    "client_library_type": "manual",
+    "description": "Cloud IAM",
+    "distribution_name": "cloud.google.com/go/iam",
+    "language": "go",
+    "library_type": "CORE",
+    "release_level": "stable"
 }

--- a/iam/apiv1/.repo-metadata.json
+++ b/iam/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "iam-meta-api",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/iam/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "IAM Meta API",
-  "distribution_name": "cloud.google.com/go/iam/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "iam-meta-api",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/iam/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "IAM Meta API",
+    "distribution_name": "cloud.google.com/go/iam/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/iam/apiv2/.repo-metadata.json
+++ b/iam/apiv2/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "iam",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/iam/latest/apiv2",
-  "client_library_type": "generated",
-  "description": "Identity and Access Management (IAM) API",
-  "distribution_name": "cloud.google.com/go/iam/apiv2",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "iam",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/iam/latest/apiv2",
+    "client_library_type": "generated",
+    "description": "Identity and Access Management (IAM) API",
+    "distribution_name": "cloud.google.com/go/iam/apiv2",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/iam/apiv3/.repo-metadata.json
+++ b/iam/apiv3/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "iam",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/iam/latest/apiv3",
-  "client_library_type": "generated",
-  "description": "Identity and Access Management (IAM) API",
-  "distribution_name": "cloud.google.com/go/iam/apiv3",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "iam",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/iam/latest/apiv3",
+    "client_library_type": "generated",
+    "description": "Identity and Access Management (IAM) API",
+    "distribution_name": "cloud.google.com/go/iam/apiv3",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/iam/apiv3beta/.repo-metadata.json
+++ b/iam/apiv3beta/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "iam",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/iam/latest/apiv3beta",
-  "client_library_type": "generated",
-  "description": "Identity and Access Management (IAM) API",
-  "distribution_name": "cloud.google.com/go/iam/apiv3beta",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "iam",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/iam/latest/apiv3beta",
+    "client_library_type": "generated",
+    "description": "Identity and Access Management (IAM) API",
+    "distribution_name": "cloud.google.com/go/iam/apiv3beta",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/iam/credentials/apiv1/.repo-metadata.json
+++ b/iam/credentials/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "iamcredentials",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/iam/latest/credentials/apiv1",
-  "client_library_type": "generated",
-  "description": "IAM Service Account Credentials API",
-  "distribution_name": "cloud.google.com/go/iam/credentials/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "iamcredentials",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/iam/latest/credentials/apiv1",
+    "client_library_type": "generated",
+    "description": "IAM Service Account Credentials API",
+    "distribution_name": "cloud.google.com/go/iam/credentials/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/iap/apiv1/.repo-metadata.json
+++ b/iap/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "iap",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/iap/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Cloud Identity-Aware Proxy API",
-  "distribution_name": "cloud.google.com/go/iap/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "iap",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/iap/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Cloud Identity-Aware Proxy API",
+    "distribution_name": "cloud.google.com/go/iap/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/identitytoolkit/apiv2/.repo-metadata.json
+++ b/identitytoolkit/apiv2/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "identitytoolkit",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/identitytoolkit/latest/apiv2",
-  "client_library_type": "generated",
-  "description": "Identity Toolkit API",
-  "distribution_name": "cloud.google.com/go/identitytoolkit/apiv2",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "identitytoolkit",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/identitytoolkit/latest/apiv2",
+    "client_library_type": "generated",
+    "description": "Identity Toolkit API",
+    "distribution_name": "cloud.google.com/go/identitytoolkit/apiv2",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/ids/apiv1/.repo-metadata.json
+++ b/ids/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "ids",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/ids/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Cloud IDS API",
-  "distribution_name": "cloud.google.com/go/ids/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "ids",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/ids/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Cloud IDS API",
+    "distribution_name": "cloud.google.com/go/ids/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/iot/apiv1/.repo-metadata.json
+++ b/iot/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "cloudiot",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/iot/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Cloud IoT API",
-  "distribution_name": "cloud.google.com/go/iot/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "cloudiot",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/iot/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Cloud IoT API",
+    "distribution_name": "cloud.google.com/go/iot/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/kms/apiv1/.repo-metadata.json
+++ b/kms/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "cloudkms",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/kms/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Cloud Key Management Service (KMS) API",
-  "distribution_name": "cloud.google.com/go/kms/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "cloudkms",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/kms/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Cloud Key Management Service (KMS) API",
+    "distribution_name": "cloud.google.com/go/kms/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/kms/inventory/apiv1/.repo-metadata.json
+++ b/kms/inventory/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "kmsinventory",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/kms/latest/inventory/apiv1",
-  "client_library_type": "generated",
-  "description": "KMS Inventory API",
-  "distribution_name": "cloud.google.com/go/kms/inventory/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "kmsinventory",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/kms/latest/inventory/apiv1",
+    "client_library_type": "generated",
+    "description": "KMS Inventory API",
+    "distribution_name": "cloud.google.com/go/kms/inventory/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/language/apiv1/.repo-metadata.json
+++ b/language/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "language",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/language/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Cloud Natural Language API",
-  "distribution_name": "cloud.google.com/go/language/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "language",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/language/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Cloud Natural Language API",
+    "distribution_name": "cloud.google.com/go/language/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/language/apiv1beta2/.repo-metadata.json
+++ b/language/apiv1beta2/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "language",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/language/latest/apiv1beta2",
-  "client_library_type": "generated",
-  "description": "Cloud Natural Language API",
-  "distribution_name": "cloud.google.com/go/language/apiv1beta2",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "language",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/language/latest/apiv1beta2",
+    "client_library_type": "generated",
+    "description": "Cloud Natural Language API",
+    "distribution_name": "cloud.google.com/go/language/apiv1beta2",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/language/apiv2/.repo-metadata.json
+++ b/language/apiv2/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "language",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/language/latest/apiv2",
-  "client_library_type": "generated",
-  "description": "Cloud Natural Language API",
-  "distribution_name": "cloud.google.com/go/language/apiv2",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "language",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/language/latest/apiv2",
+    "client_library_type": "generated",
+    "description": "Cloud Natural Language API",
+    "distribution_name": "cloud.google.com/go/language/apiv2",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/licensemanager/apiv1/.repo-metadata.json
+++ b/licensemanager/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "licensemanager",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/licensemanager/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "License Manager API",
-  "distribution_name": "cloud.google.com/go/licensemanager/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "licensemanager",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/licensemanager/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "License Manager API",
+    "distribution_name": "cloud.google.com/go/licensemanager/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/lifesciences/apiv2beta/.repo-metadata.json
+++ b/lifesciences/apiv2beta/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "lifesciences",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/lifesciences/latest/apiv2beta",
-  "client_library_type": "generated",
-  "description": "Cloud Life Sciences API",
-  "distribution_name": "cloud.google.com/go/lifesciences/apiv2beta",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "lifesciences",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/lifesciences/latest/apiv2beta",
+    "client_library_type": "generated",
+    "description": "Cloud Life Sciences API",
+    "distribution_name": "cloud.google.com/go/lifesciences/apiv2beta",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/locationfinder/apiv1/.repo-metadata.json
+++ b/locationfinder/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "cloudlocationfinder",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/locationfinder/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Cloud Location Finder API",
-  "distribution_name": "cloud.google.com/go/locationfinder/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "cloudlocationfinder",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/locationfinder/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Cloud Location Finder API",
+    "distribution_name": "cloud.google.com/go/locationfinder/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/logging/.repo-metadata.json
+++ b/logging/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "logging",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/logging/latest",
-  "client_library_type": "manual",
-  "description": "Cloud Logging API",
-  "distribution_name": "cloud.google.com/go/logging",
-  "language": "go",
-  "library_type": "GAPIC_MANUAL",
-  "release_level": "stable"
+    "api_shortname": "logging",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/logging/latest",
+    "client_library_type": "manual",
+    "description": "Cloud Logging API",
+    "distribution_name": "cloud.google.com/go/logging",
+    "language": "go",
+    "library_type": "GAPIC_MANUAL",
+    "release_level": "stable"
 }

--- a/logging/apiv2/.repo-metadata.json
+++ b/logging/apiv2/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "logging",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/logging/latest/apiv2",
-  "client_library_type": "generated",
-  "description": "Cloud Logging API",
-  "distribution_name": "cloud.google.com/go/logging/apiv2",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "logging",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/logging/latest/apiv2",
+    "client_library_type": "generated",
+    "description": "Cloud Logging API",
+    "distribution_name": "cloud.google.com/go/logging/apiv2",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/longrunning/autogen/.repo-metadata.json
+++ b/longrunning/autogen/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "longrunning",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/longrunning/latest/autogen",
-  "client_library_type": "generated",
-  "description": "Long Running Operations API",
-  "distribution_name": "cloud.google.com/go/longrunning/autogen",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "longrunning",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/longrunning/latest/autogen",
+    "client_library_type": "generated",
+    "description": "Long Running Operations API",
+    "distribution_name": "cloud.google.com/go/longrunning/autogen",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/lustre/apiv1/.repo-metadata.json
+++ b/lustre/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "lustre",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/lustre/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Google Cloud Managed Lustre API",
-  "distribution_name": "cloud.google.com/go/lustre/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "lustre",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/lustre/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Google Cloud Managed Lustre API",
+    "distribution_name": "cloud.google.com/go/lustre/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/maintenance/api/apiv1/.repo-metadata.json
+++ b/maintenance/api/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "maintenance",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/maintenance/latest/api/apiv1",
-  "client_library_type": "generated",
-  "description": "Maintenance API",
-  "distribution_name": "cloud.google.com/go/maintenance/api/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "maintenance",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/maintenance/latest/api/apiv1",
+    "client_library_type": "generated",
+    "description": "Maintenance API",
+    "distribution_name": "cloud.google.com/go/maintenance/api/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/maintenance/api/apiv1beta/.repo-metadata.json
+++ b/maintenance/api/apiv1beta/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "maintenance",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/maintenance/latest/api/apiv1beta",
-  "client_library_type": "generated",
-  "description": "Maintenance API",
-  "distribution_name": "cloud.google.com/go/maintenance/api/apiv1beta",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "maintenance",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/maintenance/latest/api/apiv1beta",
+    "client_library_type": "generated",
+    "description": "Maintenance API",
+    "distribution_name": "cloud.google.com/go/maintenance/api/apiv1beta",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/maintenance/apiv1beta/.repo-metadata.json
+++ b/maintenance/apiv1beta/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "maintenance",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/maintenance/latest/api/apiv1beta",
-  "client_library_type": "generated",
-  "description": "Maintenance API",
-  "distribution_name": "cloud.google.com/go/maintenance/api/apiv1beta",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "maintenance",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/maintenance/latest/api/apiv1beta",
+    "client_library_type": "generated",
+    "description": "Maintenance API",
+    "distribution_name": "cloud.google.com/go/maintenance/api/apiv1beta",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/managedidentities/apiv1/.repo-metadata.json
+++ b/managedidentities/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "managedidentities",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/managedidentities/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Managed Service for Microsoft Active Directory API",
-  "distribution_name": "cloud.google.com/go/managedidentities/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "managedidentities",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/managedidentities/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Managed Service for Microsoft Active Directory API",
+    "distribution_name": "cloud.google.com/go/managedidentities/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/managedkafka/apiv1/.repo-metadata.json
+++ b/managedkafka/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "managedkafka",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/managedkafka/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Managed Service for Apache Kafka API",
-  "distribution_name": "cloud.google.com/go/managedkafka/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "managedkafka",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/managedkafka/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Managed Service for Apache Kafka API",
+    "distribution_name": "cloud.google.com/go/managedkafka/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/managedkafka/schemaregistry/apiv1/.repo-metadata.json
+++ b/managedkafka/schemaregistry/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "managedkafka",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/managedkafka/latest/schemaregistry/apiv1",
-  "client_library_type": "generated",
-  "description": "Managed Service for Apache Kafka API",
-  "distribution_name": "cloud.google.com/go/managedkafka/schemaregistry/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "managedkafka",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/managedkafka/latest/schemaregistry/apiv1",
+    "client_library_type": "generated",
+    "description": "Managed Service for Apache Kafka API",
+    "distribution_name": "cloud.google.com/go/managedkafka/schemaregistry/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/maps/addressvalidation/apiv1/.repo-metadata.json
+++ b/maps/addressvalidation/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "addressvalidation",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/maps/latest/addressvalidation/apiv1",
-  "client_library_type": "generated",
-  "description": "Address Validation API",
-  "distribution_name": "cloud.google.com/go/maps/addressvalidation/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "addressvalidation",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/maps/latest/addressvalidation/apiv1",
+    "client_library_type": "generated",
+    "description": "Address Validation API",
+    "distribution_name": "cloud.google.com/go/maps/addressvalidation/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/maps/areainsights/apiv1/.repo-metadata.json
+++ b/maps/areainsights/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "areainsights",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/maps/latest/areainsights/apiv1",
-  "client_library_type": "generated",
-  "description": "Places Aggregate API",
-  "distribution_name": "cloud.google.com/go/maps/areainsights/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "areainsights",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/maps/latest/areainsights/apiv1",
+    "client_library_type": "generated",
+    "description": "Places Aggregate API",
+    "distribution_name": "cloud.google.com/go/maps/areainsights/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/maps/fleetengine/apiv1/.repo-metadata.json
+++ b/maps/fleetengine/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "fleetengine",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/maps/latest/fleetengine/apiv1",
-  "client_library_type": "generated",
-  "description": "Local Rides and Deliveries API",
-  "distribution_name": "cloud.google.com/go/maps/fleetengine/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "fleetengine",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/maps/latest/fleetengine/apiv1",
+    "client_library_type": "generated",
+    "description": "Local Rides and Deliveries API",
+    "distribution_name": "cloud.google.com/go/maps/fleetengine/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/maps/fleetengine/delivery/apiv1/.repo-metadata.json
+++ b/maps/fleetengine/delivery/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "fleetengine",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/maps/latest/fleetengine/delivery/apiv1",
-  "client_library_type": "generated",
-  "description": "Last Mile Fleet Solution Delivery API",
-  "distribution_name": "cloud.google.com/go/maps/fleetengine/delivery/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "fleetengine",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/maps/latest/fleetengine/delivery/apiv1",
+    "client_library_type": "generated",
+    "description": "Last Mile Fleet Solution Delivery API",
+    "distribution_name": "cloud.google.com/go/maps/fleetengine/delivery/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/maps/places/apiv1/.repo-metadata.json
+++ b/maps/places/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "places",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/maps/latest/places/apiv1",
-  "client_library_type": "generated",
-  "description": "Places API (New)",
-  "distribution_name": "cloud.google.com/go/maps/places/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "places",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/maps/latest/places/apiv1",
+    "client_library_type": "generated",
+    "description": "Places API (New)",
+    "distribution_name": "cloud.google.com/go/maps/places/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/maps/routeoptimization/apiv1/.repo-metadata.json
+++ b/maps/routeoptimization/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "routeoptimization",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/maps/latest/routeoptimization/apiv1",
-  "client_library_type": "generated",
-  "description": "Route Optimization API",
-  "distribution_name": "cloud.google.com/go/maps/routeoptimization/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "routeoptimization",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/maps/latest/routeoptimization/apiv1",
+    "client_library_type": "generated",
+    "description": "Route Optimization API",
+    "distribution_name": "cloud.google.com/go/maps/routeoptimization/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/maps/routing/apiv2/.repo-metadata.json
+++ b/maps/routing/apiv2/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "routes",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/maps/latest/routing/apiv2",
-  "client_library_type": "generated",
-  "description": "Routes API",
-  "distribution_name": "cloud.google.com/go/maps/routing/apiv2",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "routes",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/maps/latest/routing/apiv2",
+    "client_library_type": "generated",
+    "description": "Routes API",
+    "distribution_name": "cloud.google.com/go/maps/routing/apiv2",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/maps/solar/apiv1/.repo-metadata.json
+++ b/maps/solar/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "solar",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/maps/latest/solar/apiv1",
-  "client_library_type": "generated",
-  "description": "Solar API",
-  "distribution_name": "cloud.google.com/go/maps/solar/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "solar",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/maps/latest/solar/apiv1",
+    "client_library_type": "generated",
+    "description": "Solar API",
+    "distribution_name": "cloud.google.com/go/maps/solar/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/mediatranslation/apiv1beta1/.repo-metadata.json
+++ b/mediatranslation/apiv1beta1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "mediatranslation",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/mediatranslation/latest/apiv1beta1",
-  "client_library_type": "generated",
-  "description": "Media Translation API",
-  "distribution_name": "cloud.google.com/go/mediatranslation/apiv1beta1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "mediatranslation",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/mediatranslation/latest/apiv1beta1",
+    "client_library_type": "generated",
+    "description": "Media Translation API",
+    "distribution_name": "cloud.google.com/go/mediatranslation/apiv1beta1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/memcache/apiv1/.repo-metadata.json
+++ b/memcache/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "memcache",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/memcache/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Cloud Memorystore for Memcached API",
-  "distribution_name": "cloud.google.com/go/memcache/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "memcache",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/memcache/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Cloud Memorystore for Memcached API",
+    "distribution_name": "cloud.google.com/go/memcache/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/memcache/apiv1beta2/.repo-metadata.json
+++ b/memcache/apiv1beta2/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "memcache",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/memcache/latest/apiv1beta2",
-  "client_library_type": "generated",
-  "description": "Cloud Memorystore for Memcached API",
-  "distribution_name": "cloud.google.com/go/memcache/apiv1beta2",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "memcache",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/memcache/latest/apiv1beta2",
+    "client_library_type": "generated",
+    "description": "Cloud Memorystore for Memcached API",
+    "distribution_name": "cloud.google.com/go/memcache/apiv1beta2",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/memorystore/apiv1/.repo-metadata.json
+++ b/memorystore/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "memorystore",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/memorystore/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Memorystore API",
-  "distribution_name": "cloud.google.com/go/memorystore/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "memorystore",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/memorystore/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Memorystore API",
+    "distribution_name": "cloud.google.com/go/memorystore/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/memorystore/apiv1beta/.repo-metadata.json
+++ b/memorystore/apiv1beta/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "memorystore",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/memorystore/latest/apiv1beta",
-  "client_library_type": "generated",
-  "description": "Memorystore API",
-  "distribution_name": "cloud.google.com/go/memorystore/apiv1beta",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "memorystore",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/memorystore/latest/apiv1beta",
+    "client_library_type": "generated",
+    "description": "Memorystore API",
+    "distribution_name": "cloud.google.com/go/memorystore/apiv1beta",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/metastore/apiv1/.repo-metadata.json
+++ b/metastore/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "metastore",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/metastore/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Dataproc Metastore API",
-  "distribution_name": "cloud.google.com/go/metastore/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "metastore",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/metastore/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Dataproc Metastore API",
+    "distribution_name": "cloud.google.com/go/metastore/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/metastore/apiv1alpha/.repo-metadata.json
+++ b/metastore/apiv1alpha/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "metastore",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/metastore/latest/apiv1alpha",
-  "client_library_type": "generated",
-  "description": "Dataproc Metastore API",
-  "distribution_name": "cloud.google.com/go/metastore/apiv1alpha",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "metastore",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/metastore/latest/apiv1alpha",
+    "client_library_type": "generated",
+    "description": "Dataproc Metastore API",
+    "distribution_name": "cloud.google.com/go/metastore/apiv1alpha",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/metastore/apiv1beta/.repo-metadata.json
+++ b/metastore/apiv1beta/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "metastore",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/metastore/latest/apiv1beta",
-  "client_library_type": "generated",
-  "description": "Dataproc Metastore API",
-  "distribution_name": "cloud.google.com/go/metastore/apiv1beta",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "metastore",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/metastore/latest/apiv1beta",
+    "client_library_type": "generated",
+    "description": "Dataproc Metastore API",
+    "distribution_name": "cloud.google.com/go/metastore/apiv1beta",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/migrationcenter/apiv1/.repo-metadata.json
+++ b/migrationcenter/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "migrationcenter",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/migrationcenter/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Migration Center API",
-  "distribution_name": "cloud.google.com/go/migrationcenter/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "migrationcenter",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/migrationcenter/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Migration Center API",
+    "distribution_name": "cloud.google.com/go/migrationcenter/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/modelarmor/apiv1/.repo-metadata.json
+++ b/modelarmor/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "modelarmor",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/modelarmor/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Model Armor API",
-  "distribution_name": "cloud.google.com/go/modelarmor/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "modelarmor",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/modelarmor/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Model Armor API",
+    "distribution_name": "cloud.google.com/go/modelarmor/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/modelarmor/apiv1beta/.repo-metadata.json
+++ b/modelarmor/apiv1beta/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "modelarmor",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/modelarmor/latest/apiv1beta",
-  "client_library_type": "generated",
-  "description": "Model Armor API",
-  "distribution_name": "cloud.google.com/go/modelarmor/apiv1beta",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "modelarmor",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/modelarmor/latest/apiv1beta",
+    "client_library_type": "generated",
+    "description": "Model Armor API",
+    "distribution_name": "cloud.google.com/go/modelarmor/apiv1beta",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/monitoring/apiv3/v2/.repo-metadata.json
+++ b/monitoring/apiv3/v2/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "monitoring",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/monitoring/latest/apiv3/v2",
-  "client_library_type": "generated",
-  "description": "Cloud Monitoring API",
-  "distribution_name": "cloud.google.com/go/monitoring/apiv3/v2",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "monitoring",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/monitoring/latest/apiv3/v2",
+    "client_library_type": "generated",
+    "description": "Cloud Monitoring API",
+    "distribution_name": "cloud.google.com/go/monitoring/apiv3/v2",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/monitoring/dashboard/apiv1/.repo-metadata.json
+++ b/monitoring/dashboard/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "monitoring",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/monitoring/latest/dashboard/apiv1",
-  "client_library_type": "generated",
-  "description": "Cloud Monitoring API",
-  "distribution_name": "cloud.google.com/go/monitoring/dashboard/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "monitoring",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/monitoring/latest/dashboard/apiv1",
+    "client_library_type": "generated",
+    "description": "Cloud Monitoring API",
+    "distribution_name": "cloud.google.com/go/monitoring/dashboard/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/monitoring/metricsscope/apiv1/.repo-metadata.json
+++ b/monitoring/metricsscope/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "monitoring",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/monitoring/latest/metricsscope/apiv1",
-  "client_library_type": "generated",
-  "description": "Cloud Monitoring API",
-  "distribution_name": "cloud.google.com/go/monitoring/metricsscope/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "monitoring",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/monitoring/latest/metricsscope/apiv1",
+    "client_library_type": "generated",
+    "description": "Cloud Monitoring API",
+    "distribution_name": "cloud.google.com/go/monitoring/metricsscope/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/netapp/apiv1/.repo-metadata.json
+++ b/netapp/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "netapp",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/netapp/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "NetApp API",
-  "distribution_name": "cloud.google.com/go/netapp/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "netapp",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/netapp/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "NetApp API",
+    "distribution_name": "cloud.google.com/go/netapp/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/networkconnectivity/apiv1/.repo-metadata.json
+++ b/networkconnectivity/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "networkconnectivity",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/networkconnectivity/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Network Connectivity API",
-  "distribution_name": "cloud.google.com/go/networkconnectivity/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "networkconnectivity",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/networkconnectivity/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Network Connectivity API",
+    "distribution_name": "cloud.google.com/go/networkconnectivity/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/networkconnectivity/apiv1alpha1/.repo-metadata.json
+++ b/networkconnectivity/apiv1alpha1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "networkconnectivity",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/networkconnectivity/latest/apiv1alpha1",
-  "client_library_type": "generated",
-  "description": "Network Connectivity API",
-  "distribution_name": "cloud.google.com/go/networkconnectivity/apiv1alpha1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "networkconnectivity",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/networkconnectivity/latest/apiv1alpha1",
+    "client_library_type": "generated",
+    "description": "Network Connectivity API",
+    "distribution_name": "cloud.google.com/go/networkconnectivity/apiv1alpha1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/networkconnectivity/apiv1beta/.repo-metadata.json
+++ b/networkconnectivity/apiv1beta/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "networkconnectivity",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/networkconnectivity/latest/apiv1beta",
-  "client_library_type": "generated",
-  "description": "Network Connectivity API",
-  "distribution_name": "cloud.google.com/go/networkconnectivity/apiv1beta",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "networkconnectivity",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/networkconnectivity/latest/apiv1beta",
+    "client_library_type": "generated",
+    "description": "Network Connectivity API",
+    "distribution_name": "cloud.google.com/go/networkconnectivity/apiv1beta",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/networkmanagement/apiv1/.repo-metadata.json
+++ b/networkmanagement/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "networkmanagement",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/networkmanagement/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Network Management API",
-  "distribution_name": "cloud.google.com/go/networkmanagement/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "networkmanagement",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/networkmanagement/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Network Management API",
+    "distribution_name": "cloud.google.com/go/networkmanagement/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/networksecurity/apiv1beta1/.repo-metadata.json
+++ b/networksecurity/apiv1beta1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "networksecurity",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/networksecurity/latest/apiv1beta1",
-  "client_library_type": "generated",
-  "description": "Network Security API",
-  "distribution_name": "cloud.google.com/go/networksecurity/apiv1beta1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "networksecurity",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/networksecurity/latest/apiv1beta1",
+    "client_library_type": "generated",
+    "description": "Network Security API",
+    "distribution_name": "cloud.google.com/go/networksecurity/apiv1beta1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/networkservices/apiv1/.repo-metadata.json
+++ b/networkservices/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "networkservices",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/networkservices/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Network Services API",
-  "distribution_name": "cloud.google.com/go/networkservices/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "networkservices",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/networkservices/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Network Services API",
+    "distribution_name": "cloud.google.com/go/networkservices/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/notebooks/apiv1/.repo-metadata.json
+++ b/notebooks/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "notebooks",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/notebooks/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Notebooks API",
-  "distribution_name": "cloud.google.com/go/notebooks/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "notebooks",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/notebooks/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Notebooks API",
+    "distribution_name": "cloud.google.com/go/notebooks/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/notebooks/apiv1beta1/.repo-metadata.json
+++ b/notebooks/apiv1beta1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "notebooks",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/notebooks/latest/apiv1beta1",
-  "client_library_type": "generated",
-  "description": "Notebooks API",
-  "distribution_name": "cloud.google.com/go/notebooks/apiv1beta1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "notebooks",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/notebooks/latest/apiv1beta1",
+    "client_library_type": "generated",
+    "description": "Notebooks API",
+    "distribution_name": "cloud.google.com/go/notebooks/apiv1beta1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/notebooks/apiv2/.repo-metadata.json
+++ b/notebooks/apiv2/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "notebooks",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/notebooks/latest/apiv2",
-  "client_library_type": "generated",
-  "description": "Notebooks API",
-  "distribution_name": "cloud.google.com/go/notebooks/apiv2",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "notebooks",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/notebooks/latest/apiv2",
+    "client_library_type": "generated",
+    "description": "Notebooks API",
+    "distribution_name": "cloud.google.com/go/notebooks/apiv2",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/optimization/apiv1/.repo-metadata.json
+++ b/optimization/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "cloudoptimization",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/optimization/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Cloud Optimization API",
-  "distribution_name": "cloud.google.com/go/optimization/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "cloudoptimization",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/optimization/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Cloud Optimization API",
+    "distribution_name": "cloud.google.com/go/optimization/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/oracledatabase/apiv1/.repo-metadata.json
+++ b/oracledatabase/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "oracledatabase",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/oracledatabase/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Oracle Database@Google Cloud API",
-  "distribution_name": "cloud.google.com/go/oracledatabase/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "oracledatabase",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/oracledatabase/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Oracle Database@Google Cloud API",
+    "distribution_name": "cloud.google.com/go/oracledatabase/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/orchestration/airflow/service/apiv1/.repo-metadata.json
+++ b/orchestration/airflow/service/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "composer",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/orchestration/latest/airflow/service/apiv1",
-  "client_library_type": "generated",
-  "description": "Cloud Composer API",
-  "distribution_name": "cloud.google.com/go/orchestration/airflow/service/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "composer",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/orchestration/latest/airflow/service/apiv1",
+    "client_library_type": "generated",
+    "description": "Cloud Composer API",
+    "distribution_name": "cloud.google.com/go/orchestration/airflow/service/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/orchestration/apiv1/.repo-metadata.json
+++ b/orchestration/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "composer",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/orchestration/latest/airflow/service/apiv1",
-  "client_library_type": "generated",
-  "description": "Cloud Composer API",
-  "distribution_name": "cloud.google.com/go/orchestration/airflow/service/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "composer",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/orchestration/latest/airflow/service/apiv1",
+    "client_library_type": "generated",
+    "description": "Cloud Composer API",
+    "distribution_name": "cloud.google.com/go/orchestration/airflow/service/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/orgpolicy/apiv2/.repo-metadata.json
+++ b/orgpolicy/apiv2/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "orgpolicy",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/orgpolicy/latest/apiv2",
-  "client_library_type": "generated",
-  "description": "Organization Policy API",
-  "distribution_name": "cloud.google.com/go/orgpolicy/apiv2",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "orgpolicy",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/orgpolicy/latest/apiv2",
+    "client_library_type": "generated",
+    "description": "Organization Policy API",
+    "distribution_name": "cloud.google.com/go/orgpolicy/apiv2",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/osconfig/agentendpoint/apiv1/.repo-metadata.json
+++ b/osconfig/agentendpoint/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "osconfig",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/osconfig/latest/agentendpoint/apiv1",
-  "client_library_type": "generated",
-  "description": "OS Config API",
-  "distribution_name": "cloud.google.com/go/osconfig/agentendpoint/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "osconfig",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/osconfig/latest/agentendpoint/apiv1",
+    "client_library_type": "generated",
+    "description": "OS Config API",
+    "distribution_name": "cloud.google.com/go/osconfig/agentendpoint/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/osconfig/agentendpoint/apiv1beta/.repo-metadata.json
+++ b/osconfig/agentendpoint/apiv1beta/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "osconfig",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/osconfig/latest/agentendpoint/apiv1beta",
-  "client_library_type": "generated",
-  "description": "OS Config API",
-  "distribution_name": "cloud.google.com/go/osconfig/agentendpoint/apiv1beta",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "osconfig",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/osconfig/latest/agentendpoint/apiv1beta",
+    "client_library_type": "generated",
+    "description": "OS Config API",
+    "distribution_name": "cloud.google.com/go/osconfig/agentendpoint/apiv1beta",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/osconfig/apiv1/.repo-metadata.json
+++ b/osconfig/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "osconfig",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/osconfig/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "OS Config API",
-  "distribution_name": "cloud.google.com/go/osconfig/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "osconfig",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/osconfig/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "OS Config API",
+    "distribution_name": "cloud.google.com/go/osconfig/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/osconfig/apiv1alpha/.repo-metadata.json
+++ b/osconfig/apiv1alpha/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "osconfig",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/osconfig/latest/apiv1alpha",
-  "client_library_type": "generated",
-  "description": "OS Config API",
-  "distribution_name": "cloud.google.com/go/osconfig/apiv1alpha",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "osconfig",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/osconfig/latest/apiv1alpha",
+    "client_library_type": "generated",
+    "description": "OS Config API",
+    "distribution_name": "cloud.google.com/go/osconfig/apiv1alpha",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/osconfig/apiv1beta/.repo-metadata.json
+++ b/osconfig/apiv1beta/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "osconfig",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/osconfig/latest/apiv1beta",
-  "client_library_type": "generated",
-  "description": "OS Config API",
-  "distribution_name": "cloud.google.com/go/osconfig/apiv1beta",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "osconfig",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/osconfig/latest/apiv1beta",
+    "client_library_type": "generated",
+    "description": "OS Config API",
+    "distribution_name": "cloud.google.com/go/osconfig/apiv1beta",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/oslogin/apiv1/.repo-metadata.json
+++ b/oslogin/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "oslogin",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/oslogin/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Cloud OS Login API",
-  "distribution_name": "cloud.google.com/go/oslogin/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "oslogin",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/oslogin/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Cloud OS Login API",
+    "distribution_name": "cloud.google.com/go/oslogin/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/oslogin/apiv1beta/.repo-metadata.json
+++ b/oslogin/apiv1beta/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "oslogin",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/oslogin/latest/apiv1beta",
-  "client_library_type": "generated",
-  "description": "Cloud OS Login API",
-  "distribution_name": "cloud.google.com/go/oslogin/apiv1beta",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "oslogin",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/oslogin/latest/apiv1beta",
+    "client_library_type": "generated",
+    "description": "Cloud OS Login API",
+    "distribution_name": "cloud.google.com/go/oslogin/apiv1beta",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/parallelstore/apiv1/.repo-metadata.json
+++ b/parallelstore/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "parallelstore",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/parallelstore/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Parallelstore API",
-  "distribution_name": "cloud.google.com/go/parallelstore/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "parallelstore",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/parallelstore/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Parallelstore API",
+    "distribution_name": "cloud.google.com/go/parallelstore/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/parallelstore/apiv1beta/.repo-metadata.json
+++ b/parallelstore/apiv1beta/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "parallelstore",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/parallelstore/latest/apiv1beta",
-  "client_library_type": "generated",
-  "description": "Parallelstore API",
-  "distribution_name": "cloud.google.com/go/parallelstore/apiv1beta",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "parallelstore",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/parallelstore/latest/apiv1beta",
+    "client_library_type": "generated",
+    "description": "Parallelstore API",
+    "distribution_name": "cloud.google.com/go/parallelstore/apiv1beta",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/parametermanager/apiv1/.repo-metadata.json
+++ b/parametermanager/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "parametermanager",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/parametermanager/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Parameter Manager API",
-  "distribution_name": "cloud.google.com/go/parametermanager/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "parametermanager",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/parametermanager/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Parameter Manager API",
+    "distribution_name": "cloud.google.com/go/parametermanager/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/phishingprotection/apiv1beta1/.repo-metadata.json
+++ b/phishingprotection/apiv1beta1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "phishingprotection",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/phishingprotection/latest/apiv1beta1",
-  "client_library_type": "generated",
-  "description": "Phishing Protection API",
-  "distribution_name": "cloud.google.com/go/phishingprotection/apiv1beta1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "phishingprotection",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/phishingprotection/latest/apiv1beta1",
+    "client_library_type": "generated",
+    "description": "Phishing Protection API",
+    "distribution_name": "cloud.google.com/go/phishingprotection/apiv1beta1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/policysimulator/apiv1/.repo-metadata.json
+++ b/policysimulator/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "policysimulator",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/policysimulator/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Policy Simulator API",
-  "distribution_name": "cloud.google.com/go/policysimulator/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "policysimulator",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/policysimulator/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Policy Simulator API",
+    "distribution_name": "cloud.google.com/go/policysimulator/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/policytroubleshooter/apiv1/.repo-metadata.json
+++ b/policytroubleshooter/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "policytroubleshooter",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/policytroubleshooter/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Policy Troubleshooter API",
-  "distribution_name": "cloud.google.com/go/policytroubleshooter/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "policytroubleshooter",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/policytroubleshooter/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Policy Troubleshooter API",
+    "distribution_name": "cloud.google.com/go/policytroubleshooter/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/policytroubleshooter/apiv3/.repo-metadata.json
+++ b/policytroubleshooter/apiv3/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "policytroubleshooter",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/policytroubleshooter/latest/iam/apiv3",
-  "client_library_type": "generated",
-  "description": "Policy Troubleshooter API",
-  "distribution_name": "cloud.google.com/go/policytroubleshooter/iam/apiv3",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "policytroubleshooter",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/policytroubleshooter/latest/iam/apiv3",
+    "client_library_type": "generated",
+    "description": "Policy Troubleshooter API",
+    "distribution_name": "cloud.google.com/go/policytroubleshooter/iam/apiv3",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/policytroubleshooter/iam/apiv3/.repo-metadata.json
+++ b/policytroubleshooter/iam/apiv3/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "policytroubleshooter",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/policytroubleshooter/latest/iam/apiv3",
-  "client_library_type": "generated",
-  "description": "Policy Troubleshooter API",
-  "distribution_name": "cloud.google.com/go/policytroubleshooter/iam/apiv3",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "policytroubleshooter",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/policytroubleshooter/latest/iam/apiv3",
+    "client_library_type": "generated",
+    "description": "Policy Troubleshooter API",
+    "distribution_name": "cloud.google.com/go/policytroubleshooter/iam/apiv3",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/privatecatalog/apiv1beta1/.repo-metadata.json
+++ b/privatecatalog/apiv1beta1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "cloudprivatecatalog",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/privatecatalog/latest/apiv1beta1",
-  "client_library_type": "generated",
-  "description": "Cloud Private Catalog API",
-  "distribution_name": "cloud.google.com/go/privatecatalog/apiv1beta1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "cloudprivatecatalog",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/privatecatalog/latest/apiv1beta1",
+    "client_library_type": "generated",
+    "description": "Cloud Private Catalog API",
+    "distribution_name": "cloud.google.com/go/privatecatalog/apiv1beta1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/privilegedaccessmanager/apiv1/.repo-metadata.json
+++ b/privilegedaccessmanager/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "privilegedaccessmanager",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/privilegedaccessmanager/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Privileged Access Manager API",
-  "distribution_name": "cloud.google.com/go/privilegedaccessmanager/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "privilegedaccessmanager",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/privilegedaccessmanager/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Privileged Access Manager API",
+    "distribution_name": "cloud.google.com/go/privilegedaccessmanager/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/profiler/.repo-metadata.json
+++ b/profiler/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "cloudprofiler",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/profiler/latest",
-  "client_library_type": "manual",
-  "description": "Cloud Profiler",
-  "distribution_name": "cloud.google.com/go/profiler",
-  "language": "go",
-  "library_type": "AGENT",
-  "release_level": "stable"
+    "api_shortname": "cloudprofiler",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/profiler/latest",
+    "client_library_type": "manual",
+    "description": "Cloud Profiler",
+    "distribution_name": "cloud.google.com/go/profiler",
+    "language": "go",
+    "library_type": "AGENT",
+    "release_level": "stable"
 }

--- a/pubsub/.repo-metadata.json
+++ b/pubsub/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "pubsub",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/pubsub/latest",
-  "client_library_type": "manual",
-  "description": "Cloud PubSub",
-  "distribution_name": "cloud.google.com/go/pubsub",
-  "language": "go",
-  "library_type": "GAPIC_MANUAL",
-  "release_level": "stable"
+    "api_shortname": "pubsub",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/pubsub/latest",
+    "client_library_type": "manual",
+    "description": "Cloud PubSub",
+    "distribution_name": "cloud.google.com/go/pubsub",
+    "language": "go",
+    "library_type": "GAPIC_MANUAL",
+    "release_level": "stable"
 }

--- a/pubsub/v2/.repo-metadata.json
+++ b/pubsub/v2/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "pubsub",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/pubsub/v2/latest",
-  "client_library_type": "manual",
-  "description": "Pub/Sub API",
-  "distribution_name": "cloud.google.com/go/pubsub/v2",
-  "language": "go",
-  "library_type": "GAPIC_MANUAL",
-  "release_level": "stable"
+    "api_shortname": "pubsub",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/pubsub/v2/latest",
+    "client_library_type": "manual",
+    "description": "Pub/Sub API",
+    "distribution_name": "cloud.google.com/go/pubsub/v2",
+    "language": "go",
+    "library_type": "GAPIC_MANUAL",
+    "release_level": "stable"
 }

--- a/pubsub/v2/apiv1/.repo-metadata.json
+++ b/pubsub/v2/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "pubsub",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/pubsub/v2/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Cloud Pub/Sub API",
-  "distribution_name": "cloud.google.com/go/pubsub/v2/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "pubsub",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/pubsub/v2/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Cloud Pub/Sub API",
+    "distribution_name": "cloud.google.com/go/pubsub/v2/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/pubsublite/.repo-metadata.json
+++ b/pubsublite/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "pubsublite",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/pubsublite/latest",
-  "client_library_type": "manual",
-  "description": "Cloud PubSub Lite",
-  "distribution_name": "cloud.google.com/go/pubsublite",
-  "language": "go",
-  "library_type": "GAPIC_MANUAL",
-  "release_level": "stable"
+    "api_shortname": "pubsublite",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/pubsublite/latest",
+    "client_library_type": "manual",
+    "description": "Cloud PubSub Lite",
+    "distribution_name": "cloud.google.com/go/pubsublite",
+    "language": "go",
+    "library_type": "GAPIC_MANUAL",
+    "release_level": "stable"
 }

--- a/pubsublite/apiv1/.repo-metadata.json
+++ b/pubsublite/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "pubsublite",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/pubsublite/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Pub/Sub Lite API",
-  "distribution_name": "cloud.google.com/go/pubsublite/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "pubsublite",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/pubsublite/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Pub/Sub Lite API",
+    "distribution_name": "cloud.google.com/go/pubsublite/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/rapidmigrationassessment/apiv1/.repo-metadata.json
+++ b/rapidmigrationassessment/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "rapidmigrationassessment",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/rapidmigrationassessment/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Rapid Migration Assessment API",
-  "distribution_name": "cloud.google.com/go/rapidmigrationassessment/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "rapidmigrationassessment",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/rapidmigrationassessment/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Rapid Migration Assessment API",
+    "distribution_name": "cloud.google.com/go/rapidmigrationassessment/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/recaptchaenterprise/apiv1/.repo-metadata.json
+++ b/recaptchaenterprise/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "recaptchaenterprise",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/recaptchaenterprise/v2/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "reCAPTCHA Enterprise API",
-  "distribution_name": "cloud.google.com/go/recaptchaenterprise/v2/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "recaptchaenterprise",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/recaptchaenterprise/v2/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "reCAPTCHA Enterprise API",
+    "distribution_name": "cloud.google.com/go/recaptchaenterprise/v2/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/recaptchaenterprise/apiv1beta1/.repo-metadata.json
+++ b/recaptchaenterprise/apiv1beta1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "recaptchaenterprise",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/recaptchaenterprise/v2/latest/apiv1beta1",
-  "client_library_type": "generated",
-  "description": "reCAPTCHA Enterprise API",
-  "distribution_name": "cloud.google.com/go/recaptchaenterprise/v2/apiv1beta1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "recaptchaenterprise",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/recaptchaenterprise/v2/latest/apiv1beta1",
+    "client_library_type": "generated",
+    "description": "reCAPTCHA Enterprise API",
+    "distribution_name": "cloud.google.com/go/recaptchaenterprise/v2/apiv1beta1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/recommendationengine/apiv1beta1/.repo-metadata.json
+++ b/recommendationengine/apiv1beta1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "recommendationengine",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/recommendationengine/latest/apiv1beta1",
-  "client_library_type": "generated",
-  "description": "Recommendations AI",
-  "distribution_name": "cloud.google.com/go/recommendationengine/apiv1beta1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "recommendationengine",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/recommendationengine/latest/apiv1beta1",
+    "client_library_type": "generated",
+    "description": "Recommendations AI",
+    "distribution_name": "cloud.google.com/go/recommendationengine/apiv1beta1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/recommender/apiv1/.repo-metadata.json
+++ b/recommender/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "recommender",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/recommender/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Recommender API",
-  "distribution_name": "cloud.google.com/go/recommender/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "recommender",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/recommender/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Recommender API",
+    "distribution_name": "cloud.google.com/go/recommender/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/recommender/apiv1beta1/.repo-metadata.json
+++ b/recommender/apiv1beta1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "recommender",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/recommender/latest/apiv1beta1",
-  "client_library_type": "generated",
-  "description": "Recommender API",
-  "distribution_name": "cloud.google.com/go/recommender/apiv1beta1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "recommender",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/recommender/latest/apiv1beta1",
+    "client_library_type": "generated",
+    "description": "Recommender API",
+    "distribution_name": "cloud.google.com/go/recommender/apiv1beta1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/redis/apiv1/.repo-metadata.json
+++ b/redis/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "redis",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/redis/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Google Cloud Memorystore for Redis API",
-  "distribution_name": "cloud.google.com/go/redis/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "redis",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/redis/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Google Cloud Memorystore for Redis API",
+    "distribution_name": "cloud.google.com/go/redis/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/redis/apiv1beta1/.repo-metadata.json
+++ b/redis/apiv1beta1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "redis",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/redis/latest/apiv1beta1",
-  "client_library_type": "generated",
-  "description": "Google Cloud Memorystore for Redis API",
-  "distribution_name": "cloud.google.com/go/redis/apiv1beta1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "redis",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/redis/latest/apiv1beta1",
+    "client_library_type": "generated",
+    "description": "Google Cloud Memorystore for Redis API",
+    "distribution_name": "cloud.google.com/go/redis/apiv1beta1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/redis/cluster/apiv1/.repo-metadata.json
+++ b/redis/cluster/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "redis",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/redis/latest/cluster/apiv1",
-  "client_library_type": "generated",
-  "description": "Google Cloud Memorystore for Redis API",
-  "distribution_name": "cloud.google.com/go/redis/cluster/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "redis",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/redis/latest/cluster/apiv1",
+    "client_library_type": "generated",
+    "description": "Google Cloud Memorystore for Redis API",
+    "distribution_name": "cloud.google.com/go/redis/cluster/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/resourcemanager/apiv2/.repo-metadata.json
+++ b/resourcemanager/apiv2/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "cloudresourcemanager",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/resourcemanager/latest/apiv2",
-  "client_library_type": "generated",
-  "description": "Cloud Resource Manager API",
-  "distribution_name": "cloud.google.com/go/resourcemanager/apiv2",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "cloudresourcemanager",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/resourcemanager/latest/apiv2",
+    "client_library_type": "generated",
+    "description": "Cloud Resource Manager API",
+    "distribution_name": "cloud.google.com/go/resourcemanager/apiv2",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/resourcemanager/apiv3/.repo-metadata.json
+++ b/resourcemanager/apiv3/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "cloudresourcemanager",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/resourcemanager/latest/apiv3",
-  "client_library_type": "generated",
-  "description": "Cloud Resource Manager API",
-  "distribution_name": "cloud.google.com/go/resourcemanager/apiv3",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "cloudresourcemanager",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/resourcemanager/latest/apiv3",
+    "client_library_type": "generated",
+    "description": "Cloud Resource Manager API",
+    "distribution_name": "cloud.google.com/go/resourcemanager/apiv3",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/retail/apiv2/.repo-metadata.json
+++ b/retail/apiv2/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "retail",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/retail/latest/apiv2",
-  "client_library_type": "generated",
-  "description": "Vertex AI Search for commerce API",
-  "distribution_name": "cloud.google.com/go/retail/apiv2",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "retail",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/retail/latest/apiv2",
+    "client_library_type": "generated",
+    "description": "Vertex AI Search for commerce API",
+    "distribution_name": "cloud.google.com/go/retail/apiv2",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/retail/apiv2alpha/.repo-metadata.json
+++ b/retail/apiv2alpha/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "retail",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/retail/latest/apiv2alpha",
-  "client_library_type": "generated",
-  "description": "Vertex AI Search for commerce API",
-  "distribution_name": "cloud.google.com/go/retail/apiv2alpha",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "retail",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/retail/latest/apiv2alpha",
+    "client_library_type": "generated",
+    "description": "Vertex AI Search for commerce API",
+    "distribution_name": "cloud.google.com/go/retail/apiv2alpha",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/retail/apiv2beta/.repo-metadata.json
+++ b/retail/apiv2beta/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "retail",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/retail/latest/apiv2beta",
-  "client_library_type": "generated",
-  "description": "Vertex AI Search for commerce API",
-  "distribution_name": "cloud.google.com/go/retail/apiv2beta",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "retail",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/retail/latest/apiv2beta",
+    "client_library_type": "generated",
+    "description": "Vertex AI Search for commerce API",
+    "distribution_name": "cloud.google.com/go/retail/apiv2beta",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/rpcreplay/.repo-metadata.json
+++ b/rpcreplay/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "rpcreplay",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/latest/rpcreplay",
-  "client_library_type": "manual",
-  "description": "RPC Replay",
-  "distribution_name": "cloud.google.com/go/rpcreplay",
-  "language": "go",
-  "library_type": "OTHER",
-  "release_level": "stable"
+    "api_shortname": "rpcreplay",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/latest/rpcreplay",
+    "client_library_type": "manual",
+    "description": "RPC Replay",
+    "distribution_name": "cloud.google.com/go/rpcreplay",
+    "language": "go",
+    "library_type": "OTHER",
+    "release_level": "stable"
 }

--- a/run/apiv2/.repo-metadata.json
+++ b/run/apiv2/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "run",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/run/latest/apiv2",
-  "client_library_type": "generated",
-  "description": "Cloud Run Admin API",
-  "distribution_name": "cloud.google.com/go/run/apiv2",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "run",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/run/latest/apiv2",
+    "client_library_type": "generated",
+    "description": "Cloud Run Admin API",
+    "distribution_name": "cloud.google.com/go/run/apiv2",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/saasplatform/saasservicemgmt/apiv1beta1/.repo-metadata.json
+++ b/saasplatform/saasservicemgmt/apiv1beta1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "saasservicemgmt",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/saasplatform/latest/saasservicemgmt/apiv1beta1",
-  "client_library_type": "generated",
-  "description": "SaaS Runtime API",
-  "distribution_name": "cloud.google.com/go/saasplatform/saasservicemgmt/apiv1beta1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "saasservicemgmt",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/saasplatform/latest/saasservicemgmt/apiv1beta1",
+    "client_library_type": "generated",
+    "description": "SaaS Runtime API",
+    "distribution_name": "cloud.google.com/go/saasplatform/saasservicemgmt/apiv1beta1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/scheduler/apiv1/.repo-metadata.json
+++ b/scheduler/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "cloudscheduler",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/scheduler/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Cloud Scheduler API",
-  "distribution_name": "cloud.google.com/go/scheduler/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "cloudscheduler",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/scheduler/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Cloud Scheduler API",
+    "distribution_name": "cloud.google.com/go/scheduler/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/scheduler/apiv1beta1/.repo-metadata.json
+++ b/scheduler/apiv1beta1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "cloudscheduler",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/scheduler/latest/apiv1beta1",
-  "client_library_type": "generated",
-  "description": "Cloud Scheduler API",
-  "distribution_name": "cloud.google.com/go/scheduler/apiv1beta1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "cloudscheduler",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/scheduler/latest/apiv1beta1",
+    "client_library_type": "generated",
+    "description": "Cloud Scheduler API",
+    "distribution_name": "cloud.google.com/go/scheduler/apiv1beta1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/secretmanager/apiv1/.repo-metadata.json
+++ b/secretmanager/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "secretmanager",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/secretmanager/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Secret Manager API",
-  "distribution_name": "cloud.google.com/go/secretmanager/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "secretmanager",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/secretmanager/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Secret Manager API",
+    "distribution_name": "cloud.google.com/go/secretmanager/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/secretmanager/apiv1beta2/.repo-metadata.json
+++ b/secretmanager/apiv1beta2/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "secretmanager",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/secretmanager/latest/apiv1beta2",
-  "client_library_type": "generated",
-  "description": "Secret Manager API",
-  "distribution_name": "cloud.google.com/go/secretmanager/apiv1beta2",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "secretmanager",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/secretmanager/latest/apiv1beta2",
+    "client_library_type": "generated",
+    "description": "Secret Manager API",
+    "distribution_name": "cloud.google.com/go/secretmanager/apiv1beta2",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/securesourcemanager/apiv1/.repo-metadata.json
+++ b/securesourcemanager/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "securesourcemanager",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/securesourcemanager/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Secure Source Manager API",
-  "distribution_name": "cloud.google.com/go/securesourcemanager/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "securesourcemanager",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/securesourcemanager/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Secure Source Manager API",
+    "distribution_name": "cloud.google.com/go/securesourcemanager/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/security/apiv1/.repo-metadata.json
+++ b/security/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "publicca",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/security/latest/publicca/apiv1",
-  "client_library_type": "generated",
-  "description": "Public Certificate Authority API",
-  "distribution_name": "cloud.google.com/go/security/publicca/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "publicca",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/security/latest/publicca/apiv1",
+    "client_library_type": "generated",
+    "description": "Public Certificate Authority API",
+    "distribution_name": "cloud.google.com/go/security/publicca/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/security/apiv1beta1/.repo-metadata.json
+++ b/security/apiv1beta1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "publicca",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/security/latest/publicca/apiv1beta1",
-  "client_library_type": "generated",
-  "description": "Public Certificate Authority API",
-  "distribution_name": "cloud.google.com/go/security/publicca/apiv1beta1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "publicca",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/security/latest/publicca/apiv1beta1",
+    "client_library_type": "generated",
+    "description": "Public Certificate Authority API",
+    "distribution_name": "cloud.google.com/go/security/publicca/apiv1beta1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/security/privateca/apiv1/.repo-metadata.json
+++ b/security/privateca/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "privateca",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/security/latest/privateca/apiv1",
-  "client_library_type": "generated",
-  "description": "Certificate Authority API",
-  "distribution_name": "cloud.google.com/go/security/privateca/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "privateca",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/security/latest/privateca/apiv1",
+    "client_library_type": "generated",
+    "description": "Certificate Authority API",
+    "distribution_name": "cloud.google.com/go/security/privateca/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/security/publicca/apiv1/.repo-metadata.json
+++ b/security/publicca/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "publicca",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/security/latest/publicca/apiv1",
-  "client_library_type": "generated",
-  "description": "Public Certificate Authority API",
-  "distribution_name": "cloud.google.com/go/security/publicca/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "publicca",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/security/latest/publicca/apiv1",
+    "client_library_type": "generated",
+    "description": "Public Certificate Authority API",
+    "distribution_name": "cloud.google.com/go/security/publicca/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/security/publicca/apiv1beta1/.repo-metadata.json
+++ b/security/publicca/apiv1beta1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "publicca",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/security/latest/publicca/apiv1beta1",
-  "client_library_type": "generated",
-  "description": "Public Certificate Authority API",
-  "distribution_name": "cloud.google.com/go/security/publicca/apiv1beta1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "publicca",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/security/latest/publicca/apiv1beta1",
+    "client_library_type": "generated",
+    "description": "Public Certificate Authority API",
+    "distribution_name": "cloud.google.com/go/security/publicca/apiv1beta1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/securitycenter/apiv1/.repo-metadata.json
+++ b/securitycenter/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "securitycenter",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/securitycenter/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Security Command Center API",
-  "distribution_name": "cloud.google.com/go/securitycenter/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "securitycenter",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/securitycenter/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Security Command Center API",
+    "distribution_name": "cloud.google.com/go/securitycenter/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/securitycenter/apiv1beta1/.repo-metadata.json
+++ b/securitycenter/apiv1beta1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "securitycenter",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/securitycenter/latest/apiv1beta1",
-  "client_library_type": "generated",
-  "description": "Security Command Center API",
-  "distribution_name": "cloud.google.com/go/securitycenter/apiv1beta1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "securitycenter",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/securitycenter/latest/apiv1beta1",
+    "client_library_type": "generated",
+    "description": "Security Command Center API",
+    "distribution_name": "cloud.google.com/go/securitycenter/apiv1beta1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/securitycenter/apiv1p1beta1/.repo-metadata.json
+++ b/securitycenter/apiv1p1beta1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "securitycenter",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/securitycenter/latest/apiv1p1beta1",
-  "client_library_type": "generated",
-  "description": "Security Command Center API",
-  "distribution_name": "cloud.google.com/go/securitycenter/apiv1p1beta1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "securitycenter",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/securitycenter/latest/apiv1p1beta1",
+    "client_library_type": "generated",
+    "description": "Security Command Center API",
+    "distribution_name": "cloud.google.com/go/securitycenter/apiv1p1beta1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/securitycenter/apiv2/.repo-metadata.json
+++ b/securitycenter/apiv2/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "securitycenter",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/securitycenter/latest/apiv2",
-  "client_library_type": "generated",
-  "description": "Security Command Center API",
-  "distribution_name": "cloud.google.com/go/securitycenter/apiv2",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "securitycenter",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/securitycenter/latest/apiv2",
+    "client_library_type": "generated",
+    "description": "Security Command Center API",
+    "distribution_name": "cloud.google.com/go/securitycenter/apiv2",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/securitycenter/settings/apiv1beta1/.repo-metadata.json
+++ b/securitycenter/settings/apiv1beta1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "securitycenter",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/securitycenter/latest/settings/apiv1beta1",
-  "client_library_type": "generated",
-  "description": "Cloud Security Command Center API",
-  "distribution_name": "cloud.google.com/go/securitycenter/settings/apiv1beta1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "securitycenter",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/securitycenter/latest/settings/apiv1beta1",
+    "client_library_type": "generated",
+    "description": "Cloud Security Command Center API",
+    "distribution_name": "cloud.google.com/go/securitycenter/settings/apiv1beta1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/securitycentermanagement/apiv1/.repo-metadata.json
+++ b/securitycentermanagement/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "securitycentermanagement",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/securitycentermanagement/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Security Command Center Management API",
-  "distribution_name": "cloud.google.com/go/securitycentermanagement/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "securitycentermanagement",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/securitycentermanagement/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Security Command Center Management API",
+    "distribution_name": "cloud.google.com/go/securitycentermanagement/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/securityposture/apiv1/.repo-metadata.json
+++ b/securityposture/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "securityposture",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/securityposture/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Security Posture API",
-  "distribution_name": "cloud.google.com/go/securityposture/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "securityposture",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/securityposture/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Security Posture API",
+    "distribution_name": "cloud.google.com/go/securityposture/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/servicecontrol/apiv1/.repo-metadata.json
+++ b/servicecontrol/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "servicecontrol",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/servicecontrol/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Service Control API",
-  "distribution_name": "cloud.google.com/go/servicecontrol/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "servicecontrol",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/servicecontrol/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Service Control API",
+    "distribution_name": "cloud.google.com/go/servicecontrol/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/servicedirectory/apiv1/.repo-metadata.json
+++ b/servicedirectory/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "servicedirectory",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/servicedirectory/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Service Directory API",
-  "distribution_name": "cloud.google.com/go/servicedirectory/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "servicedirectory",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/servicedirectory/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Service Directory API",
+    "distribution_name": "cloud.google.com/go/servicedirectory/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/servicedirectory/apiv1beta1/.repo-metadata.json
+++ b/servicedirectory/apiv1beta1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "servicedirectory",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/servicedirectory/latest/apiv1beta1",
-  "client_library_type": "generated",
-  "description": "Service Directory API",
-  "distribution_name": "cloud.google.com/go/servicedirectory/apiv1beta1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "servicedirectory",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/servicedirectory/latest/apiv1beta1",
+    "client_library_type": "generated",
+    "description": "Service Directory API",
+    "distribution_name": "cloud.google.com/go/servicedirectory/apiv1beta1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/servicehealth/apiv1/.repo-metadata.json
+++ b/servicehealth/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "servicehealth",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/servicehealth/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Service Health API",
-  "distribution_name": "cloud.google.com/go/servicehealth/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "servicehealth",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/servicehealth/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Service Health API",
+    "distribution_name": "cloud.google.com/go/servicehealth/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/servicemanagement/apiv1/.repo-metadata.json
+++ b/servicemanagement/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "servicemanagement",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/servicemanagement/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Service Management API",
-  "distribution_name": "cloud.google.com/go/servicemanagement/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "servicemanagement",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/servicemanagement/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Service Management API",
+    "distribution_name": "cloud.google.com/go/servicemanagement/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/serviceusage/apiv1/.repo-metadata.json
+++ b/serviceusage/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "serviceusage",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/serviceusage/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Service Usage API",
-  "distribution_name": "cloud.google.com/go/serviceusage/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "serviceusage",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/serviceusage/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Service Usage API",
+    "distribution_name": "cloud.google.com/go/serviceusage/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/shell/apiv1/.repo-metadata.json
+++ b/shell/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "cloudshell",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/shell/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Cloud Shell API",
-  "distribution_name": "cloud.google.com/go/shell/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "cloudshell",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/shell/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Cloud Shell API",
+    "distribution_name": "cloud.google.com/go/shell/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/shopping/css/apiv1/.repo-metadata.json
+++ b/shopping/css/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "css",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/shopping/latest/css/apiv1",
-  "client_library_type": "generated",
-  "description": "CSS API",
-  "distribution_name": "cloud.google.com/go/shopping/css/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "css",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/shopping/latest/css/apiv1",
+    "client_library_type": "generated",
+    "description": "CSS API",
+    "distribution_name": "cloud.google.com/go/shopping/css/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/shopping/merchant/accounts/apiv1/.repo-metadata.json
+++ b/shopping/merchant/accounts/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "merchantapi",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/shopping/latest/merchant/accounts/apiv1",
-  "client_library_type": "generated",
-  "description": "Merchant API",
-  "distribution_name": "cloud.google.com/go/shopping/merchant/accounts/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "merchantapi",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/shopping/latest/merchant/accounts/apiv1",
+    "client_library_type": "generated",
+    "description": "Merchant API",
+    "distribution_name": "cloud.google.com/go/shopping/merchant/accounts/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/shopping/merchant/accounts/apiv1beta/.repo-metadata.json
+++ b/shopping/merchant/accounts/apiv1beta/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "merchantapi",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/shopping/latest/merchant/accounts/apiv1beta",
-  "client_library_type": "generated",
-  "description": "Merchant API",
-  "distribution_name": "cloud.google.com/go/shopping/merchant/accounts/apiv1beta",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "merchantapi",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/shopping/latest/merchant/accounts/apiv1beta",
+    "client_library_type": "generated",
+    "description": "Merchant API",
+    "distribution_name": "cloud.google.com/go/shopping/merchant/accounts/apiv1beta",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/shopping/merchant/conversions/apiv1/.repo-metadata.json
+++ b/shopping/merchant/conversions/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "merchantapi",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/shopping/latest/merchant/conversions/apiv1",
-  "client_library_type": "generated",
-  "description": "Merchant API",
-  "distribution_name": "cloud.google.com/go/shopping/merchant/conversions/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "merchantapi",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/shopping/latest/merchant/conversions/apiv1",
+    "client_library_type": "generated",
+    "description": "Merchant API",
+    "distribution_name": "cloud.google.com/go/shopping/merchant/conversions/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/shopping/merchant/conversions/apiv1beta/.repo-metadata.json
+++ b/shopping/merchant/conversions/apiv1beta/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "merchantapi",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/shopping/latest/merchant/conversions/apiv1beta",
-  "client_library_type": "generated",
-  "description": "Merchant API",
-  "distribution_name": "cloud.google.com/go/shopping/merchant/conversions/apiv1beta",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "merchantapi",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/shopping/latest/merchant/conversions/apiv1beta",
+    "client_library_type": "generated",
+    "description": "Merchant API",
+    "distribution_name": "cloud.google.com/go/shopping/merchant/conversions/apiv1beta",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/shopping/merchant/datasources/apiv1/.repo-metadata.json
+++ b/shopping/merchant/datasources/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "merchantapi",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/shopping/latest/merchant/datasources/apiv1",
-  "client_library_type": "generated",
-  "description": "Merchant API",
-  "distribution_name": "cloud.google.com/go/shopping/merchant/datasources/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "merchantapi",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/shopping/latest/merchant/datasources/apiv1",
+    "client_library_type": "generated",
+    "description": "Merchant API",
+    "distribution_name": "cloud.google.com/go/shopping/merchant/datasources/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/shopping/merchant/datasources/apiv1beta/.repo-metadata.json
+++ b/shopping/merchant/datasources/apiv1beta/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "merchantapi",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/shopping/latest/merchant/datasources/apiv1beta",
-  "client_library_type": "generated",
-  "description": "Merchant API",
-  "distribution_name": "cloud.google.com/go/shopping/merchant/datasources/apiv1beta",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "merchantapi",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/shopping/latest/merchant/datasources/apiv1beta",
+    "client_library_type": "generated",
+    "description": "Merchant API",
+    "distribution_name": "cloud.google.com/go/shopping/merchant/datasources/apiv1beta",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/shopping/merchant/inventories/apiv1/.repo-metadata.json
+++ b/shopping/merchant/inventories/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "merchantapi",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/shopping/latest/merchant/inventories/apiv1",
-  "client_library_type": "generated",
-  "description": "Merchant API",
-  "distribution_name": "cloud.google.com/go/shopping/merchant/inventories/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "merchantapi",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/shopping/latest/merchant/inventories/apiv1",
+    "client_library_type": "generated",
+    "description": "Merchant API",
+    "distribution_name": "cloud.google.com/go/shopping/merchant/inventories/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/shopping/merchant/inventories/apiv1beta/.repo-metadata.json
+++ b/shopping/merchant/inventories/apiv1beta/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "merchantapi",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/shopping/latest/merchant/inventories/apiv1beta",
-  "client_library_type": "generated",
-  "description": "Merchant API",
-  "distribution_name": "cloud.google.com/go/shopping/merchant/inventories/apiv1beta",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "merchantapi",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/shopping/latest/merchant/inventories/apiv1beta",
+    "client_library_type": "generated",
+    "description": "Merchant API",
+    "distribution_name": "cloud.google.com/go/shopping/merchant/inventories/apiv1beta",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/shopping/merchant/issueresolution/apiv1/.repo-metadata.json
+++ b/shopping/merchant/issueresolution/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "merchantapi",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/shopping/latest/merchant/issueresolution/apiv1",
-  "client_library_type": "generated",
-  "description": "Merchant API",
-  "distribution_name": "cloud.google.com/go/shopping/merchant/issueresolution/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "merchantapi",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/shopping/latest/merchant/issueresolution/apiv1",
+    "client_library_type": "generated",
+    "description": "Merchant API",
+    "distribution_name": "cloud.google.com/go/shopping/merchant/issueresolution/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/shopping/merchant/issueresolution/apiv1beta/.repo-metadata.json
+++ b/shopping/merchant/issueresolution/apiv1beta/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "merchantapi",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/shopping/latest/merchant/issueresolution/apiv1beta",
-  "client_library_type": "generated",
-  "description": "Merchant API",
-  "distribution_name": "cloud.google.com/go/shopping/merchant/issueresolution/apiv1beta",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "merchantapi",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/shopping/latest/merchant/issueresolution/apiv1beta",
+    "client_library_type": "generated",
+    "description": "Merchant API",
+    "distribution_name": "cloud.google.com/go/shopping/merchant/issueresolution/apiv1beta",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/shopping/merchant/lfp/apiv1/.repo-metadata.json
+++ b/shopping/merchant/lfp/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "merchantapi",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/shopping/latest/merchant/lfp/apiv1",
-  "client_library_type": "generated",
-  "description": "Merchant API",
-  "distribution_name": "cloud.google.com/go/shopping/merchant/lfp/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "merchantapi",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/shopping/latest/merchant/lfp/apiv1",
+    "client_library_type": "generated",
+    "description": "Merchant API",
+    "distribution_name": "cloud.google.com/go/shopping/merchant/lfp/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/shopping/merchant/lfp/apiv1beta/.repo-metadata.json
+++ b/shopping/merchant/lfp/apiv1beta/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "merchantapi",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/shopping/latest/merchant/lfp/apiv1beta",
-  "client_library_type": "generated",
-  "description": "Merchant API",
-  "distribution_name": "cloud.google.com/go/shopping/merchant/lfp/apiv1beta",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "merchantapi",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/shopping/latest/merchant/lfp/apiv1beta",
+    "client_library_type": "generated",
+    "description": "Merchant API",
+    "distribution_name": "cloud.google.com/go/shopping/merchant/lfp/apiv1beta",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/shopping/merchant/notifications/apiv1/.repo-metadata.json
+++ b/shopping/merchant/notifications/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "merchantapi",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/shopping/latest/merchant/notifications/apiv1",
-  "client_library_type": "generated",
-  "description": "Merchant API",
-  "distribution_name": "cloud.google.com/go/shopping/merchant/notifications/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "merchantapi",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/shopping/latest/merchant/notifications/apiv1",
+    "client_library_type": "generated",
+    "description": "Merchant API",
+    "distribution_name": "cloud.google.com/go/shopping/merchant/notifications/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/shopping/merchant/notifications/apiv1beta/.repo-metadata.json
+++ b/shopping/merchant/notifications/apiv1beta/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "merchantapi",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/shopping/latest/merchant/notifications/apiv1beta",
-  "client_library_type": "generated",
-  "description": "Merchant API",
-  "distribution_name": "cloud.google.com/go/shopping/merchant/notifications/apiv1beta",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "merchantapi",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/shopping/latest/merchant/notifications/apiv1beta",
+    "client_library_type": "generated",
+    "description": "Merchant API",
+    "distribution_name": "cloud.google.com/go/shopping/merchant/notifications/apiv1beta",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/shopping/merchant/ordertracking/apiv1/.repo-metadata.json
+++ b/shopping/merchant/ordertracking/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "merchantapi",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/shopping/latest/merchant/ordertracking/apiv1",
-  "client_library_type": "generated",
-  "description": "Merchant API",
-  "distribution_name": "cloud.google.com/go/shopping/merchant/ordertracking/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "merchantapi",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/shopping/latest/merchant/ordertracking/apiv1",
+    "client_library_type": "generated",
+    "description": "Merchant API",
+    "distribution_name": "cloud.google.com/go/shopping/merchant/ordertracking/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/shopping/merchant/ordertracking/apiv1beta/.repo-metadata.json
+++ b/shopping/merchant/ordertracking/apiv1beta/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "merchantapi",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/shopping/latest/merchant/ordertracking/apiv1beta",
-  "client_library_type": "generated",
-  "description": "Merchant API",
-  "distribution_name": "cloud.google.com/go/shopping/merchant/ordertracking/apiv1beta",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "merchantapi",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/shopping/latest/merchant/ordertracking/apiv1beta",
+    "client_library_type": "generated",
+    "description": "Merchant API",
+    "distribution_name": "cloud.google.com/go/shopping/merchant/ordertracking/apiv1beta",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/shopping/merchant/products/apiv1/.repo-metadata.json
+++ b/shopping/merchant/products/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "merchantapi",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/shopping/latest/merchant/products/apiv1",
-  "client_library_type": "generated",
-  "description": "Merchant API",
-  "distribution_name": "cloud.google.com/go/shopping/merchant/products/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "merchantapi",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/shopping/latest/merchant/products/apiv1",
+    "client_library_type": "generated",
+    "description": "Merchant API",
+    "distribution_name": "cloud.google.com/go/shopping/merchant/products/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/shopping/merchant/products/apiv1beta/.repo-metadata.json
+++ b/shopping/merchant/products/apiv1beta/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "merchantapi",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/shopping/latest/merchant/products/apiv1beta",
-  "client_library_type": "generated",
-  "description": "Merchant API",
-  "distribution_name": "cloud.google.com/go/shopping/merchant/products/apiv1beta",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "merchantapi",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/shopping/latest/merchant/products/apiv1beta",
+    "client_library_type": "generated",
+    "description": "Merchant API",
+    "distribution_name": "cloud.google.com/go/shopping/merchant/products/apiv1beta",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/shopping/merchant/productstudio/apiv1alpha/.repo-metadata.json
+++ b/shopping/merchant/productstudio/apiv1alpha/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "merchantapi",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/shopping/latest/merchant/productstudio/apiv1alpha",
-  "client_library_type": "generated",
-  "description": "Merchant API",
-  "distribution_name": "cloud.google.com/go/shopping/merchant/productstudio/apiv1alpha",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "merchantapi",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/shopping/latest/merchant/productstudio/apiv1alpha",
+    "client_library_type": "generated",
+    "description": "Merchant API",
+    "distribution_name": "cloud.google.com/go/shopping/merchant/productstudio/apiv1alpha",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/shopping/merchant/promotions/apiv1/.repo-metadata.json
+++ b/shopping/merchant/promotions/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "merchantapi",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/shopping/latest/merchant/promotions/apiv1",
-  "client_library_type": "generated",
-  "description": "Merchant API",
-  "distribution_name": "cloud.google.com/go/shopping/merchant/promotions/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "merchantapi",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/shopping/latest/merchant/promotions/apiv1",
+    "client_library_type": "generated",
+    "description": "Merchant API",
+    "distribution_name": "cloud.google.com/go/shopping/merchant/promotions/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/shopping/merchant/promotions/apiv1beta/.repo-metadata.json
+++ b/shopping/merchant/promotions/apiv1beta/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "merchantapi",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/shopping/latest/merchant/promotions/apiv1beta",
-  "client_library_type": "generated",
-  "description": "Merchant API",
-  "distribution_name": "cloud.google.com/go/shopping/merchant/promotions/apiv1beta",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "merchantapi",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/shopping/latest/merchant/promotions/apiv1beta",
+    "client_library_type": "generated",
+    "description": "Merchant API",
+    "distribution_name": "cloud.google.com/go/shopping/merchant/promotions/apiv1beta",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/shopping/merchant/quota/apiv1/.repo-metadata.json
+++ b/shopping/merchant/quota/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "merchantapi",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/shopping/latest/merchant/quota/apiv1",
-  "client_library_type": "generated",
-  "description": "Merchant API",
-  "distribution_name": "cloud.google.com/go/shopping/merchant/quota/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "merchantapi",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/shopping/latest/merchant/quota/apiv1",
+    "client_library_type": "generated",
+    "description": "Merchant API",
+    "distribution_name": "cloud.google.com/go/shopping/merchant/quota/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/shopping/merchant/quota/apiv1beta/.repo-metadata.json
+++ b/shopping/merchant/quota/apiv1beta/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "merchantapi",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/shopping/latest/merchant/quota/apiv1beta",
-  "client_library_type": "generated",
-  "description": "Merchant API",
-  "distribution_name": "cloud.google.com/go/shopping/merchant/quota/apiv1beta",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "merchantapi",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/shopping/latest/merchant/quota/apiv1beta",
+    "client_library_type": "generated",
+    "description": "Merchant API",
+    "distribution_name": "cloud.google.com/go/shopping/merchant/quota/apiv1beta",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/shopping/merchant/reports/apiv1/.repo-metadata.json
+++ b/shopping/merchant/reports/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "merchantapi",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/shopping/latest/merchant/reports/apiv1",
-  "client_library_type": "generated",
-  "description": "Merchant API",
-  "distribution_name": "cloud.google.com/go/shopping/merchant/reports/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "merchantapi",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/shopping/latest/merchant/reports/apiv1",
+    "client_library_type": "generated",
+    "description": "Merchant API",
+    "distribution_name": "cloud.google.com/go/shopping/merchant/reports/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/shopping/merchant/reports/apiv1beta/.repo-metadata.json
+++ b/shopping/merchant/reports/apiv1beta/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "merchantapi",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/shopping/latest/merchant/reports/apiv1beta",
-  "client_library_type": "generated",
-  "description": "Merchant API",
-  "distribution_name": "cloud.google.com/go/shopping/merchant/reports/apiv1beta",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "merchantapi",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/shopping/latest/merchant/reports/apiv1beta",
+    "client_library_type": "generated",
+    "description": "Merchant API",
+    "distribution_name": "cloud.google.com/go/shopping/merchant/reports/apiv1beta",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/shopping/merchant/reviews/apiv1beta/.repo-metadata.json
+++ b/shopping/merchant/reviews/apiv1beta/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "merchantapi",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/shopping/latest/merchant/reviews/apiv1beta",
-  "client_library_type": "generated",
-  "description": "Merchant API",
-  "distribution_name": "cloud.google.com/go/shopping/merchant/reviews/apiv1beta",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "merchantapi",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/shopping/latest/merchant/reviews/apiv1beta",
+    "client_library_type": "generated",
+    "description": "Merchant API",
+    "distribution_name": "cloud.google.com/go/shopping/merchant/reviews/apiv1beta",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/spanner/.repo-metadata.json
+++ b/spanner/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "spanner",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/spanner/latest",
-  "client_library_type": "manual",
-  "description": "Cloud Spanner",
-  "distribution_name": "cloud.google.com/go/spanner",
-  "language": "go",
-  "library_type": "GAPIC_MANUAL",
-  "release_level": "stable"
+    "api_shortname": "spanner",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/spanner/latest",
+    "client_library_type": "manual",
+    "description": "Cloud Spanner",
+    "distribution_name": "cloud.google.com/go/spanner",
+    "language": "go",
+    "library_type": "GAPIC_MANUAL",
+    "release_level": "stable"
 }

--- a/spanner/adapter/apiv1/.repo-metadata.json
+++ b/spanner/adapter/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "spanner",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/spanner/latest/adapter/apiv1",
-  "client_library_type": "generated",
-  "description": "Cloud Spanner API",
-  "distribution_name": "cloud.google.com/go/spanner/adapter/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "spanner",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/spanner/latest/adapter/apiv1",
+    "client_library_type": "generated",
+    "description": "Cloud Spanner API",
+    "distribution_name": "cloud.google.com/go/spanner/adapter/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/spanner/admin/database/apiv1/.repo-metadata.json
+++ b/spanner/admin/database/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "spanner",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/spanner/latest/admin/database/apiv1",
-  "client_library_type": "generated",
-  "description": "Cloud Spanner API",
-  "distribution_name": "cloud.google.com/go/spanner/admin/database/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "spanner",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/spanner/latest/admin/database/apiv1",
+    "client_library_type": "generated",
+    "description": "Cloud Spanner API",
+    "distribution_name": "cloud.google.com/go/spanner/admin/database/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/spanner/admin/instance/apiv1/.repo-metadata.json
+++ b/spanner/admin/instance/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "spanner",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/spanner/latest/admin/instance/apiv1",
-  "client_library_type": "generated",
-  "description": "Cloud Spanner API",
-  "distribution_name": "cloud.google.com/go/spanner/admin/instance/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "spanner",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/spanner/latest/admin/instance/apiv1",
+    "client_library_type": "generated",
+    "description": "Cloud Spanner API",
+    "distribution_name": "cloud.google.com/go/spanner/admin/instance/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/spanner/apiv1/.repo-metadata.json
+++ b/spanner/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "spanner",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/spanner/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Cloud Spanner API",
-  "distribution_name": "cloud.google.com/go/spanner/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "spanner",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/spanner/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Cloud Spanner API",
+    "distribution_name": "cloud.google.com/go/spanner/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/spanner/executor/apiv1/.repo-metadata.json
+++ b/spanner/executor/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "spanner-cloud-executor",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/spanner/latest/executor/apiv1",
-  "client_library_type": "generated",
-  "description": "Cloud Spanner Executor test API",
-  "distribution_name": "cloud.google.com/go/spanner/executor/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "spanner-cloud-executor",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/spanner/latest/executor/apiv1",
+    "client_library_type": "generated",
+    "description": "Cloud Spanner Executor test API",
+    "distribution_name": "cloud.google.com/go/spanner/executor/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/speech/apiv1/.repo-metadata.json
+++ b/speech/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "speech",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/speech/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Cloud Speech-to-Text API",
-  "distribution_name": "cloud.google.com/go/speech/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "speech",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/speech/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Cloud Speech-to-Text API",
+    "distribution_name": "cloud.google.com/go/speech/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/speech/apiv1p1beta1/.repo-metadata.json
+++ b/speech/apiv1p1beta1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "speech",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/speech/latest/apiv1p1beta1",
-  "client_library_type": "generated",
-  "description": "Cloud Speech-to-Text API",
-  "distribution_name": "cloud.google.com/go/speech/apiv1p1beta1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "speech",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/speech/latest/apiv1p1beta1",
+    "client_library_type": "generated",
+    "description": "Cloud Speech-to-Text API",
+    "distribution_name": "cloud.google.com/go/speech/apiv1p1beta1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/speech/apiv2/.repo-metadata.json
+++ b/speech/apiv2/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "speech",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/speech/latest/apiv2",
-  "client_library_type": "generated",
-  "description": "Cloud Speech-to-Text API",
-  "distribution_name": "cloud.google.com/go/speech/apiv2",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "speech",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/speech/latest/apiv2",
+    "client_library_type": "generated",
+    "description": "Cloud Speech-to-Text API",
+    "distribution_name": "cloud.google.com/go/speech/apiv2",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/storage/.repo-metadata.json
+++ b/storage/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "storage",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/storage/latest",
-  "client_library_type": "manual",
-  "description": "Cloud Storage (GCS)",
-  "distribution_name": "cloud.google.com/go/storage",
-  "language": "go",
-  "library_type": "GAPIC_MANUAL",
-  "release_level": "stable"
+    "api_shortname": "storage",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/storage/latest",
+    "client_library_type": "manual",
+    "description": "Cloud Storage (GCS)",
+    "distribution_name": "cloud.google.com/go/storage",
+    "language": "go",
+    "library_type": "GAPIC_MANUAL",
+    "release_level": "stable"
 }

--- a/storage/control/apiv2/.repo-metadata.json
+++ b/storage/control/apiv2/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "storage",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/storage/latest/control/apiv2",
-  "client_library_type": "generated",
-  "description": "Storage Control API",
-  "distribution_name": "cloud.google.com/go/storage/control/apiv2",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "storage",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/storage/latest/control/apiv2",
+    "client_library_type": "generated",
+    "description": "Storage Control API",
+    "distribution_name": "cloud.google.com/go/storage/control/apiv2",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/storage/internal/apiv2/.repo-metadata.json
+++ b/storage/internal/apiv2/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "storage",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/storage/latest/internal/apiv2",
-  "client_library_type": "generated",
-  "description": "Cloud Storage API",
-  "distribution_name": "cloud.google.com/go/storage/internal/apiv2",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "storage",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/storage/latest/internal/apiv2",
+    "client_library_type": "generated",
+    "description": "Cloud Storage API",
+    "distribution_name": "cloud.google.com/go/storage/internal/apiv2",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/storagebatchoperations/apiv1/.repo-metadata.json
+++ b/storagebatchoperations/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "storagebatchoperations",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/storagebatchoperations/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Storage Batch Operations API",
-  "distribution_name": "cloud.google.com/go/storagebatchoperations/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "storagebatchoperations",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/storagebatchoperations/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Storage Batch Operations API",
+    "distribution_name": "cloud.google.com/go/storagebatchoperations/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/storageinsights/apiv1/.repo-metadata.json
+++ b/storageinsights/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "storageinsights",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/storageinsights/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Storage Insights API",
-  "distribution_name": "cloud.google.com/go/storageinsights/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "storageinsights",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/storageinsights/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Storage Insights API",
+    "distribution_name": "cloud.google.com/go/storageinsights/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/storagetransfer/apiv1/.repo-metadata.json
+++ b/storagetransfer/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "storagetransfer",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/storagetransfer/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Storage Transfer API",
-  "distribution_name": "cloud.google.com/go/storagetransfer/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "storagetransfer",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/storagetransfer/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Storage Transfer API",
+    "distribution_name": "cloud.google.com/go/storagetransfer/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/streetview/publish/apiv1/.repo-metadata.json
+++ b/streetview/publish/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "streetviewpublish",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/streetview/latest/publish/apiv1",
-  "client_library_type": "generated",
-  "description": "Street View Publish API",
-  "distribution_name": "cloud.google.com/go/streetview/publish/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "streetviewpublish",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/streetview/latest/publish/apiv1",
+    "client_library_type": "generated",
+    "description": "Street View Publish API",
+    "distribution_name": "cloud.google.com/go/streetview/publish/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/support/apiv2/.repo-metadata.json
+++ b/support/apiv2/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "cloudsupport",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/support/latest/apiv2",
-  "client_library_type": "generated",
-  "description": "Google Cloud Support API",
-  "distribution_name": "cloud.google.com/go/support/apiv2",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "cloudsupport",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/support/latest/apiv2",
+    "client_library_type": "generated",
+    "description": "Google Cloud Support API",
+    "distribution_name": "cloud.google.com/go/support/apiv2",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/support/apiv2beta/.repo-metadata.json
+++ b/support/apiv2beta/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "cloudsupport",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/support/latest/apiv2beta",
-  "client_library_type": "generated",
-  "description": "Google Cloud Support API",
-  "distribution_name": "cloud.google.com/go/support/apiv2beta",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "cloudsupport",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/support/latest/apiv2beta",
+    "client_library_type": "generated",
+    "description": "Google Cloud Support API",
+    "distribution_name": "cloud.google.com/go/support/apiv2beta",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/talent/apiv4/.repo-metadata.json
+++ b/talent/apiv4/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "jobs",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/talent/latest/apiv4",
-  "client_library_type": "generated",
-  "description": "Cloud Talent Solution API",
-  "distribution_name": "cloud.google.com/go/talent/apiv4",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "jobs",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/talent/latest/apiv4",
+    "client_library_type": "generated",
+    "description": "Cloud Talent Solution API",
+    "distribution_name": "cloud.google.com/go/talent/apiv4",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/talent/apiv4beta1/.repo-metadata.json
+++ b/talent/apiv4beta1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "jobs",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/talent/latest/apiv4beta1",
-  "client_library_type": "generated",
-  "description": "Cloud Talent Solution API",
-  "distribution_name": "cloud.google.com/go/talent/apiv4beta1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "jobs",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/talent/latest/apiv4beta1",
+    "client_library_type": "generated",
+    "description": "Cloud Talent Solution API",
+    "distribution_name": "cloud.google.com/go/talent/apiv4beta1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/telcoautomation/apiv1/.repo-metadata.json
+++ b/telcoautomation/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "telcoautomation",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/telcoautomation/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Telco Automation API",
-  "distribution_name": "cloud.google.com/go/telcoautomation/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "telcoautomation",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/telcoautomation/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Telco Automation API",
+    "distribution_name": "cloud.google.com/go/telcoautomation/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/texttospeech/apiv1/.repo-metadata.json
+++ b/texttospeech/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "texttospeech",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/texttospeech/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Cloud Text-to-Speech API",
-  "distribution_name": "cloud.google.com/go/texttospeech/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "texttospeech",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/texttospeech/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Cloud Text-to-Speech API",
+    "distribution_name": "cloud.google.com/go/texttospeech/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/tpu/apiv1/.repo-metadata.json
+++ b/tpu/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "tpu",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/tpu/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Cloud TPU API",
-  "distribution_name": "cloud.google.com/go/tpu/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "tpu",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/tpu/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Cloud TPU API",
+    "distribution_name": "cloud.google.com/go/tpu/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/trace/apiv1/.repo-metadata.json
+++ b/trace/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "cloudtrace",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/trace/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Stackdriver Trace API",
-  "distribution_name": "cloud.google.com/go/trace/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "cloudtrace",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/trace/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Stackdriver Trace API",
+    "distribution_name": "cloud.google.com/go/trace/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/trace/apiv2/.repo-metadata.json
+++ b/trace/apiv2/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "cloudtrace",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/trace/latest/apiv2",
-  "client_library_type": "generated",
-  "description": "Stackdriver Trace API",
-  "distribution_name": "cloud.google.com/go/trace/apiv2",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "cloudtrace",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/trace/latest/apiv2",
+    "client_library_type": "generated",
+    "description": "Stackdriver Trace API",
+    "distribution_name": "cloud.google.com/go/trace/apiv2",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/translate/apiv3/.repo-metadata.json
+++ b/translate/apiv3/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "translate",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/translate/latest/apiv3",
-  "client_library_type": "generated",
-  "description": "Cloud Translation API",
-  "distribution_name": "cloud.google.com/go/translate/apiv3",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "translate",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/translate/latest/apiv3",
+    "client_library_type": "generated",
+    "description": "Cloud Translation API",
+    "distribution_name": "cloud.google.com/go/translate/apiv3",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/vectorsearch/apiv1/.repo-metadata.json
+++ b/vectorsearch/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "vectorsearch",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/vectorsearch/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Vector Search API",
-  "distribution_name": "cloud.google.com/go/vectorsearch/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "vectorsearch",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/vectorsearch/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Vector Search API",
+    "distribution_name": "cloud.google.com/go/vectorsearch/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/vectorsearch/apiv1beta/.repo-metadata.json
+++ b/vectorsearch/apiv1beta/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "vectorsearch",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/vectorsearch/latest/apiv1beta",
-  "client_library_type": "generated",
-  "description": "Vector Search API",
-  "distribution_name": "cloud.google.com/go/vectorsearch/apiv1beta",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "vectorsearch",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/vectorsearch/latest/apiv1beta",
+    "client_library_type": "generated",
+    "description": "Vector Search API",
+    "distribution_name": "cloud.google.com/go/vectorsearch/apiv1beta",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/video/livestream/apiv1/.repo-metadata.json
+++ b/video/livestream/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "livestream",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/video/latest/livestream/apiv1",
-  "client_library_type": "generated",
-  "description": "Live Stream API",
-  "distribution_name": "cloud.google.com/go/video/livestream/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "livestream",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/video/latest/livestream/apiv1",
+    "client_library_type": "generated",
+    "description": "Live Stream API",
+    "distribution_name": "cloud.google.com/go/video/livestream/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/video/stitcher/apiv1/.repo-metadata.json
+++ b/video/stitcher/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "videostitcher",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/video/latest/stitcher/apiv1",
-  "client_library_type": "generated",
-  "description": "Video Stitcher API",
-  "distribution_name": "cloud.google.com/go/video/stitcher/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "videostitcher",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/video/latest/stitcher/apiv1",
+    "client_library_type": "generated",
+    "description": "Video Stitcher API",
+    "distribution_name": "cloud.google.com/go/video/stitcher/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/video/transcoder/apiv1/.repo-metadata.json
+++ b/video/transcoder/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "transcoder",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/video/latest/transcoder/apiv1",
-  "client_library_type": "generated",
-  "description": "Transcoder API",
-  "distribution_name": "cloud.google.com/go/video/transcoder/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "transcoder",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/video/latest/transcoder/apiv1",
+    "client_library_type": "generated",
+    "description": "Transcoder API",
+    "distribution_name": "cloud.google.com/go/video/transcoder/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/videointelligence/apiv1/.repo-metadata.json
+++ b/videointelligence/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "videointelligence",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/videointelligence/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Cloud Video Intelligence API",
-  "distribution_name": "cloud.google.com/go/videointelligence/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "videointelligence",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/videointelligence/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Cloud Video Intelligence API",
+    "distribution_name": "cloud.google.com/go/videointelligence/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/videointelligence/apiv1beta2/.repo-metadata.json
+++ b/videointelligence/apiv1beta2/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "videointelligence",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/videointelligence/latest/apiv1beta2",
-  "client_library_type": "generated",
-  "description": "Google Cloud Video Intelligence API",
-  "distribution_name": "cloud.google.com/go/videointelligence/apiv1beta2",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "videointelligence",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/videointelligence/latest/apiv1beta2",
+    "client_library_type": "generated",
+    "description": "Google Cloud Video Intelligence API",
+    "distribution_name": "cloud.google.com/go/videointelligence/apiv1beta2",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/videointelligence/apiv1p3beta1/.repo-metadata.json
+++ b/videointelligence/apiv1p3beta1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "videointelligence",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/videointelligence/latest/apiv1p3beta1",
-  "client_library_type": "generated",
-  "description": "Cloud Video Intelligence API",
-  "distribution_name": "cloud.google.com/go/videointelligence/apiv1p3beta1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "videointelligence",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/videointelligence/latest/apiv1p3beta1",
+    "client_library_type": "generated",
+    "description": "Cloud Video Intelligence API",
+    "distribution_name": "cloud.google.com/go/videointelligence/apiv1p3beta1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/vision/apiv1/.repo-metadata.json
+++ b/vision/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "vision",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/vision/v2/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Cloud Vision API",
-  "distribution_name": "cloud.google.com/go/vision/v2/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "vision",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/vision/v2/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Cloud Vision API",
+    "distribution_name": "cloud.google.com/go/vision/v2/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/vision/apiv1p1beta1/.repo-metadata.json
+++ b/vision/apiv1p1beta1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "vision",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/vision/v2/latest/apiv1p1beta1",
-  "client_library_type": "generated",
-  "description": "Cloud Vision API",
-  "distribution_name": "cloud.google.com/go/vision/v2/apiv1p1beta1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "vision",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/vision/v2/latest/apiv1p1beta1",
+    "client_library_type": "generated",
+    "description": "Cloud Vision API",
+    "distribution_name": "cloud.google.com/go/vision/v2/apiv1p1beta1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/visionai/apiv1/.repo-metadata.json
+++ b/visionai/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "visionai",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/visionai/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Vision AI API",
-  "distribution_name": "cloud.google.com/go/visionai/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "visionai",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/visionai/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Vision AI API",
+    "distribution_name": "cloud.google.com/go/visionai/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/vmmigration/apiv1/.repo-metadata.json
+++ b/vmmigration/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "vmmigration",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/vmmigration/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "VM Migration API",
-  "distribution_name": "cloud.google.com/go/vmmigration/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "vmmigration",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/vmmigration/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "VM Migration API",
+    "distribution_name": "cloud.google.com/go/vmmigration/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/vmwareengine/apiv1/.repo-metadata.json
+++ b/vmwareengine/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "vmwareengine",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/vmwareengine/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "VMware Engine API",
-  "distribution_name": "cloud.google.com/go/vmwareengine/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "vmwareengine",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/vmwareengine/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "VMware Engine API",
+    "distribution_name": "cloud.google.com/go/vmwareengine/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/vpcaccess/apiv1/.repo-metadata.json
+++ b/vpcaccess/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "vpcaccess",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/vpcaccess/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Serverless VPC Access API",
-  "distribution_name": "cloud.google.com/go/vpcaccess/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "vpcaccess",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/vpcaccess/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Serverless VPC Access API",
+    "distribution_name": "cloud.google.com/go/vpcaccess/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/webrisk/apiv1/.repo-metadata.json
+++ b/webrisk/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "webrisk",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/webrisk/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Web Risk API",
-  "distribution_name": "cloud.google.com/go/webrisk/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "webrisk",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/webrisk/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Web Risk API",
+    "distribution_name": "cloud.google.com/go/webrisk/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/webrisk/apiv1beta1/.repo-metadata.json
+++ b/webrisk/apiv1beta1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "webrisk",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/webrisk/latest/apiv1beta1",
-  "client_library_type": "generated",
-  "description": "Web Risk API",
-  "distribution_name": "cloud.google.com/go/webrisk/apiv1beta1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "webrisk",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/webrisk/latest/apiv1beta1",
+    "client_library_type": "generated",
+    "description": "Web Risk API",
+    "distribution_name": "cloud.google.com/go/webrisk/apiv1beta1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/websecurityscanner/apiv1/.repo-metadata.json
+++ b/websecurityscanner/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "websecurityscanner",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/websecurityscanner/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Web Security Scanner API",
-  "distribution_name": "cloud.google.com/go/websecurityscanner/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "websecurityscanner",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/websecurityscanner/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Web Security Scanner API",
+    "distribution_name": "cloud.google.com/go/websecurityscanner/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/workflows/apiv1/.repo-metadata.json
+++ b/workflows/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "workflows",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/workflows/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Workflows API",
-  "distribution_name": "cloud.google.com/go/workflows/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "workflows",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/workflows/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Workflows API",
+    "distribution_name": "cloud.google.com/go/workflows/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/workflows/apiv1beta/.repo-metadata.json
+++ b/workflows/apiv1beta/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "workflows",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/workflows/latest/apiv1beta",
-  "client_library_type": "generated",
-  "description": "Workflows API",
-  "distribution_name": "cloud.google.com/go/workflows/apiv1beta",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "workflows",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/workflows/latest/apiv1beta",
+    "client_library_type": "generated",
+    "description": "Workflows API",
+    "distribution_name": "cloud.google.com/go/workflows/apiv1beta",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/workflows/executions/apiv1/.repo-metadata.json
+++ b/workflows/executions/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "workflowexecutions",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/workflows/latest/executions/apiv1",
-  "client_library_type": "generated",
-  "description": "Workflow Executions API",
-  "distribution_name": "cloud.google.com/go/workflows/executions/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "workflowexecutions",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/workflows/latest/executions/apiv1",
+    "client_library_type": "generated",
+    "description": "Workflow Executions API",
+    "distribution_name": "cloud.google.com/go/workflows/executions/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/workflows/executions/apiv1beta/.repo-metadata.json
+++ b/workflows/executions/apiv1beta/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "workflowexecutions",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/workflows/latest/executions/apiv1beta",
-  "client_library_type": "generated",
-  "description": "Workflow Executions API",
-  "distribution_name": "cloud.google.com/go/workflows/executions/apiv1beta",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "workflowexecutions",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/workflows/latest/executions/apiv1beta",
+    "client_library_type": "generated",
+    "description": "Workflow Executions API",
+    "distribution_name": "cloud.google.com/go/workflows/executions/apiv1beta",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/workloadmanager/apiv1/.repo-metadata.json
+++ b/workloadmanager/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "workloadmanager",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/workloadmanager/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Workload Manager API",
-  "distribution_name": "cloud.google.com/go/workloadmanager/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "workloadmanager",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/workloadmanager/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Workload Manager API",
+    "distribution_name": "cloud.google.com/go/workloadmanager/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }

--- a/workstations/apiv1/.repo-metadata.json
+++ b/workstations/apiv1/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "workstations",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/workstations/latest/apiv1",
-  "client_library_type": "generated",
-  "description": "Cloud Workstations API",
-  "distribution_name": "cloud.google.com/go/workstations/apiv1",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "stable"
+    "api_shortname": "workstations",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/workstations/latest/apiv1",
+    "client_library_type": "generated",
+    "description": "Cloud Workstations API",
+    "distribution_name": "cloud.google.com/go/workstations/apiv1",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "stable"
 }

--- a/workstations/apiv1beta/.repo-metadata.json
+++ b/workstations/apiv1beta/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
-  "api_shortname": "workstations",
-  "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/workstations/latest/apiv1beta",
-  "client_library_type": "generated",
-  "description": "Cloud Workstations API",
-  "distribution_name": "cloud.google.com/go/workstations/apiv1beta",
-  "language": "go",
-  "library_type": "GAPIC_AUTO",
-  "release_level": "preview"
+    "api_shortname": "workstations",
+    "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/workstations/latest/apiv1beta",
+    "client_library_type": "generated",
+    "description": "Cloud Workstations API",
+    "distribution_name": "cloud.google.com/go/workstations/apiv1beta",
+    "language": "go",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "preview"
 }


### PR DESCRIPTION
Format repo metadata, prepare for librarian Go migration.

The change is made through the following commands:
```
# sort keys and increase indent
find . -name ".repo-metadata.json" -exec sh -c 'jq -S --indent 4 "." "$1" > "$1.tmp" && mv "$1.tmp" "$1"' _ {} \;
# remove the newline at the end of file
find . -name ".repo-metadata.json" -exec perl -i -pe 'chomp if eof' {} +
```