### PR TITLE
chore: librarian release pull request: 20260330T174154Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -359,7 +359,7 @@ libraries:
       - internal/generated/snippets/bigquery/v2
     tag_format: bigquery/v{version}
   - id: bigtable
-    version: 1.43.0
+    version: 1.44.0
     last_generated_commit: ""
     apis: []
     source_roots:

--- a/bigtable/CHANGES.md
+++ b/bigtable/CHANGES.md
@@ -1,5 +1,7 @@
 # Changes
 
+## [1.44.0](https://github.com/googleapis/google-cloud-go/releases/tag/bigtable%2Fv1.44.0) (2026-03-30)
+
 ## [1.43.0](https://github.com/googleapis/google-cloud-go/releases/tag/bigtable%2Fv1.43.0) (2026-03-16)
 
 ### Features

--- a/bigtable/internal/version.go
+++ b/bigtable/internal/version.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     https://www.apache.org/licenses/LICENSE-2.0
+//      http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "1.43.0"
+const Version = "1.44.0"


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.9.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go@sha256:ac1efa3ad3c6d99efed878535b3a0fe63d0cce6701c335f03811d8b49004d652
<details><summary>bigtable: v1.44.0</summary>

## [v1.44.0](https://github.com/googleapis/google-cloud-go/compare/bigtable/v1.43.0...bigtable/v1.44.0) (2026-03-30)

</details>