### PR TITLE
chore: librarian release pull request: 20260504T175203Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -470,7 +470,7 @@ libraries:
       - internal/generated/snippets/biglake/
     tag_format: '{id}/v{version}'
   - id: bigquery
-    version: 1.76.0
+    version: 1.77.0
     last_generated_commit: ""
     apis:
       - path: google/cloud/bigquery/analyticshub/v1

--- a/bigquery/CHANGES.md
+++ b/bigquery/CHANGES.md
@@ -3,6 +3,8 @@
 
 
 
+## [1.77.0](https://github.com/googleapis/google-cloud-go/releases/tag/bigquery%2Fv1.77.0) (2026-05-04)
+
 ## [1.76.0](https://github.com/googleapis/google-cloud-go/releases/tag/bigquery%2Fv1.76.0) (2026-04-09)
 
 ## [1.75.0](https://github.com/googleapis/google-cloud-go/releases/tag/bigquery%2Fv1.75.0) (2026-03-30)

--- a/bigquery/internal/version.go
+++ b/bigquery/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "1.76.0"
+const Version = "1.77.0"

--- a/internal/generated/snippets/bigquery/analyticshub/apiv1/snippet_metadata.google.cloud.bigquery.analyticshub.v1.json
+++ b/internal/generated/snippets/bigquery/analyticshub/apiv1/snippet_metadata.google.cloud.bigquery.analyticshub.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/bigquery/analyticshub/apiv1",
-    "version": "1.76.0"
+    "version": "1.77.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/bigquery/biglake/apiv1/snippet_metadata.google.cloud.bigquery.biglake.v1.json
+++ b/internal/generated/snippets/bigquery/biglake/apiv1/snippet_metadata.google.cloud.bigquery.biglake.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/bigquery/biglake/apiv1",
-    "version": "1.76.0"
+    "version": "1.77.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/bigquery/biglake/apiv1alpha1/snippet_metadata.google.cloud.bigquery.biglake.v1alpha1.json
+++ b/internal/generated/snippets/bigquery/biglake/apiv1alpha1/snippet_metadata.google.cloud.bigquery.biglake.v1alpha1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/bigquery/biglake/apiv1alpha1",
-    "version": "1.76.0"
+    "version": "1.77.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/bigquery/connection/apiv1/snippet_metadata.google.cloud.bigquery.connection.v1.json
+++ b/internal/generated/snippets/bigquery/connection/apiv1/snippet_metadata.google.cloud.bigquery.connection.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/bigquery/connection/apiv1",
-    "version": "1.76.0"
+    "version": "1.77.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/bigquery/connection/apiv1beta1/snippet_metadata.google.cloud.bigquery.connection.v1beta1.json
+++ b/internal/generated/snippets/bigquery/connection/apiv1beta1/snippet_metadata.google.cloud.bigquery.connection.v1beta1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/bigquery/connection/apiv1beta1",
-    "version": "1.76.0"
+    "version": "1.77.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/bigquery/dataexchange/apiv1beta1/snippet_metadata.google.cloud.bigquery.dataexchange.v1beta1.json
+++ b/internal/generated/snippets/bigquery/dataexchange/apiv1beta1/snippet_metadata.google.cloud.bigquery.dataexchange.v1beta1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/bigquery/dataexchange/apiv1beta1",
-    "version": "1.76.0"
+    "version": "1.77.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/bigquery/datapolicies/apiv1/snippet_metadata.google.cloud.bigquery.datapolicies.v1.json
+++ b/internal/generated/snippets/bigquery/datapolicies/apiv1/snippet_metadata.google.cloud.bigquery.datapolicies.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/bigquery/datapolicies/apiv1",
-    "version": "1.76.0"
+    "version": "1.77.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/bigquery/datapolicies/apiv1beta1/snippet_metadata.google.cloud.bigquery.datapolicies.v1beta1.json
+++ b/internal/generated/snippets/bigquery/datapolicies/apiv1beta1/snippet_metadata.google.cloud.bigquery.datapolicies.v1beta1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/bigquery/datapolicies/apiv1beta1",
-    "version": "1.76.0"
+    "version": "1.77.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/bigquery/datapolicies/apiv2/snippet_metadata.google.cloud.bigquery.datapolicies.v2.json
+++ b/internal/generated/snippets/bigquery/datapolicies/apiv2/snippet_metadata.google.cloud.bigquery.datapolicies.v2.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/bigquery/datapolicies/apiv2",
-    "version": "1.76.0"
+    "version": "1.77.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/bigquery/datapolicies/apiv2beta1/snippet_metadata.google.cloud.bigquery.datapolicies.v2beta1.json
+++ b/internal/generated/snippets/bigquery/datapolicies/apiv2beta1/snippet_metadata.google.cloud.bigquery.datapolicies.v2beta1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/bigquery/datapolicies/apiv2beta1",
-    "version": "1.76.0"
+    "version": "1.77.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/bigquery/datatransfer/apiv1/snippet_metadata.google.cloud.bigquery.datatransfer.v1.json
+++ b/internal/generated/snippets/bigquery/datatransfer/apiv1/snippet_metadata.google.cloud.bigquery.datatransfer.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/bigquery/datatransfer/apiv1",
-    "version": "1.76.0"
+    "version": "1.77.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/bigquery/migration/apiv2/snippet_metadata.google.cloud.bigquery.migration.v2.json
+++ b/internal/generated/snippets/bigquery/migration/apiv2/snippet_metadata.google.cloud.bigquery.migration.v2.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/bigquery/migration/apiv2",
-    "version": "1.76.0"
+    "version": "1.77.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/bigquery/migration/apiv2alpha/snippet_metadata.google.cloud.bigquery.migration.v2alpha.json
+++ b/internal/generated/snippets/bigquery/migration/apiv2alpha/snippet_metadata.google.cloud.bigquery.migration.v2alpha.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/bigquery/migration/apiv2alpha",
-    "version": "1.76.0"
+    "version": "1.77.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/bigquery/reservation/apiv1/snippet_metadata.google.cloud.bigquery.reservation.v1.json
+++ b/internal/generated/snippets/bigquery/reservation/apiv1/snippet_metadata.google.cloud.bigquery.reservation.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/bigquery/reservation/apiv1",
-    "version": "1.76.0"
+    "version": "1.77.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/bigquery/storage/apiv1/snippet_metadata.google.cloud.bigquery.storage.v1.json
+++ b/internal/generated/snippets/bigquery/storage/apiv1/snippet_metadata.google.cloud.bigquery.storage.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/bigquery/storage/apiv1",
-    "version": "1.76.0"
+    "version": "1.77.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/bigquery/storage/apiv1alpha/snippet_metadata.google.cloud.bigquery.storage.v1alpha.json
+++ b/internal/generated/snippets/bigquery/storage/apiv1alpha/snippet_metadata.google.cloud.bigquery.storage.v1alpha.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/bigquery/storage/apiv1alpha",
-    "version": "1.76.0"
+    "version": "1.77.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/bigquery/storage/apiv1beta/snippet_metadata.google.cloud.bigquery.storage.v1beta.json
+++ b/internal/generated/snippets/bigquery/storage/apiv1beta/snippet_metadata.google.cloud.bigquery.storage.v1beta.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/bigquery/storage/apiv1beta",
-    "version": "1.76.0"
+    "version": "1.77.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/bigquery/storage/apiv1beta1/snippet_metadata.google.cloud.bigquery.storage.v1beta1.json
+++ b/internal/generated/snippets/bigquery/storage/apiv1beta1/snippet_metadata.google.cloud.bigquery.storage.v1beta1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/bigquery/storage/apiv1beta1",
-    "version": "1.76.0"
+    "version": "1.77.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/bigquery/storage/apiv1beta2/snippet_metadata.google.cloud.bigquery.storage.v1beta2.json
+++ b/internal/generated/snippets/bigquery/storage/apiv1beta2/snippet_metadata.google.cloud.bigquery.storage.v1beta2.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/bigquery/storage/apiv1beta2",
-    "version": "1.76.0"
+    "version": "1.77.0"
   },
   "snippets": [
     {

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -405,7 +405,7 @@ libraries:
             - F_open_telemetry_attributes
           path: google/cloud/biglake/hive/v1beta
   - name: bigquery
-    version: 1.76.0
+    version: 1.77.0
     apis:
       - path: google/cloud/bigquery/migration/v2
       - path: google/cloud/bigquery/datapolicies/v2


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.11.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go@sha256:b04b076f5eedbb5546bd6fc1404969dd3698c8b19c0f34ae815a84ae735a606a
<details><summary>bigquery: v1.77.0</summary>

## [v1.77.0](https://github.com/googleapis/google-cloud-go/compare/bigquery/v1.76.0...bigquery/v1.77.0) (2026-05-04)

</details>