### PR TITLE
chore: update librarian to v0.11.0

### DIFF
--- a/apihub/apiv1/doc.go
+++ b/apihub/apiv1/doc.go
@@ -42,7 +42,7 @@
 //	// - It may require correct/in-range values for request initialization.
 //	// - It may require specifying regional endpoints when creating the service client as shown in:
 //	//   https://pkg.go.dev/cloud.google.com/go#hdr-Client_Options
-//	c, err := apihub.NewClient(ctx)
+//	c, err := apihub.NewRESTClient(ctx)
 //	if err != nil {
 //		// TODO: Handle error.
 //	}
@@ -69,7 +69,7 @@
 //
 // # Use of Context
 //
-// The ctx passed to NewClient is used for authentication requests and
+// The ctx passed to NewRESTClient is used for authentication requests and
 // for creating the underlying connection, but is not used for subsequent calls.
 // Individual methods on the client use the ctx given to them.
 //

--- a/compute/apiv1/doc.go
+++ b/compute/apiv1/doc.go
@@ -40,7 +40,7 @@
 //	// - It may require correct/in-range values for request initialization.
 //	// - It may require specifying regional endpoints when creating the service client as shown in:
 //	//   https://pkg.go.dev/cloud.google.com/go#hdr-Client_Options
-//	c, err := compute.NewAcceleratorTypesClient(ctx)
+//	c, err := compute.NewAcceleratorTypesRESTClient(ctx)
 //	if err != nil {
 //		// TODO: Handle error.
 //	}
@@ -79,7 +79,7 @@
 //
 // # Use of Context
 //
-// The ctx passed to NewAcceleratorTypesClient is used for authentication requests and
+// The ctx passed to NewAcceleratorTypesRESTClient is used for authentication requests and
 // for creating the underlying connection, but is not used for subsequent calls.
 // Individual methods on the client use the ctx given to them.
 //

--- a/compute/apiv1beta/doc.go
+++ b/compute/apiv1beta/doc.go
@@ -42,7 +42,7 @@
 //	// - It may require correct/in-range values for request initialization.
 //	// - It may require specifying regional endpoints when creating the service client as shown in:
 //	//   https://pkg.go.dev/cloud.google.com/go#hdr-Client_Options
-//	c, err := compute.NewAcceleratorTypesClient(ctx)
+//	c, err := compute.NewAcceleratorTypesRESTClient(ctx)
 //	if err != nil {
 //		// TODO: Handle error.
 //	}
@@ -81,7 +81,7 @@
 //
 // # Use of Context
 //
-// The ctx passed to NewAcceleratorTypesClient is used for authentication requests and
+// The ctx passed to NewAcceleratorTypesRESTClient is used for authentication requests and
 // for creating the underlying connection, but is not used for subsequent calls.
 // Individual methods on the client use the ctx given to them.
 //

--- a/gkeconnect/gateway/apiv1/doc.go
+++ b/gkeconnect/gateway/apiv1/doc.go
@@ -45,7 +45,7 @@
 //	// - It may require correct/in-range values for request initialization.
 //	// - It may require specifying regional endpoints when creating the service client as shown in:
 //	//   https://pkg.go.dev/cloud.google.com/go#hdr-Client_Options
-//	c, err := gateway.NewGatewayControlClient(ctx)
+//	c, err := gateway.NewGatewayControlRESTClient(ctx)
 //	if err != nil {
 //		// TODO: Handle error.
 //	}
@@ -72,7 +72,7 @@
 //
 // # Use of Context
 //
-// The ctx passed to NewGatewayControlClient is used for authentication requests and
+// The ctx passed to NewGatewayControlRESTClient is used for authentication requests and
 // for creating the underlying connection, but is not used for subsequent calls.
 // Individual methods on the client use the ctx given to them.
 //

--- a/gkeconnect/gateway/apiv1beta1/doc.go
+++ b/gkeconnect/gateway/apiv1beta1/doc.go
@@ -45,7 +45,7 @@
 //	// - It may require correct/in-range values for request initialization.
 //	// - It may require specifying regional endpoints when creating the service client as shown in:
 //	//   https://pkg.go.dev/cloud.google.com/go#hdr-Client_Options
-//	c, err := gateway.NewGatewayControlClient(ctx)
+//	c, err := gateway.NewGatewayControlRESTClient(ctx)
 //	if err != nil {
 //		// TODO: Handle error.
 //	}
@@ -72,7 +72,7 @@
 //
 // # Use of Context
 //
-// The ctx passed to NewGatewayControlClient is used for authentication requests and
+// The ctx passed to NewGatewayControlRESTClient is used for authentication requests and
 // for creating the underlying connection, but is not used for subsequent calls.
 // Individual methods on the client use the ctx given to them.
 //

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 language: go
-version: v0.10.2-0.20260421220535-e13512b2b859
+version: v0.11.0
 repo: googleapis/google-cloud-go
 sources:
   googleapis:

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -1465,6 +1465,7 @@ libraries:
       - path: google/maps/solar/v1
       - path: google/maps/fleetengine/delivery/v1
       - path: google/maps/mapmanagement/v2beta
+    title_override: Google Maps Platform
     go:
       go_apis:
         - enabled_generator_features:

--- a/maps/README.md
+++ b/maps/README.md
@@ -1,8 +1,8 @@
-# Geocoding API
+# Google Maps Platform
 
 [![Go Reference](https://pkg.go.dev/badge/cloud.google.com/go/maps.svg)](https://pkg.go.dev/cloud.google.com/go/maps)
 
-Go Client Library for Geocoding API.
+Go Client Library for Google Maps Platform.
 
 ## Install
 

--- a/maps/README.md
+++ b/maps/README.md
@@ -1,8 +1,8 @@
-# Google Maps Platform
+# Geocoding API
 
 [![Go Reference](https://pkg.go.dev/badge/cloud.google.com/go/maps.svg)](https://pkg.go.dev/cloud.google.com/go/maps)
 
-Go Client Library for Google Maps Platform.
+Go Client Library for Geocoding API.
 
 ## Install
 

--- a/memorystore/apiv1/doc.go
+++ b/memorystore/apiv1/doc.go
@@ -42,7 +42,7 @@
 //	// - It may require correct/in-range values for request initialization.
 //	// - It may require specifying regional endpoints when creating the service client as shown in:
 //	//   https://pkg.go.dev/cloud.google.com/go#hdr-Client_Options
-//	c, err := memorystore.NewClient(ctx)
+//	c, err := memorystore.NewRESTClient(ctx)
 //	if err != nil {
 //		// TODO: Handle error.
 //	}
@@ -74,7 +74,7 @@
 //
 // # Use of Context
 //
-// The ctx passed to NewClient is used for authentication requests and
+// The ctx passed to NewRESTClient is used for authentication requests and
 // for creating the underlying connection, but is not used for subsequent calls.
 // Individual methods on the client use the ctx given to them.
 //

--- a/memorystore/apiv1beta/doc.go
+++ b/memorystore/apiv1beta/doc.go
@@ -42,7 +42,7 @@
 //	// - It may require correct/in-range values for request initialization.
 //	// - It may require specifying regional endpoints when creating the service client as shown in:
 //	//   https://pkg.go.dev/cloud.google.com/go#hdr-Client_Options
-//	c, err := memorystore.NewClient(ctx)
+//	c, err := memorystore.NewRESTClient(ctx)
 //	if err != nil {
 //		// TODO: Handle error.
 //	}
@@ -74,7 +74,7 @@
 //
 // # Use of Context
 //
-// The ctx passed to NewClient is used for authentication requests and
+// The ctx passed to NewRESTClient is used for authentication requests and
 // for creating the underlying connection, but is not used for subsequent calls.
 // Individual methods on the client use the ctx given to them.
 //

--- a/shopping/type/.repo-metadata.json
+++ b/shopping/type/.repo-metadata.json
@@ -1,6 +1,7 @@
 {
     "client_documentation": "https://cloud.google.com/go/docs/reference/cloud.google.com/go/shopping/latest/type",
     "client_library_type": "generated",
+    "description": "Shopping Common Types",
     "distribution_name": "cloud.google.com/go/shopping/type",
     "language": "go",
     "library_type": "GAPIC_AUTO",


### PR DESCRIPTION
b/507461277

This change updates the librarian to v0.11.0 and includes the generated code by it.

This also restores the title of the Maps library that was accidentally removed in https://github.com/googleapis/google-cloud-go/pull/14491/changes#diff-464bebf2dae71c02c30ec0ece355447da9494ccd906ffd3127e3efb9a7c50fcfL1468.


```
suztomo@suztomo:/tmp/suztomo-patch-1$ gh pr checkout 5554
remote: Enumerating objects: 3, done.
remote: Counting objects: 100% (3/3), done.
remote: Compressing objects: 100% (3/3), done.
remote: Total 3 (delta 0), reused 0 (delta 0), pack-reused 0 (from 0)
Unpacking objects: 100% (3/3), 10.92 KiB | 2.73 MiB/s, done.
From https://github.com/googleapis/google-cloud-rust
 * [new branch]          suztomo-patch-1 -> upstream-bkup/suztomo-patch-1
Already on 'suztomo-patch-1'
Updating 615f139e8..a43219ffb
Fast-forward
 librarian.yaml | 2 ++
 1 file changed, 2 insertions(+)
suztomo@suztomo:/tmp/suztomo-patch-1$ go run github.com/googleapis/librarian/cmd/librarian@${V} install rust
go: github.com/googleapis/librarian@v0.11.0 requires go >= 1.26.1; switching to go1.26.2
suztomo@suztomo:/tmp/suztomo-patch-1$ taplo
Usage: taplo [OPTIONS] <COMMAND>

Commands:
  lint         Lint TOML documents [aliases: check, validate]
  format       Format TOML documents [aliases: fmt]
  lsp          Language server operations
  config       Operations with the Taplo config file [aliases: cfg]
  get          Extract a value from the given TOML document
  toml-test    Start a decoder for `toml-test` (https://github.com/BurntSushi/toml-test)
  completions  Generate completions for Taplo CLI
  help         Print this message or the help of the given subcommand(s)

Options:
      --colors <COLORS>  [default: auto] [possible values: auto, always, never]
      --verbose          Enable a verbose logging format
      --log-spans        Enable logging spans
  -h, --help             Print help (see more with '--help')
  -V, --version          Print version
```