### PR TITLE
fix(spanner): fix staticcheck ST1019 error

### DIFF
--- a/spanner/read_test.go
+++ b/spanner/read_test.go
@@ -36,8 +36,7 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/durationpb"
-	proto3 "google.golang.org/protobuf/types/known/structpb"
-	structpb "google.golang.org/protobuf/types/known/structpb"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 var (
@@ -170,17 +169,17 @@ func describeRows(l []*Row) string {
 
 // Helper for generating proto3 Value_ListValue instances, making test code
 // shorter and readable.
-func genProtoListValue(v ...string) *proto3.Value_ListValue {
-	r := &proto3.Value_ListValue{
-		ListValue: &proto3.ListValue{
-			Values: []*proto3.Value{},
+func genProtoListValue(v ...string) *structpb.Value_ListValue {
+	r := &structpb.Value_ListValue{
+		ListValue: &structpb.ListValue{
+			Values: []*structpb.Value{},
 		},
 	}
 	for _, e := range v {
 		r.ListValue.Values = append(
 			r.ListValue.Values,
-			&proto3.Value{
-				Kind: &proto3.Value_StringValue{StringValue: e},
+			&structpb.Value{
+				Kind: &structpb.Value_StringValue{StringValue: e},
 			},
 		)
 	}
@@ -208,18 +207,18 @@ func TestPartialResultSetDecoder(t *testing.T) {
 			input: []*sppb.PartialResultSet{
 				{
 					Metadata: kvMeta,
-					Values: []*proto3.Value{
-						{Kind: &proto3.Value_StringValue{StringValue: "foo"}},
-						{Kind: &proto3.Value_StringValue{StringValue: "bar"}},
+					Values: []*structpb.Value{
+						{Kind: &structpb.Value_StringValue{StringValue: "foo"}},
+						{Kind: &structpb.Value_StringValue{StringValue: "bar"}},
 					},
 				},
 			},
 			wantF: []*Row{
 				{
 					fields: kvMeta.RowType.Fields,
-					vals: []*proto3.Value{
-						{Kind: &proto3.Value_StringValue{StringValue: "foo"}},
-						{Kind: &proto3.Value_StringValue{StringValue: "bar"}},
+					vals: []*structpb.Value{
+						{Kind: &structpb.Value_StringValue{StringValue: "foo"}},
+						{Kind: &structpb.Value_StringValue{StringValue: "bar"}},
 					},
 				},
 			},
@@ -231,8 +230,8 @@ func TestPartialResultSetDecoder(t *testing.T) {
 			input: []*sppb.PartialResultSet{
 				{
 					Metadata: kvMeta,
-					Values: []*proto3.Value{
-						{Kind: &proto3.Value_StringValue{StringValue: "foo"}},
+					Values: []*structpb.Value{
+						{Kind: &structpb.Value_StringValue{StringValue: "foo"}},
 					},
 				},
 			},
@@ -244,22 +243,22 @@ func TestPartialResultSetDecoder(t *testing.T) {
 			input: []*sppb.PartialResultSet{
 				{
 					Metadata: kvMeta,
-					Values: []*proto3.Value{
-						{Kind: &proto3.Value_StringValue{StringValue: "foo"}},
+					Values: []*structpb.Value{
+						{Kind: &structpb.Value_StringValue{StringValue: "foo"}},
 					},
 				},
 				{
-					Values: []*proto3.Value{
-						{Kind: &proto3.Value_StringValue{StringValue: "bar"}},
+					Values: []*structpb.Value{
+						{Kind: &structpb.Value_StringValue{StringValue: "bar"}},
 					},
 				},
 			},
 			wantF: []*Row{
 				{
 					fields: kvMeta.RowType.Fields,
-					vals: []*proto3.Value{
-						{Kind: &proto3.Value_StringValue{StringValue: "foo"}},
-						{Kind: &proto3.Value_StringValue{StringValue: "bar"}},
+					vals: []*structpb.Value{
+						{Kind: &structpb.Value_StringValue{StringValue: "foo"}},
+						{Kind: &structpb.Value_StringValue{StringValue: "bar"}},
 					},
 				},
 			},
@@ -271,40 +270,40 @@ func TestPartialResultSetDecoder(t *testing.T) {
 			input: []*sppb.PartialResultSet{
 				{
 					Metadata: kvMeta,
-					Values: []*proto3.Value{
-						{Kind: &proto3.Value_StringValue{StringValue: "foo"}},
-						{Kind: &proto3.Value_StringValue{StringValue: "bar"}},
-						{Kind: &proto3.Value_StringValue{StringValue: "A"}},
+					Values: []*structpb.Value{
+						{Kind: &structpb.Value_StringValue{StringValue: "foo"}},
+						{Kind: &structpb.Value_StringValue{StringValue: "bar"}},
+						{Kind: &structpb.Value_StringValue{StringValue: "A"}},
 					},
 				},
 				{
-					Values: []*proto3.Value{
-						{Kind: &proto3.Value_StringValue{StringValue: "1"}},
-						{Kind: &proto3.Value_StringValue{StringValue: "B"}},
-						{Kind: &proto3.Value_StringValue{StringValue: "2"}},
+					Values: []*structpb.Value{
+						{Kind: &structpb.Value_StringValue{StringValue: "1"}},
+						{Kind: &structpb.Value_StringValue{StringValue: "B"}},
+						{Kind: &structpb.Value_StringValue{StringValue: "2"}},
 					},
 				},
 			},
 			wantF: []*Row{
 				{
 					fields: kvMeta.RowType.Fields,
-					vals: []*proto3.Value{
-						{Kind: &proto3.Value_StringValue{StringValue: "foo"}},
-						{Kind: &proto3.Value_StringValue{StringValue: "bar"}},
+					vals: []*structpb.Value{
+						{Kind: &structpb.Value_StringValue{StringValue: "foo"}},
+						{Kind: &structpb.Value_StringValue{StringValue: "bar"}},
 					},
 				},
 				{
 					fields: kvMeta.RowType.Fields,
-					vals: []*proto3.Value{
-						{Kind: &proto3.Value_StringValue{StringValue: "A"}},
-						{Kind: &proto3.Value_StringValue{StringValue: "1"}},
+					vals: []*structpb.Value{
+						{Kind: &structpb.Value_StringValue{StringValue: "A"}},
+						{Kind: &structpb.Value_StringValue{StringValue: "1"}},
 					},
 				},
 				{
 					fields: kvMeta.RowType.Fields,
-					vals: []*proto3.Value{
-						{Kind: &proto3.Value_StringValue{StringValue: "B"}},
-						{Kind: &proto3.Value_StringValue{StringValue: "2"}},
+					vals: []*structpb.Value{
+						{Kind: &structpb.Value_StringValue{StringValue: "B"}},
+						{Kind: &structpb.Value_StringValue{StringValue: "2"}},
 					},
 				},
 			},
@@ -316,30 +315,30 @@ func TestPartialResultSetDecoder(t *testing.T) {
 			input: []*sppb.PartialResultSet{
 				{
 					Metadata: kvMeta,
-					Values: []*proto3.Value{
-						{Kind: &proto3.Value_StringValue{StringValue: "Hello"}},
-						{Kind: &proto3.Value_StringValue{StringValue: "W"}},
+					Values: []*structpb.Value{
+						{Kind: &structpb.Value_StringValue{StringValue: "Hello"}},
+						{Kind: &structpb.Value_StringValue{StringValue: "W"}},
 					},
 					ChunkedValue: true,
 				},
 				{
-					Values: []*proto3.Value{
-						{Kind: &proto3.Value_StringValue{StringValue: "orl"}},
+					Values: []*structpb.Value{
+						{Kind: &structpb.Value_StringValue{StringValue: "orl"}},
 					},
 					ChunkedValue: true,
 				},
 				{
-					Values: []*proto3.Value{
-						{Kind: &proto3.Value_StringValue{StringValue: "d"}},
+					Values: []*structpb.Value{
+						{Kind: &structpb.Value_StringValue{StringValue: "d"}},
 					},
 				},
 			},
 			wantF: []*Row{
 				{
 					fields: kvMeta.RowType.Fields,
-					vals: []*proto3.Value{
-						{Kind: &proto3.Value_StringValue{StringValue: "Hello"}},
-						{Kind: &proto3.Value_StringValue{StringValue: "World"}},
+					vals: []*structpb.Value{
+						{Kind: &structpb.Value_StringValue{StringValue: "Hello"}},
+						{Kind: &structpb.Value_StringValue{StringValue: "World"}},
 					},
 				},
 			},
@@ -352,54 +351,54 @@ func TestPartialResultSetDecoder(t *testing.T) {
 			input: []*sppb.PartialResultSet{
 				{
 					Metadata: kvMeta,
-					Values: []*proto3.Value{
-						{Kind: &proto3.Value_StringValue{StringValue: "Hello"}},
-						{Kind: &proto3.Value_StringValue{StringValue: "W"}}, // start split in value
+					Values: []*structpb.Value{
+						{Kind: &structpb.Value_StringValue{StringValue: "Hello"}},
+						{Kind: &structpb.Value_StringValue{StringValue: "W"}}, // start split in value
 					},
 					ChunkedValue: true,
 				},
 				{
-					Values: []*proto3.Value{
-						{Kind: &proto3.Value_StringValue{StringValue: "orld"}}, // complete value
-						{Kind: &proto3.Value_StringValue{StringValue: "i"}},    // start split in key
+					Values: []*structpb.Value{
+						{Kind: &structpb.Value_StringValue{StringValue: "orld"}}, // complete value
+						{Kind: &structpb.Value_StringValue{StringValue: "i"}},    // start split in key
 					},
 					ChunkedValue: true,
 				},
 				{
-					Values: []*proto3.Value{
-						{Kind: &proto3.Value_StringValue{StringValue: "s"}}, // complete key
-						{Kind: &proto3.Value_StringValue{StringValue: "not"}},
-						{Kind: &proto3.Value_StringValue{StringValue: "a"}},
-						{Kind: &proto3.Value_StringValue{StringValue: "qu"}}, // split in value
+					Values: []*structpb.Value{
+						{Kind: &structpb.Value_StringValue{StringValue: "s"}}, // complete key
+						{Kind: &structpb.Value_StringValue{StringValue: "not"}},
+						{Kind: &structpb.Value_StringValue{StringValue: "a"}},
+						{Kind: &structpb.Value_StringValue{StringValue: "qu"}}, // split in value
 					},
 					ChunkedValue: true,
 				},
 				{
-					Values: []*proto3.Value{
-						{Kind: &proto3.Value_StringValue{StringValue: "estion"}}, // complete value
+					Values: []*structpb.Value{
+						{Kind: &structpb.Value_StringValue{StringValue: "estion"}}, // complete value
 					},
 				},
 			},
 			wantF: []*Row{
 				{
 					fields: kvMeta.RowType.Fields,
-					vals: []*proto3.Value{
-						{Kind: &proto3.Value_StringValue{StringValue: "Hello"}},
-						{Kind: &proto3.Value_StringValue{StringValue: "World"}},
+					vals: []*structpb.Value{
+						{Kind: &structpb.Value_StringValue{StringValue: "Hello"}},
+						{Kind: &structpb.Value_StringValue{StringValue: "World"}},
 					},
 				},
 				{
 					fields: kvMeta.RowType.Fields,
-					vals: []*proto3.Value{
-						{Kind: &proto3.Value_StringValue{StringValue: "is"}},
-						{Kind: &proto3.Value_StringValue{StringValue: "not"}},
+					vals: []*structpb.Value{
+						{Kind: &structpb.Value_StringValue{StringValue: "is"}},
+						{Kind: &structpb.Value_StringValue{StringValue: "not"}},
 					},
 				},
 				{
 					fields: kvMeta.RowType.Fields,
-					vals: []*proto3.Value{
-						{Kind: &proto3.Value_StringValue{StringValue: "a"}},
-						{Kind: &proto3.Value_StringValue{StringValue: "question"}},
+					vals: []*structpb.Value{
+						{Kind: &structpb.Value_StringValue{StringValue: "a"}},
+						{Kind: &structpb.Value_StringValue{StringValue: "question"}},
 					},
 				},
 			},
@@ -412,14 +411,14 @@ func TestPartialResultSetDecoder(t *testing.T) {
 			input: []*sppb.PartialResultSet{
 				{
 					Metadata: kvListMeta,
-					Values: []*proto3.Value{
+					Values: []*structpb.Value{
 						{
 							Kind: genProtoListValue("foo-1", "foo-2"),
 						},
 					},
 				},
 				{
-					Values: []*proto3.Value{
+					Values: []*structpb.Value{
 						{
 							Kind: genProtoListValue("bar-1", "bar-2"),
 						},
@@ -429,7 +428,7 @@ func TestPartialResultSetDecoder(t *testing.T) {
 			wantF: []*Row{
 				{
 					fields: kvListMeta.RowType.Fields,
-					vals: []*proto3.Value{
+					vals: []*structpb.Value{
 						{
 							Kind: genProtoListValue("foo-1", "foo-2"),
 						},
@@ -448,7 +447,7 @@ func TestPartialResultSetDecoder(t *testing.T) {
 			input: []*sppb.PartialResultSet{
 				{
 					Metadata: kvListMeta,
-					Values: []*proto3.Value{
+					Values: []*structpb.Value{
 						{
 							Kind: genProtoListValue("foo-1", "foo-"),
 						},
@@ -456,14 +455,14 @@ func TestPartialResultSetDecoder(t *testing.T) {
 					ChunkedValue: true,
 				},
 				{
-					Values: []*proto3.Value{
+					Values: []*structpb.Value{
 						{
 							Kind: genProtoListValue("2"),
 						},
 					},
 				},
 				{
-					Values: []*proto3.Value{
+					Values: []*structpb.Value{
 						{
 							Kind: genProtoListValue("bar-1", "bar-2"),
 						},
@@ -473,7 +472,7 @@ func TestPartialResultSetDecoder(t *testing.T) {
 			wantF: []*Row{
 				{
 					fields: kvListMeta.RowType.Fields,
-					vals: []*proto3.Value{
+					vals: []*structpb.Value{
 						{
 							Kind: genProtoListValue("foo-1", "foo-2"),
 						},
@@ -493,12 +492,12 @@ func TestPartialResultSetDecoder(t *testing.T) {
 			input: []*sppb.PartialResultSet{
 				{
 					Metadata: kvObjectMeta,
-					Values: []*proto3.Value{
+					Values: []*structpb.Value{
 						{
-							Kind: &proto3.Value_ListValue{
-								ListValue: &proto3.ListValue{
-									Values: []*proto3.Value{
-										{Kind: &proto3.Value_NumberValue{NumberValue: 23}},
+							Kind: &structpb.Value_ListValue{
+								ListValue: &structpb.ListValue{
+									Values: []*structpb.Value{
+										{Kind: &structpb.Value_NumberValue{NumberValue: 23}},
 										{Kind: genProtoListValue("foo-1", "fo")},
 									},
 								},
@@ -508,11 +507,11 @@ func TestPartialResultSetDecoder(t *testing.T) {
 					ChunkedValue: true,
 				},
 				{
-					Values: []*proto3.Value{
+					Values: []*structpb.Value{
 						{
-							Kind: &proto3.Value_ListValue{
-								ListValue: &proto3.ListValue{
-									Values: []*proto3.Value{
+							Kind: &structpb.Value_ListValue{
+								ListValue: &structpb.ListValue{
+									Values: []*structpb.Value{
 										{Kind: genProtoListValue("o-2", "f")},
 									},
 								},
@@ -522,21 +521,21 @@ func TestPartialResultSetDecoder(t *testing.T) {
 					ChunkedValue: true,
 				},
 				{
-					Values: []*proto3.Value{
+					Values: []*structpb.Value{
 						{
-							Kind: &proto3.Value_ListValue{
-								ListValue: &proto3.ListValue{
-									Values: []*proto3.Value{
+							Kind: &structpb.Value_ListValue{
+								ListValue: &structpb.ListValue{
+									Values: []*structpb.Value{
 										{Kind: genProtoListValue("oo-3")},
 									},
 								},
 							},
 						},
 						{
-							Kind: &proto3.Value_ListValue{
-								ListValue: &proto3.ListValue{
-									Values: []*proto3.Value{
-										{Kind: &proto3.Value_NumberValue{NumberValue: 45}},
+							Kind: &structpb.Value_ListValue{
+								ListValue: &structpb.ListValue{
+									Values: []*structpb.Value{
+										{Kind: &structpb.Value_NumberValue{NumberValue: 45}},
 										{Kind: genProtoListValue("bar-1")},
 									},
 								},
@@ -548,22 +547,22 @@ func TestPartialResultSetDecoder(t *testing.T) {
 			wantF: []*Row{
 				{
 					fields: kvObjectMeta.RowType.Fields,
-					vals: []*proto3.Value{
+					vals: []*structpb.Value{
 						{
-							Kind: &proto3.Value_ListValue{
-								ListValue: &proto3.ListValue{
-									Values: []*proto3.Value{
-										{Kind: &proto3.Value_NumberValue{NumberValue: 23}},
+							Kind: &structpb.Value_ListValue{
+								ListValue: &structpb.ListValue{
+									Values: []*structpb.Value{
+										{Kind: &structpb.Value_NumberValue{NumberValue: 23}},
 										{Kind: genProtoListValue("foo-1", "foo-2", "foo-3")},
 									},
 								},
 							},
 						},
 						{
-							Kind: &proto3.Value_ListValue{
-								ListValue: &proto3.ListValue{
-									Values: []*proto3.Value{
-										{Kind: &proto3.Value_NumberValue{NumberValue: 45}},
+							Kind: &structpb.Value_ListValue{
+								ListValue: &structpb.ListValue{
+									Values: []*structpb.Value{
+										{Kind: &structpb.Value_NumberValue{NumberValue: 45}},
 										{Kind: genProtoListValue("bar-1")},
 									},
 								},
@@ -613,9 +612,9 @@ func setMaxBytesBetweenResumeTokens() func() {
 	o := atomic.LoadInt32(&maxBytesBetweenResumeTokens)
 	atomic.StoreInt32(&maxBytesBetweenResumeTokens, int32(maxBuffers*proto.Size(&sppb.PartialResultSet{
 		Metadata: kvMeta,
-		Values: []*proto3.Value{
-			{Kind: &proto3.Value_StringValue{StringValue: keyStr(0)}},
-			{Kind: &proto3.Value_StringValue{StringValue: valStr(0)}},
+		Values: []*structpb.Value{
+			{Kind: &structpb.Value_StringValue{StringValue: keyStr(0)}},
+			{Kind: &structpb.Value_StringValue{StringValue: valStr(0)}},
 		},
 	})))
 	return func() {
@@ -662,18 +661,18 @@ func TestRsdNonblockingStates(t *testing.T) {
 			want: []*sppb.PartialResultSet{
 				{
 					Metadata: kvMeta,
-					Values: []*proto3.Value{
-						{Kind: &proto3.Value_StringValue{StringValue: keyStr(0)}},
-						{Kind: &proto3.Value_StringValue{StringValue: valStr(0)}},
+					Values: []*structpb.Value{
+						{Kind: &structpb.Value_StringValue{StringValue: keyStr(0)}},
+						{Kind: &structpb.Value_StringValue{StringValue: valStr(0)}},
 					},
 				},
 			},
 			queue: []*sppb.PartialResultSet{
 				{
 					Metadata: kvMeta,
-					Values: []*proto3.Value{
-						{Kind: &proto3.Value_StringValue{StringValue: keyStr(1)}},
-						{Kind: &proto3.Value_StringValue{StringValue: valStr(1)}},
+					Values: []*structpb.Value{
+						{Kind: &structpb.Value_StringValue{StringValue: keyStr(1)}},
+						{Kind: &structpb.Value_StringValue{StringValue: valStr(1)}},
 					},
 				},
 			},
@@ -696,16 +695,16 @@ func TestRsdNonblockingStates(t *testing.T) {
 			want: []*sppb.PartialResultSet{
 				{
 					Metadata: kvMeta,
-					Values: []*proto3.Value{
-						{Kind: &proto3.Value_StringValue{StringValue: keyStr(0)}},
-						{Kind: &proto3.Value_StringValue{StringValue: valStr(0)}},
+					Values: []*structpb.Value{
+						{Kind: &structpb.Value_StringValue{StringValue: keyStr(0)}},
+						{Kind: &structpb.Value_StringValue{StringValue: valStr(0)}},
 					},
 				},
 				{
 					Metadata: kvMeta,
-					Values: []*proto3.Value{
-						{Kind: &proto3.Value_StringValue{StringValue: keyStr(1)}},
-						{Kind: &proto3.Value_StringValue{StringValue: valStr(1)}},
+					Values: []*structpb.Value{
+						{Kind: &structpb.Value_StringValue{StringValue: keyStr(1)}},
+						{Kind: &structpb.Value_StringValue{StringValue: valStr(1)}},
 					},
 					ResumeToken: EncodeResumeToken(1),
 				},
@@ -729,9 +728,9 @@ func TestRsdNonblockingStates(t *testing.T) {
 				for i := 0; i < maxBuffers+1; i++ {
 					s = append(s, &sppb.PartialResultSet{
 						Metadata: kvMeta,
-						Values: []*proto3.Value{
-							{Kind: &proto3.Value_StringValue{StringValue: keyStr(i)}},
-							{Kind: &proto3.Value_StringValue{StringValue: valStr(i)}},
+						Values: []*structpb.Value{
+							{Kind: &structpb.Value_StringValue{StringValue: keyStr(i)}},
+							{Kind: &structpb.Value_StringValue{StringValue: valStr(i)}},
 						},
 					})
 				}
@@ -766,9 +765,9 @@ func TestRsdNonblockingStates(t *testing.T) {
 				for i := 0; i < maxBuffers; i++ {
 					s = append(s, &sppb.PartialResultSet{
 						Metadata: kvMeta,
-						Values: []*proto3.Value{
-							{Kind: &proto3.Value_StringValue{StringValue: keyStr(i)}},
-							{Kind: &proto3.Value_StringValue{StringValue: valStr(i)}},
+						Values: []*structpb.Value{
+							{Kind: &structpb.Value_StringValue{StringValue: keyStr(i)}},
+							{Kind: &structpb.Value_StringValue{StringValue: valStr(i)}},
 						},
 					})
 				}
@@ -955,24 +954,24 @@ func TestRsdBlockingStates(t *testing.T) {
 			want: []*sppb.PartialResultSet{
 				{
 					Metadata: kvMeta,
-					Values: []*proto3.Value{
-						{Kind: &proto3.Value_StringValue{StringValue: keyStr(0)}},
-						{Kind: &proto3.Value_StringValue{StringValue: valStr(0)}},
+					Values: []*structpb.Value{
+						{Kind: &structpb.Value_StringValue{StringValue: keyStr(0)}},
+						{Kind: &structpb.Value_StringValue{StringValue: valStr(0)}},
 					},
 				},
 				{
 					Metadata: kvMeta,
-					Values: []*proto3.Value{
-						{Kind: &proto3.Value_StringValue{StringValue: keyStr(1)}},
-						{Kind: &proto3.Value_StringValue{StringValue: valStr(1)}},
+					Values: []*structpb.Value{
+						{Kind: &structpb.Value_StringValue{StringValue: keyStr(1)}},
+						{Kind: &structpb.Value_StringValue{StringValue: valStr(1)}},
 					},
 					ResumeToken: EncodeResumeToken(1),
 				},
 				{
 					Metadata: kvMeta,
-					Values: []*proto3.Value{
-						{Kind: &proto3.Value_StringValue{StringValue: keyStr(2)}},
-						{Kind: &proto3.Value_StringValue{StringValue: valStr(2)}},
+					Values: []*structpb.Value{
+						{Kind: &structpb.Value_StringValue{StringValue: keyStr(2)}},
+						{Kind: &structpb.Value_StringValue{StringValue: valStr(2)}},
 					},
 					ResumeToken: EncodeResumeToken(2),
 				},
@@ -980,18 +979,18 @@ func TestRsdBlockingStates(t *testing.T) {
 				// flush out all messages in the internal queue.
 				{
 					Metadata: kvMeta,
-					Values: []*proto3.Value{
-						{Kind: &proto3.Value_StringValue{StringValue: keyStr(3)}},
-						{Kind: &proto3.Value_StringValue{StringValue: valStr(3)}},
+					Values: []*structpb.Value{
+						{Kind: &structpb.Value_StringValue{StringValue: keyStr(3)}},
+						{Kind: &structpb.Value_StringValue{StringValue: valStr(3)}},
 					},
 				},
 			},
 			queue: []*sppb.PartialResultSet{
 				{
 					Metadata: kvMeta,
-					Values: []*proto3.Value{
-						{Kind: &proto3.Value_StringValue{StringValue: keyStr(3)}},
-						{Kind: &proto3.Value_StringValue{StringValue: valStr(3)}},
+					Values: []*structpb.Value{
+						{Kind: &structpb.Value_StringValue{StringValue: keyStr(3)}},
+						{Kind: &structpb.Value_StringValue{StringValue: valStr(3)}},
 					},
 				},
 			},
@@ -1025,9 +1024,9 @@ func TestRsdBlockingStates(t *testing.T) {
 				for i := 0; i < maxBuffers+3; i++ {
 					s = append(s, &sppb.PartialResultSet{
 						Metadata: kvMeta,
-						Values: []*proto3.Value{
-							{Kind: &proto3.Value_StringValue{StringValue: keyStr(i)}},
-							{Kind: &proto3.Value_StringValue{StringValue: valStr(i)}},
+						Values: []*structpb.Value{
+							{Kind: &structpb.Value_StringValue{StringValue: keyStr(i)}},
+							{Kind: &structpb.Value_StringValue{StringValue: valStr(i)}},
 						},
 					})
 				}
@@ -1038,9 +1037,9 @@ func TestRsdBlockingStates(t *testing.T) {
 			queue: []*sppb.PartialResultSet{
 				{
 					Metadata: kvMeta,
-					Values: []*proto3.Value{
-						{Kind: &proto3.Value_StringValue{StringValue: keyStr(maxBuffers + 2)}},
-						{Kind: &proto3.Value_StringValue{StringValue: valStr(maxBuffers + 2)}},
+					Values: []*structpb.Value{
+						{Kind: &structpb.Value_StringValue{StringValue: keyStr(maxBuffers + 2)}},
+						{Kind: &structpb.Value_StringValue{StringValue: valStr(maxBuffers + 2)}},
 					},
 				},
 			},
@@ -1070,9 +1069,9 @@ func TestRsdBlockingStates(t *testing.T) {
 				for i := 0; i < maxBuffers; i++ {
 					s = append(s, &sppb.PartialResultSet{
 						Metadata: kvMeta,
-						Values: []*proto3.Value{
-							{Kind: &proto3.Value_StringValue{StringValue: keyStr(i)}},
-							{Kind: &proto3.Value_StringValue{StringValue: valStr(i)}},
+						Values: []*structpb.Value{
+							{Kind: &structpb.Value_StringValue{StringValue: keyStr(i)}},
+							{Kind: &structpb.Value_StringValue{StringValue: valStr(i)}},
 						},
 					})
 				}
@@ -1162,7 +1161,7 @@ func TestRsdBlockingStates(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to set up a result for a statement: %v", err)
 			}
-			var mutex = &sync.Mutex{}
+			mutex := &sync.Mutex{}
 			var rs []*sppb.PartialResultSet
 			rowsFetched := make(chan int)
 			go func() {
@@ -1312,9 +1311,9 @@ func TestQueueBytes(t *testing.T) {
 
 	sizeOfPRS := proto.Size(&sppb.PartialResultSet{
 		Metadata: kvMeta,
-		Values: []*proto3.Value{
-			{Kind: &proto3.Value_StringValue{StringValue: keyStr(0)}},
-			{Kind: &proto3.Value_StringValue{StringValue: valStr(0)}},
+		Values: []*structpb.Value{
+			{Kind: &structpb.Value_StringValue{StringValue: keyStr(0)}},
+			{Kind: &structpb.Value_StringValue{StringValue: valStr(0)}},
 		},
 		ResumeToken: rt1,
 	})
@@ -1428,23 +1427,23 @@ func TestResumeToken(t *testing.T) {
 	want := []*Row{
 		{
 			fields: kvMeta.RowType.Fields,
-			vals: []*proto3.Value{
-				{Kind: &proto3.Value_StringValue{StringValue: keyStr(0)}},
-				{Kind: &proto3.Value_StringValue{StringValue: valStr(0)}},
+			vals: []*structpb.Value{
+				{Kind: &structpb.Value_StringValue{StringValue: keyStr(0)}},
+				{Kind: &structpb.Value_StringValue{StringValue: valStr(0)}},
 			},
 		},
 		{
 			fields: kvMeta.RowType.Fields,
-			vals: []*proto3.Value{
-				{Kind: &proto3.Value_StringValue{StringValue: keyStr(1)}},
-				{Kind: &proto3.Value_StringValue{StringValue: valStr(1)}},
+			vals: []*structpb.Value{
+				{Kind: &structpb.Value_StringValue{StringValue: keyStr(1)}},
+				{Kind: &structpb.Value_StringValue{StringValue: valStr(1)}},
 			},
 		},
 		{
 			fields: kvMeta.RowType.Fields,
-			vals: []*proto3.Value{
-				{Kind: &proto3.Value_StringValue{StringValue: keyStr(2)}},
-				{Kind: &proto3.Value_StringValue{StringValue: valStr(2)}},
+			vals: []*structpb.Value{
+				{Kind: &structpb.Value_StringValue{StringValue: keyStr(2)}},
+				{Kind: &structpb.Value_StringValue{StringValue: valStr(2)}},
 			},
 		},
 	}
@@ -1493,16 +1492,16 @@ func TestResumeToken(t *testing.T) {
 	want = []*Row{
 		{
 			fields: kvMeta.RowType.Fields,
-			vals: []*proto3.Value{
-				{Kind: &proto3.Value_StringValue{StringValue: keyStr(0)}},
-				{Kind: &proto3.Value_StringValue{StringValue: valStr(0)}},
+			vals: []*structpb.Value{
+				{Kind: &structpb.Value_StringValue{StringValue: keyStr(0)}},
+				{Kind: &structpb.Value_StringValue{StringValue: valStr(0)}},
 			},
 		},
 		{
 			fields: kvMeta.RowType.Fields,
-			vals: []*proto3.Value{
-				{Kind: &proto3.Value_StringValue{StringValue: keyStr(1)}},
-				{Kind: &proto3.Value_StringValue{StringValue: valStr(1)}},
+			vals: []*structpb.Value{
+				{Kind: &structpb.Value_StringValue{StringValue: keyStr(1)}},
+				{Kind: &structpb.Value_StringValue{StringValue: valStr(1)}},
 			},
 		},
 	}
@@ -1552,7 +1551,6 @@ func TestGrpcReconnect(t *testing.T) {
 				Sql:         SelectSingerIDAlbumIDAlbumTitleFromAlbums,
 				ResumeToken: resumeToken,
 			}, opts...)
-
 		},
 		nil,
 		func(error) {}, mc.(*grpcSpannerClient))
@@ -1611,7 +1609,6 @@ func TestRetryResourceExhaustedWithoutRetryInfo(t *testing.T) {
 				Sql:         SelectSingerIDAlbumIDAlbumTitleFromAlbums,
 				ResumeToken: resumeToken,
 			}, opts...)
-
 		},
 		nil,
 		func(error) {}, mc.(*grpcSpannerClient))
@@ -1677,7 +1674,6 @@ func TestRetryResourceExhaustedWithRetryInfo(t *testing.T) {
 				Sql:         SelectSingerIDAlbumIDAlbumTitleFromAlbums,
 				ResumeToken: resumeToken,
 			}, opts...)
-
 		},
 		nil,
 		func(error) {}, mc.(*grpcSpannerClient))

--- a/spanner/statement.go
+++ b/spanner/statement.go
@@ -22,8 +22,7 @@ import (
 
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
 	"google.golang.org/grpc/codes"
-	proto3 "google.golang.org/protobuf/types/known/structpb"
-	structpb "google.golang.org/protobuf/types/known/structpb"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 // A Statement is a SQL query with named parameters.
@@ -51,8 +50,8 @@ func NewStatement(sql string) Statement {
 // convertParams converts a statement's parameters into proto Param and
 // ParamTypes.
 func (s *Statement) convertParams() (*structpb.Struct, map[string]*sppb.Type, error) {
-	params := &proto3.Struct{
-		Fields: map[string]*proto3.Value{},
+	params := &structpb.Struct{
+		Fields: map[string]*structpb.Value{},
 	}
 	paramTypes := map[string]*sppb.Type{}
 	for k, v := range s.Params {

--- a/spanner/transaction_test.go
+++ b/spanner/transaction_test.go
@@ -34,7 +34,6 @@ import (
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	gstatus "google.golang.org/grpc/status"
 	durationpb "google.golang.org/protobuf/types/known/durationpb"
 )
 
@@ -68,7 +67,6 @@ func TestSingle(t *testing.T) {
 
 // Re-using ReadOnlyTransaction: can recover from acquire failure.
 func TestReadOnlyTransaction_RecoverFromFailure(t *testing.T) {
-
 	ctx := context.Background()
 	server, client, teardown := setupMockedTestServer(t)
 	defer teardown()
@@ -77,7 +75,7 @@ func TestReadOnlyTransaction_RecoverFromFailure(t *testing.T) {
 	defer txn.Close()
 
 	// First request will fail.
-	errUsr := gstatus.Error(codes.Unknown, "error")
+	errUsr := status.Error(codes.Unknown, "error")
 	server.TestSpanner.PutExecutionTime(MethodBeginTransaction,
 		SimulatedExecutionTime{
 			Errors: []error{errUsr},
@@ -220,7 +218,6 @@ func TestApply_RetryOnAbort(t *testing.T) {
 			t.Fatalf("transaction tag mismatch\n Got: %v\nWant: %v", g, w)
 		}
 	}
-
 }
 
 // When an error is returned from the closure sent into ReadWriteTransaction, it
@@ -2123,7 +2120,7 @@ func requestsOfType(requests []interface{}, t reflect.Type) []interface{} {
 }
 
 func newAbortedErrorWithMinimalRetryDelay() error {
-	st := gstatus.New(codes.Aborted, "Transaction has been aborted")
+	st := status.New(codes.Aborted, "Transaction has been aborted")
 	retry := &errdetails.RetryInfo{
 		RetryDelay: durationpb.New(time.Nanosecond),
 	}

--- a/spanner/value_test.go
+++ b/spanner/value_test.go
@@ -38,8 +38,7 @@ import (
 	"google.golang.org/protobuf/encoding/prototext"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/testing/protocmp"
-	proto3 "google.golang.org/protobuf/types/known/structpb"
-	structpb "google.golang.org/protobuf/types/known/structpb"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 var (
@@ -324,7 +323,7 @@ func TestEncodeValue(t *testing.T) {
 	)
 	for i, test := range []struct {
 		in       interface{}
-		want     *proto3.Value
+		want     *structpb.Value
 		wantType *sppb.Type
 		name     string
 	}{
@@ -643,12 +642,13 @@ func TestEncodeInvalidValues(t *testing.T) {
 type encodeTest struct {
 	desc     string
 	in       interface{}
-	want     *proto3.Value
+	want     *structpb.Value
 	wantType *sppb.Type
 }
 
-func checkStructEncoding(desc string, got *proto3.Value, gotType *sppb.Type,
-	want *proto3.Value, wantType *sppb.Type, t *testing.T) {
+func checkStructEncoding(desc string, got *structpb.Value, gotType *sppb.Type,
+	want *structpb.Value, wantType *sppb.Type, t *testing.T,
+) {
 	if !testEqual(got, want) {
 		t.Errorf("Test %s: got encode result: %v, want %v", desc, got, want)
 	}
@@ -831,7 +831,7 @@ func TestEncodeStructValueArrayStructFields(t *testing.T) {
 				Intf       int
 				ArrStructf []structf
 			}{10, []structf{}},
-			listProto(intProto(10), listProto([]*proto3.Value{}...)),
+			listProto(intProto(10), listProto([]*structpb.Value{}...)),
 			structType(
 				mkField("Intf", intType()),
 				mkField("ArrStructf", listType(structfType))),
@@ -915,7 +915,7 @@ func TestEncodeStructValueStructFields(t *testing.T) {
 				Intf    int
 				Structf struct{}
 			}{10, struct{}{}},
-			listProto(intProto(10), listProto([]*proto3.Value{}...)),
+			listProto(intProto(10), listProto([]*structpb.Value{}...)),
 			structType(
 				mkField("Intf", intType()),
 				mkField("Structf", structType([]*sppb.StructType_Field{}...))),
@@ -1585,7 +1585,7 @@ func TestDecodeValue(t *testing.T) {
 
 	for _, test := range []struct {
 		desc      string
-		proto     *proto3.Value
+		proto     *structpb.Value
 		protoType *sppb.Type
 		want      interface{}
 		wantErr   bool
@@ -1611,7 +1611,7 @@ func TestDecodeValue(t *testing.T) {
 		// BYTES ARRAY
 		{desc: "decode ARRAY<BYTES> to [][]byte", proto: listProto(bytesProto([]byte("ab")), nullProto()), protoType: listType(bytesType()), want: [][]byte{[]byte("ab"), nil}},
 		{desc: "decode NULL to [][]byte", proto: nullProto(), protoType: listType(bytesType()), want: [][]byte(nil)},
-		//INT64
+		// INT64
 		{desc: "decode INT64 to int64", proto: intProto(15), protoType: intType(), want: int64(15)},
 		{desc: "decode NULL to int64", proto: nullProto(), protoType: intType(), want: int64(0), wantErr: true},
 		{desc: "decode INT64 to *int64", proto: intProto(15), protoType: intType(), want: &iValue},
@@ -1823,7 +1823,7 @@ func TestDecodeValue(t *testing.T) {
 								),
 							),
 						},
-						vals: []*proto3.Value{
+						vals: []*structpb.Value{
 							intProto(3),
 							listProto(
 								listProto(floatProto(3.14), stringProto("this")),
@@ -1847,7 +1847,7 @@ func TestDecodeValue(t *testing.T) {
 								),
 							),
 						},
-						vals: []*proto3.Value{
+						vals: []*structpb.Value{
 							nullProto(),
 							nullProto(),
 						},
@@ -2128,7 +2128,7 @@ func TestDecodeValue(t *testing.T) {
 func TestDecodeValueErrors(t *testing.T) {
 	var s string
 	for i, test := range []struct {
-		in *proto3.Value
+		in *structpb.Value
 		t  *sppb.Type
 		v  interface{}
 	}{
@@ -2302,7 +2302,7 @@ func TestNaN(t *testing.T) {
 	if err != nil {
 		t.Errorf("encodeValue returns %q for NaN, want nil", err)
 	}
-	x, ok := v.GetKind().(*proto3.Value_NumberValue)
+	x, ok := v.GetKind().(*structpb.Value_NumberValue)
 	if !ok {
 		t.Errorf("incorrect type for v.GetKind(): %T, want *proto3.Value_NumberValue", v.GetKind())
 	}
@@ -2314,7 +2314,7 @@ func TestNaN(t *testing.T) {
 	if err != nil {
 		t.Errorf("encodeValue returns %q for NaN, want nil", err)
 	}
-	x, ok = v.GetKind().(*proto3.Value_NumberValue)
+	x, ok = v.GetKind().(*structpb.Value_NumberValue)
 	if !ok {
 		t.Errorf("incorrect type for v.GetKind(): %T, want *proto3.Value_NumberValue", v.GetKind())
 	}
@@ -2348,7 +2348,7 @@ func TestFloat32NaN(t *testing.T) {
 	if err != nil {
 		t.Errorf("encodeValue returns %q for NaN, want nil", err)
 	}
-	x, ok := v.GetKind().(*proto3.Value_NumberValue)
+	x, ok := v.GetKind().(*structpb.Value_NumberValue)
 	if !ok {
 		t.Errorf("incorrect type for v.GetKind(): %T, want *proto3.Value_NumberValue", v.GetKind())
 	}
@@ -2360,7 +2360,7 @@ func TestFloat32NaN(t *testing.T) {
 	if err != nil {
 		t.Errorf("encodeValue returns %q for NaN, want nil", err)
 	}
-	x, ok = v.GetKind().(*proto3.Value_NumberValue)
+	x, ok = v.GetKind().(*structpb.Value_NumberValue)
 	if !ok {
 		t.Errorf("incorrect type for v.GetKind(): %T, want *proto3.Value_NumberValue", v.GetKind())
 	}
@@ -2537,7 +2537,7 @@ func TestDecodeStructWithPointers(t *testing.T) {
 		{Name: "TimeArray", Type: listType(timeType())},
 		{Name: "DateArray", Type: listType(dateType())},
 	}}
-	lv := []*proto3.ListValue{
+	lv := []*structpb.ListValue{
 		listValueProto(
 			stringProto("id"),
 			intProto(15),
@@ -2740,7 +2740,7 @@ func TestEncodeStructValueDynamicStructs(t *testing.T) {
 		{
 			"Empty array of dynamic structs.",
 			reflect.MakeSlice(dynStructArrType, 0, 0).Interface(),
-			listProto([]*proto3.Value{}...),
+			listProto([]*structpb.Value{}...),
 			arrProtoType,
 		},
 		{
@@ -2769,7 +2769,7 @@ func TestEncodeStructValueDynamicStructs(t *testing.T) {
 }
 
 func TestEncodeStructValueEmptyStruct(t *testing.T) {
-	emptyListValue := listProto([]*proto3.Value{}...)
+	emptyListValue := listProto([]*structpb.Value{}...)
 	emptyStructType := structType([]*sppb.StructType_Field{}...)
 	emptyStruct := struct{}{}
 	nullEmptyStruct := (*struct{})(nil)
@@ -2885,8 +2885,8 @@ func TestBindParamsDynamic(t *testing.T) {
 		Params: map[string]interface{}{"var": nil},
 	}
 	want := &sppb.ExecuteSqlRequest{
-		Params: &proto3.Struct{
-			Fields: map[string]*proto3.Value{"var": nil},
+		Params: &structpb.Struct{
+			Fields: map[string]*structpb.Value{"var": nil},
 		},
 		ParamTypes: map[string]*sppb.Type{"var": nil},
 	}
@@ -2920,7 +2920,7 @@ func TestBindParamsDynamic(t *testing.T) {
 
 	for _, test := range []struct {
 		val       interface{}
-		wantField *proto3.Value
+		wantField *structpb.Value
 		wantType  *sppb.Type
 	}{
 		{
@@ -3622,7 +3622,7 @@ func TestInterval(t *testing.T) {
 	tests := []struct {
 		name     string
 		interval Interval
-		want     *proto3.Value
+		want     *structpb.Value
 		wantType *sppb.Type
 	}{
 		{
@@ -3632,8 +3632,8 @@ func TestInterval(t *testing.T) {
 				Days:   3,
 				Nanos:  big.NewInt(43926789000123),
 			},
-			want: &proto3.Value{
-				Kind: &proto3.Value_StringValue{
+			want: &structpb.Value{
+				Kind: &structpb.Value_StringValue{
 					StringValue: "P1Y2M3DT12H12M6.789000123S",
 				},
 			},
@@ -3648,8 +3648,8 @@ func TestInterval(t *testing.T) {
 				Days:   0,
 				Nanos:  big.NewInt(0),
 			},
-			want: &proto3.Value{
-				Kind: &proto3.Value_StringValue{
+			want: &structpb.Value{
+				Kind: &structpb.Value_StringValue{
 					StringValue: "P10M",
 				},
 			},
@@ -3664,8 +3664,8 @@ func TestInterval(t *testing.T) {
 				Days:   10,
 				Nanos:  big.NewInt(0),
 			},
-			want: &proto3.Value{
-				Kind: &proto3.Value_StringValue{
+			want: &structpb.Value{
+				Kind: &structpb.Value_StringValue{
 					StringValue: "P10D",
 				},
 			},
@@ -3680,8 +3680,8 @@ func TestInterval(t *testing.T) {
 				Days:   0,
 				Nanos:  big.NewInt(10000000000),
 			},
-			want: &proto3.Value{
-				Kind: &proto3.Value_StringValue{
+			want: &structpb.Value{
+				Kind: &structpb.Value_StringValue{
 					StringValue: "PT10S",
 				},
 			},
@@ -3696,8 +3696,8 @@ func TestInterval(t *testing.T) {
 				Days:   0,
 				Nanos:  big.NewInt(10000000),
 			},
-			want: &proto3.Value{
-				Kind: &proto3.Value_StringValue{
+			want: &structpb.Value{
+				Kind: &structpb.Value_StringValue{
 					StringValue: "PT0.010S",
 				},
 			},
@@ -3712,8 +3712,8 @@ func TestInterval(t *testing.T) {
 				Days:   0,
 				Nanos:  big.NewInt(10000),
 			},
-			want: &proto3.Value{
-				Kind: &proto3.Value_StringValue{
+			want: &structpb.Value{
+				Kind: &structpb.Value_StringValue{
 					StringValue: "PT0.000010S",
 				},
 			},
@@ -3728,8 +3728,8 @@ func TestInterval(t *testing.T) {
 				Days:   0,
 				Nanos:  big.NewInt(10),
 			},
-			want: &proto3.Value{
-				Kind: &proto3.Value_StringValue{
+			want: &structpb.Value{
+				Kind: &structpb.Value_StringValue{
 					StringValue: "PT0.000000010S",
 				},
 			},
@@ -3744,8 +3744,8 @@ func TestInterval(t *testing.T) {
 				Days:   20,
 				Nanos:  big.NewInt(1030),
 			},
-			want: &proto3.Value{
-				Kind: &proto3.Value_StringValue{
+			want: &structpb.Value{
+				Kind: &structpb.Value_StringValue{
 					StringValue: "P10M20DT0.000001030S",
 				},
 			},
@@ -3760,8 +3760,8 @@ func TestInterval(t *testing.T) {
 				Days:   20,
 				Nanos:  big.NewInt(-1030),
 			},
-			want: &proto3.Value{
-				Kind: &proto3.Value_StringValue{
+			want: &structpb.Value{
+				Kind: &structpb.Value_StringValue{
 					StringValue: "P10M20DT-0.000001030S",
 				},
 			},
@@ -3776,8 +3776,8 @@ func TestInterval(t *testing.T) {
 				Days:   -3,
 				Nanos:  big.NewInt(-43926789000123),
 			},
-			want: &proto3.Value{
-				Kind: &proto3.Value_StringValue{
+			want: &structpb.Value{
+				Kind: &structpb.Value_StringValue{
 					StringValue: "P-1Y-2M-3DT-12H-12M-6.789000123S",
 				},
 			},
@@ -3792,8 +3792,8 @@ func TestInterval(t *testing.T) {
 				Days:   3,
 				Nanos:  big.NewInt(-41401234000000),
 			},
-			want: &proto3.Value{
-				Kind: &proto3.Value_StringValue{
+			want: &structpb.Value{
+				Kind: &structpb.Value_StringValue{
 					StringValue: "P10M3DT-11H-30M-1.234S",
 				},
 			},
@@ -3808,8 +3808,8 @@ func TestInterval(t *testing.T) {
 				Days:   15,
 				Nanos:  func() *big.Int { n, _ := new(big.Int).SetString("316223999999999999999", 10); return n }(),
 			},
-			want: &proto3.Value{
-				Kind: &proto3.Value_StringValue{
+			want: &structpb.Value{
+				Kind: &structpb.Value_StringValue{
 					StringValue: "P2Y1M15DT87839999H59M59.999999999S",
 				},
 			},
@@ -3824,8 +3824,8 @@ func TestInterval(t *testing.T) {
 				Days:   0,
 				Nanos:  big.NewInt(0),
 			},
-			want: &proto3.Value{
-				Kind: &proto3.Value_StringValue{
+			want: &structpb.Value{
+				Kind: &structpb.Value_StringValue{
 					StringValue: "P0Y",
 				},
 			},
@@ -3858,7 +3858,7 @@ func TestNullInterval(t *testing.T) {
 	tests := []struct {
 		name     string
 		interval NullInterval
-		want     *proto3.Value
+		want     *structpb.Value
 		wantType *sppb.Type
 	}{
 		{
@@ -3871,8 +3871,8 @@ func TestNullInterval(t *testing.T) {
 				},
 				Valid: true,
 			},
-			want: &proto3.Value{
-				Kind: &proto3.Value_StringValue{
+			want: &structpb.Value{
+				Kind: &structpb.Value_StringValue{
 					StringValue: "P1Y2M3DT4H5M6S",
 				},
 			},
@@ -3886,8 +3886,8 @@ func TestNullInterval(t *testing.T) {
 				Interval: Interval{},
 				Valid:    false,
 			},
-			want: &proto3.Value{
-				Kind: &proto3.Value_NullValue{},
+			want: &structpb.Value{
+				Kind: &structpb.Value_NullValue{},
 			},
 			wantType: &sppb.Type{
 				Code: sppb.TypeCode_INTERVAL,


### PR DESCRIPTION
Fix staticcheck ST1019 error.
- https://staticcheck.dev/docs/checks#ST1019

```console
$ staticcheck -checks ST1019 .
read_test.go:39:2: package "google.golang.org/protobuf/types/known/structpb" is being imported more than once (ST1019)
	read_test.go:40:2: other import of "google.golang.org/protobuf/types/known/structpb"
statement.go:25:2: package "google.golang.org/protobuf/types/known/structpb" is being imported more than once (ST1019)
	statement.go:26:2: other import of "google.golang.org/protobuf/types/known/structpb"
transaction_test.go:36:2: package "google.golang.org/grpc/status" is being imported more than once (ST1019)
	transaction_test.go:37:2: other import of "google.golang.org/grpc/status"
value_test.go:41:2: package "google.golang.org/protobuf/types/known/structpb" is being imported more than once (ST1019)
	value_test.go:42:2: other import of "google.golang.org/protobuf/types/known/structpb"
```