### PR TITLE
chore: restore librarian tools, update gapic-generator-go version

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -18,7 +18,15 @@ sources:
   googleapis:
     commit: 939ba3bf8408af83f0f73ae35c76c4b11a8c8c8d
     sha256: 70829cda81b9c69ae4f5f2a42f347c263b62cd69eb6a87b70555aab6ae5b6d74
-tools: {}
+tools: 
+  - name: github.com/googleapis/gapic-generator-go/cmd/protoc-gen-go_gapic
+    version: v0.59.0
+  - name: golang.org/x/tools/cmd/goimports
+    version: v0.44.0
+  - name: google.golang.org/grpc/cmd/protoc-gen-go-grpc
+    version: v1.3.0
+  - name: google.golang.org/protobuf/cmd/protoc-gen-go
+    version: v1.36.11
 release: {}
 default:
   tag_format: '{name}/v{version}'

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -19,14 +19,15 @@ sources:
     commit: 939ba3bf8408af83f0f73ae35c76c4b11a8c8c8d
     sha256: 70829cda81b9c69ae4f5f2a42f347c263b62cd69eb6a87b70555aab6ae5b6d74
 tools: 
-  - name: github.com/googleapis/gapic-generator-go/cmd/protoc-gen-go_gapic
-    version: v0.59.0
-  - name: golang.org/x/tools/cmd/goimports
-    version: v0.44.0
-  - name: google.golang.org/grpc/cmd/protoc-gen-go-grpc
-    version: v1.3.0
-  - name: google.golang.org/protobuf/cmd/protoc-gen-go
-    version: v1.36.11
+  go:
+    - name: github.com/googleapis/gapic-generator-go/cmd/protoc-gen-go_gapic
+      version: v0.59.0
+    - name: golang.org/x/tools/cmd/goimports
+      version: v0.44.0
+    - name: google.golang.org/grpc/cmd/protoc-gen-go-grpc
+      version: v1.3.0
+    - name: google.golang.org/protobuf/cmd/protoc-gen-go
+      version: v1.36.11
 release: {}
 default:
   tag_format: '{name}/v{version}'


### PR DESCRIPTION
This PR does two things:

* restore the tools section of librarian yaml, which got purged as part of https://github.com/googleapis/google-cloud-go/pull/14491
* Update the gapic-generator-go version to 0.59.0