### PR TITLE
chore: librarian release pull request: 20260406T214019Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -325,7 +325,7 @@ libraries:
     remove_regex: []
     tag_format: '{id}/v{version}'
   - id: auth
-    version: 0.19.0
+    version: 0.20.0
     last_generated_commit: ""
     apis: []
     source_roots:
@@ -430,7 +430,9 @@ libraries:
     last_generated_commit: ""
     apis:
       - path: google/cloud/biglake/v1
+        service_config: ""
       - path: google/cloud/biglake/hive/v1beta
+        service_config: ""
     source_roots:
       - biglake
     preserve_regex: []
@@ -885,6 +887,7 @@ libraries:
       - path: google/cloud/datacatalog/v1beta1
         service_config: datacatalog_v1beta1.yaml
       - path: google/cloud/datacatalog/lineage/configmanagement/v1
+        service_config: ""
     source_roots:
       - datacatalog
       - internal/generated/snippets/datacatalog
@@ -1677,6 +1680,7 @@ libraries:
       - path: google/maps/solar/v1
         service_config: solar_v1.yaml
       - path: google/maps/geocode/v4
+        service_config: ""
     source_roots:
       - maps
       - internal/generated/snippets/maps

--- a/auth/CHANGES.md
+++ b/auth/CHANGES.md
@@ -1,5 +1,7 @@
 # Changes
 
+## [0.20.0](https://github.com/googleapis/google-cloud-go/releases/tag/auth%2Fv0.20.0) (2026-04-06)
+
 ## [0.19.0](https://github.com/googleapis/google-cloud-go/releases/tag/auth%2Fv0.19.0) (2026-03-23)
 
 ### Features

--- a/auth/internal/version.go
+++ b/auth/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "0.19.0"
+const Version = "0.20.0"

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -163,7 +163,7 @@ libraries:
     apis:
       - path: google/cloud/auditmanager/v1
   - name: auth
-    version: 0.19.0
+    version: 0.20.0
     keep:
       - README.md
       - internal/version.go


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.9.1
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go@sha256:fc7fb9c27d224fab3aea2f95282b5d396c06554ac71a692a9b1a31cc97a8c91f
<details><summary>auth: v0.20.0</summary>

## [v0.20.0](https://github.com/googleapis/google-cloud-go/compare/auth/v0.19.0...auth/v0.20.0) (2026-04-06)

</details>