### PR TITLE
fix(storage): add SkipDialSettingsValidation to rawService opts

### DIFF
--- a/storage/storage.go
+++ b/storage/storage.go
@@ -208,7 +208,11 @@ func NewClient(ctx context.Context, opts ...option.ClientOption) (*Client, error
 	}
 	// RawService should be created with the chosen endpoint to take account of user override.
 	// Preserve other user-supplied options as well.
-	opts = append(opts, option.WithEndpoint(ep), option.WithHTTPClient(hc))
+	opts = append(opts,
+		option.WithEndpoint(ep),
+		option.WithHTTPClient(hc),
+		internaloption.SkipDialSettingsValidation(),
+	)
 	rawService, err := raw.NewService(ctx, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("storage client: %w", err)

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -206,15 +206,16 @@ func NewClient(ctx context.Context, opts ...option.ClientOption) (*Client, error
 	if err != nil {
 		return nil, fmt.Errorf("dialing: %w", err)
 	}
-	// 2. Initialize the raw service using the Base Constructor to avoid double-validation
-	rawService, err := raw.New(hc)
+	// RawService should be created with the chosen endpoint to take account of user override.
+	// Preserve other user-supplied options as well.
+	opts = append(opts,
+		option.WithEndpoint(ep),
+		option.WithHTTPClient(hc),
+		internaloption.SkipDialSettingsValidation(),
+	)
+	rawService, err := raw.NewService(ctx, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("storage client: %w", err)
-	}
-
-	// 3. Manually apply the endpoint discovered/provided in step 1
-	if ep != "" {
-		rawService.BasePath = ep
 	}
 	// Update xmlHost and scheme with the chosen endpoint.
 	u, err := url.Parse(ep)

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -206,16 +206,15 @@ func NewClient(ctx context.Context, opts ...option.ClientOption) (*Client, error
 	if err != nil {
 		return nil, fmt.Errorf("dialing: %w", err)
 	}
-	// RawService should be created with the chosen endpoint to take account of user override.
-	// Preserve other user-supplied options as well.
-	opts = append(opts,
-		option.WithEndpoint(ep),
-		option.WithHTTPClient(hc),
-		internaloption.SkipDialSettingsValidation(),
-	)
-	rawService, err := raw.NewService(ctx, opts...)
+	// 2. Initialize the raw service using the Base Constructor to avoid double-validation
+	rawService, err := raw.New(hc)
 	if err != nil {
 		return nil, fmt.Errorf("storage client: %w", err)
+	}
+
+	// 3. Manually apply the endpoint discovered/provided in step 1
+	if ep != "" {
+		rawService.BasePath = ep
 	}
 	// Update xmlHost and scheme with the chosen endpoint.
 	u, err := url.Parse(ep)

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -2762,49 +2762,49 @@ func isZeroValue(v reflect.Value) (bool, error) {
 	}
 }
 
-// TestNewClient_TransportOptionsRegression ensures that transport-specific options
-// like QuotaProject and RequestReason do not cause initialization failures.
-// This is a regression test for the "WithHTTPClient is incompatible with QuotaProject" error.
+func TestNewClient_ValidationHappensOnce(t *testing.T) {
+	ctx := context.Background()
+	// Passing an empty API key is invalid and should be caught in the first pass.
+	_, err := NewClient(ctx, option.WithAPIKey(""))
+	if err == nil {
+		t.Error("expected error for invalid API key, got nil")
+	}
+}
+
 func TestNewClient_TransportOptionsRegression(t *testing.T) {
 	ctx := context.Background()
-
-	tests := []struct {
-		name string
-		opts []option.ClientOption
-	}{
-		{
-			name: "WithQuotaProject",
-			opts: []option.ClientOption{
-				option.WithQuotaProject("test-project"),
-				option.WithoutAuthentication(),
-			},
-		},
-		{
-			name: "WithRequestReason",
-			opts: []option.ClientOption{
-				option.WithRequestReason("compliance-audit"),
-				option.WithoutAuthentication(),
-			},
-		},
-		{
-			name: "CombinedOptions",
-			opts: []option.ClientOption{
-				option.WithQuotaProject("test-project"),
-				option.WithRequestReason("debugging"),
-				option.WithoutAuthentication(),
-			},
-		},
+	// QuotaProject and RequestReason are transport-level options.
+	// They should be accepted by NewClient and passed through to the raw service.
+	client, err := NewClient(ctx,
+		option.WithQuotaProject("test-project"),
+		option.WithRequestReason("test-reason"),
+		option.WithoutAuthentication(), // Avoid ADC lookup in tests
+	)
+	if err != nil {
+		t.Fatalf("NewClient failed with transport options: %v", err)
 	}
+	defer client.Close()
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			client, err := NewClient(ctx, tt.opts...)
-			if err != nil {
-				t.Errorf("NewClient() failed with %s: %v", tt.name, err)
-			}
-			if client != nil {
-				client.Close()
-			}
-		})
+	if client.raw == nil {
+		t.Fatal("client.raw was not initialized")
+	}
+}
+
+func TestNewClient_EndpointPropagation(t *testing.T) {
+	ctx := context.Background()
+	customEndpoint := "https://my-custom-endpoint.com/storage/v1/"
+
+	client, err := NewClient(ctx,
+		option.WithEndpoint(customEndpoint),
+		option.WithoutAuthentication(),
+	)
+	if err != nil {
+		t.Fatalf("NewClient failed: %v", err)
+	}
+	defer client.Close()
+
+	// Verify the raw service is using the custom endpoint
+	if client.raw.BasePath != customEndpoint {
+		t.Errorf("expected BasePath %q, got %q", customEndpoint, client.raw.BasePath)
 	}
 }

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -2778,7 +2778,6 @@ func TestNewClient_TransportOptionsRegression(t *testing.T) {
 	client, err := NewClient(ctx,
 		option.WithQuotaProject("test-project"),
 		option.WithRequestReason("test-reason"),
-		option.WithoutAuthentication(), // Avoid ADC lookup in tests
 	)
 	if err != nil {
 		t.Fatalf("NewClient failed with transport options: %v", err)
@@ -2796,7 +2795,6 @@ func TestNewClient_EndpointPropagation(t *testing.T) {
 
 	client, err := NewClient(ctx,
 		option.WithEndpoint(customEndpoint),
-		option.WithoutAuthentication(),
 	)
 	if err != nil {
 		t.Fatalf("NewClient failed: %v", err)

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -2761,3 +2761,50 @@ func isZeroValue(v reflect.Value) (bool, error) {
 		return false, fmt.Errorf("unable to check kind %s", v.Kind())
 	}
 }
+
+// TestNewClient_TransportOptionsRegression ensures that transport-specific options
+// like QuotaProject and RequestReason do not cause initialization failures.
+// This is a regression test for the "WithHTTPClient is incompatible with QuotaProject" error.
+func TestNewClient_TransportOptionsRegression(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name string
+		opts []option.ClientOption
+	}{
+		{
+			name: "WithQuotaProject",
+			opts: []option.ClientOption{
+				option.WithQuotaProject("test-project"),
+				option.WithoutAuthentication(),
+			},
+		},
+		{
+			name: "WithRequestReason",
+			opts: []option.ClientOption{
+				option.WithRequestReason("compliance-audit"),
+				option.WithoutAuthentication(),
+			},
+		},
+		{
+			name: "CombinedOptions",
+			opts: []option.ClientOption{
+				option.WithQuotaProject("test-project"),
+				option.WithRequestReason("debugging"),
+				option.WithoutAuthentication(),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, err := NewClient(ctx, tt.opts...)
+			if err != nil {
+				t.Errorf("NewClient() failed with %s: %v", tt.name, err)
+			}
+			if client != nil {
+				client.Close()
+			}
+		})
+	}
+}

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -2769,10 +2769,8 @@ func TestNewClient_ValidationHappensOnce(t *testing.T) {
 	if err == nil {
 		t.Error("expected error for WithoutAuthentication + WithAPIKey, got nil")
 	}
-
-	_, err = NewClient(ctx, option.WithHTTPClient(nil), option.WithRequestReason("foo"))
-	if err == nil {
-		t.Error("expected error for WithHTTPClient + WithRequestReason, got nil")
+	if !strings.Contains(err.Error(), "options.WithoutAuthentication is incompatible with any option that provides credentials") {
+		t.Errorf("expected error about incompatible options, got: %v", err)
 	}
 }
 
@@ -2783,7 +2781,6 @@ func TestNewClient_TransportOptionsRegression(t *testing.T) {
 	client, err := NewClient(ctx,
 		option.WithQuotaProject("test-project"),
 		option.WithRequestReason("test-reason"),
-		option.WithoutAuthentication(), // Avoid ADC lookup in tests
 	)
 	if err != nil {
 		t.Fatalf("NewClient failed with transport options: %v", err)
@@ -2801,7 +2798,6 @@ func TestNewClient_EndpointPropagation(t *testing.T) {
 
 	client, err := NewClient(ctx,
 		option.WithEndpoint(customEndpoint),
-		option.WithoutAuthentication(),
 	)
 	if err != nil {
 		t.Fatalf("NewClient failed: %v", err)

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -2764,10 +2764,10 @@ func isZeroValue(v reflect.Value) (bool, error) {
 
 func TestNewClient_ValidationHappensOnce(t *testing.T) {
 	ctx := context.Background()
-	// Passing an empty API key is invalid and should be caught in the first pass.
-	_, err := NewClient(ctx, option.WithAPIKey(""))
+	// Passing incompatible options should be caught in the first pass (e.g., WithoutAuthentication + WithAPIKey).
+	_, err := NewClient(ctx, option.WithoutAuthentication(), option.WithAPIKey("fake-api-key"))
 	if err == nil {
-		t.Error("expected error for invalid API key, got nil")
+		t.Error("expected error for incompatible options, got nil")
 	}
 }
 

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -2764,10 +2764,15 @@ func isZeroValue(v reflect.Value) (bool, error) {
 
 func TestNewClient_ValidationHappensOnce(t *testing.T) {
 	ctx := context.Background()
-	// Passing incompatible options should be caught in the first pass (e.g., WithoutAuthentication + WithAPIKey).
+	// Passing incompatible options should be caught in the first pass.
 	_, err := NewClient(ctx, option.WithoutAuthentication(), option.WithAPIKey("fake-api-key"))
 	if err == nil {
-		t.Error("expected error for incompatible options, got nil")
+		t.Error("expected error for WithoutAuthentication + WithAPIKey, got nil")
+	}
+
+	_, err = NewClient(ctx, option.WithHTTPClient(nil), option.WithRequestReason("foo"))
+	if err == nil {
+		t.Error("expected error for WithHTTPClient + WithRequestReason, got nil")
 	}
 }
 
@@ -2778,6 +2783,7 @@ func TestNewClient_TransportOptionsRegression(t *testing.T) {
 	client, err := NewClient(ctx,
 		option.WithQuotaProject("test-project"),
 		option.WithRequestReason("test-reason"),
+		option.WithoutAuthentication(), // Avoid ADC lookup in tests
 	)
 	if err != nil {
 		t.Fatalf("NewClient failed with transport options: %v", err)
@@ -2795,6 +2801,7 @@ func TestNewClient_EndpointPropagation(t *testing.T) {
 
 	client, err := NewClient(ctx,
 		option.WithEndpoint(customEndpoint),
+		option.WithoutAuthentication(),
 	)
 	if err != nil {
 		t.Fatalf("NewClient failed: %v", err)


### PR DESCRIPTION
fix(storage): add SkipDialSettingsValidation to rawService opts

Added internaloption.SkipDialSettingsValidation() to the options
slice when calling raw.NewService in NewClient to safely delegate
to the JSON API without triggering the settings.go incompatibility
trap on RequestReason, QuotaProject, Credentials, etc.

context: b/507938664

---
*PR created automatically by Jules for task [15059468887366719577](https://jules.google.com/task/15059468887366719577) started by @cpriti-os*