### PR TITLE
chore: begin migrating generation to use proto.CloneOf

### DIFF
--- a/bigquery/v2/apiv2/dataset_client.go
+++ b/bigquery/v2/apiv2/dataset_client.go
@@ -706,7 +706,7 @@ func (c *datasetGRPCClient) ListDatasets(ctx context.Context, req *bigquerypb.Li
 	}
 	opts = append((*c.CallOptions).ListDatasets[0:len((*c.CallOptions).ListDatasets):len((*c.CallOptions).ListDatasets)], opts...)
 	it := &ListFormatDatasetIterator{}
-	req = proto.Clone(req).(*bigquerypb.ListDatasetsRequest)
+	req = proto.CloneOf(req)
 	it.InternalFetch = func(pageSize int, pageToken string) ([]*bigquerypb.ListFormatDataset, string, error) {
 		resp := &bigquerypb.DatasetList{}
 		if pageToken != "" {
@@ -1093,7 +1093,7 @@ func (c *datasetRESTClient) DeleteDataset(ctx context.Context, req *bigquerypb.D
 // granted the READER dataset role.
 func (c *datasetRESTClient) ListDatasets(ctx context.Context, req *bigquerypb.ListDatasetsRequest, opts ...gax.CallOption) *ListFormatDatasetIterator {
 	it := &ListFormatDatasetIterator{}
-	req = proto.Clone(req).(*bigquerypb.ListDatasetsRequest)
+	req = proto.CloneOf(req)
 	unm := protojson.UnmarshalOptions{AllowPartial: true, DiscardUnknown: true}
 	it.InternalFetch = func(pageSize int, pageToken string) ([]*bigquerypb.ListFormatDataset, string, error) {
 		resp := &bigquerypb.DatasetList{}

--- a/bigquery/v2/apiv2/job_client.go
+++ b/bigquery/v2/apiv2/job_client.go
@@ -686,7 +686,7 @@ func (c *jobGRPCClient) ListJobs(ctx context.Context, req *bigquerypb.ListJobsRe
 	}
 	opts = append((*c.CallOptions).ListJobs[0:len((*c.CallOptions).ListJobs):len((*c.CallOptions).ListJobs)], opts...)
 	it := &ListFormatJobIterator{}
-	req = proto.Clone(req).(*bigquerypb.ListJobsRequest)
+	req = proto.CloneOf(req)
 	it.InternalFetch = func(pageSize int, pageToken string) ([]*bigquerypb.ListFormatJob, string, error) {
 		resp := &bigquerypb.JobList{}
 		if pageToken != "" {
@@ -1019,7 +1019,7 @@ func (c *jobRESTClient) DeleteJob(ctx context.Context, req *bigquerypb.DeleteJob
 // property.
 func (c *jobRESTClient) ListJobs(ctx context.Context, req *bigquerypb.ListJobsRequest, opts ...gax.CallOption) *ListFormatJobIterator {
 	it := &ListFormatJobIterator{}
-	req = proto.Clone(req).(*bigquerypb.ListJobsRequest)
+	req = proto.CloneOf(req)
 	unm := protojson.UnmarshalOptions{AllowPartial: true, DiscardUnknown: true}
 	it.InternalFetch = func(pageSize int, pageToken string) ([]*bigquerypb.ListFormatJob, string, error) {
 		resp := &bigquerypb.JobList{}

--- a/bigquery/v2/apiv2/model_client.go
+++ b/bigquery/v2/apiv2/model_client.go
@@ -472,7 +472,7 @@ func (c *modelGRPCClient) ListModels(ctx context.Context, req *bigquerypb.ListMo
 	}
 	opts = append((*c.CallOptions).ListModels[0:len((*c.CallOptions).ListModels):len((*c.CallOptions).ListModels)], opts...)
 	it := &ModelIterator{}
-	req = proto.Clone(req).(*bigquerypb.ListModelsRequest)
+	req = proto.CloneOf(req)
 	it.InternalFetch = func(pageSize int, pageToken string) ([]*bigquerypb.Model, string, error) {
 		resp := &bigquerypb.ListModelsResponse{}
 		if pageToken != "" {
@@ -614,7 +614,7 @@ func (c *modelRESTClient) GetModel(ctx context.Context, req *bigquerypb.GetModel
 // particular model by calling the models.get method.
 func (c *modelRESTClient) ListModels(ctx context.Context, req *bigquerypb.ListModelsRequest, opts ...gax.CallOption) *ModelIterator {
 	it := &ModelIterator{}
-	req = proto.Clone(req).(*bigquerypb.ListModelsRequest)
+	req = proto.CloneOf(req)
 	unm := protojson.UnmarshalOptions{AllowPartial: true, DiscardUnknown: true}
 	it.InternalFetch = func(pageSize int, pageToken string) ([]*bigquerypb.Model, string, error) {
 		resp := &bigquerypb.ListModelsResponse{}

--- a/bigquery/v2/apiv2/routine_client.go
+++ b/bigquery/v2/apiv2/routine_client.go
@@ -601,7 +601,7 @@ func (c *routineGRPCClient) ListRoutines(ctx context.Context, req *bigquerypb.Li
 	}
 	opts = append((*c.CallOptions).ListRoutines[0:len((*c.CallOptions).ListRoutines):len((*c.CallOptions).ListRoutines)], opts...)
 	it := &RoutineIterator{}
-	req = proto.Clone(req).(*bigquerypb.ListRoutinesRequest)
+	req = proto.CloneOf(req)
 	it.InternalFetch = func(pageSize int, pageToken string) ([]*bigquerypb.Routine, string, error) {
 		resp := &bigquerypb.ListRoutinesResponse{}
 		if pageToken != "" {
@@ -854,7 +854,7 @@ func (c *routineRESTClient) DeleteRoutine(ctx context.Context, req *bigquerypb.D
 // role.
 func (c *routineRESTClient) ListRoutines(ctx context.Context, req *bigquerypb.ListRoutinesRequest, opts ...gax.CallOption) *RoutineIterator {
 	it := &RoutineIterator{}
-	req = proto.Clone(req).(*bigquerypb.ListRoutinesRequest)
+	req = proto.CloneOf(req)
 	unm := protojson.UnmarshalOptions{AllowPartial: true, DiscardUnknown: true}
 	it.InternalFetch = func(pageSize int, pageToken string) ([]*bigquerypb.Routine, string, error) {
 		resp := &bigquerypb.ListRoutinesResponse{}

--- a/bigquery/v2/apiv2/row_access_policy_client.go
+++ b/bigquery/v2/apiv2/row_access_policy_client.go
@@ -542,7 +542,7 @@ func (c *rowAccessPolicyGRPCClient) ListRowAccessPolicies(ctx context.Context, r
 	}
 	opts = append((*c.CallOptions).ListRowAccessPolicies[0:len((*c.CallOptions).ListRowAccessPolicies):len((*c.CallOptions).ListRowAccessPolicies)], opts...)
 	it := &RowAccessPolicyIterator{}
-	req = proto.Clone(req).(*bigquerypb.ListRowAccessPoliciesRequest)
+	req = proto.CloneOf(req)
 	it.InternalFetch = func(pageSize int, pageToken string) ([]*bigquerypb.RowAccessPolicy, string, error) {
 		resp := &bigquerypb.ListRowAccessPoliciesResponse{}
 		if pageToken != "" {
@@ -696,7 +696,7 @@ func (c *rowAccessPolicyGRPCClient) BatchDeleteRowAccessPolicies(ctx context.Con
 // ListRowAccessPolicies lists all row access policies on the specified table.
 func (c *rowAccessPolicyRESTClient) ListRowAccessPolicies(ctx context.Context, req *bigquerypb.ListRowAccessPoliciesRequest, opts ...gax.CallOption) *RowAccessPolicyIterator {
 	it := &RowAccessPolicyIterator{}
-	req = proto.Clone(req).(*bigquerypb.ListRowAccessPoliciesRequest)
+	req = proto.CloneOf(req)
 	unm := protojson.UnmarshalOptions{AllowPartial: true, DiscardUnknown: true}
 	it.InternalFetch = func(pageSize int, pageToken string) ([]*bigquerypb.RowAccessPolicy, string, error) {
 		resp := &bigquerypb.ListRowAccessPoliciesResponse{}

--- a/bigquery/v2/apiv2/table_client.go
+++ b/bigquery/v2/apiv2/table_client.go
@@ -671,7 +671,7 @@ func (c *tableGRPCClient) ListTables(ctx context.Context, req *bigquerypb.ListTa
 	}
 	opts = append((*c.CallOptions).ListTables[0:len((*c.CallOptions).ListTables):len((*c.CallOptions).ListTables)], opts...)
 	it := &ListFormatTableIterator{}
-	req = proto.Clone(req).(*bigquerypb.ListTablesRequest)
+	req = proto.CloneOf(req)
 	it.InternalFetch = func(pageSize int, pageToken string) ([]*bigquerypb.ListFormatTable, string, error) {
 		resp := &bigquerypb.TableList{}
 		if pageToken != "" {
@@ -1014,7 +1014,7 @@ func (c *tableRESTClient) DeleteTable(ctx context.Context, req *bigquerypb.Delet
 // role.
 func (c *tableRESTClient) ListTables(ctx context.Context, req *bigquerypb.ListTablesRequest, opts ...gax.CallOption) *ListFormatTableIterator {
 	it := &ListFormatTableIterator{}
-	req = proto.Clone(req).(*bigquerypb.ListTablesRequest)
+	req = proto.CloneOf(req)
 	unm := protojson.UnmarshalOptions{AllowPartial: true, DiscardUnknown: true}
 	it.InternalFetch = func(pageSize int, pageToken string) ([]*bigquerypb.ListFormatTable, string, error) {
 		resp := &bigquerypb.TableList{}

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -522,6 +522,7 @@ libraries:
             - F_dynamic_resource_heuristics
             - F_open_telemetry_attributes
             - F_wrapper_types_for_page_size
+            - F_proto_cloneof
           import_path: bigquery/v2/apiv2
           path: google/cloud/bigquery/v2
   - name: bigtable
@@ -1848,6 +1849,7 @@ libraries:
         - enabled_generator_features:
             - F_mtls_hard_bound_tokens
             - F_open_telemetry_attributes
+            - F_proto_cloneof
           import_path: pubsub/v2/apiv1
           no_metadata: true
           path: google/pubsub/v1
@@ -1860,6 +1862,7 @@ libraries:
       go_apis:
         - enabled_generator_features:
             - F_open_telemetry_attributes
+            - F_proto_cloneof
           path: google/cloud/pubsublite/v1
   - name: rapidmigrationassessment
     version: 1.4.0
@@ -2009,10 +2012,12 @@ libraries:
         - enabled_generator_features:
             - F_mtls_hard_bound_tokens
             - F_open_telemetry_attributes
+            - F_proto_cloneof
           path: google/cloud/secretmanager/v1
         - enabled_generator_features:
             - F_mtls_hard_bound_tokens
             - F_open_telemetry_attributes
+            - F_proto_cloneof
           path: google/cloud/secretmanager/v1beta2
   - name: securesourcemanager
     version: 1.7.0

--- a/pubsub/v2/apiv1/schema_client.go
+++ b/pubsub/v2/apiv1/schema_client.go
@@ -743,7 +743,7 @@ func (c *schemaGRPCClient) ListSchemas(ctx context.Context, req *pubsubpb.ListSc
 	}
 	opts = append((*c.CallOptions).ListSchemas[0:len((*c.CallOptions).ListSchemas):len((*c.CallOptions).ListSchemas)], opts...)
 	it := &SchemaIterator{}
-	req = proto.Clone(req).(*pubsubpb.ListSchemasRequest)
+	req = proto.CloneOf(req)
 	it.InternalFetch = func(pageSize int, pageToken string) ([]*pubsubpb.Schema, string, error) {
 		resp := &pubsubpb.ListSchemasResponse{}
 		if pageToken != "" {
@@ -795,7 +795,7 @@ func (c *schemaGRPCClient) ListSchemaRevisions(ctx context.Context, req *pubsubp
 	}
 	opts = append((*c.CallOptions).ListSchemaRevisions[0:len((*c.CallOptions).ListSchemaRevisions):len((*c.CallOptions).ListSchemaRevisions)], opts...)
 	it := &SchemaIterator{}
-	req = proto.Clone(req).(*pubsubpb.ListSchemaRevisionsRequest)
+	req = proto.CloneOf(req)
 	it.InternalFetch = func(pageSize int, pageToken string) ([]*pubsubpb.Schema, string, error) {
 		resp := &pubsubpb.ListSchemaRevisionsResponse{}
 		if pageToken != "" {
@@ -1176,7 +1176,7 @@ func (c *schemaRESTClient) GetSchema(ctx context.Context, req *pubsubpb.GetSchem
 // ListSchemas lists schemas in a project.
 func (c *schemaRESTClient) ListSchemas(ctx context.Context, req *pubsubpb.ListSchemasRequest, opts ...gax.CallOption) *SchemaIterator {
 	it := &SchemaIterator{}
-	req = proto.Clone(req).(*pubsubpb.ListSchemasRequest)
+	req = proto.CloneOf(req)
 	unm := protojson.UnmarshalOptions{AllowPartial: true, DiscardUnknown: true}
 	it.InternalFetch = func(pageSize int, pageToken string) ([]*pubsubpb.Schema, string, error) {
 		resp := &pubsubpb.ListSchemasResponse{}
@@ -1257,7 +1257,7 @@ func (c *schemaRESTClient) ListSchemas(ctx context.Context, req *pubsubpb.ListSc
 // ListSchemaRevisions lists all schema revisions for the named schema.
 func (c *schemaRESTClient) ListSchemaRevisions(ctx context.Context, req *pubsubpb.ListSchemaRevisionsRequest, opts ...gax.CallOption) *SchemaIterator {
 	it := &SchemaIterator{}
-	req = proto.Clone(req).(*pubsubpb.ListSchemaRevisionsRequest)
+	req = proto.CloneOf(req)
 	unm := protojson.UnmarshalOptions{AllowPartial: true, DiscardUnknown: true}
 	it.InternalFetch = func(pageSize int, pageToken string) ([]*pubsubpb.Schema, string, error) {
 		resp := &pubsubpb.ListSchemaRevisionsResponse{}

--- a/pubsub/v2/apiv1/subscription_admin_client.go
+++ b/pubsub/v2/apiv1/subscription_admin_client.go
@@ -1080,7 +1080,7 @@ func (c *subscriptionAdminGRPCClient) ListSubscriptions(ctx context.Context, req
 	}
 	opts = append((*c.CallOptions).ListSubscriptions[0:len((*c.CallOptions).ListSubscriptions):len((*c.CallOptions).ListSubscriptions)], opts...)
 	it := &SubscriptionIterator{}
-	req = proto.Clone(req).(*pubsubpb.ListSubscriptionsRequest)
+	req = proto.CloneOf(req)
 	it.InternalFetch = func(pageSize int, pageToken string) ([]*pubsubpb.Subscription, string, error) {
 		resp := &pubsubpb.ListSubscriptionsResponse{}
 		if pageToken != "" {
@@ -1280,7 +1280,7 @@ func (c *subscriptionAdminGRPCClient) ListSnapshots(ctx context.Context, req *pu
 	}
 	opts = append((*c.CallOptions).ListSnapshots[0:len((*c.CallOptions).ListSnapshots):len((*c.CallOptions).ListSnapshots)], opts...)
 	it := &SnapshotIterator{}
-	req = proto.Clone(req).(*pubsubpb.ListSnapshotsRequest)
+	req = proto.CloneOf(req)
 	it.InternalFetch = func(pageSize int, pageToken string) ([]*pubsubpb.Snapshot, string, error) {
 		resp := &pubsubpb.ListSnapshotsResponse{}
 		if pageToken != "" {
@@ -1675,7 +1675,7 @@ func (c *subscriptionAdminRESTClient) UpdateSubscription(ctx context.Context, re
 // ListSubscriptions lists matching subscriptions.
 func (c *subscriptionAdminRESTClient) ListSubscriptions(ctx context.Context, req *pubsubpb.ListSubscriptionsRequest, opts ...gax.CallOption) *SubscriptionIterator {
 	it := &SubscriptionIterator{}
-	req = proto.Clone(req).(*pubsubpb.ListSubscriptionsRequest)
+	req = proto.CloneOf(req)
 	unm := protojson.UnmarshalOptions{AllowPartial: true, DiscardUnknown: true}
 	it.InternalFetch = func(pageSize int, pageToken string) ([]*pubsubpb.Subscription, string, error) {
 		resp := &pubsubpb.ListSubscriptionsResponse{}
@@ -2098,7 +2098,7 @@ func (c *subscriptionAdminRESTClient) GetSnapshot(ctx context.Context, req *pubs
 // state captured by a snapshot.
 func (c *subscriptionAdminRESTClient) ListSnapshots(ctx context.Context, req *pubsubpb.ListSnapshotsRequest, opts ...gax.CallOption) *SnapshotIterator {
 	it := &SnapshotIterator{}
-	req = proto.Clone(req).(*pubsubpb.ListSnapshotsRequest)
+	req = proto.CloneOf(req)
 	unm := protojson.UnmarshalOptions{AllowPartial: true, DiscardUnknown: true}
 	it.InternalFetch = func(pageSize int, pageToken string) ([]*pubsubpb.Snapshot, string, error) {
 		resp := &pubsubpb.ListSnapshotsResponse{}

--- a/pubsub/v2/apiv1/topic_admin_client.go
+++ b/pubsub/v2/apiv1/topic_admin_client.go
@@ -801,7 +801,7 @@ func (c *topicAdminGRPCClient) ListTopics(ctx context.Context, req *pubsubpb.Lis
 	}
 	opts = append((*c.CallOptions).ListTopics[0:len((*c.CallOptions).ListTopics):len((*c.CallOptions).ListTopics)], opts...)
 	it := &TopicIterator{}
-	req = proto.Clone(req).(*pubsubpb.ListTopicsRequest)
+	req = proto.CloneOf(req)
 	it.InternalFetch = func(pageSize int, pageToken string) ([]*pubsubpb.Topic, string, error) {
 		resp := &pubsubpb.ListTopicsResponse{}
 		if pageToken != "" {
@@ -853,7 +853,7 @@ func (c *topicAdminGRPCClient) ListTopicSubscriptions(ctx context.Context, req *
 	}
 	opts = append((*c.CallOptions).ListTopicSubscriptions[0:len((*c.CallOptions).ListTopicSubscriptions):len((*c.CallOptions).ListTopicSubscriptions)], opts...)
 	it := &StringIterator{}
-	req = proto.Clone(req).(*pubsubpb.ListTopicSubscriptionsRequest)
+	req = proto.CloneOf(req)
 	it.InternalFetch = func(pageSize int, pageToken string) ([]string, string, error) {
 		resp := &pubsubpb.ListTopicSubscriptionsResponse{}
 		if pageToken != "" {
@@ -905,7 +905,7 @@ func (c *topicAdminGRPCClient) ListTopicSnapshots(ctx context.Context, req *pubs
 	}
 	opts = append((*c.CallOptions).ListTopicSnapshots[0:len((*c.CallOptions).ListTopicSnapshots):len((*c.CallOptions).ListTopicSnapshots)], opts...)
 	it := &StringIterator{}
-	req = proto.Clone(req).(*pubsubpb.ListTopicSnapshotsRequest)
+	req = proto.CloneOf(req)
 	it.InternalFetch = func(pageSize int, pageToken string) ([]string, string, error) {
 		resp := &pubsubpb.ListTopicSnapshotsResponse{}
 		if pageToken != "" {
@@ -1309,7 +1309,7 @@ func (c *topicAdminRESTClient) GetTopic(ctx context.Context, req *pubsubpb.GetTo
 // ListTopics lists matching topics.
 func (c *topicAdminRESTClient) ListTopics(ctx context.Context, req *pubsubpb.ListTopicsRequest, opts ...gax.CallOption) *TopicIterator {
 	it := &TopicIterator{}
-	req = proto.Clone(req).(*pubsubpb.ListTopicsRequest)
+	req = proto.CloneOf(req)
 	unm := protojson.UnmarshalOptions{AllowPartial: true, DiscardUnknown: true}
 	it.InternalFetch = func(pageSize int, pageToken string) ([]*pubsubpb.Topic, string, error) {
 		resp := &pubsubpb.ListTopicsResponse{}
@@ -1387,7 +1387,7 @@ func (c *topicAdminRESTClient) ListTopics(ctx context.Context, req *pubsubpb.Lis
 // ListTopicSubscriptions lists the names of the attached subscriptions on this topic.
 func (c *topicAdminRESTClient) ListTopicSubscriptions(ctx context.Context, req *pubsubpb.ListTopicSubscriptionsRequest, opts ...gax.CallOption) *StringIterator {
 	it := &StringIterator{}
-	req = proto.Clone(req).(*pubsubpb.ListTopicSubscriptionsRequest)
+	req = proto.CloneOf(req)
 	unm := protojson.UnmarshalOptions{AllowPartial: true, DiscardUnknown: true}
 	it.InternalFetch = func(pageSize int, pageToken string) ([]string, string, error) {
 		resp := &pubsubpb.ListTopicSubscriptionsResponse{}
@@ -1469,7 +1469,7 @@ func (c *topicAdminRESTClient) ListTopicSubscriptions(ctx context.Context, req *
 // state captured by a snapshot.
 func (c *topicAdminRESTClient) ListTopicSnapshots(ctx context.Context, req *pubsubpb.ListTopicSnapshotsRequest, opts ...gax.CallOption) *StringIterator {
 	it := &StringIterator{}
-	req = proto.Clone(req).(*pubsubpb.ListTopicSnapshotsRequest)
+	req = proto.CloneOf(req)
 	unm := protojson.UnmarshalOptions{AllowPartial: true, DiscardUnknown: true}
 	it.InternalFetch = func(pageSize int, pageToken string) ([]string, string, error) {
 		resp := &pubsubpb.ListTopicSnapshotsResponse{}

--- a/pubsublite/apiv1/admin_client.go
+++ b/pubsublite/apiv1/admin_client.go
@@ -867,7 +867,7 @@ func (c *adminGRPCClient) ListTopics(ctx context.Context, req *pubsublitepb.List
 	}
 	opts = append((*c.CallOptions).ListTopics[0:len((*c.CallOptions).ListTopics):len((*c.CallOptions).ListTopics)], opts...)
 	it := &TopicIterator{}
-	req = proto.Clone(req).(*pubsublitepb.ListTopicsRequest)
+	req = proto.CloneOf(req)
 	it.InternalFetch = func(pageSize int, pageToken string) ([]*pubsublitepb.Topic, string, error) {
 		resp := &pubsublitepb.ListTopicsResponse{}
 		if pageToken != "" {
@@ -960,7 +960,7 @@ func (c *adminGRPCClient) ListTopicSubscriptions(ctx context.Context, req *pubsu
 	}
 	opts = append((*c.CallOptions).ListTopicSubscriptions[0:len((*c.CallOptions).ListTopicSubscriptions):len((*c.CallOptions).ListTopicSubscriptions)], opts...)
 	it := &StringIterator{}
-	req = proto.Clone(req).(*pubsublitepb.ListTopicSubscriptionsRequest)
+	req = proto.CloneOf(req)
 	it.InternalFetch = func(pageSize int, pageToken string) ([]string, string, error) {
 		resp := &pubsublitepb.ListTopicSubscriptionsResponse{}
 		if pageToken != "" {
@@ -1060,7 +1060,7 @@ func (c *adminGRPCClient) ListSubscriptions(ctx context.Context, req *pubsublite
 	}
 	opts = append((*c.CallOptions).ListSubscriptions[0:len((*c.CallOptions).ListSubscriptions):len((*c.CallOptions).ListSubscriptions)], opts...)
 	it := &SubscriptionIterator{}
-	req = proto.Clone(req).(*pubsublitepb.ListSubscriptionsRequest)
+	req = proto.CloneOf(req)
 	it.InternalFetch = func(pageSize int, pageToken string) ([]*pubsublitepb.Subscription, string, error) {
 		resp := &pubsublitepb.ListSubscriptionsResponse{}
 		if pageToken != "" {
@@ -1227,7 +1227,7 @@ func (c *adminGRPCClient) ListReservations(ctx context.Context, req *pubsublitep
 	}
 	opts = append((*c.CallOptions).ListReservations[0:len((*c.CallOptions).ListReservations):len((*c.CallOptions).ListReservations)], opts...)
 	it := &ReservationIterator{}
-	req = proto.Clone(req).(*pubsublitepb.ListReservationsRequest)
+	req = proto.CloneOf(req)
 	it.InternalFetch = func(pageSize int, pageToken string) ([]*pubsublitepb.Reservation, string, error) {
 		resp := &pubsublitepb.ListReservationsResponse{}
 		if pageToken != "" {
@@ -1320,7 +1320,7 @@ func (c *adminGRPCClient) ListReservationTopics(ctx context.Context, req *pubsub
 	}
 	opts = append((*c.CallOptions).ListReservationTopics[0:len((*c.CallOptions).ListReservationTopics):len((*c.CallOptions).ListReservationTopics)], opts...)
 	it := &StringIterator{}
-	req = proto.Clone(req).(*pubsublitepb.ListReservationTopicsRequest)
+	req = proto.CloneOf(req)
 	it.InternalFetch = func(pageSize int, pageToken string) ([]string, string, error) {
 		resp := &pubsublitepb.ListReservationTopicsResponse{}
 		if pageToken != "" {
@@ -1424,7 +1424,7 @@ func (c *adminGRPCClient) ListOperations(ctx context.Context, req *longrunningpb
 	}
 	opts = append((*c.CallOptions).ListOperations[0:len((*c.CallOptions).ListOperations):len((*c.CallOptions).ListOperations)], opts...)
 	it := &OperationIterator{}
-	req = proto.Clone(req).(*longrunningpb.ListOperationsRequest)
+	req = proto.CloneOf(req)
 	it.InternalFetch = func(pageSize int, pageToken string) ([]*longrunningpb.Operation, string, error) {
 		resp := &longrunningpb.ListOperationsResponse{}
 		if pageToken != "" {

--- a/pubsublite/apiv1/cursor_client.go
+++ b/pubsublite/apiv1/cursor_client.go
@@ -389,7 +389,7 @@ func (c *cursorGRPCClient) ListPartitionCursors(ctx context.Context, req *pubsub
 	}
 	opts = append((*c.CallOptions).ListPartitionCursors[0:len((*c.CallOptions).ListPartitionCursors):len((*c.CallOptions).ListPartitionCursors)], opts...)
 	it := &PartitionCursorIterator{}
-	req = proto.Clone(req).(*pubsublitepb.ListPartitionCursorsRequest)
+	req = proto.CloneOf(req)
 	it.InternalFetch = func(pageSize int, pageToken string) ([]*pubsublitepb.PartitionCursor, string, error) {
 		resp := &pubsublitepb.ListPartitionCursorsResponse{}
 		if pageToken != "" {
@@ -493,7 +493,7 @@ func (c *cursorGRPCClient) ListOperations(ctx context.Context, req *longrunningp
 	}
 	opts = append((*c.CallOptions).ListOperations[0:len((*c.CallOptions).ListOperations):len((*c.CallOptions).ListOperations)], opts...)
 	it := &OperationIterator{}
-	req = proto.Clone(req).(*longrunningpb.ListOperationsRequest)
+	req = proto.CloneOf(req)
 	it.InternalFetch = func(pageSize int, pageToken string) ([]*longrunningpb.Operation, string, error) {
 		resp := &longrunningpb.ListOperationsResponse{}
 		if pageToken != "" {

--- a/pubsublite/apiv1/partition_assignment_client.go
+++ b/pubsublite/apiv1/partition_assignment_client.go
@@ -376,7 +376,7 @@ func (c *partitionAssignmentGRPCClient) ListOperations(ctx context.Context, req 
 	}
 	opts = append((*c.CallOptions).ListOperations[0:len((*c.CallOptions).ListOperations):len((*c.CallOptions).ListOperations)], opts...)
 	it := &OperationIterator{}
-	req = proto.Clone(req).(*longrunningpb.ListOperationsRequest)
+	req = proto.CloneOf(req)
 	it.InternalFetch = func(pageSize int, pageToken string) ([]*longrunningpb.Operation, string, error) {
 		resp := &longrunningpb.ListOperationsResponse{}
 		if pageToken != "" {

--- a/pubsublite/apiv1/publisher_client.go
+++ b/pubsublite/apiv1/publisher_client.go
@@ -380,7 +380,7 @@ func (c *publisherGRPCClient) ListOperations(ctx context.Context, req *longrunni
 	}
 	opts = append((*c.CallOptions).ListOperations[0:len((*c.CallOptions).ListOperations):len((*c.CallOptions).ListOperations)], opts...)
 	it := &OperationIterator{}
-	req = proto.Clone(req).(*longrunningpb.ListOperationsRequest)
+	req = proto.CloneOf(req)
 	it.InternalFetch = func(pageSize int, pageToken string) ([]*longrunningpb.Operation, string, error) {
 		resp := &longrunningpb.ListOperationsResponse{}
 		if pageToken != "" {

--- a/pubsublite/apiv1/subscriber_client.go
+++ b/pubsublite/apiv1/subscriber_client.go
@@ -370,7 +370,7 @@ func (c *subscriberGRPCClient) ListOperations(ctx context.Context, req *longrunn
 	}
 	opts = append((*c.CallOptions).ListOperations[0:len((*c.CallOptions).ListOperations):len((*c.CallOptions).ListOperations)], opts...)
 	it := &OperationIterator{}
-	req = proto.Clone(req).(*longrunningpb.ListOperationsRequest)
+	req = proto.CloneOf(req)
 	it.InternalFetch = func(pageSize int, pageToken string) ([]*longrunningpb.Operation, string, error) {
 		resp := &longrunningpb.ListOperationsResponse{}
 		if pageToken != "" {

--- a/pubsublite/apiv1/topic_stats_client.go
+++ b/pubsublite/apiv1/topic_stats_client.go
@@ -490,7 +490,7 @@ func (c *topicStatsGRPCClient) ListOperations(ctx context.Context, req *longrunn
 	}
 	opts = append((*c.CallOptions).ListOperations[0:len((*c.CallOptions).ListOperations):len((*c.CallOptions).ListOperations)], opts...)
 	it := &OperationIterator{}
-	req = proto.Clone(req).(*longrunningpb.ListOperationsRequest)
+	req = proto.CloneOf(req)
 	it.InternalFetch = func(pageSize int, pageToken string) ([]*longrunningpb.Operation, string, error) {
 		resp := &longrunningpb.ListOperationsResponse{}
 		if pageToken != "" {

--- a/secretmanager/apiv1/secret_manager_client.go
+++ b/secretmanager/apiv1/secret_manager_client.go
@@ -658,7 +658,7 @@ func (c *gRPCClient) ListSecrets(ctx context.Context, req *secretmanagerpb.ListS
 	}
 	opts = append((*c.CallOptions).ListSecrets[0:len((*c.CallOptions).ListSecrets):len((*c.CallOptions).ListSecrets)], opts...)
 	it := &SecretIterator{}
-	req = proto.Clone(req).(*secretmanagerpb.ListSecretsRequest)
+	req = proto.CloneOf(req)
 	it.InternalFetch = func(pageSize int, pageToken string) ([]*secretmanagerpb.Secret, string, error) {
 		resp := &secretmanagerpb.ListSecretsResponse{}
 		if pageToken != "" {
@@ -823,7 +823,7 @@ func (c *gRPCClient) ListSecretVersions(ctx context.Context, req *secretmanagerp
 	}
 	opts = append((*c.CallOptions).ListSecretVersions[0:len((*c.CallOptions).ListSecretVersions):len((*c.CallOptions).ListSecretVersions)], opts...)
 	it := &SecretVersionIterator{}
-	req = proto.Clone(req).(*secretmanagerpb.ListSecretVersionsRequest)
+	req = proto.CloneOf(req)
 	it.InternalFetch = func(pageSize int, pageToken string) ([]*secretmanagerpb.SecretVersion, string, error) {
 		resp := &secretmanagerpb.ListSecretVersionsResponse{}
 		if pageToken != "" {
@@ -1085,7 +1085,7 @@ func (c *gRPCClient) ListLocations(ctx context.Context, req *locationpb.ListLoca
 	}
 	opts = append((*c.CallOptions).ListLocations[0:len((*c.CallOptions).ListLocations):len((*c.CallOptions).ListLocations)], opts...)
 	it := &LocationIterator{}
-	req = proto.Clone(req).(*locationpb.ListLocationsRequest)
+	req = proto.CloneOf(req)
 	it.InternalFetch = func(pageSize int, pageToken string) ([]*locationpb.Location, string, error) {
 		resp := &locationpb.ListLocationsResponse{}
 		if pageToken != "" {
@@ -1127,7 +1127,7 @@ func (c *gRPCClient) ListLocations(ctx context.Context, req *locationpb.ListLoca
 // ListSecrets lists Secrets.
 func (c *restClient) ListSecrets(ctx context.Context, req *secretmanagerpb.ListSecretsRequest, opts ...gax.CallOption) *SecretIterator {
 	it := &SecretIterator{}
-	req = proto.Clone(req).(*secretmanagerpb.ListSecretsRequest)
+	req = proto.CloneOf(req)
 	unm := protojson.UnmarshalOptions{AllowPartial: true, DiscardUnknown: true}
 	it.InternalFetch = func(pageSize int, pageToken string) ([]*secretmanagerpb.Secret, string, error) {
 		resp := &secretmanagerpb.ListSecretsResponse{}
@@ -1511,7 +1511,7 @@ func (c *restClient) DeleteSecret(ctx context.Context, req *secretmanagerpb.Dele
 // call does not return secret data.
 func (c *restClient) ListSecretVersions(ctx context.Context, req *secretmanagerpb.ListSecretVersionsRequest, opts ...gax.CallOption) *SecretVersionIterator {
 	it := &SecretVersionIterator{}
-	req = proto.Clone(req).(*secretmanagerpb.ListSecretVersionsRequest)
+	req = proto.CloneOf(req)
 	unm := protojson.UnmarshalOptions{AllowPartial: true, DiscardUnknown: true}
 	it.InternalFetch = func(pageSize int, pageToken string) ([]*secretmanagerpb.SecretVersion, string, error) {
 		resp := &secretmanagerpb.ListSecretVersionsResponse{}
@@ -2169,7 +2169,7 @@ func (c *restClient) GetLocation(ctx context.Context, req *locationpb.GetLocatio
 // ListLocations lists information about the supported locations for this service.
 func (c *restClient) ListLocations(ctx context.Context, req *locationpb.ListLocationsRequest, opts ...gax.CallOption) *LocationIterator {
 	it := &LocationIterator{}
-	req = proto.Clone(req).(*locationpb.ListLocationsRequest)
+	req = proto.CloneOf(req)
 	unm := protojson.UnmarshalOptions{AllowPartial: true, DiscardUnknown: true}
 	it.InternalFetch = func(pageSize int, pageToken string) ([]*locationpb.Location, string, error) {
 		resp := &locationpb.ListLocationsResponse{}

--- a/secretmanager/apiv1beta2/secret_manager_client.go
+++ b/secretmanager/apiv1beta2/secret_manager_client.go
@@ -665,7 +665,7 @@ func (c *gRPCClient) ListSecrets(ctx context.Context, req *secretmanagerpb.ListS
 	}
 	opts = append((*c.CallOptions).ListSecrets[0:len((*c.CallOptions).ListSecrets):len((*c.CallOptions).ListSecrets)], opts...)
 	it := &SecretIterator{}
-	req = proto.Clone(req).(*secretmanagerpb.ListSecretsRequest)
+	req = proto.CloneOf(req)
 	it.InternalFetch = func(pageSize int, pageToken string) ([]*secretmanagerpb.Secret, string, error) {
 		resp := &secretmanagerpb.ListSecretsResponse{}
 		if pageToken != "" {
@@ -830,7 +830,7 @@ func (c *gRPCClient) ListSecretVersions(ctx context.Context, req *secretmanagerp
 	}
 	opts = append((*c.CallOptions).ListSecretVersions[0:len((*c.CallOptions).ListSecretVersions):len((*c.CallOptions).ListSecretVersions)], opts...)
 	it := &SecretVersionIterator{}
-	req = proto.Clone(req).(*secretmanagerpb.ListSecretVersionsRequest)
+	req = proto.CloneOf(req)
 	it.InternalFetch = func(pageSize int, pageToken string) ([]*secretmanagerpb.SecretVersion, string, error) {
 		resp := &secretmanagerpb.ListSecretVersionsResponse{}
 		if pageToken != "" {
@@ -1092,7 +1092,7 @@ func (c *gRPCClient) ListLocations(ctx context.Context, req *locationpb.ListLoca
 	}
 	opts = append((*c.CallOptions).ListLocations[0:len((*c.CallOptions).ListLocations):len((*c.CallOptions).ListLocations)], opts...)
 	it := &LocationIterator{}
-	req = proto.Clone(req).(*locationpb.ListLocationsRequest)
+	req = proto.CloneOf(req)
 	it.InternalFetch = func(pageSize int, pageToken string) ([]*locationpb.Location, string, error) {
 		resp := &locationpb.ListLocationsResponse{}
 		if pageToken != "" {
@@ -1134,7 +1134,7 @@ func (c *gRPCClient) ListLocations(ctx context.Context, req *locationpb.ListLoca
 // ListSecrets lists Secrets.
 func (c *restClient) ListSecrets(ctx context.Context, req *secretmanagerpb.ListSecretsRequest, opts ...gax.CallOption) *SecretIterator {
 	it := &SecretIterator{}
-	req = proto.Clone(req).(*secretmanagerpb.ListSecretsRequest)
+	req = proto.CloneOf(req)
 	unm := protojson.UnmarshalOptions{AllowPartial: true, DiscardUnknown: true}
 	it.InternalFetch = func(pageSize int, pageToken string) ([]*secretmanagerpb.Secret, string, error) {
 		resp := &secretmanagerpb.ListSecretsResponse{}
@@ -1521,7 +1521,7 @@ func (c *restClient) DeleteSecret(ctx context.Context, req *secretmanagerpb.Dele
 // This call does not return secret data.
 func (c *restClient) ListSecretVersions(ctx context.Context, req *secretmanagerpb.ListSecretVersionsRequest, opts ...gax.CallOption) *SecretVersionIterator {
 	it := &SecretVersionIterator{}
-	req = proto.Clone(req).(*secretmanagerpb.ListSecretVersionsRequest)
+	req = proto.CloneOf(req)
 	unm := protojson.UnmarshalOptions{AllowPartial: true, DiscardUnknown: true}
 	it.InternalFetch = func(pageSize int, pageToken string) ([]*secretmanagerpb.SecretVersion, string, error) {
 		resp := &secretmanagerpb.ListSecretVersionsResponse{}
@@ -2183,7 +2183,7 @@ func (c *restClient) GetLocation(ctx context.Context, req *locationpb.GetLocatio
 // ListLocations lists information about the supported locations for this service.
 func (c *restClient) ListLocations(ctx context.Context, req *locationpb.ListLocationsRequest, opts ...gax.CallOption) *LocationIterator {
 	it := &LocationIterator{}
-	req = proto.Clone(req).(*locationpb.ListLocationsRequest)
+	req = proto.CloneOf(req)
 	unm := protojson.UnmarshalOptions{AllowPartial: true, DiscardUnknown: true}
 	it.InternalFetch = func(pageSize int, pageToken string) ([]*locationpb.Location, string, error) {
 		resp := &locationpb.ListLocationsResponse{}


### PR DESCRIPTION
This PR enables the new proto.CloneOf rewrite in the generator for a few services and regenerates sources.