### PR TITLE
chore: fill release_exclude_paths

### DIFF
--- a/.github/workflows/generation_check.yaml
+++ b/.github/workflows/generation_check.yaml
@@ -6,7 +6,6 @@ on:
     - cron: '0 4 * * *'
   # Allows manual triggering for debugging purpose.
   workflow_dispatch:
-  pull_request:
 permissions:
   contents: read
   issues: write


### PR DESCRIPTION
Fill `release_exclude_paths` with `internal/generated/snippets/{ID}` for a pure generated library if this value is missing in state.yaml.