### PR TITLE
chore: fix librarian regeneration check

### DIFF
--- a/.github/workflows/generation_check.yaml
+++ b/.github/workflows/generation_check.yaml
@@ -30,7 +30,6 @@ jobs:
           version=$(sed -n 's/^version: *//p' librarian.yaml)
           go run "github.com/googleapis/librarian/cmd/librarian@${version}" generate -all
       - name: Create issue on diff
-        if: failure()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -52,4 +51,19 @@ jobs:
               echo "Issue #$EXISTING_ISSUE already exists, adding a comment."
               gh issue comment "$EXISTING_ISSUE" --body "Another failure with diff occurred: $RUN_URL"
             fi
+          fi
+      - name: Create issue on generation failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TITLE="Regeneration failed"
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          BODY="The post-submit [regeneration check]($RUN_URL) failed."
+          EXISTING_ISSUE=$(gh issue list --state open --search "in:title \"$TITLE\"" --json number --jq '.[0].number')
+          if [ -z "$EXISTING_ISSUE" ]; then
+            gh issue create --title "$TITLE" --body "$BODY"
+          else
+            echo "Issue #$EXISTING_ISSUE already exists, adding a comment."
+            gh issue comment "$EXISTING_ISSUE" --body "Another regeneration failure occurred: $RUN_URL"
           fi


### PR DESCRIPTION
There are two reasons we should create an issue:
- Regeneration failed
- Regeneration succeeded, but created a diff

The previous implementation was half of one, half of the other. This separates out the two cases, creating an appropriate issue in each case.

Fixes https://github.com/googleapis/librarian/issues/5866