### PR TITLE
chore: librarian release pull request: 20260331T201226Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1632,7 +1632,7 @@ libraries:
       - internal/generated/snippets/pubsub/
     tag_format: '{id}/v{version}'
   - id: pubsub/v2
-    version: 2.5.0
+    version: 2.5.1
     last_generated_commit: ""
     apis: []
     source_roots:

--- a/pubsub/v2/CHANGES.md
+++ b/pubsub/v2/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+## [2.5.1](https://github.com/googleapis/google-cloud-go/releases/tag/pubsub%2Fv2.5.1) (2026-03-31)
+
+### Bug Fixes
+
+* prevent nil span panic in Subscriber.Receive (#14278) ([c590c35](https://github.com/googleapis/google-cloud-go/commit/c590c350583b42d9739842e838811caef254c72e))
+
 ## [2.5.0](https://github.com/googleapis/google-cloud-go/releases/tag/pubsub%2Fv2.5.0) (2026-03-19)
 
 ### Features

--- a/pubsub/v2/internal/version.go
+++ b/pubsub/v2/internal/version.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     https://www.apache.org/licenses/LICENSE-2.0
+//      https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "2.5.0"
+const Version = "2.5.1"


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.8.3
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go@sha256:f8558b849eab319c3b9fc0b0ee8cab738b7e0b88e746275c759b38b194247a42
<details><summary>pubsub/v2: v2.5.1</summary>

## [v2.5.1](https://github.com/googleapis/google-cloud-go/compare/pubsub/v2.5.0...pubsub/v2.5.1) (2026-03-31)

### Bug Fixes

* prevent nil span panic in Subscriber.Receive (#14278) ([c590c350](https://github.com/googleapis/google-cloud-go/commit/c590c350))

</details>