### PR TITLE
chore: librarian release pull request: 20260427T183321Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1046,7 +1046,7 @@ libraries:
       - internal/generated/snippets/dataqna/
     tag_format: '{id}/v{version}'
   - id: datastore
-    version: 1.22.0
+    version: 1.23.0
     last_generated_commit: ""
     apis:
       - path: google/datastore/admin/v1

--- a/datastore/CHANGES.md
+++ b/datastore/CHANGES.md
@@ -1,5 +1,7 @@
 # Changes
 
+## [1.23.0](https://github.com/googleapis/google-cloud-go/releases/tag/datastore%2Fv1.23.0) (2026-04-27)
+
 ## [1.22.0](https://github.com/googleapis/google-cloud-go/releases/tag/datastore%2Fv1.22.0) (2026-02-04)
 
 ### Features

--- a/datastore/internal/version.go
+++ b/datastore/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "1.22.0"
+const Version = "1.23.0"

--- a/internal/generated/snippets/datastore/admin/apiv1/snippet_metadata.google.datastore.admin.v1.json
+++ b/internal/generated/snippets/datastore/admin/apiv1/snippet_metadata.google.datastore.admin.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/datastore/admin/apiv1",
-    "version": "1.22.0"
+    "version": "1.23.0"
   },
   "snippets": [
     {

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -18,16 +18,7 @@ sources:
   googleapis:
     commit: 939ba3bf8408af83f0f73ae35c76c4b11a8c8c8d
     sha256: 70829cda81b9c69ae4f5f2a42f347c263b62cd69eb6a87b70555aab6ae5b6d74
-tools:
-  go:
-    - name: github.com/googleapis/gapic-generator-go/cmd/protoc-gen-go_gapic
-      version: v0.58.0
-    - name: golang.org/x/tools/cmd/goimports
-      version: v0.44.0
-    - name: google.golang.org/grpc/cmd/protoc-gen-go-grpc
-      version: v1.3.0
-    - name: google.golang.org/protobuf/cmd/protoc-gen-go
-      version: v1.36.11
+tools: {}
 release: {}
 default:
   tag_format: '{name}/v{version}'
@@ -935,7 +926,7 @@ libraries:
             - F_open_telemetry_attributes
           path: google/cloud/dataqna/v1alpha
   - name: datastore
-    version: 1.22.0
+    version: 1.23.0
     apis:
       - path: google/datastore/v1
       - path: google/datastore/admin/v1
@@ -1465,7 +1456,6 @@ libraries:
       - path: google/maps/solar/v1
       - path: google/maps/fleetengine/delivery/v1
       - path: google/maps/mapmanagement/v2beta
-    title_override: Google Maps Platform
     go:
       go_apis:
         - enabled_generator_features:


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.10.1
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go@sha256:b04b076f5eedbb5546bd6fc1404969dd3698c8b19c0f34ae815a84ae735a606a
<details><summary>datastore: v1.23.0</summary>

## [v1.23.0](https://github.com/googleapis/google-cloud-go/compare/datastore/v1.22.0...datastore/v1.23.0) (2026-04-27)

</details>