### PR TITLE
feat(spanner): add EnableDirectAccess field to ClientConfig

### DIFF
--- a/spanner/client.go
+++ b/spanner/client.go
@@ -501,7 +501,10 @@ func newClientWithConfig(ctx context.Context, database string, config ClientConf
 	isAFEBuiltInMetricEnabled := strings.EqualFold("false", os.Getenv("SPANNER_DISABLE_AFE_SERVER_TIMING"))
 	isGRPCBuiltInMetricsEnabled := strings.EqualFold("false", os.Getenv("SPANNER_DISABLE_DIRECT_ACCESS_GRPC_BUILTIN_METRICS"))
 	// enable the AFE/GRPC built-in metrics if direct-path is enabled
-	isDirectPathEnabled, _ := strconv.ParseBool(os.Getenv("GOOGLE_SPANNER_ENABLE_DIRECT_ACCESS"))
+	isDirectPathEnabled := config.EnableDirectAccess
+	if enableDirectPathXdsString := os.Getenv("GOOGLE_SPANNER_ENABLE_DIRECT_ACCESS"); enableDirectPathXdsString != "" {
+		isDirectPathEnabled, _ = strconv.ParseBool(enableDirectPathXdsString)
+	}
 	if isDirectPathEnabled {
 		isAFEBuiltInMetricEnabled = true
 		isGRPCBuiltInMetricsEnabled = true


### PR DESCRIPTION
This change introduces the `EnableDirectAccess` boolean to `ClientConfig`, allowing users to explicitly configure whether the Spanner client connects to the directpath XDS endpoint.

The environment variable `GOOGLE_SPANNER_ENABLE_DIRECT_ACCESS` continues to remain fully supported, and takes precedence over the programmatic client configuration for flexible overriding.