### PR TITLE
chore: update header in internal/version.go

### DIFF
--- a/internal/librariangen/module/_internal_version.go.txt
+++ b/internal/librariangen/module/_internal_version.go.txt
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//      http://www.apache.org/licenses/LICENSE-2.0
+//      https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
Update the header in `internal/version.go` to include the same URL in librarian.

`internal/version.go` will be regenerated in legacylibrarian stage so we should keep the header the same across two tools.