### PR TITLE
fix(auth): avoid double impersonation in idtoken and clarify docs

### DIFF
--- a/auth/credentials/detect.go
+++ b/auth/credentials/detect.go
@@ -138,6 +138,10 @@ func OnGCE() bool {
 // Google APIs can compromise the security of your systems and data. For
 // more information, refer to [Validate credential configurations from
 // external sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
+//
+// Note: If the detected credential configuration file contains a
+// `service_account_impersonation_url` field, the returned credentials will
+// yield tokens that are already impersonated to that target service account.
 func DetectDefault(opts *DetectOptions) (*auth.Credentials, error) {
 	if err := opts.validate(); err != nil {
 		return nil, err

--- a/auth/credentials/idtoken/file.go
+++ b/auth/credentials/idtoken/file.go
@@ -215,7 +215,11 @@ func baseCredsForImpersonation(t string, b []byte, opts *Options, creds *auth.Cr
 		if err != nil {
 			return nil, err
 		}
-		baseCreds = sourceCreds
+		baseCreds = auth.NewCredentials(&auth.CredentialsOptions{
+			TokenProvider:          sourceCreds,
+			JSON:                   b,
+			UniverseDomainProvider: auth.CredentialsPropertyFunc(creds.UniverseDomain),
+		})
 	}
 	return baseCreds, nil
 }

--- a/auth/credentials/idtoken/file.go
+++ b/auth/credentials/idtoken/file.go
@@ -23,6 +23,7 @@ import (
 	"cloud.google.com/go/auth"
 	"cloud.google.com/go/auth/credentials"
 	"cloud.google.com/go/auth/credentials/impersonate"
+	intexternalaccount "cloud.google.com/go/auth/credentials/internal/externalaccount"
 	intimpersonate "cloud.google.com/go/auth/credentials/internal/impersonate"
 	"cloud.google.com/go/auth/internal"
 	"cloud.google.com/go/auth/internal/credsfile"
@@ -34,6 +35,13 @@ const (
 	iamCredAud  = "https://iamcredentials.googleapis.com/"
 )
 
+// credsFromDefault takes the credentials detected from the environment or JSON
+// and constructs appropriate ID token credentials.
+//
+// Note: For ExternalAccount and ImpersonatedServiceAccount types, this function
+// will create a new, non-impersonated base credential to avoid double
+// impersonation when generating the ID token. It does not use the provided
+// 'creds' as-is for these types.
 func credsFromDefault(creds *auth.Credentials, opts *Options) (*auth.Credentials, error) {
 	b := creds.JSON()
 	t, err := credsfile.ParseFileType(b)
@@ -82,12 +90,18 @@ func credsFromDefault(creds *auth.Credentials, opts *Options) (*auth.Credentials
 		}
 		account := filepath.Base(accountURL.ServiceAccountImpersonationURL)
 		account = strings.Split(account, ":")[0]
+
+		baseCreds, err := baseCredsForImpersonation(t, b, opts, creds)
+		if err != nil {
+			return nil, err
+		}
+
 		config := impersonate.IDTokenOptions{
 			Audience:        opts.Audience,
 			TargetPrincipal: account,
 			IncludeEmail:    true,
 			Client:          opts.client(),
-			Credentials:     creds,
+			Credentials:     baseCreds, // Use the non-impersonated base credentials!
 			Logger:          internallog.New(opts.Logger),
 		}
 		idTokenCreds, err := impersonate.NewIDTokenCredentials(&config)
@@ -140,4 +154,68 @@ func resolveUniverseDomain(f *credsfile.ServiceAccountFile) string {
 		return f.UniverseDomain
 	}
 	return internal.DefaultUniverseDomain
+}
+
+// baseCredsForImpersonation constructs a non-impersonated base credential
+// provider to avoid double impersonation. The 'creds' object returned by
+// DetectDefault is already impersonated because it faithfully fulfills the
+// instructions in the configuration file. However, for the specific context of
+// generating an ID token, we must bypass that first layer of impersonation and
+// use the source principal directly to call the generateIdToken API. This
+// maintains separation of concerns by letting DetectDefault act as a general
+// loader while handling the specific needs of idtoken generation here, avoiding
+// a leaky abstraction in core packages.
+func baseCredsForImpersonation(t string, b []byte, opts *Options, creds *auth.Credentials) (*auth.Credentials, error) {
+	var baseCreds *auth.Credentials
+	if credentials.CredType(t) == credentials.ExternalAccount {
+		f, err := credsfile.ParseExternalAccount(b)
+		if err != nil {
+			return nil, err
+		}
+		externalOpts := &intexternalaccount.Options{
+			Audience:                 f.Audience,
+			SubjectTokenType:         f.SubjectTokenType,
+			TokenURL:                 f.TokenURL,
+			TokenInfoURL:             f.TokenInfoURL,
+			ClientSecret:             f.ClientSecret,
+			ClientID:                 f.ClientID,
+			CredentialSource:         f.CredentialSource,
+			QuotaProjectID:           f.QuotaProjectID,
+			Scopes:                   []string{"https://www.googleapis.com/auth/cloud-platform"},
+			WorkforcePoolUserProject: f.WorkforcePoolUserProject,
+			Client:                   opts.client(),
+			Logger:                   opts.Logger,
+			IsDefaultClient:          opts.Client == nil,
+		}
+		// Do NOT set ServiceAccountImpersonationURL here to avoid the first layer of impersonation!
+		baseTP, err := intexternalaccount.NewTokenProvider(externalOpts)
+		if err != nil {
+			return nil, err
+		}
+		baseCreds = auth.NewCredentials(&auth.CredentialsOptions{
+			TokenProvider:          baseTP,
+			JSON:                   b,
+			UniverseDomainProvider: auth.CredentialsPropertyFunc(creds.UniverseDomain),
+		})
+	} else {
+		// For ImpersonatedServiceAccount
+		f, err := credsfile.ParseImpersonatedServiceAccount(b)
+		if err != nil {
+			return nil, err
+		}
+		// Extract source credentials
+		sourceOpts := &credentials.DetectOptions{
+			Scopes:           []string{"https://www.googleapis.com/auth/cloud-platform"},
+			CredentialsJSON:  f.CredSource,
+			Client:           opts.client(),
+			UseSelfSignedJWT: true,
+		}
+		// Detect credentials for the source
+		sourceCreds, err := credentials.DetectDefault(sourceOpts)
+		if err != nil {
+			return nil, err
+		}
+		baseCreds = sourceCreds
+	}
+	return baseCreds, nil
 }

--- a/auth/credentials/idtoken/idtoken.go
+++ b/auth/credentials/idtoken/idtoken.go
@@ -176,7 +176,11 @@ func (o *Options) validate() error {
 // empty, an attempt will be made to detect credentials from the environment
 // (see [cloud.google.com/go/auth/credentials.DetectDefault]). Only service
 // account, impersonated service account, external account and Compute
-// credentials are supported.
+// credentials are supported. Note: If the provided external account
+// configuration (e.g., Workload Identity Federation) is configured to
+// impersonate a service account, the returned credentials will yield ID tokens
+// representing that target service account, rather than the external workload
+// principal that initiated the request.
 func NewCredentials(opts *Options) (*auth.Credentials, error) {
 	if err := opts.validate(); err != nil {
 		return nil, err

--- a/auth/credentials/idtoken/idtoken_test.go
+++ b/auth/credentials/idtoken/idtoken_test.go
@@ -275,6 +275,17 @@ func TestNewCredentials_ImpersonatedAndExternal(t *testing.T) {
 			if tok.Value != wantTok {
 				t.Errorf("got %q, want %q", tok.Value, wantTok)
 			}
+			// Assertions for JSON and UniverseDomain propagation
+			if len(creds.JSON()) == 0 {
+				t.Error("expected non-empty JSON from credentials")
+			}
+			ud, err := creds.UniverseDomain(context.Background())
+			if err != nil {
+				t.Fatal(err)
+			}
+			if ud != internal.DefaultUniverseDomain {
+				t.Errorf("got %q, want %q", ud, internal.DefaultUniverseDomain)
+			}
 		})
 	}
 }

--- a/auth/credentials/idtoken/idtoken_test.go
+++ b/auth/credentials/idtoken/idtoken_test.go
@@ -241,6 +241,9 @@ func TestNewCredentials_ImpersonatedAndExternal(t *testing.T) {
 			client := internal.DefaultClient()
 			client.Transport = mockTransport{
 				handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if strings.Contains(r.URL.Path, "generateAccessToken") {
+						t.Errorf("unexpected call to generateAccessToken")
+					}
 					w.Write([]byte(fmt.Sprintf(`{"token": %q}`, wantTok)))
 				}),
 			}


### PR DESCRIPTION
When using Workload Identity Federation or Impersonated Service Accounts with a service account impersonation URL, `idtoken.NewCredentials` fails due to double impersonation. `credentials.DetectDefault` correctly creates a provider that impersonates the service account to get an access token (fulfilling the file's request for general use).

However, `idtoken.NewCredentials` incorrectly wraps that already-impersonated provider in another impersonation layer to get an ID token, failing to recognize the pre-existing impersonation state. This results in the service account trying to impersonate itself, failing with a 403 PERMISSION_DENIED error on `iam.serviceAccounts.getOpenIdToken`.

This PR fixes the issue by ensuring we use a non-impersonated base credential provider to do the initial token fetch, and then wrap that in a single impersonated provider to get the ID token.

We also update the documentation for `NewCredentials` and `DetectDefault` to clarify their behavior regarding impersonation.

closes: #11105