### PR TITLE
fix(datastore): enable gRPC keepalives and expand retries 

### DIFF
--- a/datastore/client.go
+++ b/datastore/client.go
@@ -18,18 +18,13 @@ import (
 	"context"
 	"fmt"
 	"net/url"
-	"time"
 
 	pb "cloud.google.com/go/datastore/apiv1/datastorepb"
 	"cloud.google.com/go/datastore/internal"
-	cloudinternal "cloud.google.com/go/internal"
 	"cloud.google.com/go/internal/trace"
 	"cloud.google.com/go/internal/version"
-	gax "github.com/googleapis/gax-go/v2"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
-	"google.golang.org/grpc/status"
 )
 
 // datastoreClient is a wrapper for the pb.DatastoreClient that includes gRPC
@@ -64,7 +59,7 @@ func (dc *datastoreClient) Lookup(ctx context.Context, in *pb.LookupRequest, opt
 	ctx = trace.StartSpan(ctx, "cloud.google.com/go/datastore.datastoreClient.Lookup")
 	defer func() { trace.EndSpan(ctx, err) }()
 
-	err = dc.invoke(ctx, true, func(ctx context.Context) error {
+	err = dc.invoke(ctx, func(ctx context.Context) error {
 		res, err = dc.c.Lookup(ctx, in, opts...)
 		return err
 	})
@@ -75,7 +70,7 @@ func (dc *datastoreClient) RunQuery(ctx context.Context, in *pb.RunQueryRequest,
 	ctx = trace.StartSpan(ctx, "cloud.google.com/go/datastore.datastoreClient.RunQuery")
 	defer func() { trace.EndSpan(ctx, err) }()
 
-	err = dc.invoke(ctx, true, func(ctx context.Context) error {
+	err = dc.invoke(ctx, func(ctx context.Context) error {
 		res, err = dc.c.RunQuery(ctx, in, opts...)
 		return err
 	})
@@ -86,7 +81,7 @@ func (dc *datastoreClient) RunAggregationQuery(ctx context.Context, in *pb.RunAg
 	ctx = trace.StartSpan(ctx, "cloud.google.com/go/datastore.datastoreClient.RunAggregationQuery")
 	defer func() { trace.EndSpan(ctx, err) }()
 
-	err = dc.invoke(ctx, true, func(ctx context.Context) error {
+	err = dc.invoke(ctx, func(ctx context.Context) error {
 		res, err = dc.c.RunAggregationQuery(ctx, in, opts...)
 		return err
 	})
@@ -97,7 +92,7 @@ func (dc *datastoreClient) BeginTransaction(ctx context.Context, in *pb.BeginTra
 	ctx = trace.StartSpan(ctx, "cloud.google.com/go/datastore.datastoreClient.BeginTransaction")
 	defer func() { trace.EndSpan(ctx, err) }()
 
-	err = dc.invoke(ctx, false, func(ctx context.Context) error {
+	err = dc.invoke(ctx, func(ctx context.Context) error {
 		res, err = dc.c.BeginTransaction(ctx, in, opts...)
 		return err
 	})
@@ -108,7 +103,7 @@ func (dc *datastoreClient) Commit(ctx context.Context, in *pb.CommitRequest, opt
 	ctx = trace.StartSpan(ctx, "cloud.google.com/go/datastore.datastoreClient.Commit")
 	defer func() { trace.EndSpan(ctx, err) }()
 
-	err = dc.invoke(ctx, false, func(ctx context.Context) error {
+	err = dc.invoke(ctx, func(ctx context.Context) error {
 		res, err = dc.c.Commit(ctx, in, opts...)
 		return err
 	})
@@ -119,7 +114,7 @@ func (dc *datastoreClient) Rollback(ctx context.Context, in *pb.RollbackRequest,
 	ctx = trace.StartSpan(ctx, "cloud.google.com/go/datastore.datastoreClient.Rollback")
 	defer func() { trace.EndSpan(ctx, err) }()
 
-	err = dc.invoke(ctx, true, func(ctx context.Context) error {
+	err = dc.invoke(ctx, func(ctx context.Context) error {
 		res, err = dc.c.Rollback(ctx, in, opts...)
 		return err
 	})
@@ -130,7 +125,7 @@ func (dc *datastoreClient) AllocateIds(ctx context.Context, in *pb.AllocateIdsRe
 	ctx = trace.StartSpan(ctx, "cloud.google.com/go/datastore.datastoreClient.AllocateIds")
 	defer func() { trace.EndSpan(ctx, err) }()
 
-	err = dc.invoke(ctx, false, func(ctx context.Context) error {
+	err = dc.invoke(ctx, func(ctx context.Context) error {
 		res, err = dc.c.AllocateIds(ctx, in, opts...)
 		return err
 	})
@@ -141,35 +136,14 @@ func (dc *datastoreClient) ReserveIds(ctx context.Context, in *pb.ReserveIdsRequ
 	ctx = trace.StartSpan(ctx, "cloud.google.com/go/datastore.datastoreClient.ReserveIds")
 	defer func() { trace.EndSpan(ctx, err) }()
 
-	err = dc.invoke(ctx, true, func(ctx context.Context) error {
+	err = dc.invoke(ctx, func(ctx context.Context) error {
 		res, err = dc.c.ReserveIds(ctx, in, opts...)
 		return err
 	})
 	return res, err
 }
 
-func (dc *datastoreClient) invoke(ctx context.Context, isIdempotent bool, f func(ctx context.Context) error) error {
+func (dc *datastoreClient) invoke(ctx context.Context, f func(ctx context.Context) error) error {
 	ctx = metadata.NewOutgoingContext(ctx, dc.md)
-	return cloudinternal.Retry(ctx, gax.Backoff{Initial: 100 * time.Millisecond}, func() (stop bool, err error) {
-		err = f(ctx)
-		return !shouldRetry(err, isIdempotent), err
-	})
-}
-
-func shouldRetry(err error, isIdempotent bool) bool {
-	if err == nil {
-		return false
-	}
-	s, ok := status.FromError(err)
-	if !ok {
-		return false
-	}
-	code := s.Code()
-	if code == codes.Unavailable {
-		return true
-	}
-	if isIdempotent && (code == codes.DeadlineExceeded || code == codes.Internal || code == codes.ResourceExhausted) {
-		return true
-	}
-	return false
+	return f(ctx)
 }

--- a/datastore/client.go
+++ b/datastore/client.go
@@ -97,7 +97,7 @@ func (dc *datastoreClient) BeginTransaction(ctx context.Context, in *pb.BeginTra
 	ctx = trace.StartSpan(ctx, "cloud.google.com/go/datastore.datastoreClient.BeginTransaction")
 	defer func() { trace.EndSpan(ctx, err) }()
 
-	err = dc.invoke(ctx, true, func(ctx context.Context) error {
+	err = dc.invoke(ctx, false, func(ctx context.Context) error {
 		res, err = dc.c.BeginTransaction(ctx, in, opts...)
 		return err
 	})

--- a/datastore/client.go
+++ b/datastore/client.go
@@ -64,7 +64,7 @@ func (dc *datastoreClient) Lookup(ctx context.Context, in *pb.LookupRequest, opt
 	ctx = trace.StartSpan(ctx, "cloud.google.com/go/datastore.datastoreClient.Lookup")
 	defer func() { trace.EndSpan(ctx, err) }()
 
-	err = dc.invoke(ctx, func(ctx context.Context) error {
+	err = dc.invoke(ctx, true, func(ctx context.Context) error {
 		res, err = dc.c.Lookup(ctx, in, opts...)
 		return err
 	})
@@ -75,7 +75,7 @@ func (dc *datastoreClient) RunQuery(ctx context.Context, in *pb.RunQueryRequest,
 	ctx = trace.StartSpan(ctx, "cloud.google.com/go/datastore.datastoreClient.RunQuery")
 	defer func() { trace.EndSpan(ctx, err) }()
 
-	err = dc.invoke(ctx, func(ctx context.Context) error {
+	err = dc.invoke(ctx, true, func(ctx context.Context) error {
 		res, err = dc.c.RunQuery(ctx, in, opts...)
 		return err
 	})
@@ -86,7 +86,7 @@ func (dc *datastoreClient) RunAggregationQuery(ctx context.Context, in *pb.RunAg
 	ctx = trace.StartSpan(ctx, "cloud.google.com/go/datastore.datastoreClient.RunAggregationQuery")
 	defer func() { trace.EndSpan(ctx, err) }()
 
-	err = dc.invoke(ctx, func(ctx context.Context) error {
+	err = dc.invoke(ctx, true, func(ctx context.Context) error {
 		res, err = dc.c.RunAggregationQuery(ctx, in, opts...)
 		return err
 	})
@@ -97,7 +97,7 @@ func (dc *datastoreClient) BeginTransaction(ctx context.Context, in *pb.BeginTra
 	ctx = trace.StartSpan(ctx, "cloud.google.com/go/datastore.datastoreClient.BeginTransaction")
 	defer func() { trace.EndSpan(ctx, err) }()
 
-	err = dc.invoke(ctx, func(ctx context.Context) error {
+	err = dc.invoke(ctx, true, func(ctx context.Context) error {
 		res, err = dc.c.BeginTransaction(ctx, in, opts...)
 		return err
 	})
@@ -108,7 +108,7 @@ func (dc *datastoreClient) Commit(ctx context.Context, in *pb.CommitRequest, opt
 	ctx = trace.StartSpan(ctx, "cloud.google.com/go/datastore.datastoreClient.Commit")
 	defer func() { trace.EndSpan(ctx, err) }()
 
-	err = dc.invoke(ctx, func(ctx context.Context) error {
+	err = dc.invoke(ctx, false, func(ctx context.Context) error {
 		res, err = dc.c.Commit(ctx, in, opts...)
 		return err
 	})
@@ -119,7 +119,7 @@ func (dc *datastoreClient) Rollback(ctx context.Context, in *pb.RollbackRequest,
 	ctx = trace.StartSpan(ctx, "cloud.google.com/go/datastore.datastoreClient.Rollback")
 	defer func() { trace.EndSpan(ctx, err) }()
 
-	err = dc.invoke(ctx, func(ctx context.Context) error {
+	err = dc.invoke(ctx, true, func(ctx context.Context) error {
 		res, err = dc.c.Rollback(ctx, in, opts...)
 		return err
 	})
@@ -130,7 +130,7 @@ func (dc *datastoreClient) AllocateIds(ctx context.Context, in *pb.AllocateIdsRe
 	ctx = trace.StartSpan(ctx, "cloud.google.com/go/datastore.datastoreClient.AllocateIds")
 	defer func() { trace.EndSpan(ctx, err) }()
 
-	err = dc.invoke(ctx, func(ctx context.Context) error {
+	err = dc.invoke(ctx, false, func(ctx context.Context) error {
 		res, err = dc.c.AllocateIds(ctx, in, opts...)
 		return err
 	})
@@ -141,22 +141,22 @@ func (dc *datastoreClient) ReserveIds(ctx context.Context, in *pb.ReserveIdsRequ
 	ctx = trace.StartSpan(ctx, "cloud.google.com/go/datastore.datastoreClient.ReserveIds")
 	defer func() { trace.EndSpan(ctx, err) }()
 
-	err = dc.invoke(ctx, func(ctx context.Context) error {
+	err = dc.invoke(ctx, true, func(ctx context.Context) error {
 		res, err = dc.c.ReserveIds(ctx, in, opts...)
 		return err
 	})
 	return res, err
 }
 
-func (dc *datastoreClient) invoke(ctx context.Context, f func(ctx context.Context) error) error {
+func (dc *datastoreClient) invoke(ctx context.Context, isIdempotent bool, f func(ctx context.Context) error) error {
 	ctx = metadata.NewOutgoingContext(ctx, dc.md)
 	return cloudinternal.Retry(ctx, gax.Backoff{Initial: 100 * time.Millisecond}, func() (stop bool, err error) {
 		err = f(ctx)
-		return !shouldRetry(err), err
+		return !shouldRetry(err, isIdempotent), err
 	})
 }
 
-func shouldRetry(err error) bool {
+func shouldRetry(err error, isIdempotent bool) bool {
 	if err == nil {
 		return false
 	}
@@ -164,8 +164,12 @@ func shouldRetry(err error) bool {
 	if !ok {
 		return false
 	}
-	// Only retry on UNAVAILABLE as per https://aip.dev/194. Other errors from
-	// https://cloud.google.com/datastore/docs/concepts/errors may be retried
-	// by the user if desired, but are not retried by the clientg.
-	return s.Code() == codes.Unavailable
+	code := s.Code()
+	if code == codes.Unavailable {
+		return true
+	}
+	if isIdempotent && (code == codes.DeadlineExceeded || code == codes.Internal || code == codes.ResourceExhausted) {
+		return true
+	}
+	return false
 }

--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -43,6 +43,27 @@ const (
 	userAgent            = "gcloud-golang-datastore/20160401"
 )
 
+// retryPolicy is based on https://github.com/googleapis/googleapis/blob/master/google/datastore/v1/datastore_grpc_service_config.json
+// but updated to include INTERNAL and RESOURCE_EXHAUSTED for the data plane.
+const retryPolicy = `{
+  "methodConfig": [{
+    "name": [
+      {"service": "google.datastore.v1.Datastore", "method": "Lookup"},
+      {"service": "google.datastore.v1.Datastore", "method": "RunQuery"},
+      {"service": "google.datastore.v1.Datastore", "method": "RunAggregationQuery"},
+      {"service": "google.datastore.v1.Datastore", "method": "ReserveIds"}
+    ],
+    "timeout": "60s",
+    "retryPolicy": {
+      "maxAttempts": 5,
+      "initialBackoff": "0.100s",
+      "maxBackoff": "60s",
+      "backoffMultiplier": 1.3,
+      "retryableStatusCodes": ["UNAVAILABLE", "DEADLINE_EXCEEDED", "INTERNAL", "RESOURCE_EXHAUSTED"]
+    }
+  }]
+}`
+
 // ScopeDatastore grants permissions to view and/or manage datastore entities
 const ScopeDatastore = "https://www.googleapis.com/auth/datastore"
 
@@ -129,6 +150,9 @@ func NewClientWithDatabase(ctx context.Context, projectID, databaseID string, op
 			internaloption.EnableNewAuthLibrary(),
 			option.WithScopes(ScopeDatastore),
 			option.WithUserAgent(userAgent),
+			// Add the Service Config for retries
+			option.WithGRPCDialOption(grpc.WithDefaultServiceConfig(retryPolicy)),
+			// Add Keepalives to prune zombie connections
 			option.WithGRPCDialOption(grpc.WithKeepaliveParams(keepalive.ClientParameters{
 				Time:                1 * time.Minute,
 				Timeout:             20 * time.Second,

--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -32,6 +32,7 @@ import (
 	gtransport "google.golang.org/api/transport/grpc"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/keepalive"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -128,6 +129,11 @@ func NewClientWithDatabase(ctx context.Context, projectID, databaseID string, op
 			internaloption.EnableNewAuthLibrary(),
 			option.WithScopes(ScopeDatastore),
 			option.WithUserAgent(userAgent),
+			option.WithGRPCDialOption(grpc.WithKeepaliveParams(keepalive.ClientParameters{
+				Time:                1 * time.Minute,
+				Timeout:             20 * time.Second,
+				PermitWithoutStream: true,
+			})),
 		}
 	}
 	// Warn if we see the legacy emulator environment variables.


### PR DESCRIPTION
This change improves the library's resilience to abrupt connection losses, such as those caused by Cloud Front End (CFE) host failures or kernel panics. These events can currently lead to extended application hangs (e.g., the 6-minute outage observed in [b/473841984](https://b.corp.google.com/issues/473841984)) because the library lacks proactive health checks and does not retry on certain transient errors