### PR TITLE
test(spanner): disable TestIntegration_QueueMutations

### DIFF
--- a/spanner/integration_test.go
+++ b/spanner/integration_test.go
@@ -6031,6 +6031,7 @@ func TestIntegration_WithDirectedReadOptions_ReadWriteTransaction_ShouldThrowErr
 }
 
 func TestIntegration_QueueMutations(t *testing.T) {
+	t.Skip("Cloud Queues are not supported yet")
 	// Run in cloud-devel only since this queue feature is not fully enabled yet.
 	onlyRunOnCloudDevel(t)
 	// DDL not fully enabled for PG yet.

--- a/spanner/integration_test.go
+++ b/spanner/integration_test.go
@@ -6031,6 +6031,7 @@ func TestIntegration_WithDirectedReadOptions_ReadWriteTransaction_ShouldThrowErr
 }
 
 func TestIntegration_QueueMutations(t *testing.T) {
+	// TODO: Re-enable once Cloud Queues are supported.
 	t.Skip("Cloud Queues are not supported yet")
 	// Run in cloud-devel only since this queue feature is not fully enabled yet.
 	onlyRunOnCloudDevel(t)


### PR DESCRIPTION
Cloud Queues are not supported yet, so skip the test until the feature is fully enabled.