### PR TITLE
chore: librarian release pull request: 20260505T082048Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,3 +1,16 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go@sha256:718167d5c23ed389b41f617b3a00ac839bdd938a6bd2d48ae0c2f1fa51ab1c3d
 libraries:
   - id: accessapproval
@@ -4080,7 +4093,6 @@ libraries:
     last_generated_commit: c288189b43c016dd3cf1ec73ce3cadee8b732f07
     apis:
       - path: google/cloud/orgpolicy/v1
-        service_config: ""
       - path: google/cloud/orgpolicy/v2
         service_config: orgpolicy_v2.yaml
     source_roots:
@@ -4194,7 +4206,6 @@ libraries:
       - path: google/cloud/oslogin/v1beta
         service_config: oslogin_v1beta.yaml
       - path: google/cloud/oslogin/common
-        service_config: ""
     source_roots:
       - oslogin
       - internal/generated/snippets/oslogin
@@ -5338,7 +5349,6 @@ libraries:
       - path: google/shopping/merchant/reviews/v1beta
         service_config: merchantapi_v1beta.yaml
       - path: google/shopping/type
-        service_config: ""
     source_roots:
       - shopping
       - internal/generated/snippets/shopping
@@ -5750,7 +5760,7 @@ libraries:
       - internal/generated/snippets/speech/
     tag_format: '{id}/v{version}'
   - id: storage
-    version: 1.59.1
+    version: 1.59.3
     last_generated_commit: effe5c4fa816021e724ca856d5640f2e55b14a8b
     apis:
       - path: google/storage/control/v2

--- a/internal/generated/snippets/storage/control/apiv2/snippet_metadata.google.storage.control.v2.json
+++ b/internal/generated/snippets/storage/control/apiv2/snippet_metadata.google.storage.control.v2.json
@@ -1,7 +1,7 @@
 {
   "clientLibrary": {
     "name": "cloud.google.com/go/storage/control/apiv2",
-    "version": "1.59.1",
+    "version": "1.59.3",
     "language": "GO",
     "apis": [
       {

--- a/storage/CHANGES.md
+++ b/storage/CHANGES.md
@@ -1,6 +1,13 @@
 # Changes
 
 
+## [1.59.3](https://github.com/googleapis/google-cloud-go/releases/tag/storage%2Fv1.59.3) (2026-05-05)
+
+### Bug Fixes
+
+* deadlock in event loop while coordinating channels (#13652) ([ff6c8e7](https://github.com/googleapis/google-cloud-go/commit/ff6c8e780b2207b154808ba22e3124b68d6b4f7d))
+* handle MRD hang corner case (#14509) ([b3112f4](https://github.com/googleapis/google-cloud-go/commit/b3112f44a489c25bcf89a5bc296bde3a0da7c3ab))
+
 ## [1.59.1](https://github.com/googleapis/google-cloud-go/releases/tag/storage%2Fv1.59.1) (2026-01-14)
 
 ### Bug Fixes

--- a/storage/internal/version.go
+++ b/storage/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "1.59.1"
+const Version = "1.59.3"


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.12.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go@sha256:718167d5c23ed389b41f617b3a00ac839bdd938a6bd2d48ae0c2f1fa51ab1c3d
<details><summary>storage: v1.59.3</summary>

## [v1.59.3](https://github.com/googleapis/google-cloud-go/compare/storage/v1.59.1...storage/v1.59.3) (2026-05-05)

### Bug Fixes

* handle MRD hang corner case (#14509) ([b3112f44](https://github.com/googleapis/google-cloud-go/commit/b3112f44))

* deadlock in event loop while coordinating channels (#13652) ([ff6c8e78](https://github.com/googleapis/google-cloud-go/commit/ff6c8e78))

</details>