### PR TITLE
chore: librarian release pull request: 20260326T233413Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -5760,7 +5760,7 @@ libraries:
       - internal/generated/snippets/shopping/
     tag_format: '{id}/v{version}'
   - id: spanner
-    version: 1.88.0
+    version: 1.89.0
     last_generated_commit: 6df3ecf4fd43b64826de6a477d1a535ec18b0d7c
     apis:
       - path: google/spanner/adapter/v1

--- a/internal/generated/snippets/spanner/adapter/apiv1/snippet_metadata.google.spanner.adapter.v1.json
+++ b/internal/generated/snippets/spanner/adapter/apiv1/snippet_metadata.google.spanner.adapter.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/spanner/adapter/apiv1",
-    "version": "1.88.0"
+    "version": "1.89.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/spanner/admin/database/apiv1/snippet_metadata.google.spanner.admin.database.v1.json
+++ b/internal/generated/snippets/spanner/admin/database/apiv1/snippet_metadata.google.spanner.admin.database.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/spanner/admin/database/apiv1",
-    "version": "1.88.0"
+    "version": "1.89.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/spanner/admin/instance/apiv1/snippet_metadata.google.spanner.admin.instance.v1.json
+++ b/internal/generated/snippets/spanner/admin/instance/apiv1/snippet_metadata.google.spanner.admin.instance.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/spanner/admin/instance/apiv1",
-    "version": "1.88.0"
+    "version": "1.89.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/spanner/apiv1/snippet_metadata.google.spanner.v1.json
+++ b/internal/generated/snippets/spanner/apiv1/snippet_metadata.google.spanner.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/spanner/apiv1",
-    "version": "1.88.0"
+    "version": "1.89.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/spanner/executor/apiv1/snippet_metadata.google.spanner.executor.v1.json
+++ b/internal/generated/snippets/spanner/executor/apiv1/snippet_metadata.google.spanner.executor.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/spanner/executor/apiv1",
-    "version": "1.88.0"
+    "version": "1.89.0"
   },
   "snippets": [
     {

--- a/spanner/CHANGES.md
+++ b/spanner/CHANGES.md
@@ -1,5 +1,28 @@
 # Changes
 
+## [1.89.0](https://github.com/googleapis/google-cloud-go/releases/tag/spanner%2Fv1.89.0) (2026-03-26)
+
+### Features
+
+* Add E2E fallback to the spanner client. (#13518) ([16af6a1](https://github.com/googleapis/google-cloud-go/commit/16af6a1cac04c2a7aea93b0c6f151ac7d42f471b))
+* Add gRPC A66/A94 metrics (#13825) ([d695802](https://github.com/googleapis/google-cloud-go/commit/d695802a29815599e60132d13dc114a03a2366de))
+* add SI, adapt, split point related proto ([d3eb851](https://github.com/googleapis/google-cloud-go/commit/d3eb851d1b09f28ae2b6c7c63d694eb67b0c11c7))
+* include cache updates and routing hint into BeginTransaction and Commit request/response respectively ([9c80b8b](https://github.com/googleapis/google-cloud-go/commit/9c80b8b4442a54c610826c1bb89cec5158b49314))
+* support Scan from string to NullUUID (#14128) ([d897b6d](https://github.com/googleapis/google-cloud-go/commit/d897b6db5a01291e151f09d8491ea1dd195d55ea))
+
+### Bug Fixes
+
+* guard rollback when aborted commit cleared session handle (#14218) ([6315105](https://github.com/googleapis/google-cloud-go/commit/63151055c1d238f1a89dc8bd96eba0f05512bd7b))
+* replace multiplexed session request loop with shared in-flight creation (#14215) ([3e3bd2d](https://github.com/googleapis/google-cloud-go/commit/3e3bd2d33a7b36e9d7ed4568603bae800268073a))
+
+### Documentation
+
+* A comment for field `execution_options` in message `.google.spanner.executor.v1.StartTransactionAction` is changed ([d3eb851](https://github.com/googleapis/google-cloud-go/commit/d3eb851d1b09f28ae2b6c7c63d694eb67b0c11c7))
+* A comment for field `routing_hint` in messages `.google.spanner.v1.ResultSet` and `.google.spanner.v1.PartialResultSet` are changed ([9c80b8b](https://github.com/googleapis/google-cloud-go/commit/9c80b8b4442a54c610826c1bb89cec5158b49314))
+* A comment for message `ListCloudInstancesAction` is changed ([d3eb851](https://github.com/googleapis/google-cloud-go/commit/d3eb851d1b09f28ae2b6c7c63d694eb67b0c11c7))
+* A comment for message `TransactionExecutionOptions` is changed ([d3eb851](https://github.com/googleapis/google-cloud-go/commit/d3eb851d1b09f28ae2b6c7c63d694eb67b0c11c7))
+* A comment in message `.google.spanner.v1.TransactionOptions.ReadWrite.ReadLockMode` is changed ([9c80b8b](https://github.com/googleapis/google-cloud-go/commit/9c80b8b4442a54c610826c1bb89cec5158b49314))
+
 ## [1.88.0](https://github.com/googleapis/google-cloud-go/releases/tag/spanner%2Fv1.88.0) (2026-02-11)
 
 ### Features

--- a/spanner/internal/version.go
+++ b/spanner/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "1.88.0"
+const Version = "1.89.0"


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.8.4
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go@sha256:ac1efa3ad3c6d99efed878535b3a0fe63d0cce6701c335f03811d8b49004d652
<details><summary>spanner: v1.89.0</summary>

## [v1.89.0](https://github.com/googleapis/google-cloud-go/compare/spanner/v1.88.0...spanner/v1.89.0) (2026-03-26)

### Features

* Add E2E fallback to the spanner client. (#13518) ([16af6a1c](https://github.com/googleapis/google-cloud-go/commit/16af6a1c))

* include cache updates and routing hint into BeginTransaction and Commit request/response respectively (PiperOrigin-RevId: 878019893) ([9c80b8b4](https://github.com/googleapis/google-cloud-go/commit/9c80b8b4))

* add SI, adapt, split point related proto (PiperOrigin-RevId: 871366927) ([d3eb851d](https://github.com/googleapis/google-cloud-go/commit/d3eb851d))

* Add gRPC A66/A94 metrics (#13825) ([d695802a](https://github.com/googleapis/google-cloud-go/commit/d695802a))

* support Scan from string to NullUUID (#14128) ([d897b6db](https://github.com/googleapis/google-cloud-go/commit/d897b6db))

### Bug Fixes

* replace multiplexed session request loop with shared in-flight creation (#14215) ([3e3bd2d3](https://github.com/googleapis/google-cloud-go/commit/3e3bd2d3))

* guard rollback when aborted commit cleared session handle (#14218) ([63151055](https://github.com/googleapis/google-cloud-go/commit/63151055))

### Documentation

* A comment for field `routing_hint` in messages `.google.spanner.v1.ResultSet` and `.google.spanner.v1.PartialResultSet` are changed (PiperOrigin-RevId: 878019893) ([9c80b8b4](https://github.com/googleapis/google-cloud-go/commit/9c80b8b4))

* A comment in message `.google.spanner.v1.TransactionOptions.ReadWrite.ReadLockMode` is changed (PiperOrigin-RevId: 878019893) ([9c80b8b4](https://github.com/googleapis/google-cloud-go/commit/9c80b8b4))

* A comment for message `ListCloudInstancesAction` is changed (PiperOrigin-RevId: 871366927) ([d3eb851d](https://github.com/googleapis/google-cloud-go/commit/d3eb851d))

* A comment for field `execution_options` in message `.google.spanner.executor.v1.StartTransactionAction` is changed (PiperOrigin-RevId: 871366927) ([d3eb851d](https://github.com/googleapis/google-cloud-go/commit/d3eb851d))

* A comment for message `TransactionExecutionOptions` is changed (PiperOrigin-RevId: 871366927) ([d3eb851d](https://github.com/googleapis/google-cloud-go/commit/d3eb851d))

</details>