### PR TITLE
chore: update version.go template

### DIFF
--- a/internal/librariangen/module/_internal_version.go.txt
+++ b/internal/librariangen/module/_internal_version.go.txt
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//      https://www.apache.org/licenses/LICENSE-2.0
+//     https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
The template in librariangen has one more space than the template in librarian.

This pull request remove this discrepancy.