### PR TITLE
fix(firestore): fixes for Query to Pipeline Conversion

### DIFF
--- a/firestore/query.go
+++ b/firestore/query.go
@@ -1823,11 +1823,19 @@ type AggregationResponse struct {
 }
 
 func (q *Query) toPipeline() *Pipeline {
+	// Create a copy of the query to avoid modifying the original.
+	qCopy := *q
+	q = &qCopy
+
 	var p *Pipeline
 	if q.allDescendants {
 		p = q.c.Pipeline().CollectionGroup(q.collectionID)
 	} else {
-		p = q.c.Pipeline().Collection(q.collectionID)
+		// q.path is the full resource path: projects/P/databases/D/documents/C1/D1/C2...
+		// We need the relative path starting from after "/documents/".
+		prefix := q.c.path() + "/documents/"
+		relPath := strings.TrimPrefix(q.path, prefix)
+		p = q.c.Pipeline().Collection(relPath)
 	}
 
 	if q.err != nil {
@@ -1835,75 +1843,31 @@ func (q *Query) toPipeline() *Pipeline {
 		return p
 	}
 
-	var allFilters []BooleanExpression
-
 	// Original filters
 	for _, f := range q.filters {
-		var filterExpr BooleanExpression
-		var err error
-		if fieldFilter := f.GetFieldFilter(); fieldFilter != nil {
-			filterExpr, err = newQueryFilter(q, fieldFilter)
-			if err != nil {
-				p.err = err
-				return p
-			}
-		} else if unaryFilter := f.GetUnaryFilter(); unaryFilter != nil {
-			filterExpr, err = newQueryUnaryFilter(unaryFilter)
-			if err != nil {
-				p.err = err
-				return p
-			}
-		}
-		allFilters = append(allFilters, filterExpr)
-	}
-
-	// Start at
-	if q.startCursorSpecified() {
-		var startFilter BooleanExpression
-		var err error
-		if q.startDoc != nil {
-			startFilter, err = newCursorFilter(q.orders, q.startDoc, q.startBefore, true)
-		} else {
-			startFilter, err = newCursorFilterWithValues(q.orders, q.startVals, q.startBefore, true)
-		}
+		filterExpr, err := filterToExpression(q, f)
 		if err != nil {
 			p.err = err
 			return p
 		}
-		allFilters = append(allFilters, startFilter)
+		if filterExpr != nil {
+			p = p.Where(filterExpr)
+		}
 	}
 
-	// End at
-	if q.endCursorSpecified() {
-		var endFilter BooleanExpression
-		var err error
-		if q.endDoc != nil {
-			endFilter, err = newCursorFilter(q.orders, q.endDoc, q.endBefore, false)
-		} else {
-			endFilter, err = newCursorFilterWithValues(q.orders, q.endVals, q.endBefore, false)
+	// Existence filters for explicitly ordered fields (to match Query semantics)
+	for _, o := range q.orders {
+		if !o.isDocumentID() {
+			p = p.Where(FieldOf(o.fieldPath).FieldExists())
 		}
-		if err != nil {
-			p.err = err
-			return p
-		}
-		allFilters = append(allFilters, endFilter)
 	}
 
-	// Order by
+	// Prepare orders for Sort stage and cursors.
+	// We use adjustOrders() to get the tie-breaker.
+	adjustedOrders := q.adjustOrders()
 	var orders []Ordering
-	for _, o := range q.adjustOrders() {
-		var fp FieldPath
-		if o.fieldReference != nil {
-			var err error
-			fp, err = fieldPathFromFieldRef(o.fieldReference)
-			if err != nil {
-				p.err = err
-				return p
-			}
-		} else {
-			fp = o.fieldPath
-		}
-		field := FieldOf(fp)
+	for _, o := range adjustedOrders {
+		field := FieldOf(o.fieldPath)
 		var direction OrderingDirection
 		if o.dir == Asc {
 			direction = OrderingAsc
@@ -1912,22 +1876,62 @@ func (q *Query) toPipeline() *Pipeline {
 		}
 		orders = append(orders, Ordering{Expr: field, Direction: direction})
 	}
-	p = p.Sort(orders)
-	// Combine all filters
-	if len(allFilters) == 1 {
-		p = p.Where(allFilters[0])
-	} else if len(allFilters) > 1 {
-		p = p.Where(And(allFilters[0], allFilters[1:]...))
+
+	// Start at
+	if q.startCursorSpecified() {
+		var startFilter BooleanExpression
+		var err error
+		if q.startDoc != nil {
+			startFilter, err = newCursorFilter(q, adjustedOrders, q.startDoc, q.startBefore, true)
+		} else {
+			startFilter, err = newCursorFilterWithValues(q, adjustedOrders, q.startVals, q.startBefore, true)
+		}
+		if err != nil {
+			p.err = err
+			return p
+		}
+		p = p.Where(startFilter)
+	}
+
+	// End at
+	if q.endCursorSpecified() {
+		var endFilter BooleanExpression
+		var err error
+		if q.endDoc != nil {
+			endFilter, err = newCursorFilter(q, adjustedOrders, q.endDoc, q.endBefore, false)
+		} else {
+			endFilter, err = newCursorFilterWithValues(q, adjustedOrders, q.endVals, q.endBefore, false)
+		}
+		if err != nil {
+			p.err = err
+			return p
+		}
+		p = p.Where(endFilter)
+	}
+
+	// Limit and Sort
+	if q.limit != nil {
+		if !q.limitToLast {
+			p = p.Sort(orders).Limit(int(q.limit.Value))
+		} else {
+			// LimitToLast behavior: Sort reversed, Limit, then Sort original.
+			var reversedOrders []Ordering
+			for _, o := range orders {
+				dir := OrderingAsc
+				if o.Direction == OrderingAsc {
+					dir = OrderingDesc
+				}
+				reversedOrders = append(reversedOrders, Ordering{Expr: o.Expr, Direction: dir})
+			}
+			p = p.Sort(reversedOrders).Limit(int(q.limit.Value)).Sort(orders)
+		}
+	} else {
+		p = p.Sort(orders)
 	}
 
 	// Offset
 	if q.offset > 0 {
 		p = p.Offset(int(q.offset))
-	}
-
-	// Limit
-	if q.limit != nil {
-		p = p.Limit(int(q.limit.Value))
 	}
 
 	// Select
@@ -1948,16 +1952,6 @@ func (q *Query) toPipeline() *Pipeline {
 
 	// FindNearest
 	if q.findNearest != nil {
-		var measure PipelineDistanceMeasure
-		switch q.findNearest.DistanceMeasure {
-		case pb.StructuredQuery_FindNearest_EUCLIDEAN:
-			measure = PipelineDistanceMeasureEuclidean
-		case pb.StructuredQuery_FindNearest_COSINE:
-			measure = PipelineDistanceMeasureCosine
-		case pb.StructuredQuery_FindNearest_DOT_PRODUCT:
-			measure = PipelineDistanceMeasureDotProduct
-		}
-
 		vectorField, err := fieldPathFromFieldRef(q.findNearest.VectorField)
 		if err != nil {
 			p.err = err
@@ -1969,6 +1963,20 @@ func (q *Query) toPipeline() *Pipeline {
 			p.err = err
 			return p
 		}
+
+		var measure PipelineDistanceMeasure
+		switch q.findNearest.DistanceMeasure {
+		case pb.StructuredQuery_FindNearest_EUCLIDEAN:
+			measure = PipelineDistanceMeasureEuclidean
+		case pb.StructuredQuery_FindNearest_COSINE:
+			measure = PipelineDistanceMeasureCosine
+		case pb.StructuredQuery_FindNearest_DOT_PRODUCT:
+			measure = PipelineDistanceMeasureDotProduct
+		default:
+			p.err = fmt.Errorf("firestore: unknown distance measure: %v", q.findNearest.DistanceMeasure)
+			return p
+		}
+
 		var opts []FindNearestOption
 		if q.findNearest.Limit != nil {
 			val := int(q.findNearest.Limit.Value)
@@ -1987,6 +1995,46 @@ func (q *Query) toPipeline() *Pipeline {
 
 func fieldPathFromFieldRef(ref *pb.StructuredQuery_FieldReference) (FieldPath, error) {
 	return parseDotSeparatedString(ref.FieldPath)
+}
+
+func filterToExpression(q *Query, f *pb.StructuredQuery_Filter) (BooleanExpression, error) {
+	if ff := f.GetFieldFilter(); ff != nil {
+		return newQueryFilter(q, ff)
+	}
+	if uf := f.GetUnaryFilter(); uf != nil {
+		return newQueryUnaryFilter(uf)
+	}
+	if cf := f.GetCompositeFilter(); cf != nil {
+		var exprs []BooleanExpression
+		for _, sub := range cf.Filters {
+			e, err := filterToExpression(q, sub)
+			if err != nil {
+				return nil, err
+			}
+			if e != nil {
+				exprs = append(exprs, e)
+			}
+		}
+		if cf.Op == pb.StructuredQuery_CompositeFilter_AND {
+			if len(exprs) == 0 {
+				return nil, nil
+			}
+			if len(exprs) == 1 {
+				return exprs[0], nil
+			}
+			return And(exprs[0], exprs[1:]...), nil
+		}
+		if cf.Op == pb.StructuredQuery_CompositeFilter_OR {
+			if len(exprs) == 0 {
+				return nil, nil
+			}
+			if len(exprs) == 1 {
+				return exprs[0], nil
+			}
+			return Or(exprs[0], exprs[1:]...), nil
+		}
+	}
+	return nil, fmt.Errorf("firestore: unknown filter type: %v", f)
 }
 
 func newQueryFilter(q *Query, f *pb.StructuredQuery_FieldFilter) (BooleanExpression, error) {
@@ -2045,12 +2093,12 @@ func newQueryUnaryFilter(f *pb.StructuredQuery_UnaryFilter) (BooleanExpression, 
 }
 
 // newCursorFilter creates a pipeline filter expression from a document snapshot cursor.
-func newCursorFilter(orders []order, doc *DocumentSnapshot, before, isStart bool) (BooleanExpression, error) {
+func newCursorFilter(q *Query, orders []order, doc *DocumentSnapshot, before, isStart bool) (BooleanExpression, error) {
 	values := make([]interface{}, len(orders))
 	for i, o := range orders {
 		var err error
 		if o.isDocumentID() {
-			values[i] = doc.Ref.ID
+			values[i] = doc.Ref
 		} else {
 			values[i], err = doc.DataAt(o.fieldPath.toServiceFieldPath())
 			if err != nil {
@@ -2058,17 +2106,17 @@ func newCursorFilter(orders []order, doc *DocumentSnapshot, before, isStart bool
 			}
 		}
 	}
-	return newCursorFilterWithValues(orders, values, before, isStart)
+	return newCursorFilterWithValues(q, orders, values, before, isStart)
 }
 
 // newCursorFilterWithValues creates a pipeline filter expression from a list of values.
-func newCursorFilterWithValues(orders []order, values []interface{}, before, isStart bool) (BooleanExpression, error) {
-	if len(orders) != len(values) {
-		return nil, errors.New("firestore: number of cursor values does not match number of OrderBy fields")
+func newCursorFilterWithValues(q *Query, orders []order, values []interface{}, before, isStart bool) (BooleanExpression, error) {
+	if len(values) > len(orders) {
+		return nil, errors.New("firestore: too many cursor values for OrderBy fields")
 	}
 
 	var orTerms []BooleanExpression
-	for i := 1; i <= len(orders); i++ {
+	for i := 1; i <= len(values); i++ {
 		prefixOrders := orders[:i]
 		prefixValues := values[:i]
 		var andTerms []BooleanExpression
@@ -2076,36 +2124,63 @@ func newCursorFilterWithValues(orders []order, values []interface{}, before, isS
 			fp := o.fieldPath
 			val := prefixValues[j]
 
+			if o.isDocumentID() {
+				if s, ok := val.(string); ok {
+					prefix := q.c.path() + "/documents/"
+					relPath := strings.TrimPrefix(q.path, prefix)
+					val = q.c.Doc(relPath + "/" + s)
+				}
+			}
+
 			var op string
 			if j < len(prefixOrders)-1 {
 				op = "=="
 			} else {
-				if isStart {
-					if before { // StartAt
-						if o.dir == Asc {
-							op = ">="
-						} else {
-							op = "<="
-						}
-					} else { // StartAfter
+				// For the last element of this prefix term.
+				if i < len(values) {
+					// Intermediate terms are always exclusive.
+					if isStart {
 						if o.dir == Asc {
 							op = ">"
 						} else {
 							op = "<"
+						}
+					} else { // End
+						if o.dir == Asc {
+							op = "<"
+						} else {
+							op = ">"
 						}
 					}
-				} else { // End
-					if before { // EndBefore
-						if o.dir == Asc {
-							op = "<"
-						} else {
-							op = ">"
+				} else {
+					// The very last term uses the cursor's inclusive/exclusive setting.
+					if isStart {
+						if before { // StartAt
+							if o.dir == Asc {
+								op = ">="
+							} else {
+								op = "<="
+							}
+						} else { // StartAfter
+							if o.dir == Asc {
+								op = ">"
+							} else {
+								op = "<"
+							}
 						}
-					} else { // EndAt
-						if o.dir == Asc {
-							op = "<="
-						} else {
-							op = ">="
+					} else { // End
+						if before { // EndBefore
+							if o.dir == Asc {
+								op = "<"
+							} else {
+								op = ">"
+							}
+						} else { // EndAt
+							if o.dir == Asc {
+								op = "<="
+							} else {
+								op = ">="
+							}
 						}
 					}
 				}
@@ -2131,6 +2206,9 @@ func newCursorFilterWithValues(orders []order, values []interface{}, before, isS
 		}
 	}
 
+	if len(orTerms) == 0 {
+		return nil, nil
+	}
 	if len(orTerms) == 1 {
 		return orTerms[0], nil
 	}

--- a/firestore/query_to_pipeline_test.go
+++ b/firestore/query_to_pipeline_test.go
@@ -1,0 +1,592 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package firestore
+
+import (
+	"math"
+	"testing"
+
+	pb "cloud.google.com/go/firestore/apiv1/firestorepb"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"google.golang.org/protobuf/testing/protocmp"
+)
+
+func TestQueryToPipeline(t *testing.T) {
+	c := newTestClient()
+	coll := c.Collection("C")
+
+	// Some common expected parts
+	collStage := func(path string) *pb.Pipeline_Stage {
+		return &pb.Pipeline_Stage{
+			Name: "collection",
+			Args: []*pb.Value{refval(path)},
+		}
+	}
+
+	sortStage := func(sorts ...map[string]any) *pb.Pipeline_Stage {
+		var args []*pb.Value
+		for _, s := range sorts {
+			args = append(args, mapval(anyMapToValueMap(s)))
+		}
+		return &pb.Pipeline_Stage{
+			Name: "sort",
+			Args: args,
+		}
+	}
+
+	whereStage := func(expr *pb.Value) *pb.Pipeline_Stage {
+		return &pb.Pipeline_Stage{
+			Name: "where",
+			Args: []*pb.Value{expr},
+		}
+	}
+
+	limitStage := func(n int64) *pb.Pipeline_Stage {
+		return &pb.Pipeline_Stage{
+			Name: "limit",
+			Args: []*pb.Value{int64val(n)},
+		}
+	}
+
+	ascending := func(field string) map[string]any {
+		return map[string]any{
+			"direction":  "ascending",
+			"expression": fieldReference(field),
+		}
+	}
+
+	descending := func(field string) map[string]any {
+		return map[string]any{
+			"direction":  "descending",
+			"expression": fieldReference(field),
+		}
+	}
+
+	exists := func(field string) *pb.Value {
+		return functionval("exists", fieldReference(field))
+	}
+
+	equal := func(field string, val *pb.Value) *pb.Value {
+		return functionval("equal", fieldReference(field), val)
+	}
+
+	greaterThanOrEqual := func(field string, val *pb.Value) *pb.Value {
+		return functionval("greater_than_or_equal", fieldReference(field), val)
+	}
+
+	lessThanOrEqual := func(field string, val *pb.Value) *pb.Value {
+		return functionval("less_than_or_equal", fieldReference(field), val)
+	}
+
+	greaterThan := func(field string, val *pb.Value) *pb.Value {
+		return functionval("greater_than", fieldReference(field), val)
+	}
+
+	lessThan := func(field string, val *pb.Value) *pb.Value {
+		return functionval("less_than", fieldReference(field), val)
+	}
+
+	notEqual := func(field string, val *pb.Value) *pb.Value {
+		return functionval("not_equal", fieldReference(field), val)
+	}
+
+	or := func(args ...*pb.Value) *pb.Value {
+		return functionval("or", args...)
+	}
+
+	and := func(args ...*pb.Value) *pb.Value {
+		return functionval("and", args...)
+	}
+
+	array := func(args ...*pb.Value) *pb.Value {
+		return functionval("array", args...)
+	}
+
+	fullRef := func(path string) *pb.Value {
+		return refval("projects/test-project/databases/test-db/documents" + path)
+	}
+
+	testCases := []struct {
+		name  string
+		query Query
+		want  []*pb.Pipeline_Stage
+	}{
+		{
+			name:  "supportsDefaultQuery",
+			query: coll.Query,
+			want: []*pb.Pipeline_Stage{
+				collStage("/C"),
+				sortStage(ascending("__name__")),
+			},
+		},
+		{
+			name:  "supportsFilteredQuery",
+			query: coll.Where("foo", "==", 1),
+			want: []*pb.Pipeline_Stage{
+				collStage("/C"),
+				whereStage(equal("foo", int64val(1))),
+				sortStage(ascending("__name__")),
+			},
+		},
+		{
+			name:  "supportsFilteredQueryWithFieldPath",
+			query: coll.WherePath([]string{"foo"}, "==", 1),
+			want: []*pb.Pipeline_Stage{
+				collStage("/C"),
+				whereStage(equal("foo", int64val(1))),
+				sortStage(ascending("__name__")),
+			},
+		},
+		{
+			name:  "supportsOrderedQueryWithDefaultOrder",
+			query: coll.OrderBy("foo", Asc),
+			want: []*pb.Pipeline_Stage{
+				collStage("/C"),
+				whereStage(exists("foo")),
+				sortStage(ascending("foo"), ascending("__name__")),
+			},
+		},
+		{
+			name:  "supportsOrderedQueryWithAsc",
+			query: coll.OrderBy("foo", Asc),
+			want: []*pb.Pipeline_Stage{
+				collStage("/C"),
+				whereStage(exists("foo")),
+				sortStage(ascending("foo"), ascending("__name__")),
+			},
+		},
+		{
+			name:  "supportsOrderedQueryWithDesc",
+			query: coll.OrderBy("foo", Desc),
+			want: []*pb.Pipeline_Stage{
+				collStage("/C"),
+				whereStage(exists("foo")),
+				sortStage(descending("foo"), descending("__name__")),
+			},
+		},
+		{
+			name:  "supportsLimitQuery",
+			query: coll.OrderBy("foo", Asc).Limit(1),
+			want: []*pb.Pipeline_Stage{
+				collStage("/C"),
+				whereStage(exists("foo")),
+				sortStage(ascending("foo"), ascending("__name__")),
+				limitStage(1),
+			},
+		},
+		{
+			name:  "supportsLimitToLastQuery",
+			query: coll.OrderBy("foo", Asc).LimitToLast(2),
+			want: []*pb.Pipeline_Stage{
+				collStage("/C"),
+				whereStage(exists("foo")),
+				sortStage(descending("foo"), descending("__name__")),
+				limitStage(2),
+				sortStage(ascending("foo"), ascending("__name__")),
+			},
+		},
+		{
+			name:  "supportsStartAt",
+			query: coll.OrderBy("foo", Asc).StartAt(2),
+			want: []*pb.Pipeline_Stage{
+				collStage("/C"),
+				whereStage(exists("foo")),
+				whereStage(greaterThanOrEqual("foo", int64val(2))),
+				sortStage(ascending("foo"), ascending("__name__")),
+			},
+		},
+		{
+			name:  "supportsStartAtWithLimitToLast",
+			query: coll.OrderBy("foo", Asc).StartAt(3).LimitToLast(4),
+			want: []*pb.Pipeline_Stage{
+				collStage("/C"),
+				whereStage(exists("foo")),
+				whereStage(greaterThanOrEqual("foo", int64val(3))),
+				sortStage(descending("foo"), descending("__name__")),
+				limitStage(4),
+				sortStage(ascending("foo"), ascending("__name__")),
+			},
+		},
+		{
+			name:  "supportsEndAtWithLimitToLast",
+			query: coll.OrderBy("foo", Asc).EndAt(3).LimitToLast(2),
+			want: []*pb.Pipeline_Stage{
+				collStage("/C"),
+				whereStage(exists("foo")),
+				whereStage(lessThanOrEqual("foo", int64val(3))),
+				sortStage(descending("foo"), descending("__name__")),
+				limitStage(2),
+				sortStage(ascending("foo"), ascending("__name__")),
+			},
+		},
+		{
+			name:  "supportsStartAfter",
+			query: coll.OrderBy("foo", Asc).StartAfter(1),
+			want: []*pb.Pipeline_Stage{
+				collStage("/C"),
+				whereStage(exists("foo")),
+				whereStage(greaterThan("foo", int64val(1))),
+				sortStage(ascending("foo"), ascending("__name__")),
+			},
+		},
+		{
+			name:  "supportsEndAt",
+			query: coll.OrderBy("foo", Asc).EndAt(1),
+			want: []*pb.Pipeline_Stage{
+				collStage("/C"),
+				whereStage(exists("foo")),
+				whereStage(lessThanOrEqual("foo", int64val(1))),
+				sortStage(ascending("foo"), ascending("__name__")),
+			},
+		},
+		{
+			name:  "supportsEndBefore",
+			query: coll.OrderBy("foo", Asc).EndBefore(2),
+			want: []*pb.Pipeline_Stage{
+				collStage("/C"),
+				whereStage(exists("foo")),
+				whereStage(lessThan("foo", int64val(2))),
+				sortStage(ascending("foo"), ascending("__name__")),
+			},
+		},
+		{
+			name: "supportsStartAfterWithDocumentSnapshot",
+			query: coll.OrderBy("foo", Asc).OrderBy("bar", Asc).OrderBy("baz", Asc).StartAfter(&DocumentSnapshot{
+				Ref: &DocumentRef{Path: "projects/test-project/databases/test-db/documents/C/2", shortPath: "C/2", Parent: coll, ID: "2"},
+				proto: &pb.Document{
+					Fields: map[string]*pb.Value{
+						"foo": int64val(1),
+						"bar": int64val(1),
+						"baz": int64val(2),
+					},
+				},
+			}),
+			want: []*pb.Pipeline_Stage{
+				collStage("/C"),
+				whereStage(exists("foo")),
+				whereStage(exists("bar")),
+				whereStage(exists("baz")),
+				whereStage(or(
+					greaterThan("foo", int64val(1)),
+					and(
+						equal("foo", int64val(1)),
+						greaterThan("bar", int64val(1)),
+					),
+					and(
+						equal("foo", int64val(1)),
+						equal("bar", int64val(1)),
+						greaterThan("baz", int64val(2)),
+					),
+					and(
+						equal("foo", int64val(1)),
+						equal("bar", int64val(1)),
+						equal("baz", int64val(2)),
+						greaterThan("__name__", fullRef("/C/2")),
+					),
+				)),
+				sortStage(ascending("foo"), ascending("bar"), ascending("baz"), ascending("__name__")),
+			},
+		},
+		{
+			name:  "supportsQueryOverCollectionPathWithSpecialCharacters",
+			query: coll.Doc("so!@#$%^&*()_+special").Collection("so!@#$%^&*()_+special").OrderBy("foo", Asc),
+			want: []*pb.Pipeline_Stage{
+				collStage("/C/so!@#$%^&*()_+special/so!@#$%^&*()_+special"),
+				whereStage(exists("foo")),
+				sortStage(ascending("foo"), ascending("__name__")),
+			},
+		},
+		{
+			name:  "supportsPagination",
+			query: coll.OrderBy("foo", Asc).Limit(1).StartAfter(1),
+			want: []*pb.Pipeline_Stage{
+				collStage("/C"),
+				whereStage(exists("foo")),
+				whereStage(greaterThan("foo", int64val(1))),
+				sortStage(ascending("foo"), ascending("__name__")),
+				limitStage(1),
+			},
+		},
+		{
+			name:  "supportsPaginationOnDocumentIds",
+			query: coll.OrderBy("foo", Asc).OrderBy(DocumentID, Asc).Limit(1).StartAfter(1, "doc1"),
+			want: []*pb.Pipeline_Stage{
+				collStage("/C"),
+				whereStage(exists("foo")),
+				whereStage(or(
+					greaterThan("foo", int64val(1)),
+					and(
+						equal("foo", int64val(1)),
+						greaterThan("__name__", fullRef("/C/doc1")),
+					),
+				)),
+				sortStage(ascending("foo"), ascending("__name__")),
+				limitStage(1),
+			},
+		},
+		{
+			name:  "supportsCollectionGroups",
+			query: c.CollectionGroup("G").OrderBy(DocumentID, Asc),
+			want: []*pb.Pipeline_Stage{
+				{
+					Name: "collection_group",
+					Args: []*pb.Value{refval(""), strval("G")},
+				},
+				sortStage(ascending("__name__")),
+			},
+		},
+		{
+			name: "supportsMultipleInequalityOnSameField",
+			query: coll.WhereEntity(AndFilter{[]EntityFilter{
+				PropertyFilter{Path: "id", Operator: ">", Value: 2},
+				PropertyFilter{Path: "id", Operator: "<=", Value: 10},
+			}}).OrderBy("id", Asc),
+			want: []*pb.Pipeline_Stage{
+				collStage("/C"),
+				whereStage(and(
+					greaterThan("id", int64val(2)),
+					lessThanOrEqual("id", int64val(10)),
+				)),
+				whereStage(exists("id")),
+				sortStage(ascending("id"), ascending("__name__")),
+			},
+		},
+		{
+			name: "supportsMultipleInequalityOnDifferentFields",
+			query: coll.WhereEntity(AndFilter{[]EntityFilter{
+				PropertyFilter{Path: "id", Operator: ">=", Value: 2},
+				PropertyFilter{Path: "baz", Operator: "<", Value: 2},
+			}}).OrderBy("id", Asc),
+			want: []*pb.Pipeline_Stage{
+				collStage("/C"),
+				whereStage(and(
+					greaterThanOrEqual("id", int64val(2)),
+					lessThan("baz", int64val(2)),
+				)),
+				whereStage(exists("id")),
+				sortStage(ascending("id"), ascending("__name__")),
+			},
+		},
+		{
+			name:  "supportsCollectionGroupQuery",
+			query: c.CollectionGroup("C").Query,
+			want: []*pb.Pipeline_Stage{
+				{
+					Name: "collection_group",
+					Args: []*pb.Value{refval(""), strval("C")},
+				},
+				sortStage(ascending("__name__")),
+			},
+		},
+		{
+			name:  "supportsEqNan",
+			query: coll.Where("bar", "==", math.NaN()),
+			want: []*pb.Pipeline_Stage{
+				collStage("/C"),
+				whereStage(equal("bar", floatval(math.NaN()))),
+				sortStage(ascending("__name__")),
+			},
+		},
+		{
+			name:  "supportsNeqNan",
+			query: coll.Where("bar", "!=", math.NaN()).OrderBy("foo", Asc),
+			want: []*pb.Pipeline_Stage{
+				collStage("/C"),
+				whereStage(notEqual("bar", floatval(math.NaN()))),
+				whereStage(exists("foo")),
+				sortStage(ascending("foo"), ascending("__name__")),
+			},
+		},
+		{
+			name:  "supportsEqNull",
+			query: coll.Where("bar", "==", nil),
+			want: []*pb.Pipeline_Stage{
+				collStage("/C"),
+				whereStage(equal("bar", nullValue)),
+				sortStage(ascending("__name__")),
+			},
+		},
+		{
+			name:  "supportsNeqNull",
+			query: coll.Where("bar", "!=", nil),
+			want: []*pb.Pipeline_Stage{
+				collStage("/C"),
+				whereStage(notEqual("bar", nullValue)),
+				sortStage(ascending("__name__")),
+			},
+		},
+		{
+			name:  "supportsNeq",
+			query: coll.Where("bar", "!=", 0),
+			want: []*pb.Pipeline_Stage{
+				collStage("/C"),
+				whereStage(notEqual("bar", int64val(0))),
+				sortStage(ascending("bar"), ascending("__name__")),
+			},
+		},
+		{
+			name:  "supportsArrayContains",
+			query: coll.Where("bar", "array-contains", 4),
+			want: []*pb.Pipeline_Stage{
+				collStage("/C"),
+				whereStage(functionval("array_contains", fieldReference("bar"), int64val(4))),
+				sortStage(ascending("__name__")),
+			},
+		},
+		{
+			name:  "supportsArrayContainsAny",
+			query: coll.Where("bar", "array-contains-any", []int{4, 5}),
+			want: []*pb.Pipeline_Stage{
+				collStage("/C"),
+				whereStage(functionval("array_contains_any", fieldReference("bar"), array(int64val(4), int64val(5)))),
+				sortStage(ascending("__name__")),
+			},
+		},
+		{
+			name:  "supportsIn",
+			query: coll.Where("bar", "in", []int{0, 10, 20}),
+			want: []*pb.Pipeline_Stage{
+				collStage("/C"),
+				whereStage(functionval("equal_any", fieldReference("bar"), array(int64val(0), int64val(10), int64val(20)))),
+				sortStage(ascending("__name__")),
+			},
+		},
+		{
+			name:  "supportsInWith1",
+			query: coll.Where("bar", "in", []int{2}),
+			want: []*pb.Pipeline_Stage{
+				collStage("/C"),
+				whereStage(functionval("equal_any", fieldReference("bar"), array(int64val(2)))),
+				sortStage(ascending("__name__")),
+			},
+		},
+		{
+			name:  "supportsNotIn",
+			query: coll.Where("bar", "not-in", []int{0, 10, 20}).OrderBy("foo", Asc),
+			want: []*pb.Pipeline_Stage{
+				collStage("/C"),
+				whereStage(functionval("not_equal_any", fieldReference("bar"), array(int64val(0), int64val(10), int64val(20)))),
+				whereStage(exists("foo")),
+				sortStage(ascending("foo"), ascending("__name__")),
+			},
+		},
+		{
+			name:  "supportsNotInWith1",
+			query: coll.Where("bar", "not-in", []int{2}).OrderBy("foo", Asc),
+			want: []*pb.Pipeline_Stage{
+				collStage("/C"),
+				whereStage(functionval("not_equal_any", fieldReference("bar"), array(int64val(2)))),
+				whereStage(exists("foo")),
+				sortStage(ascending("foo"), ascending("__name__")),
+			},
+		},
+		{
+			name: "supportsOrOperator",
+			query: coll.WhereEntity(OrFilter{[]EntityFilter{
+				PropertyFilter{Path: "bar", Operator: "==", Value: 2},
+				PropertyFilter{Path: "foo", Operator: "==", Value: 3},
+			}}).OrderBy("foo", Asc),
+			want: []*pb.Pipeline_Stage{
+				collStage("/C"),
+				whereStage(or(
+					equal("bar", int64val(2)),
+					equal("foo", int64val(3)),
+				)),
+				whereStage(exists("foo")),
+				sortStage(ascending("foo"), ascending("__name__")),
+			},
+		},
+		{
+			name:  "testNotEqualIncludesMissingField",
+			query: coll.Where("bar", "!=", 1),
+			want: []*pb.Pipeline_Stage{
+				collStage("/C"),
+				whereStage(notEqual("bar", int64val(1))),
+				sortStage(ascending("bar"), ascending("__name__")),
+			},
+		},
+		{
+			name:  "testNotInIncludesMissingField",
+			query: coll.Where("bar", "not-in", []int{1}),
+			want: []*pb.Pipeline_Stage{
+				collStage("/C"),
+				whereStage(functionval("not_equal_any", fieldReference("bar"), array(int64val(1)))),
+				sortStage(ascending("bar"), ascending("__name__")),
+			},
+		},
+		{
+			name:  "testInequalityMaintainsExistenceFilter",
+			query: coll.Where("bar", "<", 1),
+			want: []*pb.Pipeline_Stage{
+				collStage("/C"),
+				whereStage(lessThan("bar", int64val(1))),
+				sortStage(ascending("bar"), ascending("__name__")),
+			},
+		},
+		{
+			name:  "testExplicitOrderMaintainsExistenceFilter",
+			query: coll.OrderBy("bar", Asc),
+			want: []*pb.Pipeline_Stage{
+				collStage("/C"),
+				whereStage(exists("bar")),
+				sortStage(ascending("bar"), ascending("__name__")),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := tc.query.Pipeline()
+			if p.err != nil {
+				t.Fatalf("Pipeline() error: %v", p.err)
+			}
+			req, err := p.toExecutePipelineRequest()
+			if err != nil {
+				t.Fatalf("toExecutePipelineRequest() error: %v", err)
+			}
+			got := req.GetStructuredPipeline().GetPipeline().GetStages()
+			if diff := cmp.Diff(tc.want, got, protocmp.Transform(), cmpopts.EquateNaNs()); diff != "" {
+				t.Errorf("Mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func fieldReference(name string) *pb.Value {
+	return &pb.Value{ValueType: &pb.Value_FieldReferenceValue{FieldReferenceValue: name}}
+}
+
+func functionval(name string, args ...*pb.Value) *pb.Value {
+	return &pb.Value{ValueType: &pb.Value_FunctionValue{FunctionValue: &pb.Function{
+		Name: name,
+		Args: args,
+	}}}
+}
+
+func anyMapToValueMap(m map[string]any) map[string]*pb.Value {
+	res := make(map[string]*pb.Value)
+	for k, v := range m {
+		switch x := v.(type) {
+		case string:
+			res[k] = strval(x)
+		case *pb.Value:
+			res[k] = x
+		default:
+			panic("unsupported type in anyMapToValueMap")
+		}
+	}
+	return res
+}


### PR DESCRIPTION
This PR addresses several critical discrepancies and missing features in how standard Firestore Queries are converted into Pipeline requests via the `toPipeline()` method. 

#### 1. Correct `__name__` Cursor Conversion
**Issue:** When a user passes a string ID to a pagination cursor (like `StartAt` or `StartAfter`) to break ties using the `__name__` field, the Go SDK was directly encoding it as a primitive string (`stringValue`) in the pipeline payload. Firestore pipelines strictly require document keys to be passed as fully-qualified reference values (`referenceValue`), leading to silent failures to match documents.
**Fix:** We now intercept string values passed for the `__name__` field inside cursors and translate them into `*DocumentRef` objects. This ensures they are serialized correctly as `ReferenceValue` in the final gRPC payload.
**Example:**
For a query like `coll.OrderBy("__name__", Asc).StartAfter("doc-1")`:
*   *Before:* Cursor value encoded as `{"stringValue": "doc-1"}`.
*   *After:* Cursor value encoded as `{"referenceValue": "projects/.../databases/.../documents/coll/doc-1"}`.

#### 2. Native Support for `LimitToLast`
**Issue:** The `limitToLast()` feature is a client-side convenience that isn't directly supported by the Firestore backend API (including Pipelines). Previously, `toPipeline()` did not handle the logic required to simulate `LimitToLast`.
**Fix:** We implemented the standard `LimitToLast` turnaround pattern inside the pipeline generation. When `limitToLast` is requested, the pipeline now explicitly reverses the user's `OrderBy` clauses, applies the `Limit`, and then adds a final `Sort` stage to restore the original requested order.
**Example:**
For a query like `coll.OrderBy("age", Asc).LimitToLast(5)`:
*   *Before:* Emitted a standard `Limit(5)` without reversing the order.
*   *After:* Pipeline becomes `Sort("age", Desc) -> Limit(5) -> Sort("age", Asc)`.

#### 3. Correct Prefix Cursors Logic
**Issue:** When a cursor was provided fewer values than the number of `OrderBy` clauses (a "prefix cursor"), the boolean logic generated to represent the bounding constraints included the cursor's inclusive/exclusive behavior too early in the `OR` statements. This caused intermediate constraints to inadvertently include or exclude the wrong documents.
**Fix:** The mathematical construction of the cursor boolean tree has been fixed. For a prefix cursor, all intermediate terms must use an *exclusive* operator (`>` or `<`). Only the very last term in the prefix respects the inclusive/exclusive nature of the specific cursor (`StartAt` vs `StartAfter`).
**Example:**
For `OrderBy("A").OrderBy("B")` with `StartAt(valA)` (where the user only provided a value for A):
*   *Before:* `A >= valA`
*   *After:* `A >= valA` (For a single prefix value, it remains identical, but the logic scales correctly for N-depth prefixes where the final term determines inclusivity).

#### 4. Addition of Implicit `Exists` Filters
**Issue:** Standard Firestore queries implicitly filter out documents that do not contain the fields specified in an `OrderBy` clause. The pipeline translation was missing these existence checks, causing pipeline queries to potentially return more documents than their standard Query counterparts.
**Fix:** We now iterate over the `OrderBy` fields and explicitly append a `.Where(FieldExists(...))` stage to the pipeline for every ordered field (excluding the intrinsic `__name__` field).
**Example:**
For `coll.OrderBy("age", Asc)`:
*   *Before:* Pipeline emitted only `Sort("age", Asc)`.
*   *After:* Pipeline emits `Where(Exists("age")) -> Sort("age", Asc)`.