### PR TITLE
fix(bigquery):  migrate usages of proto.Clone to proto.CloneOf

### DIFF
--- a/bigquery/storage/managedwriter/appendresult.go
+++ b/bigquery/storage/managedwriter/appendresult.go
@@ -103,7 +103,7 @@ func (ar *AppendResult) FullResponse(ctx context.Context) (*storagepb.AppendRows
 			}
 		}
 		if ar.response != nil {
-			return proto.Clone(ar.response).(*storagepb.AppendRowsResponse), err
+			return proto.CloneOf(ar.response), err
 		}
 		return nil, err
 	}
@@ -136,7 +136,7 @@ func (ar *AppendResult) UpdatedSchema(ctx context.Context) (*storagepb.TableSche
 	case <-ar.Ready():
 		if ar.response != nil {
 			if schema := ar.response.GetUpdatedSchema(); schema != nil {
-				return proto.Clone(schema).(*storagepb.TableSchema), nil
+				return proto.CloneOf(schema), nil
 			}
 		}
 		return nil, nil
@@ -229,7 +229,7 @@ func (pw *pendingWrite) markDone(resp *storagepb.AppendRowsResponse, err error) 
 func (pw *pendingWrite) constructFullRequest(addTrace bool) *storagepb.AppendRowsRequest {
 	req := &storagepb.AppendRowsRequest{}
 	if pw.reqTmpl != nil {
-		req = proto.Clone(pw.reqTmpl.tmpl).(*storagepb.AppendRowsRequest)
+		req = proto.CloneOf(pw.reqTmpl.tmpl)
 	}
 	if pw.req != nil {
 		proto.Merge(req, pw.req)

--- a/bigquery/storage/managedwriter/integration_test.go
+++ b/bigquery/storage/managedwriter/integration_test.go
@@ -723,7 +723,7 @@ func testSimpleCDC(ctx context.Context, t *testing.T, mwClient *Client, bqClient
 	defer updateWriter.Close()
 
 	// Change bob via an UPSERT CDC
-	newBob := proto.Clone(initialEmployees[1]).(*testdata.ExampleEmployeeCDC)
+	newBob := proto.CloneOf(initialEmployees[1])
 	newBob.Salary = proto.Int64(105000)
 	newBob.Departments = []string{"research", "product"}
 	newBob.XCHANGE_TYPE = proto.String("UPSERT")

--- a/bigquery/storage/managedwriter/send_optimizer.go
+++ b/bigquery/storage/managedwriter/send_optimizer.go
@@ -217,7 +217,7 @@ func (vt *versionedTemplate) revise(changes ...templateRevisionF) *versionedTemp
 	}
 	out := &versionedTemplate{
 		versionTime: time.Now(),
-		tmpl:        proto.Clone(before.tmpl).(*storagepb.AppendRowsRequest),
+		tmpl:        proto.CloneOf(before.tmpl),
 	}
 	for _, r := range changes {
 		r(out.tmpl)
@@ -246,7 +246,7 @@ func reviseProtoSchema(newSchema *descriptorpb.DescriptorProto) templateRevision
 			m.Rows = &storagepb.AppendRowsRequest_ProtoRows{
 				ProtoRows: &storagepb.AppendRowsRequest_ProtoData{
 					WriterSchema: &storagepb.ProtoSchema{
-						ProtoDescriptor: proto.Clone(newSchema).(*descriptorpb.DescriptorProto),
+						ProtoDescriptor: proto.CloneOf(newSchema),
 					},
 				},
 			}

--- a/bigquery/storage/managedwriter/send_optimizer_test.go
+++ b/bigquery/storage/managedwriter/send_optimizer_test.go
@@ -41,12 +41,12 @@ func TestSendOptimizer(t *testing.T) {
 	}
 	exampleStreamID := "foo"
 	exampleTraceID := "trace_id"
-	exampleReqFull := proto.Clone(exampleReq).(*storagepb.AppendRowsRequest)
+	exampleReqFull := proto.CloneOf(exampleReq)
 	exampleReqFull.WriteStream = exampleStreamID
 	exampleReqFull.TraceId = buildTraceID(&streamSettings{TraceID: exampleTraceID})
 	exampleDP := &descriptorpb.DescriptorProto{Name: proto.String("schema")}
 	exampleReqFull.GetProtoRows().WriterSchema = &storagepb.ProtoSchema{
-		ProtoDescriptor: proto.Clone(exampleDP).(*descriptorpb.DescriptorProto),
+		ProtoDescriptor: proto.CloneOf(exampleDP),
 	}
 
 	ctx := context.Background()
@@ -64,9 +64,9 @@ func TestSendOptimizer(t *testing.T) {
 			reqs: func() []*pendingWrite {
 				tmpl := newVersionedTemplate().revise(reviseProtoSchema(exampleDP))
 				return []*pendingWrite{
-					newPendingWrite(ctx, nil, proto.Clone(exampleReq).(*storagepb.AppendRowsRequest), tmpl, exampleStreamID, exampleTraceID),
-					newPendingWrite(ctx, nil, proto.Clone(exampleReq).(*storagepb.AppendRowsRequest), tmpl, exampleStreamID, exampleTraceID),
-					newPendingWrite(ctx, nil, proto.Clone(exampleReq).(*storagepb.AppendRowsRequest), tmpl, exampleStreamID, exampleTraceID),
+					newPendingWrite(ctx, nil, proto.CloneOf(exampleReq), tmpl, exampleStreamID, exampleTraceID),
+					newPendingWrite(ctx, nil, proto.CloneOf(exampleReq), tmpl, exampleStreamID, exampleTraceID),
+					newPendingWrite(ctx, nil, proto.CloneOf(exampleReq), tmpl, exampleStreamID, exampleTraceID),
 				}
 			}(),
 			sendResults: []error{
@@ -75,9 +75,9 @@ func TestSendOptimizer(t *testing.T) {
 				io.EOF,
 			},
 			wantReqs: []*storagepb.AppendRowsRequest{
-				proto.Clone(exampleReqFull).(*storagepb.AppendRowsRequest),
-				proto.Clone(exampleReqFull).(*storagepb.AppendRowsRequest),
-				proto.Clone(exampleReqFull).(*storagepb.AppendRowsRequest),
+				proto.CloneOf(exampleReqFull),
+				proto.CloneOf(exampleReqFull),
+				proto.CloneOf(exampleReqFull),
 			},
 		},
 		{
@@ -86,9 +86,9 @@ func TestSendOptimizer(t *testing.T) {
 			reqs: func() []*pendingWrite {
 				tmpl := newVersionedTemplate().revise(reviseProtoSchema(exampleDP))
 				return []*pendingWrite{
-					newPendingWrite(ctx, nil, proto.Clone(exampleReq).(*storagepb.AppendRowsRequest), tmpl, exampleStreamID, exampleTraceID),
-					newPendingWrite(ctx, nil, proto.Clone(exampleReq).(*storagepb.AppendRowsRequest), tmpl, exampleStreamID, exampleTraceID),
-					newPendingWrite(ctx, nil, proto.Clone(exampleReq).(*storagepb.AppendRowsRequest), tmpl, exampleStreamID, exampleTraceID),
+					newPendingWrite(ctx, nil, proto.CloneOf(exampleReq), tmpl, exampleStreamID, exampleTraceID),
+					newPendingWrite(ctx, nil, proto.CloneOf(exampleReq), tmpl, exampleStreamID, exampleTraceID),
+					newPendingWrite(ctx, nil, proto.CloneOf(exampleReq), tmpl, exampleStreamID, exampleTraceID),
 				}
 			}(),
 			sendResults: []error{
@@ -99,8 +99,8 @@ func TestSendOptimizer(t *testing.T) {
 			wantReqs: func() []*storagepb.AppendRowsRequest {
 				want := make([]*storagepb.AppendRowsRequest, 3)
 				// first has no redactions.
-				want[0] = proto.Clone(exampleReqFull).(*storagepb.AppendRowsRequest)
-				req := proto.Clone(want[0]).(*storagepb.AppendRowsRequest)
+				want[0] = proto.CloneOf(exampleReqFull)
+				req := proto.CloneOf(want[0])
 				req.GetProtoRows().WriterSchema = nil
 				req.TraceId = ""
 				req.WriteStream = ""
@@ -116,9 +116,9 @@ func TestSendOptimizer(t *testing.T) {
 			reqs: func() []*pendingWrite {
 				tmpl := newVersionedTemplate().revise(reviseProtoSchema(exampleDP))
 				return []*pendingWrite{
-					newPendingWrite(ctx, nil, proto.Clone(exampleReq).(*storagepb.AppendRowsRequest), tmpl, exampleStreamID, exampleTraceID),
-					newPendingWrite(ctx, nil, proto.Clone(exampleReq).(*storagepb.AppendRowsRequest), tmpl, exampleStreamID, exampleTraceID),
-					newPendingWrite(ctx, nil, proto.Clone(exampleReq).(*storagepb.AppendRowsRequest), tmpl, exampleStreamID, exampleTraceID),
+					newPendingWrite(ctx, nil, proto.CloneOf(exampleReq), tmpl, exampleStreamID, exampleTraceID),
+					newPendingWrite(ctx, nil, proto.CloneOf(exampleReq), tmpl, exampleStreamID, exampleTraceID),
+					newPendingWrite(ctx, nil, proto.CloneOf(exampleReq), tmpl, exampleStreamID, exampleTraceID),
 				}
 			}(),
 			sendResults: []error{
@@ -128,8 +128,8 @@ func TestSendOptimizer(t *testing.T) {
 			},
 			wantReqs: func() []*storagepb.AppendRowsRequest {
 				want := make([]*storagepb.AppendRowsRequest, 3)
-				want[0] = proto.Clone(exampleReqFull).(*storagepb.AppendRowsRequest)
-				req := proto.Clone(want[0]).(*storagepb.AppendRowsRequest)
+				want[0] = proto.CloneOf(exampleReqFull)
+				req := proto.CloneOf(want[0])
 				req.GetProtoRows().WriterSchema = nil
 				req.TraceId = ""
 				req.WriteStream = ""
@@ -146,9 +146,9 @@ func TestSendOptimizer(t *testing.T) {
 			reqs: func() []*pendingWrite {
 				tmpl := newVersionedTemplate().revise(reviseProtoSchema(exampleDP))
 				return []*pendingWrite{
-					newPendingWrite(ctx, nil, proto.Clone(exampleReq).(*storagepb.AppendRowsRequest), tmpl, exampleStreamID, exampleTraceID),
-					newPendingWrite(ctx, nil, proto.Clone(exampleReq).(*storagepb.AppendRowsRequest), tmpl, exampleStreamID, exampleTraceID),
-					newPendingWrite(ctx, nil, proto.Clone(exampleReq).(*storagepb.AppendRowsRequest), tmpl, exampleStreamID, exampleTraceID),
+					newPendingWrite(ctx, nil, proto.CloneOf(exampleReq), tmpl, exampleStreamID, exampleTraceID),
+					newPendingWrite(ctx, nil, proto.CloneOf(exampleReq), tmpl, exampleStreamID, exampleTraceID),
+					newPendingWrite(ctx, nil, proto.CloneOf(exampleReq), tmpl, exampleStreamID, exampleTraceID),
 				}
 			}(),
 			sendResults: []error{
@@ -157,9 +157,9 @@ func TestSendOptimizer(t *testing.T) {
 				io.EOF,
 			},
 			wantReqs: []*storagepb.AppendRowsRequest{
-				proto.Clone(exampleReqFull).(*storagepb.AppendRowsRequest),
-				proto.Clone(exampleReqFull).(*storagepb.AppendRowsRequest),
-				proto.Clone(exampleReqFull).(*storagepb.AppendRowsRequest),
+				proto.CloneOf(exampleReqFull),
+				proto.CloneOf(exampleReqFull),
+				proto.CloneOf(exampleReqFull),
 			},
 		},
 		{
@@ -168,9 +168,9 @@ func TestSendOptimizer(t *testing.T) {
 			reqs: func() []*pendingWrite {
 				tmpl := newVersionedTemplate().revise(reviseProtoSchema(exampleDP))
 				return []*pendingWrite{
-					newPendingWrite(ctx, nil, proto.Clone(exampleReq).(*storagepb.AppendRowsRequest), tmpl, exampleStreamID, exampleTraceID),
-					newPendingWrite(ctx, nil, proto.Clone(exampleReq).(*storagepb.AppendRowsRequest), tmpl, exampleStreamID, exampleTraceID),
-					newPendingWrite(ctx, nil, proto.Clone(exampleReq).(*storagepb.AppendRowsRequest), tmpl, exampleStreamID, exampleTraceID),
+					newPendingWrite(ctx, nil, proto.CloneOf(exampleReq), tmpl, exampleStreamID, exampleTraceID),
+					newPendingWrite(ctx, nil, proto.CloneOf(exampleReq), tmpl, exampleStreamID, exampleTraceID),
+					newPendingWrite(ctx, nil, proto.CloneOf(exampleReq), tmpl, exampleStreamID, exampleTraceID),
 				}
 			}(),
 			sendResults: []error{
@@ -180,8 +180,8 @@ func TestSendOptimizer(t *testing.T) {
 			},
 			wantReqs: func() []*storagepb.AppendRowsRequest {
 				want := make([]*storagepb.AppendRowsRequest, 3)
-				want[0] = proto.Clone(exampleReqFull).(*storagepb.AppendRowsRequest)
-				req := proto.Clone(want[0]).(*storagepb.AppendRowsRequest)
+				want[0] = proto.CloneOf(exampleReqFull)
+				req := proto.CloneOf(want[0])
 				req.GetProtoRows().WriterSchema = nil
 				req.TraceId = ""
 				want[1] = req
@@ -196,10 +196,10 @@ func TestSendOptimizer(t *testing.T) {
 				tmplA := newVersionedTemplate().revise(reviseProtoSchema(exampleDP))
 				tmplB := newVersionedTemplate().revise(reviseProtoSchema(protodesc.ToDescriptorProto((&testdata.AllSupportedTypes{}).ProtoReflect().Descriptor())))
 
-				reqA := proto.Clone(exampleReq).(*storagepb.AppendRowsRequest)
+				reqA := proto.CloneOf(exampleReq)
 				reqA.WriteStream = "alpha"
 
-				reqB := proto.Clone(exampleReq).(*storagepb.AppendRowsRequest)
+				reqB := proto.CloneOf(exampleReq)
 				reqB.WriteStream = "beta"
 
 				writes := make([]*pendingWrite, 10)
@@ -231,24 +231,24 @@ func TestSendOptimizer(t *testing.T) {
 			wantReqs: func() []*storagepb.AppendRowsRequest {
 				want := make([]*storagepb.AppendRowsRequest, 10)
 
-				wantReqAFull := proto.Clone(exampleReqFull).(*storagepb.AppendRowsRequest)
+				wantReqAFull := proto.CloneOf(exampleReqFull)
 				wantReqAFull.WriteStream = "alpha"
 
-				wantReqANoTrace := proto.Clone(wantReqAFull).(*storagepb.AppendRowsRequest)
+				wantReqANoTrace := proto.CloneOf(wantReqAFull)
 				wantReqANoTrace.TraceId = ""
 
-				wantReqAOpt := proto.Clone(wantReqAFull).(*storagepb.AppendRowsRequest)
+				wantReqAOpt := proto.CloneOf(wantReqAFull)
 				wantReqAOpt.GetProtoRows().WriterSchema = nil
 				wantReqAOpt.TraceId = ""
 
-				wantReqBFull := proto.Clone(exampleReqFull).(*storagepb.AppendRowsRequest)
+				wantReqBFull := proto.CloneOf(exampleReqFull)
 				wantReqBFull.WriteStream = "beta"
 				wantReqBFull.GetProtoRows().GetWriterSchema().ProtoDescriptor = protodesc.ToDescriptorProto((&testdata.AllSupportedTypes{}).ProtoReflect().Descriptor())
 
-				wantReqBNoTrace := proto.Clone(wantReqBFull).(*storagepb.AppendRowsRequest)
+				wantReqBNoTrace := proto.CloneOf(wantReqBFull)
 				wantReqBNoTrace.TraceId = ""
 
-				wantReqBOpt := proto.Clone(wantReqBFull).(*storagepb.AppendRowsRequest)
+				wantReqBOpt := proto.CloneOf(wantReqBFull)
 				wantReqBOpt.GetProtoRows().WriterSchema = nil
 				wantReqBOpt.TraceId = ""
 
@@ -273,7 +273,7 @@ func TestSendOptimizer(t *testing.T) {
 				tmplOld := newVersionedTemplate().revise(reviseProtoSchema(exampleDP))
 				tmplNew := tmplOld.revise(reviseProtoSchema(&descriptorpb.DescriptorProto{Name: proto.String("new")}))
 
-				example := proto.Clone(exampleReq).(*storagepb.AppendRowsRequest)
+				example := proto.CloneOf(exampleReq)
 
 				writes := make([]*pendingWrite, 4)
 				writes[0] = newPendingWrite(ctx, nil, example, tmplOld, exampleStreamID, exampleTraceID)
@@ -292,13 +292,13 @@ func TestSendOptimizer(t *testing.T) {
 			wantReqs: func() []*storagepb.AppendRowsRequest {
 				want := make([]*storagepb.AppendRowsRequest, 4)
 
-				wantBaseReqFull := proto.Clone(exampleReqFull).(*storagepb.AppendRowsRequest)
+				wantBaseReqFull := proto.CloneOf(exampleReqFull)
 
-				wantBaseReqOpt := proto.Clone(wantBaseReqFull).(*storagepb.AppendRowsRequest)
+				wantBaseReqOpt := proto.CloneOf(wantBaseReqFull)
 				wantBaseReqOpt.TraceId = ""
 				wantBaseReqOpt.GetProtoRows().WriterSchema = nil
 
-				wantEvolved := proto.Clone(wantBaseReqOpt).(*storagepb.AppendRowsRequest)
+				wantEvolved := proto.CloneOf(wantBaseReqOpt)
 				wantEvolved.GetProtoRows().WriterSchema = &storagepb.ProtoSchema{
 					ProtoDescriptor: &descriptorpb.DescriptorProto{Name: proto.String("new")},
 				}
@@ -315,7 +315,7 @@ func TestSendOptimizer(t *testing.T) {
 	for _, tc := range testCases {
 		testARC := &testAppendRowsClient{}
 		testARC.sendF = func(req *storagepb.AppendRowsRequest) error {
-			testARC.requests = append(testARC.requests, proto.Clone(req).(*storagepb.AppendRowsRequest))
+			testARC.requests = append(testARC.requests, proto.CloneOf(req))
 			respErr := tc.sendResults[0]
 			tc.sendResults = tc.sendResults[1:]
 			return respErr

--- a/bigquery/v2/query/helper.go
+++ b/bigquery/v2/query/helper.go
@@ -51,7 +51,7 @@ func NewHelper(c *apiv2_client.Client, projectID string, opts ...option.ClientOp
 // handle to the running query. The returned Query object can be used to wait for
 // completion and retrieve results.
 func (h *Helper) StartQuery(ctx context.Context, req *bigquerypb.PostQueryRequest, opts ...gax.CallOption) (*Query, error) {
-	req = proto.Clone(req).(*bigquerypb.PostQueryRequest)
+	req = proto.CloneOf(req)
 	qr := req.GetQueryRequest()
 	if qr == nil {
 		return nil, fmt.Errorf("bigquery: request is missing QueryRequest")
@@ -65,7 +65,7 @@ func (h *Helper) StartQuery(ctx context.Context, req *bigquerypb.PostQueryReques
 
 // StartQueryJob from a bigquerypb.Job definition. Should have job.Configuration.Query filled out.
 func (h *Helper) StartQueryJob(ctx context.Context, job *bigquerypb.Job, opts ...gax.CallOption) (*Query, error) {
-	job = proto.Clone(job).(*bigquerypb.Job)
+	job = proto.CloneOf(job)
 	config := job.GetConfiguration()
 	if config == nil {
 		return nil, fmt.Errorf("bigquery: job is missing configuration")
@@ -94,7 +94,7 @@ func (h *Helper) StartQueryJob(ctx context.Context, job *bigquerypb.Job, opts ..
 // used to monitor the job's status, wait for its completion, and retrieve its
 // results.
 func (h *Helper) AttachJob(ctx context.Context, jobRef *bigquerypb.JobReference, opts ...gax.CallOption) (*Query, error) {
-	jobRef = proto.Clone(jobRef).(*bigquerypb.JobReference)
+	jobRef = proto.CloneOf(jobRef)
 	if jobRef == nil {
 		return nil, fmt.Errorf("bigquery: AttachJob requires a non-nil JobReference")
 	}


### PR DESCRIPTION
Migration removes our need to cast each usage of clone back to its message type.