### PR TITLE
fix(pubsub/v2): prevent nil span panic in Subscriber.Receive

### DIFF
--- a/pubsub/v2/subscriber.go
+++ b/pubsub/v2/subscriber.go
@@ -423,7 +423,7 @@ func (s *Subscriber) Receive(ctx context.Context, f func(context.Context, *Messa
 						// Return nil if the context is done, not err.
 						return nil
 					}
-					if iter.enableTracing {
+					if iter.enableTracing && ccSpan != nil {
 						ccSpan.End()
 					}
 


### PR DESCRIPTION
## Why?

When tracing is enabled on a pubsub v2 subscriber, there is a race between the subscriber loop and the ack/nack/expiry paths. `activeSpans` is a `sync.Map` shared across goroutines, and the span can be deleted between the `Store` (message received in `iter.receive`) and the `Load` (message dispatched in `Subscriber.Receive`):

1. `iter.receive()` stores the subscribe span in `activeSpans` ([iterator.go:382](https://github.com/googleapis/google-cloud-go/blob/25079346ab69a3f5dedce34b3a9ab48b04686632/pubsub/v2/iterator.go#L382))
2. Before the subscriber loop reads it, one of these deletes the span concurrently:
   - **Message expiry**: `keepAliveDeadlines` cleanup calls `activeSpans.LoadAndDelete` ([iterator.go:582](https://github.com/googleapis/google-cloud-go/blob/25079346ab69a3f5dedce34b3a9ab48b04686632/pubsub/v2/iterator.go#L582))
   - **Ack**: `sendAck` calls `activeSpans.LoadAndDelete` ([iterator.go:659](https://github.com/googleapis/google-cloud-go/blob/25079346ab69a3f5dedce34b3a9ab48b04686632/pubsub/v2/iterator.go#L659))
   - **Nack**: `sendModAck` with `isNack=true` calls `activeSpans.LoadAndDelete` ([iterator.go:739](https://github.com/googleapis/google-cloud-go/blob/25079346ab69a3f5dedce34b3a9ab48b04686632/pubsub/v2/iterator.go#L739))
3. `activeSpans.Load(ackh.ackID)` returns `ok=false`, so `ccSpan` stays nil ([subscriber.go:408](https://github.com/googleapis/google-cloud-go/blob/25079346ab69a3f5dedce34b3a9ab48b04686632/pubsub/v2/subscriber.go#L408))
4. `ccSpan.End()` panics on nil ([subscriber.go:427](https://github.com/googleapis/google-cloud-go/blob/25079346ab69a3f5dedce34b3a9ab48b04686632/pubsub/v2/subscriber.go#L427))

## What?

Add a nil check before calling `ccSpan.End()`. If the parent subscribe span was already removed from `activeSpans`, there is nothing to link the concurrency control span to — skipping it seems like the correct semantic behavior.

## Notes

The issue reporter (@magnusewe) noted "this started happening after the client had been running for a while", which aligns with message expiry being the most likely trigger.

Fixes #14277