### PR TITLE
Allow for Arrow compression

### DIFF
--- a/bigquery/options.go
+++ b/bigquery/options.go
@@ -21,7 +21,8 @@ import (
 
 // type for collecting custom ClientOption values.
 type customClientConfig struct {
-	jobCreationMode JobCreationMode
+	jobCreationMode       JobCreationMode
+	arrowCompressionCodec ArrowCompressionCodec
 }
 
 type customClientOption interface {
@@ -70,4 +71,33 @@ type applierJobCreationMode struct {
 
 func (s *applierJobCreationMode) ApplyCustomClientOpt(c *customClientConfig) {
 	c.jobCreationMode = s.mode
+}
+
+// ArrowCompressionCodec controls the compression codec used for Arrow buffers in
+// serialized record batches when using the Storage Read API.
+type ArrowCompressionCodec string
+
+const (
+	// ArrowCompressionUnspecified is the default (unspecified) option.
+	ArrowCompressionUnspecified ArrowCompressionCodec = "COMPRESSION_UNSPECIFIED"
+	// ArrowCompressionLZ4Frame indicates LZ4_FRAME compression.
+	ArrowCompressionLZ4Frame ArrowCompressionCodec = "LZ4_FRAME"
+	// ArrowCompressionZSTD indicates ZSTD compression.
+	ArrowCompressionZSTD ArrowCompressionCodec = "ZSTD"
+)
+
+// WithArrowCompression is a ClientOption that governs the compression codec used
+// for Arrow buffers when fetching results via the Storage Read API.
+func WithArrowCompression(codec ArrowCompressionCodec) option.ClientOption {
+	return &applierArrowCompression{codec: codec}
+}
+
+// applier for propagating the custom client option to the config object
+type applierArrowCompression struct {
+	internaloption.EmbeddableAdapter
+	codec ArrowCompressionCodec
+}
+
+func (s *applierArrowCompression) ApplyCustomClientOpt(c *customClientConfig) {
+	c.arrowCompressionCodec = s.codec
 }

--- a/bigquery/storage_client.go
+++ b/bigquery/storage_client.go
@@ -37,16 +37,18 @@ type readClient struct {
 }
 
 type readClientSettings struct {
-	maxStreamCount int
-	maxWorkerCount int
+	maxStreamCount        int
+	maxWorkerCount        int
+	arrowCompressionCodec ArrowCompressionCodec
 }
 
 func defaultReadClientSettings() readClientSettings {
 	maxWorkerCount := runtime.GOMAXPROCS(0)
 	return readClientSettings{
 		// with zero, the server will provide a value of streams so as to produce reasonable throughput
-		maxStreamCount: 0,
-		maxWorkerCount: maxWorkerCount,
+		maxStreamCount:        0,
+		maxWorkerCount:        maxWorkerCount,
+		arrowCompressionCodec: ArrowCompressionUnspecified,
 	}
 }
 
@@ -74,7 +76,10 @@ func newReadClient(ctx context.Context, projectID string, opts ...option.ClientO
 		return nil, err
 	}
 
+	conf := newCustomClientConfig(opts...)
 	settings := defaultReadClientSettings()
+	settings.arrowCompressionCodec = conf.arrowCompressionCodec
+
 	rc := &readClient{
 		rawClient: rawClient,
 		projectID: projectID,
@@ -151,6 +156,26 @@ func (rs *readSession) start() error {
 		MaxStreamCount:          maxStreamCount,
 		PreferredMinStreamCount: preferredMinStreamCount,
 	}
+
+	codec := storagepb.ArrowSerializationOptions_COMPRESSION_UNSPECIFIED
+	switch rs.settings.arrowCompressionCodec {
+	case ArrowCompressionLZ4Frame:
+		codec = storagepb.ArrowSerializationOptions_LZ4_FRAME
+	case ArrowCompressionZSTD:
+		codec = storagepb.ArrowSerializationOptions_ZSTD
+	}
+
+	if codec != storagepb.ArrowSerializationOptions_COMPRESSION_UNSPECIFIED {
+		if createReadSessionRequest.ReadSession.ReadOptions == nil {
+			createReadSessionRequest.ReadSession.ReadOptions = &storagepb.ReadSession_TableReadOptions{}
+		}
+		createReadSessionRequest.ReadSession.ReadOptions.OutputFormatSerializationOptions = &storagepb.ReadSession_TableReadOptions_ArrowSerializationOptions{
+			ArrowSerializationOptions: &storagepb.ArrowSerializationOptions{
+				BufferCompression: codec,
+			},
+		}
+	}
+
 	rpcOpts := gax.WithGRPCOptions(
 		// Read API can send batches up to 128MB
 		// https://cloud.google.com/bigquery/quotas#storage-limits

--- a/bigquery/storage_client_test.go
+++ b/bigquery/storage_client_test.go
@@ -1,0 +1,87 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bigquery
+
+import (
+	"context"
+	"testing"
+
+	"cloud.google.com/go/bigquery/storage/apiv1/storagepb"
+	gax "github.com/googleapis/gax-go/v2"
+)
+
+func TestReadSessionStart_ArrowCompression(t *testing.T) {
+	ctx := context.Background()
+	testCases := []struct {
+		desc      string
+		codec     ArrowCompressionCodec
+		wantCodec storagepb.ArrowSerializationOptions_CompressionCodec
+	}{
+		{
+			desc:      "unspecified",
+			codec:     ArrowCompressionUnspecified,
+			wantCodec: storagepb.ArrowSerializationOptions_COMPRESSION_UNSPECIFIED,
+		},
+		{
+			desc:      "lz4",
+			codec:     ArrowCompressionLZ4Frame,
+			wantCodec: storagepb.ArrowSerializationOptions_LZ4_FRAME,
+		},
+		{
+			desc:      "zstd",
+			codec:     ArrowCompressionZSTD,
+			wantCodec: storagepb.ArrowSerializationOptions_ZSTD,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			settings := defaultReadClientSettings()
+			settings.arrowCompressionCodec = tc.codec
+
+			var capturedReq *storagepb.CreateReadSessionRequest
+			rs := &readSession{
+				ctx:      ctx,
+				settings: settings,
+				createReadSessionFunc: func(ctx context.Context, req *storagepb.CreateReadSessionRequest, opts ...gax.CallOption) (*storagepb.ReadSession, error) {
+					capturedReq = req
+					return &storagepb.ReadSession{}, nil
+				},
+			}
+
+			if err := rs.start(); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if capturedReq == nil {
+				t.Fatal("request was not captured")
+			}
+
+			if tc.wantCodec == storagepb.ArrowSerializationOptions_COMPRESSION_UNSPECIFIED {
+				if capturedReq.ReadSession.ReadOptions != nil && capturedReq.ReadSession.ReadOptions.GetArrowSerializationOptions() != nil {
+					t.Errorf("expected no arrow serialization options for unspecified codec, got %v", capturedReq.ReadSession.ReadOptions.GetArrowSerializationOptions())
+				}
+			} else {
+				opts := capturedReq.ReadSession.ReadOptions.GetArrowSerializationOptions()
+				if opts == nil {
+					t.Fatal("expected arrow serialization options, got nil")
+				}
+				if opts.BufferCompression != tc.wantCodec {
+					t.Errorf("expected codec %v, got %v", tc.wantCodec, opts.BufferCompression)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Right now, the library doesn't support the Arrow compression settings. The options exist on the API, so we just need to wire it all up and expose it on the client.