### PR TITLE
chore: exclude generated protobuf files from GCA

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -2,6 +2,8 @@
 # More info:
 # https://developers.google.com/gemini-code-assist/docs/customize-gemini-behavior-github
 have_fun: false
+ignore_patterns:
+  - *.pb.go
 memory_config:
   disabled: false
 code_review:


### PR DESCRIPTION
Ignore generated pb files to reduce unactionable review feedback.

We're for the most part not the owner of the IDL artifacts, and pb.go files are generated from those IDL artifacts.