### PR TITLE
fix(pubsub/v2): skip stream keep-alive when using binary emulator

### DIFF
--- a/pubsub/v2/iterator.go
+++ b/pubsub/v2/iterator.go
@@ -164,7 +164,6 @@ func newMessageIterator(subc *vkit.SubscriptionAdminClient, subName string, po *
 	ackTicker := time.NewTicker(ackInterval)
 	nackTicker := time.NewTicker(nackInterval)
 	receiptTicker := time.NewTicker(receiptInterval)
-	
 	pingTicker := time.NewTicker(clientPingInterval)
 	serverMonitorTicker := time.NewTicker(serverMonitorInterval)
 

--- a/pubsub/v2/iterator.go
+++ b/pubsub/v2/iterator.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"io"
 	"log"
+	"os"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -163,7 +164,7 @@ func newMessageIterator(subc *vkit.SubscriptionAdminClient, subName string, po *
 	ackTicker := time.NewTicker(ackInterval)
 	nackTicker := time.NewTicker(nackInterval)
 	receiptTicker := time.NewTicker(receiptInterval)
-
+	
 	pingTicker := time.NewTicker(clientPingInterval)
 	serverMonitorTicker := time.NewTicker(serverMonitorInterval)
 
@@ -200,7 +201,11 @@ func newMessageIterator(subc *vkit.SubscriptionAdminClient, subName string, po *
 		serverTimeout:       serverPingTimeoutDuration,
 	}
 	it.wg.Add(1)
-	go it.streamKeepAliveHandler()
+	// skip dead-stream detection when using the binary PubSub emulator, which does
+	// not respond to keep-alive pings and would cause repeated false stream teardowns.
+	if os.Getenv("PUBSUB_EMULATOR_HOST") == "" {
+		go it.streamKeepAliveHandler()
+	}
 	go it.sender()
 	return it
 }

--- a/pubsub/v2/iterator.go
+++ b/pubsub/v2/iterator.go
@@ -200,12 +200,12 @@ func newMessageIterator(subc *vkit.SubscriptionAdminClient, subName string, po *
 		lastClientPing:      time.UnixMicro(0),
 		serverTimeout:       serverPingTimeoutDuration,
 	}
-	it.wg.Add(1)
 	// skip dead-stream detection when using the binary PubSub emulator, which does
 	// not respond to keep-alive pings and would cause repeated false stream teardowns.
 	if os.Getenv("PUBSUB_EMULATOR_HOST") == "" {
 		go it.streamKeepAliveHandler()
 	}
+	it.wg.Add(1)
 	go it.sender()
 	return it
 }

--- a/pubsub/v2/iterator_test.go
+++ b/pubsub/v2/iterator_test.go
@@ -856,3 +856,59 @@ func TestStreamingPullKeepAlive_ReopenStream(t *testing.T) {
 		t.Fatalf("expected at least 2 streams opened, got %v", streamsOpened)
 	}
 }
+
+// TestStreamingPullKeepAlive_Disabled verifies that when PUBSUB_EMULATOR_HOST is set,
+// the stream is not torn down even if the server does not respond to pings.
+func TestStreamingPullKeepAlive_Disabled(t *testing.T) {
+	// save old variables
+	oldClient := clientPingInterval
+	oldServerPing := serverPingTimeoutDuration
+	oldServerMonitor := serverMonitorInterval
+	oldProtocol := protocolVersion
+
+	// aggressive intervals so the handler would tear down the stream quickly if active
+	clientPingInterval = 1 * time.Second
+	serverPingTimeoutDuration = 0 * time.Second
+	serverMonitorInterval = 1 * time.Second
+
+	// make the fake server not respond to pings, simulating the binary emulator
+	protocolVersion = 0
+
+	t.Cleanup(func() {
+		clientPingInterval = oldClient
+		serverPingTimeoutDuration = oldServerPing
+		serverMonitorInterval = oldServerMonitor
+		protocolVersion = oldProtocol
+	})
+
+	t.Setenv("PUBSUB_EMULATOR_HOST", "localhost:9999")
+
+	c, srv := newFake(t)
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	srv.Publish(fullyQualifiedTopicName, []byte("creating a topic"), nil)
+	_, err := c.SubscriptionAdminClient.CreateSubscription(ctx, &pb.Subscription{
+		Name:  fullyQualifiedSubName,
+		Topic: fullyQualifiedTopicName,
+	})
+	if err != nil {
+		t.Fatalf("failed to create subscription: %v", err)
+	}
+
+	iter := newMessageIterator(c.SubscriptionAdminClient, fullyQualifiedSubName, &pullOptions{})
+	defer iter.stop()
+
+	go func() {
+		iter.receive()
+	}()
+
+	// long enough for the handler to have fired multiple times if it were active
+	time.Sleep(3 * time.Second)
+	iter.stop()
+
+	streamsOpened := iter.ps.openCount.Load()
+	if streamsOpened != 1 {
+		t.Fatalf("expected exactly 1 stream opened (no reconnects), got %v", streamsOpened)
+	}
+}


### PR DESCRIPTION
## Problem

Fixes #14358

`pubsub/v2` v2.5.0 introduced dead-stream detection (`streamKeepAliveHandler`) that sends periodic keep-alive pings and tears down the stream if the server doesn't respond. The binary PubSub emulator (`gcloud beta emulators pubsub start`) silently discards these pings, causing repeated false stream teardowns and 15–45s message delivery delays.

## Solution

Skip `streamKeepAliveHandler` when `PUBSUB_EMULATOR_HOST` is set — the same env var already used to configure insecure credentials for the emulator. Tickers are still created unconditionally to avoid nil-guard changes throughout the codebase; they simply tick into the void.

## Changes

- `iterator.go`: gate `go it.streamKeepAliveHandler()` behind `os.Getenv("PUBSUB_EMULATOR_HOST") == ""`
- `iterator_test.go`: add `TestStreamingPullKeepAlive_Disabled` — mirrors the existing reconnect test with aggressive intervals and `protocolVersion=0`, but asserts `openCount == 1` (no reconnects) when the env var is set