### PR TITLE
docs: Rebrand Vertex AI to Gemini Enterprise Agent Platform

### DIFF
--- a/vertexai/README.md
+++ b/vertexai/README.md
@@ -6,6 +6,8 @@
 > New users are encouraged to use the Google GenAI Go SDK available at [google.golang.org/genai](http://pkg.go.dev/google.golang.org/genai)
 > For information about migrating to the Google Gen AI SDK, see [Vertex AI SDK migration guide](https://cloud.google.com/vertex-ai/generative-ai/docs/deprecations/genai-vertexai-sdk).
 
+Vertex AI is now Gemini Enterprise Agent Platform
+
 The Vertex AI Go SDK enables developers to use Google's state-of-the-art
 generative AI models (like Gemini) to build AI-powered features and
 applications.


### PR DESCRIPTION
Updated README to reflect rebranding of Vertex AI to Gemini Enterprise Agent Platform.