### PR TITLE
chore: update librarian to v0.10.2-0.20260421180302-dc35d110f9bb

### DIFF
--- a/apigeeregistry/apiv1/.repo-metadata.json
+++ b/apigeeregistry/apiv1/.repo-metadata.json
@@ -6,5 +6,5 @@
     "distribution_name": "cloud.google.com/go/apigeeregistry/apiv1",
     "language": "go",
     "library_type": "GAPIC_AUTO",
-    "release_level": "stable"
+    "release_level": "preview"
 }

--- a/apigeeregistry/apiv1/doc.go
+++ b/apigeeregistry/apiv1/doc.go
@@ -17,6 +17,8 @@
 // Package apigeeregistry is an auto-generated package for the
 // Apigee Registry API.
 //
+//	NOTE: This package is in beta. It is not stable, and may be subject to changes.
+//
 // # General documentation
 //
 // For information that is relevant for all client libraries please reference

--- a/compute/apiv1beta/doc.go
+++ b/compute/apiv1beta/doc.go
@@ -17,6 +17,8 @@
 // Package compute is an auto-generated package for the
 // Google Compute Engine API.
 //
+//	NOTE: This package is in beta. It is not stable, and may be subject to changes.
+//
 // # General documentation
 //
 // For information that is relevant for all client libraries please reference

--- a/identitytoolkit/apiv2/.repo-metadata.json
+++ b/identitytoolkit/apiv2/.repo-metadata.json
@@ -6,5 +6,5 @@
     "distribution_name": "cloud.google.com/go/identitytoolkit/apiv2",
     "language": "go",
     "library_type": "GAPIC_AUTO",
-    "release_level": "stable"
+    "release_level": "preview"
 }

--- a/identitytoolkit/apiv2/doc.go
+++ b/identitytoolkit/apiv2/doc.go
@@ -20,6 +20,8 @@
 // The Google Identity Toolkit API lets you use open standards to verify a
 // user’s identity.
 //
+//	NOTE: This package is in beta. It is not stable, and may be subject to changes.
+//
 // # General documentation
 //
 // For information that is relevant for all client libraries please reference

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 language: go
-version: v0.10.1-0.20260408193841-095ea7e727aa
+version: v0.10.2-0.20260421180302-dc35d110f9bb
 repo: googleapis/google-cloud-go
 sources:
   googleapis:

--- a/maps/README.md
+++ b/maps/README.md
@@ -1,8 +1,8 @@
-# Geocoding API
+# Google Maps Platform
 
 [![Go Reference](https://pkg.go.dev/badge/cloud.google.com/go/maps.svg)](https://pkg.go.dev/cloud.google.com/go/maps)
 
-Go Client Library for Geocoding API.
+Go Client Library for Google Maps Platform.
 
 ## Install
 

--- a/networkservices/apiv1/.repo-metadata.json
+++ b/networkservices/apiv1/.repo-metadata.json
@@ -6,5 +6,5 @@
     "distribution_name": "cloud.google.com/go/networkservices/apiv1",
     "language": "go",
     "library_type": "GAPIC_AUTO",
-    "release_level": "stable"
+    "release_level": "preview"
 }

--- a/networkservices/apiv1/doc.go
+++ b/networkservices/apiv1/doc.go
@@ -17,6 +17,8 @@
 // Package networkservices is an auto-generated package for the
 // Network Services API.
 //
+//	NOTE: This package is in beta. It is not stable, and may be subject to changes.
+//
 // # General documentation
 //
 // For information that is relevant for all client libraries please reference

--- a/policysimulator/apiv1/.repo-metadata.json
+++ b/policysimulator/apiv1/.repo-metadata.json
@@ -6,5 +6,5 @@
     "distribution_name": "cloud.google.com/go/policysimulator/apiv1",
     "language": "go",
     "library_type": "GAPIC_AUTO",
-    "release_level": "stable"
+    "release_level": "preview"
 }

--- a/policysimulator/apiv1/doc.go
+++ b/policysimulator/apiv1/doc.go
@@ -25,6 +25,8 @@
 // and compares those results to determine how your members’ access might
 // change under the proposed policy.
 //
+//	NOTE: This package is in beta. It is not stable, and may be subject to changes.
+//
 // # General documentation
 //
 // For information that is relevant for all client libraries please reference

--- a/visionai/apiv1/.repo-metadata.json
+++ b/visionai/apiv1/.repo-metadata.json
@@ -6,5 +6,5 @@
     "distribution_name": "cloud.google.com/go/visionai/apiv1",
     "language": "go",
     "library_type": "GAPIC_AUTO",
-    "release_level": "stable"
+    "release_level": "preview"
 }

--- a/visionai/apiv1/doc.go
+++ b/visionai/apiv1/doc.go
@@ -17,6 +17,8 @@
 // Package visionai is an auto-generated package for the
 // Vision AI API.
 //
+//	NOTE: This package is in beta. It is not stable, and may be subject to changes.
+//
 // # General documentation
 //
 // For information that is relevant for all client libraries please reference


### PR DESCRIPTION
Update `librarian` version and run `generate --all`.

Some `release_level` properties were updated based on a change in `librarian` heuristics for deriving the value. In each case, the change aligns with expectations imo. The heuristic is as follows:
* if the API path contains alpha or beta, the release_level is the `alpha` or `beta`
* if the API path is "stable" e.g. v1, but the client's version is `0.x`, the release_level is `beta`
* if the API path is "stable" e.g. v1, and the client's version is `x.0`, the release_level is `ga`

In each case changed below, the heuristic makes the appropriate change.

I separately filed a bug to work with y'all to promote the long tail of `0.x` clients to `1.x` which will automatically set these `vN` packages to release_level `ga` https://github.com/googleapis/librarian/issues/5303 :)