### PR TITLE
chore: librarian release pull request: 20260327T235343Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1205,7 +1205,7 @@ libraries:
       - internal/generated/snippets/bigquery/v2
     tag_format: bigquery/v{version}
   - id: bigtable
-    version: 1.43.0
+    version: 2.0.0
     last_generated_commit: 59d5f2b46924714af627ac29ea6de78641a00835
     apis:
       - path: google/bigtable/admin/v2

--- a/bigtable/CHANGES.md
+++ b/bigtable/CHANGES.md
@@ -1,5 +1,18 @@
 # Changes
 
+## [2.0.0](https://github.com/googleapis/google-cloud-go/releases/tag/bigtable%2Fv2.0.0) (2026-03-27)
+
+### Features
+
+* add locations field to AutomatedBackupPolicy ([5e50d57](https://github.com/googleapis/google-cloud-go/commit/5e50d57d4ca4bceff2e7dfe4118c281c24375b99))
+* obey if user want to disable directpath and populate reason ([2507934](https://github.com/googleapis/google-cloud-go/commit/25079346ab69a3f5dedce34b3a9ab48b04686632))
+* update admin.go to support automatedbackuppolicy locations (#14274) ([269dd2d](https://github.com/googleapis/google-cloud-go/commit/269dd2de0bb639288a609712543668cd21fe16e3))
+
+### Documentation
+
+* A comment for field `frequency` in message `.google.bigtable.admin.v2.Table` is changed ([5e50d57](https://github.com/googleapis/google-cloud-go/commit/5e50d57d4ca4bceff2e7dfe4118c281c24375b99))
+* A comment for field `retention_period` in message `.google.bigtable.admin.v2.Table` is changed ([5e50d57](https://github.com/googleapis/google-cloud-go/commit/5e50d57d4ca4bceff2e7dfe4118c281c24375b99))
+
 ## [1.43.0](https://github.com/googleapis/google-cloud-go/releases/tag/bigtable%2Fv1.43.0) (2026-03-16)
 
 ### Features

--- a/bigtable/internal/version.go
+++ b/bigtable/internal/version.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     https://www.apache.org/licenses/LICENSE-2.0
+//      http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "1.43.0"
+const Version = "2.0.0"


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.8.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go@sha256:ac1efa3ad3c6d99efed878535b3a0fe63d0cce6701c335f03811d8b49004d652
<details><summary>bigtable: 2.0.0</summary>

## [2.0.0](https://github.com/googleapis/google-cloud-go/compare/bigtable/v1.43.0...bigtable/v2.0.0) (2026-03-27)

### Features

* obey if user want to disable directpath and populate reason ([25079346](https://github.com/googleapis/google-cloud-go/commit/25079346))

* update admin.go to support automatedbackuppolicy locations (#14274) ([269dd2de](https://github.com/googleapis/google-cloud-go/commit/269dd2de))

* add locations field to AutomatedBackupPolicy (PiperOrigin-RevId: 888234464) ([5e50d57d](https://github.com/googleapis/google-cloud-go/commit/5e50d57d))

### Documentation

* A comment for field `frequency` in message `.google.bigtable.admin.v2.Table` is changed (PiperOrigin-RevId: 888234464) ([5e50d57d](https://github.com/googleapis/google-cloud-go/commit/5e50d57d))

* A comment for field `retention_period` in message `.google.bigtable.admin.v2.Table` is changed (PiperOrigin-RevId: 888234464) ([5e50d57d](https://github.com/googleapis/google-cloud-go/commit/5e50d57d))

</details>