### PR TITLE
chore: librarian release pull request: 20260414T234638Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1303,7 +1303,7 @@ libraries:
       - internal/generated/snippets/financialservices/
     tag_format: '{id}/v{version}'
   - id: firestore
-    version: 1.21.0
+    version: 1.22.0
     last_generated_commit: ""
     apis:
       - path: google/firestore/admin/v1

--- a/firestore/CHANGES.md
+++ b/firestore/CHANGES.md
@@ -1,5 +1,7 @@
 # Changes
 
+## [1.22.0](https://github.com/googleapis/google-cloud-go/releases/tag/firestore%2Fv1.22.0) (2026-04-14)
+
 ## [1.21.0](https://github.com/googleapis/google-cloud-go/releases/tag/firestore%2Fv1.21.0) (2026-01-15)
 
 ### Features

--- a/firestore/internal/version.go
+++ b/firestore/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "1.21.0"
+const Version = "1.22.0"

--- a/internal/generated/snippets/firestore/apiv1/admin/snippet_metadata.google.firestore.admin.v1.json
+++ b/internal/generated/snippets/firestore/apiv1/admin/snippet_metadata.google.firestore.admin.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/firestore/apiv1/admin",
-    "version": "1.21.0"
+    "version": "1.22.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/firestore/apiv1/snippet_metadata.google.firestore.v1.json
+++ b/internal/generated/snippets/firestore/apiv1/snippet_metadata.google.firestore.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/firestore/apiv1",
-    "version": "1.21.0"
+    "version": "1.22.0"
   },
   "snippets": [
     {

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -1126,7 +1126,7 @@ libraries:
             - F_open_telemetry_attributes
           path: google/cloud/financialservices/v1
   - name: firestore
-    version: 1.21.0
+    version: 1.22.0
     apis:
       - path: google/firestore/v1
       - path: google/firestore/admin/v1


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.10.1
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go@sha256:b04b076f5eedbb5546bd6fc1404969dd3698c8b19c0f34ae815a84ae735a606a
<details><summary>firestore: v1.22.0</summary>

## [v1.22.0](https://github.com/googleapis/google-cloud-go/compare/firestore/v1.21.0...firestore/v1.22.0) (2026-04-14)

</details>