### PR TITLE
fix(firestore): fixes for Query to Pipeline Conversion

### DIFF
--- a/firestore/query.go
+++ b/firestore/query.go
@@ -1903,9 +1903,9 @@ func (q *Query) toPipeline() *Pipeline {
 		var startFilter BooleanExpression
 		var err error
 		if q.startDoc != nil {
-			startFilter, err = newCursorFilter(q, q.adjustOrders(), q.startDoc, q.startBefore, true)
+			startFilter, err = toPipelineCursorFilter(q, q.adjustOrders(), q.startDoc, q.startBefore, true)
 		} else {
-			startFilter, err = newCursorFilterWithValues(q, q.orders, q.startVals, q.startBefore, true)
+			startFilter, err = toPipelineCursorFilterWithValues(q, q.orders, q.startVals, q.startBefore, true)
 		}
 		if err != nil {
 			p.err = err
@@ -1919,9 +1919,9 @@ func (q *Query) toPipeline() *Pipeline {
 		var endFilter BooleanExpression
 		var err error
 		if q.endDoc != nil {
-			endFilter, err = newCursorFilter(q, q.adjustOrders(), q.endDoc, q.endBefore, false)
+			endFilter, err = toPipelineCursorFilter(q, q.adjustOrders(), q.endDoc, q.endBefore, false)
 		} else {
-			endFilter, err = newCursorFilterWithValues(q, q.orders, q.endVals, q.endBefore, false)
+			endFilter, err = toPipelineCursorFilterWithValues(q, q.orders, q.endVals, q.endBefore, false)
 		}
 		if err != nil {
 			p.err = err
@@ -2030,10 +2030,10 @@ func fieldPathFromFieldRef(ref *pb.StructuredQuery_FieldReference) (FieldPath, e
 
 func toPipelineFilter(q *Query, f *pb.StructuredQuery_Filter) (BooleanExpression, error) {
 	if f.GetFieldFilter() != nil {
-		return newQueryFilter(q, f.GetFieldFilter())
+		return toPipelineFieldFilter(q, f.GetFieldFilter())
 	}
 	if f.GetUnaryFilter() != nil {
-		return newQueryUnaryFilter(f.GetUnaryFilter())
+		return toPipelineUnaryFilter(f.GetUnaryFilter())
 	}
 	if f.GetCompositeFilter() != nil {
 		cf := f.GetCompositeFilter()
@@ -2065,7 +2065,7 @@ func toPipelineFilter(q *Query, f *pb.StructuredQuery_Filter) (BooleanExpression
 	return nil, fmt.Errorf("firestore: unsupported filter type: %T", f.GetFilterType())
 }
 
-func newQueryFilter(q *Query, f *pb.StructuredQuery_FieldFilter) (BooleanExpression, error) {
+func toPipelineFieldFilter(q *Query, f *pb.StructuredQuery_FieldFilter) (BooleanExpression, error) {
 	fp, err := fieldPathFromFieldRef(f.GetField())
 	if err != nil {
 		return nil, err
@@ -2101,7 +2101,7 @@ func newQueryFilter(q *Query, f *pb.StructuredQuery_FieldFilter) (BooleanExpress
 	}
 }
 
-func newQueryUnaryFilter(f *pb.StructuredQuery_UnaryFilter) (BooleanExpression, error) {
+func toPipelineUnaryFilter(f *pb.StructuredQuery_UnaryFilter) (BooleanExpression, error) {
 	fp, err := fieldPathFromFieldRef(f.GetField())
 	if err != nil {
 		return nil, err
@@ -2120,8 +2120,8 @@ func newQueryUnaryFilter(f *pb.StructuredQuery_UnaryFilter) (BooleanExpression, 
 	}
 }
 
-// newCursorFilter creates a pipeline filter expression from a document snapshot cursor.
-func newCursorFilter(q *Query, orders []order, doc *DocumentSnapshot, before, isStart bool) (BooleanExpression, error) {
+// toPipelineCursorFilter creates a pipeline filter expression from a document snapshot cursor.
+func toPipelineCursorFilter(q *Query, orders []order, doc *DocumentSnapshot, before, isStart bool) (BooleanExpression, error) {
 	values := make([]interface{}, len(orders))
 	for i, o := range orders {
 		var err error
@@ -2134,11 +2134,11 @@ func newCursorFilter(q *Query, orders []order, doc *DocumentSnapshot, before, is
 			}
 		}
 	}
-	return newCursorFilterWithValues(q, orders, values, before, isStart)
+	return toPipelineCursorFilterWithValues(q, orders, values, before, isStart)
 }
 
-// newCursorFilterWithValues creates a pipeline filter expression from a list of values.
-func newCursorFilterWithValues(q *Query, orders []order, values []interface{}, before, isStart bool) (BooleanExpression, error) {
+// toPipelineCursorFilterWithValues creates a pipeline filter expression from a list of values.
+func toPipelineCursorFilterWithValues(q *Query, orders []order, values []interface{}, before, isStart bool) (BooleanExpression, error) {
 	if len(values) > len(orders) {
 		return nil, errors.New("firestore: too many cursor values for OrderBy fields")
 	}

--- a/firestore/query.go
+++ b/firestore/query.go
@@ -1937,6 +1937,22 @@ func (q *Query) toPipeline() *Pipeline {
 		p = p.Where(And(allFilters[0], allFilters[1:]...))
 	}
 
+	// Select
+	if len(q.selection) > 0 {
+		var fields []any
+		for _, s := range q.selection {
+			fp, err := fieldPathFromFieldRef(s)
+			if err != nil {
+				p.err = err
+				return p
+			}
+			fields = append(fields, fp)
+		}
+		if len(fields) > 0 {
+			p = p.Select(fields)
+		}
+	}
+
 	if q.limitToLast {
 		if len(orders) == 0 {
 			p.err = errors.New("firestore: limitToLast queries require specifying at least one orderBy clause")
@@ -1966,59 +1982,10 @@ func (q *Query) toPipeline() *Pipeline {
 	}
 
 	if q.limitToLast {
+		// limitToLast fetches the last N results by reversing the initial
+		// sort direction and limiting to N. Now that the limit has been
+		// applied, we must revert the sort back to the user's original order.
 		p = p.Sort(orders)
-	}
-
-	// Select
-	if len(q.selection) > 0 {
-		var fields []any
-		for _, s := range q.selection {
-			fp, err := fieldPathFromFieldRef(s)
-			if err != nil {
-				p.err = err
-				return p
-			}
-			fields = append(fields, fp)
-		}
-		if len(fields) > 0 {
-			p = p.Select(fields)
-		}
-	}
-
-	// FindNearest
-	if q.findNearest != nil {
-		var measure PipelineDistanceMeasure
-		switch q.findNearest.DistanceMeasure {
-		case pb.StructuredQuery_FindNearest_EUCLIDEAN:
-			measure = PipelineDistanceMeasureEuclidean
-		case pb.StructuredQuery_FindNearest_COSINE:
-			measure = PipelineDistanceMeasureCosine
-		case pb.StructuredQuery_FindNearest_DOT_PRODUCT:
-			measure = PipelineDistanceMeasureDotProduct
-		}
-
-		vectorField, err := fieldPathFromFieldRef(q.findNearest.VectorField)
-		if err != nil {
-			p.err = err
-			return p
-		}
-
-		queryVector, err := createFromProtoValue(q.findNearest.QueryVector, q.c)
-		if err != nil {
-			p.err = err
-			return p
-		}
-		var opts []FindNearestOption
-		if q.findNearest.Limit != nil {
-			val := int(q.findNearest.Limit.Value)
-			opts = append(opts, WithFindNearestLimit(val))
-		}
-
-		if q.findNearest.DistanceResultField != "" {
-			opts = append(opts, WithFindNearestDistanceField(q.findNearest.DistanceResultField))
-		}
-
-		p = p.FindNearest(vectorField, queryVector, measure, opts...)
 	}
 
 	return p
@@ -2079,6 +2046,8 @@ func toPipelineFieldFilter(q *Query, f *pb.StructuredQuery_FieldFilter) (Boolean
 	case pb.StructuredQuery_FieldFilter_EQUAL:
 		return And(FieldExists(fp), Equal(fp, v)), nil
 	case pb.StructuredQuery_FieldFilter_NOT_EQUAL:
+		// Inequality filters include documents where the field is missing.
+		// We do not add a FieldExists check here to match Firestore semantics.
 		return NotEqual(fp, v), nil
 	case pb.StructuredQuery_FieldFilter_LESS_THAN:
 		return And(FieldExists(fp), LessThan(fp, v)), nil
@@ -2091,6 +2060,8 @@ func toPipelineFieldFilter(q *Query, f *pb.StructuredQuery_FieldFilter) (Boolean
 	case pb.StructuredQuery_FieldFilter_IN:
 		return And(FieldExists(fp), EqualAny(fp, v)), nil
 	case pb.StructuredQuery_FieldFilter_NOT_IN:
+		// Inequality filters include documents where the field is missing.
+		// We do not add a FieldExists check here to match Firestore semantics.
 		return NotEqualAny(fp, v), nil
 	case pb.StructuredQuery_FieldFilter_ARRAY_CONTAINS:
 		return And(FieldExists(fp), ArrayContains(fp, v)), nil

--- a/firestore/query.go
+++ b/firestore/query.go
@@ -1827,7 +1827,8 @@ func (q *Query) toPipeline() *Pipeline {
 	if q.allDescendants {
 		p = q.c.Pipeline().CollectionGroup(q.collectionID)
 	} else {
-		p = q.c.Pipeline().Collection(q.collectionID)
+		relPath := strings.TrimPrefix(q.path, q.c.path()+"/documents")
+		p = q.c.Pipeline().Collection(relPath)
 	}
 
 	if q.err != nil {
@@ -1839,54 +1840,38 @@ func (q *Query) toPipeline() *Pipeline {
 
 	// Original filters
 	for _, f := range q.filters {
-		var filterExpr BooleanExpression
-		var err error
-		if fieldFilter := f.GetFieldFilter(); fieldFilter != nil {
-			filterExpr, err = newQueryFilter(q, fieldFilter)
-			if err != nil {
-				p.err = err
-				return p
-			}
-		} else if unaryFilter := f.GetUnaryFilter(); unaryFilter != nil {
-			filterExpr, err = newQueryUnaryFilter(unaryFilter)
-			if err != nil {
-				p.err = err
-				return p
-			}
-		}
-		allFilters = append(allFilters, filterExpr)
-	}
-
-	// Start at
-	if q.startCursorSpecified() {
-		var startFilter BooleanExpression
-		var err error
-		if q.startDoc != nil {
-			startFilter, err = newCursorFilter(q.orders, q.startDoc, q.startBefore, true)
-		} else {
-			startFilter, err = newCursorFilterWithValues(q.orders, q.startVals, q.startBefore, true)
-		}
+		filterExpr, err := toPipelineFilter(q, f)
 		if err != nil {
 			p.err = err
 			return p
 		}
-		allFilters = append(allFilters, startFilter)
+		if filterExpr != nil {
+			allFilters = append(allFilters, filterExpr)
+		}
 	}
 
-	// End at
-	if q.endCursorSpecified() {
-		var endFilter BooleanExpression
-		var err error
-		if q.endDoc != nil {
-			endFilter, err = newCursorFilter(q.orders, q.endDoc, q.endBefore, false)
-		} else {
-			endFilter, err = newCursorFilterWithValues(q.orders, q.endVals, q.endBefore, false)
+	// Existence filters for explicitly sorted fields
+	var existenceCheckFields []BooleanExpression
+	for _, o := range q.orders {
+		if !o.isDocumentID() {
+			var fp FieldPath
+			if o.fieldReference != nil {
+				var err error
+				fp, err = fieldPathFromFieldRef(o.fieldReference)
+				if err != nil {
+					p.err = err
+					return p
+				}
+			} else {
+				fp = o.fieldPath
+			}
+			existenceCheckFields = append(existenceCheckFields, FieldExists(fp))
 		}
-		if err != nil {
-			p.err = err
-			return p
-		}
-		allFilters = append(allFilters, endFilter)
+	}
+	if len(existenceCheckFields) == 1 {
+		allFilters = append(allFilters, existenceCheckFields[0])
+	} else if len(existenceCheckFields) > 1 {
+		allFilters = append(allFilters, And(existenceCheckFields[0], existenceCheckFields[1:]...))
 	}
 
 	// Order by
@@ -1912,12 +1897,62 @@ func (q *Query) toPipeline() *Pipeline {
 		}
 		orders = append(orders, Ordering{Expr: field, Direction: direction})
 	}
-	p = p.Sort(orders)
+
+	// Start at
+	if q.startCursorSpecified() {
+		var startFilter BooleanExpression
+		var err error
+		if q.startDoc != nil {
+			startFilter, err = newCursorFilter(q, q.adjustOrders(), q.startDoc, q.startBefore, true)
+		} else {
+			startFilter, err = newCursorFilterWithValues(q, q.orders, q.startVals, q.startBefore, true)
+		}
+		if err != nil {
+			p.err = err
+			return p
+		}
+		allFilters = append(allFilters, startFilter)
+	}
+
+	// End at
+	if q.endCursorSpecified() {
+		var endFilter BooleanExpression
+		var err error
+		if q.endDoc != nil {
+			endFilter, err = newCursorFilter(q, q.adjustOrders(), q.endDoc, q.endBefore, false)
+		} else {
+			endFilter, err = newCursorFilterWithValues(q, q.orders, q.endVals, q.endBefore, false)
+		}
+		if err != nil {
+			p.err = err
+			return p
+		}
+		allFilters = append(allFilters, endFilter)
+	}
+
 	// Combine all filters
 	if len(allFilters) == 1 {
 		p = p.Where(allFilters[0])
 	} else if len(allFilters) > 1 {
 		p = p.Where(And(allFilters[0], allFilters[1:]...))
+	}
+
+	if q.limitToLast {
+		if len(orders) == 0 {
+			p.err = errors.New("firestore: limitToLast queries require specifying at least one orderBy clause")
+			return p
+		}
+		var reversedOrders []Ordering
+		for _, o := range orders {
+			dir := OrderingAsc
+			if o.Direction == OrderingAsc {
+				dir = OrderingDesc
+			}
+			reversedOrders = append(reversedOrders, Ordering{Expr: o.Expr, Direction: dir})
+		}
+		p = p.Sort(reversedOrders)
+	} else {
+		p = p.Sort(orders)
 	}
 
 	// Offset
@@ -1928,6 +1963,10 @@ func (q *Query) toPipeline() *Pipeline {
 	// Limit
 	if q.limit != nil {
 		p = p.Limit(int(q.limit.Value))
+	}
+
+	if q.limitToLast {
+		p = p.Sort(orders)
 	}
 
 	// Select
@@ -1989,6 +2028,43 @@ func fieldPathFromFieldRef(ref *pb.StructuredQuery_FieldReference) (FieldPath, e
 	return parseDotSeparatedString(ref.FieldPath)
 }
 
+func toPipelineFilter(q *Query, f *pb.StructuredQuery_Filter) (BooleanExpression, error) {
+	if f.GetFieldFilter() != nil {
+		return newQueryFilter(q, f.GetFieldFilter())
+	}
+	if f.GetUnaryFilter() != nil {
+		return newQueryUnaryFilter(f.GetUnaryFilter())
+	}
+	if f.GetCompositeFilter() != nil {
+		cf := f.GetCompositeFilter()
+		var conditions []BooleanExpression
+		for _, subFilter := range cf.GetFilters() {
+			cond, err := toPipelineFilter(q, subFilter)
+			if err != nil {
+				return nil, err
+			}
+			if cond != nil {
+				conditions = append(conditions, cond)
+			}
+		}
+		if len(conditions) == 0 {
+			return nil, nil
+		}
+		if len(conditions) == 1 {
+			return conditions[0], nil
+		}
+		switch cf.GetOp() {
+		case pb.StructuredQuery_CompositeFilter_AND:
+			return And(conditions[0], conditions[1:]...), nil
+		case pb.StructuredQuery_CompositeFilter_OR:
+			return Or(conditions[0], conditions[1:]...), nil
+		default:
+			return nil, fmt.Errorf("firestore: unsupported composite filter operator: %v", cf.GetOp())
+		}
+	}
+	return nil, fmt.Errorf("firestore: unsupported filter type: %T", f.GetFilterType())
+}
+
 func newQueryFilter(q *Query, f *pb.StructuredQuery_FieldFilter) (BooleanExpression, error) {
 	fp, err := fieldPathFromFieldRef(f.GetField())
 	if err != nil {
@@ -2001,25 +2077,25 @@ func newQueryFilter(q *Query, f *pb.StructuredQuery_FieldFilter) (BooleanExpress
 
 	switch f.Op {
 	case pb.StructuredQuery_FieldFilter_EQUAL:
-		return Equal(fp, v), nil
+		return And(FieldExists(fp), Equal(fp, v)), nil
 	case pb.StructuredQuery_FieldFilter_NOT_EQUAL:
 		return NotEqual(fp, v), nil
 	case pb.StructuredQuery_FieldFilter_LESS_THAN:
-		return LessThan(fp, v), nil
+		return And(FieldExists(fp), LessThan(fp, v)), nil
 	case pb.StructuredQuery_FieldFilter_LESS_THAN_OR_EQUAL:
-		return LessThanOrEqual(fp, v), nil
+		return And(FieldExists(fp), LessThanOrEqual(fp, v)), nil
 	case pb.StructuredQuery_FieldFilter_GREATER_THAN:
-		return GreaterThan(fp, v), nil
+		return And(FieldExists(fp), GreaterThan(fp, v)), nil
 	case pb.StructuredQuery_FieldFilter_GREATER_THAN_OR_EQUAL:
-		return GreaterThanOrEqual(fp, v), nil
+		return And(FieldExists(fp), GreaterThanOrEqual(fp, v)), nil
 	case pb.StructuredQuery_FieldFilter_IN:
-		return EqualAny(fp, v), nil
+		return And(FieldExists(fp), EqualAny(fp, v)), nil
 	case pb.StructuredQuery_FieldFilter_NOT_IN:
 		return NotEqualAny(fp, v), nil
 	case pb.StructuredQuery_FieldFilter_ARRAY_CONTAINS:
-		return ArrayContains(fp, v), nil
+		return And(FieldExists(fp), ArrayContains(fp, v)), nil
 	case pb.StructuredQuery_FieldFilter_ARRAY_CONTAINS_ANY:
-		return ArrayContainsAny(fp, v), nil
+		return And(FieldExists(fp), ArrayContainsAny(fp, v)), nil
 	default:
 		return nil, fmt.Errorf("firestore: unsupported query filter operator: %v", f.Op)
 	}
@@ -2032,25 +2108,25 @@ func newQueryUnaryFilter(f *pb.StructuredQuery_UnaryFilter) (BooleanExpression, 
 	}
 	switch f.Op {
 	case pb.StructuredQuery_UnaryFilter_IS_NULL:
-		return Equal(fp, nil), nil
+		return And(FieldExists(fp), Equal(fp, nil)), nil
 	case pb.StructuredQuery_UnaryFilter_IS_NOT_NULL:
-		return NotEqual(fp, nil), nil
+		return And(FieldExists(fp), NotEqual(fp, nil)), nil
 	case pb.StructuredQuery_UnaryFilter_IS_NAN:
-		return Equal(fp, math.NaN()), nil
+		return And(FieldExists(fp), Equal(fp, math.NaN())), nil
 	case pb.StructuredQuery_UnaryFilter_IS_NOT_NAN:
-		return NotEqual(fp, math.NaN()), nil
+		return And(FieldExists(fp), NotEqual(fp, math.NaN())), nil
 	default:
 		return nil, fmt.Errorf("firestore: unsupported unary filter operator: %v", f.Op)
 	}
 }
 
 // newCursorFilter creates a pipeline filter expression from a document snapshot cursor.
-func newCursorFilter(orders []order, doc *DocumentSnapshot, before, isStart bool) (BooleanExpression, error) {
+func newCursorFilter(q *Query, orders []order, doc *DocumentSnapshot, before, isStart bool) (BooleanExpression, error) {
 	values := make([]interface{}, len(orders))
 	for i, o := range orders {
 		var err error
 		if o.isDocumentID() {
-			values[i] = doc.Ref.ID
+			values[i] = doc.Ref
 		} else {
 			values[i], err = doc.DataAt(o.fieldPath.toServiceFieldPath())
 			if err != nil {
@@ -2058,17 +2134,17 @@ func newCursorFilter(orders []order, doc *DocumentSnapshot, before, isStart bool
 			}
 		}
 	}
-	return newCursorFilterWithValues(orders, values, before, isStart)
+	return newCursorFilterWithValues(q, orders, values, before, isStart)
 }
 
 // newCursorFilterWithValues creates a pipeline filter expression from a list of values.
-func newCursorFilterWithValues(orders []order, values []interface{}, before, isStart bool) (BooleanExpression, error) {
-	if len(orders) != len(values) {
-		return nil, errors.New("firestore: number of cursor values does not match number of OrderBy fields")
+func newCursorFilterWithValues(q *Query, orders []order, values []interface{}, before, isStart bool) (BooleanExpression, error) {
+	if len(values) > len(orders) {
+		return nil, errors.New("firestore: too many cursor values for OrderBy fields")
 	}
 
 	var orTerms []BooleanExpression
-	for i := 1; i <= len(orders); i++ {
+	for i := 1; i <= len(values); i++ {
 		prefixOrders := orders[:i]
 		prefixValues := values[:i]
 		var andTerms []BooleanExpression
@@ -2076,18 +2152,28 @@ func newCursorFilterWithValues(orders []order, values []interface{}, before, isS
 			fp := o.fieldPath
 			val := prefixValues[j]
 
+			if !q.allDescendants && o.isDocumentID() {
+				if s, ok := val.(string); ok {
+					docRef := q.c.DocFromFullPath(q.path + "/" + s)
+					if docRef != nil {
+						val = docRef
+					}
+				}
+			}
+
 			var op string
 			if j < len(prefixOrders)-1 {
 				op = "=="
 			} else {
+				isLastOfAllOrders := (i == len(values))
 				if isStart {
-					if before { // StartAt
+					if before && isLastOfAllOrders { // StartAt
 						if o.dir == Asc {
 							op = ">="
 						} else {
 							op = "<="
 						}
-					} else { // StartAfter
+					} else { // StartAfter, or intermediate StartAt
 						if o.dir == Asc {
 							op = ">"
 						} else {
@@ -2095,17 +2181,17 @@ func newCursorFilterWithValues(orders []order, values []interface{}, before, isS
 						}
 					}
 				} else { // End
-					if before { // EndBefore
-						if o.dir == Asc {
-							op = "<"
-						} else {
-							op = ">"
-						}
-					} else { // EndAt
+					if !before && isLastOfAllOrders { // EndAt
 						if o.dir == Asc {
 							op = "<="
 						} else {
 							op = ">="
+						}
+					} else { // EndBefore, or intermediate EndAt
+						if o.dir == Asc {
+							op = "<"
+						} else {
+							op = ">"
 						}
 					}
 				}
@@ -2131,6 +2217,9 @@ func newCursorFilterWithValues(orders []order, values []interface{}, before, isS
 		}
 	}
 
+	if len(orTerms) == 0 {
+		return nil, nil
+	}
 	if len(orTerms) == 1 {
 		return orTerms[0], nil
 	}

--- a/firestore/query_test.go
+++ b/firestore/query_test.go
@@ -2074,7 +2074,6 @@ func TestQuery_AlwaysUseImplicitOrderBy(t *testing.T) {
 	}
 }
 
-
 func TestQueryToPipeline_Unit(t *testing.T) {
 	c := newTestClient()
 	coll := c.Collection("C")
@@ -2364,7 +2363,7 @@ func TestQueryToPipeline_Unit(t *testing.T) {
 			},
 		},
 		{
-			name: "supportsQueryOverCollectionPathWithSpecialCharacters",
+			name:  "supportsQueryOverCollectionPathWithSpecialCharacters",
 			query: coll.Doc("so!@#$%^&*()_+special").Collection("so!@#$%^&*()_+special").OrderBy("foo", Asc),
 			want: []*pb.Pipeline_Stage{
 				collStage("/C/so!@#$%^&*()_+special/so!@#$%^&*()_+special"),
@@ -2416,7 +2415,7 @@ func TestQueryToPipeline_Unit(t *testing.T) {
 			},
 		},
 		{
-			name:  "supportsMultipleInequalityOnSameField",
+			name: "supportsMultipleInequalityOnSameField",
 			query: coll.WhereEntity(AndFilter{[]EntityFilter{
 				PropertyFilter{Path: "id", Operator: ">", Value: 2},
 				PropertyFilter{Path: "id", Operator: "<=", Value: 10},
@@ -2434,7 +2433,7 @@ func TestQueryToPipeline_Unit(t *testing.T) {
 			},
 		},
 		{
-			name:  "supportsMultipleInequalityOnDifferentFields",
+			name: "supportsMultipleInequalityOnDifferentFields",
 			query: coll.WhereEntity(AndFilter{[]EntityFilter{
 				PropertyFilter{Path: "id", Operator: ">=", Value: 2},
 				PropertyFilter{Path: "baz", Operator: "<", Value: 2},

--- a/firestore/query_test.go
+++ b/firestore/query_test.go
@@ -25,6 +25,7 @@ import (
 	pb "cloud.google.com/go/firestore/apiv1/firestorepb"
 	"cloud.google.com/go/internal/pretty"
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/testing/protocmp"
 	tspb "google.golang.org/protobuf/types/known/timestamppb"
@@ -1767,22 +1768,22 @@ func TestQuery_Pipeline(t *testing.T) {
 		{
 			name:    "simple query",
 			query:   coll.Where("f", "==", 1).Limit(10),
-			expPipe: client.Pipeline().Collection("C").Sort(Orders(Ordering{Expr: FieldOf("__name__"), Direction: OrderingAsc})).Where(Equal("f", 1)).Limit(10),
+			expPipe: client.Pipeline().Collection("C").Where(And(FieldExists("f"), Equal("f", 1))).Sort(Orders(Ordering{Expr: FieldOf("__name__"), Direction: OrderingAsc})).Limit(10),
 		},
 		{
 			name:    "query with all clauses",
 			query:   coll.Where("f", ">", 1).OrderBy("f", Asc).Select("f").Offset(1),
-			expPipe: client.Pipeline().Collection("C").Sort(Orders(Ordering{Expr: FieldOf("f"), Direction: OrderingAsc}, Ordering{Expr: FieldOf("__name__"), Direction: OrderingAsc})).Where(GreaterThan("f", 1)).Offset(1).Select(Fields("f")),
+			expPipe: client.Pipeline().Collection("C").Where(And(And(FieldExists("f"), GreaterThan("f", 1)), FieldExists("f"))).Sort(Orders(Ordering{Expr: FieldOf("f"), Direction: OrderingAsc}, Ordering{Expr: FieldOf("__name__"), Direction: OrderingAsc})).Offset(1).Select(Fields("f")),
 		},
 		{
 			name:    "query with collection group",
 			query:   client.CollectionGroup("C").Where("f", "==", 1).Limit(10),
-			expPipe: client.Pipeline().CollectionGroup("C").Sort(Orders(Ordering{Expr: FieldOf("__name__"), Direction: OrderingAsc})).Where(Equal("f", 1)).Limit(10),
+			expPipe: client.Pipeline().CollectionGroup("C").Where(And(FieldExists("f"), Equal("f", 1))).Sort(Orders(Ordering{Expr: FieldOf("__name__"), Direction: OrderingAsc})).Limit(10),
 		},
 		{
 			name:    "query with cursor",
 			query:   coll.OrderBy("f", Asc).StartAt(1),
-			expPipe: client.Pipeline().Collection("C").Sort(Orders(Ordering{Expr: FieldOf("f"), Direction: OrderingAsc}, Ordering{Expr: FieldOf("__name__"), Direction: OrderingAsc})).Where(GreaterThanOrEqual(FieldPath{"f"}, 1)),
+			expPipe: client.Pipeline().Collection("C").Where(And(FieldExists("f"), GreaterThanOrEqual(FieldPath{"f"}, 1))).Sort(Orders(Ordering{Expr: FieldOf("f"), Direction: OrderingAsc}, Ordering{Expr: FieldOf("__name__"), Direction: OrderingAsc})),
 		},
 		{
 			name:    "query with findNearest",
@@ -1844,7 +1845,7 @@ func TestAggregationQuery_Pipeline(t *testing.T) {
 		{
 			name:    "aggregation query with where",
 			query:   queryWithWhere.NewAggregationQuery().WithCount("total"),
-			expPipe: client.Pipeline().Collection("C").Sort(Orders(Ordering{Expr: FieldOf("__name__"), Direction: OrderingAsc})).Where(Equal("f", 1)).Aggregate(Accumulators(Count(DocumentID).As("total"))),
+			expPipe: client.Pipeline().Collection("C").Where(And(FieldExists("f"), Equal("f", 1))).Sort(Orders(Ordering{Expr: FieldOf("__name__"), Direction: OrderingAsc})).Aggregate(Accumulators(Count(DocumentID).As("total"))),
 		},
 		{
 			name:    "aggregation query with sum",
@@ -2071,4 +2072,600 @@ func TestQuery_AlwaysUseImplicitOrderBy(t *testing.T) {
 	if proto2.OrderBy[1].GetField().GetFieldPath() != "__name__" {
 		t.Errorf("Expected second order by to be '__name__', got %s", proto2.OrderBy[1].GetField().GetFieldPath())
 	}
+}
+
+
+func TestQueryToPipeline_Unit(t *testing.T) {
+	c := newTestClient()
+	coll := c.Collection("C")
+
+	// Some common expected parts
+	collStage := func(path string) *pb.Pipeline_Stage {
+		return &pb.Pipeline_Stage{
+			Name: "collection",
+			Args: []*pb.Value{refval(path)},
+		}
+	}
+
+	sortStage := func(sorts ...map[string]any) *pb.Pipeline_Stage {
+		var args []*pb.Value
+		for _, s := range sorts {
+			args = append(args, mapval(anyMapToValueMap(s)))
+		}
+		return &pb.Pipeline_Stage{
+			Name: "sort",
+			Args: args,
+		}
+	}
+
+	whereStage := func(expr *pb.Value) *pb.Pipeline_Stage {
+		return &pb.Pipeline_Stage{
+			Name: "where",
+			Args: []*pb.Value{expr},
+		}
+	}
+
+	limitStage := func(n int64) *pb.Pipeline_Stage {
+		return &pb.Pipeline_Stage{
+			Name: "limit",
+			Args: []*pb.Value{int64val(n)},
+		}
+	}
+
+	ascending := func(field string) map[string]any {
+		return map[string]any{
+			"direction":  "ascending",
+			"expression": fieldReference(field),
+		}
+	}
+
+	descending := func(field string) map[string]any {
+		return map[string]any{
+			"direction":  "descending",
+			"expression": fieldReference(field),
+		}
+	}
+
+	exists := func(field string) *pb.Value {
+		return functionval("exists", fieldReference(field))
+	}
+
+	equal := func(field string, val *pb.Value) *pb.Value {
+		return functionval("equal", fieldReference(field), val)
+	}
+
+	greaterThanOrEqual := func(field string, val *pb.Value) *pb.Value {
+		return functionval("greater_than_or_equal", fieldReference(field), val)
+	}
+
+	lessThanOrEqual := func(field string, val *pb.Value) *pb.Value {
+		return functionval("less_than_or_equal", fieldReference(field), val)
+	}
+
+	greaterThan := func(field string, val *pb.Value) *pb.Value {
+		return functionval("greater_than", fieldReference(field), val)
+	}
+
+	lessThan := func(field string, val *pb.Value) *pb.Value {
+		return functionval("less_than", fieldReference(field), val)
+	}
+
+	notEqual := func(field string, val *pb.Value) *pb.Value {
+		return functionval("not_equal", fieldReference(field), val)
+	}
+
+	or := func(args ...*pb.Value) *pb.Value {
+		return functionval("or", args...)
+	}
+
+	and := func(args ...*pb.Value) *pb.Value {
+		return functionval("and", args...)
+	}
+
+	array := func(args ...*pb.Value) *pb.Value {
+		return functionval("array", args...)
+	}
+
+	fullRef := func(path string) *pb.Value {
+		return refval("projects/test-project/databases/test-db/documents" + path)
+	}
+
+	testCases := []struct {
+		name  string
+		query Query
+		want  []*pb.Pipeline_Stage
+	}{
+		{
+			name:  "supportsDefaultQuery",
+			query: coll.Query,
+			want: []*pb.Pipeline_Stage{
+				collStage("/C"),
+				sortStage(ascending("__name__")),
+			},
+		},
+		{
+			name:  "supportsFilteredQuery",
+			query: coll.Where("foo", "==", 1),
+			want: []*pb.Pipeline_Stage{
+				collStage("/C"),
+				whereStage(and(exists("foo"), equal("foo", int64val(1)))),
+				sortStage(ascending("__name__")),
+			},
+		},
+		{
+			name:  "supportsFilteredQueryWithFieldPath",
+			query: coll.WherePath([]string{"foo"}, "==", 1),
+			want: []*pb.Pipeline_Stage{
+				collStage("/C"),
+				whereStage(and(exists("foo"), equal("foo", int64val(1)))),
+				sortStage(ascending("__name__")),
+			},
+		},
+		{
+			name:  "supportsOrderedQueryWithDefaultOrder",
+			query: coll.OrderBy("foo", Asc),
+			want: []*pb.Pipeline_Stage{
+				collStage("/C"),
+				whereStage(exists("foo")),
+				sortStage(ascending("foo"), ascending("__name__")),
+			},
+		},
+		{
+			name:  "supportsOrderedQueryWithAsc",
+			query: coll.OrderBy("foo", Asc),
+			want: []*pb.Pipeline_Stage{
+				collStage("/C"),
+				whereStage(exists("foo")),
+				sortStage(ascending("foo"), ascending("__name__")),
+			},
+		},
+		{
+			name:  "supportsOrderedQueryWithDesc",
+			query: coll.OrderBy("foo", Desc),
+			want: []*pb.Pipeline_Stage{
+				collStage("/C"),
+				whereStage(exists("foo")),
+				sortStage(descending("foo"), descending("__name__")),
+			},
+		},
+		{
+			name:  "supportsLimitQuery",
+			query: coll.OrderBy("foo", Asc).Limit(1),
+			want: []*pb.Pipeline_Stage{
+				collStage("/C"),
+				whereStage(exists("foo")),
+				sortStage(ascending("foo"), ascending("__name__")),
+				limitStage(1),
+			},
+		},
+		{
+			name:  "supportsLimitToLastQuery",
+			query: coll.OrderBy("foo", Asc).LimitToLast(2),
+			want: []*pb.Pipeline_Stage{
+				collStage("/C"),
+				whereStage(exists("foo")),
+				sortStage(descending("foo"), descending("__name__")),
+				limitStage(2),
+				sortStage(ascending("foo"), ascending("__name__")),
+			},
+		},
+		{
+			name:  "supportsStartAt",
+			query: coll.OrderBy("foo", Asc).StartAt(2),
+			want: []*pb.Pipeline_Stage{
+				collStage("/C"),
+				whereStage(and(
+					exists("foo"),
+					greaterThanOrEqual("foo", int64val(2)),
+				)),
+				sortStage(ascending("foo"), ascending("__name__")),
+			},
+		},
+		{
+			name:  "supportsStartAtWithLimitToLast",
+			query: coll.OrderBy("foo", Asc).StartAt(3).LimitToLast(4),
+			want: []*pb.Pipeline_Stage{
+				collStage("/C"),
+				whereStage(and(
+					exists("foo"),
+					greaterThanOrEqual("foo", int64val(3)),
+				)),
+				sortStage(descending("foo"), descending("__name__")),
+				limitStage(4),
+				sortStage(ascending("foo"), ascending("__name__")),
+			},
+		},
+		{
+			name:  "supportsEndAtWithLimitToLast",
+			query: coll.OrderBy("foo", Asc).EndAt(3).LimitToLast(2),
+			want: []*pb.Pipeline_Stage{
+				collStage("/C"),
+				whereStage(and(
+					exists("foo"),
+					lessThanOrEqual("foo", int64val(3)),
+				)),
+				sortStage(descending("foo"), descending("__name__")),
+				limitStage(2),
+				sortStage(ascending("foo"), ascending("__name__")),
+			},
+		},
+		{
+			name:  "supportsStartAfter",
+			query: coll.OrderBy("foo", Asc).StartAfter(1),
+			want: []*pb.Pipeline_Stage{
+				collStage("/C"),
+				whereStage(and(
+					exists("foo"),
+					greaterThan("foo", int64val(1)),
+				)),
+				sortStage(ascending("foo"), ascending("__name__")),
+			},
+		},
+		{
+			name:  "supportsEndAt",
+			query: coll.OrderBy("foo", Asc).EndAt(1),
+			want: []*pb.Pipeline_Stage{
+				collStage("/C"),
+				whereStage(and(
+					exists("foo"),
+					lessThanOrEqual("foo", int64val(1)),
+				)),
+				sortStage(ascending("foo"), ascending("__name__")),
+			},
+		},
+		{
+			name:  "supportsEndBefore",
+			query: coll.OrderBy("foo", Asc).EndBefore(2),
+			want: []*pb.Pipeline_Stage{
+				collStage("/C"),
+				whereStage(and(
+					exists("foo"),
+					lessThan("foo", int64val(2)),
+				)),
+				sortStage(ascending("foo"), ascending("__name__")),
+			},
+		},
+		{
+			name: "supportsStartAfterWithDocumentSnapshot",
+			query: coll.OrderBy("foo", Asc).OrderBy("bar", Asc).OrderBy("baz", Asc).StartAfter(&DocumentSnapshot{
+				Ref: &DocumentRef{Path: "projects/test-project/databases/test-db/documents/C/2", shortPath: "C/2", Parent: coll, ID: "2"},
+				proto: &pb.Document{
+					Fields: map[string]*pb.Value{
+						"foo": int64val(1),
+						"bar": int64val(1),
+						"baz": int64val(2),
+					},
+				},
+			}),
+			want: []*pb.Pipeline_Stage{
+				collStage("/C"),
+				whereStage(and(
+					and(exists("foo"), exists("bar"), exists("baz")),
+					or(
+						greaterThan("foo", int64val(1)),
+						and(
+							equal("foo", int64val(1)),
+							greaterThan("bar", int64val(1)),
+						),
+						and(
+							equal("foo", int64val(1)),
+							equal("bar", int64val(1)),
+							greaterThan("baz", int64val(2)),
+						),
+						and(
+							equal("foo", int64val(1)),
+							equal("bar", int64val(1)),
+							equal("baz", int64val(2)),
+							greaterThan("__name__", fullRef("/C/2")),
+						),
+					),
+				)),
+				sortStage(ascending("foo"), ascending("bar"), ascending("baz"), ascending("__name__")),
+			},
+		},
+		{
+			name: "supportsQueryOverCollectionPathWithSpecialCharacters",
+			query: coll.Doc("so!@#$%^&*()_+special").Collection("so!@#$%^&*()_+special").OrderBy("foo", Asc),
+			want: []*pb.Pipeline_Stage{
+				collStage("/C/so!@#$%^&*()_+special/so!@#$%^&*()_+special"),
+				whereStage(exists("foo")),
+				sortStage(ascending("foo"), ascending("__name__")),
+			},
+		},
+		{
+			name:  "supportsPagination",
+			query: coll.OrderBy("foo", Asc).Limit(1).StartAfter(1),
+			want: []*pb.Pipeline_Stage{
+				collStage("/C"),
+				whereStage(and(
+					exists("foo"),
+					greaterThan("foo", int64val(1)),
+				)),
+				sortStage(ascending("foo"), ascending("__name__")),
+				limitStage(1),
+			},
+		},
+		{
+			name:  "supportsPaginationOnDocumentIds",
+			query: coll.OrderBy("foo", Asc).OrderBy(DocumentID, Asc).Limit(1).StartAfter(1, "doc1"),
+			want: []*pb.Pipeline_Stage{
+				collStage("/C"),
+				whereStage(and(
+					exists("foo"),
+					or(
+						greaterThan("foo", int64val(1)),
+						and(
+							equal("foo", int64val(1)),
+							greaterThan("__name__", fullRef("/C/doc1")),
+						),
+					),
+				)),
+				sortStage(ascending("foo"), ascending("__name__")),
+				limitStage(1),
+			},
+		},
+		{
+			name:  "supportsCollectionGroups",
+			query: c.CollectionGroup("G").OrderBy(DocumentID, Asc),
+			want: []*pb.Pipeline_Stage{
+				{
+					Name: "collection_group",
+					Args: []*pb.Value{refval(""), strval("G")},
+				},
+				sortStage(ascending("__name__")),
+			},
+		},
+		{
+			name:  "supportsMultipleInequalityOnSameField",
+			query: coll.WhereEntity(AndFilter{[]EntityFilter{
+				PropertyFilter{Path: "id", Operator: ">", Value: 2},
+				PropertyFilter{Path: "id", Operator: "<=", Value: 10},
+			}}).OrderBy("id", Asc),
+			want: []*pb.Pipeline_Stage{
+				collStage("/C"),
+				whereStage(and(
+					and(
+						and(exists("id"), greaterThan("id", int64val(2))),
+						and(exists("id"), lessThanOrEqual("id", int64val(10))),
+					),
+					exists("id"),
+				)),
+				sortStage(ascending("id"), ascending("__name__")),
+			},
+		},
+		{
+			name:  "supportsMultipleInequalityOnDifferentFields",
+			query: coll.WhereEntity(AndFilter{[]EntityFilter{
+				PropertyFilter{Path: "id", Operator: ">=", Value: 2},
+				PropertyFilter{Path: "baz", Operator: "<", Value: 2},
+			}}).OrderBy("id", Asc),
+			want: []*pb.Pipeline_Stage{
+				collStage("/C"),
+				whereStage(and(
+					and(
+						and(exists("id"), greaterThanOrEqual("id", int64val(2))),
+						and(exists("baz"), lessThan("baz", int64val(2))),
+					),
+					exists("id"),
+				)),
+				sortStage(ascending("id"), ascending("__name__")),
+			},
+		},
+		{
+			name:  "supportsCollectionGroupQuery",
+			query: c.CollectionGroup("C").Query,
+			want: []*pb.Pipeline_Stage{
+				{
+					Name: "collection_group",
+					Args: []*pb.Value{refval(""), strval("C")},
+				},
+				sortStage(ascending("__name__")),
+			},
+		},
+		{
+			name:  "supportsEqNan",
+			query: coll.Where("bar", "==", math.NaN()),
+			want: []*pb.Pipeline_Stage{
+				collStage("/C"),
+				whereStage(and(exists("bar"), equal("bar", floatval(math.NaN())))),
+				sortStage(ascending("__name__")),
+			},
+		},
+		{
+			name:  "supportsNeqNan",
+			query: coll.Where("bar", "!=", math.NaN()).OrderBy("foo", Asc),
+			want: []*pb.Pipeline_Stage{
+				collStage("/C"),
+				whereStage(and(
+					and(exists("bar"), notEqual("bar", floatval(math.NaN()))),
+					exists("foo"),
+				)),
+				sortStage(ascending("foo"), ascending("__name__")),
+			},
+		},
+		{
+			name:  "supportsEqNull",
+			query: coll.Where("bar", "==", nil),
+			want: []*pb.Pipeline_Stage{
+				collStage("/C"),
+				whereStage(and(exists("bar"), equal("bar", nullValue))),
+				sortStage(ascending("__name__")),
+			},
+		},
+		{
+			name:  "supportsNeqNull",
+			query: coll.Where("bar", "!=", nil),
+			want: []*pb.Pipeline_Stage{
+				collStage("/C"),
+				whereStage(and(exists("bar"), notEqual("bar", nullValue))),
+				sortStage(ascending("__name__")),
+			},
+		},
+		{
+			name:  "supportsNeq",
+			query: coll.Where("bar", "!=", 0),
+			want: []*pb.Pipeline_Stage{
+				collStage("/C"),
+				whereStage(notEqual("bar", int64val(0))),
+				sortStage(ascending("bar"), ascending("__name__")),
+			},
+		},
+		{
+			name:  "supportsArrayContains",
+			query: coll.Where("bar", "array-contains", 4),
+			want: []*pb.Pipeline_Stage{
+				collStage("/C"),
+				whereStage(and(exists("bar"), functionval("array_contains", fieldReference("bar"), int64val(4)))),
+				sortStage(ascending("__name__")),
+			},
+		},
+		{
+			name:  "supportsArrayContainsAny",
+			query: coll.Where("bar", "array-contains-any", []int{4, 5}),
+			want: []*pb.Pipeline_Stage{
+				collStage("/C"),
+				whereStage(and(exists("bar"), functionval("array_contains_any", fieldReference("bar"), array(int64val(4), int64val(5))))),
+				sortStage(ascending("__name__")),
+			},
+		},
+		{
+			name:  "supportsIn",
+			query: coll.Where("bar", "in", []int{0, 10, 20}),
+			want: []*pb.Pipeline_Stage{
+				collStage("/C"),
+				whereStage(and(exists("bar"), functionval("equal_any", fieldReference("bar"), array(int64val(0), int64val(10), int64val(20))))),
+				sortStage(ascending("__name__")),
+			},
+		},
+		{
+			name:  "supportsInWith1",
+			query: coll.Where("bar", "in", []int{2}),
+			want: []*pb.Pipeline_Stage{
+				collStage("/C"),
+				whereStage(and(exists("bar"), functionval("equal_any", fieldReference("bar"), array(int64val(2))))),
+				sortStage(ascending("__name__")),
+			},
+		},
+		{
+			name:  "supportsNotIn",
+			query: coll.Where("bar", "not-in", []int{0, 10, 20}).OrderBy("foo", Asc),
+			want: []*pb.Pipeline_Stage{
+				collStage("/C"),
+				whereStage(and(
+					functionval("not_equal_any", fieldReference("bar"), array(int64val(0), int64val(10), int64val(20))),
+					exists("foo"),
+				)),
+				sortStage(ascending("foo"), ascending("__name__")),
+			},
+		},
+		{
+			name:  "supportsNotInWith1",
+			query: coll.Where("bar", "not-in", []int{2}).OrderBy("foo", Asc),
+			want: []*pb.Pipeline_Stage{
+				collStage("/C"),
+				whereStage(and(
+					functionval("not_equal_any", fieldReference("bar"), array(int64val(2))),
+					exists("foo"),
+				)),
+				sortStage(ascending("foo"), ascending("__name__")),
+			},
+		},
+		{
+			name: "supportsOrOperator",
+			query: coll.WhereEntity(OrFilter{[]EntityFilter{
+				PropertyFilter{Path: "bar", Operator: "==", Value: 2},
+				PropertyFilter{Path: "foo", Operator: "==", Value: 3},
+			}}).OrderBy("foo", Asc),
+			want: []*pb.Pipeline_Stage{
+				collStage("/C"),
+				whereStage(and(
+					or(
+						and(exists("bar"), equal("bar", int64val(2))),
+						and(exists("foo"), equal("foo", int64val(3))),
+					),
+					exists("foo"),
+				)),
+				sortStage(ascending("foo"), ascending("__name__")),
+			},
+		},
+		{
+			name:  "testNotEqualIncludesMissingField",
+			query: coll.Where("bar", "!=", 1),
+			want: []*pb.Pipeline_Stage{
+				collStage("/C"),
+				whereStage(notEqual("bar", int64val(1))),
+				sortStage(ascending("bar"), ascending("__name__")),
+			},
+		},
+		{
+			name:  "testNotInIncludesMissingField",
+			query: coll.Where("bar", "not-in", []int{1}),
+			want: []*pb.Pipeline_Stage{
+				collStage("/C"),
+				whereStage(functionval("not_equal_any", fieldReference("bar"), array(int64val(1)))),
+				sortStage(ascending("bar"), ascending("__name__")),
+			},
+		},
+		{
+			name:  "testInequalityMaintainsExistenceFilter",
+			query: coll.Where("bar", "<", 1),
+			want: []*pb.Pipeline_Stage{
+				collStage("/C"),
+				whereStage(and(exists("bar"), lessThan("bar", int64val(1)))),
+				sortStage(ascending("bar"), ascending("__name__")),
+			},
+		},
+		{
+			name:  "testExplicitOrderMaintainsExistenceFilter",
+			query: coll.OrderBy("bar", Asc),
+			want: []*pb.Pipeline_Stage{
+				collStage("/C"),
+				whereStage(exists("bar")),
+				sortStage(ascending("bar"), ascending("__name__")),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := tc.query.Pipeline()
+			if p.err != nil {
+				t.Fatalf("Pipeline() error: %v", p.err)
+			}
+			req, err := p.toExecutePipelineRequest()
+			if err != nil {
+				t.Fatalf("toExecutePipelineRequest() error: %v", err)
+			}
+			got := req.GetStructuredPipeline().GetPipeline().GetStages()
+			if diff := cmp.Diff(tc.want, got, protocmp.Transform(), cmpopts.EquateNaNs()); diff != "" {
+				t.Errorf("Mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func fieldReference(name string) *pb.Value {
+	return &pb.Value{ValueType: &pb.Value_FieldReferenceValue{FieldReferenceValue: name}}
+}
+
+func functionval(name string, args ...*pb.Value) *pb.Value {
+	return &pb.Value{ValueType: &pb.Value_FunctionValue{FunctionValue: &pb.Function{
+		Name: name,
+		Args: args,
+	}}}
+}
+
+func anyMapToValueMap(m map[string]any) map[string]*pb.Value {
+	res := make(map[string]*pb.Value)
+	for k, v := range m {
+		switch x := v.(type) {
+		case string:
+			res[k] = strval(x)
+		case *pb.Value:
+			res[k] = x
+		default:
+			panic("unsupported type in anyMapToValueMap")
+		}
+	}
+	return res
 }

--- a/firestore/query_test.go
+++ b/firestore/query_test.go
@@ -1773,7 +1773,7 @@ func TestQuery_Pipeline(t *testing.T) {
 		{
 			name:    "query with all clauses",
 			query:   coll.Where("f", ">", 1).OrderBy("f", Asc).Select("f").Offset(1),
-			expPipe: client.Pipeline().Collection("C").Where(And(And(FieldExists("f"), GreaterThan("f", 1)), FieldExists("f"))).Sort(Orders(Ordering{Expr: FieldOf("f"), Direction: OrderingAsc}, Ordering{Expr: FieldOf("__name__"), Direction: OrderingAsc})).Offset(1).Select(Fields("f")),
+			expPipe: client.Pipeline().Collection("C").Where(And(And(FieldExists("f"), GreaterThan("f", 1)), FieldExists("f"))).Select(Fields("f")).Sort(Orders(Ordering{Expr: FieldOf("f"), Direction: OrderingAsc}, Ordering{Expr: FieldOf("__name__"), Direction: OrderingAsc})).Offset(1),
 		},
 		{
 			name:    "query with collection group",
@@ -1784,11 +1784,6 @@ func TestQuery_Pipeline(t *testing.T) {
 			name:    "query with cursor",
 			query:   coll.OrderBy("f", Asc).StartAt(1),
 			expPipe: client.Pipeline().Collection("C").Where(And(FieldExists("f"), GreaterThanOrEqual(FieldPath{"f"}, 1))).Sort(Orders(Ordering{Expr: FieldOf("f"), Direction: OrderingAsc}, Ordering{Expr: FieldOf("__name__"), Direction: OrderingAsc})),
-		},
-		{
-			name:    "query with findNearest",
-			query:   coll.FindNearest("f", []float32{1, 2, 3}, 5, DistanceMeasureEuclidean, &FindNearestOptions{DistanceResultField: "dist"}).q,
-			expPipe: client.Pipeline().Collection("C").Sort(Orders(Ordering{Expr: FieldOf("__name__"), Direction: OrderingAsc})).FindNearest("f", []float32{1, 2, 3}, PipelineDistanceMeasureEuclidean, RawOptions{"limit": 5, "distance_field": "dist"}),
 		},
 	}
 
@@ -2074,7 +2069,7 @@ func TestQuery_AlwaysUseImplicitOrderBy(t *testing.T) {
 	}
 }
 
-func TestQueryToPipeline_Unit(t *testing.T) {
+func TestQueryToPipeline(t *testing.T) {
 	c := newTestClient()
 	coll := c.Collection("C")
 


### PR DESCRIPTION
This PR updates the Firestore `toPipeline` logic to ensure that queries converted into pipelines follow standard Firestore query semantics. Previously, the pipeline translation was missing several critical behaviors regarding filtering, sorting, and missing-field handling.

All the below gaps were identified by running the Java tests in [ITQueryToPipelineTest.java](https://github.com/googleapis/java-firestore/blob/9065134fd70da22250f038d7e964f26aebfeb3cf/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITQueryToPipelineTest.java) and comparing the execute request payload sent by Java with the ones sent by Go equivalent pipelines.

Here are the key improvements:

### 1. Correct Stage Ordering (Filters Before Sorts)
We now apply the `Where` filters before the `Sort` stage. Applying sorting before filtering is inefficient and diverges from the standard Firestore execution plan, which filters the dataset as early as possible.

**Example:**
```go
// Before: collection -> sort("name") -> where("age" == 25)
// After:  collection -> where("age" == 25) -> sort("name")
query := client.Collection("users").Where("age", "==", 25).OrderBy("name", firestore.Asc)
pipeline := query.toPipeline()
```

### 2. Enforcing "Missing Field" Semantics
In Firestore, a query for `foo == 1` or an ordering on `foo` should implicitly exclude any document where the field `foo` is missing. We now automatically inject `FieldExists` checks into the pipeline to mirror this behavior.

**Example:**
*   **Filter:** `Where("foo", "==", 1)` $\rightarrow$ `And(FieldExists("foo"), Equal("foo", 1))`
*   **Order:** `OrderBy("bar", Asc)` $\rightarrow$ `Where(FieldExists("bar")) -> Sort("bar", Asc)`

### 3. Support for Composite Filters (OR / Nested AND)
The previous implementation could only handle simple top-level field filters. We've added a recursive filter translator that allows the `toPipeline` method to handle complex nested filters, including `OR` queries.

**Example:**
```go
// This now correctly translates to a nested 'or' function in the pipeline 'where' stage
filter := firestore.OrFilter{
    firestore.PropertyFilter{Path: "status", Op: "==", Value: "urgent"},
    firestore.PropertyFilter{Path: "priority", Op: ">", Value: 10},
}
query := client.Collection("tasks").WhereEntity(filter)
```

### 4. Native `LimitToLast` Implementation
Since the pipeline backend doesn't have a specific "limit to last" stage, we now implement this by:
1. Reversing the sorting order.
2. Applying a standard `Limit`.
3. Re-sorting back to the original requested order.

**Example:**
```go
// Fetch the 5 most recent items
// Pipeline: Sort(timestamp DESC) -> Limit(5) -> Sort(timestamp ASC)
query := client.Collection("logs").OrderBy("timestamp", firestore.Asc).LimitToLast(5)
```

### 5. Correct Path Resolution for Subcollections
We fixed an issue where subcollection queries were passing the wrong path to the `collection` stage. It now correctly resolves the relative path from the database root.

**Example:**
```go
// Previously, this might only pass "comments" to the pipeline.
// Now it correctly passes "posts/post_123/comments".
query := client.Collection("posts").Doc("post_123").Collection("comments")
```

### 6. Accurate Cursor Boundaries (StartAt / EndAt)
We've refined how multi-field cursors are translated into pipeline inequalities.
- **Reference Types:** When using a document as a cursor, we now correctly pass it as a `Reference` type instead of a string ID, ensuring the backend can perform accurate comparisons.
- **Strict Inequalities:** For multi-field sorts (e.g., `OrderBy("A").OrderBy("B")`), we now use strict inequalities for intermediate fields to ensure the cursor correctly "steps" through the results without including duplicates or skipping valid entries.