### PR TITLE
feat(firestore): support vector query in transactions

### DIFF
--- a/firestore/query.go
+++ b/firestore/query.go
@@ -604,10 +604,7 @@ func (vq VectorQuery) Serialize() ([]byte, error) {
 // VectorQuery object that can be used to execute that VectorQuery.
 func (vq VectorQuery) Deserialize(bytes []byte) (VectorQuery, error) {
 	q, err := vq.q.Deserialize(bytes)
-	if err != nil {
-		return VectorQuery{q: q}, err
-	}
-	return VectorQuery{q: q}, nil
+	return VectorQuery{q: q}, err
 }
 
 // FindNearestPath is like [Query.FindNearest] but it accepts a [FieldPath].

--- a/firestore/query.go
+++ b/firestore/query.go
@@ -587,6 +587,29 @@ func (vq VectorQuery) Documents(ctx context.Context) *DocumentIterator {
 	return vq.q.Documents(ctx)
 }
 
+func (vq VectorQuery) query() *Query {
+	return &vq.q
+}
+
+// Serialize creates a RunQueryRequest wire-format byte slice from a VectorQuery object.
+// This can be used in combination with Deserialize to marshal VectorQuery objects.
+// This could be useful, for instance, if executing a query formed in one
+// process in another.
+func (vq VectorQuery) Serialize() ([]byte, error) {
+	return vq.q.Serialize()
+}
+
+// Deserialize takes a slice of bytes holding the wire-format message of RunQueryRequest,
+// the underlying proto message used by Queries. It then populates and returns a
+// VectorQuery object that can be used to execute that VectorQuery.
+func (vq VectorQuery) Deserialize(bytes []byte) (VectorQuery, error) {
+	q, err := vq.q.Deserialize(bytes)
+	if err != nil {
+		return VectorQuery{q: q}, err
+	}
+	return VectorQuery{q: q}, nil
+}
+
 // FindNearestPath is like [Query.FindNearest] but it accepts a [FieldPath].
 func (q Query) FindNearestPath(vectorFieldPath FieldPath, queryVector any, limit int, measure DistanceMeasure, options *FindNearestOptions) VectorQuery {
 	vq := VectorQuery{q: q}

--- a/firestore/query_test.go
+++ b/firestore/query_test.go
@@ -2663,3 +2663,33 @@ func anyMapToValueMap(m map[string]any) map[string]*pb.Value {
 	}
 	return res
 }
+
+func TestVectorQueryFromProtoRoundTrip(t *testing.T) {
+	c := &Client{projectID: "P", databaseID: "DB"}
+	q := Query{c: c, collectionID: "C"}
+	vq := q.FindNearest("vectorField", []float64{1.0, 2.0, 3.0}, 10, DistanceMeasureEuclidean, nil)
+
+	protoBytes, err := vq.Serialize()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	gotvq, err := VectorQuery{q: Query{c: c}}.Deserialize(protoBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := gotvq.q.toRunQueryRequestProto()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want, err := vq.q.toRunQueryRequestProto()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
+		t.Errorf("mismatch (-want, +got)\n: %s", diff)
+	}
+}

--- a/firestore/transaction_test.go
+++ b/firestore/transaction_test.go
@@ -25,6 +25,7 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
 	"google.golang.org/protobuf/types/known/timestamppb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 func TestRunTransaction(t *testing.T) {
@@ -680,6 +681,72 @@ func TestTransaction_WithReadOptions(t *testing.T) {
 		tx.WithReadOptions(ReadTime(tm)).Get(docref)
 		return nil
 	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRunTransaction_VectorQuery(t *testing.T) {
+	ctx := context.Background()
+	c, srv, cleanup := newMock(t)
+	defer cleanup()
+
+	const db = "projects/projectID/databases/(default)"
+	tid := []byte{1}
+
+	beginReq := &pb.BeginTransactionRequest{Database: db}
+	beginRes := &pb.BeginTransactionResponse{Transaction: tid}
+	commitReq := &pb.CommitRequest{Database: db, Transaction: tid}
+
+	srv.addRPC(beginReq, beginRes)
+
+	distanceThreshold := 20.0
+	srv.addRPC(
+		&pb.RunQueryRequest{
+			Parent: db + "/documents",
+			QueryType: &pb.RunQueryRequest_StructuredQuery{
+				StructuredQuery: &pb.StructuredQuery{
+					From: []*pb.StructuredQuery_CollectionSelector{{CollectionId: "C"}},
+					FindNearest: &pb.StructuredQuery_FindNearest{
+						VectorField: &pb.StructuredQuery_FieldReference{FieldPath: "vectorField"},
+						QueryVector: &pb.Value{ValueType: &pb.Value_MapValue{MapValue: &pb.MapValue{
+							Fields: map[string]*pb.Value{
+								"__type__": {ValueType: &pb.Value_StringValue{StringValue: "__vector__"}},
+								"value": {ValueType: &pb.Value_ArrayValue{ArrayValue: &pb.ArrayValue{
+									Values: []*pb.Value{
+										{ValueType: &pb.Value_DoubleValue{DoubleValue: 1.0}},
+										{ValueType: &pb.Value_DoubleValue{DoubleValue: 2.0}},
+										{ValueType: &pb.Value_DoubleValue{DoubleValue: 3.0}},
+									},
+								}}},
+							},
+						}}},
+						DistanceMeasure:     pb.StructuredQuery_FindNearest_EUCLIDEAN,
+						Limit:               &wrapperspb.Int32Value{Value: 10},
+						DistanceResultField: "distance",
+						DistanceThreshold:   &wrapperspb.DoubleValue{Value: distanceThreshold},
+					},
+				},
+			},
+			ConsistencySelector: &pb.RunQueryRequest_Transaction{Transaction: tid},
+		},
+		[]interface{}{},
+	)
+	srv.addRPC(commitReq, &pb.CommitResponse{CommitTime: aTimestamp})
+
+	err := c.RunTransaction(ctx, func(_ context.Context, tx *Transaction) error {
+		vq := c.Collection("C").FindNearest("vectorField", []float64{1.0, 2.0, 3.0}, 10, DistanceMeasureEuclidean, &FindNearestOptions{
+			DistanceResultField: "distance",
+			DistanceThreshold:   &distanceThreshold,
+		})
+		it := tx.Documents(vq)
+		defer it.Stop()
+		_, err := it.Next()
+		if err != iterator.Done {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/googleapis/google-cloud-go/issues/12837


   - Implements the unexported query() method on the VectorQuery struct in query.go. This satisfies the Queryer interface, allowing VectorQuery to be used natively with Transaction.Documents(q Queryer) and Transaction.GetAll(q Queryer).
   - Adds exported Serialize() and Deserialize([]byte) methods to VectorQuery, enabling developers to marshal and unmarshal vector queries back into protobuf format.