### PR TITLE
test(firestore): add BulkWriter backpressure tests and fix flaky

### DIFF
--- a/firestore/bulkwriter_test.go
+++ b/firestore/bulkwriter_test.go
@@ -592,7 +592,7 @@ func TestBulkWriterBackpressureThrottling(t *testing.T) {
 	select {
 	case <-doneChan:
 		t.Fatal("Create() unblocked before Flush(), expected it to block due to backpressure")
-	case <-time.After(50 * time.Millisecond):
+	case <-time.After(200 * time.Millisecond):
 		// Good, it's blocked as expected.
 	}
 
@@ -614,5 +614,3 @@ func TestBulkWriterBackpressureThrottling(t *testing.T) {
 		t.Fatal("Second Create() returned nil BulkWriterJob")
 	}
 }
-
-

--- a/firestore/bulkwriter_test.go
+++ b/firestore/bulkwriter_test.go
@@ -19,11 +19,13 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"time"
 
 	pb "cloud.google.com/go/firestore/apiv1/firestorepb"
 	"google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 )
 
 type bulkwriterTestCase struct {
@@ -513,3 +515,104 @@ func TestBulkWriterSendCancelled(t *testing.T) {
 		t.Errorf("want context.Canceled, got %v", err)
 	}
 }
+
+func TestBulkWriterBackpressure(t *testing.T) {
+	c, _, cleanup := newMock(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	ctxTimeout, cancel := context.WithTimeout(ctx, 200*time.Millisecond)
+	defer cancel()
+
+	bw := c.BulkWriter(ctxTimeout)
+
+	w, err := c.Doc("C/a").newCreateWrites(testData)
+	if err != nil {
+		t.Fatalf("newCreateWrites failed: %v", err)
+	}
+	// Set the limit to exactly the size of the first write request.
+	bw.bundler.BufferedByteLimit = proto.Size(w[0])
+
+	// First write adds successfully as the buffer is initially empty.
+	_, err = bw.Create(c.Doc("C/a"), testData)
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	// Second write blocks because the limit is exceeded, eventually timing out.
+	_, err = bw.Create(c.Doc("C/b"), testData)
+	if err == nil {
+		t.Error("wanted error due to timeout from backpressure, got nil")
+	}
+	if err != context.DeadlineExceeded {
+		t.Errorf("wanted context.DeadlineExceeded, got %v", err)
+	}
+}
+
+func TestBulkWriterBackpressureThrottling(t *testing.T) {
+	c, srv, cleanup := newMock(t)
+	defer cleanup()
+
+	// Use wildcard RPC matching so that Flush works correctly
+	srv.reset()
+	for i := 0; i < 2; i++ {
+		srv.addRPC(nil, &pb.BatchWriteResponse{
+			WriteResults: []*pb.WriteResult{{UpdateTime: aTimestamp}},
+			Status:       []*status.Status{{Code: int32(codes.OK)}},
+		})
+	}
+
+	ctx := context.Background()
+	bw := c.BulkWriter(ctx)
+
+	w, err := c.Doc("C/a").newCreateWrites(testData)
+	if err != nil {
+		t.Fatalf("newCreateWrites failed: %v", err)
+	}
+	// Set the limit to exactly the size of the first write request.
+	bw.bundler.BufferedByteLimit = proto.Size(w[0])
+
+	// First write adds successfully as the buffer is initially empty.
+	_, err = bw.Create(c.Doc("C/a"), testData)
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	// The second write will block since the buffer is already at limit.
+	doneChan := make(chan struct{})
+	var secondJob *BulkWriterJob
+	var secondErr error
+
+	go func() {
+		secondJob, secondErr = bw.Create(c.Doc("C/b"), testData)
+		close(doneChan)
+	}()
+
+	// Wait for a short duration to let the goroutine run and block
+	select {
+	case <-doneChan:
+		t.Fatal("Create() unblocked before Flush(), expected it to block due to backpressure")
+	case <-time.After(50 * time.Millisecond):
+		// Good, it's blocked as expected.
+	}
+
+	// Now Flush the first write so that the buffer empties and makes room.
+	bw.Flush()
+
+	// The second Create() should unblock immediately and finish successfully.
+	select {
+	case <-doneChan:
+		// Success, it unblocked!
+	case <-time.After(1 * time.Second):
+		t.Fatal("Create() timed out after Flush, expected it to unblock")
+	}
+
+	if secondErr != nil {
+		t.Fatalf("Second Create() returned error: %v", secondErr)
+	}
+	if secondJob == nil {
+		t.Fatal("Second Create() returned nil BulkWriterJob")
+	}
+}
+
+

--- a/firestore/integration_test.go
+++ b/firestore/integration_test.go
@@ -187,6 +187,10 @@ func initIntegrationTest() {
 // deleteCollection recursively deletes the documents in the specified collection
 func deleteCollection(ctx context.Context, coll *CollectionRef) error {
 	bulkwriter := iClient.BulkWriter(ctx)
+	defer func() {
+		bulkwriter.End()
+		bulkwriter.Flush()
+	}()
 
 	// Get  documents
 	iter := coll.DocumentRefs(ctx)
@@ -208,9 +212,6 @@ func deleteCollection(ctx context.Context, coll *CollectionRef) error {
 			return err
 		}
 	}
-
-	bulkwriter.End()
-	bulkwriter.Flush()
 
 	return nil
 }
@@ -3106,6 +3107,8 @@ func TestIntegration_AggregationQueries(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.desc, func(t *testing.T) {
 			testutil.Retry(t, 5, 5*time.Second, func(r *testutil.R) {
+				ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+				defer cancel()
 				var gotResult AggregationResult
 				var err error
 				if tc.runInTransaction {


### PR DESCRIPTION
## Description

This PR introduces unit tests for the `BulkWriter` backpressure functionality https://github.com/googleapis/google-cloud-go/pull/12938#pullrequestreview-4208549194 , improves BulkWriter resource cleanup within integration tests, and addresses a timeout issue in aggregation query testing.

### Key Changes

- **BulkWriter Backpressure Tests:**
  - Added `TestBulkWriterBackpressure` to verify that a second write blocks when the byte limit is reached and returns a deadline exceeded error upon context expiration.
  - Added `TestBulkWriterBackpressureThrottling` to ensure that a blocked write goroutine unblocks and successfully finishes once capacity is freed in the buffer via `Flush()`.

- **Resource Cleanup & Resilience Improvements:**
  - Updated `deleteCollection` in [integration_test.go](file:///usr/local/google/home/bahaaiman/Documents/cfdb-workspace-01/google-cloud-go/firestore/integration_test.go) to defer `bulkwriter.End()` and `bulkwriter.Flush()`, guaranteeing the BulkWriter is flushed and closed even upon early returns or unexpected errors.

- **Aggregation Queries Test Timeout Mitigation:**
  - Wrapped the individual test runs within the retry loop of `TestIntegration_AggregationQueries` inside a short-lived timeout context (`30*time.Second`) to avoid test hangs and indefinite timeouts.



Fixes: #14371