### PR TITLE
chore: librarian release pull request: 20260331T201740Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1619,7 +1619,7 @@ libraries:
     remove_regex: []
     tag_format: '{id}/v{version}'
   - id: pubsub
-    version: 1.50.1
+    version: 2.0.0
     last_generated_commit: ""
     apis: []
     source_roots:

--- a/pubsub/CHANGES.md
+++ b/pubsub/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+## [2.0.0](https://github.com/googleapis/google-cloud-go/releases/tag/pubsub%2Fv2.0.0) (2026-03-31)
+
+### Bug Fixes
+
+* check for nil concurrency control span (#14303) ([4c0232a](https://github.com/googleapis/google-cloud-go/commit/4c0232a7c1197769af2d6c6a4378c02089ae2955))
+
 ## [1.50.1](https://github.com/googleapis/google-cloud-go/compare/pubsub/v1.50.0...pubsub/v1.50.1) (2025-09-04)
 
 

--- a/pubsub/internal/version.go
+++ b/pubsub/internal/version.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     https://www.apache.org/licenses/LICENSE-2.0
+//      https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "1.50.1"
+const Version = "2.0.0"


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.8.3
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go@sha256:f8558b849eab319c3b9fc0b0ee8cab738b7e0b88e746275c759b38b194247a42
<details><summary>pubsub: v2.0.0</summary>

## [v2.0.0](https://github.com/googleapis/google-cloud-go/compare/pubsub/v1.50.1...pubsub/v2.0.0) (2026-03-31)

### Bug Fixes

* check for nil concurrency control span (#14303) ([4c0232a7](https://github.com/googleapis/google-cloud-go/commit/4c0232a7))

</details>