### PR TITLE
fix(pubsub/v2/pstest): make ackIDs unique per delivery

### DIFF
--- a/pubsub/v2/pstest/fake.go
+++ b/pubsub/v2/pstest/fake.go
@@ -1002,7 +1002,10 @@ func (s *GServer) ModifyAckDeadline(_ context.Context, req *pb.ModifyAckDeadline
 	}
 	now := time.Now()
 	for _, id := range req.AckIds {
-		s.msgsByID[id].modacks = append(s.msgsByID[id].modacks, Modack{AckID: id, AckDeadline: req.AckDeadlineSeconds, ReceivedAt: now})
+		msgID := parseAckID(id)
+		if m := s.msgsByID[msgID]; m != nil {
+			m.modacks = append(m.modacks, Modack{AckID: id, AckDeadline: req.AckDeadlineSeconds, ReceivedAt: now})
+		}
 	}
 	dur := secsToDur(req.AckDeadlineSeconds)
 	for _, id := range req.AckIds {
@@ -1163,6 +1166,7 @@ func (s *subscription) pull(max int) []*pb.ReceivedMessage {
 		if s.proto.DeadLetterPolicy != nil {
 			m.proto.DeliveryAttempt = int32(*m.deliveries)
 		}
+		m.proto.AckId = fmt.Sprintf("%s:%d", m.proto.Message.MessageId, *m.deliveries)
 		m.ackDeadline = now.Add(s.ackTimeout)
 		msgs = append(msgs, m.proto)
 		if len(msgs) >= max {
@@ -1261,6 +1265,13 @@ func (s *subscription) tryDeliverMessage(m *message, start int, now time.Time) (
 	if s.proto.DeadLetterPolicy != nil {
 		m.proto.DeliveryAttempt = int32(*m.deliveries) + 1
 	}
+	var oldAckID string
+	if m.proto != nil {
+		oldAckID = m.proto.AckId
+		if m.proto.Message != nil {
+			m.proto.AckId = fmt.Sprintf("%s:%d", m.proto.Message.MessageId, *m.deliveries+1)
+		}
+	}
 
 	for i := 0; i < len(s.streams); i++ {
 		idx := (i + start) % len(s.streams)
@@ -1282,6 +1293,9 @@ func (s *subscription) tryDeliverMessage(m *message, start int, now time.Time) (
 	// Restore the correct value of DeliveryAttempt if we were not able to deliver the message.
 	if s.proto.DeadLetterPolicy != nil {
 		m.proto.DeliveryAttempt = int32(*m.deliveries)
+	}
+	if m.proto != nil {
+		m.proto.AckId = oldAckID
 	}
 	return 0, false
 }
@@ -1493,22 +1507,31 @@ func (s *subscription) handleStreamingPullRequest(st *stream, req *pb.StreamingP
 }
 
 // Must be called with the lock held.
-func (s *subscription) ack(id string) {
-	m := s.msgs[id]
+func (s *subscription) ack(ackID string) {
+	msgID := parseAckID(ackID)
+	m := s.msgs[msgID]
 	if m != nil {
+		if m.proto.AckId != ackID {
+			return // ignore old ack
+		}
 		(*m.acks)++
-		delete(s.msgs, id)
+		delete(s.msgs, msgID)
 	}
 }
 
 // Must be called with the lock held.
-func (s *subscription) modifyAckDeadline(id string, d time.Duration) {
-	m := s.msgs[id]
+func (s *subscription) modifyAckDeadline(ackID string, d time.Duration) {
+	msgID := parseAckID(ackID)
+	m := s.msgs[msgID]
 	if m == nil { // already acked: ignore.
 		return
 	}
+	if m.proto.AckId != ackID {
+		return // ignore old modack
+	}
 	if d == 0 { // nack
 		m.makeAvailable()
+		m.proto.AckId = "" // Ensure subsequent modacks for this same AckId fail
 	} else { // extend the deadline by d
 		m.ackDeadline = s.timeNowFunc().Add(d)
 	}
@@ -1516,6 +1539,13 @@ func (s *subscription) modifyAckDeadline(id string, d time.Duration) {
 
 func secsToDur(secs int32) time.Duration {
 	return time.Duration(secs) * time.Second
+}
+
+func parseAckID(ackID string) string {
+	if i := strings.LastIndex(ackID, ":"); i >= 0 {
+		return ackID[:i]
+	}
+	return ackID
 }
 
 // runReactor looks up the reactors for a function, then launches them until handled=true

--- a/pubsub/v2/pstest_test.go
+++ b/pubsub/v2/pstest_test.go
@@ -21,6 +21,7 @@ import (
 	"strconv"
 	"sync"
 	"testing"
+	"time"
 
 	"cloud.google.com/go/internal/testutil"
 	"cloud.google.com/go/pubsub/v2"
@@ -104,5 +105,80 @@ func TestPSTest(t *testing.T) {
 	})
 	if err != nil && !errors.Is(err, context.Canceled) {
 		t.Fatal(err)
+	}
+}
+
+func TestNackRedelivery(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	srv := pstest.NewServer()
+	defer srv.Close()
+
+	conn, err := grpc.Dial(srv.Addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	projID := "test-project"
+	opts := withGRPCHeadersAssertionAlt(t, option.WithGRPCConn(conn))
+	client, err := pubsub.NewClient(ctx, projID, opts...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	topicName := fmt.Sprintf("projects/%s/topics/test-topic", projID)
+	_, err = client.TopicAdminClient.CreateTopic(ctx, &pb.Topic{
+		Name: topicName,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	subName := fmt.Sprintf("projects/%s/subscriptions/test-sub", projID)
+	_, err = client.SubscriptionAdminClient.CreateSubscription(ctx, &pb.Subscription{
+		Name:               subName,
+		Topic:              topicName,
+		AckDeadlineSeconds: 10,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	publisher := client.Publisher(topicName)
+	res := publisher.Publish(ctx, &pubsub.Message{Data: []byte("hello")})
+	_, err = res.Get(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	publisher.Stop()
+
+	sub := client.Subscriber("test-sub")
+
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	var mu sync.Mutex
+	var deliveryCount int
+	err = sub.Receive(ctx, func(ctx context.Context, msg *pubsub.Message) {
+		mu.Lock()
+		defer mu.Unlock()
+		deliveryCount++
+		if deliveryCount == 1 {
+			msg.Nack()
+		} else {
+			msg.Ack()
+			cancel()
+		}
+	})
+	if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatal(err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if deliveryCount < 2 {
+		t.Errorf("Expected at least 2 deliveries, got %d", deliveryCount)
 	}
 }


### PR DESCRIPTION
In the fake currently, ackIDs are just the message ID.
This PR switches the logic to a per-delivery unique `AckID` values in the format
`messageID:deliveryCount` at dispatch time.

This fixes a race condition in the fake PubSub server where late-arriving
batched modacks for a previous message delivery attempt could overwrite
an explicit Nack(), preventing immediate redelivery.

Fixes #10707