### PR TITLE
chore: librarian release pull request: 20260422T160822Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -2623,7 +2623,7 @@ libraries:
       - internal/generated/snippets/shopping/
     tag_format: '{id}/v{version}'
   - id: spanner
-    version: 1.90.0
+    version: 1.91.0
     last_generated_commit: ""
     apis:
       - path: google/spanner/adapter/v1

--- a/internal/generated/snippets/spanner/adapter/apiv1/snippet_metadata.google.spanner.adapter.v1.json
+++ b/internal/generated/snippets/spanner/adapter/apiv1/snippet_metadata.google.spanner.adapter.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/spanner/adapter/apiv1",
-    "version": "1.90.0"
+    "version": "1.91.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/spanner/admin/database/apiv1/snippet_metadata.google.spanner.admin.database.v1.json
+++ b/internal/generated/snippets/spanner/admin/database/apiv1/snippet_metadata.google.spanner.admin.database.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/spanner/admin/database/apiv1",
-    "version": "1.90.0"
+    "version": "1.91.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/spanner/admin/instance/apiv1/snippet_metadata.google.spanner.admin.instance.v1.json
+++ b/internal/generated/snippets/spanner/admin/instance/apiv1/snippet_metadata.google.spanner.admin.instance.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/spanner/admin/instance/apiv1",
-    "version": "1.90.0"
+    "version": "1.91.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/spanner/apiv1/snippet_metadata.google.spanner.v1.json
+++ b/internal/generated/snippets/spanner/apiv1/snippet_metadata.google.spanner.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/spanner/apiv1",
-    "version": "1.90.0"
+    "version": "1.91.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/spanner/executor/apiv1/snippet_metadata.google.spanner.executor.v1.json
+++ b/internal/generated/snippets/spanner/executor/apiv1/snippet_metadata.google.spanner.executor.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/spanner/executor/apiv1",
-    "version": "1.90.0"
+    "version": "1.91.0"
   },
   "snippets": [
     {

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -2262,7 +2262,7 @@ libraries:
             - F_open_telemetry_attributes
           path: google/shopping/merchant/productstudio/v1alpha
   - name: spanner
-    version: 1.90.0
+    version: 1.91.0
     apis:
       - path: google/spanner/v1
       - path: google/spanner/adapter/v1

--- a/spanner/CHANGES.md
+++ b/spanner/CHANGES.md
@@ -1,5 +1,7 @@
 # Changes
 
+## [1.91.0](https://github.com/googleapis/google-cloud-go/releases/tag/spanner%2Fv1.91.0) (2026-04-22)
+
 ## [1.90.0](https://github.com/googleapis/google-cloud-go/releases/tag/spanner%2Fv1.90.0) (2026-04-14)
 
 ### Features

--- a/spanner/internal/version.go
+++ b/spanner/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "1.90.0"
+const Version = "1.91.0"


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.10.2-0.20260421180302-dc35d110f9bb
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go@sha256:b04b076f5eedbb5546bd6fc1404969dd3698c8b19c0f34ae815a84ae735a606a
<details><summary>spanner: v1.91.0</summary>

## [v1.91.0](https://github.com/googleapis/google-cloud-go/compare/spanner/v1.90.0...spanner/v1.91.0) (2026-04-22)

</details>