### PR TITLE
fix(storage): limit error response body reads to prevent OOM

### DIFF
--- a/storage/http_client.go
+++ b/storage/http_client.go
@@ -1497,7 +1497,10 @@ func readerReopen(ctx context.Context, header http.Header, params *newRangeReade
 				return ErrObjectNotExist
 			}
 			if res.StatusCode < 200 || res.StatusCode > 299 {
-				body, _ := io.ReadAll(res.Body)
+				// Limit error body reads to avoid OOM on malicious or
+				// misbehaving servers returning arbitrarily large bodies.
+				const maxErrorBodySize = 64 * 1024 // 64 KiB
+				body, _ := io.ReadAll(io.LimitReader(res.Body, maxErrorBodySize))
 				res.Body.Close()
 				return &googleapi.Error{
 					Code:   res.StatusCode,


### PR DESCRIPTION
## Problem

In `storage/http_client.go`, the XML download path reads HTTP error response bodies with an unbounded `io.ReadAll`:

```go
if res.StatusCode < 200 || res.StatusCode > 299 {
    body, _ := io.ReadAll(res.Body)  // no size limit
    ...
}
```

A server returning a very large error body (e.g. a GCS-compatible proxy, a misconfigured endpoint, or an MITM attacker) can cause the client process to exhaust memory.

## Fix

Wrap the read with `io.LimitReader` capped at 64 KiB — sufficient to capture any meaningful error message while bounding memory allocation.

```go
const maxErrorBodySize = 64 * 1024
body, _ := io.ReadAll(io.LimitReader(res.Body, maxErrorBodySize))
```

This is consistent with the 8 KiB limit already applied in the OTel transport layer (`internal/trace/transport.go`).