### PR TITLE
chore: librarian release pull request: 20260504T175933Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -355,7 +355,7 @@ libraries:
       - internal/generated/snippets/auditmanager/
     tag_format: '{id}/v{version}'
   - id: auth
-    version: 0.20.0
+    version: 0.21.0
     last_generated_commit: ""
     apis: []
     source_roots:

--- a/auth/CHANGES.md
+++ b/auth/CHANGES.md
@@ -1,5 +1,7 @@
 # Changes
 
+## [0.21.0](https://github.com/googleapis/google-cloud-go/releases/tag/auth%2Fv0.21.0) (2026-05-04)
+
 ## [0.20.0](https://github.com/googleapis/google-cloud-go/releases/tag/auth%2Fv0.20.0) (2026-04-06)
 
 ## [0.19.0](https://github.com/googleapis/google-cloud-go/releases/tag/auth%2Fv0.19.0) (2026-03-23)

--- a/auth/internal/version.go
+++ b/auth/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "0.20.0"
+const Version = "0.21.0"

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -313,7 +313,7 @@ libraries:
             - F_open_telemetry_attributes
           path: google/cloud/auditmanager/v1
   - name: auth
-    version: 0.20.0
+    version: 0.21.0
     keep:
       - README.md
       - internal/version.go


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.11.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go@sha256:b04b076f5eedbb5546bd6fc1404969dd3698c8b19c0f34ae815a84ae735a606a
<details><summary>auth: v0.21.0</summary>

## [v0.21.0](https://github.com/googleapis/google-cloud-go/compare/auth/v0.20.0...auth/v0.21.0) (2026-05-04)

</details>