### PR TITLE
chore: librarian release pull request: 20260414T204508Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -2157,7 +2157,7 @@ libraries:
       - internal/generated/snippets/pubsub/
     tag_format: '{id}/v{version}'
   - id: pubsub/v2
-    version: 2.5.1
+    version: 2.6.0
     last_generated_commit: ""
     apis:
       - path: google/pubsub/v1

--- a/internal/generated/snippets/pubsub/v2/apiv1/snippet_metadata.google.pubsub.v1.json
+++ b/internal/generated/snippets/pubsub/v2/apiv1/snippet_metadata.google.pubsub.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/pubsub/v2/apiv1",
-    "version": "2.5.1"
+    "version": "2.6.0"
   },
   "snippets": [
     {

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -1824,7 +1824,7 @@ libraries:
     go:
       nested_module: v2
   - name: pubsub/v2
-    version: 2.5.1
+    version: 2.6.0
     apis:
       - path: google/pubsub/v1
     keep:

--- a/pubsub/v2/CHANGES.md
+++ b/pubsub/v2/CHANGES.md
@@ -1,5 +1,7 @@
 # Changes
 
+## [2.6.0](https://github.com/googleapis/google-cloud-go/releases/tag/pubsub%2Fv2.6.0) (2026-04-14)
+
 ## [2.5.1](https://github.com/googleapis/google-cloud-go/releases/tag/pubsub%2Fv2.5.1) (2026-03-31)
 
 ### Bug Fixes

--- a/pubsub/v2/internal/version.go
+++ b/pubsub/v2/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "2.5.1"
+const Version = "2.6.0"


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.10.1
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go@sha256:b04b076f5eedbb5546bd6fc1404969dd3698c8b19c0f34ae815a84ae735a606a
<details><summary>pubsub/v2: v2.6.0</summary>

## [v2.6.0](https://github.com/googleapis/google-cloud-go/compare/pubsub/v2.5.1...pubsub/v2.6.0) (2026-04-14)

</details>