### PR TITLE
chore(firestore): update experimental warnings for pipeline features

### DIFF
--- a/firestore/client.go
+++ b/firestore/client.go
@@ -183,9 +183,6 @@ func withRequestParamsHeader(ctx context.Context, requestParams string) context.
 }
 
 // Pipeline creates a PipelineSource to start building a Firestore pipeline.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func (c *Client) Pipeline() *PipelineSource {
 	return &PipelineSource{client: c}
 }

--- a/firestore/pipeline.go
+++ b/firestore/pipeline.go
@@ -44,9 +44,6 @@ var (
 // NOTE: The chained stages do not prescribe exactly how Firestore will execute the pipeline.
 // Instead, Firestore only guarantees that the result is the same as if the chained stages were
 // executed in order.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 type Pipeline struct {
 	c               *Client
 	stages          []pipelineStage
@@ -73,9 +70,6 @@ type executeSettings struct {
 }
 
 // ExecuteOption is an option for executing a pipeline query.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 type ExecuteOption interface {
 	apply(*executeSettings)
 }
@@ -95,9 +89,6 @@ func newFuncExecuteOption(f func(*executeSettings)) *funcExecuteOption {
 }
 
 // ExplainMode is the execution mode for pipeline explain.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 type ExplainMode string
 
 const (
@@ -111,9 +102,6 @@ type executeExplainOptions struct {
 }
 
 // WithExplainMode sets the execution mode for pipeline explain.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func WithExplainMode(mode ExplainMode) ExecuteOption {
 	return newFuncExecuteOption(func(eo *executeSettings) {
 		eo.ExplainOptions = &executeExplainOptions{Mode: mode}
@@ -121,9 +109,6 @@ func WithExplainMode(mode ExplainMode) ExecuteOption {
 }
 
 // StageOption is an option for configuring a pipeline stage.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 type StageOption interface {
 	applyStage(options map[string]any)
 }
@@ -131,9 +116,6 @@ type StageOption interface {
 // RawOptions specifies raw options to be passed to the Firestore backend.
 // These options are not validated by the SDK and are passed directly to the backend.
 // Options specified here will take precedence over any options with the same name set by the SDK.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 type RawOptions map[string]any
 
 func (r RawOptions) applyStage(options map[string]any) {
@@ -205,53 +187,35 @@ func (r RawOptions) apply(eo *executeSettings) {
 
 // Fields is a helper function that returns its arguments as a slice of any.
 // It is used to provide variadic-like ergonomics for pipeline stages that accept a slice of fields or expressions.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func Fields(f ...any) []any {
 	return []any(f)
 }
 
 // Orders is a helper function that returns its arguments as a slice of Ordering.
 // It is used to provide variadic-like ergonomics for the Sort pipeline stage.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func Orders(o ...Ordering) []Ordering {
 	return []Ordering(o)
 }
 
 // Accumulators is a helper function that returns its arguments as a slice of *AliasedAggregate.
 // It is used to provide variadic-like ergonomics for the Aggregate pipeline stage.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func Accumulators(a ...*AliasedAggregate) []*AliasedAggregate {
 	return []*AliasedAggregate(a)
 }
 
 // Selectables is a helper function that returns its arguments as a slice of Selectable.
 // It is used to provide variadic-like ergonomics for pipeline stages that accept a slice of Selectable expressions.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func Selectables(s ...Selectable) []Selectable {
 	return []Selectable(s)
 }
 
 // AliasedExpressions is a helper function that returns its arguments as a slice of *AliasedExpression.
 // It is used to provide variadic-like ergonomics for the [Pipeline.Define] pipeline stage.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func AliasedExpressions(v ...*AliasedExpression) []*AliasedExpression {
 	return v
 }
 
 // Execute executes the pipeline and returns a snapshot of the results.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func (p *Pipeline) Execute(ctx context.Context, opts ...ExecuteOption) *PipelineSnapshot {
 	newP := p
 	if len(opts) > 0 {
@@ -372,9 +336,6 @@ func (p *Pipeline) copy() *Pipeline {
 
 // WithReadOptions specifies constraints for accessing documents from the database,
 // such as ReadTime.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func (p *Pipeline) WithReadOptions(opts ...ReadOption) *Pipeline {
 	newP := p.copy()
 	for _, opt := range opts {
@@ -396,18 +357,12 @@ func (p *Pipeline) append(s pipelineStage) *Pipeline {
 }
 
 // LimitOption is an option for a Limit pipeline stage.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 type LimitOption interface {
 	StageOption
 	isLimitOption()
 }
 
 // Limit limits the maximum number of documents returned by previous stages.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func (p *Pipeline) Limit(limit int, opts ...LimitOption) *Pipeline {
 	if p.err != nil {
 		return p
@@ -422,9 +377,6 @@ func (p *Pipeline) Limit(limit int, opts ...LimitOption) *Pipeline {
 }
 
 // OrderingDirection is the sort direction for pipeline result ordering.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 type OrderingDirection string
 
 const (
@@ -436,34 +388,22 @@ const (
 )
 
 // Ordering specifies the field and direction for sorting.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 type Ordering struct {
 	Expr      Expression
 	Direction OrderingDirection
 }
 
 // Ascending creates an Ordering for ascending sort direction.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func Ascending(expr Expression) Ordering {
 	return Ordering{Expr: expr, Direction: OrderingAsc}
 }
 
 // Descending creates an Ordering for descending sort direction.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func Descending(expr Expression) Ordering {
 	return Ordering{Expr: expr, Direction: OrderingDesc}
 }
 
 // SortOption is an option for a Sort pipeline stage.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 type SortOption interface {
 	StageOption
 	isSortOption()
@@ -471,9 +411,6 @@ type SortOption interface {
 
 // Sort sorts the documents by the given fields and directions.
 // Use [Orders] to provide variadic-like ergonomics for the orders argument.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func (p *Pipeline) Sort(orders []Ordering, opts ...SortOption) *Pipeline {
 	if p.err != nil {
 		return p
@@ -488,9 +425,6 @@ func (p *Pipeline) Sort(orders []Ordering, opts ...SortOption) *Pipeline {
 }
 
 // OffsetOption is an option for an Offset pipeline stage.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 type OffsetOption interface {
 	StageOption
 	isOffsetOption()
@@ -508,9 +442,6 @@ type OffsetOption interface {
 //	  client.Pipeline().Collection("books").
 //		  .Offset(20)   // Skip the first 20 results
 //		  .Limit(20)    // Take the next 20 results
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func (p *Pipeline) Offset(offset int, opts ...OffsetOption) *Pipeline {
 	if p.err != nil {
 		return p
@@ -525,9 +456,6 @@ func (p *Pipeline) Offset(offset int, opts ...OffsetOption) *Pipeline {
 }
 
 // SelectOption is an option for a Select pipeline stage.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 type SelectOption interface {
 	StageOption
 	isSelectOption()
@@ -548,9 +476,6 @@ type SelectOption interface {
 //		client.Pipeline().Collection("users").Select(Fields(FieldOf([]string{"info", "email"})))
 //		client.Pipeline().Collection("users").Select([]any{"info.email", "name"})
 //	 	client.Pipeline().Collection("users").Select(Fields(Add("age", 5).As("agePlus5")))
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func (p *Pipeline) Select(fields []any, opts ...SelectOption) *Pipeline {
 	if p.err != nil {
 		return p
@@ -570,9 +495,6 @@ func (p *Pipeline) Select(fields []any, opts ...SelectOption) *Pipeline {
 }
 
 // DistinctOption is an option for a Distinct pipeline stage.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 type DistinctOption interface {
 	StageOption
 	isDistinctOption()
@@ -583,9 +505,6 @@ type DistinctOption interface {
 // You can optionally specify fields or [Selectable] expressions to determine distinctness.
 // If no fields are specified, the entire document is used to determine distinctness.
 // Use [Fields] to provide variadic-like ergonomics for the fields argument.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func (p *Pipeline) Distinct(fields []any, opts ...DistinctOption) *Pipeline {
 	if p.err != nil {
 		return p
@@ -605,9 +524,6 @@ func (p *Pipeline) Distinct(fields []any, opts ...DistinctOption) *Pipeline {
 }
 
 // AddFieldsOption is an option for an AddFields pipeline stage.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 type AddFieldsOption interface {
 	StageOption
 	isAddFieldsOption()
@@ -621,9 +537,6 @@ type AddFieldsOption interface {
 //
 // The added fields are defined using [Selectable]'s.
 // Use [Selectables] to provide variadic-like ergonomics for the fields argument.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func (p *Pipeline) AddFields(fields []Selectable, opts ...AddFieldsOption) *Pipeline {
 	if p.err != nil {
 		return p
@@ -643,9 +556,6 @@ func (p *Pipeline) AddFields(fields []Selectable, opts ...AddFieldsOption) *Pipe
 }
 
 // RemoveFieldsOption is an option for an RemoveFields pipeline stage.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 type RemoveFieldsOption interface {
 	StageOption
 	isRemoveFieldsOption()
@@ -654,9 +564,6 @@ type RemoveFieldsOption interface {
 // RemoveFields removes fields from outputs from previous stages.
 // fieldpaths can be a string or a [FieldPath] or an expression obtained by calling [FieldOf].
 // Use [Fields] to provide variadic-like ergonomics for the fields argument.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func (p *Pipeline) RemoveFields(fields []any, opts ...RemoveFieldsOption) *Pipeline {
 	if p.err != nil {
 		return p
@@ -676,9 +583,6 @@ func (p *Pipeline) RemoveFields(fields []any, opts ...RemoveFieldsOption) *Pipel
 }
 
 // WhereOption is an option for a Where pipeline stage.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 type WhereOption interface {
 	StageOption
 	isWhereOption()
@@ -687,9 +591,6 @@ type WhereOption interface {
 // Where filters the documents from previous stages to only include those matching the specified [BooleanExpression].
 //
 // This stage allows you to apply conditions to the data, similar to a "WHERE" clause in SQL.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func (p *Pipeline) Where(condition BooleanExpression, opts ...WhereOption) *Pipeline {
 	if p.err != nil {
 		return p
@@ -709,9 +610,6 @@ func (p *Pipeline) Where(condition BooleanExpression, opts ...WhereOption) *Pipe
 }
 
 // AggregateOption is an option for executing a pipeline aggregation stage.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 type AggregateOption interface {
 	StageOption
 	applyAggregate(options map[string]any)
@@ -740,9 +638,6 @@ func newFuncAggregateOption(f func(map[string]any)) *funcAggregateOption {
 
 // WithAggregateGroups specifies the fields or expressions to group the documents by.
 // Each of the grouping keys can be a string field path, a [FieldPath], or a [Selectable] expression.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func WithAggregateGroups(groups ...any) AggregateOption {
 	return newFuncAggregateOption(func(ao map[string]any) {
 		g, ok := ao["groups"].([]any)
@@ -763,9 +658,6 @@ func WithAggregateGroups(groups ...any) AggregateOption {
 //
 //	client.Pipeline().Collection("users").
 //		Aggregate(Accumulators(Sum("age").As("age_sum")))
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func (p *Pipeline) Aggregate(accumulators []*AliasedAggregate, opts ...AggregateOption) *Pipeline {
 	if p.err != nil {
 		return p
@@ -785,9 +677,6 @@ func (p *Pipeline) Aggregate(accumulators []*AliasedAggregate, opts ...Aggregate
 }
 
 // UnnestOption is an option for executing a pipeline unnest stage.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 type UnnestOption interface {
 	StageOption
 	isUnnestOption()
@@ -810,9 +699,6 @@ func newFuncUnnestOption(f func(map[string]any)) *funcUnnestOption {
 }
 
 // WithUnnestIndexField specifies the name of the field to store the array index of the unnested element.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func WithUnnestIndexField(indexField any) UnnestOption {
 	return newFuncUnnestOption(func(uo map[string]any) {
 		uo["index_field"] = indexField
@@ -824,9 +710,6 @@ func WithUnnestIndexField(indexField any) UnnestOption {
 // Each output document is a copy of the input document, but the array field is replaced by an element from the array.
 // The `field` parameter specifies the array field to unnest. It can be a string representing the field path or a [Selectable] expression.
 // The alias of the selectable will be used as the new field name.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func (p *Pipeline) Unnest(field Selectable, opts ...UnnestOption) *Pipeline {
 	if p.err != nil {
 		return p
@@ -847,9 +730,6 @@ func (p *Pipeline) Unnest(field Selectable, opts ...UnnestOption) *Pipeline {
 
 // UnnestWithAlias produces a document for each element in an array field, with a specified alias for the unnested field.
 // It can optionally take UnnestOptions.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func (p *Pipeline) UnnestWithAlias(fieldpath any, alias string, opts ...UnnestOption) *Pipeline {
 	if p.err != nil {
 		return p
@@ -881,9 +761,6 @@ func (p *Pipeline) UnnestWithAlias(fieldpath any, alias string, opts ...UnnestOp
 }
 
 // UnionOption is an option for a Union pipeline stage.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 type UnionOption interface {
 	StageOption
 	isUnionOption()
@@ -900,9 +777,6 @@ type UnionOption interface {
 //	// Emit documents from books collection and magazines collection.
 //	client.Pipeline().Collection("books").
 //		Union(client.Pipeline().Collection("magazines"))
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func (p *Pipeline) Union(other *Pipeline, opts ...UnionOption) *Pipeline {
 	if p.err != nil {
 		return p
@@ -926,9 +800,6 @@ func (p *Pipeline) Union(other *Pipeline, opts ...UnionOption) *Pipeline {
 }
 
 // SampleMode defines the mode for the sample stage.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 type SampleMode string
 
 const (
@@ -939,34 +810,22 @@ const (
 )
 
 // Sampler is used to define a sample operation.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 type Sampler struct {
 	Size any
 	Mode SampleMode
 }
 
 // WithDocLimit creates a Sampler for sampling a fixed number of documents.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func WithDocLimit(limit int) *Sampler {
 	return &Sampler{Size: limit, Mode: SampleModeDocuments}
 }
 
 // WithPercentage creates a Sampler for sampling a percentage of documents.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func WithPercentage(percentage float64) *Sampler {
 	return &Sampler{Size: percentage, Mode: SampleModePercent}
 }
 
 // SampleOption is an option for a Sample pipeline stage.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 type SampleOption interface {
 	StageOption
 	isSampleOption()
@@ -984,9 +843,6 @@ type SampleOption interface {
 //
 //	// Sample 50% of books.
 //	client.Pipeline().Collection("books").Sample(WithPercentage(0.5))
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func (p *Pipeline) Sample(sampler *Sampler, opts ...SampleOption) *Pipeline {
 	if p.err != nil {
 		return p
@@ -1006,9 +862,6 @@ func (p *Pipeline) Sample(sampler *Sampler, opts ...SampleOption) *Pipeline {
 }
 
 // ReplaceWithOption is an option for a ReplaceWith pipeline stage.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 type ReplaceWithOption interface {
 	StageOption
 	isReplaceWithOption()
@@ -1025,9 +878,6 @@ type ReplaceWithOption interface {
 //	// Emit parents as document.
 //	client.Pipeline().Collection("people").ReplaceWith("parents")
 //	// Output: { "father": "John Doe Sr.", "mother": "Jane Doe" }
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func (p *Pipeline) ReplaceWith(fieldpathOrExpr any, opts ...ReplaceWithOption) *Pipeline {
 	if p.err != nil {
 		return p
@@ -1047,9 +897,6 @@ func (p *Pipeline) ReplaceWith(fieldpathOrExpr any, opts ...ReplaceWithOption) *
 }
 
 // PipelineDistanceMeasure is the distance measure for find_nearest pipeline stage.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 type PipelineDistanceMeasure string
 
 const (
@@ -1062,9 +909,6 @@ const (
 )
 
 // FindNearestOption is an option for a FindNearest pipeline stage.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 type FindNearestOption interface {
 	StageOption
 	isFindNearestOption()
@@ -1087,9 +931,6 @@ func newFuncFindNearestOption(f func(map[string]any)) *funcFindNearestOption {
 }
 
 // WithFindNearestLimit specifies the maximum number of nearest neighbors to return.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func WithFindNearestLimit(limit int) FindNearestOption {
 	return newFuncFindNearestOption(func(ao map[string]any) {
 		ao["limit"] = limit
@@ -1097,9 +938,6 @@ func WithFindNearestLimit(limit int) FindNearestOption {
 }
 
 // WithFindNearestDistanceField specifies the name of the field to store the calculated distance.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func WithFindNearestDistanceField(field string) FindNearestOption {
 	return newFuncFindNearestOption(func(ao map[string]any) {
 		ao["distance_field"] = field
@@ -1114,9 +952,6 @@ func WithFindNearestDistanceField(field string) FindNearestOption {
 //
 // The vectorField can be a string, a FieldPath or an Expr.
 // The queryVector can be Vector32, Vector64, []float32, or []float64.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func (p *Pipeline) FindNearest(vectorField any, queryVector any, measure PipelineDistanceMeasure, opts ...FindNearestOption) *Pipeline {
 	if p.err != nil {
 		return p
@@ -1258,9 +1093,6 @@ func (p *Pipeline) Search(opts ...SearchOption) *Pipeline {
 //	client.Pipeline().Collection("books").
 //		RawStage("where", []any{LessThan(FieldOf("published"), 1900)}).
 //		Select(Fields("title", "author"))
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func (p *Pipeline) RawStage(name string, args []any, opts ...StageOption) *Pipeline {
 	if p.err != nil {
 		return p
@@ -1413,9 +1245,6 @@ func (p *Pipeline) Delete(opts ...DeleteOption) *Pipeline {
 //	//     }
 //	//   }
 //	// ]
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func (p *Pipeline) ToScalarExpression() Expression {
 	return newBaseFunction("scalar", []Expression{newPipelineValueExpression(p)})
 }
@@ -1441,17 +1270,11 @@ func (p *Pipeline) ToScalarExpression() Expression {
 //	//     ]
 //	//   }
 //	// ]
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func (p *Pipeline) ToArrayExpression() Expression {
 	return newBaseFunction("array", []Expression{newPipelineValueExpression(p)})
 }
 
 // DefineOption is an option for a Define pipeline stage.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 type DefineOption interface {
 	StageOption
 	isDefineOption()
@@ -1477,9 +1300,6 @@ type DefineOption interface {
 //		)).
 //		Where(LessThan(Variable("discountedPrice"), 100)).
 //		Select(Fields("name", Variable("newStock")))
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func (p *Pipeline) Define(variables []*AliasedExpression, opts ...DefineOption) *Pipeline {
 	if p.err != nil {
 		return p

--- a/firestore/pipeline.go
+++ b/firestore/pipeline.go
@@ -972,7 +972,8 @@ func (p *Pipeline) FindNearest(vectorField any, queryVector any, measure Pipelin
 
 // SearchOption is an option for a Search pipeline stage.
 //
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
+// Experimental: Update, Delete and Search stages in pipeline queries are in public preview
+// and are subject to potential breaking changes in future versions,
 // regardless of any other documented package stability guarantees.
 type SearchOption interface {
 	StageOption
@@ -1004,7 +1005,8 @@ func newFuncSearchOption(f func(map[string]any)) *funcSearchOption {
 //		WithSearchQuery("waffles"),
 //	)
 //
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
+// Experimental: Update, Delete and Search stages in pipeline queries are in public preview
+// and are subject to potential breaking changes in future versions,
 // regardless of any other documented package stability guarantees.
 func WithSearchQuery(query any) SearchOption {
 	return newFuncSearchOption(func(so map[string]any) {
@@ -1014,7 +1016,8 @@ func WithSearchQuery(query any) SearchOption {
 
 // WithSearchSort specifies how the returned documents are sorted. One or more ordering are required.
 //
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
+// Experimental: Update, Delete and Search stages in pipeline queries are in public preview
+// and are subject to potential breaking changes in future versions,
 // regardless of any other documented package stability guarantees.
 func WithSearchSort(orders ...Ordering) SearchOption {
 	return newFuncSearchOption(func(so map[string]any) {
@@ -1028,7 +1031,8 @@ func WithSearchSort(orders ...Ordering) SearchOption {
 
 // WithSearchAddFields specifies the fields to add to each document.
 //
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
+// Experimental: Update, Delete and Search stages in pipeline queries are in public preview
+// and are subject to potential breaking changes in future versions,
 // regardless of any other documented package stability guarantees.
 func WithSearchAddFields(fields ...Selectable) SearchOption {
 	return newFuncSearchOption(func(so map[string]any) {
@@ -1043,7 +1047,8 @@ func WithSearchAddFields(fields ...Selectable) SearchOption {
 // WithSearchRetrievalDepth specifies the maximum number of documents to retrieve. Documents will be retrieved in the
 // pre-sort order specified by the search index.
 //
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
+// Experimental: Update, Delete and Search stages in pipeline queries are in public preview
+// and are subject to potential breaking changes in future versions,
 // regardless of any other documented package stability guarantees.
 func WithSearchRetrievalDepth(depth int64) SearchOption {
 	return newFuncSearchOption(func(so map[string]any) {
@@ -1064,7 +1069,8 @@ func WithSearchRetrievalDepth(depth int64) SearchOption {
 //		WithSearchRetrievalDepth(10),
 //	)
 //
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
+// Experimental: Update, Delete and Search stages in pipeline queries are in public preview
+// and are subject to potential breaking changes in future versions,
 // regardless of any other documented package stability guarantees.
 func (p *Pipeline) Search(opts ...SearchOption) *Pipeline {
 	if p.err != nil {
@@ -1115,7 +1121,8 @@ func (p *Pipeline) RawStage(name string, args []any, opts ...StageOption) *Pipel
 
 // UpdateOption is an option for an Update pipeline stage.
 //
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
+// Experimental: Update, Delete and Search stages in pipeline queries are in public preview
+// and are subject to potential breaking changes in future versions,
 // regardless of any other documented package stability guarantees.
 type UpdateOption interface {
 	StageOption
@@ -1140,7 +1147,8 @@ func newFuncUpdateOption(f func(map[string]any)) *funcUpdateOption {
 
 // WithUpdateTransformations specifies the list of field transformations to apply in an update operation.
 //
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
+// Experimental: Update, Delete and Search stages in pipeline queries are in public preview
+// and are subject to potential breaking changes in future versions,
 // regardless of any other documented package stability guarantees.
 func WithUpdateTransformations(field Selectable, additionalFields ...Selectable) UpdateOption {
 	return newFuncUpdateOption(func(uo map[string]any) {
@@ -1168,7 +1176,8 @@ func WithUpdateTransformations(field Selectable, additionalFields ...Selectable)
 //		Where(GreaterThan("price", 50)).
 //		Update(WithUpdateTransformations(ConstantOf("Discounted").As("status")))
 //
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
+// Experimental: Update, Delete and Search stages in pipeline queries are in public preview
+// and are subject to potential breaking changes in future versions,
 // regardless of any other documented package stability guarantees.
 func (p *Pipeline) Update(opts ...UpdateOption) *Pipeline {
 	if p.err != nil {
@@ -1192,7 +1201,8 @@ func (p *Pipeline) Update(opts ...UpdateOption) *Pipeline {
 
 // DeleteOption is an option for a Delete pipeline stage.
 //
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
+// Experimental: Update, Delete and Search stages in pipeline queries are in public preview
+// and are subject to potential breaking changes in future versions,
 // regardless of any other documented package stability guarantees.
 type DeleteOption interface {
 	StageOption
@@ -1207,7 +1217,8 @@ type DeleteOption interface {
 //		Where(Equal("status", "archived")).
 //		Delete()
 //
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
+// Experimental: Update, Delete and Search stages in pipeline queries are in public preview
+// and are subject to potential breaking changes in future versions,
 // regardless of any other documented package stability guarantees.
 func (p *Pipeline) Delete(opts ...DeleteOption) *Pipeline {
 	if p.err != nil {

--- a/firestore/pipeline_aggregate.go
+++ b/firestore/pipeline_aggregate.go
@@ -21,9 +21,6 @@ import (
 )
 
 // AggregateFunction represents an aggregation function in a pipeline.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 type AggregateFunction interface {
 	toProto() (*pb.Value, error)
 	getBaseAggregateFunction() *baseAggregateFunction
@@ -98,9 +95,6 @@ var _ AggregateFunction = (*baseAggregateFunction)(nil)
 
 // AliasedAggregate is an aliased [AggregateFunction].
 // It's used to give a name to the result of an aggregation.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 type AliasedAggregate struct {
 	aggregate AggregateFunction
 	alias     string
@@ -114,9 +108,6 @@ type AliasedAggregate struct {
 // Example:
 //
 //	RawAggregate("sum", "orderAmount").As("totalRevenue")
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func RawAggregate(name string, fieldOrExprs ...any) AggregateFunction {
 	return newBaseAggregateFunction(name, fieldOrExprs...)
 }
@@ -129,9 +120,6 @@ func RawAggregate(name string, fieldOrExprs ...any) AggregateFunction {
 //		// Calculate the total revenue from a set of orders
 //		Sum(FieldOf("orderAmount")).As("totalRevenue") // FieldOf returns Expr
 //	 	Sum("orderAmount").As("totalRevenue")          // String implicitly becomes FieldOf(...).As(...)
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func Sum(fieldOrExpr any) AggregateFunction {
 	return newBaseAggregateFunction("sum", fieldOrExpr)
 }
@@ -146,9 +134,6 @@ func Sum(fieldOrExpr any) AggregateFunction {
 //		Average(FieldOfPath("info.age")).As("averageAge") // FieldOfPath returns Expr
 //	    Average("info.age").As("averageAge")              // String implicitly becomes FieldOf(...).As(...)
 //	    Average(FieldPath([]string{"info", "age"})).As("averageAge")
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func Average(fieldOrExpr any) AggregateFunction {
 	return newBaseAggregateFunction("average", fieldOrExpr)
 }
@@ -162,9 +147,6 @@ func Average(fieldOrExpr any) AggregateFunction {
 //		Count(FieldOf("price").Gt(10)).As("expensiveItemCount") // FieldOf("price").Gt(10) is a BooleanExpr
 //	    // Count the total number of products
 //		Count("productId").As("totalProducts")                  // String implicitly becomes FieldOf(...).As(...)
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func Count(fieldOrExpr any) AggregateFunction {
 	return newBaseAggregateFunction("count", fieldOrExpr)
 }
@@ -175,9 +157,6 @@ func Count(fieldOrExpr any) AggregateFunction {
 //
 //		// Count the total number of users
 //	    CountAll().As("totalUsers")
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func CountAll() AggregateFunction {
 	return newBaseAggregateFunction("count")
 }
@@ -191,25 +170,16 @@ func CountAll() AggregateFunction {
 //		CountDistinct(FieldOf("price").Gt(10)).As("expensiveItemCount") // FieldOf("price").Gt(10) is a BooleanExpr
 //	    // CountDistinct the total number of distinct products
 //		CountDistinct("productId").As("totalProducts")                  // String implicitly becomes FieldOf(...).As(...)
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func CountDistinct(fieldOrExpr any) AggregateFunction {
 	return newBaseAggregateFunction("count_distinct", fieldOrExpr)
 }
 
 // First returns the value of the expression for the first document in the group.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func First(fieldOrExpr any) AggregateFunction {
 	return newBaseAggregateFunction("first", fieldOrExpr)
 }
 
 // Last returns the value of the expression for the last document in the group.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func Last(fieldOrExpr any) AggregateFunction {
 	return newBaseAggregateFunction("last", fieldOrExpr)
 }
@@ -217,9 +187,6 @@ func Last(fieldOrExpr any) AggregateFunction {
 // ArrayAgg returns an array containing all values of the expression when evaluated on each document in the group.
 // If the expression resolves to an absent value, it is converted to NULL.
 // The order of elements in the output array is not stable and shouldn't be relied upon.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func ArrayAgg(fieldOrExpr any) AggregateFunction {
 	return newBaseAggregateFunction("array_agg", fieldOrExpr)
 }
@@ -227,9 +194,6 @@ func ArrayAgg(fieldOrExpr any) AggregateFunction {
 // ArrayAggDistinct returns an array containing all distinct values of the expression when evaluated on each document in the group.
 // If the expression resolves to an absent value, it is converted to NULL.
 // The order of elements in the output array is not stable and shouldn't be relied upon.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func ArrayAggDistinct(fieldOrExpr any) AggregateFunction {
 	return newBaseAggregateFunction("array_agg_distinct", fieldOrExpr)
 }
@@ -239,9 +203,6 @@ func ArrayAggDistinct(fieldOrExpr any) AggregateFunction {
 // Example:
 //
 //	CountIf(FieldOf("published").Equal(true)).As("publishedCount")
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func CountIf(condition BooleanExpression) AggregateFunction {
 	return newBaseAggregateFunction("count_if", condition)
 }
@@ -254,9 +215,6 @@ func CountIf(condition BooleanExpression) AggregateFunction {
 //		// Find the highest order amount
 //		Maximum(FieldOf("orderAmount")).As("maxOrderAmount") // FieldOf returns Expr
 //	 	Maximum("orderAmount").As("maxOrderAmount")          // String implicitly becomes FieldOf(...).As(...)
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func Maximum(fieldOrExpr any) AggregateFunction {
 	return newBaseAggregateFunction("maximum", fieldOrExpr)
 }
@@ -269,9 +227,6 @@ func Maximum(fieldOrExpr any) AggregateFunction {
 //		// Find the lowest order amount
 //		Minimum(FieldOf("orderAmount")).As("minOrderAmount") // FieldOf returns Expr
 //	 	Minimum("orderAmount").As("minOrderAmount")          // String implicitly becomes FieldOf(...).As(...)
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func Minimum(fieldOrExpr any) AggregateFunction {
 	return newBaseAggregateFunction("minimum", fieldOrExpr)
 }

--- a/firestore/pipeline_constant.go
+++ b/firestore/pipeline_constant.go
@@ -32,9 +32,6 @@ type constant struct {
 // ConstantOf creates a new constant [Expression] from a Go value.
 // It accepts primitive types (strings, numbers, booleans), slices, arrays, maps, structs, and specific
 // Firestore types such as time.Time, *timestamppb.Timestamp, []byte, Vector32, Vector64, *latlng.LatLng, and *DocumentRef.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func ConstantOf(value any) Expression {
 	if value == nil {
 		return ConstantOfNull()
@@ -78,26 +75,17 @@ func ConstantOf(value any) Expression {
 }
 
 // ConstantOfNull creates a new constant [Expression] representing a null value.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func ConstantOfNull() Expression {
 	pbVal, _, err := toProtoValue(reflect.ValueOf(nil))
 	return &constant{baseExpression: &baseExpression{pbVal: pbVal, err: err}}
 }
 
 // ConstantOfVector32 creates a new [Vector32] constant [Expression] from a slice of float32s.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func ConstantOfVector32(value []float32) Expression {
 	return ConstantOf(Vector32(value))
 }
 
 // ConstantOfVector64 creates a new [Vector64] constant [Expression] from a slice of float64s.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func ConstantOfVector64(value []float64) Expression {
 	return ConstantOf(Vector64(value))
 }

--- a/firestore/pipeline_expression.go
+++ b/firestore/pipeline_expression.go
@@ -559,7 +559,8 @@ type Expression interface {
 	//			WithSearchSort(Ascending(FieldOf("location").GeoDistance(&latlng.LatLng{Latitude: 37.0, Longitude: -122.0}))),
 	//		)
 	//
-	// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
+	// Experimental: Update, Delete and Search stages in pipeline queries are in public preview
+	// and are subject to potential breaking changes in future versions,
 	// regardless of any other documented package stability guarantees.
 	GeoDistance(location *latlng.LatLng) Expression
 
@@ -839,7 +840,8 @@ func (b *baseExpression) VectorLength() Expression               { return Vector
 func (b *baseExpression) Ascending() Ordering  { return Ascending(b) }
 func (b *baseExpression) Descending() Ordering { return Descending(b) }
 
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
+// Experimental: Update, Delete and Search stages in pipeline queries are in public preview
+// and are subject to potential breaking changes in future versions,
 // regardless of any other documented package stability guarantees.
 func (b *baseExpression) GeoDistance(location *latlng.LatLng) Expression {
 	return GeoDistance(b, location)

--- a/firestore/pipeline_expression.go
+++ b/firestore/pipeline_expression.go
@@ -20,9 +20,6 @@ import (
 )
 
 // Selectable is an interface for expressions that can be selected in a pipeline.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 type Selectable interface {
 	// getSelectionDetails returns the output alias and the underlying expression.
 	getSelectionDetails() (alias string, expr Expression)
@@ -43,9 +40,6 @@ type Selectable interface {
 //
 // The [Expression] interface provides a fluent API for building expressions. You can chain together
 // method calls to create complex expressions.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 type Expression interface {
 	isExpr()
 	toProto() (*pb.Value, error)
@@ -845,6 +839,8 @@ func (b *baseExpression) VectorLength() Expression               { return Vector
 func (b *baseExpression) Ascending() Ordering  { return Ascending(b) }
 func (b *baseExpression) Descending() Ordering { return Descending(b) }
 
+// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
+// regardless of any other documented package stability guarantees.
 func (b *baseExpression) GeoDistance(location *latlng.LatLng) Expression {
 	return GeoDistance(b, location)
 }
@@ -858,9 +854,6 @@ var _ Expression = (*baseExpression)(nil)
 
 // AliasedExpression represents an expression with an alias.
 // It implements the [Selectable] interface, allowing it to be used in projection stages like `Select` and `AddFields`.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 type AliasedExpression struct {
 	expr  Expression
 	alias string

--- a/firestore/pipeline_field.go
+++ b/firestore/pipeline_field.go
@@ -29,9 +29,6 @@ type field struct {
 }
 
 // FieldOf creates a new field [Expression] from a dot separated field path string or [FieldPath].
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func FieldOf[T string | FieldPath](path T) Expression {
 	var fieldPath FieldPath
 	switch p := any(path).(type) {

--- a/firestore/pipeline_filter_condition.go
+++ b/firestore/pipeline_filter_condition.go
@@ -15,9 +15,6 @@
 package firestore
 
 // BooleanExpression is an interface that represents a boolean expression in a pipeline.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 type BooleanExpression interface {
 	Expression // Embed Expr interface
 	isBooleanExpr()
@@ -69,9 +66,6 @@ var _ BooleanExpression = (*baseBooleanExpression)(nil)
 //
 //	// Check if the 'tags' array contains "Go".
 //	ArrayContains("tags", "Go")
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func ArrayContains(exprOrFieldPath any, value any) BooleanExpression {
 	return &baseBooleanExpression{baseFunction: newBaseFunction("array_contains", []Expression{asFieldExpr(exprOrFieldPath), toExprOrConstant(value)})}
 }
@@ -84,9 +78,6 @@ func ArrayContains(exprOrFieldPath any, value any) BooleanExpression {
 //
 //	// Check if the 'tags' array contains both "Go" and "Firestore".
 //	ArrayContainsAll("tags", []string{"Go", "Firestore"})
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func ArrayContainsAll(exprOrFieldPath any, values any) BooleanExpression {
 	return newFieldAndArrayBooleanExpr("array_contains_all", exprOrFieldPath, values)
 }
@@ -99,9 +90,6 @@ func ArrayContainsAll(exprOrFieldPath any, values any) BooleanExpression {
 //
 //	// Check if the 'tags' array contains either "Go" or "Firestore".
 //	ArrayContainsAny("tags", []string{"Go", "Firestore"})
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func ArrayContainsAny(exprOrFieldPath any, values any) BooleanExpression {
 	return newFieldAndArrayBooleanExpr("array_contains_any", exprOrFieldPath, values)
 }
@@ -114,9 +102,6 @@ func ArrayContainsAny(exprOrFieldPath any, values any) BooleanExpression {
 //
 //	// Check if the 'status' field is either "active" or "pending".
 //	EqualAny("status", []string{"active", "pending"})
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func EqualAny(exprOrFieldPath any, values any) BooleanExpression {
 	return newFieldAndArrayBooleanExpr("equal_any", exprOrFieldPath, values)
 }
@@ -129,9 +114,6 @@ func EqualAny(exprOrFieldPath any, values any) BooleanExpression {
 //
 //	// Check if the 'status' field is not "archived" or "deleted".
 //	NotEqualAny("status", []string{"archived", "deleted"})
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func NotEqualAny(exprOrFieldPath any, values any) BooleanExpression {
 	return newFieldAndArrayBooleanExpr("not_equal_any", exprOrFieldPath, values)
 }
@@ -154,9 +136,6 @@ func NotEqualAny(exprOrFieldPath any, values any) BooleanExpression {
 //
 //		// Check if the 'city' field is equal to string constant "London"
 //		Equal("city", "London")
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func Equal(left, right any) BooleanExpression {
 	return &baseBooleanExpression{baseFunction: leftRightToBaseFunction("equal", left, right)}
 }
@@ -179,9 +158,6 @@ func Equal(left, right any) BooleanExpression {
 //
 //		// Check if the 'city' field is not equal to string constant "London"
 //		NotEqual("city", "London")
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func NotEqual(left, right any) BooleanExpression {
 	return &baseBooleanExpression{baseFunction: leftRightToBaseFunction("not_equal", left, right)}
 }
@@ -201,9 +177,6 @@ func NotEqual(left, right any) BooleanExpression {
 //
 //		// Check if the 'age' field is greater than the 'limit' field
 //		GreaterThan("age", FieldOf("limit"))
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func GreaterThan(left, right any) BooleanExpression {
 	return &baseBooleanExpression{baseFunction: leftRightToBaseFunction("greater_than", left, right)}
 }
@@ -223,9 +196,6 @@ func GreaterThan(left, right any) BooleanExpression {
 //
 //		// Check if the 'age' field is greater than or equal to the 'limit' field
 //		GreaterThanOrEqual("age", FieldOf("limit"))
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func GreaterThanOrEqual(left, right any) BooleanExpression {
 	return &baseBooleanExpression{baseFunction: leftRightToBaseFunction("greater_than_or_equal", left, right)}
 }
@@ -245,9 +215,6 @@ func GreaterThanOrEqual(left, right any) BooleanExpression {
 //
 //		// Check if the 'age' field is less than the 'limit' field
 //		LessThan("age", FieldOf("limit"))
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func LessThan(left, right any) BooleanExpression {
 	return &baseBooleanExpression{baseFunction: leftRightToBaseFunction("less_than", left, right)}
 }
@@ -267,9 +234,6 @@ func LessThan(left, right any) BooleanExpression {
 //
 //		// Check if the 'age' field is less than or equal to the 'limit' field
 //		LessThanOrEqual("age", FieldOf("limit"))
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func LessThanOrEqual(left, right any) BooleanExpression {
 	return &baseBooleanExpression{baseFunction: leftRightToBaseFunction("less_than_or_equal", left, right)}
 }
@@ -282,9 +246,6 @@ func LessThanOrEqual(left, right any) BooleanExpression {
 //
 //	// Check if the 'filename' field ends with ".go".
 //	EndsWith("filename", ".go")
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func EndsWith(exprOrFieldPath any, suffix any) BooleanExpression {
 	return &baseBooleanExpression{baseFunction: newBaseFunction("ends_with", []Expression{asFieldExpr(exprOrFieldPath), asStringExpr(suffix)})}
 }
@@ -297,9 +258,6 @@ func EndsWith(exprOrFieldPath any, suffix any) BooleanExpression {
 //
 //	// Check if the 'name' field starts with "G".
 //	Like("name", "G%")
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func Like(exprOrFieldPath any, pattern any) BooleanExpression {
 	return &baseBooleanExpression{baseFunction: newBaseFunction("like", []Expression{asFieldExpr(exprOrFieldPath), asStringExpr(pattern)})}
 }
@@ -312,9 +270,6 @@ func Like(exprOrFieldPath any, pattern any) BooleanExpression {
 //
 //	// Check if the 'email' field contains a gmail address.
 //	RegexContains("email", "@gmail\\.com$")
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func RegexContains(exprOrFieldPath any, pattern any) BooleanExpression {
 	return &baseBooleanExpression{baseFunction: newBaseFunction("regex_contains", []Expression{asFieldExpr(exprOrFieldPath), asStringExpr(pattern)})}
 }
@@ -327,9 +282,6 @@ func RegexContains(exprOrFieldPath any, pattern any) BooleanExpression {
 //
 //	// Check if the 'zip_code' field is a 5-digit number.
 //	RegexMatch("zip_code", "^[0-9]{5}$")
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func RegexMatch(exprOrFieldPath any, pattern any) BooleanExpression {
 	return &baseBooleanExpression{baseFunction: newBaseFunction("regex_match", []Expression{asFieldExpr(exprOrFieldPath), asStringExpr(pattern)})}
 }
@@ -342,9 +294,6 @@ func RegexMatch(exprOrFieldPath any, pattern any) BooleanExpression {
 //
 //	// Check if the 'name' field starts with "Mr.".
 //	StartsWith("name", "Mr.")
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func StartsWith(exprOrFieldPath any, prefix any) BooleanExpression {
 	return &baseBooleanExpression{baseFunction: newBaseFunction("starts_with", []Expression{asFieldExpr(exprOrFieldPath), asStringExpr(prefix)})}
 }
@@ -357,82 +306,52 @@ func StartsWith(exprOrFieldPath any, prefix any) BooleanExpression {
 //
 //	// Check if the 'description' field contains the word "Firestore".
 //	StringContains("description", "Firestore")
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func StringContains(exprOrFieldPath any, substring any) BooleanExpression {
 	return &baseBooleanExpression{baseFunction: newBaseFunction("string_contains", []Expression{asFieldExpr(exprOrFieldPath), asStringExpr(substring)})}
 }
 
 // And creates an expression that performs a logical 'AND' operation.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func And(condition BooleanExpression, right ...BooleanExpression) BooleanExpression {
 	return &baseBooleanExpression{baseFunction: newBaseFunctionFromBooleans("and", append([]BooleanExpression{condition}, right...))}
 }
 
 // FieldExists creates an expression that checks if a field exists.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func FieldExists(exprOrField any) BooleanExpression {
 	return &baseBooleanExpression{baseFunction: newBaseFunction("exists", []Expression{asFieldExpr(exprOrField)})}
 }
 
 // Not creates an expression that negates a boolean expression.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func Not(condition BooleanExpression) BooleanExpression {
 	return &baseBooleanExpression{baseFunction: newBaseFunction("not", []Expression{condition})}
 }
 
 // Nor creates an expression that performs a logical 'NOR' operation.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func Nor(condition BooleanExpression, right ...BooleanExpression) BooleanExpression {
 	return &baseBooleanExpression{baseFunction: newBaseFunctionFromBooleans("nor", append([]BooleanExpression{condition}, right...))}
 }
 
 // Or creates an expression that performs a logical 'OR' operation.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func Or(condition BooleanExpression, right ...BooleanExpression) BooleanExpression {
 	return &baseBooleanExpression{baseFunction: newBaseFunctionFromBooleans("or", append([]BooleanExpression{condition}, right...))}
 }
 
 // Xor creates an expression that performs a logical 'XOR' operation.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func Xor(condition BooleanExpression, right ...BooleanExpression) BooleanExpression {
 	return &baseBooleanExpression{baseFunction: newBaseFunctionFromBooleans("xor", append([]BooleanExpression{condition}, right...))}
 }
 
 // IsError creates an expression that checks if an expression evaluates to an error.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func IsError(expr Expression) BooleanExpression {
 	return &baseBooleanExpression{baseFunction: newBaseFunction("is_error", []Expression{expr})}
 }
 
 // IsAbsent creates an expression that checks if an expression evaluates to an absent value.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func IsAbsent(exprOrField any) BooleanExpression {
 	return &baseBooleanExpression{baseFunction: newBaseFunction("is_absent", []Expression{asFieldExpr(exprOrField)})}
 }
 
 // RawBooleanFunction creates a 'raw' boolean function expression.
 // This is useful if the expression is available in the backend, but not yet in the current version of the SDK.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func RawBooleanFunction(name string, exprs ...any) BooleanExpression {
 	expressions := make([]Expression, len(exprs))
 	for i, expr := range exprs {
@@ -447,9 +366,6 @@ func RawBooleanFunction(name string, exprs ...any) BooleanExpression {
 //     "null", "array", "boolean", "bytes", "timestamp", "geo_point", "number", "int32", "int64",
 //     "float64", "decimal128", "map", "reference", "string", "vector", "max_key", "min_key",
 //     "min_array", "object_id", "regex", "request_timestamp"
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func IsType(exprOrField any, dataType string) BooleanExpression {
 	return &baseBooleanExpression{baseFunction: newBaseFunction("is_type", []Expression{asFieldExpr(exprOrField), ConstantOf(dataType)})}
 }

--- a/firestore/pipeline_function.go
+++ b/firestore/pipeline_function.go
@@ -23,9 +23,6 @@ import (
 
 // FunctionExpression represents Firestore [Pipeline] functions, which can be evaluated within pipeline
 // execution.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 type FunctionExpression interface {
 	Expression
 	isFunction()
@@ -71,9 +68,6 @@ func newBaseFunctionFromBooleans(name string, params []BooleanExpression) *baseF
 // Add creates an expression that adds two expressions together, returning it as an Expr.
 // - left can be a field path string, [FieldPath] or [Expression].
 // - right can be a numeric constant or a numeric [Expression].
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func Add(left, right any) Expression {
 	return leftNumericRightToBaseFunction("add", left, right)
 }
@@ -81,9 +75,6 @@ func Add(left, right any) Expression {
 // Subtract creates an expression that subtracts the right expression from the left expression, returning it as an Expr.
 // - left can be a field path string, [FieldPath] or [Expression].
 // - right can be a numeric constant or a numeric [Expression].
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func Subtract(left, right any) Expression {
 	return leftNumericRightToBaseFunction("subtract", left, right)
 }
@@ -91,9 +82,6 @@ func Subtract(left, right any) Expression {
 // Multiply creates an expression that multiplies the left and right expressions, returning it as an Expr.
 // - left can be a field path string, [FieldPath] or [Expression].
 // - right can be a numeric constant or a numeric [Expression].
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func Multiply(left, right any) Expression {
 	return leftNumericRightToBaseFunction("multiply", left, right)
 }
@@ -101,45 +89,30 @@ func Multiply(left, right any) Expression {
 // Divide creates an expression that divides the left expression by the right expression, returning it as an Expr.
 // - left can be a field path string, [FieldPath] or [Expression].
 // - right can be a numeric constant or a numeric [Expression].
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func Divide(left, right any) Expression {
 	return leftNumericRightToBaseFunction("divide", left, right)
 }
 
 // Abs creates an expression that is the absolute value of the input field or expression.
 // - numericExprOrFieldPath can be a field path string, [FieldPath] or an [Expression] that returns a number when evaluated.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func Abs(numericExprOrFieldPath any) Expression {
 	return newBaseFunction("abs", []Expression{asFieldExpr(numericExprOrFieldPath)})
 }
 
 // Floor creates an expression that is the largest integer that isn't less than the input field or expression.
 // - numericExprOrFieldPath can be a field path string, [FieldPath] or an [Expression] that returns a number when evaluated.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func Floor(numericExprOrFieldPath any) Expression {
 	return newBaseFunction("floor", []Expression{asFieldExpr(numericExprOrFieldPath)})
 }
 
 // Ceil creates an expression that is the smallest integer that isn't less than the input field or expression.
 // - numericExprOrFieldPath can be a field path string, [FieldPath] or an [Expression] that returns a number when evaluated.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func Ceil(numericExprOrFieldPath any) Expression {
 	return newBaseFunction("ceil", []Expression{asFieldExpr(numericExprOrFieldPath)})
 }
 
 // Exp creates an expression that is the Euler's number e raised to the power of the input field or expression.
 // - numericExprOrFieldPath can be a field path string, [FieldPath] or an [Expression] that returns a number when evaluated.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func Exp(numericExprOrFieldPath any) Expression {
 	return newBaseFunction("exp", []Expression{asFieldExpr(numericExprOrFieldPath)})
 }
@@ -147,27 +120,18 @@ func Exp(numericExprOrFieldPath any) Expression {
 // Log creates an expression that is logarithm of the left expression to base as the right expression, returning it as an Expr.
 // - left can be a field path string, [FieldPath] or [Expression].
 // - right can be a constant or an [Expression].
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func Log(left, right any) Expression {
 	return leftNumericRightToBaseFunction("log", left, right)
 }
 
 // Log10 creates an expression that is the base 10 logarithm of the input field or expression.
 // - numericExprOrFieldPath can be a field path string, [FieldPath] or an [Expression] that returns a number when evaluated.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func Log10(numericExprOrFieldPath any) Expression {
 	return newBaseFunction("log10", []Expression{asFieldExpr(numericExprOrFieldPath)})
 }
 
 // Ln creates an expression that is the natural logarithm (base e) of the input field or expression.
 // - numericExprOrFieldPath can be a field path string, [FieldPath] or an [Expression] that returns a number when evaluated.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func Ln(numericExprOrFieldPath any) Expression {
 	return newBaseFunction("ln", []Expression{asFieldExpr(numericExprOrFieldPath)})
 }
@@ -175,9 +139,6 @@ func Ln(numericExprOrFieldPath any) Expression {
 // Mod creates an expression that computes the modulo of the left expression by the right expression, returning it as an Expr.
 // - left can be a field path string, [FieldPath] or [Expression].
 // - right can be a numeric constant or a numeric [Expression].
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func Mod(left, right any) Expression {
 	return leftNumericRightToBaseFunction("mod", left, right)
 }
@@ -185,18 +146,12 @@ func Mod(left, right any) Expression {
 // Pow creates an expression that computes the left expression raised to the power of the right expression, returning it as an Expr.
 // - left can be a field path string, [FieldPath] or [Expression].
 // - right can be a numeric constant or a numeric [Expression].
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func Pow(left, right any) Expression {
 	return leftNumericRightToBaseFunction("pow", left, right)
 }
 
 // Round creates an expression that rounds the input field or expression to nearest integer.
 // - numericExprOrFieldPath can be a field path string, [FieldPath] or an [Expression] that returns a number when evaluated.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func Round(numericExprOrFieldPath any) Expression {
 	return newBaseFunction("round", []Expression{asFieldExpr(numericExprOrFieldPath)})
 }
@@ -206,18 +161,12 @@ func Round(numericExprOrFieldPath any) Expression {
 // If places is negative, rounds off digits to the left of the decimal point.
 // - numericExprOrFieldPath can be a field path string, [FieldPath] or an [Expression] that returns a number when evaluated.
 // - places can be an int, int32, int64 or [Expression].
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func RoundToPrecision(numericExprOrFieldPath any, places any) Expression {
 	return newBaseFunction("round", []Expression{asFieldExpr(numericExprOrFieldPath), asInt64Expr(places)})
 }
 
 // Trunc creates an expression that truncates a number to an integer.
 // - numericExprOrFieldPath can be a field path string, [FieldPath] or an [Expression] that returns a number when evaluated.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func Trunc(numericExprOrFieldPath any) Expression {
 	return newBaseFunction("trunc", []Expression{asFieldExpr(numericExprOrFieldPath)})
 }
@@ -225,18 +174,12 @@ func Trunc(numericExprOrFieldPath any) Expression {
 // TruncToPrecision creates an expression that truncates a number to a specified number of decimal places.
 // - numericExprOrFieldPath can be a field path string, [FieldPath] or an [Expression] that returns a number when evaluated.
 // - places can be an int, int32, int64 or [Expression].
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func TruncToPrecision(numericExprOrFieldPath any, places any) Expression {
 	return newBaseFunction("trunc", []Expression{asFieldExpr(numericExprOrFieldPath), asInt64Expr(places)})
 }
 
 // Sqrt creates an expression that is the square root of the input field or expression.
 // - numericExprOrFieldPath can be a field path string, [FieldPath] or an [Expression] that returns a number when evaluated.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func Sqrt(numericExprOrFieldPath any) Expression {
 	return newBaseFunction("sqrt", []Expression{asFieldExpr(numericExprOrFieldPath)})
 }
@@ -245,9 +188,6 @@ func Sqrt(numericExprOrFieldPath any) Expression {
 // Returns -1 if left < right, 0 if left == right, and 1 if left > right.
 // - left can be a field path string, [FieldPath] or [Expression].
 // - right can be a constant or an [Expression].
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func Cmp(left, right any) Expression {
 	return leftRightToBaseFunction("cmp", left, right)
 }
@@ -256,9 +196,6 @@ func Cmp(left, right any) Expression {
 // - timestamp can be a field path string, [FieldPath] or [Expression].
 // - unit can be a string or an [Expression]. Valid units include "microsecond", "millisecond", "second", "minute", "hour" and "day".
 // - amount can be an int, int32, int64 or [Expression].
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func TimestampAdd(timestamp, unit, amount any) Expression {
 	return newBaseFunction("timestamp_add", []Expression{asFieldExpr(timestamp), validateTimestampUnit(unit), asInt64Expr(amount)})
 }
@@ -267,9 +204,6 @@ func TimestampAdd(timestamp, unit, amount any) Expression {
 // - timestamp can be a field path string, [FieldPath] or [Expression].
 // - unit can be a string or an [Expression]. Valid units include "microsecond", "millisecond", "second", "minute", "hour" and "day".
 // - amount can be an int, int32, int64 or [Expression].
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func TimestampSubtract(timestamp, unit, amount any) Expression {
 	return newBaseFunction("timestamp_subtract", []Expression{asFieldExpr(timestamp), validateTimestampUnit(unit), asInt64Expr(amount)})
 }
@@ -279,9 +213,6 @@ func TimestampSubtract(timestamp, unit, amount any) Expression {
 //   - part can be a string or an [Expression]. Valid parts include "microsecond", "millisecond", "second", "minute", "hour", "day",
 //     "dayofweek", "dayofyear", "week", "week(monday)", "week(tuesday)", "week(wednesday)", "week(thursday)",
 //     "week(friday)", "week(saturday)", "week(sunday)", "month", "quarter", "year", "isoweek", and "isoyear".
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func TimestampExtract(timestamp, part any) Expression {
 	return newBaseFunction("timestamp_extract", []Expression{asFieldExpr(timestamp), validateTimestampPart(part)})
 }
@@ -292,9 +223,6 @@ func TimestampExtract(timestamp, part any) Expression {
 //     "dayofweek", "dayofyear", "week", "week(monday)", "week(tuesday)", "week(wednesday)", "week(thursday)",
 //     "week(friday)", "week(saturday)", "week(sunday)", "month", "quarter", "year", "isoweek", and "isoyear".
 //   - timezone can be a string or an [Expression].
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func TimestampExtractWithTimezone(timestamp, part, timezone any) Expression {
 	return newBaseFunction("timestamp_extract", []Expression{asFieldExpr(timestamp), validateTimestampPart(part), asStringExpr(timezone)})
 }
@@ -303,9 +231,6 @@ func TimestampExtractWithTimezone(timestamp, part, timezone any) Expression {
 // - end can be a field path string, [FieldPath] or [Expression].
 // - start can be a field path string, [FieldPath] or [Expression].
 // - unit can be a string or an [Expression]. Valid units include "microsecond", "millisecond", "second", "minute", "hour" and "day".
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func TimestampDiff(end, start, unit any) Expression {
 	return newBaseFunction("timestamp_diff", []Expression{asFieldExpr(end), asFieldExpr(start), validateTimestampUnit(unit)})
 }
@@ -316,9 +241,6 @@ func TimestampDiff(end, start, unit any) Expression {
 //     "millisecond", "second", "minute", "hour", "day", "week", "week(monday)", "week(tuesday)",
 //     "week(wednesday)", "week(thursday)", "week(friday)", "week(saturday)", "week(sunday)",
 //     "isoweek", "month", "quarter", "year", and "isoyear".
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func TimestampTruncate(timestamp, granularity any) Expression {
 	return newBaseFunction("timestamp_trunc", []Expression{asFieldExpr(timestamp), validateTimestampGranularity(granularity)})
 }
@@ -331,9 +253,6 @@ func TimestampTruncate(timestamp, granularity any) Expression {
 //     "isoweek", "month", "quarter", "year", and "isoyear".
 //   - timezone can be a string or an [Expression]. Valid values are from the TZ database
 //     (e.g., "America/Los_Angeles") or in the format "Etc/GMT-1".
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func TimestampTruncateWithTimezone(timestamp, granularity any, timezone any) Expression {
 	return newBaseFunction("timestamp_trunc", []Expression{asFieldExpr(timestamp), validateTimestampGranularity(granularity), asStringExpr(timezone)})
 }
@@ -341,9 +260,6 @@ func TimestampTruncateWithTimezone(timestamp, granularity any, timezone any) Exp
 // TimestampToUnixMicros creates an expression that converts a timestamp expression to the number of microseconds since
 // the Unix epoch (1970-01-01 00:00:00 UTC).
 // - timestamp can be a field path string, [FieldPath] or [Expression].
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func TimestampToUnixMicros(timestamp any) Expression {
 	return newBaseFunction("timestamp_to_unix_micros", []Expression{asFieldExpr(timestamp)})
 }
@@ -351,9 +267,6 @@ func TimestampToUnixMicros(timestamp any) Expression {
 // TimestampToUnixMillis creates an expression that converts a timestamp expression to the number of milliseconds since
 // the Unix epoch (1970-01-01 00:00:00 UTC).
 // - timestamp can be a field path string, [FieldPath] or [Expression].
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func TimestampToUnixMillis(timestamp any) Expression {
 	return newBaseFunction("timestamp_to_unix_millis", []Expression{asFieldExpr(timestamp)})
 }
@@ -361,44 +274,29 @@ func TimestampToUnixMillis(timestamp any) Expression {
 // TimestampToUnixSeconds creates an expression that converts a timestamp expression to the number of seconds since
 // the Unix epoch (1970-01-01 00:00:00 UTC).
 // - timestamp can be a field path string, [FieldPath] or [Expression].
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func TimestampToUnixSeconds(timestamp any) Expression {
 	return newBaseFunction("timestamp_to_unix_seconds", []Expression{asFieldExpr(timestamp)})
 }
 
 // UnixMicrosToTimestamp creates an expression that converts a Unix timestamp in microseconds to a Firestore timestamp.
 // - micros can be a field path string, [FieldPath] or [Expression].
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func UnixMicrosToTimestamp(micros any) Expression {
 	return newBaseFunction("unix_micros_to_timestamp", []Expression{asFieldExpr(micros)})
 }
 
 // UnixMillisToTimestamp creates an expression that converts a Unix timestamp in milliseconds to a Firestore timestamp.
 // - millis can be a field path string, [FieldPath] or [Expression].
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func UnixMillisToTimestamp(millis any) Expression {
 	return newBaseFunction("unix_millis_to_timestamp", []Expression{asFieldExpr(millis)})
 }
 
 // UnixSecondsToTimestamp creates an expression that converts a Unix timestamp in seconds to a Firestore timestamp.
 // - seconds can be a field path string, [FieldPath] or [Expression].
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func UnixSecondsToTimestamp(seconds any) Expression {
 	return newBaseFunction("unix_seconds_to_timestamp", []Expression{asFieldExpr(seconds)})
 }
 
 // CurrentTimestamp creates an expression that returns the current timestamp.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func CurrentTimestamp() Expression {
 	return newBaseFunction("current_timestamp", []Expression{})
 }
@@ -415,9 +313,6 @@ func CurrentTimestamp() Expression {
 //		Define(AliasedExpressions(CurrentDocument().As("doc"))).
 //		// Access a field from the defined document variable
 //		Select(Fields(GetField(Variable("doc"), "title")))
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func CurrentDocument() Expression {
 	return newBaseFunction("current_document", []Expression{})
 }
@@ -430,9 +325,6 @@ func CurrentDocument() Expression {
 //	client.Pipeline().Collection("products").
 //		Define(AliasedExpressions(Multiply("price", 0.9).As("discountedPrice"))).
 //		Where(LessThan(Variable("discountedPrice"), 100))
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func Variable(name string) Expression {
 	pbVal := &pb.Value{ValueType: &pb.Value_VariableReferenceValue{VariableReferenceValue: name}}
 	return &baseExpression{pbVal: pbVal}
@@ -440,18 +332,12 @@ func Variable(name string) Expression {
 
 // ArrayLength creates an expression that calculates the length of an array.
 // - exprOrFieldPath can be a field path string, [FieldPath] or an [Expression] that evaluates to an array.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func ArrayLength(exprOrFieldPath any) Expression {
 	return newBaseFunction("array_length", []Expression{asFieldExpr(exprOrFieldPath)})
 }
 
 // Array creates an expression that represents a Firestore array.
 // - elements can be any number of values or expressions that will form the elements of the array.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func Array(elements ...any) Expression {
 	return newBaseFunction("array", toArrayOfExprOrConstant(elements))
 }
@@ -460,9 +346,6 @@ func Array(elements ...any) Expression {
 // This function is necessary for creating an array from an existing typed slice (e.g., []int),
 // as the [Array] function (which takes variadic arguments) cannot directly accept a typed slice
 // using the spread operator (...). It handles the conversion of each element to `any` internally.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func ArrayFromSlice[T any](elements []T) Expression {
 	return newBaseFunction("array", toExprsFromSlice(elements))
 }
@@ -478,9 +361,6 @@ func ArrayFromSlice[T any](elements []T) Expression {
 //
 // - exprOrFieldPath can be a field path string, [FieldPath] or an [Expression] that evaluates to an array.
 // - offset is the 0-based index of the element to retrieve. Supports negative indexing.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func ArrayGet(exprOrFieldPath any, offset any) Expression {
 	return newBaseFunction("array_get", []Expression{asFieldExpr(exprOrFieldPath), asInt64Expr(offset)})
 }
@@ -493,18 +373,12 @@ func ArrayGet(exprOrFieldPath any, offset any) Expression {
 //   - exprOrFieldPath can be a field path string, [FieldPath] or an [Expression] that evaluates to an array.
 //   - index is the 0-based index of the element to retrieve. It can be an int or an [Expression].
 //     Supports negative indexing (e.g., -1 returns the last element).
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func Offset(exprOrFieldPath any, index any) Expression {
 	return newBaseFunction("offset", []Expression{asFieldExpr(exprOrFieldPath), asInt64Expr(index)})
 }
 
 // ArrayReverse creates an expression that reverses the order of elements in an array.
 // - exprOrFieldPath can be a field path string, [FieldPath] or an [Expression] that evaluates to an array.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func ArrayReverse(exprOrFieldPath any) Expression {
 	return newBaseFunction("array_reverse", []Expression{asFieldExpr(exprOrFieldPath)})
 }
@@ -512,36 +386,24 @@ func ArrayReverse(exprOrFieldPath any) Expression {
 // ArrayConcat creates an expression that concatenates multiple arrays into a single array.
 // - exprOrFieldPath can be a field path string, [FieldPath] or an [Expression] that evaluates to an array.
 // - otherArrays are the other arrays to concatenate.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func ArrayConcat(exprOrFieldPath any, otherArrays ...any) Expression {
 	return newBaseFunction("array_concat", append([]Expression{asFieldExpr(exprOrFieldPath)}, toArrayOfExprOrConstant(otherArrays)...))
 }
 
 // ArraySum creates an expression that calculates the sum of all elements in a numeric array.
 // - exprOrFieldPath can be a field path string, [FieldPath] or an [Expression] that evaluates to a numeric array.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func ArraySum(exprOrFieldPath any) Expression {
 	return newBaseFunction("sum", []Expression{asFieldExpr(exprOrFieldPath)})
 }
 
 // ArrayMaximum creates an expression that finds the maximum element in a numeric array.
 // - exprOrFieldPath can be a field path string, [FieldPath] or an [Expression] that evaluates to a numeric array.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func ArrayMaximum(exprOrFieldPath any) Expression {
 	return newBaseFunction("maximum", []Expression{asFieldExpr(exprOrFieldPath)})
 }
 
 // ArrayMinimum creates an expression that finds the minimum element in a numeric array.
 // - exprOrFieldPath can be a field path string, [FieldPath] or an [Expression] that evaluates to a numeric array.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func ArrayMinimum(exprOrFieldPath any) Expression {
 	return newBaseFunction("minimum", []Expression{asFieldExpr(exprOrFieldPath)})
 }
@@ -549,9 +411,6 @@ func ArrayMinimum(exprOrFieldPath any) Expression {
 // ArrayMaximumN creates an expression that finds the N maximum elements in an array.
 // - exprOrFieldPath can be a field path string, [FieldPath] or an [Expression] that evaluates to an array.
 // - n can be an int, int32, int64 or [Expression].
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func ArrayMaximumN(exprOrFieldPath any, n any) Expression {
 	return newBaseFunction("maximum_n", []Expression{asFieldExpr(exprOrFieldPath), asInt64Expr(n)})
 }
@@ -559,18 +418,12 @@ func ArrayMaximumN(exprOrFieldPath any, n any) Expression {
 // ArrayMinimumN creates an expression that finds the N minimum elements in an array.
 // - exprOrFieldPath can be a field path string, [FieldPath] or an [Expression] that evaluates to an array.
 // - n can be an int, int32, int64 or [Expression].
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func ArrayMinimumN(exprOrFieldPath any, n any) Expression {
 	return newBaseFunction("minimum_n", []Expression{asFieldExpr(exprOrFieldPath), asInt64Expr(n)})
 }
 
 // ArrayFirst creates an expression that returns the first element of an array.
 // - exprOrFieldPath can be a field path string, [FieldPath] or an [Expression] that evaluates to an array.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func ArrayFirst(exprOrFieldPath any) Expression {
 	return newBaseFunction("array_first", []Expression{asFieldExpr(exprOrFieldPath)})
 }
@@ -578,18 +431,12 @@ func ArrayFirst(exprOrFieldPath any) Expression {
 // ArrayFirstN creates an expression that returns the first N elements of an array.
 // - exprOrFieldPath can be a field path string, [FieldPath] or an [Expression] that evaluates to an array.
 // - n can be an int, int32, int64 or [Expression].
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func ArrayFirstN(exprOrFieldPath any, n any) Expression {
 	return newBaseFunction("array_first_n", []Expression{asFieldExpr(exprOrFieldPath), asInt64Expr(n)})
 }
 
 // ArrayLast creates an expression that returns the last element of an array.
 // - exprOrFieldPath can be a field path string, [FieldPath] or an [Expression] that evaluates to an array.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func ArrayLast(exprOrFieldPath any) Expression {
 	return newBaseFunction("array_last", []Expression{asFieldExpr(exprOrFieldPath)})
 }
@@ -597,9 +444,6 @@ func ArrayLast(exprOrFieldPath any) Expression {
 // ArrayLastN creates an expression that returns the last N elements of an array.
 // - exprOrFieldPath can be a field path string, [FieldPath] or an [Expression] that evaluates to an array.
 // - n can be an int, int32, int64 or [Expression].
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func ArrayLastN(exprOrFieldPath any, n any) Expression {
 	return newBaseFunction("array_last_n", []Expression{asFieldExpr(exprOrFieldPath), asInt64Expr(n)})
 }
@@ -607,9 +451,6 @@ func ArrayLastN(exprOrFieldPath any, n any) Expression {
 // ArraySliceToEnd creates an expression that returns a slice of an array starting from the specified offset.
 // - exprOrFieldPath can be a field path string, [FieldPath] or an [Expression] that evaluates to an array.
 // - offset is the 0-based index of the first element to include. It can be an int, int32, int64 or [Expression].
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func ArraySliceToEnd(exprOrFieldPath any, offset any) Expression {
 	return newBaseFunction("array_slice", []Expression{asFieldExpr(exprOrFieldPath), asInt64Expr(offset)})
 }
@@ -618,9 +459,6 @@ func ArraySliceToEnd(exprOrFieldPath any, offset any) Expression {
 // - exprOrFieldPath can be a field path string, [FieldPath] or an [Expression] that evaluates to an array.
 // - offset is the 0-based index of the first element to include. It can be an int, int32, int64 or [Expression].
 // - length is the number of elements to include. It can be an int, int32, int64 or [Expression].
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func ArraySlice(exprOrFieldPath any, offset any, length any) Expression {
 	return newBaseFunction("array_slice", []Expression{asFieldExpr(exprOrFieldPath), asInt64Expr(offset), asInt64Expr(length)})
 }
@@ -628,9 +466,6 @@ func ArraySlice(exprOrFieldPath any, offset any, length any) Expression {
 // ReferenceSliceToEnd creates an expression that returns a subset of segments from a document reference.
 // - exprOrField can be a field path string, [FieldPath] or an [Expression] that evaluates to a document reference.
 // - offset is the 0-based index of the first segment to include. It can be an int, int32, int64 or [Expression].
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func ReferenceSliceToEnd(exprOrFieldPath any, offset any) Expression {
 	return newBaseFunction("reference_slice", []Expression{asFieldExpr(exprOrFieldPath), asInt64Expr(offset)})
 }
@@ -639,9 +474,6 @@ func ReferenceSliceToEnd(exprOrFieldPath any, offset any) Expression {
 // - exprOrField can be a field path string, [FieldPath] or an [Expression] that evaluates to a document reference.
 // - offset is the 0-based index of the first segment to include. It can be an int, int32, int64 or [Expression].
 // - length is the number of segments to include. It can be an int, int32, int64 or [Expression].
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func ReferenceSlice(exprOrFieldPath any, offset any, length any) Expression {
 	return newBaseFunction("reference_slice", []Expression{asFieldExpr(exprOrFieldPath), asInt64Expr(offset), asInt64Expr(length)})
 }
@@ -650,9 +482,6 @@ func ReferenceSlice(exprOrFieldPath any, offset any, length any) Expression {
 // - array can be a field path string, [FieldPath] or an [Expression] that evaluates to an array.
 // - param is the name of the parameter to use in the body expression.
 // - body is the expression to evaluate for each element of the array.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func ArrayFilter(array any, param string, body BooleanExpression) Expression {
 	return newBaseFunction("array_filter", []Expression{asFieldExpr(array), ConstantOf(param), body})
 }
@@ -661,9 +490,6 @@ func ArrayFilter(array any, param string, body BooleanExpression) Expression {
 // - array can be a field path string, [FieldPath] or an [Expression] that evaluates to an array.
 // - param is the name of the parameter to use in the transform expression.
 // - body is the expression to evaluate for each element of the array.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func ArrayTransform(array any, param string, body Expression) Expression {
 	return newBaseFunction("array_transform", []Expression{asFieldExpr(array), ConstantOf(param), body})
 }
@@ -673,9 +499,6 @@ func ArrayTransform(array any, param string, body Expression) Expression {
 // - param is the name of the parameter to use in the transform expression for the element.
 // - indexParam is the name of the parameter to use in the transform expression for the index.
 // - body is the expression to evaluate for each element of the array.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func ArrayTransformWithIndex(array any, param, indexParam string, body Expression) Expression {
 	return newBaseFunction("array_transform", []Expression{asFieldExpr(array), ConstantOf(param), ConstantOf(indexParam), body})
 }
@@ -683,9 +506,6 @@ func ArrayTransformWithIndex(array any, param, indexParam string, body Expressio
 // ArrayIndexOf creates an expression that returns the first index of a search value in an array.
 // - exprOrFieldPath can be a field path string, [FieldPath] or an [Expression] that evaluates to an array.
 // - search is the value to search for. It can be a constant or [Expression].
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func ArrayIndexOf(exprOrFieldPath any, search any) Expression {
 	return newBaseFunction("array_index_of", []Expression{asFieldExpr(exprOrFieldPath), toExprOrConstant(search), toExprOrConstant("first")})
 }
@@ -693,9 +513,6 @@ func ArrayIndexOf(exprOrFieldPath any, search any) Expression {
 // ArrayLastIndexOf creates an expression that returns the last index of a search value in an array.
 // - exprOrFieldPath can be a field path string, [FieldPath] or an [Expression] that evaluates to an array.
 // - search is the value to search for. It can be a constant or [Expression].
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func ArrayLastIndexOf(exprOrFieldPath any, search any) Expression {
 	return newBaseFunction("array_index_of", []Expression{asFieldExpr(exprOrFieldPath), toExprOrConstant(search), toExprOrConstant("last")})
 }
@@ -703,18 +520,12 @@ func ArrayLastIndexOf(exprOrFieldPath any, search any) Expression {
 // ArrayIndexOfAll creates an expression that returns the indices of all occurrences of a search value in an array.
 // - exprOrFieldPath can be a field path string, [FieldPath] or an [Expression] that evaluates to an array.
 // - search is the value to search for. It can be a constant or [Expression].
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func ArrayIndexOfAll(exprOrFieldPath any, search any) Expression {
 	return newBaseFunction("array_index_of_all", []Expression{asFieldExpr(exprOrFieldPath), toExprOrConstant(search)})
 }
 
 // StorageSize creates an expression that calculates the storage size of a field or [Expression] in bytes.
 //   - exprOrFieldPath can be a field path string, [FieldPath] or [Expression].
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func StorageSize(exprOrFieldPath any) Expression {
 	return newBaseFunction("storage_size", []Expression{asFieldExpr(exprOrFieldPath)})
 }
@@ -722,18 +533,12 @@ func StorageSize(exprOrFieldPath any) Expression {
 // ByteLength creates an expression that calculates the length of a string represented by a field or [Expression] in UTF-8
 // bytes.
 //   - exprOrFieldPath can be a field path string, [FieldPath] or [Expression].
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func ByteLength(exprOrFieldPath any) Expression {
 	return newBaseFunction("byte_length", []Expression{asFieldExpr(exprOrFieldPath)})
 }
 
 // CharLength creates an expression that calculates the character length of a string field or expression in UTF8.
 //   - exprOrFieldPath can be a field path string, [FieldPath] or [Expression].
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func CharLength(exprOrFieldPath any) Expression {
 	return newBaseFunction("char_length", []Expression{asFieldExpr(exprOrFieldPath)})
 }
@@ -741,9 +546,6 @@ func CharLength(exprOrFieldPath any) Expression {
 // StringConcat creates an expression that concatenates multiple strings into a single string.
 // - exprOrFieldPath can be a field path string, [FieldPath] or an [Expression] that evaluates to a string.
 // - otherStrings are optional additional string expressions or string constants to concatenate.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func StringConcat(exprOrFieldPath any, otherStrings ...any) Expression {
 	args := make([]Expression, 1+len(otherStrings))
 	args[0] = asFieldExpr(exprOrFieldPath)
@@ -756,9 +558,6 @@ func StringConcat(exprOrFieldPath any, otherStrings ...any) Expression {
 // StringRepeat creates an expression that repeats a string a specified number of times.
 // - exprOrFieldPath can be a field path string, [FieldPath] or an [Expression] that evaluates to a string.
 // - repetition is the number of times to repeat the string. It can be an int, int32, int64 or [Expression].
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func StringRepeat(exprOrFieldPath any, repetition any) Expression {
 	return newBaseFunction("string_repeat", []Expression{asFieldExpr(exprOrFieldPath), asInt64Expr(repetition)})
 }
@@ -767,9 +566,6 @@ func StringRepeat(exprOrFieldPath any, repetition any) Expression {
 // - exprOrFieldPath can be a field path string, [FieldPath] or an [Expression] that evaluates to a string.
 // - search is the value to search for. It can be a string or [Expression].
 // - replacement is the value to replace with. It can be a string or [Expression].
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func StringReplaceOne(exprOrFieldPath any, search, replacement any) Expression {
 	return newBaseFunction("string_replace_one", []Expression{asFieldExpr(exprOrFieldPath), asStringExpr(search), asStringExpr(replacement)})
 }
@@ -778,18 +574,12 @@ func StringReplaceOne(exprOrFieldPath any, search, replacement any) Expression {
 // - exprOrFieldPath can be a field path string, [FieldPath] or an [Expression] that evaluates to a string.
 // - search is the value to search for. It can be a string or [Expression].
 // - replacement is the value to replace with. It can be a string or [Expression].
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func StringReplaceAll(exprOrFieldPath any, search, replacement any) Expression {
 	return newBaseFunction("string_replace_all", []Expression{asFieldExpr(exprOrFieldPath), asStringExpr(search), asStringExpr(replacement)})
 }
 
 // StringReverse creates an expression that reverses a string.
 // - exprOrFieldPath can be a field path string, [FieldPath] or an [Expression] that evaluates to a string.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func StringReverse(exprOrFieldPath any) Expression {
 	return newBaseFunction("string_reverse", []Expression{asFieldExpr(exprOrFieldPath)})
 }
@@ -797,9 +587,6 @@ func StringReverse(exprOrFieldPath any) Expression {
 // StringIndexOf creates an expression that returns the index of a search value in a string.
 // - exprOrFieldPath can be a field path string, [FieldPath] or an [Expression] that evaluates to a string.
 // - search is the value to search for. It can be a string or [Expression].
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func StringIndexOf(exprOrFieldPath any, search any) Expression {
 	return newBaseFunction("string_index_of", []Expression{asFieldExpr(exprOrFieldPath), asStringExpr(search)})
 }
@@ -807,9 +594,6 @@ func StringIndexOf(exprOrFieldPath any, search any) Expression {
 // Join creates an expression that joins the elements of a string array into a single string.
 // - exprOrFieldPath can be a field path string, [FieldPath] or an [Expression] that evaluates to a string array.
 // - delimiter is the string to use as a separator between elements.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func Join(exprOrFieldPath any, delimiter any) Expression {
 	return newBaseFunction("join", []Expression{asFieldExpr(exprOrFieldPath), asStringExpr(delimiter)})
 }
@@ -818,36 +602,24 @@ func Join(exprOrFieldPath any, delimiter any) Expression {
 // - exprOrFieldPath can be a field path string, [FieldPath] or an [Expression] that evaluates to a string.
 // - index is the starting index of the substring.
 // - length is the length of the substring.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func Substring(exprOrFieldPath any, index any, length any) Expression {
 	return newBaseFunction("substring", []Expression{asFieldExpr(exprOrFieldPath), asInt64Expr(index), asInt64Expr(length)})
 }
 
 // ToLower creates an expression that converts a string to lowercase.
 // - exprOrFieldPath can be a field path string, [FieldPath] or an [Expression] that evaluates to a string.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func ToLower(exprOrFieldPath any) Expression {
 	return newBaseFunction("to_lower", []Expression{asFieldExpr(exprOrFieldPath)})
 }
 
 // ToUpper creates an expression that converts a string to uppercase.
 // - exprOrFieldPath can be a field path string, [FieldPath] or an [Expression] that evaluates to a string.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func ToUpper(exprOrFieldPath any) Expression {
 	return newBaseFunction("to_upper", []Expression{asFieldExpr(exprOrFieldPath)})
 }
 
 // Trim creates an expression that removes leading and trailing whitespace from a string.
 // - exprOrFieldPath can be a field path string, [FieldPath] or an [Expression] that evaluates to a string.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func Trim(exprOrFieldPath any) Expression {
 	return newBaseFunction("trim", []Expression{asFieldExpr(exprOrFieldPath)})
 }
@@ -855,18 +627,12 @@ func Trim(exprOrFieldPath any) Expression {
 // TrimValue creates an expression that removes specified characters from the beginning and end of a string.
 // - exprOrFieldPath can be a field path string, [FieldPath] or an [Expression] that evaluates to a string.
 // - charsOrExprToTrim is a string or [Expression] specifying characters to remove.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func TrimValue(exprOrFieldPath any, charsOrExprToTrim any) Expression {
 	return newBaseFunction("trim", []Expression{asFieldExpr(exprOrFieldPath), asStringExpr(charsOrExprToTrim)})
 }
 
 // LTrim creates an expression that removes leading whitespace from a string.
 // - exprOrFieldPath can be a field path string, [FieldPath] or an [Expression] that evaluates to a string.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func LTrim(exprOrFieldPath any) Expression {
 	return newBaseFunction("ltrim", []Expression{asFieldExpr(exprOrFieldPath)})
 }
@@ -874,18 +640,12 @@ func LTrim(exprOrFieldPath any) Expression {
 // LTrimValue creates an expression that removes leading whitespace or specified characters from a string.
 // - exprOrFieldPath can be a field path string, [FieldPath] or an [Expression] that evaluates to a string.
 // - charsOrExprToTrim is a string or [Expression] specifying characters to remove.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func LTrimValue(exprOrFieldPath any, charsOrExprToTrim any) Expression {
 	return newBaseFunction("ltrim", []Expression{asFieldExpr(exprOrFieldPath), asStringExpr(charsOrExprToTrim)})
 }
 
 // RTrim creates an expression that removes trailing whitespace from a string.
 // - exprOrFieldPath can be a field path string, [FieldPath] or an [Expression] that evaluates to a string.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func RTrim(exprOrFieldPath any) Expression {
 	return newBaseFunction("rtrim", []Expression{asFieldExpr(exprOrFieldPath)})
 }
@@ -893,9 +653,6 @@ func RTrim(exprOrFieldPath any) Expression {
 // RTrimValue creates an expression that removes trailing whitespace or specified characters from a string.
 // - exprOrFieldPath can be a field path string, [FieldPath] or an [Expression] that evaluates to a string.
 // - charsOrExprToTrim is a string or [Expression] specifying characters to remove.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func RTrimValue(exprOrFieldPath any, charsOrExprToTrim any) Expression {
 	return newBaseFunction("rtrim", []Expression{asFieldExpr(exprOrFieldPath), asStringExpr(charsOrExprToTrim)})
 }
@@ -903,18 +660,12 @@ func RTrimValue(exprOrFieldPath any, charsOrExprToTrim any) Expression {
 // Split creates an expression that splits a string by a delimiter.
 // - exprOrFieldPath can be a field path string, [FieldPath] or an [Expression] that evaluates to a string.
 // - delimiter is the string to use to split by.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func Split(exprOrFieldPath any, delimiter any) Expression {
 	return newBaseFunction("split", []Expression{asFieldExpr(exprOrFieldPath), asStringExpr(delimiter)})
 }
 
 // Type creates an expression that returns the type of the expression.
 // - exprOrFieldPath can be a field path string, [FieldPath] or an [Expression].
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func Type(exprOrFieldPath any) Expression {
 	return newBaseFunction("type", []Expression{asFieldExpr(exprOrFieldPath)})
 }
@@ -922,9 +673,6 @@ func Type(exprOrFieldPath any) Expression {
 // CosineDistance creates an expression that calculates the cosine distance between two vectors.
 //   - vector1 can be a field path string, [FieldPath] or [Expression].
 //   - vector2 can be [Vector32], [Vector64], []float32, []float64 or [Expression].
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func CosineDistance(vector1 any, vector2 any) Expression {
 	return newBaseFunction("cosine_distance", []Expression{asFieldExpr(vector1), asVectorExpr(vector2)})
 }
@@ -932,9 +680,6 @@ func CosineDistance(vector1 any, vector2 any) Expression {
 // DotProduct creates an expression that calculates the dot product of two vectors.
 //   - vector1 can be a field path string, [FieldPath] or [Expression].
 //   - vector2 can be [Vector32], [Vector64], []float32, []float64 or [Expression].
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func DotProduct(vector1 any, vector2 any) Expression {
 	return newBaseFunction("dot_product", []Expression{asFieldExpr(vector1), asVectorExpr(vector2)})
 }
@@ -942,18 +687,12 @@ func DotProduct(vector1 any, vector2 any) Expression {
 // EuclideanDistance creates an expression that calculates the euclidean distance between two vectors.
 //   - vector1 can be a field path string, [FieldPath] or [Expression].
 //   - vector2 can be [Vector32], [Vector64], []float32, []float64 or [Expression].
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func EuclideanDistance(vector1 any, vector2 any) Expression {
 	return newBaseFunction("euclidean_distance", []Expression{asFieldExpr(vector1), asVectorExpr(vector2)})
 }
 
 // VectorLength creates an expression that calculates the length of a vector.
 //   - exprOrFieldPath can be a field path string, [FieldPath] or [Expression].
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func VectorLength(exprOrFieldPath any) Expression {
 	return newBaseFunction("vector_length", []Expression{asFieldExpr(exprOrFieldPath)})
 }
@@ -965,9 +704,6 @@ func VectorLength(exprOrFieldPath any) Expression {
 //
 //	// Length of the 'name' field.
 //	Length("name")
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func Length(exprOrField any) Expression {
 	return newBaseFunction("length", []Expression{asFieldExpr(exprOrField)})
 }
@@ -980,9 +716,6 @@ func Length(exprOrField any) Expression {
 //	// Reverse the 'name' field.
 //
 // Reverse("name")
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func Reverse(exprOrField any) Expression {
 	return newBaseFunction("reverse", []Expression{asFieldExpr(exprOrField)})
 }
@@ -995,27 +728,18 @@ func Reverse(exprOrField any) Expression {
 //
 //	// Concat the 'name' field with a constant string.
 //	Concat("name", "-suffix")
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func Concat(exprOrField any, others ...any) Expression {
 	return newBaseFunction("concat", append([]Expression{asFieldExpr(exprOrField)}, toArrayOfExprOrConstant(others)...))
 }
 
 // GetCollectionID creates an expression that returns the ID of the collection that contains the document.
 // - exprOrField can be a field path string, [FieldPath] or an [Expression] that evaluates to a field path.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func GetCollectionID(exprOrField any) Expression {
 	return newBaseFunction("collection_id", []Expression{asFieldExpr(exprOrField)})
 }
 
 // GetDocumentID creates an expression that returns the ID of the document.
 // - exprStringOrDocRef can be a string, a [DocumentRef], or an [Expression] that evaluates to a document reference.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func GetDocumentID(exprStringOrDocRef any) Expression {
 	var expr Expression
 	switch v := exprStringOrDocRef.(type) {
@@ -1034,9 +758,6 @@ func GetDocumentID(exprStringOrDocRef any) Expression {
 
 // GetParent creates an expression that returns the parent document of a document reference.
 // - exprStringOrDocRef can be a string representation of the document path, a [DocumentRef], or an [Expression] that evaluates to a document path.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func GetParent(exprStringOrDocRef any) Expression {
 	var expr Expression
 	switch v := exprStringOrDocRef.(type) {
@@ -1056,9 +777,6 @@ func GetParent(exprStringOrDocRef any) Expression {
 // GetField creates an expression that accesses a field/property of a document field using the provided key.
 // - exprOrField: The expression representing the document or map.
 // - key: The key of the field to access.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func GetField(exprOrField any, key any) Expression {
 	return newBaseFunction("get_field", []Expression{asFieldExpr(exprOrField), asStringExpr(key)})
 }
@@ -1067,9 +785,6 @@ func GetField(exprOrField any, key any) Expression {
 // - condition is the boolean expression to evaluate.
 // - thenValOrExpr is the value or expression to return if the condition is true.
 // - elseValOrExpr is the value or expression to return if the condition is false.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func Conditional(condition BooleanExpression, thenValOrExpr, elseValOrExpr any) Expression {
 	return newBaseFunction("conditional", []Expression{condition, toExprOrConstant(thenValOrExpr), toExprOrConstant(elseValOrExpr)})
 }
@@ -1077,9 +792,6 @@ func Conditional(condition BooleanExpression, thenValOrExpr, elseValOrExpr any) 
 // LogicalMaximum creates an expression that evaluates to the maximum value in a list of expressions.
 // - exprOrField can be a field path string, [FieldPath] or an [Expression].
 // - others can be a list of constants or [Expression].
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func LogicalMaximum(exprOrField any, others ...any) Expression {
 	return newBaseFunction("maximum", append([]Expression{asFieldExpr(exprOrField)}, toArrayOfExprOrConstant(others)...))
 }
@@ -1087,9 +799,6 @@ func LogicalMaximum(exprOrField any, others ...any) Expression {
 // LogicalMinimum creates an expression that evaluates to the minimum value in a list of expressions.
 // - exprOrField can be a field path string, [FieldPath] or an [Expression].
 // - others can be a list of constants or [Expression].
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func LogicalMinimum(exprOrField any, others ...any) Expression {
 	return newBaseFunction("minimum", append([]Expression{asFieldExpr(exprOrField)}, toArrayOfExprOrConstant(others)...))
 }
@@ -1099,9 +808,6 @@ func LogicalMinimum(exprOrField any, others ...any) Expression {
 // the if_error operation.
 // - tryExpr is the expression to try.
 // - catchExprOrValue is the expression or value to return if `tryExpr` errors.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func IfError(tryExpr Expression, catchExprOrValue any) Expression {
 	return newBaseFunction("if_error", []Expression{tryExpr, toExprOrConstant(catchExprOrValue)})
 }
@@ -1111,9 +817,6 @@ func IfError(tryExpr Expression, catchExprOrValue any) Expression {
 // the if_error operation.
 // - tryExpr is the boolean expression to try.
 // - catchExpr is the boolean expression to return if `tryExpr` errors.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func IfErrorBoolean(tryExpr BooleanExpression, catchExpr BooleanExpression) BooleanExpression {
 	return &baseBooleanExpression{baseFunction: newBaseFunction("if_error", []Expression{tryExpr, catchExpr})}
 }
@@ -1121,9 +824,6 @@ func IfErrorBoolean(tryExpr BooleanExpression, catchExpr BooleanExpression) Bool
 // IfAbsent creates an expression that returns a default value if an expression evaluates to an absent value.
 // - exprOrField is the field or expression to check. It can be a field path string, [FieldPath] or an [Expression].
 // - elseValueOrExpr is the value or expression to return if the expression is absent. It can be a constant or an [Expression].
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func IfAbsent(exprOrField any, elseValueOrExpr any) Expression {
 	return newBaseFunction("if_absent", []Expression{asFieldExpr(exprOrField), toExprOrConstant(elseValueOrExpr)})
 }
@@ -1133,9 +833,6 @@ func IfAbsent(exprOrField any, elseValueOrExpr any) Expression {
 // IfAbsent only triggers for missing fields.
 // - exprOrField can be a field path string, [FieldPath] or an [Expression].
 // - elseValueOrExpr is the default value or expression to return if the first evaluates to null.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func IfNull(exprOrField any, elseValueOrExpr any) Expression {
 	return newBaseFunction("if_null", []Expression{asFieldExpr(exprOrField), toExprOrConstant(elseValueOrExpr)})
 }
@@ -1145,9 +842,6 @@ func IfNull(exprOrField any, elseValueOrExpr any) Expression {
 // - exprOrField can be a field path string, [FieldPath] or an [Expression].
 // - replacement is the fallback expression or value if the first one evaluates to null or is absent.
 // - others are optional additional expressions or values to check.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func Coalesce(exprOrField any, replacement any, others ...any) Expression {
 	exprs := make([]Expression, 0, len(others)+2)
 	exprs = append(exprs, asFieldExpr(exprOrField), toExprOrConstant(replacement))
@@ -1175,9 +869,6 @@ func Coalesce(exprOrField any, replacement any, others ...any) Expression {
 //	    firestore.FieldOf("score").GreaterThan(80), "B",
 //	    "F", // Default result
 //	)
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func SwitchOn(condition BooleanExpression, result any, others ...any) Expression {
 	exprs := make([]Expression, 0, len(others)+2)
 	exprs = append(exprs, condition, toExprOrConstant(result))
@@ -1189,9 +880,6 @@ func SwitchOn(condition BooleanExpression, result any, others ...any) Expression
 
 // Map creates an expression that creates a Firestore map value from an input object.
 // - elements: The input map to evaluate in the expression.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func Map(elements map[string]any) Expression {
 	exprs := make([]Expression, 0, len(elements)*2)
 	for k, v := range elements {
@@ -1203,9 +891,6 @@ func Map(elements map[string]any) Expression {
 // MapGet creates an expression that accesses a value from a map (object) field using the provided key.
 // - exprOrField: The expression representing the map.
 // - strOrExprkey: The key to access in the map.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func MapGet(exprOrField any, strOrExprkey any) Expression {
 	return newBaseFunction("map_get", []Expression{asFieldExpr(exprOrField), asStringExpr(strOrExprkey)})
 }
@@ -1215,9 +900,6 @@ func MapGet(exprOrField any, strOrExprkey any) Expression {
 // - exprOrField: First map field path string, [FieldPath] or an [Expression]
 // - secondMap: Second map expression that will be merged.
 // - otherMaps: Additional maps to merge.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func MapMerge(exprOrField any, secondMap Expression, otherMaps ...Expression) Expression {
 	return newBaseFunction("map_merge", append([]Expression{asFieldExpr(exprOrField), secondMap}, otherMaps...))
 }
@@ -1225,9 +907,6 @@ func MapMerge(exprOrField any, secondMap Expression, otherMaps ...Expression) Ex
 // MapRemove creates an expression that removes a key from a map.
 // - exprOrField: The expression representing the map.
 // - strOrExprkey: The key to remove from the map.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func MapRemove(exprOrField any, strOrExprkey any) Expression {
 	return newBaseFunction("map_remove", []Expression{asFieldExpr(exprOrField), asStringExpr(strOrExprkey)})
 }
@@ -1237,9 +916,6 @@ func MapRemove(exprOrField any, strOrExprkey any) Expression {
 // - key: The first key to set. It can be a string or an [Expression].
 // - value: The first value to set. It can be a literal value or an [Expression].
 // - moreKeysAndValues: Optional additional alternating key and value arguments.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func MapSet(exprOrField any, key any, value any, moreKeysAndValues ...any) Expression {
 	exprs := make([]Expression, 0, len(moreKeysAndValues)+3)
 	exprs = append(exprs, asFieldExpr(exprOrField), toExprOrConstant(key), toExprOrConstant(value))
@@ -1251,27 +927,18 @@ func MapSet(exprOrField any, key any, value any, moreKeysAndValues ...any) Expre
 
 // MapKeys creates an expression that returns the keys of a map as an array.
 // - exprOrField: The expression representing the map.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func MapKeys(exprOrField any) Expression {
 	return newBaseFunction("map_keys", []Expression{asFieldExpr(exprOrField)})
 }
 
 // MapValues creates an expression that returns the values of a map as an array.
 // - exprOrField: The expression representing the map.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func MapValues(exprOrField any) Expression {
 	return newBaseFunction("map_values", []Expression{asFieldExpr(exprOrField)})
 }
 
 // MapEntries creates an expression that returns the entries of a map as an array of key-value maps.
 // - exprOrField: The expression representing the map.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func MapEntries(exprOrField any) Expression {
 	return newBaseFunction("map_entries", []Expression{asFieldExpr(exprOrField)})
 }
@@ -1279,9 +946,6 @@ func MapEntries(exprOrField any) Expression {
 // RegexFind creates an expression that returns the first substring that matches the specified regex pattern.
 // - exprOrField: The expression representing the string to search.
 // - pattern is the regular expression to search for. It can be a string or [Expression] that evaluates to a string.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func RegexFind(exprOrField any, pattern any) Expression {
 	return newBaseFunction("regex_find", []Expression{asFieldExpr(exprOrField), asStringExpr(pattern)})
 }
@@ -1291,9 +955,6 @@ func RegexFind(exprOrField any, pattern any) Expression {
 // - pattern is the regular expression to search for. It can be a string or [Expression] that evaluates to a string.
 //
 // This expression uses the [RE2](https://github.com/google/re2/wiki/Syntax) regular expression syntax.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func RegexFindAll(exprOrField any, pattern any) Expression {
 	return newBaseFunction("regex_find_all", []Expression{asFieldExpr(exprOrField), asStringExpr(pattern)})
 }
@@ -1350,9 +1011,6 @@ func GeoDistance(field any, location *latlng.LatLng) Expression {
 //
 //	client.Pipeline().Collection("restaurants").
 //		Search(WithSearchQuery("waffles"), WithSearchSort(Descending(Score())))
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func Score() Expression {
 	return newBaseFunction("score", nil)
 }

--- a/firestore/pipeline_function.go
+++ b/firestore/pipeline_function.go
@@ -1017,6 +1017,10 @@ func GeoDistance(field any, location *latlng.LatLng) Expression {
 // Experimental: Update, Delete and Search stages in pipeline queries are in public preview
 // and are subject to potential breaking changes in future versions,
 // regardless of any other documented package stability guarantees.
+//
+// Experimental: Update, Delete and Search stages in pipeline queries are in public preview
+// and are subject to potential breaking changes in future versions,
+// regardless of any other documented package stability guarantees.
 func Score() Expression {
 	return newBaseFunction("score", nil)
 }

--- a/firestore/pipeline_function.go
+++ b/firestore/pipeline_function.go
@@ -975,7 +975,8 @@ func Rand() Expression {
 //
 // - query: Define the search query using the search domain-specific language (DSL).
 //
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
+// Experimental: Update, Delete and Search stages in pipeline queries are in public preview
+// and are subject to potential breaking changes in future versions,
 // regardless of any other documented package stability guarantees.
 func DocumentMatches(query string) BooleanExpression {
 	return &baseBooleanExpression{baseFunction: newBaseFunction("document_matches", []Expression{ConstantOf(query)})}
@@ -996,7 +997,8 @@ func DocumentMatches(query string) BooleanExpression {
 // - field: Specifies the field in the document which contains the GeoPoint for distance computation. It can be a field path string, [FieldPath] or [Expression].
 // - location: Compute distance to this GeoPoint.
 //
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
+// Experimental: Update, Delete and Search stages in pipeline queries are in public preview
+// and are subject to potential breaking changes in future versions,
 // regardless of any other documented package stability guarantees.
 func GeoDistance(field any, location *latlng.LatLng) Expression {
 	return newBaseFunction("geo_distance", []Expression{asFieldExpr(field), ConstantOf(location)})
@@ -1011,6 +1013,10 @@ func GeoDistance(field any, location *latlng.LatLng) Expression {
 //
 //	client.Pipeline().Collection("restaurants").
 //		Search(WithSearchQuery("waffles"), WithSearchSort(Descending(Score())))
+//
+// Experimental: Update, Delete and Search stages in pipeline queries are in public preview
+// and are subject to potential breaking changes in future versions,
+// regardless of any other documented package stability guarantees.
 func Score() Expression {
 	return newBaseFunction("score", nil)
 }

--- a/firestore/pipeline_function.go
+++ b/firestore/pipeline_function.go
@@ -1017,10 +1017,6 @@ func GeoDistance(field any, location *latlng.LatLng) Expression {
 // Experimental: Update, Delete and Search stages in pipeline queries are in public preview
 // and are subject to potential breaking changes in future versions,
 // regardless of any other documented package stability guarantees.
-//
-// Experimental: Update, Delete and Search stages in pipeline queries are in public preview
-// and are subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func Score() Expression {
 	return newBaseFunction("score", nil)
 }

--- a/firestore/pipeline_result.go
+++ b/firestore/pipeline_result.go
@@ -30,9 +30,6 @@ import (
 )
 
 // PipelineResult is a result returned from executing a pipeline.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 type PipelineResult struct {
 	// ref is the DocumentRef for this result. It may be nil if the result
 	// does not correspond to a specific Firestore document (e.g., an aggregation result
@@ -108,9 +105,6 @@ func (p *PipelineResult) ExecutionTime() *time.Time {
 
 // Exists reports whether the PipelineResult represents an  document.
 // Even if Exists returns false, the rest of the fields are valid.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func (p *PipelineResult) Exists() bool {
 	return p.proto != nil
 }
@@ -120,9 +114,6 @@ func (p *PipelineResult) Exists() bool {
 //
 //	var m map[string]any
 //	p.DataTo(&m)
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func (p *PipelineResult) Data() map[string]any {
 	if p == nil || !p.Exists() {
 		return nil
@@ -139,9 +130,6 @@ func (p *PipelineResult) Data() map[string]any {
 // DataTo uses the PipelineResult's fields to populate v, which can be a pointer to a
 // map[string]any or a pointer to a struct.
 // This is similar to [DocumentSnapshot.DataTo]
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func (p *PipelineResult) DataTo(v any) error {
 	if p == nil || !p.Exists() {
 		return status.Errorf(codes.NotFound, "document does not exist")
@@ -150,9 +138,6 @@ func (p *PipelineResult) DataTo(v any) error {
 }
 
 // PipelineResultIterator is an iterator over PipelineResults from a pipeline execution.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 type PipelineResultIterator struct {
 	iter pipelineResultIteratorInternal
 	err  error // Stores sticky error from Next() or construction
@@ -161,9 +146,6 @@ type PipelineResultIterator struct {
 // Next returns the next result. Its second return value is iterator.Done if there
 // are no more results. Once Next returns Done, all subsequent calls will return
 // Done.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func (it *PipelineResultIterator) Next() (*PipelineResult, error) {
 	if it.err != nil {
 		return nil, it.err
@@ -182,9 +164,6 @@ func (it *PipelineResultIterator) Next() (*PipelineResult, error) {
 // Stop stops the iterator, freeing its resources.
 // Always call Stop when you are done with a DocumentIterator.
 // It is not safe to call Stop concurrently with Next.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func (it *PipelineResultIterator) Stop() {
 	if it.iter != nil {
 		it.iter.stop()
@@ -197,9 +176,6 @@ func (it *PipelineResultIterator) Stop() {
 
 // GetAll returns all the documents remaining from the iterator.
 // It is not necessary to call Stop on the iterator after calling GetAll.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func (it *PipelineResultIterator) GetAll() ([]*PipelineResult, error) {
 	if it.err != nil {
 		return nil, it.err

--- a/firestore/pipeline_snapshot.go
+++ b/firestore/pipeline_snapshot.go
@@ -28,9 +28,6 @@ import (
 // PipelineSnapshot contains zero or more [PipelineResult] objects
 // representing the documents returned by a pipeline query. It provides methods
 // to iterate over the documents and access metadata about the query results.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 type PipelineSnapshot struct {
 	iter *PipelineResultIterator
 }
@@ -38,18 +35,12 @@ type PipelineSnapshot struct {
 var errExecutionTimeBeforeEnd = errors.New("firestore: ExecutionTime is available only after the iterator reaches the end")
 
 // Results returns an iterator over the query results.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func (ps *PipelineSnapshot) Results() *PipelineResultIterator {
 	return ps.iter
 }
 
 // ExecutionTime returns the time at which the pipeline was executed.
 // It is available only after the iterator reaches the end.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func (ps *PipelineSnapshot) ExecutionTime() (*time.Time, error) {
 	if ps == nil {
 		return nil, errors.New("firestore: PipelineSnapshot is nil")
@@ -65,9 +56,6 @@ func (ps *PipelineSnapshot) ExecutionTime() (*time.Time, error) {
 
 // ExplainStats returns stats from query explain.
 // If [WithExplainMode] was set to [ExplainModeExplain] or left unset, then no stats will be available.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func (ps *PipelineSnapshot) ExplainStats() *ExplainStats {
 	if ps == nil {
 		return &ExplainStats{err: errors.New("firestore: PipelineSnapshot is nil")}
@@ -86,9 +74,6 @@ func (ps *PipelineSnapshot) ExplainStats() *ExplainStats {
 //
 // Contains all metadata related to pipeline planning and execution, specific
 // contents depend on the supplied pipeline options.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 type ExplainStats struct {
 	statsPb *pb.ExplainStats
 	err     error
@@ -96,9 +81,6 @@ type ExplainStats struct {
 
 // RawData returns the explain stats in an encoded proto format, as returned from the Firestore backend.
 // The caller is responsible for unpacking this proto message.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func (es *ExplainStats) RawData() (*anypb.Any, error) {
 	if es.err != nil {
 		return nil, es.err
@@ -114,9 +96,6 @@ func (es *ExplainStats) RawData() (*anypb.Any, error) {
 // If explain stats were requested with `outputFormat = 'text'`, the string is
 // returned verbatim. If `outputFormat = 'json'`, this returns the explain stats
 // as stringified JSON.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func (es *ExplainStats) Text() (string, error) {
 	if es.err != nil {
 		return "", es.err

--- a/firestore/pipeline_source.go
+++ b/firestore/pipeline_source.go
@@ -18,17 +18,11 @@ import "fmt"
 
 // PipelineSource is a factory for creating Pipeline instances.
 // It is obtained by calling [Client.Pipeline].
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 type PipelineSource struct {
 	client *Client
 }
 
 // WithForceIndex specifies an index to force the query to use.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func WithForceIndex(index string) CollectionSourceOption {
 	return newFuncOption(func(options map[string]any) {
 		options["force_index"] = index
@@ -36,9 +30,6 @@ func WithForceIndex(index string) CollectionSourceOption {
 }
 
 // WithIgnoreIndexFields specifies fields to ignore when selecting an index.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func WithIgnoreIndexFields(fields ...string) CollectionSourceOption {
 	return newFuncOption(func(options map[string]any) {
 		options["ignore_index_fields"] = fields
@@ -46,27 +37,18 @@ func WithIgnoreIndexFields(fields ...string) CollectionSourceOption {
 }
 
 // CollectionOption is an option for a Collection pipeline stage.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 type CollectionOption interface {
 	StageOption
 	isCollectionOption()
 }
 
 // CollectionGroupOption is an option for a CollectionGroup pipeline stage.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 type CollectionGroupOption interface {
 	StageOption
 	isCollectionGroupOption()
 }
 
 // CollectionSourceOption is an option that can be applied to both Collection and CollectionGroup pipeline stages.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 type CollectionSourceOption interface {
 	CollectionOption
 	CollectionGroupOption
@@ -92,9 +74,6 @@ func newFuncOption(f func(map[string]any)) *funcOption {
 }
 
 // Collection creates a new [Pipeline] that operates on the specified Firestore collection.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func (ps *PipelineSource) Collection(path string, opts ...CollectionOption) *Pipeline {
 	options := make(map[string]any)
 	for _, opt := range opts {
@@ -114,9 +93,6 @@ func (ps *PipelineSource) Collection(path string, opts ...CollectionOption) *Pip
 //
 // CollectionGroup can be used to query across all "Cities" regardless of
 // its parent "Countries".
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func (ps *PipelineSource) CollectionGroup(collectionID string, opts ...CollectionGroupOption) *Pipeline {
 	options := make(map[string]any)
 	for _, opt := range opts {
@@ -128,18 +104,12 @@ func (ps *PipelineSource) CollectionGroup(collectionID string, opts ...Collectio
 }
 
 // DatabaseOption is an option for a Database pipeline stage.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 type DatabaseOption interface {
 	StageOption
 	isDatabaseOption()
 }
 
 // Database creates a new [Pipeline] that operates on all documents in the Firestore database.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func (ps *PipelineSource) Database(opts ...DatabaseOption) *Pipeline {
 	options := make(map[string]any)
 	for _, opt := range opts {
@@ -151,18 +121,12 @@ func (ps *PipelineSource) Database(opts ...DatabaseOption) *Pipeline {
 }
 
 // DocumentsOption is an option for a Documents pipeline stage.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 type DocumentsOption interface {
 	StageOption
 	isDocumentsOption()
 }
 
 // Documents creates a new [Pipeline] that operates on a specific set of Firestore documents.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func (ps *PipelineSource) Documents(refs []*DocumentRef, opts ...DocumentsOption) *Pipeline {
 	options := make(map[string]any)
 	for _, opt := range opts {
@@ -182,35 +146,23 @@ func (ps *PipelineSource) Documents(refs []*DocumentRef, opts ...DocumentsOption
 
 // CreateFromQuery creates a new [Pipeline] from the given [Queryer]. Under the hood, this will
 // translate the query semantics (order by document ID, etc.) to an equivalent pipeline.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func (ps *PipelineSource) CreateFromQuery(query Queryer) *Pipeline {
 	return query.query().Pipeline()
 }
 
 // CreateFromAggregationQuery creates a new [Pipeline] from the given [AggregationQuery]. Under the hood, this will
 // translate the query semantics (order by document ID, etc.) to an equivalent pipeline.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func (ps *PipelineSource) CreateFromAggregationQuery(query *AggregationQuery) *Pipeline {
 	return query.Pipeline()
 }
 
 // LiteralsOption is an option for a Literals pipeline stage.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 type LiteralsOption interface {
 	StageOption
 	isLiteralsOption()
 }
 
 // Literals creates a new [Pipeline] that operates on a fixed set of predefined document objects.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func (ps *PipelineSource) Literals(documents []map[string]any, opts ...LiteralsOption) *Pipeline {
 	options := make(map[string]any)
 	for _, opt := range opts {
@@ -237,9 +189,6 @@ func (ps *PipelineSource) Literals(documents []map[string]any, opts ...LiteralsO
 //				Aggregate(Accumulators(Average("rating").As("avg_rating"))).
 //				ToScalarExpression().As("average_rating"),
 //		))
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func Subcollection(path string) *Pipeline {
 	return newPipeline(nil, newInputStageSubcollection(path))
 }

--- a/firestore/query.go
+++ b/firestore/query.go
@@ -2201,9 +2201,6 @@ func toPipelineCursorFilterWithValues(q *Query, orders []order, values []interfa
 // All of the operations of the query will be converted to pipeline stages.
 // For example, `query.Where("f", "==", 1).Limit(10).OrderBy("f", Asc).Pipeline()` is equivalent to
 // `client.Pipeline().Collection("C").Where(Equal("f", 1)).Limit(10).Sort(Ascending("f"))`.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func (q Query) Pipeline() *Pipeline {
 	return q.toPipeline()
 }
@@ -2211,9 +2208,6 @@ func (q Query) Pipeline() *Pipeline {
 // Pipeline creates a new [Pipeline] from the aggregation query.
 // All of the operations of the underlying query will be converted to pipeline stages,
 // and an aggregate stage will be added for the aggregations.
-//
-// Experimental: Firestore Pipelines is currently in preview and is subject to potential breaking changes in future versions,
-// regardless of any other documented package stability guarantees.
 func (aq *AggregationQuery) Pipeline() *Pipeline {
 	p := aq.query.toPipeline()
 	if p.err != nil {


### PR DESCRIPTION
This PR updates the documentation for Firestore Pipeline features in the Go SDK regarding their experimental status.
I have removed the general "Experimental" warning from most pipeline-related APIs that are moving out of preview. However, I have retained or restored the full experimental warning for specific features that are still in Public Preview and subject to breaking changes.
**Features retaining/restoring experimental warning:**
- `Search`, `Update`, and `Delete` pipeline stages in `pipeline.go`.
- `SearchOption`, `UpdateOption`, and `DeleteOption` interfaces and their implementations in `pipeline.go`.
- `DocumentMatches` and `GeoDistance` functions in `pipeline_function.go`.
- `GeoDistance` method in `pipeline_expression.go` (both interface and implementation).
- `Score`