### PR TITLE
chore: librarian release pull request: 20260414T185624Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,16 +1,3 @@
-# Copyright 2026 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go@sha256:b04b076f5eedbb5546bd6fc1404969dd3698c8b19c0f34ae815a84ae735a606a
 libraries:
   - id: accessapproval
@@ -248,6 +235,7 @@ libraries:
     last_generated_commit: ""
     apis:
       - path: google/cloud/appoptimize/v1beta
+        service_config: ""
     source_roots:
       - appoptimize
       - internal/generated/snippets/appoptimize
@@ -460,7 +448,9 @@ libraries:
     last_generated_commit: ""
     apis:
       - path: google/cloud/biglake/v1
+        service_config: ""
       - path: google/cloud/biglake/hive/v1beta
+        service_config: ""
     source_roots:
       - biglake
       - internal/generated/snippets/biglake
@@ -922,6 +912,7 @@ libraries:
       - path: google/cloud/datacatalog/v1beta1
         service_config: datacatalog_v1beta1.yaml
       - path: google/cloud/datacatalog/lineage/configmanagement/v1
+        service_config: ""
     source_roots:
       - datacatalog
       - internal/generated/snippets/datacatalog
@@ -1724,6 +1715,7 @@ libraries:
       - path: google/maps/solar/v1
         service_config: solar_v1.yaml
       - path: google/maps/geocode/v4
+        service_config: ""
     source_roots:
       - maps
       - internal/generated/snippets/maps
@@ -1983,6 +1975,7 @@ libraries:
     last_generated_commit: ""
     apis:
       - path: google/cloud/orgpolicy/v1
+        service_config: ""
       - path: google/cloud/orgpolicy/v2
         service_config: orgpolicy_v2.yaml
     source_roots:
@@ -2024,6 +2017,7 @@ libraries:
       - path: google/cloud/oslogin/v1beta
         service_config: oslogin_v1beta.yaml
       - path: google/cloud/oslogin/common
+        service_config: ""
     source_roots:
       - oslogin
       - internal/generated/snippets/oslogin
@@ -2157,7 +2151,7 @@ libraries:
       - internal/generated/snippets/pubsub/
     tag_format: '{id}/v{version}'
   - id: pubsub/v2
-    version: 2.5.1
+    version: 2.6.0
     last_generated_commit: ""
     apis:
       - path: google/pubsub/v1
@@ -2614,6 +2608,7 @@ libraries:
       - path: google/shopping/merchant/reviews/v1beta
         service_config: merchantapi_v1beta.yaml
       - path: google/shopping/type
+        service_config: ""
     source_roots:
       - shopping
       - internal/generated/snippets/shopping

--- a/internal/generated/snippets/pubsub/v2/apiv1/snippet_metadata.google.pubsub.v1.json
+++ b/internal/generated/snippets/pubsub/v2/apiv1/snippet_metadata.google.pubsub.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/pubsub/v2/apiv1",
-    "version": "2.5.1"
+    "version": "2.6.0"
   },
   "snippets": [
     {

--- a/pubsub/v2/CHANGES.md
+++ b/pubsub/v2/CHANGES.md
@@ -1,5 +1,19 @@
 # Changes
 
+## [2.6.0](https://github.com/googleapis/google-cloud-go/releases/tag/pubsub%2Fv2.6.0) (2026-04-14)
+
+### Features
+
+* enable open telemetry attrs (#14426) ([74eab64](https://github.com/googleapis/google-cloud-go/commit/74eab64d1b4e22d8c79b0de4e5fc9a36bc4c6c19))
+
+### Bug Fixes
+
+* fix span linking and add missing attributes (#14326) ([ec20708](https://github.com/googleapis/google-cloud-go/commit/ec20708bfb2c04a60909ffc3bd956580b82a4713))
+
+### Documentation
+
+* revamp package docs (#14317) ([71df27f](https://github.com/googleapis/google-cloud-go/commit/71df27f8820459b3e2452c20b5aa802d8c17b61a))
+
 ## [2.5.1](https://github.com/googleapis/google-cloud-go/releases/tag/pubsub%2Fv2.5.1) (2026-03-31)
 
 ### Bug Fixes

--- a/pubsub/v2/internal/version.go
+++ b/pubsub/v2/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "2.5.1"
+const Version = "2.6.0"


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.8.3
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go@sha256:b04b076f5eedbb5546bd6fc1404969dd3698c8b19c0f34ae815a84ae735a606a
<details><summary>pubsub/v2: v2.6.0</summary>

## [v2.6.0](https://github.com/googleapis/google-cloud-go/compare/pubsub/v2.5.1...pubsub/v2.6.0) (2026-04-14)

### Features

* enable open telemetry attrs (#14426) ([74eab64d](https://github.com/googleapis/google-cloud-go/commit/74eab64d))

### Bug Fixes

* fix span linking and add missing attributes (#14326) ([ec20708b](https://github.com/googleapis/google-cloud-go/commit/ec20708b))

### Documentation

* revamp package docs (#14317) ([71df27f8](https://github.com/googleapis/google-cloud-go/commit/71df27f8))

</details>