### PR TITLE
chore: update to librarian v0.10.0

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 language: go
-version: v0.9.2-0.20260406151210-ffc16075d341
+version: v0.10.0
 repo: googleapis/google-cloud-go
 sources:
   googleapis:


### PR DESCRIPTION
Updates the `librarian.yaml` to the latest tag of `librarian` - [v0.10.0](https://github.com/googleapis/librarian/releases/tag/v0.10.0).