### PR TITLE
test(pubsub/v2): fix streaming pull mock test race condition

### DIFF
--- a/pubsub/mock_test.go
+++ b/pubsub/mock_test.go
@@ -112,11 +112,13 @@ func (s *mockServer) StreamingPull(stream pb.Subscriber_StreamingPullServer) err
 		s.mu.Unlock()
 		return errors.New("mock server stopped")
 	}
-	// Add 2 to the WaitGroup: one for this main loop and one for the receive goroutine below.
-	s.wg.Add(2)
+	s.wg.Add(1)
+	defer s.wg.Done()
+
+	// increment the waitgroup again to account for the goroutine below
+	s.wg.Add(1)
 	s.mu.Unlock()
 
-	defer s.wg.Done()
 	errc := make(chan error, 1)
 	go func() {
 		defer s.wg.Done()

--- a/pubsub/mock_test.go
+++ b/pubsub/mock_test.go
@@ -43,6 +43,7 @@ type mockServer struct {
 	modAckErrs    []error
 	wg            sync.WaitGroup
 	sub           *pb.Subscription
+	stopped       bool
 }
 
 type pullResponse struct {
@@ -99,11 +100,24 @@ func (s *mockServer) wait() {
 	s.wg.Wait()
 }
 
+func (s *mockServer) stop() {
+	s.mu.Lock()
+	s.stopped = true
+	s.mu.Unlock()
+}
+
 func (s *mockServer) StreamingPull(stream pb.Subscriber_StreamingPullServer) error {
-	s.wg.Add(1)
+	s.mu.Lock()
+	if s.stopped {
+		s.mu.Unlock()
+		return errors.New("mock server stopped")
+	}
+	// Add 2 to the WaitGroup: one for this main loop and one for the receive goroutine below.
+	s.wg.Add(2)
+	s.mu.Unlock()
+
 	defer s.wg.Done()
 	errc := make(chan error, 1)
-	s.wg.Add(1)
 	go func() {
 		defer s.wg.Done()
 		for {

--- a/pubsub/mock_test.go
+++ b/pubsub/mock_test.go
@@ -112,10 +112,11 @@ func (s *mockServer) StreamingPull(stream pb.Subscriber_StreamingPullServer) err
 		s.mu.Unlock()
 		return errors.New("mock server stopped")
 	}
+	// this first Add accounts for the outer send loop.
 	s.wg.Add(1)
 	defer s.wg.Done()
 
-	// increment the waitgroup again to account for the goroutine below
+	// this second Add accounts for the recv loop inside the goroutine.
 	s.wg.Add(1)
 	s.mu.Unlock()
 

--- a/pubsub/streaming_pull_test.go
+++ b/pubsub/streaming_pull_test.go
@@ -243,9 +243,10 @@ func TestStreamingPullRetry(t *testing.T) {
 		if !testutil.Equal(got, want, opts...) {
 			t.Errorf("%d: got\n%#v\nwant\n%#v", i, got, want)
 		}
-		server.stop()
-		server.wait()
-		for i := 0; i < len(testMessages); i++ {
+	}
+	server.stop()
+	server.wait()
+	for i := 0; i < len(testMessages); i++ {
 		id := testMessages[i].AckId
 		server.mu.Lock()
 		if i%2 == 0 {

--- a/pubsub/streaming_pull_test.go
+++ b/pubsub/streaming_pull_test.go
@@ -113,6 +113,7 @@ func testStreamingPullIteration(t *testing.T, client *Client, server *mockServer
 			t.Errorf("%d: got\n%#v\nwant\n%#v", i, got, want)
 		}
 	}
+	server.stop()
 	server.wait()
 	for i := 0; i < len(msgs); i++ {
 		id := msgs[i].AckId
@@ -242,9 +243,9 @@ func TestStreamingPullRetry(t *testing.T) {
 		if !testutil.Equal(got, want, opts...) {
 			t.Errorf("%d: got\n%#v\nwant\n%#v", i, got, want)
 		}
-	}
-	server.wait()
-	for i := 0; i < len(testMessages); i++ {
+		server.stop()
+		server.wait()
+		for i := 0; i < len(testMessages); i++ {
 		id := testMessages[i].AckId
 		server.mu.Lock()
 		if i%2 == 0 {

--- a/pubsub/v2/mock_test.go
+++ b/pubsub/v2/mock_test.go
@@ -112,11 +112,13 @@ func (s *mockServer) StreamingPull(stream pb.Subscriber_StreamingPullServer) err
 		s.mu.Unlock()
 		return errors.New("mock server stopped")
 	}
-	// Add 2 to the WaitGroup: one for this main loop and one for the receive goroutine below.
-	s.wg.Add(2)
+	s.wg.Add(1)
+	defer s.wg.Done()
+
+	// increment the waitgroup again to account for the goroutine below
+	s.wg.Add(1)
 	s.mu.Unlock()
 
-	defer s.wg.Done()
 	errc := make(chan error, 1)
 	go func() {
 		defer s.wg.Done()

--- a/pubsub/v2/mock_test.go
+++ b/pubsub/v2/mock_test.go
@@ -43,6 +43,7 @@ type mockServer struct {
 	modAckErrs    []error
 	wg            sync.WaitGroup
 	sub           *pb.Subscription
+	stopped       bool
 }
 
 type pullResponse struct {
@@ -99,11 +100,24 @@ func (s *mockServer) wait() {
 	s.wg.Wait()
 }
 
+func (s *mockServer) stop() {
+	s.mu.Lock()
+	s.stopped = true
+	s.mu.Unlock()
+}
+
 func (s *mockServer) StreamingPull(stream pb.Subscriber_StreamingPullServer) error {
-	s.wg.Add(1)
+	s.mu.Lock()
+	if s.stopped {
+		s.mu.Unlock()
+		return errors.New("mock server stopped")
+	}
+	// Add 2 to the WaitGroup: one for this main loop and one for the receive goroutine below.
+	s.wg.Add(2)
+	s.mu.Unlock()
+
 	defer s.wg.Done()
 	errc := make(chan error, 1)
-	s.wg.Add(1)
 	go func() {
 		defer s.wg.Done()
 		for {

--- a/pubsub/v2/mock_test.go
+++ b/pubsub/v2/mock_test.go
@@ -112,10 +112,11 @@ func (s *mockServer) StreamingPull(stream pb.Subscriber_StreamingPullServer) err
 		s.mu.Unlock()
 		return errors.New("mock server stopped")
 	}
+	// this first Add accounts for the outer send loop.
 	s.wg.Add(1)
 	defer s.wg.Done()
 
-	// increment the waitgroup again to account for the goroutine below
+	// this second Add accounts for the recv loop inside the goroutine.
 	s.wg.Add(1)
 	s.mu.Unlock()
 

--- a/pubsub/v2/streaming_pull_test.go
+++ b/pubsub/v2/streaming_pull_test.go
@@ -113,6 +113,7 @@ func testStreamingPullIteration(t *testing.T, client *Client, server *mockServer
 			t.Errorf("%d: got\n%#v\nwant\n%#v", i, got, want)
 		}
 	}
+	server.stop()
 	server.wait()
 	server.mu.Lock()
 	defer server.mu.Unlock()
@@ -245,6 +246,7 @@ func TestStreamingPullRetry(t *testing.T) {
 			t.Errorf("%d: got\n%#v\nwant\n%#v", i, got, want)
 		}
 	}
+	server.stop()
 	server.wait()
 	for i := 0; i < len(testMessages); i++ {
 		id := testMessages[i].AckId


### PR DESCRIPTION
The same changes are mirrored between `pubsub` and `pubsub/v2`

Fixes #13748