### PR TITLE
chore: librarian release pull request: 20260330T155104Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -330,7 +330,7 @@ libraries:
       - internal/generated/snippets/beyondcorp/
     tag_format: '{id}/v{version}'
   - id: bigquery
-    version: 1.74.0
+    version: 1.75.0
     last_generated_commit: ""
     apis: []
     source_roots:

--- a/bigquery/CHANGES.md
+++ b/bigquery/CHANGES.md
@@ -3,6 +3,8 @@
 
 
 
+## [1.75.0](https://github.com/googleapis/google-cloud-go/releases/tag/bigquery%2Fv1.75.0) (2026-03-30)
+
 ## [1.74.0](https://github.com/googleapis/google-cloud-go/releases/tag/bigquery%2Fv1.74.0) (2026-02-25)
 
 ### Features

--- a/bigquery/internal/version.go
+++ b/bigquery/internal/version.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     https://www.apache.org/licenses/LICENSE-2.0
+//      http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "1.74.0"
+const Version = "1.75.0"


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.9.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go@sha256:ac1efa3ad3c6d99efed878535b3a0fe63d0cce6701c335f03811d8b49004d652
<details><summary>bigquery: v1.75.0</summary>

## [v1.75.0](https://github.com/googleapis/google-cloud-go/compare/bigquery/v1.74.0...bigquery/v1.75.0) (2026-03-30)

</details>