### PR TITLE
test(spanner): skip DirectPath-incompatible tests when DirectPath is enabled

### DIFF
--- a/spanner/request_id_header_test.go
+++ b/spanner/request_id_header_test.go
@@ -1616,6 +1616,7 @@ func TestRequestIDHeader_SingleUseReadOnly_ExecuteStreamingSql_Unavailable(t *te
 }
 
 func TestRequestIDHeader_SingleUseReadOnly_ExecuteStreamingSql_InvalidArgument(t *testing.T) {
+	skipDirectPathTest(t)
 	t.Parallel()
 
 	ctx := context.Background()
@@ -1750,6 +1751,7 @@ func TestRequestIDHeader_Commit_ContextDeadlineExceeded(t *testing.T) {
 }
 
 func TestRequestIDHeader_VerifyChannelNumber(t *testing.T) {
+	skipDirectPathTest(t)
 	t.Parallel()
 
 	ctx := context.Background()

--- a/spanner/sessionclient_test.go
+++ b/spanner/sessionclient_test.go
@@ -78,6 +78,7 @@ func newTestConsumer(numExpected int32) *testConsumer {
 }
 
 func TestNextClient(t *testing.T) {
+	skipDirectPathTest(t)
 	t.Parallel()
 	if useGRPCgcp {
 		// For GCPMultiEndpoint the nextClient is indirectly tested via TestBatchCreateAndCloseSession.


### PR DESCRIPTION
Skips TestNextClient, TestRequestIDHeader_VerifyChannelNumber, and TestRequestIDHeader_SingleUseReadOnly_ExecuteStreamingSql_InvalidArgument when GOOGLE_SPANNER_ENABLE_DIRECT_ACCESS is true. These tests rely on specific channel behaviors or mock server interactions that are not compatible with DirectPath.