### PR TITLE
chore: exclude generated files from GCA review

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -11,3 +11,6 @@ code_review:
     summary: false
     code_review: true
     include_drafts: true
+ignore_patterns:
+  - "*.pb.go"
+  - "**/internal/version.go"


### PR DESCRIPTION
These files are derived from IDL artifacts or wholly templated.

Main change from previous attempt: string encapsulating the patterns, based on prior art in some other repos