### PR TITLE
chore: update librarian-go image

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,4 +1,4 @@
-image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go@sha256:fc7fb9c27d224fab3aea2f95282b5d396c06554ac71a692a9b1a31cc97a8c91f
+image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go@sha256:b04b076f5eedbb5546bd6fc1404969dd3698c8b19c0f34ae815a84ae735a606a
 libraries:
   - id: accessapproval
     version: 1.9.0


### PR DESCRIPTION
Update librarian-go image, this one removes configure, generate and build functions.