### PR TITLE
fix(maps): set title override

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -1444,6 +1444,7 @@ libraries:
           path: google/cloud/managedkafka/schemaregistry/v1
   - name: maps
     version: 1.33.0
+    title_override: "Google Maps Platform"
     apis:
       - path: google/maps/geocode/v4
       - path: google/maps/routing/v2


### PR DESCRIPTION
Maps does not have a single root API and instead group multiple independent services. Therefore, the first, highest level API is used instead, unless a title override is specified.