### PR TITLE
docs(firestore): document terminal error behavior for iterators

### DIFF
--- a/firestore/docref.go
+++ b/firestore/docref.go
@@ -754,6 +754,10 @@ func (it *CollectionIterator) PageInfo() *iterator.PageInfo { return it.pageInfo
 // Next returns the next result. Its second return value is iterator.Done if there
 // are no more results. Once Next returns Done, all subsequent calls will return
 // Done.
+//
+// In addition, if Next returns an error other than iterator.Done, all
+// subsequent calls will return the same error. To continue iteration, a new
+// CollectionIterator must be created.
 func (it *CollectionIterator) Next() (*CollectionRef, error) {
 	if err := it.nextFunc(); err != nil {
 		return nil, err
@@ -842,6 +846,10 @@ type DocumentSnapshotIterator struct {
 //
 // Next is not expected to return iterator.Done unless it is called after Stop.
 // Rarely, networking issues may also cause iterator.Done to be returned.
+//
+// In addition, if Next returns an error other than iterator.Done, all
+// subsequent calls will return the same error. To continue iteration, a new
+// DocumentSnapshotIterator must be created.
 func (it *DocumentSnapshotIterator) Next() (*DocumentSnapshot, error) {
 	btree, _, rt, err := it.ws.nextSnapshot()
 	if err != nil {

--- a/firestore/list_documents.go
+++ b/firestore/list_documents.go
@@ -70,6 +70,10 @@ func (it *DocumentRefIterator) PageInfo() *iterator.PageInfo { return it.pageInf
 // Next returns the next result. Its second return value is iterator.Done if there
 // are no more results. Once Next returns Done, all subsequent calls will return
 // Done.
+//
+// In addition, if Next returns an error other than iterator.Done, all
+// subsequent calls will return the same error. To continue iteration, a new
+// DocumentRefIterator must be created.
 func (it *DocumentRefIterator) Next() (*DocumentRef, error) {
 	if err := it.nextFunc(); err != nil {
 		return nil, err

--- a/firestore/pipeline_result.go
+++ b/firestore/pipeline_result.go
@@ -146,6 +146,10 @@ type PipelineResultIterator struct {
 // Next returns the next result. Its second return value is iterator.Done if there
 // are no more results. Once Next returns Done, all subsequent calls will return
 // Done.
+//
+// In addition, if Next returns an error other than iterator.Done, all
+// subsequent calls will return the same error. To continue iteration, a new
+// PipelineResultIterator must be created.
 func (it *PipelineResultIterator) Next() (*PipelineResult, error) {
 	if it.err != nil {
 		return nil, it.err

--- a/firestore/query.go
+++ b/firestore/query.go
@@ -1354,6 +1354,10 @@ func (it *DocumentIterator) ExplainMetrics() (*ExplainMetrics, error) {
 // Next returns the next result. Its second return value is iterator.Done if there
 // are no more results. Once Next returns Done, all subsequent calls will return
 // Done.
+//
+// In addition, if Next returns an error other than iterator.Done, all
+// subsequent calls will return the same error. To continue iteration, a new
+// DocumentIterator must be created.
 func (it *DocumentIterator) Next() (*DocumentSnapshot, error) {
 	if it.err != nil {
 		return nil, it.err
@@ -1540,6 +1544,10 @@ type QuerySnapshotIterator struct {
 //
 // Next is not expected to return iterator.Done unless it is called after Stop.
 // Rarely, networking issues may also cause iterator.Done to be returned.
+//
+// In addition, if Next returns an error other than iterator.Done, all
+// subsequent calls will return the same error. To continue iteration, a new
+// QuerySnapshotIterator must be created.
 func (it *QuerySnapshotIterator) Next() (*QuerySnapshot, error) {
 	if it.err != nil {
 		return nil, it.err


### PR DESCRIPTION
Update the documentation for handwritten iterators to explicitly state that they return the same error indefinitely after an error occurs.

This allows:
1.  **Repository Consistency**: storage and [spanner](https://github.com/googleapis/google-cloud-go/blob/a1a30091f329a3b22e8510e5089c0d95fc632e9d/spanner/read.go#L159-L161)   already behave this way (and `storage` explicitly [documents](https://github.com/googleapis/google-cloud-go/blob/a1a30091f329a3b22e8510e5089c0d95fc632e9d/storage/bucket.go#L2482-L2484) it). Keeping this behavior in Firestore maintains consistency across the google-cloud-go repository. Changing it only in Firestore would create a special case.
2.  **Adherence to Guidelines**: The [Iterator-Guidelines](https://github.com/googleapis/google-cloud-go/wiki/Iterator-Guidelines) state that if it's not feasible to continue after an error, it should be documented. Updating the documentation brings Firestore into compliance with this rule.
3.  **Avoiding Error Masking**: If we change the behavior to return `iterator.Done` on the second call, we risk masking the error. If a user ignores the error on the first call and calls `Next()` again, they will get `iterator.Done` and might assume the iteration completed successfully, processing a partial list of results without realizing an error occurred.

Fixes: #12694
Fixes: #13359
