### PR TITLE
fix(spanner): set gauge metric start time to match end time

### DIFF
--- a/spanner/metrics_monitoring_exporter.go
+++ b/spanner/metrics_monitoring_exporter.go
@@ -359,7 +359,7 @@ func toNonemptyTimeIntervalpb(start, end time.Time, isGauge bool) (*monitoringpb
 	// previous interval, for all non-gauge types.
 	// https://cloud.google.com/monitoring/api/ref_v3/rpc/google.monitoring.v3#timeinterval
 	if isGauge {
-		end = start
+		start = end
 	} else if end.Sub(start).Milliseconds() <= 1 {
 		end = start.Add(time.Millisecond)
 	}


### PR DESCRIPTION
This commit fixes an InvalidArgument error ("One or more points were written
more frequently than the maximum sampling period") when exporting gauge metrics
like `open_connections` to Cloud Monitoring.

Previously, the time interval for these gauge metrics started from the moment
the application booted up. This created long, continuously overlapping time
intervals. Cloud Monitoring strictly rejected these because it requires gauges
to be exact, point-in-time measurements, not long durations.

By simply setting the start time equal to the end time (`start = end`), we
correctly format the data as instantaneous point-in-time snapshots. This
satisfies Cloud Monitoring's requirements and allows the metrics to export
successfully on every cycle.