### PR TITLE
chore(agentplatform): onboard to librarian manual releases

### DIFF
--- a/.librarian/config.yaml
+++ b/.librarian/config.yaml
@@ -18,6 +18,8 @@ global_files_allowlist:
 # libraries have "release_blocked: true" so that releases are
 # explicitly initiated
 libraries:
+  - id: "agentplatform"
+    release_blocked: true
   - id: "auth"
     release_blocked: true
   - id: "auth/oauth2adapt"

--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -56,7 +56,7 @@ libraries:
       - internal/generated/snippets/advisorynotifications/
     tag_format: '{id}/v{version}'
   - id: agentplatform
-    version: 0.19.0
+    version: 0.0.0
     last_generated_commit: ""
     apis: []
     source_roots:

--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -55,6 +55,15 @@ libraries:
     release_exclude_paths:
       - internal/generated/snippets/advisorynotifications/
     tag_format: '{id}/v{version}'
+  - id: agentplatform
+    version: 0.19.0
+    last_generated_commit: ""
+    apis: []
+    source_roots:
+      - agentplatform
+    preserve_regex: []
+    remove_regex: []
+    tag_format: '{id}/v{version}'
   - id: ai
     version: 0.19.0
     last_generated_commit: ""

--- a/agentplatform/internal/version.go
+++ b/agentplatform/internal/version.go
@@ -15,4 +15,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "0.19.0"
+const Version = "0.0.0"

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -59,6 +59,10 @@ libraries:
         - enabled_generator_features:
             - F_open_telemetry_attributes
           path: google/cloud/advisorynotifications/v1
+  - name: agentplatform
+    version: 0.19.0
+    skip_release: true
+    skip_generate: true
   - name: ai
     version: 0.19.0
     apis:

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -60,9 +60,9 @@ libraries:
             - F_open_telemetry_attributes
           path: google/cloud/advisorynotifications/v1
   - name: agentplatform
-    version: 0.19.0
-    skip_release: true
+    version: 0.0.0
     skip_generate: true
+    skip_release: true
   - name: ai
     version: 0.19.0
     apis:


### PR DESCRIPTION
Onboards `agentplatform` to `librarian` toolchain for manual releases (as indicated by `release_blocked`/`skip_release` being `true`).

The `version` pointers needed to be reset to `0.0.0` to start, and the first release should use the `-library-version=0.20.0` flag to force the desired version. This is because `legacylibrarian` expects any non-`0.0.0` version to have a tag to reference for "changes since previous release" logic. Since this has yet to be released, that fails, unless we force it back to `0.0.0`.

Tested locally with the following command:
```shell
go run github.com/googleapis/librarian/cmd/legacylibrarian@v0.11.0 release stage -library=agentplatform -library-version=0.20.0
```

Which produced the expected changes (version bump in all the right places, addition of `CHANGES.md`, etc.).

Fixes b/507855908
