### PR TITLE
fix(bigtable): disable connection pooling when emulator is set

### DIFF
--- a/bigtable/integration_test.go
+++ b/bigtable/integration_test.go
@@ -38,8 +38,8 @@ import (
 
 	cryptorand "crypto/rand"
 
-	"cloud.google.com/go/bigtable/bttest"
 	btapb "cloud.google.com/go/bigtable/admin/apiv2/adminpb"
+	"cloud.google.com/go/bigtable/bttest"
 	"cloud.google.com/go/civil"
 	"cloud.google.com/go/iam"
 	"cloud.google.com/go/internal"

--- a/bigtable/integration_test.go
+++ b/bigtable/integration_test.go
@@ -38,6 +38,7 @@ import (
 
 	cryptorand "crypto/rand"
 
+	"cloud.google.com/go/bigtable/bttest"
 	btapb "cloud.google.com/go/bigtable/admin/apiv2/adminpb"
 	"cloud.google.com/go/civil"
 	"cloud.google.com/go/iam"
@@ -485,6 +486,23 @@ func TestIntegration_NoopMetricsProvider(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadRows: %v", err)
 	}
+}
+
+func TestIntegration_NewClientWithEmulatorHost(t *testing.T) {
+	srv, err := bttest.NewServer("localhost:0")
+	if err != nil {
+		t.Fatalf("failed to start bttest server: %v", err)
+	}
+	defer srv.Close()
+
+	t.Setenv("BIGTABLE_EMULATOR_HOST", srv.Addr)
+
+	ctx := context.Background()
+	client, err := NewClient(ctx, "test-project", "test-instance")
+	if err != nil {
+		t.Fatalf("NewClient failed with emulator host: %v", err)
+	}
+	defer client.Close()
 }
 
 func TestIntegration_ExportBuiltInMetrics(t *testing.T) {

--- a/bigtable/internal/option/option.go
+++ b/bigtable/internal/option/option.go
@@ -193,6 +193,10 @@ func BigtableLoadBalancingStrategy() LoadBalancingStrategy {
 
 // EnableBigtableConnectionPool uses new conn pool unless envVar is explicitly false.
 func EnableBigtableConnectionPool() bool {
+	// Connection pool is not supported/needed with the emulator.
+	if os.Getenv("BIGTABLE_EMULATOR_HOST") != "" {
+		return false
+	}
 	bigtableConnPoolEnvVal := os.Getenv(BigtableConnectionPoolEnvVar)
 	if bigtableConnPoolEnvVal == "" {
 		return true

--- a/bigtable/internal/option/option.go
+++ b/bigtable/internal/option/option.go
@@ -191,7 +191,7 @@ func BigtableLoadBalancingStrategy() LoadBalancingStrategy {
 	return parseLoadBalancingStrategy(strategyStr)
 }
 
-// EnableBigtableConnectionPool uses new conn pool unless envVar is explicitly false.
+// EnableBigtableConnectionPool returns true if the custom connection pool should be used. It returns false if the emulator is detected or if the pool is explicitly disabled via environment variable.
 func EnableBigtableConnectionPool() bool {
 	// Connection pool is not supported/needed with the emulator.
 	if os.Getenv("BIGTABLE_EMULATOR_HOST") != "" {

--- a/bigtable/internal/option/option_test.go
+++ b/bigtable/internal/option/option_test.go
@@ -33,6 +33,12 @@ func TestEnableBigtableConnectionPool(t *testing.T) {
 			want:         false,
 		},
 		{
+			desc:         "emulator host set, conn pool env true, should return false",
+			emulatorHost: "localhost:8086",
+			connPoolEnv:  "true",
+			want:         false,
+		},
+		{
 			desc:         "emulator host not set, conn pool env not set, should return true",
 			emulatorHost: "",
 			connPoolEnv:  "",

--- a/bigtable/internal/option/option_test.go
+++ b/bigtable/internal/option/option_test.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package option
+
+import (
+	"testing"
+)
+
+func TestEnableBigtableConnectionPool(t *testing.T) {
+	tests := []struct {
+		desc          string
+		emulatorHost  string
+		connPoolEnv   string
+		want          bool
+	}{
+		{
+			desc:         "emulator host set, should return false",
+			emulatorHost: "localhost:8086",
+			want:         false,
+		},
+		{
+			desc:         "emulator host not set, conn pool env not set, should return true",
+			emulatorHost: "",
+			connPoolEnv:  "",
+			want:         true,
+		},
+		{
+			desc:         "emulator host not set, conn pool env true, should return true",
+			emulatorHost: "",
+			connPoolEnv:  "true",
+			want:         true,
+		},
+		{
+			desc:         "emulator host not set, conn pool env false, should return false",
+			emulatorHost: "",
+			connPoolEnv:  "false",
+			want:         false,
+		},
+		{
+			desc:         "emulator host not set, conn pool env invalid, should return true",
+			emulatorHost: "",
+			connPoolEnv:  "invalid",
+			want:         true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			if test.emulatorHost != "" {
+				t.Setenv("BIGTABLE_EMULATOR_HOST", test.emulatorHost)
+			} else {
+				t.Setenv("BIGTABLE_EMULATOR_HOST", "")
+			}
+
+			if test.connPoolEnv != "" {
+				t.Setenv(BigtableConnectionPoolEnvVar, test.connPoolEnv)
+			} else {
+				t.Setenv(BigtableConnectionPoolEnvVar, "")
+			}
+
+			got := EnableBigtableConnectionPool()
+			if got != test.want {
+				t.Errorf("EnableBigtableConnectionPool() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}

--- a/bigtable/internal/option/option_test.go
+++ b/bigtable/internal/option/option_test.go
@@ -22,10 +22,10 @@ import (
 
 func TestEnableBigtableConnectionPool(t *testing.T) {
 	tests := []struct {
-		desc          string
-		emulatorHost  string
-		connPoolEnv   string
-		want          bool
+		desc         string
+		emulatorHost string
+		connPoolEnv  string
+		want         bool
 	}{
 		{
 			desc:         "emulator host set, should return false",


### PR DESCRIPTION


#### Summary
This PR fixes issue #14480 . The fix automatically disables the custom connection pool whenever the `BIGTABLE_EMULATOR_HOST` environment variable is detected.

#### Root Cause
In recent versions (v1.26.0+), the custom Bigtable connection pool is enabled by default for production traffic . However, when `BIGTABLE_EMULATOR_HOST` is set, the client library initializes a single shared `*grpc.ClientConn` . 

The custom connection pool expects to manage the lifecycle of multiple unique channels. Because the emulator uses a single pre-dialed connection, the pool's attempt to "prime" or manage multiple internal connections results in conflicts. Specifically, if the pool attempts to close or recycle a connection wrapper, it inadvertently closes the shared underlying gRPC connection for all other members of the pool, leading to errors such as `rpc error: code = Canceled desc = grpc: the client connection is closing`.

#### Changes
Modified `google3/third_party/golang/cloud_google_com/go/bigtable/v/v1/internal/option/option.go`:
- Updated `EnableBigtableConnectionPool` to check for the `BIGTABLE_EMULATOR_HOST` environment variable .
- If the emulator host is set, the function now returns `false`, ensuring the client falls back to the standard connection logic.

This change automates the current manual workaround of setting `CBT_BIGTABLE_CONN_POOL=false` when using the emulator .


Fixes: #14480 