### PR TITLE
fix(pubsub/v2): check for nil concurrency control span

### DIFF
--- a/pubsub/v2/subscriber.go
+++ b/pubsub/v2/subscriber.go
@@ -423,7 +423,7 @@ func (s *Subscriber) Receive(ctx context.Context, f func(context.Context, *Messa
 						// Return nil if the context is done, not err.
 						return nil
 					}
-					if iter.enableTracing {
+					if iter.enableTracing && ccSpan != nil {
 						ccSpan.End()
 					}
 


### PR DESCRIPTION
Spans can be expired between attempting to acquire concurrency control (flow control) and after. This causes the span info to be deleted, and can cause nil panic.

Fixes #14277