### PR TITLE
fix(auth/httptransport): prevent bearer token leakage on cross-host redirects

### DIFF
--- a/auth/httptransport/transport.go
+++ b/auth/httptransport/transport.go
@@ -535,9 +535,9 @@ func (t *authTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	// re-inject it. If req.Response is set, this call is a redirect; skip
 	// auth injection when the destination host differs from the previous hop.
 	if prev := req.Response; prev != nil && prev.Request != nil {
-		if prev.Request.URL.Host != req.URL.Host {
+		if !strings.EqualFold(prev.Request.URL.Host, req.URL.Host) {
 			reqBodyClosed = true
-			return t.base.RoundTrip(req.Clone(req.Context()))
+			return t.base.RoundTrip(req)
 		}
 	}
 

--- a/auth/httptransport/transport.go
+++ b/auth/httptransport/transport.go
@@ -528,6 +528,19 @@ func (t *authTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 			}
 		}()
 	}
+
+	// Prevent bearer token leakage on cross-host redirects. Go's http.Client
+	// strips the Authorization header before calling the RoundTripper for a
+	// redirect to a different host, but this transport would unconditionally
+	// re-inject it. If req.Response is set, this call is a redirect; skip
+	// auth injection when the destination host differs from the previous hop.
+	if prev := req.Response; prev != nil && prev.Request != nil {
+		if prev.Request.URL.Host != req.URL.Host {
+			reqBodyClosed = true
+			return t.base.RoundTrip(req.Clone(req.Context()))
+		}
+	}
+
 	token, err := t.creds.Token(req.Context())
 	if err != nil {
 		return nil, err

--- a/auth/httptransport/transport_test.go
+++ b/auth/httptransport/transport_test.go
@@ -15,8 +15,11 @@
 package httptransport
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	"cloud.google.com/go/auth"
 	"cloud.google.com/go/auth/internal"
 )
 
@@ -63,5 +66,90 @@ func TestAuthTransport_GetClientUniverseDomain(t *testing.T) {
 				t.Errorf("got %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+// TestAuthTransport_CrossHostRedirectDoesNotLeakToken verifies that the
+// authTransport does not forward bearer tokens to a different host when
+// following a redirect. An attacker-controlled redirect (e.g. via an open
+// redirect on the target API) must not receive the caller's credentials.
+func TestAuthTransport_CrossHostRedirectDoesNotLeakToken(t *testing.T) {
+	const token = "super-secret-token"
+
+	// victim receives requests and records whether the auth header was present.
+	var victimSawToken bool
+	victim := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "" {
+			victimSawToken = true
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer victim.Close()
+
+	// redirector redirects all requests to the victim (different host).
+	redirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, victim.URL+"/", http.StatusFound)
+	}))
+	defer redirector.Close()
+
+	creds := auth.NewCredentials(&auth.CredentialsOptions{
+		TokenProvider: staticTP(token),
+	})
+	client := &http.Client{
+		Transport: &authTransport{
+			creds: creds,
+			base:  http.DefaultTransport,
+		},
+	}
+
+	resp, err := client.Get(redirector.URL + "/resource")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	resp.Body.Close()
+
+	if victimSawToken {
+		t.Error("bearer token was leaked to cross-host redirect destination")
+	}
+}
+
+// TestAuthTransport_SameHostRedirectIsAuthorized verifies that same-host
+// redirects continue to carry the bearer token.
+func TestAuthTransport_SameHostRedirectIsAuthorized(t *testing.T) {
+	const token = "super-secret-token"
+
+	var finalSawToken bool
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	mux.HandleFunc("/final", func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "Bearer "+token {
+			finalSawToken = true
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("/redirect", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, srv.URL+"/final", http.StatusFound)
+	})
+
+	creds := auth.NewCredentials(&auth.CredentialsOptions{
+		TokenProvider: staticTP(token),
+	})
+	client := &http.Client{
+		Transport: &authTransport{
+			creds: creds,
+			base:  http.DefaultTransport,
+		},
+	}
+
+	resp, err := client.Get(srv.URL + "/redirect")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	resp.Body.Close()
+
+	if !finalSawToken {
+		t.Error("bearer token was not forwarded to same-host redirect destination")
 	}
 }


### PR DESCRIPTION
## Problem

`authTransport.RoundTrip` unconditionally injects the `Authorization` header on every call, including the intermediate calls `http.Client` makes when following redirects.

Go's `http.Client` strips the `Authorization` header before building a cross-host redirect request (per the standard library's `shouldCopyHeaderOnRedirect` logic), but `authTransport` immediately re-adds the bearer token — forwarding it to **every host in the redirect chain**.

### Reproduction sketch

```go
// Two test servers on different ports/hosts.
// victim records whether Authorization header was present.
victim := httptest.NewServer(...)
redirector := httptest.NewServer(func(w, r) {
    http.Redirect(w, r, victim.URL, http.StatusFound)
})

client, _ := httptransport.NewClient(&httptransport.Options{Credentials: creds})
client.Get(redirector.URL)
// bearer token is present in victim's received request — credential leak
```

Any application using `NewClient` or `AddAuthorizationMiddleware` that follows a cross-host redirect (a webhook caller, an API proxy, or code that accepts user-provided URLs) will forward its OAuth bearer token to the redirect destination. An attacker who controls a redirect via an open redirect on a Google API endpoint or a user-controlled URL can steal the token.

Note: the same class of bug is being fixed upstream in `golang.org/x/oauth2` ([PR #804](https://github.com/golang/oauth2/pull/804)); this is an independent fix for the `cloud.google.com/go/auth` transport layer.

## Fix

Check `req.Response` in `RoundTrip`. When `req.Response` is non-nil, the call is a redirect. If the current URL's host differs from the previous hop's host, skip auth injection and delegate directly to the base transport.

```go
if prev := req.Response; prev != nil && prev.Request != nil {
    if prev.Request.URL.Host != req.URL.Host {
        reqBodyClosed = true
        return t.base.RoundTrip(req.Clone(req.Context()))
    }
}
```

Same-host redirects continue to carry the bearer token as before.

## Tests

- `TestAuthTransport_CrossHostRedirectDoesNotLeakToken`: verifies the token is NOT forwarded to a different-host redirect destination.
- `TestAuthTransport_SameHostRedirectIsAuthorized`: verifies same-host redirects remain fully authorized.