### PR TITLE
chore: set release only mode

### DIFF
--- a/.librarian/config.yaml
+++ b/.librarian/config.yaml
@@ -1,5 +1,5 @@
 # Hand-maintained configuration for libraries.
-
+release_only_mode: true
 global_files_allowlist:
  # Paths (currently just one) that need to modified during configure
  - path: "internal/generated/snippets/go.mod"


### PR DESCRIPTION
Set `release_only_mode` to `true`, preventing legacylibrarian generate works on this repo. Prepare for librarian Go migration.