### PR TITLE
feat(firestore): refine Pipelines API, error handling, and tests

### DIFF
--- a/firestore/integration_test.go
+++ b/firestore/integration_test.go
@@ -2285,7 +2285,7 @@ func TestIntegration_WatchQueryCancel(t *testing.T) {
 }
 
 func TestIntegration_MissingDocs(t *testing.T) {
-	// skipIfEnterprise(t, "MissingDocs")
+	skipIfEdition(t, "show_missing", editionEnterprise)
 	ctx := context.Background()
 	h := testHelper{t}
 	client := integrationClient(t)

--- a/firestore/integration_test.go
+++ b/firestore/integration_test.go
@@ -81,7 +81,7 @@ func TestMain(m *testing.M) {
 		testParams[firestoreEditionKey] = edition
 		initIntegrationTest()
 		status := m.Run()
-		cleanupIntegrationTest()
+		// cleanupIntegrationTest()
 		if status != 0 {
 			os.Exit(status)
 		}
@@ -90,9 +90,9 @@ func TestMain(m *testing.M) {
 	os.Exit(0)
 }
 
-func skipIfEnterprise(t *testing.T, featureName string) {
-	if getCurrentEdition() == editionEnterprise {
-		t.Skip("Skipping. Feature \"" + featureName + "\" not supported in Enterprise Edition.")
+func skipIfEdition(t *testing.T, featureName string, edition firestoreEdition) {
+	if getCurrentEdition() == edition {
+		t.Skip("Skipping. Feature \"" + featureName + "\" not supported in " + edition.String() + " Edition.")
 	}
 }
 
@@ -189,12 +189,12 @@ func deleteCollection(ctx context.Context, coll *CollectionRef) error {
 	bulkwriter := iClient.BulkWriter(ctx)
 
 	// Get  documents
-	iter := coll.DocumentRefs(ctx)
+	iter := coll.Select().Documents(ctx)
 
 	// Iterate through the documents, adding
 	// a delete operation for each one to the BulkWriter.
 	for {
-		docRef, err := iter.Next()
+		docSnap, err := iter.Next()
 		if err == iterator.Done {
 			break
 		}
@@ -202,8 +202,7 @@ func deleteCollection(ctx context.Context, coll *CollectionRef) error {
 			log.Printf("Failed to get next document: %+v\n", err)
 			return err
 		}
-
-		err = deleteDocument(ctx, docRef, bulkwriter)
+		err = deleteDocument(ctx, docSnap.Ref, bulkwriter)
 		if err != nil {
 			log.Printf("Failed to delete document: %+v\n", err)
 			return err
@@ -373,6 +372,10 @@ var (
 func TestIntegration_Create(t *testing.T) {
 	ctx := context.Background()
 	doc := integrationColl(t).NewDoc()
+	emptyDoc := integrationColl(t).NewDoc()
+	t.Cleanup(func() {
+		deleteDocuments([]*DocumentRef{doc, emptyDoc})
+	})
 	start := time.Now()
 	h := testHelper{t}
 	wr := h.mustCreate(doc, integrationTestMap)
@@ -381,17 +384,17 @@ func TestIntegration_Create(t *testing.T) {
 	_, err := doc.Create(ctx, integrationTestMap)
 	codeEq(t, "Create on a present doc", codes.AlreadyExists, err)
 	// OK to create an empty document.
-	emptyDoc := integrationColl(t).NewDoc()
 	_, err = emptyDoc.Create(ctx, map[string]interface{}{})
 	codeEq(t, "Create empty doc", codes.OK, err)
-	t.Cleanup(func() {
-		deleteDocuments([]*DocumentRef{doc, emptyDoc})
-	})
 }
 
 func TestIntegration_Get(t *testing.T) {
 	ctx := context.Background()
 	doc := integrationColl(t).NewDoc()
+	emptyDoc := integrationColl(t).NewDoc()
+	t.Cleanup(func() {
+		deleteDocuments([]*DocumentRef{doc, emptyDoc})
+	})
 	h := testHelper{t}
 	h.mustCreate(doc, integrationTestMap)
 	ds := h.mustGet(doc)
@@ -410,7 +413,6 @@ func TestIntegration_Get(t *testing.T) {
 		t.Errorf("got\n%v\nwant\n%v", pretty.Value(got), pretty.Value(want))
 	}
 
-	emptyDoc := integrationColl(t).NewDoc()
 	empty := map[string]interface{}{}
 	h.mustCreate(emptyDoc, empty)
 	ds = h.mustGet(emptyDoc)
@@ -429,10 +431,6 @@ func TestIntegration_Get(t *testing.T) {
 	if ds.ReadTime.IsZero() {
 		t.Error("got zero read time")
 	}
-
-	t.Cleanup(func() {
-		deleteDocuments([]*DocumentRef{doc, emptyDoc})
-	})
 }
 
 func TestIntegration_GetAll(t *testing.T) {
@@ -442,6 +440,9 @@ func TestIntegration_GetAll(t *testing.T) {
 	coll := integrationColl(t)
 	ctx := context.Background()
 	var docRefs []*DocumentRef
+	t.Cleanup(func() {
+		deleteDocuments(docRefs)
+	})
 	for i := 0; i < 5; i++ {
 		doc := coll.NewDoc()
 		docRefs = append(docRefs, doc)
@@ -477,9 +478,6 @@ func TestIntegration_GetAll(t *testing.T) {
 			t.Errorf("%d: got zero read time", i)
 		}
 	}
-	t.Cleanup(func() {
-		deleteDocuments(docRefs)
-	})
 }
 
 type runWithOptionsTestcase struct {
@@ -662,11 +660,11 @@ func TestIntegration_Add(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	end := time.Now()
-	checkTimeBetween(t, wr.UpdateTime, start, end)
 	t.Cleanup(func() {
 		deleteDocuments([]*DocumentRef{docRef})
 	})
+	end := time.Now()
+	checkTimeBetween(t, wr.UpdateTime, start, end)
 }
 
 func TestIntegration_Set(t *testing.T) {
@@ -676,6 +674,10 @@ func TestIntegration_Set(t *testing.T) {
 
 	// Set Should be able to create a new doc.
 	doc := coll.NewDoc()
+	doc2 := coll.NewDoc()
+	t.Cleanup(func() {
+		deleteDocuments([]*DocumentRef{doc, doc2})
+	})
 	wr1 := h.mustSet(doc, integrationTestMap)
 	// Calling Set on the doc completely replaces the contents.
 	// The update time should increase.
@@ -752,17 +754,12 @@ func TestIntegration_Set(t *testing.T) {
 	}
 
 	// Writing an empty doc with MergeAll should create the doc.
-	doc2 := coll.NewDoc()
 	want = map[string]interface{}{}
 	h.mustSet(doc2, want, MergeAll)
 	ds = h.mustGet(doc2)
 	if got := ds.Data(); !testEqual(got, want) {
 		t.Errorf("got %v, want %v", got, want)
 	}
-
-	t.Cleanup(func() {
-		deleteDocuments([]*DocumentRef{doc, doc2})
-	})
 }
 
 func TestIntegration_Delete(t *testing.T) {
@@ -792,6 +789,9 @@ func TestIntegration_Delete(t *testing.T) {
 func TestIntegration_Update(t *testing.T) {
 	ctx := context.Background()
 	doc := integrationColl(t).NewDoc()
+	t.Cleanup(func() {
+		deleteDocuments([]*DocumentRef{doc})
+	})
 	h := testHelper{t}
 
 	h.mustCreate(doc, integrationTestMap)
@@ -835,9 +835,6 @@ func TestIntegration_Update(t *testing.T) {
 	if !testEqual(got, want) {
 		t.Errorf("got\n%#v\nwant\n%#v", got, want)
 	}
-	t.Cleanup(func() {
-		deleteDocuments([]*DocumentRef{doc})
-	})
 }
 
 func TestIntegration_Collections(t *testing.T) {
@@ -845,6 +842,9 @@ func TestIntegration_Collections(t *testing.T) {
 	h := testHelper{t}
 
 	doc := integrationColl(t).NewDoc()
+	t.Cleanup(func() {
+		deleteDocuments([]*DocumentRef{doc})
+	})
 	got, err := doc.Collections(ctx).GetAll()
 	if err != nil {
 		t.Fatal(err)
@@ -866,9 +866,6 @@ func TestIntegration_Collections(t *testing.T) {
 	if !testEqual(got, want) {
 		t.Errorf("got\n%#v\nwant\n%#v", got, want)
 	}
-	t.Cleanup(func() {
-		deleteDocuments([]*DocumentRef{doc})
-	})
 }
 
 func TestIntegration_ServerTimestamp(t *testing.T) {
@@ -888,6 +885,9 @@ func TestIntegration_ServerTimestamp(t *testing.T) {
 	}
 	h := testHelper{t}
 	doc := integrationColl(t).NewDoc()
+	t.Cleanup(func() {
+		deleteDocuments([]*DocumentRef{doc})
+	})
 	// Bound times of the RPC, with some slack for clock skew.
 	start := time.Now()
 	h.mustCreate(doc, data)
@@ -907,13 +907,13 @@ func TestIntegration_ServerTimestamp(t *testing.T) {
 	if g, w := got.E, got.C; !testEqual(g, w) {
 		t.Errorf(`E = %s, want equal to C (%s)`, g, w)
 	}
-	t.Cleanup(func() {
-		deleteDocuments([]*DocumentRef{doc})
-	})
 }
 
 func TestIntegration_MergeServerTimestamp(t *testing.T) {
 	doc := integrationColl(t).NewDoc()
+	t.Cleanup(func() {
+		deleteDocuments([]*DocumentRef{doc})
+	})
 	h := testHelper{t}
 
 	// Create a doc with an ordinary field "a" and a ServerTimestamp field "b".
@@ -934,13 +934,13 @@ func TestIntegration_MergeServerTimestamp(t *testing.T) {
 	if !t1.Before(t2) {
 		t.Errorf("got t1=%s, t2=%s; want t1 before t2", t1, t2)
 	}
-	t.Cleanup(func() {
-		deleteDocuments([]*DocumentRef{doc})
-	})
 }
 
 func TestIntegration_MergeNestedServerTimestamp(t *testing.T) {
 	doc := integrationColl(t).NewDoc()
+	t.Cleanup(func() {
+		deleteDocuments([]*DocumentRef{doc})
+	})
 	h := testHelper{t}
 
 	// Create a doc with an ordinary field "a" a ServerTimestamp field "b",
@@ -973,9 +973,6 @@ func TestIntegration_MergeNestedServerTimestamp(t *testing.T) {
 	if !t1.Before(t2) {
 		t.Errorf("got t1=%s, t2=%s; want t1 before t2", t1, t2)
 	}
-	t.Cleanup(func() {
-		deleteDocuments([]*DocumentRef{doc})
-	})
 }
 
 type omitZeroStruct struct {
@@ -1097,6 +1094,9 @@ func TestIntegration_WriteBatch(t *testing.T) {
 	h := testHelper{t}
 	doc1 := iColl.NewDoc()
 	doc2 := iColl.NewDoc()
+	t.Cleanup(func() {
+		deleteDocuments([]*DocumentRef{doc1, doc2})
+	})
 	b.Create(doc1, integrationTestMap)
 	b.Set(doc2, integrationTestMap)
 	b.Update(doc1, []Update{{Path: "bool", Value: false}})
@@ -1122,10 +1122,6 @@ func TestIntegration_WriteBatch(t *testing.T) {
 	}
 	// TODO(jba): test two updates to the same document when it is supported.
 	// TODO(jba): test verify when it is supported.
-
-	t.Cleanup(func() {
-		deleteDocuments([]*DocumentRef{doc1, doc2})
-	})
 }
 
 func TestIntegration_QueryDocuments_WhereEntity(t *testing.T) {
@@ -1150,6 +1146,9 @@ func TestIntegration_QueryDocuments_WhereEntity(t *testing.T) {
 	}
 	var wants []map[string]interface{}
 	var createdDocRefs []*DocumentRef
+	t.Cleanup(func() {
+		deleteDocuments(createdDocRefs)
+	})
 	for _, doc := range docs {
 		newDoc := coll.NewDoc()
 		createdDocRefs = append(createdDocRefs, newDoc)
@@ -1284,9 +1283,6 @@ func TestIntegration_QueryDocuments_WhereEntity(t *testing.T) {
 			}
 		}
 	}
-	t.Cleanup(func() {
-		deleteDocuments(createdDocRefs)
-	})
 }
 
 func reverseSlice(s []map[string]interface{}) []map[string]interface{} {
@@ -1304,6 +1300,9 @@ func TestIntegration_QueryDocuments(t *testing.T) {
 	h := testHelper{t}
 	var wants []map[string]interface{}
 	var createdDocRefs []*DocumentRef
+	t.Cleanup(func() {
+		deleteDocuments(createdDocRefs)
+	})
 	for i := 0; i < 8; i++ {
 		doc := coll.NewDoc()
 		createdDocRefs = append(createdDocRefs, doc)
@@ -1409,10 +1408,6 @@ func TestIntegration_QueryDocuments(t *testing.T) {
 	if got, want := len(seen), len(wants); got != want {
 		t.Errorf("got %d docs with 'q', want %d", len(seen), len(wants))
 	}
-
-	t.Cleanup(func() {
-		deleteDocuments(createdDocRefs)
-	})
 }
 
 func TestIntegration_QueryDocuments_LimitToLast_Fail(t *testing.T) {
@@ -1495,6 +1490,9 @@ func TestIntegration_QueryName(t *testing.T) {
 	coll := integrationColl(t)
 	var wantIDs []string
 	var docRefs []*DocumentRef
+	t.Cleanup(func() {
+		deleteDocuments(docRefs)
+	})
 	for i := 0; i < 3; i++ {
 		doc := coll.NewDoc()
 		docRefs = append(docRefs, doc)
@@ -1512,10 +1510,6 @@ func TestIntegration_QueryName(t *testing.T) {
 	// Test cursors with __name__.
 	checkIDs(q.StartAt(wantIDs[1]), wantIDs[1:])
 	checkIDs(q.EndAt(wantIDs[1]), wantIDs[:2])
-
-	t.Cleanup(func() {
-		deleteDocuments(docRefs)
-	})
 }
 
 func TestIntegration_QueryNested(t *testing.T) {
@@ -1525,6 +1519,9 @@ func TestIntegration_QueryNested(t *testing.T) {
 	doc1 := coll1.NewDoc()
 	coll2 := doc1.Collection(collectionIDs.New())
 	doc2 := coll2.NewDoc()
+	t.Cleanup(func() {
+		deleteDocuments([]*DocumentRef{doc1, doc2})
+	})
 	wantData := map[string]interface{}{"x": int64(1)}
 	h.mustCreate(doc2, wantData)
 	q := coll2.Select("x")
@@ -1538,9 +1535,6 @@ func TestIntegration_QueryNested(t *testing.T) {
 	if gotData := got[0].Data(); !testEqual(gotData, wantData) {
 		t.Errorf("got\n%+v\nwant\n%+v", gotData, wantData)
 	}
-	t.Cleanup(func() {
-		deleteDocuments([]*DocumentRef{doc1, doc2})
-	})
 }
 
 func TestIntegration_RunTransaction(t *testing.T) {
@@ -1556,6 +1550,9 @@ func TestIntegration_RunTransaction(t *testing.T) {
 	pat := Player{Name: "Pat", Score: 3, Star: false}
 	client := integrationClient(t)
 	patDoc := iColl.Doc("pat")
+	t.Cleanup(func() {
+		deleteDocuments([]*DocumentRef{patDoc})
+	})
 	var anError error
 	incPat := func(_ context.Context, tx *Transaction) error {
 		doc, err := tx.Get(patDoc)
@@ -1612,10 +1609,6 @@ func TestIntegration_RunTransaction(t *testing.T) {
 	if got != want {
 		t.Errorf("got %+v, want %+v", got, want)
 	}
-
-	t.Cleanup(func() {
-		deleteDocuments([]*DocumentRef{patDoc})
-	})
 }
 
 func TestIntegration_RunTransaction_WithRunOptions(t *testing.T) {
@@ -1685,6 +1678,9 @@ func TestIntegration_TransactionGetAll(t *testing.T) {
 	client := integrationClient(t)
 	leeDoc := iColl.Doc("lee")
 	samDoc := iColl.Doc("sam")
+	t.Cleanup(func() {
+		deleteDocuments([]*DocumentRef{leeDoc, samDoc})
+	})
 	h.mustCreate(leeDoc, lee)
 	h.mustCreate(samDoc, sam)
 
@@ -1707,17 +1703,17 @@ func TestIntegration_TransactionGetAll(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	t.Cleanup(func() {
-		deleteDocuments([]*DocumentRef{leeDoc, samDoc})
-	})
 }
 
 func TestIntegration_WatchDocument(t *testing.T) {
+	skipIfEdition(t, "Listen queries", editionEnterprise)
 	coll := integrationColl(t)
 	ctx := context.Background()
 	h := testHelper{t}
 	doc := coll.NewDoc()
+	t.Cleanup(func() {
+		deleteDocuments([]*DocumentRef{doc})
+	})
 	it := doc.Snapshots(ctx)
 	defer it.Stop()
 
@@ -1758,10 +1754,6 @@ func TestIntegration_WatchDocument(t *testing.T) {
 	if got := snap.Data(); !testutil.Equal(got, want) {
 		t.Fatalf("got %v, want %v", got, want)
 	}
-
-	t.Cleanup(func() {
-		deleteDocuments([]*DocumentRef{doc})
-	})
 }
 
 func TestIntegration_ArrayUnion_Create(t *testing.T) {
@@ -1771,6 +1763,9 @@ func TestIntegration_ArrayUnion_Create(t *testing.T) {
 	}
 
 	doc := integrationColl(t).NewDoc()
+	t.Cleanup(func() {
+		deleteDocuments([]*DocumentRef{doc})
+	})
 	h := testHelper{t}
 	h.mustCreate(doc, data)
 	ds := h.mustGet(doc)
@@ -1788,14 +1783,13 @@ func TestIntegration_ArrayUnion_Create(t *testing.T) {
 			t.Fatalf("got\n%#v\nwant\n%#v", gotMap[path], want)
 		}
 	}
-
-	t.Cleanup(func() {
-		deleteDocuments([]*DocumentRef{doc})
-	})
 }
 
 func TestIntegration_ArrayUnion_Update(t *testing.T) {
 	doc := integrationColl(t).NewDoc()
+	t.Cleanup(func() {
+		deleteDocuments([]*DocumentRef{doc})
+	})
 	h := testHelper{t}
 	path := "somePath"
 
@@ -1824,9 +1818,6 @@ func TestIntegration_ArrayUnion_Update(t *testing.T) {
 			t.Fatalf("got\n%#v\nwant\n%#v", gotMap[path], want)
 		}
 	}
-	t.Cleanup(func() {
-		deleteDocuments([]*DocumentRef{doc})
-	})
 }
 
 func TestIntegration_ArrayUnion_Set(t *testing.T) {
@@ -1835,6 +1826,9 @@ func TestIntegration_ArrayUnion_Set(t *testing.T) {
 	path := "somePath"
 
 	doc := coll.NewDoc()
+	t.Cleanup(func() {
+		deleteDocuments([]*DocumentRef{doc})
+	})
 	newData := map[string]interface{}{
 		path: ArrayUnion("a", "b"),
 	}
@@ -1854,14 +1848,13 @@ func TestIntegration_ArrayUnion_Set(t *testing.T) {
 			t.Fatalf("got\n%#v\nwant\n%#v", gotMap[path], want)
 		}
 	}
-
-	t.Cleanup(func() {
-		deleteDocuments([]*DocumentRef{doc})
-	})
 }
 
 func TestIntegration_ArrayRemove_Create(t *testing.T) {
 	doc := integrationColl(t).NewDoc()
+	t.Cleanup(func() {
+		deleteDocuments([]*DocumentRef{doc})
+	})
 	h := testHelper{t}
 	path := "somePath"
 
@@ -1883,14 +1876,13 @@ func TestIntegration_ArrayRemove_Create(t *testing.T) {
 	if !testEqual(gotMap[path], want) {
 		t.Fatalf("got\n%#v\nwant\n%#v", gotMap[path], want)
 	}
-
-	t.Cleanup(func() {
-		deleteDocuments([]*DocumentRef{doc})
-	})
 }
 
 func TestIntegration_ArrayRemove_Update(t *testing.T) {
 	doc := integrationColl(t).NewDoc()
+	t.Cleanup(func() {
+		deleteDocuments([]*DocumentRef{doc})
+	})
 	h := testHelper{t}
 	path := "somePath"
 
@@ -1919,10 +1911,6 @@ func TestIntegration_ArrayRemove_Update(t *testing.T) {
 			t.Fatalf("got\n%#v\nwant\n%#v", gotMap[path], want)
 		}
 	}
-
-	t.Cleanup(func() {
-		deleteDocuments([]*DocumentRef{doc})
-	})
 }
 
 func TestIntegration_ArrayRemove_Set(t *testing.T) {
@@ -1931,6 +1919,9 @@ func TestIntegration_ArrayRemove_Set(t *testing.T) {
 	path := "somePath"
 
 	doc := coll.NewDoc()
+	t.Cleanup(func() {
+		deleteDocuments([]*DocumentRef{doc})
+	})
 	newData := map[string]interface{}{
 		path: ArrayRemove("a", "b"),
 	}
@@ -1948,10 +1939,6 @@ func TestIntegration_ArrayRemove_Set(t *testing.T) {
 	if !testEqual(gotMap[path], want) {
 		t.Fatalf("got\n%#v\nwant\n%#v", gotMap[path], want)
 	}
-
-	t.Cleanup(func() {
-		deleteDocuments([]*DocumentRef{doc})
-	})
 }
 
 func makeFieldTransform(transform string, value interface{}) interface{} {
@@ -1970,6 +1957,9 @@ func TestIntegration_FieldTransforms_Create(t *testing.T) {
 	for _, transform := range []string{"inc", "max", "min"} {
 		t.Run(transform, func(t *testing.T) {
 			doc := integrationColl(t).NewDoc()
+			t.Cleanup(func() {
+				deleteDocuments([]*DocumentRef{doc})
+			})
 			h := testHelper{t}
 			path := "somePath"
 			want := 7
@@ -1990,10 +1980,6 @@ func TestIntegration_FieldTransforms_Create(t *testing.T) {
 			if gotMap[path] != want {
 				t.Fatalf("want %d, got %d", want, gotMap[path])
 			}
-
-			t.Cleanup(func() {
-				deleteDocuments([]*DocumentRef{doc})
-			})
 		})
 	}
 }
@@ -2031,6 +2017,9 @@ func TestIntegration_FieldTransforms_Update(t *testing.T) {
 				typeStr := reflect.TypeOf(tc.val).String()
 				t.Run(typeStr, func(t *testing.T) {
 					doc := integrationColl(t).NewDoc()
+					t.Cleanup(func() {
+						deleteDocuments([]*DocumentRef{doc})
+					})
 					h := testHelper{t}
 					path := "somePath"
 
@@ -2097,10 +2086,6 @@ func TestIntegration_FieldTransforms_Update(t *testing.T) {
 						// switch statement.
 						t.Fatalf("unsupported type %T", want)
 					}
-
-					t.Cleanup(func() {
-						deleteDocuments([]*DocumentRef{doc})
-					})
 				})
 			})
 		}
@@ -2116,6 +2101,9 @@ func TestIntegration_FieldTransforms_Set(t *testing.T) {
 			want := 9
 
 			doc := coll.NewDoc()
+			t.Cleanup(func() {
+				deleteDocuments([]*DocumentRef{doc})
+			})
 			newData := map[string]interface{}{
 				path: makeFieldTransform(transform, want),
 			}
@@ -2132,10 +2120,6 @@ func TestIntegration_FieldTransforms_Set(t *testing.T) {
 			if gotMap[path] != want {
 				t.Fatalf("want %d, got %d", want, gotMap[path])
 			}
-
-			t.Cleanup(func() {
-				deleteDocuments([]*DocumentRef{doc})
-			})
 		})
 	}
 }
@@ -2143,7 +2127,7 @@ func TestIntegration_FieldTransforms_Set(t *testing.T) {
 type imap map[string]interface{}
 
 func TestIntegration_Serialize_Deserialize_WatchQuery(t *testing.T) {
-	skipIfEnterprise(t, "PartitionQuery")
+	skipIfEdition(t, "PartitionQuery", editionEnterprise)
 	h := testHelper{t}
 	collID := collectionIDs.New()
 	ctx := context.Background()
@@ -2193,6 +2177,7 @@ func TestIntegration_Serialize_Deserialize_WatchQuery(t *testing.T) {
 }
 
 func TestIntegration_WatchQuery(t *testing.T) {
+	skipIfEdition(t, "Listen queries", editionEnterprise)
 	ctx := context.Background()
 	coll := integrationColl(t)
 	h := testHelper{t}
@@ -2280,6 +2265,7 @@ func TestIntegration_WatchQuery(t *testing.T) {
 }
 
 func TestIntegration_WatchQueryCancel(t *testing.T) {
+	skipIfEdition(t, "Listen queries", editionEnterprise)
 	ctx := context.Background()
 	coll := integrationColl(t)
 
@@ -2345,17 +2331,17 @@ func TestIntegration_CollectionGroupQueries(t *testing.T) {
 	cr1 := client.Collection(shouldBeFoundID)
 	dr1 := cr1.Doc("should-be-found-1")
 	h.mustCreate(dr1, map[string]string{"some-key": "should-be-found"})
-	defer h.mustDelete(dr1)
+	t.Cleanup(func() { deleteDocuments([]*DocumentRef{dr1}) })
 
 	dr1.Collection(shouldBeFoundID)
 	dr2 := cr1.Doc("should-be-found-2")
 	h.mustCreate(dr2, map[string]string{"some-key": "should-be-found"})
-	defer h.mustDelete(dr2)
+	t.Cleanup(func() { deleteDocuments([]*DocumentRef{dr2}) })
 
 	cr3 := client.Collection(shouldNotBeFoundID)
 	dr3 := cr3.Doc("should-not-be-found")
 	h.mustCreate(dr3, map[string]string{"some-key": "should-NOT-be-found"})
-	defer h.mustDelete(dr3)
+	t.Cleanup(func() { deleteDocuments([]*DocumentRef{dr3}) })
 
 	cg := client.CollectionGroup(shouldBeFoundID)
 	snaps, err := cg.Documents(ctx).GetAll()
@@ -2494,8 +2480,10 @@ func TestDetectProjectID(t *testing.T) {
 	}
 
 	// Use creds with project ID.
-	if _, err := NewClient(ctx, DetectProjectID, option.WithCredentials(creds)); err != nil {
+	if c, err := NewClient(ctx, DetectProjectID, option.WithCredentials(creds)); err != nil {
 		t.Errorf("NewClient: %v", err)
+	} else {
+		c.Close()
 	}
 
 	ts := testutil.ErroringTokenSource{}
@@ -2508,7 +2496,7 @@ func TestDetectProjectID(t *testing.T) {
 }
 
 func TestIntegration_ColGroupRefPartitions(t *testing.T) {
-	skipIfEnterprise(t, "PartitionQuery")
+	skipIfEdition(t, "PartitionQuery", editionEnterprise)
 	h := testHelper{t}
 	client := integrationClient(t)
 	coll := client.Collection(collectionIDs.New())
@@ -2558,7 +2546,7 @@ func TestIntegration_ColGroupRefPartitions(t *testing.T) {
 }
 
 func TestIntegration_ColGroupRefPartitionsLarge(t *testing.T) {
-	skipIfEnterprise(t, "PartitionQuery")
+	skipIfEdition(t, "PartitionQuery", editionEnterprise)
 	// Create collection with enough documents to have multiple partitions.
 	client := integrationClient(t)
 	coll := client.Collection(collectionIDs.New())
@@ -2670,6 +2658,9 @@ func TestIntegration_NewClientWithDatabase(t *testing.T) {
 		} else if err == nil && c.databaseID != tc.dbName {
 			t.Errorf("NewClientWithDatabase: %s got %v want %v", tc.desc, c.databaseID, tc.dbName)
 		}
+		if c != nil {
+			c.Close()
+		}
 	}
 }
 
@@ -2689,6 +2680,7 @@ func TestIntegration_BulkWriter_Set(t *testing.T) {
 	if err != nil {
 		t.Errorf("bulkwriter: error performing a set write: %v\n", err)
 	}
+	bw.End()
 }
 
 func TestIntegration_BulkWriter_Create(t *testing.T) {
@@ -2808,9 +2800,6 @@ func TestIntegration_BulkWriter(t *testing.T) {
 			t.Error("bulkwriter: write attempt returned nil results")
 		}
 	}
-	t.Cleanup(func() {
-		deleteDocuments(docRefs)
-	})
 }
 
 func aggResultsEquals(r *testutil.R, m1, m2 AggregationResult) bool {
@@ -3334,7 +3323,9 @@ func TestIntegration_CountAggregationQuery(t *testing.T) {
 		iColl.NewDoc(),
 		iColl.NewDoc(),
 	}
-
+	t.Cleanup(func() {
+		deleteDocuments(docs)
+	})
 	c := integrationClient(t)
 	ctx := context.Background()
 	bw := c.BulkWriter(ctx)
@@ -3376,10 +3367,6 @@ func TestIntegration_CountAggregationQuery(t *testing.T) {
 	if cv.GetIntegerValue() != 2 {
 		t.Errorf("COUNT aggregation query mismatch;\ngot: %d, want: %d", cv.GetIntegerValue(), 2)
 	}
-
-	t.Cleanup(func() {
-		deleteDocuments(docs)
-	})
 }
 
 func TestIntegration_ClientReadTime(t *testing.T) {

--- a/firestore/integration_test.go
+++ b/firestore/integration_test.go
@@ -81,7 +81,7 @@ func TestMain(m *testing.M) {
 		testParams[firestoreEditionKey] = edition
 		initIntegrationTest()
 		status := m.Run()
-		// cleanupIntegrationTest()
+		cleanupIntegrationTest()
 		if status != 0 {
 			os.Exit(status)
 		}
@@ -189,12 +189,12 @@ func deleteCollection(ctx context.Context, coll *CollectionRef) error {
 	bulkwriter := iClient.BulkWriter(ctx)
 
 	// Get  documents
-	iter := coll.Select().Documents(ctx)
+	iter := coll.DocumentRefs(ctx)
 
 	// Iterate through the documents, adding
 	// a delete operation for each one to the BulkWriter.
 	for {
-		docSnap, err := iter.Next()
+		docRef, err := iter.Next()
 		if err == iterator.Done {
 			break
 		}
@@ -202,7 +202,7 @@ func deleteCollection(ctx context.Context, coll *CollectionRef) error {
 			log.Printf("Failed to get next document: %+v\n", err)
 			return err
 		}
-		err = deleteDocument(ctx, docSnap.Ref, bulkwriter)
+		err = deleteDocument(ctx, docRef, bulkwriter)
 		if err != nil {
 			log.Printf("Failed to delete document: %+v\n", err)
 			return err

--- a/firestore/pipeline.go
+++ b/firestore/pipeline.go
@@ -26,8 +26,8 @@ import (
 var (
 	// ErrPipelineWithoutDatabase is returned when a pipeline is executed without a database such as a subcollection pipeline.
 	ErrPipelineWithoutDatabase = errors.New("firestore: pipeline without a database cannot be executed directly, only as part of another pipeline")
-	// ErrUnionNotSupportRelativeScope is returned when a union is used with a relative scope pipeline.
-	ErrUnionNotSupportRelativeScope = errors.New("firestore: union only supports combining root pipelines; relative scope pipelines (like subcollection pipelines) are not supported")
+	// ErrRelativeScopeUnionUnsupported is returned when a union is used with a relative scope pipeline.
+	ErrRelativeScopeUnionUnsupported = errors.New("firestore: union only supports combining root pipelines; relative scope pipelines (like subcollection pipelines) are not supported")
 )
 
 // Pipeline class provides a flexible and expressive framework for building complex data
@@ -908,7 +908,7 @@ func (p *Pipeline) Union(other *Pipeline, opts ...UnionOption) *Pipeline {
 		return p
 	}
 	if other.c == nil {
-		p.err = ErrUnionNotSupportRelativeScope
+		p.err = ErrRelativeScopeUnionUnsupported
 		return p
 	}
 	options := make(map[string]any)

--- a/firestore/pipeline.go
+++ b/firestore/pipeline.go
@@ -16,10 +16,18 @@ package firestore
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 
 	pb "cloud.google.com/go/firestore/apiv1/firestorepb"
+)
+
+var (
+	// ErrPipelineWithoutDatabase is returned when a pipeline is executed without a database such as a subcollection pipeline.
+	ErrPipelineWithoutDatabase = errors.New("firestore: pipeline without a database cannot be executed directly, only as part of another pipeline")
+	// ErrUnionNotSupportRelativeScope is returned when a union is used with a relative scope pipeline.
+	ErrUnionNotSupportRelativeScope = errors.New("firestore: union only supports combining root pipelines; relative scope pipelines (like subcollection pipelines) are not supported")
 )
 
 // Pipeline class provides a flexible and expressive framework for building complex data
@@ -256,7 +264,7 @@ func (p *Pipeline) Execute(ctx context.Context, opts ...ExecuteOption) *Pipeline
 	}
 
 	if newP.c == nil {
-		newP.err = fmt.Errorf("pipeline created without a database (e.g., as a subcollection pipeline) cannot be executed directly; it can only be used as part of another pipeline")
+		newP.err = ErrPipelineWithoutDatabase
 		return &PipelineSnapshot{
 			iter: &PipelineResultIterator{
 				err: newP.err,
@@ -900,7 +908,7 @@ func (p *Pipeline) Union(other *Pipeline, opts ...UnionOption) *Pipeline {
 		return p
 	}
 	if other.c == nil {
-		p.err = fmt.Errorf("union only supports combining root pipelines; relative scope pipelines (like subcollection pipelines) are not supported")
+		p.err = ErrUnionNotSupportRelativeScope
 		return p
 	}
 	options := make(map[string]any)

--- a/firestore/pipeline_expression.go
+++ b/firestore/pipeline_expression.go
@@ -174,11 +174,11 @@ type Expression interface {
 	//
 	// The parameter 'offset' is the 0-based index of the first element to include. It can be an int, int32, int64 or [Expression].
 	ArraySlice(offset any) Expression
-	// ArraySliceWithLength creates an expression that returns a slice of an array starting from the specified offset with a given length.
+	// ArraySliceToEnd creates an expression that returns a slice of an array starting from the specified offset with a given length.
 	//
 	// The parameter 'offset' is the 0-based index of the first element to include. It can be an int, int32, int64 or [Expression].
 	// The parameter 'length' is the number of elements to include. It can be an int, int32, int64 or [Expression].
-	ArraySliceWithLength(offset, length any) Expression
+	ArraySliceToEnd(offset, length any) Expression
 	// ArrayIndexOf creates an expression that returns the first index of a search value in an array.
 	//
 	// The parameter 'search' is the value to search for. It can be a constant or [Expression].
@@ -205,12 +205,11 @@ type Expression interface {
 	// If the expression resolves to an absent value, it is converted to NULL.
 	// The order of elements in the output array is not stable and shouldn't be relied upon.
 	ArrayAggDistinct() AggregateFunction
-	// TODO: Uncomment this after fixing the proto representation of this function.
 	// ArrayFilter creates an expression for array_filter(array, param, body).
 	//
 	// The parameter 'param' is the name of the parameter to use in the body expression.
 	// The parameter 'body' is the expression to evaluate for each element of the array.
-	// ArrayFilter(param string, body BooleanExpression) Expression
+	ArrayFilter(param string, body BooleanExpression) Expression
 	// LogicalMaximum returns the maximum value of the expression and the specified values.
 	LogicalMaximum(others ...any) Expression
 	// LogicalMinimum returns the minimum value of the expression and the specified values.
@@ -242,7 +241,7 @@ type Expression interface {
 	// "week(wednesday)", "week(thursday)", "week(friday)", "week(saturday)", "week(sunday)", "isoweek", "month", "quarter", "year", and "isoyear".
 	// The parameter 'timezone' can be a string constant (e.g., "America/Los_Angeles") or an [Expression] that evaluates to a valid timezone string.
 	// Valid values are from the TZ database or in the format "Etc/GMT-1".
-	TimestampTruncateWithTimezone(granularity any, timezone string) Expression
+	TimestampTruncateWithTimezone(granularity any, timezone any) Expression
 	// TimestampToUnixMicros creates an expression that converts a timestamp expression to the number of microseconds since
 	// the Unix epoch (1970-01-01 00:00:00 UTC).
 	TimestampToUnixMicros() Expression
@@ -588,8 +587,8 @@ func (b *baseExpression) ArrayFirstN(n any) Expression     { return ArrayFirstN(
 func (b *baseExpression) ArrayLast() Expression            { return ArrayLast(b) }
 func (b *baseExpression) ArrayLastN(n any) Expression      { return ArrayLastN(b, n) }
 func (b *baseExpression) ArraySlice(offset any) Expression { return ArraySlice(b, offset) }
-func (b *baseExpression) ArraySliceWithLength(offset, length any) Expression {
-	return ArraySliceLength(b, offset, length)
+func (b *baseExpression) ArraySliceToEnd(offset, length any) Expression {
+	return ArraySliceToEnd(b, offset, length)
 }
 func (b *baseExpression) ArrayIndexOf(search any) Expression {
 	return ArrayIndexOf(b, search)
@@ -605,11 +604,9 @@ func (b *baseExpression) Last() AggregateFunction             { return Last(b) }
 func (b *baseExpression) ArrayAgg() AggregateFunction         { return ArrayAgg(b) }
 func (b *baseExpression) ArrayAggDistinct() AggregateFunction { return ArrayAggDistinct(b) }
 
-// TODO: Uncomment this after fixing the proto representation of this function.
-//
-//	func (b *baseExpression) ArrayFilter(param string, body BooleanExpression) Expression {
-//		return ArrayFilter(b, param, body)
-//	}
+func (b *baseExpression) ArrayFilter(param string, body BooleanExpression) Expression {
+	return ArrayFilter(b, param, body)
+}
 func (b *baseExpression) LogicalMaximum(others ...any) Expression {
 	return LogicalMaximum(b, others...)
 }
@@ -627,7 +624,7 @@ func (b *baseExpression) TimestampSubtract(unit, amount any) Expression {
 func (b *baseExpression) TimestampTruncate(granularity any) Expression {
 	return TimestampTruncate(b, granularity)
 }
-func (b *baseExpression) TimestampTruncateWithTimezone(granularity any, timezone string) Expression {
+func (b *baseExpression) TimestampTruncateWithTimezone(granularity any, timezone any) Expression {
 	return TimestampTruncateWithTimezone(b, granularity, timezone)
 }
 func (b *baseExpression) TimestampToUnixMicros() Expression  { return TimestampToUnixMicros(b) }

--- a/firestore/pipeline_expression.go
+++ b/firestore/pipeline_expression.go
@@ -170,15 +170,15 @@ type Expression interface {
 	//
 	// The parameter 'n' can be an integer constant or an [Expression] that evaluates to an integer.
 	ArrayLastN(n any) Expression
-	// ArraySlice creates an expression that returns a slice of an array starting from the specified offset.
+	// ArraySliceToEnd creates an expression that returns a slice of an array starting from the specified offset.
 	//
 	// The parameter 'offset' is the 0-based index of the first element to include. It can be an int, int32, int64 or [Expression].
-	ArraySlice(offset any) Expression
-	// ArraySliceToEnd creates an expression that returns a slice of an array starting from the specified offset with a given length.
+	ArraySliceToEnd(offset any) Expression
+	// ArraySlice creates an expression that returns a slice of an array starting from the specified offset with a given length.
 	//
 	// The parameter 'offset' is the 0-based index of the first element to include. It can be an int, int32, int64 or [Expression].
 	// The parameter 'length' is the number of elements to include. It can be an int, int32, int64 or [Expression].
-	ArraySliceToEnd(offset, length any) Expression
+	ArraySlice(offset, length any) Expression
 	// ArrayIndexOf creates an expression that returns the first index of a search value in an array.
 	//
 	// The parameter 'search' is the value to search for. It can be a constant or [Expression].
@@ -577,18 +577,18 @@ func (b *baseExpression) ArrayReverse() Expression                 { return Arra
 func (b *baseExpression) ArrayConcat(otherArrays ...any) Expression {
 	return ArrayConcat(b, otherArrays...)
 }
-func (b *baseExpression) ArraySum() Expression             { return ArraySum(b) }
-func (b *baseExpression) ArrayMaximum() Expression         { return ArrayMaximum(b) }
-func (b *baseExpression) ArrayMaximumN(n any) Expression   { return ArrayMaximumN(b, n) }
-func (b *baseExpression) ArrayMinimum() Expression         { return ArrayMinimum(b) }
-func (b *baseExpression) ArrayMinimumN(n any) Expression   { return ArrayMinimumN(b, n) }
-func (b *baseExpression) ArrayFirst() Expression           { return ArrayFirst(b) }
-func (b *baseExpression) ArrayFirstN(n any) Expression     { return ArrayFirstN(b, n) }
-func (b *baseExpression) ArrayLast() Expression            { return ArrayLast(b) }
-func (b *baseExpression) ArrayLastN(n any) Expression      { return ArrayLastN(b, n) }
-func (b *baseExpression) ArraySlice(offset any) Expression { return ArraySlice(b, offset) }
-func (b *baseExpression) ArraySliceToEnd(offset, length any) Expression {
-	return ArraySliceToEnd(b, offset, length)
+func (b *baseExpression) ArraySum() Expression                  { return ArraySum(b) }
+func (b *baseExpression) ArrayMaximum() Expression              { return ArrayMaximum(b) }
+func (b *baseExpression) ArrayMaximumN(n any) Expression        { return ArrayMaximumN(b, n) }
+func (b *baseExpression) ArrayMinimum() Expression              { return ArrayMinimum(b) }
+func (b *baseExpression) ArrayMinimumN(n any) Expression        { return ArrayMinimumN(b, n) }
+func (b *baseExpression) ArrayFirst() Expression                { return ArrayFirst(b) }
+func (b *baseExpression) ArrayFirstN(n any) Expression          { return ArrayFirstN(b, n) }
+func (b *baseExpression) ArrayLast() Expression                 { return ArrayLast(b) }
+func (b *baseExpression) ArrayLastN(n any) Expression           { return ArrayLastN(b, n) }
+func (b *baseExpression) ArraySliceToEnd(offset any) Expression { return ArraySliceToEnd(b, offset) }
+func (b *baseExpression) ArraySlice(offset, length any) Expression {
+	return ArraySlice(b, offset, length)
 }
 func (b *baseExpression) ArrayIndexOf(search any) Expression {
 	return ArrayIndexOf(b, search)

--- a/firestore/pipeline_function.go
+++ b/firestore/pipeline_function.go
@@ -322,7 +322,7 @@ func TimestampTruncate(timestamp, granularity any) Expression {
 //
 // Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
 // regardless of any other documented package stability guarantees.
-func TimestampTruncateWithTimezone(timestamp, granularity any, timezone string) Expression {
+func TimestampTruncateWithTimezone(timestamp, granularity any, timezone any) Expression {
 	return newBaseFunction("timestamp_trunc", []Expression{asFieldExpr(timestamp), asStringExpr(granularity), asStringExpr(timezone)})
 }
 
@@ -579,14 +579,14 @@ func ArraySlice(exprOrFieldPath any, offset any) Expression {
 	return newBaseFunction("array_slice", []Expression{asFieldExpr(exprOrFieldPath), asInt64Expr(offset)})
 }
 
-// ArraySliceLength creates an expression that returns a slice of an array starting from the specified offset with a given length.
+// ArraySliceToEnd creates an expression that returns a slice of an array starting from the specified offset with a given length.
 // - exprOrFieldPath can be a field path string, [FieldPath] or an [Expression] that evaluates to an array.
 // - offset is the 0-based index of the first element to include. It can be an int, int32, int64 or [Expression].
 // - length is the number of elements to include. It can be an int, int32, int64 or [Expression].
 //
 // Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
 // regardless of any other documented package stability guarantees.
-func ArraySliceLength(exprOrFieldPath any, offset any, length any) Expression {
+func ArraySliceToEnd(exprOrFieldPath any, offset any, length any) Expression {
 	return newBaseFunction("array_slice", []Expression{asFieldExpr(exprOrFieldPath), asInt64Expr(offset), asInt64Expr(length)})
 }
 
@@ -597,10 +597,9 @@ func ArraySliceLength(exprOrFieldPath any, offset any, length any) Expression {
 //
 // Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
 // regardless of any other documented package stability guarantees.
-// TODO: Uncomment this after fixing the proto representation of this function.
-// func ArrayFilter(array any, param string, body BooleanExpression) Expression {
-// 	return newBaseFunction("array_filter", []Expression{asFieldExpr(array), ConstantOf(param), body})
-// }
+func ArrayFilter(array any, param string, body BooleanExpression) Expression {
+	return newBaseFunction("array_filter", []Expression{asFieldExpr(array), ConstantOf(param), body})
+}
 
 // ArrayIndexOf creates an expression that returns the first index of a search value in an array.
 // - exprOrFieldPath can be a field path string, [FieldPath] or an [Expression] that evaluates to an array.

--- a/firestore/pipeline_function.go
+++ b/firestore/pipeline_function.go
@@ -569,24 +569,24 @@ func ArrayLastN(exprOrFieldPath any, n any) Expression {
 	return newBaseFunction("array_last_n", []Expression{asFieldExpr(exprOrFieldPath), asInt64Expr(n)})
 }
 
-// ArraySlice creates an expression that returns a slice of an array starting from the specified offset.
+// ArraySliceToEnd creates an expression that returns a slice of an array starting from the specified offset.
 // - exprOrFieldPath can be a field path string, [FieldPath] or an [Expression] that evaluates to an array.
 // - offset is the 0-based index of the first element to include. It can be an int, int32, int64 or [Expression].
 //
 // Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
 // regardless of any other documented package stability guarantees.
-func ArraySlice(exprOrFieldPath any, offset any) Expression {
+func ArraySliceToEnd(exprOrFieldPath any, offset any) Expression {
 	return newBaseFunction("array_slice", []Expression{asFieldExpr(exprOrFieldPath), asInt64Expr(offset)})
 }
 
-// ArraySliceToEnd creates an expression that returns a slice of an array starting from the specified offset with a given length.
+// ArraySlice creates an expression that returns a slice of an array starting from the specified offset with a given length.
 // - exprOrFieldPath can be a field path string, [FieldPath] or an [Expression] that evaluates to an array.
 // - offset is the 0-based index of the first element to include. It can be an int, int32, int64 or [Expression].
 // - length is the number of elements to include. It can be an int, int32, int64 or [Expression].
 //
 // Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
 // regardless of any other documented package stability guarantees.
-func ArraySliceToEnd(exprOrFieldPath any, offset any, length any) Expression {
+func ArraySlice(exprOrFieldPath any, offset any, length any) Expression {
 	return newBaseFunction("array_slice", []Expression{asFieldExpr(exprOrFieldPath), asInt64Expr(offset), asInt64Expr(length)})
 }
 

--- a/firestore/pipeline_function_test.go
+++ b/firestore/pipeline_function_test.go
@@ -983,7 +983,7 @@ func TestArrayFunctions(t *testing.T) {
 		},
 		{
 			desc: "ArraySliceWithLength",
-			expr: ArraySliceLength("field", 1, 2),
+			expr: ArraySliceToEnd("field", 1, 2),
 			want: &pb.Value{ValueType: &pb.Value_FunctionValue{
 				FunctionValue: &pb.Function{
 					Name: "array_slice",
@@ -995,51 +995,50 @@ func TestArrayFunctions(t *testing.T) {
 				},
 			}},
 		},
-		// TODO: Uncomment this after fixing the proto representation of this function.
-		// {
-		// 	desc: "ArrayFilter",
-		// 	expr: ArrayFilter("field", "item", FieldOf("item").GreaterThan(5)),
-		// 	want: &pb.Value{ValueType: &pb.Value_FunctionValue{
-		// 		FunctionValue: &pb.Function{
-		// 			Name: "array_filter",
-		// 			Args: []*pb.Value{
-		// 				{ValueType: &pb.Value_FieldReferenceValue{FieldReferenceValue: "field"}},
-		// 				{ValueType: &pb.Value_StringValue{StringValue: "item"}},
-		// 				{ValueType: &pb.Value_FunctionValue{
-		// 					FunctionValue: &pb.Function{
-		// 						Name: "greater_than",
-		// 						Args: []*pb.Value{
-		// 							{ValueType: &pb.Value_FieldReferenceValue{FieldReferenceValue: "item"}},
-		// 							{ValueType: &pb.Value_IntegerValue{IntegerValue: 5}},
-		// 						},
-		// 					},
-		// 				}},
-		// 			},
-		// 		},
-		// 	}},
-		// },
-		// {
-		// 	desc: "baseExpression ArrayFilter",
-		// 	expr: FieldOf("field").ArrayFilter("item", FieldOf("item").GreaterThan(5)),
-		// 	want: &pb.Value{ValueType: &pb.Value_FunctionValue{
-		// 		FunctionValue: &pb.Function{
-		// 			Name: "array_filter",
-		// 			Args: []*pb.Value{
-		// 				{ValueType: &pb.Value_FieldReferenceValue{FieldReferenceValue: "field"}},
-		// 				{ValueType: &pb.Value_StringValue{StringValue: "item"}},
-		// 				{ValueType: &pb.Value_FunctionValue{
-		// 					FunctionValue: &pb.Function{
-		// 						Name: "greater_than",
-		// 						Args: []*pb.Value{
-		// 							{ValueType: &pb.Value_FieldReferenceValue{FieldReferenceValue: "item"}},
-		// 							{ValueType: &pb.Value_IntegerValue{IntegerValue: 5}},
-		// 						},
-		// 					},
-		// 				}},
-		// 			},
-		// 		},
-		// 	}},
-		// },
+		{
+			desc: "ArrayFilter",
+			expr: ArrayFilter("field", "item", FieldOf("item").GreaterThan(5)),
+			want: &pb.Value{ValueType: &pb.Value_FunctionValue{
+				FunctionValue: &pb.Function{
+					Name: "array_filter",
+					Args: []*pb.Value{
+						{ValueType: &pb.Value_FieldReferenceValue{FieldReferenceValue: "field"}},
+						{ValueType: &pb.Value_StringValue{StringValue: "item"}},
+						{ValueType: &pb.Value_FunctionValue{
+							FunctionValue: &pb.Function{
+								Name: "greater_than",
+								Args: []*pb.Value{
+									{ValueType: &pb.Value_FieldReferenceValue{FieldReferenceValue: "item"}},
+									{ValueType: &pb.Value_IntegerValue{IntegerValue: 5}},
+								},
+							},
+						}},
+					},
+				},
+			}},
+		},
+		{
+			desc: "baseExpression ArrayFilter",
+			expr: FieldOf("field").ArrayFilter("item", FieldOf("item").GreaterThan(5)),
+			want: &pb.Value{ValueType: &pb.Value_FunctionValue{
+				FunctionValue: &pb.Function{
+					Name: "array_filter",
+					Args: []*pb.Value{
+						{ValueType: &pb.Value_FieldReferenceValue{FieldReferenceValue: "field"}},
+						{ValueType: &pb.Value_StringValue{StringValue: "item"}},
+						{ValueType: &pb.Value_FunctionValue{
+							FunctionValue: &pb.Function{
+								Name: "greater_than",
+								Args: []*pb.Value{
+									{ValueType: &pb.Value_FieldReferenceValue{FieldReferenceValue: "item"}},
+									{ValueType: &pb.Value_IntegerValue{IntegerValue: 5}},
+								},
+							},
+						}},
+					},
+				},
+			}},
+		},
 		{
 			desc: "ArrayIndexOf",
 			expr: ArrayIndexOf("field", "search"),

--- a/firestore/pipeline_function_test.go
+++ b/firestore/pipeline_function_test.go
@@ -969,8 +969,8 @@ func TestArrayFunctions(t *testing.T) {
 			}},
 		},
 		{
-			desc: "ArraySlice",
-			expr: ArraySlice("field", 1),
+			desc: "ArraySliceToEnd",
+			expr: ArraySliceToEnd("field", 1),
 			want: &pb.Value{ValueType: &pb.Value_FunctionValue{
 				FunctionValue: &pb.Function{
 					Name: "array_slice",
@@ -983,7 +983,7 @@ func TestArrayFunctions(t *testing.T) {
 		},
 		{
 			desc: "ArraySliceWithLength",
-			expr: ArraySliceToEnd("field", 1, 2),
+			expr: ArraySlice("field", 1, 2),
 			want: &pb.Value{ValueType: &pb.Value_FunctionValue{
 				FunctionValue: &pb.Function{
 					Name: "array_slice",

--- a/firestore/pipeline_integration_test.go
+++ b/firestore/pipeline_integration_test.go
@@ -931,9 +931,6 @@ func aggregationFuncs(t *testing.T) {
 		docRefs = append(docRefs, docRef)
 		h.mustCreate(docRef, d)
 	}
-	t.Cleanup(func() {
-		deleteDocuments(docRefs)
-	})
 
 	pipeline := client.Pipeline().Collection(coll.ID).
 		Sort(Orders(Ascending(FieldOf("val")))).
@@ -1501,13 +1498,13 @@ func arrayFuncs(t *testing.T) {
 			want:     map[string]interface{}{"last_n": []interface{}{int64(2), int64(3)}},
 		},
 		{
-			name:     "ArraySlice",
-			pipeline: client.Pipeline().Collection(coll.ID).Select(Fields(ArraySlice("a", 1).As("slice"))),
+			name:     "ArraySliceToEnd",
+			pipeline: client.Pipeline().Collection(coll.ID).Select(Fields(ArraySliceToEnd("a", 1).As("slice"))),
 			want:     map[string]interface{}{"slice": []interface{}{int64(2), int64(3)}},
 		},
 		{
 			name:     "ArraySliceWithLength",
-			pipeline: client.Pipeline().Collection(coll.ID).Select(Fields(ArraySliceToEnd("a", 1, 1).As("slice_len"))),
+			pipeline: client.Pipeline().Collection(coll.ID).Select(Fields(ArraySlice("a", 1, 1).As("slice_len"))),
 			want:     map[string]interface{}{"slice_len": []interface{}{int64(2)}},
 		},
 		// TODO: Uncomment this after fixing the proto representation of this function.

--- a/firestore/pipeline_integration_test.go
+++ b/firestore/pipeline_integration_test.go
@@ -30,12 +30,6 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-func skipIfNotEnterprise(t *testing.T) {
-	if testParams[firestoreEditionKey].(firestoreEdition) != editionEnterprise {
-		t.Skip("Skipping test in non-enterprise environment")
-	}
-}
-
 type Author struct {
 	Name    string `firestore:"name"`
 	Country string `firestore:"country"`
@@ -66,7 +60,7 @@ func testBooks() []Book {
 }
 
 func TestIntegration_PipelineExecute(t *testing.T) {
-	skipIfNotEnterprise(t)
+	skipIfEdition(t, "Pipeline queries", editionStandard)
 	ctx := context.Background()
 	client := integrationClient(t)
 	coll := integrationColl(t)
@@ -104,14 +98,14 @@ func TestIntegration_PipelineExecute(t *testing.T) {
 		h := testHelper{t}
 		books := testBooks()[:2]
 		var docRefs []*DocumentRef
-		for _, b := range books {
-			docRef := coll.NewDoc()
-			h.mustCreate(docRef, b)
-			docRefs = append(docRefs, docRef)
-		}
 		t.Cleanup(func() {
 			deleteDocuments(docRefs)
 		})
+		for _, b := range books {
+			docRef := coll.NewDoc()
+			docRefs = append(docRefs, docRef)
+			h.mustCreate(docRef, b)
+		}
 		p := client.Pipeline().Collection(coll.ID)
 		err := client.RunTransaction(ctx, func(ctx context.Context, txn *Transaction) error {
 			iter := txn.Execute(p).Results()
@@ -179,14 +173,14 @@ func TestIntegration_PipelineExecute(t *testing.T) {
 		coll := integrationColl(t)
 		books := testBooks()[:3]
 		var docRefs []*DocumentRef
-		for _, b := range books {
-			docRef := coll.NewDoc()
-			h.mustCreate(docRef, b)
-			docRefs = append(docRefs, docRef)
-		}
 		t.Cleanup(func() {
 			deleteDocuments(docRefs)
 		})
+		for _, b := range books {
+			docRef := coll.NewDoc()
+			docRefs = append(docRefs, docRef)
+			h.mustCreate(docRef, b)
+		}
 
 		q := coll.Where("rating", ">", 4.2)
 		p := client.Pipeline().CreateFromQuery(q)
@@ -206,14 +200,14 @@ func TestIntegration_PipelineExecute(t *testing.T) {
 		coll := integrationColl(t)
 		books := testBooks()[:3]
 		var docRefs []*DocumentRef
-		for _, b := range books {
-			docRef := coll.NewDoc()
-			h.mustCreate(docRef, b)
-			docRefs = append(docRefs, docRef)
-		}
 		t.Cleanup(func() {
 			deleteDocuments(docRefs)
 		})
+		for _, b := range books {
+			docRef := coll.NewDoc()
+			docRefs = append(docRefs, docRef)
+			h.mustCreate(docRef, b)
+		}
 
 		ag := coll.NewAggregationQuery().WithCount("count")
 		p := client.Pipeline().CreateFromAggregationQuery(ag)
@@ -234,7 +228,7 @@ func TestIntegration_PipelineExecute(t *testing.T) {
 }
 
 func TestIntegration_PipelineStages(t *testing.T) {
-	skipIfNotEnterprise(t)
+	skipIfEdition(t, "Pipeline queries", editionStandard)
 	ctx := context.Background()
 	client := integrationClient(t)
 	coll := integrationColl(t)
@@ -264,14 +258,14 @@ func TestIntegration_PipelineStages(t *testing.T) {
 		{Title: "Dune", Author: Author{Name: "Frank Herbert", Country: "USA"}, Genre: "Science Fiction", Published: 1965, Rating: 4.6, Tags: []string{"politics", "desert", "ecology"}},
 	}
 	var docRefs []*DocumentRef
-	for _, b := range books {
-		docRef := coll.NewDoc()
-		h.mustCreate(docRef, b)
-		docRefs = append(docRefs, docRef)
-	}
 	t.Cleanup(func() {
 		deleteDocuments(docRefs)
 	})
+	for _, b := range books {
+		docRef := coll.NewDoc()
+		docRefs = append(docRefs, docRef)
+		h.mustCreate(docRef, b)
+	}
 	t.Run("AddFields", func(t *testing.T) {
 		iter := client.Pipeline().Collection(coll.ID).AddFields(Selectables(Multiply(FieldOf("rating"), 2).As("doubled_rating"))).Limit(1).Execute(ctx).Results()
 		defer iter.Stop()
@@ -344,11 +338,11 @@ func TestIntegration_PipelineStages(t *testing.T) {
 		cgColl2 := doc2.Collection(cgCollID)
 		cgDoc1 := cgColl1.NewDoc()
 		cgDoc2 := cgColl2.NewDoc()
-		h.mustCreate(cgDoc1, map[string]string{"val": "a"})
-		h.mustCreate(cgDoc2, map[string]string{"val": "b"})
 		t.Cleanup(func() {
 			deleteDocuments([]*DocumentRef{cgDoc1, cgDoc2, doc1, doc2})
 		})
+		h.mustCreate(cgDoc1, map[string]string{"val": "a"})
+		h.mustCreate(cgDoc2, map[string]string{"val": "b"})
 		iter := client.Pipeline().CollectionGroup(cgCollID).Execute(ctx).Results()
 		defer iter.Stop()
 		results, err := iter.GetAll()
@@ -361,10 +355,10 @@ func TestIntegration_PipelineStages(t *testing.T) {
 	})
 	t.Run("CollectionHints", func(t *testing.T) {
 		docRef := coll.NewDoc()
-		h.mustCreate(docRef, map[string]any{"a": 1})
 		t.Cleanup(func() {
 			deleteDocuments([]*DocumentRef{docRef})
 		})
+		h.mustCreate(docRef, map[string]any{"a": 1})
 
 		// Use a hint that is likely ignored or causes no error if valid.
 		client.Pipeline().Collection(coll.ID, WithIgnoreIndexFields("a")).
@@ -375,11 +369,11 @@ func TestIntegration_PipelineStages(t *testing.T) {
 		dbDoc1 := coll.Doc("db_doc1")
 		otherColl := client.Collection(collectionIDs.New())
 		dbDoc2 := otherColl.Doc("db_doc2")
-		h.mustCreate(dbDoc1, map[string]string{"val": "a"})
-		h.mustCreate(dbDoc2, map[string]string{"val": "b"})
 		t.Cleanup(func() {
 			deleteDocuments([]*DocumentRef{dbDoc1, dbDoc2})
 		})
+		h.mustCreate(dbDoc1, map[string]string{"val": "a"})
+		h.mustCreate(dbDoc2, map[string]string{"val": "b"})
 		iter := client.Pipeline().Database().Limit(2).Execute(ctx).Results()
 		defer iter.Stop()
 		results, err := iter.GetAll()
@@ -392,9 +386,9 @@ func TestIntegration_PipelineStages(t *testing.T) {
 	})
 	t.Run("Literals", func(t *testing.T) {
 		iter := client.Pipeline().Literals([]map[string]any{
-			map[string]any{"name": "joe", "age": 10},
-			map[string]any{"name": "bob", "age": 30},
-			map[string]any{"name": "alice", "age": 40},
+			{"name": "joe", "age": 10},
+			{"name": "bob", "age": 30},
+			{"name": "alice", "age": 40},
 		}).
 			Where(GreaterThan(FieldOf("age"), 20)).
 			Execute(ctx).Results()
@@ -408,7 +402,7 @@ func TestIntegration_PipelineStages(t *testing.T) {
 		}
 	})
 	t.Run("Constants", func(t *testing.T) {
-		iter := client.Pipeline().Literals([]map[string]any{map[string]any{"a": 1}}).
+		iter := client.Pipeline().Literals([]map[string]any{{"a": 1}}).
 			Select(Fields(
 				ConstantOfNull().As("null"),
 				ConstantOfVector32([]float32{1.5, 2.5, 3.5}).As("v32"),
@@ -444,14 +438,14 @@ func TestIntegration_PipelineStages(t *testing.T) {
 			{ID: "doc3", Vector: Vector32{7.0, 8.0, 9.0}},
 		}
 		var vectorDocRefs []*DocumentRef
-		for _, d := range docsWithVector {
-			docRef := coll.NewDoc()
-			h.mustCreate(docRef, d)
-			vectorDocRefs = append(vectorDocRefs, docRef)
-		}
 		t.Cleanup(func() {
 			deleteDocuments(vectorDocRefs)
 		})
+		for _, d := range docsWithVector {
+			docRef := coll.NewDoc()
+			vectorDocRefs = append(vectorDocRefs, docRef)
+			h.mustCreate(docRef, d)
+		}
 		queryVector := Vector32{1.1, 2.1, 3.1}
 		iter := client.Pipeline().Collection(coll.ID).
 			FindNearest("vector", queryVector, PipelineDistanceMeasureEuclidean, RawOptions{"limit": 2, "distance_field": "distance"}).
@@ -570,10 +564,10 @@ func TestIntegration_PipelineStages(t *testing.T) {
 		}
 		docWithMap := DocWithMap{ID: "docWithMap", Data: map[string]int{"a": 1, "b": 2}}
 		docRef := coll.NewDoc()
-		h.mustCreate(docRef, docWithMap)
 		t.Cleanup(func() {
 			deleteDocuments([]*DocumentRef{docRef})
 		})
+		h.mustCreate(docRef, docWithMap)
 		iter := client.Pipeline().Collection(coll.ID).
 			Where(Equal(FieldOf("id"), "docWithMap")).
 			ReplaceWith("data").
@@ -704,19 +698,19 @@ func TestIntegration_PipelineStages(t *testing.T) {
 			{Name: "Bob", Address: "456 Oak Ave"},
 		}
 		var unionDocRefs []*DocumentRef
-		for _, e := range employees {
-			docRef := employeeColl.NewDoc()
-			h.mustCreate(docRef, e)
-			unionDocRefs = append(unionDocRefs, docRef)
-		}
-		for _, c := range customers {
-			docRef := customerColl.NewDoc()
-			h.mustCreate(docRef, c)
-			unionDocRefs = append(unionDocRefs, docRef)
-		}
 		t.Cleanup(func() {
 			deleteDocuments(unionDocRefs)
 		})
+		for _, e := range employees {
+			docRef := employeeColl.NewDoc()
+			unionDocRefs = append(unionDocRefs, docRef)
+			h.mustCreate(docRef, e)
+		}
+		for _, c := range customers {
+			docRef := customerColl.NewDoc()
+			unionDocRefs = append(unionDocRefs, docRef)
+			h.mustCreate(docRef, c)
+		}
 		employeePipeline := client.Pipeline().Collection(employeeColl.ID)
 		customerPipeline := client.Pipeline().Collection(customerColl.ID)
 		iter := employeePipeline.Union(customerPipeline).Execute(context.Background()).Results()
@@ -791,11 +785,9 @@ func TestIntegration_PipelineStages(t *testing.T) {
 	})
 	t.Run("UnnestWithFieldOf", func(t *testing.T) {
 		docRef := coll.NewDoc()
+		t.Cleanup(func() { deleteDocuments([]*DocumentRef{docRef}) })
 		h.mustCreate(docRef, map[string]any{
 			"tags": []string{"a", "b", "c"},
-		})
-		t.Cleanup(func() {
-			deleteDocuments([]*DocumentRef{docRef})
 		})
 
 		iter := client.Pipeline().Collection(coll.ID).
@@ -897,7 +889,7 @@ func TestIntegration_PipelineStages(t *testing.T) {
 }
 
 func TestIntegration_PipelineFunctions(t *testing.T) {
-	skipIfNotEnterprise(t)
+	skipIfEdition(t, "Pipeline queries", editionStandard)
 	t.Run("arrayFuncs", arrayFuncs)
 	t.Run("stringFuncs", stringFuncs)
 	t.Run("vectorFuncs", vectorFuncs)
@@ -930,12 +922,18 @@ func aggregationFuncs(t *testing.T) {
 	}
 
 	var docRefs []*DocumentRef
+
+	t.Cleanup(func() {
+		deleteDocuments(docRefs)
+	})
 	for _, d := range docData {
 		docRef := coll.NewDoc()
-		h.mustCreate(docRef, d)
 		docRefs = append(docRefs, docRef)
+		h.mustCreate(docRef, d)
 	}
-	defer deleteDocuments(docRefs)
+	t.Cleanup(func() {
+		deleteDocuments(docRefs)
+	})
 
 	pipeline := client.Pipeline().Collection(coll.ID).
 		Sort(Orders(Ascending(FieldOf("val")))).
@@ -1014,6 +1012,7 @@ func typeFuncs(t *testing.T) {
 	client := integrationClient(t)
 	coll := client.Collection(collectionIDs.New())
 	docRef1 := coll.NewDoc()
+	t.Cleanup(func() { deleteDocuments([]*DocumentRef{docRef1}) })
 	h.mustCreate(docRef1, map[string]interface{}{
 		"a": nil,
 		"b": true,
@@ -1027,7 +1026,6 @@ func typeFuncs(t *testing.T) {
 		"k": Vector64{1, 2, 3},
 		"l": docRef1,
 	})
-	defer deleteDocuments([]*DocumentRef{docRef1})
 
 	tests := []struct {
 		name     string
@@ -1114,7 +1112,7 @@ func typeFuncs(t *testing.T) {
 }
 
 func TestIntegration_Query_Pipeline(t *testing.T) {
-	skipIfNotEnterprise(t)
+	skipIfEdition(t, "Pipeline queries", editionStandard)
 	ctx := context.Background()
 	coll := integrationColl(t)
 	h := testHelper{t}
@@ -1132,8 +1130,8 @@ func TestIntegration_Query_Pipeline(t *testing.T) {
 	var docRefs []*DocumentRef
 	for _, b := range books {
 		docRef := coll.NewDoc()
-		h.mustCreate(docRef, b)
 		docRefs = append(docRefs, docRef)
+		h.mustCreate(docRef, b)
 	}
 	t.Cleanup(func() {
 		deleteDocuments(docRefs)
@@ -1167,7 +1165,16 @@ func TestIntegration_Query_Pipeline(t *testing.T) {
 		}
 		var publishedYears []int64
 		for _, r := range res {
-			publishedYears = append(publishedYears, r.Data()["published"].(int64))
+			if r == nil || r.Data() == nil {
+				t.Errorf("got nil document")
+				continue
+			}
+			val, ok := r.Data()["published"]
+			if !ok || val == nil {
+				t.Errorf("published field not found")
+				continue
+			}
+			publishedYears = append(publishedYears, val.(int64))
 		}
 		if !sort.SliceIsSorted(publishedYears, func(i, j int) bool { return publishedYears[i] < publishedYears[j] }) {
 			t.Errorf("results not sorted by published year: %v", publishedYears)
@@ -1222,7 +1229,7 @@ func TestIntegration_Query_Pipeline(t *testing.T) {
 }
 
 func TestIntegration_AggregationQuery_Pipeline(t *testing.T) {
-	skipIfNotEnterprise(t)
+	skipIfEdition(t, "Pipeline queries", editionStandard)
 	ctx := context.Background()
 	coll := integrationColl(t)
 	h := testHelper{t}
@@ -1238,14 +1245,14 @@ func TestIntegration_AggregationQuery_Pipeline(t *testing.T) {
 		{Title: "One Hundred Years of Solitude", Genre: "Magical Realism", Published: 1967, Rating: 4.3},
 	}
 	var docRefs []*DocumentRef
-	for _, b := range books {
-		docRef := coll.NewDoc()
-		h.mustCreate(docRef, b)
-		docRefs = append(docRefs, docRef)
-	}
 	t.Cleanup(func() {
 		deleteDocuments(docRefs)
 	})
+	for _, b := range books {
+		docRef := coll.NewDoc()
+		docRefs = append(docRefs, docRef)
+		h.mustCreate(docRef, b)
+	}
 
 	t.Run("Count", func(t *testing.T) {
 		ag := coll.NewAggregationQuery().WithCount("count")
@@ -1311,11 +1318,11 @@ func objectFuncs(t *testing.T) {
 	client := integrationClient(t)
 	coll := client.Collection(collectionIDs.New())
 	docRef1 := coll.NewDoc()
+	t.Cleanup(func() { deleteDocuments([]*DocumentRef{docRef1}) })
 	h.mustCreate(docRef1, map[string]interface{}{
 		"m1": map[string]interface{}{"a": 1, "b": 2},
 		"m2": map[string]interface{}{"c": 3, "d": 4},
 	})
-	defer deleteDocuments([]*DocumentRef{docRef1})
 
 	tests := []struct {
 		name     string
@@ -1397,6 +1404,7 @@ func arrayFuncs(t *testing.T) {
 	client := integrationClient(t)
 	coll := client.Collection(collectionIDs.New())
 	docRef1 := coll.NewDoc()
+	t.Cleanup(func() { deleteDocuments([]*DocumentRef{docRef1}) })
 	h.mustCreate(docRef1, map[string]interface{}{
 		"a":      []interface{}{1, 2, 3},
 		"b":      []interface{}{4, 5, 6},
@@ -1405,12 +1413,12 @@ func arrayFuncs(t *testing.T) {
 		"lang":   "Go",
 		"status": "active",
 	})
-	defer deleteDocuments([]*DocumentRef{docRef1})
 
 	tests := []struct {
-		name     string
-		pipeline *Pipeline
-		want     map[string]interface{}
+		name          string
+		pipeline      *Pipeline
+		want          map[string]interface{}
+		wantErrStatus *status.Status
 	}{
 		{
 			name:     "ArrayLength",
@@ -1431,6 +1439,11 @@ func arrayFuncs(t *testing.T) {
 			name:     "ArrayGet",
 			pipeline: client.Pipeline().Collection(coll.ID).Select(Fields(ArrayGet("a", 1).As("element"))),
 			want:     map[string]interface{}{"element": int64(2)},
+		},
+		{
+			name:          "ArrayGet - not an array",
+			pipeline:      client.Pipeline().Collection(coll.ID).Select(Fields(ArrayGet("lang", 1).As("element"))),
+			wantErrStatus: status.New(codes.InvalidArgument, "The function array_get(...) requires `Array` but got `STRING`."),
 		},
 		{
 			name:     "ArrayReverse",
@@ -1494,7 +1507,7 @@ func arrayFuncs(t *testing.T) {
 		},
 		{
 			name:     "ArraySliceWithLength",
-			pipeline: client.Pipeline().Collection(coll.ID).Select(Fields(ArraySliceLength("a", 1, 1).As("slice_len"))),
+			pipeline: client.Pipeline().Collection(coll.ID).Select(Fields(ArraySliceToEnd("a", 1, 1).As("slice_len"))),
 			want:     map[string]interface{}{"slice_len": []interface{}{int64(2)}},
 		},
 		// TODO: Uncomment this after fixing the proto representation of this function.
@@ -1564,6 +1577,12 @@ func arrayFuncs(t *testing.T) {
 				defer iter.Stop()
 
 				docs, err := iter.GetAll()
+				if test.wantErrStatus != nil {
+					if s, ok := status.FromError(err); !(ok && s.Code() == test.wantErrStatus.Code() && s.Message() == test.wantErrStatus.Message()) {
+						t.Fatalf("expected error %v, got %v", test.wantErrStatus, err)
+					}
+					return
+				}
 				if err != nil {
 					t.Fatalf("GetAll: %v", err)
 					return
@@ -1588,6 +1607,7 @@ func stringFuncs(t *testing.T) {
 	client := integrationClient(t)
 	coll := client.Collection(collectionIDs.New())
 	docRef1 := coll.NewDoc()
+	t.Cleanup(func() { deleteDocuments([]*DocumentRef{docRef1}) })
 	h.mustCreate(docRef1, map[string]interface{}{
 		"name":        "  John Doe  ",
 		"description": "This is a Firestore document.",
@@ -1597,7 +1617,6 @@ func stringFuncs(t *testing.T) {
 		"zipCode":     "12345",
 		"csv":         "a,b,c",
 	})
-	defer deleteDocuments([]*DocumentRef{docRef1})
 
 	doc1want := map[string]interface{}{
 		"name":        "  John Doe  ",
@@ -1824,11 +1843,11 @@ func vectorFuncs(t *testing.T) {
 	client := integrationClient(t)
 	coll := client.Collection(collectionIDs.New())
 	docRef1 := coll.NewDoc()
+	t.Cleanup(func() { deleteDocuments([]*DocumentRef{docRef1}) })
 	h.mustCreate(docRef1, map[string]interface{}{
 		"v1": Vector64{1.0, 2.0, 3.0},
 		"v2": Vector64{4.0, 5.0, 6.0},
 	})
-	defer deleteDocuments([]*DocumentRef{docRef1})
 
 	tests := []struct {
 		name     string
@@ -1902,13 +1921,13 @@ func timestampFuncs(t *testing.T) {
 	h := testHelper{t}
 	now := time.Now()
 	docRef1 := coll.NewDoc()
+	t.Cleanup(func() { deleteDocuments([]*DocumentRef{docRef1}) })
 	h.mustCreate(docRef1, map[string]interface{}{
 		"timestamp":   now,
 		"unixMicros":  now.UnixNano() / 1000,
 		"unixMillis":  now.UnixNano() / 1e6,
 		"unixSeconds": now.Unix(),
 	})
-	defer deleteDocuments([]*DocumentRef{docRef1})
 
 	tests := []struct {
 		name     string
@@ -2109,6 +2128,7 @@ func arithmeticFuncs(t *testing.T) {
 	client := integrationClient(t)
 	coll := client.Collection(collectionIDs.New())
 	docRef1 := coll.NewDoc()
+	t.Cleanup(func() { deleteDocuments([]*DocumentRef{docRef1}) })
 	h.mustCreate(docRef1, map[string]interface{}{
 		"a": int(1),
 		"b": int(2),
@@ -2116,7 +2136,6 @@ func arithmeticFuncs(t *testing.T) {
 		"d": 4.5,
 		"e": -5.5,
 	})
-	defer deleteDocuments([]*DocumentRef{docRef1})
 
 	tests := []struct {
 		name     string
@@ -2295,18 +2314,20 @@ func aggregateFuncs(t *testing.T) {
 	client := integrationClient(t)
 	coll := client.Collection(collectionIDs.New())
 	docRef1 := coll.NewDoc()
+	t.Cleanup(func() { deleteDocuments([]*DocumentRef{docRef1}) })
 	h.mustCreate(docRef1, map[string]interface{}{
 		"a": 1,
 	})
 	docRef2 := coll.NewDoc()
+	t.Cleanup(func() { deleteDocuments([]*DocumentRef{docRef1, docRef2}) })
 	h.mustCreate(docRef2, map[string]interface{}{
 		"a": 2,
 	})
 	docRef3 := coll.NewDoc()
+	t.Cleanup(func() { deleteDocuments([]*DocumentRef{docRef1, docRef2, docRef3}) })
 	h.mustCreate(docRef3, map[string]interface{}{
 		"b": 2,
 	})
-	defer deleteDocuments([]*DocumentRef{docRef1, docRef2, docRef3})
 
 	tests := []struct {
 		name     string
@@ -2415,7 +2436,9 @@ func comparisonFuncs(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
-	defer deleteDocuments([]*DocumentRef{coll.Doc("doc1"), coll.Doc("doc2")})
+	t.Cleanup(func() {
+		deleteDocuments([]*DocumentRef{coll.Doc("doc1"), coll.Doc("doc2")})
+	})
 
 	doc1want := map[string]interface{}{"a": int64(1), "b": int64(2), "c": int64(-3), "d": float64(4.5), "e": float64(-5.5), "timestamp": now.Truncate(time.Microsecond)}
 
@@ -2538,6 +2561,8 @@ func keyFuncs(t *testing.T) {
 	coll := client.Collection(collectionIDs.New())
 	docRef1 := coll.Doc("doc1")
 	subDocRef1 := docRef1.Collection("sub").Doc("sub1")
+	t.Cleanup(func() { deleteDocuments([]*DocumentRef{subDocRef1, docRef1}) })
+
 	h.mustCreate(docRef1, map[string]interface{}{
 		"a": "hello",
 		"b": "world",
@@ -2545,7 +2570,6 @@ func keyFuncs(t *testing.T) {
 	h.mustCreate(subDocRef1, map[string]interface{}{
 		"c": "sub-hello",
 	})
-	defer deleteDocuments([]*DocumentRef{subDocRef1, docRef1})
 
 	tests := []struct {
 		name     string
@@ -2592,11 +2616,11 @@ func generalFuncs(t *testing.T) {
 	client := integrationClient(t)
 	coll := client.Collection(collectionIDs.New())
 	docRef1 := coll.NewDoc()
+	t.Cleanup(func() { deleteDocuments([]*DocumentRef{docRef1}) })
 	h.mustCreate(docRef1, map[string]interface{}{
 		"a": "hello",
 		"b": "world",
 	})
-	defer deleteDocuments([]*DocumentRef{docRef1})
 
 	tests := []struct {
 		name     string
@@ -2698,6 +2722,11 @@ func logicalFuncs(t *testing.T) {
 	client := integrationClient(t)
 	coll := client.Collection(collectionIDs.New())
 	docRef1 := coll.Doc("doc1")
+	docRef2 := coll.Doc("doc2")
+
+	t.Cleanup(func() {
+		deleteDocuments([]*DocumentRef{docRef1, docRef2})
+	})
 	doc1Data := map[string]interface{}{
 		"a": 1,
 		"b": 2,
@@ -2706,8 +2735,6 @@ func logicalFuncs(t *testing.T) {
 		"e": false,
 	}
 	h.mustCreate(docRef1, doc1Data)
-
-	docRef2 := coll.Doc("doc2")
 	doc2Data := map[string]interface{}{
 		"a": 1,
 		"b": 1,
@@ -2715,7 +2742,6 @@ func logicalFuncs(t *testing.T) {
 		"e": true,
 	}
 	h.mustCreate(docRef2, doc2Data)
-	defer deleteDocuments([]*DocumentRef{docRef1, docRef2})
 
 	doc1Want := map[string]interface{}{
 		"a": int64(1),
@@ -2986,22 +3012,23 @@ func logicalFuncs(t *testing.T) {
 }
 
 func TestIntegration_PipelineSubqueriesAndVariables(t *testing.T) {
-	skipIfNotEnterprise(t)
+	skipIfEdition(t, "Pipeline queries", editionStandard)
 	ctx := context.Background()
 	client := integrationClient(t)
 	coll := integrationColl(t)
 
 	// Create test documents
 	restaurantsRef := coll.NewDoc()
+
+	t.Cleanup(func() {
+		restaurantsRef.Delete(ctx)
+	})
 	_, err := restaurantsRef.Create(ctx, map[string]interface{}{
 		"name": "The Burger Joint",
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() {
-		restaurantsRef.Delete(ctx)
-	})
 
 	review1Ref := restaurantsRef.Collection("reviews").NewDoc()
 	_, err = review1Ref.Create(ctx, map[string]interface{}{
@@ -3013,6 +3040,11 @@ func TestIntegration_PipelineSubqueriesAndVariables(t *testing.T) {
 	}
 
 	review2Ref := restaurantsRef.Collection("reviews").NewDoc()
+
+	t.Cleanup(func() {
+		review1Ref.Delete(ctx)
+		review2Ref.Delete(ctx)
+	})
 	_, err = review2Ref.Create(ctx, map[string]interface{}{
 		"reviewer": "Bob",
 		"rating":   4,
@@ -3021,12 +3053,13 @@ func TestIntegration_PipelineSubqueriesAndVariables(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	t.Cleanup(func() {
-		review1Ref.Delete(ctx)
-		review2Ref.Delete(ctx)
-	})
-
 	productsRef := coll.NewDoc()
+
+	t.Cleanup(func() {
+
+		productsRef.Delete(ctx)
+
+	})
 	_, err = productsRef.Create(ctx, map[string]interface{}{
 		"name":  "Widget",
 		"price": 100,
@@ -3035,9 +3068,6 @@ func TestIntegration_PipelineSubqueriesAndVariables(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() {
-		productsRef.Delete(ctx)
-	})
 
 	t.Run("SubcollectionAndScalar", func(t *testing.T) {
 		iter := client.Pipeline().Documents([]*DocumentRef{restaurantsRef}).

--- a/firestore/pipeline_search_integration_test.go
+++ b/firestore/pipeline_search_integration_test.go
@@ -99,7 +99,7 @@ func assertResultIds(t *testing.T, snapshot *PipelineSnapshot, ids ...string) {
 }
 
 func TestIntegration_PipelineSearch(t *testing.T) {
-	skipIfNotEnterprise(t)
+	skipIfEdition(t, "Pipeline queries", editionStandard)
 	if useEmulator {
 		t.Skip("Search queries are not supported in the emulator.")
 	}

--- a/firestore/pipeline_source.go
+++ b/firestore/pipeline_source.go
@@ -14,6 +14,8 @@
 
 package firestore
 
+import "fmt"
+
 // PipelineSource is a factory for creating Pipeline instances.
 // It is obtained by calling [Client.Pipeline].
 //
@@ -168,7 +170,14 @@ func (ps *PipelineSource) Documents(refs []*DocumentRef, opts ...DocumentsOption
 			opt.applyStage(options)
 		}
 	}
-	return newPipeline(ps.client, newInputStageDocuments(refs, options))
+	p := newPipeline(ps.client, newInputStageDocuments(refs, options))
+	for _, ref := range refs {
+		if ref == nil {
+			p.err = fmt.Errorf("firestore: Documents() cannot contain nil references")
+			break
+		}
+	}
+	return p
 }
 
 // CreateFromQuery creates a new [Pipeline] from the given [Queryer]. Under the hood, this will

--- a/firestore/pipeline_stage.go
+++ b/firestore/pipeline_stage.go
@@ -157,6 +157,9 @@ func (s *inputStageDocuments) name() string { return stageNameDocuments }
 func (s *inputStageDocuments) toProto() (*pb.Pipeline_Stage, error) {
 	args := make([]*pb.Value, len(s.refs))
 	for i, ref := range s.refs {
+		if ref == nil {
+			return nil, fmt.Errorf("firestore: internal error: inputStageDocuments contains nil reference")
+		}
 		args[i] = &pb.Value{ValueType: &pb.Value_ReferenceValue{ReferenceValue: "/" + ref.shortPath}}
 	}
 	optionsPb, err := stageOptionsToProto(s.options)
@@ -382,6 +385,9 @@ func (s *findNearestStage) toProto() (*pb.Pipeline_Stage, error) {
 	default:
 		return nil, errInvalidArg("FindNearest", s.vectorField, "string", "FieldPath", "Expression")
 	}
+	if propertyExpr == nil {
+		return nil, fmt.Errorf("firestore: internal error: findNearestStage vectorField resolved to nil expression")
+	}
 	propPb, err := propertyExpr.toProto()
 	if err != nil {
 		return nil, err
@@ -495,6 +501,9 @@ func (s *removeFieldsStage) toProto() (*pb.Pipeline_Stage, error) {
 	}
 	args := make([]*pb.Value, len(fields))
 	for i, f := range fields {
+		if f == nil {
+			return nil, fmt.Errorf("firestore: internal error: removeFieldsStage contains nil expression")
+		}
 		pb, err := f.toProto()
 		if err != nil {
 			return nil, err
@@ -532,6 +541,9 @@ func (s *replaceWithStage) toProto() (*pb.Pipeline_Stage, error) {
 		expr = v
 	default:
 		return nil, errInvalidArg("ReplaceWith", s.fieldpathOrExpr, "string", "FieldPath", "Expression")
+	}
+	if expr == nil {
+		return nil, fmt.Errorf("firestore: internal error: replaceWithStage fieldpathOrExpr resolved to nil expression")
 	}
 	exprPb, err := expr.toProto()
 	if err != nil {
@@ -610,6 +622,9 @@ func (s *searchStage) toProto() (*pb.Pipeline_Stage, error) {
 				queryExpr = qv
 			default:
 				return nil, errInvalidArg("Search", v, "string", "BooleanExpression")
+			}
+			if queryExpr == nil {
+				return nil, fmt.Errorf("firestore: internal error: searchStage query resolved to nil expression")
 			}
 			queryPb, err := queryExpr.toProto()
 			if err != nil {
@@ -729,6 +744,9 @@ func (s *sortStage) name() string { return stageNameSort }
 func (s *sortStage) toProto() (*pb.Pipeline_Stage, error) {
 	sortOrders := make([]*pb.Value, len(s.orders))
 	for i, so := range s.orders {
+		if so.Expr == nil {
+			return nil, fmt.Errorf("firestore: internal error: sortStage contains ordering with nil expression")
+		}
 		fieldPb, err := so.Expr.toProto()
 		if err != nil {
 			return nil, err
@@ -769,6 +787,9 @@ func newUnionStage(other *Pipeline, options map[string]any) (*unionStage, error)
 }
 func (s *unionStage) name() string { return stageNameUnion }
 func (s *unionStage) toProto() (*pb.Pipeline_Stage, error) {
+	if s.other == nil {
+		return nil, fmt.Errorf("firestore: internal error: unionStage contains nil pipeline")
+	}
 	otherPb, err := s.other.toProto()
 	if err != nil {
 		return nil, err
@@ -797,6 +818,9 @@ func newUnnestStage(callerName string, field Selectable, options map[string]any)
 }
 func (s *unnestStage) name() string { return stageNameUnnest }
 func (s *unnestStage) toProto() (*pb.Pipeline_Stage, error) {
+	if s.field == nil {
+		return nil, fmt.Errorf("firestore: internal error: unnestStage contains nil field")
+	}
 	alias, expr := s.field.getSelectionDetails()
 	exprPb, err := expr.toProto()
 	if err != nil {
@@ -861,6 +885,9 @@ func newWhereStage(condition BooleanExpression, options map[string]any) (*whereS
 }
 func (s *whereStage) name() string { return stageNameWhere }
 func (s *whereStage) toProto() (*pb.Pipeline_Stage, error) {
+	if s.condition == nil {
+		return nil, fmt.Errorf("firestore: internal error: whereStage condition is nil")
+	}
 	argsPb, err := s.condition.toProto()
 	if err != nil {
 		return nil, err

--- a/firestore/pipeline_stage.go
+++ b/firestore/pipeline_stage.go
@@ -158,7 +158,7 @@ func (s *inputStageDocuments) toProto() (*pb.Pipeline_Stage, error) {
 	args := make([]*pb.Value, len(s.refs))
 	for i, ref := range s.refs {
 		if ref == nil {
-			return nil, fmt.Errorf("firestore: internal error: inputStageDocuments contains nil reference")
+			return nil, fmt.Errorf("firestore: inputStageDocuments contains nil reference")
 		}
 		args[i] = &pb.Value{ValueType: &pb.Value_ReferenceValue{ReferenceValue: "/" + ref.shortPath}}
 	}


### PR DESCRIPTION
This PR introduces several refinements to the Firestore Pipelines experimental feature, aimed at improving API consistency, error reporting, and the reliability of integration tests.

  Key Changes:
   - API Refinement:
       - Renamed ArraySliceWithLength to ArraySliceToEnd to better reflect its behavior similar to [Java](https://github.com/googleapis/java-firestore/blob/9065134fd70da22250f038d7e964f26aebfeb3cf/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/Expression.java#L2644).
       - Enabled the ArrayFilter expression (previously commented out).
       - Updated TimestampTruncateWithTimezone to accept any for the timezone parameter, allowing for dynamic timezone expressions. TimestampTruncateWithTimezone in Java accepts string or expression [src](https://github.com/googleapis/java-firestore/blob/9065134fd70da22250f038d7e964f26aebfeb3cf/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/Expression.java#L3763-L3908). 
   - Error Handling:
       - Introduced typed errors ErrPipelineWithoutDatabase and ErrUnionNotSupportRelativeScope to replace generic fmt.Errorf calls https://github.com/googleapis/google-cloud-go/pull/14365#discussion_r3041945116. 
       - Added internal nil checks across various pipeline stages (inputStageDocuments, findNearestStage, removeFieldsStage, etc.) to provide more descriptive error messages during proto conversion.
   - Integration Test Enhancements:
       - Replaced skipIfEnterprise with a more flexible skipIfEdition helper to handle feature support across different Firestore editions.
       - Improved resource cleanup in tests by moving t.Cleanup calls earlier, ensuring documents are deleted even if a test fails prematurely.
   - Bug Fixes & Robustness:
       - Added nil checks when processing results in TestIntegration_Query_Pipeline.
       - Standardized test skipping logic across all pipeline-related integration tests.