### PR TITLE
chore: bulk promote stable 0.x libraries to v1.0.0

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1375,7 +1375,7 @@ libraries:
       - internal/generated/snippets/gkebackup/
     tag_format: '{id}/v{version}'
   - id: gkeconnect
-    version: 0.16.0
+    version: 1.0.0
     last_generated_commit: ""
     apis:
       - path: google/cloud/gkeconnect/gateway/v1beta1

--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -2132,7 +2132,7 @@ libraries:
       - internal/generated/snippets/privatecatalog/
     tag_format: '{id}/v{version}'
   - id: privilegedaccessmanager
-    version: 0.8.0
+    version: 1.0.0
     last_generated_commit: ""
     apis:
       - path: google/cloud/privilegedaccessmanager/v1

--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -167,7 +167,7 @@ libraries:
       - internal/generated/snippets/apigeeconnect/
     tag_format: '{id}/v{version}'
   - id: apigeeregistry
-    version: 0.15.0
+    version: 1.0.0
     last_generated_commit: ""
     apis:
       - path: google/cloud/apigeeregistry/v1

--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -2060,7 +2060,7 @@ libraries:
       - internal/generated/snippets/parallelstore/
     tag_format: '{id}/v{version}'
   - id: parametermanager
-    version: 0.8.0
+    version: 1.0.0
     last_generated_commit: ""
     apis:
       - path: google/cloud/parametermanager/v1

--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -999,7 +999,7 @@ libraries:
       - internal/generated/snippets/datalabeling/
     tag_format: '{id}/v{version}'
   - id: datamanager
-    version: 0.8.0
+    version: 1.0.0
     last_generated_commit: ""
     apis:
       - path: google/ads/datamanager/v1

--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -2467,7 +2467,7 @@ libraries:
       - internal/generated/snippets/securitycentermanagement/
     tag_format: '{id}/v{version}'
   - id: securityposture
-    version: 0.7.0
+    version: 1.0.0
     last_generated_commit: ""
     apis:
       - path: google/cloud/securityposture/v1

--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -239,7 +239,7 @@ libraries:
       - internal/generated/snippets/appengine/
     tag_format: '{id}/v{version}'
   - id: apphub
-    version: 0.9.0
+    version: 1.0.0
     last_generated_commit: ""
     apis:
       - path: google/cloud/apphub/v1

--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1584,7 +1584,7 @@ libraries:
       - internal/generated/snippets/language/
     tag_format: '{id}/v{version}'
   - id: licensemanager
-    version: 0.6.0
+    version: 1.0.0
     last_generated_commit: ""
     apis:
       - path: google/cloud/licensemanager/v1

--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1456,7 +1456,7 @@ libraries:
       - internal/generated/snippets/gsuiteaddons/
     tag_format: '{id}/v{version}'
   - id: hypercomputecluster
-    version: 0.7.0
+    version: 1.0.0
     last_generated_commit: ""
     apis:
       - path: google/cloud/hypercomputecluster/v1beta

--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -863,7 +863,7 @@ libraries:
       - internal/generated/snippets/config/
     tag_format: '{id}/v{version}'
   - id: configdelivery
-    version: 0.6.0
+    version: 1.0.0
     last_generated_commit: ""
     apis:
       - path: google/cloud/configdelivery/v1

--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -671,7 +671,7 @@ libraries:
       - internal/generated/snippets/chat/
     tag_format: '{id}/v{version}'
   - id: chronicle
-    version: 0.7.0
+    version: 1.0.0
     last_generated_commit: ""
     apis:
       - path: google/cloud/chronicle/v1

--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -731,7 +731,7 @@ libraries:
       - internal/generated/snippets/clouddms/
     tag_format: '{id}/v{version}'
   - id: cloudprofiler
-    version: 0.9.0
+    version: 1.0.0
     last_generated_commit: ""
     apis:
       - path: google/devtools/cloudprofiler/v2

--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1102,7 +1102,7 @@ libraries:
       - internal/generated/snippets/deploy/
     tag_format: '{id}/v{version}'
   - id: developerconnect
-    version: 0.10.0
+    version: 1.0.0
     last_generated_commit: ""
     apis:
       - path: google/cloud/developerconnect/v1

--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1640,7 +1640,7 @@ libraries:
       - internal/generated/snippets/logging/
     tag_format: '{id}/v{version}'
   - id: longrunning
-    version: 0.13.0
+    version: 1.0.0
     last_generated_commit: ""
     apis:
       - path: google/longrunning

--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -2936,7 +2936,7 @@ libraries:
       - internal/generated/snippets/vision/
     tag_format: '{id}/v{version}'
   - id: visionai
-    version: 0.10.0
+    version: 1.0.0
     last_generated_commit: ""
     apis:
       - path: google/cloud/visionai/v1

--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1298,7 +1298,7 @@ libraries:
       - internal/generated/snippets/filestore/
     tag_format: '{id}/v{version}'
   - id: financialservices
-    version: 0.6.0
+    version: 1.0.0
     last_generated_commit: ""
     apis:
       - path: google/cloud/financialservices/v1

--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1916,7 +1916,7 @@ libraries:
       - internal/generated/snippets/networksecurity/
     tag_format: '{id}/v{version}'
   - id: networkservices
-    version: 0.11.0
+    version: 1.0.0
     last_generated_commit: ""
     apis:
       - path: google/cloud/networkservices/v1

--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -465,7 +465,7 @@ libraries:
       - internal/generated/snippets/beyondcorp/
     tag_format: '{id}/v{version}'
   - id: biglake
-    version: 0.5.0
+    version: 1.0.0
     last_generated_commit: ""
     apis:
       - path: google/cloud/biglake/v1

--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1116,7 +1116,7 @@ libraries:
       - internal/generated/snippets/developerconnect/
     tag_format: '{id}/v{version}'
   - id: devicestreaming
-    version: 0.6.0
+    version: 1.0.0
     last_generated_commit: ""
     apis:
       - path: google/cloud/devicestreaming/v1

--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -266,7 +266,7 @@ libraries:
       - internal/generated/snippets/appoptimize/
     tag_format: '{id}/v{version}'
   - id: apps
-    version: 0.13.0
+    version: 1.0.0
     last_generated_commit: ""
     apis:
       - path: google/apps/events/subscriptions/v1

--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1346,7 +1346,7 @@ libraries:
       - internal/generated/snippets/functions/
     tag_format: '{id}/v{version}'
   - id: geminidataanalytics
-    version: 0.13.0
+    version: 1.0.0
     last_generated_commit: ""
     apis:
       - path: google/cloud/geminidataanalytics/v1beta

--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -2044,7 +2044,7 @@ libraries:
       - internal/generated/snippets/oslogin/
     tag_format: '{id}/v{version}'
   - id: parallelstore
-    version: 0.17.0
+    version: 1.0.0
     last_generated_commit: ""
     apis:
       - path: google/cloud/parallelstore/v1

--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -761,7 +761,7 @@ libraries:
       - internal/generated/snippets/cloudquotas/
     tag_format: '{id}/v{version}'
   - id: cloudsecuritycompliance
-    version: 0.6.0
+    version: 1.0.0
     last_generated_commit: ""
     apis:
       - path: google/cloud/cloudsecuritycompliance/v1

--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -955,7 +955,7 @@ libraries:
       - internal/generated/snippets/dataflow/
     tag_format: '{id}/v{version}'
   - id: dataform
-    version: 0.19.0
+    version: 1.0.0
     last_generated_commit: ""
     apis:
       - path: google/cloud/dataform/v1

--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1668,7 +1668,7 @@ libraries:
       - internal/generated/snippets/lustre/
     tag_format: '{id}/v{version}'
   - id: maintenance
-    version: 0.8.0
+    version: 1.0.0
     last_generated_commit: ""
     apis:
       - path: google/cloud/maintenance/api/v1beta

--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -3043,7 +3043,7 @@ libraries:
       - internal/generated/snippets/workflows/
     tag_format: '{id}/v{version}'
   - id: workloadmanager
-    version: 0.6.0
+    version: 1.0.0
     last_generated_commit: ""
     apis:
       - path: google/cloud/workloadmanager/v1

--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -181,7 +181,7 @@ libraries:
       - internal/generated/snippets/apigeeregistry/
     tag_format: '{id}/v{version}'
   - id: apihub
-    version: 0.7.0
+    version: 1.0.0
     last_generated_commit: ""
     apis:
       - path: google/cloud/apihub/v1

--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -2741,7 +2741,7 @@ libraries:
       - internal/generated/snippets/storagetransfer/
     tag_format: '{id}/v{version}'
   - id: streetview
-    version: 0.7.0
+    version: 1.0.0
     last_generated_commit: ""
     apis:
       - path: google/streetview/publish/v1

--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1822,7 +1822,7 @@ libraries:
       - internal/generated/snippets/migrationcenter/
     tag_format: '{id}/v{version}'
   - id: modelarmor
-    version: 0.11.0
+    version: 1.0.0
     last_generated_commit: ""
     apis:
       - path: google/cloud/modelarmor/v1

--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1774,7 +1774,7 @@ libraries:
       - internal/generated/snippets/memcache/
     tag_format: '{id}/v{version}'
   - id: memorystore
-    version: 0.9.0
+    version: 1.0.0
     last_generated_commit: ""
     apis:
       - path: google/cloud/memorystore/v1

--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1508,7 +1508,7 @@ libraries:
       - internal/generated/snippets/iap/
     tag_format: '{id}/v{version}'
   - id: identitytoolkit
-    version: 0.6.0
+    version: 1.0.0
     last_generated_commit: ""
     apis:
       - path: google/cloud/identitytoolkit/v2

--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -657,7 +657,7 @@ libraries:
       - internal/generated/snippets/channel/
     tag_format: '{id}/v{version}'
   - id: chat
-    version: 0.23.0
+    version: 1.0.0
     last_generated_commit: ""
     apis:
       - path: google/chat/v1

--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -209,7 +209,7 @@ libraries:
       - internal/generated/snippets/apikeys/
     tag_format: '{id}/v{version}'
   - id: apiregistry
-    version: 0.7.0
+    version: 1.0.0
     last_generated_commit: ""
     apis:
       - path: google/cloud/apiregistry/v1beta

--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -65,7 +65,7 @@ libraries:
     remove_regex: []
     tag_format: '{id}/v{version}'
   - id: ai
-    version: 0.20.0
+    version: 1.0.0
     last_generated_commit: ""
     apis:
       - path: google/ai/generativelanguage/v1

--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1654,7 +1654,7 @@ libraries:
       - internal/generated/snippets/longrunning/
     tag_format: '{id}/v{version}'
   - id: lustre
-    version: 0.7.0
+    version: 1.0.0
     last_generated_commit: ""
     apis:
       - path: google/cloud/lustre/v1

--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1419,7 +1419,7 @@ libraries:
       - internal/generated/snippets/gkemulticloud/
     tag_format: '{id}/v{version}'
   - id: gkerecommender
-    version: 0.6.0
+    version: 1.0.0
     last_generated_commit: ""
     apis:
       - path: google/cloud/gkerecommender/v1

--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -2699,7 +2699,7 @@ libraries:
       - storage/internal/test
     tag_format: '{id}/v{version}'
   - id: storagebatchoperations
-    version: 0.9.0
+    version: 1.0.0
     last_generated_commit: ""
     apis:
       - path: google/cloud/storagebatchoperations/v1

--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1612,7 +1612,7 @@ libraries:
       - internal/generated/snippets/lifesciences/
     tag_format: '{id}/v{version}'
   - id: locationfinder
-    version: 0.6.0
+    version: 1.0.0
     last_generated_commit: ""
     apis:
       - path: google/cloud/locationfinder/v1

--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1962,7 +1962,7 @@ libraries:
       - internal/generated/snippets/optimization/
     tag_format: '{id}/v{version}'
   - id: oracledatabase
-    version: 0.11.0
+    version: 1.0.0
     last_generated_commit: ""
     apis:
       - path: google/cloud/oracledatabase/v1

--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -350,7 +350,7 @@ libraries:
       - internal/generated/snippets/assuredworkloads/
     tag_format: '{id}/v{version}'
   - id: auditmanager
-    version: 0.7.0
+    version: 1.0.0
     last_generated_commit: ""
     apis:
       - path: google/cloud/auditmanager/v1

--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1698,7 +1698,7 @@ libraries:
       - internal/generated/snippets/managedidentities/
     tag_format: '{id}/v{version}'
   - id: managedkafka
-    version: 0.13.0
+    version: 1.0.0
     last_generated_commit: ""
     apis:
       - path: google/cloud/managedkafka/v1

--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -627,7 +627,7 @@ libraries:
       - internal/generated/snippets/certificatemanager/
     tag_format: '{id}/v{version}'
   - id: ces
-    version: 0.9.0
+    version: 1.0.0
     last_generated_commit: ""
     apis:
       - path: google/cloud/ces/v1beta

--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -2859,7 +2859,7 @@ libraries:
       - internal/generated/snippets/translate/
     tag_format: '{id}/v{version}'
   - id: vectorsearch
-    version: 0.11.0
+    version: 1.0.0
     last_generated_commit: ""
     apis:
       - path: google/cloud/vectorsearch/v1beta

--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -2088,7 +2088,7 @@ libraries:
       - internal/generated/snippets/phishingprotection/
     tag_format: '{id}/v{version}'
   - id: policysimulator
-    version: 0.9.0
+    version: 1.0.0
     last_generated_commit: ""
     apis:
       - path: google/cloud/policysimulator/v1

--- a/ai/CHANGES.md
+++ b/ai/CHANGES.md
@@ -1,6 +1,8 @@
 # Changes
 
 
+## [1.0.0](https://github.com/googleapis/google-cloud-go/releases/tag/ai%2Fv1.0.0) (2026-05-08)
+
 ## [0.20.0](https://github.com/googleapis/google-cloud-go/releases/tag/ai%2Fv0.20.0) (2026-05-07)
 
 ## [0.19.0](https://github.com/googleapis/google-cloud-go/releases/tag/ai%2Fv0.19.0) (2026-04-30)

--- a/ai/generativelanguage/apiv1/.repo-metadata.json
+++ b/ai/generativelanguage/apiv1/.repo-metadata.json
@@ -6,5 +6,5 @@
     "distribution_name": "cloud.google.com/go/ai/generativelanguage/apiv1",
     "language": "go",
     "library_type": "GAPIC_AUTO",
-    "release_level": "preview"
+    "release_level": "stable"
 }

--- a/ai/generativelanguage/apiv1/doc.go
+++ b/ai/generativelanguage/apiv1/doc.go
@@ -25,8 +25,6 @@
 // like reasoning across text and images, content generation, dialogue
 // agents, summarization and classification systems, and more.
 //
-//	NOTE: This package is in beta. It is not stable, and may be subject to changes.
-//
 // # General documentation
 //
 // For information that is relevant for all client libraries please reference

--- a/ai/internal/version.go
+++ b/ai/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "0.20.0"
+const Version = "1.0.0"

--- a/apigeeregistry/CHANGES.md
+++ b/apigeeregistry/CHANGES.md
@@ -1,5 +1,7 @@
 # Changes
 
+## [1.0.0](https://github.com/googleapis/google-cloud-go/releases/tag/apigeeregistry%2Fv1.0.0) (2026-05-08)
+
 ## [0.15.0](https://github.com/googleapis/google-cloud-go/releases/tag/apigeeregistry%2Fv0.15.0) (2026-05-07)
 
 ## [0.14.0](https://github.com/googleapis/google-cloud-go/releases/tag/apigeeregistry%2Fv0.14.0) (2026-04-30)

--- a/apigeeregistry/apiv1/.repo-metadata.json
+++ b/apigeeregistry/apiv1/.repo-metadata.json
@@ -6,5 +6,5 @@
     "distribution_name": "cloud.google.com/go/apigeeregistry/apiv1",
     "language": "go",
     "library_type": "GAPIC_AUTO",
-    "release_level": "preview"
+    "release_level": "stable"
 }

--- a/apigeeregistry/apiv1/doc.go
+++ b/apigeeregistry/apiv1/doc.go
@@ -17,8 +17,6 @@
 // Package apigeeregistry is an auto-generated package for the
 // Apigee Registry API.
 //
-//	NOTE: This package is in beta. It is not stable, and may be subject to changes.
-//
 // # General documentation
 //
 // For information that is relevant for all client libraries please reference

--- a/apigeeregistry/internal/version.go
+++ b/apigeeregistry/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "0.15.0"
+const Version = "1.0.0"

--- a/apihub/CHANGES.md
+++ b/apihub/CHANGES.md
@@ -1,5 +1,7 @@
 # Changes
 
+## [1.0.0](https://github.com/googleapis/google-cloud-go/releases/tag/apihub%2Fv1.0.0) (2026-05-08)
+
 ## [0.7.0](https://github.com/googleapis/google-cloud-go/releases/tag/apihub%2Fv0.7.0) (2026-05-07)
 
 ## [0.6.0](https://github.com/googleapis/google-cloud-go/releases/tag/apihub%2Fv0.6.0) (2026-04-30)

--- a/apihub/apiv1/.repo-metadata.json
+++ b/apihub/apiv1/.repo-metadata.json
@@ -6,5 +6,5 @@
     "distribution_name": "cloud.google.com/go/apihub/apiv1",
     "language": "go",
     "library_type": "GAPIC_AUTO",
-    "release_level": "preview"
+    "release_level": "stable"
 }

--- a/apihub/apiv1/doc.go
+++ b/apihub/apiv1/doc.go
@@ -17,8 +17,6 @@
 // Package apihub is an auto-generated package for the
 // API hub API.
 //
-//	NOTE: This package is in beta. It is not stable, and may be subject to changes.
-//
 // # General documentation
 //
 // For information that is relevant for all client libraries please reference

--- a/apihub/internal/version.go
+++ b/apihub/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "0.7.0"
+const Version = "1.0.0"

--- a/apiregistry/CHANGES.md
+++ b/apiregistry/CHANGES.md
@@ -1,5 +1,7 @@
 # Changes
 
+## [1.0.0](https://github.com/googleapis/google-cloud-go/releases/tag/apiregistry%2Fv1.0.0) (2026-05-08)
+
 ## [0.7.0](https://github.com/googleapis/google-cloud-go/releases/tag/apiregistry%2Fv0.7.0) (2026-05-07)
 
 ## [0.6.0](https://github.com/googleapis/google-cloud-go/releases/tag/apiregistry%2Fv0.6.0) (2026-04-30)

--- a/apiregistry/apiv1/.repo-metadata.json
+++ b/apiregistry/apiv1/.repo-metadata.json
@@ -6,5 +6,5 @@
     "distribution_name": "cloud.google.com/go/apiregistry/apiv1",
     "language": "go",
     "library_type": "GAPIC_AUTO",
-    "release_level": "preview"
+    "release_level": "stable"
 }

--- a/apiregistry/apiv1/doc.go
+++ b/apiregistry/apiv1/doc.go
@@ -17,8 +17,6 @@
 // Package apiregistry is an auto-generated package for the
 // Cloud API Registry API.
 //
-//	NOTE: This package is in beta. It is not stable, and may be subject to changes.
-//
 // # General documentation
 //
 // For information that is relevant for all client libraries please reference

--- a/apiregistry/internal/version.go
+++ b/apiregistry/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "0.7.0"
+const Version = "1.0.0"

--- a/apphub/CHANGES.md
+++ b/apphub/CHANGES.md
@@ -1,5 +1,7 @@
 # Changes
 
+## [1.0.0](https://github.com/googleapis/google-cloud-go/releases/tag/apphub%2Fv1.0.0) (2026-05-08)
+
 ## [0.9.0](https://github.com/googleapis/google-cloud-go/releases/tag/apphub%2Fv0.9.0) (2026-05-07)
 
 ## [0.8.0](https://github.com/googleapis/google-cloud-go/releases/tag/apphub%2Fv0.8.0) (2026-04-30)

--- a/apphub/apiv1/.repo-metadata.json
+++ b/apphub/apiv1/.repo-metadata.json
@@ -6,5 +6,5 @@
     "distribution_name": "cloud.google.com/go/apphub/apiv1",
     "language": "go",
     "library_type": "GAPIC_AUTO",
-    "release_level": "preview"
+    "release_level": "stable"
 }

--- a/apphub/apiv1/doc.go
+++ b/apphub/apiv1/doc.go
@@ -17,8 +17,6 @@
 // Package apphub is an auto-generated package for the
 // App Hub API.
 //
-//	NOTE: This package is in beta. It is not stable, and may be subject to changes.
-//
 // # General documentation
 //
 // For information that is relevant for all client libraries please reference

--- a/apphub/internal/version.go
+++ b/apphub/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "0.9.0"
+const Version = "1.0.0"

--- a/apps/CHANGES.md
+++ b/apps/CHANGES.md
@@ -1,5 +1,7 @@
 # Changes
 
+## [1.0.0](https://github.com/googleapis/google-cloud-go/releases/tag/apps%2Fv1.0.0) (2026-05-08)
+
 ## [0.13.0](https://github.com/googleapis/google-cloud-go/releases/tag/apps%2Fv0.13.0) (2026-05-07)
 
 ## [0.12.0](https://github.com/googleapis/google-cloud-go/releases/tag/apps%2Fv0.12.0) (2026-04-30)

--- a/apps/events/subscriptions/apiv1/.repo-metadata.json
+++ b/apps/events/subscriptions/apiv1/.repo-metadata.json
@@ -6,5 +6,5 @@
     "distribution_name": "cloud.google.com/go/apps/events/subscriptions/apiv1",
     "language": "go",
     "library_type": "GAPIC_AUTO",
-    "release_level": "preview"
+    "release_level": "stable"
 }

--- a/apps/events/subscriptions/apiv1/doc.go
+++ b/apps/events/subscriptions/apiv1/doc.go
@@ -20,8 +20,6 @@
 // The Google Workspace Events API lets you subscribe to events and manage
 // change notifications across Google Workspace applications.
 //
-//	NOTE: This package is in beta. It is not stable, and may be subject to changes.
-//
 // # General documentation
 //
 // For information that is relevant for all client libraries please reference

--- a/apps/internal/version.go
+++ b/apps/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "0.13.0"
+const Version = "1.0.0"

--- a/apps/meet/apiv2/.repo-metadata.json
+++ b/apps/meet/apiv2/.repo-metadata.json
@@ -6,5 +6,5 @@
     "distribution_name": "cloud.google.com/go/apps/meet/apiv2",
     "language": "go",
     "library_type": "GAPIC_AUTO",
-    "release_level": "preview"
+    "release_level": "stable"
 }

--- a/apps/meet/apiv2/doc.go
+++ b/apps/meet/apiv2/doc.go
@@ -19,8 +19,6 @@
 //
 // Create and manage meetings in Google Meet.
 //
-//	NOTE: This package is in beta. It is not stable, and may be subject to changes.
-//
 // # General documentation
 //
 // For information that is relevant for all client libraries please reference

--- a/auditmanager/CHANGES.md
+++ b/auditmanager/CHANGES.md
@@ -1,5 +1,7 @@
 # Changes
 
+## [1.0.0](https://github.com/googleapis/google-cloud-go/releases/tag/auditmanager%2Fv1.0.0) (2026-05-08)
+
 ## [0.7.0](https://github.com/googleapis/google-cloud-go/releases/tag/auditmanager%2Fv0.7.0) (2026-05-07)
 
 ## [0.6.0](https://github.com/googleapis/google-cloud-go/releases/tag/auditmanager%2Fv0.6.0) (2026-04-30)

--- a/auditmanager/apiv1/.repo-metadata.json
+++ b/auditmanager/apiv1/.repo-metadata.json
@@ -6,5 +6,5 @@
     "distribution_name": "cloud.google.com/go/auditmanager/apiv1",
     "language": "go",
     "library_type": "GAPIC_AUTO",
-    "release_level": "preview"
+    "release_level": "stable"
 }

--- a/auditmanager/apiv1/doc.go
+++ b/auditmanager/apiv1/doc.go
@@ -17,8 +17,6 @@
 // Package auditmanager is an auto-generated package for the
 // Audit Manager API.
 //
-//	NOTE: This package is in beta. It is not stable, and may be subject to changes.
-//
 // # General documentation
 //
 // For information that is relevant for all client libraries please reference

--- a/auditmanager/internal/version.go
+++ b/auditmanager/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "0.7.0"
+const Version = "1.0.0"

--- a/biglake/CHANGES.md
+++ b/biglake/CHANGES.md
@@ -1,3 +1,5 @@
+## [1.0.0](https://github.com/googleapis/google-cloud-go/releases/tag/biglake%2Fv1.0.0) (2026-05-08)
+
 ## [0.5.0](https://github.com/googleapis/google-cloud-go/releases/tag/biglake%2Fv0.5.0) (2026-05-07)
 
 ## [0.4.0](https://github.com/googleapis/google-cloud-go/releases/tag/biglake%2Fv0.4.0) (2026-04-30)

--- a/biglake/apiv1/.repo-metadata.json
+++ b/biglake/apiv1/.repo-metadata.json
@@ -6,5 +6,5 @@
     "distribution_name": "cloud.google.com/go/biglake/apiv1",
     "language": "go",
     "library_type": "GAPIC_AUTO",
-    "release_level": "preview"
+    "release_level": "stable"
 }

--- a/biglake/apiv1/doc.go
+++ b/biglake/apiv1/doc.go
@@ -21,8 +21,6 @@
 // managed, and highly available metastore for open-source data that can be
 // used for querying Apache Iceberg tables in BigQuery.
 //
-//	NOTE: This package is in beta. It is not stable, and may be subject to changes.
-//
 // # General documentation
 //
 // For information that is relevant for all client libraries please reference

--- a/biglake/internal/version.go
+++ b/biglake/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "0.5.0"
+const Version = "1.0.0"

--- a/ces/CHANGES.md
+++ b/ces/CHANGES.md
@@ -1,5 +1,7 @@
 # Changes
 
+## [1.0.0](https://github.com/googleapis/google-cloud-go/releases/tag/ces%2Fv1.0.0) (2026-05-08)
+
 ## [0.9.0](https://github.com/googleapis/google-cloud-go/releases/tag/ces%2Fv0.9.0) (2026-05-07)
 
 ## [0.8.0](https://github.com/googleapis/google-cloud-go/releases/tag/ces%2Fv0.8.0) (2026-04-30)

--- a/ces/apiv1/.repo-metadata.json
+++ b/ces/apiv1/.repo-metadata.json
@@ -6,5 +6,5 @@
     "distribution_name": "cloud.google.com/go/ces/apiv1",
     "language": "go",
     "library_type": "GAPIC_AUTO",
-    "release_level": "preview"
+    "release_level": "stable"
 }

--- a/ces/apiv1/doc.go
+++ b/ces/apiv1/doc.go
@@ -17,8 +17,6 @@
 // Package ces is an auto-generated package for the
 // Gemini Enterprise for Customer Experience API.
 //
-//	NOTE: This package is in beta. It is not stable, and may be subject to changes.
-//
 // # General documentation
 //
 // For information that is relevant for all client libraries please reference

--- a/ces/internal/version.go
+++ b/ces/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "0.9.0"
+const Version = "1.0.0"

--- a/chat/CHANGES.md
+++ b/chat/CHANGES.md
@@ -1,5 +1,7 @@
 # Changes
 
+## [1.0.0](https://github.com/googleapis/google-cloud-go/releases/tag/chat%2Fv1.0.0) (2026-05-08)
+
 ## [0.23.0](https://github.com/googleapis/google-cloud-go/releases/tag/chat%2Fv0.23.0) (2026-05-07)
 
 ### Features

--- a/chat/apiv1/.repo-metadata.json
+++ b/chat/apiv1/.repo-metadata.json
@@ -6,5 +6,5 @@
     "distribution_name": "cloud.google.com/go/chat/apiv1",
     "language": "go",
     "library_type": "GAPIC_AUTO",
-    "release_level": "preview"
+    "release_level": "stable"
 }

--- a/chat/apiv1/doc.go
+++ b/chat/apiv1/doc.go
@@ -21,8 +21,6 @@
 // with Google Chat and manage Chat resources such as spaces, members, and
 // messages.
 //
-//	NOTE: This package is in beta. It is not stable, and may be subject to changes.
-//
 // # General documentation
 //
 // For information that is relevant for all client libraries please reference

--- a/chat/internal/version.go
+++ b/chat/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "0.23.0"
+const Version = "1.0.0"

--- a/chronicle/CHANGES.md
+++ b/chronicle/CHANGES.md
@@ -1,5 +1,7 @@
 # Changes
 
+## [1.0.0](https://github.com/googleapis/google-cloud-go/releases/tag/chronicle%2Fv1.0.0) (2026-05-08)
+
 ## [0.7.0](https://github.com/googleapis/google-cloud-go/releases/tag/chronicle%2Fv0.7.0) (2026-05-07)
 
 ### Features

--- a/chronicle/apiv1/.repo-metadata.json
+++ b/chronicle/apiv1/.repo-metadata.json
@@ -6,5 +6,5 @@
     "distribution_name": "cloud.google.com/go/chronicle/apiv1",
     "language": "go",
     "library_type": "GAPIC_AUTO",
-    "release_level": "preview"
+    "release_level": "stable"
 }

--- a/chronicle/apiv1/doc.go
+++ b/chronicle/apiv1/doc.go
@@ -21,8 +21,6 @@
 // endpoints that help analysts investigate and mitigate security threats
 // throughout their lifecycle.
 //
-//	NOTE: This package is in beta. It is not stable, and may be subject to changes.
-//
 // # General documentation
 //
 // For information that is relevant for all client libraries please reference

--- a/chronicle/internal/version.go
+++ b/chronicle/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "0.7.0"
+const Version = "1.0.0"

--- a/cloudprofiler/CHANGES.md
+++ b/cloudprofiler/CHANGES.md
@@ -1,6 +1,8 @@
 # Changes
 
 
+## [1.0.0](https://github.com/googleapis/google-cloud-go/releases/tag/cloudprofiler%2Fv1.0.0) (2026-05-08)
+
 ## [0.9.0](https://github.com/googleapis/google-cloud-go/releases/tag/cloudprofiler%2Fv0.9.0) (2026-05-07)
 
 ## [0.8.0](https://github.com/googleapis/google-cloud-go/releases/tag/cloudprofiler%2Fv0.8.0) (2026-04-30)

--- a/cloudprofiler/apiv2/.repo-metadata.json
+++ b/cloudprofiler/apiv2/.repo-metadata.json
@@ -6,5 +6,5 @@
     "distribution_name": "cloud.google.com/go/cloudprofiler/apiv2",
     "language": "go",
     "library_type": "GAPIC_AUTO",
-    "release_level": "preview"
+    "release_level": "stable"
 }

--- a/cloudprofiler/apiv2/doc.go
+++ b/cloudprofiler/apiv2/doc.go
@@ -19,8 +19,6 @@
 //
 // Manages continuous profiling information.
 //
-//	NOTE: This package is in beta. It is not stable, and may be subject to changes.
-//
 // # General documentation
 //
 // For information that is relevant for all client libraries please reference

--- a/cloudprofiler/internal/version.go
+++ b/cloudprofiler/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "0.9.0"
+const Version = "1.0.0"

--- a/cloudsecuritycompliance/CHANGES.md
+++ b/cloudsecuritycompliance/CHANGES.md
@@ -1,5 +1,7 @@
 # Changes
 
+## [1.0.0](https://github.com/googleapis/google-cloud-go/releases/tag/cloudsecuritycompliance%2Fv1.0.0) (2026-05-08)
+
 ## [0.6.0](https://github.com/googleapis/google-cloud-go/releases/tag/cloudsecuritycompliance%2Fv0.6.0) (2026-05-07)
 
 ## [0.5.0](https://github.com/googleapis/google-cloud-go/releases/tag/cloudsecuritycompliance%2Fv0.5.0) (2026-04-30)

--- a/cloudsecuritycompliance/apiv1/.repo-metadata.json
+++ b/cloudsecuritycompliance/apiv1/.repo-metadata.json
@@ -6,5 +6,5 @@
     "distribution_name": "cloud.google.com/go/cloudsecuritycompliance/apiv1",
     "language": "go",
     "library_type": "GAPIC_AUTO",
-    "release_level": "preview"
+    "release_level": "stable"
 }

--- a/cloudsecuritycompliance/apiv1/doc.go
+++ b/cloudsecuritycompliance/apiv1/doc.go
@@ -17,8 +17,6 @@
 // Package cloudsecuritycompliance is an auto-generated package for the
 // Cloud Security Compliance API.
 //
-//	NOTE: This package is in beta. It is not stable, and may be subject to changes.
-//
 // # General documentation
 //
 // For information that is relevant for all client libraries please reference

--- a/cloudsecuritycompliance/internal/version.go
+++ b/cloudsecuritycompliance/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "0.6.0"
+const Version = "1.0.0"

--- a/configdelivery/CHANGES.md
+++ b/configdelivery/CHANGES.md
@@ -1,5 +1,7 @@
 # Changes
 
+## [1.0.0](https://github.com/googleapis/google-cloud-go/releases/tag/configdelivery%2Fv1.0.0) (2026-05-08)
+
 ## [0.6.0](https://github.com/googleapis/google-cloud-go/releases/tag/configdelivery%2Fv0.6.0) (2026-05-07)
 
 ## [0.5.0](https://github.com/googleapis/google-cloud-go/releases/tag/configdelivery%2Fv0.5.0) (2026-04-30)

--- a/configdelivery/apiv1/.repo-metadata.json
+++ b/configdelivery/apiv1/.repo-metadata.json
@@ -6,5 +6,5 @@
     "distribution_name": "cloud.google.com/go/configdelivery/apiv1",
     "language": "go",
     "library_type": "GAPIC_AUTO",
-    "release_level": "preview"
+    "release_level": "stable"
 }

--- a/configdelivery/apiv1/doc.go
+++ b/configdelivery/apiv1/doc.go
@@ -20,8 +20,6 @@
 // ConfigDelivery service manages the deployment of kubernetes configuration
 // to a fleet of kubernetes clusters.
 //
-//	NOTE: This package is in beta. It is not stable, and may be subject to changes.
-//
 // # General documentation
 //
 // For information that is relevant for all client libraries please reference

--- a/configdelivery/internal/version.go
+++ b/configdelivery/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "0.6.0"
+const Version = "1.0.0"

--- a/dataform/CHANGES.md
+++ b/dataform/CHANGES.md
@@ -1,5 +1,7 @@
 # Changes
 
+## [1.0.0](https://github.com/googleapis/google-cloud-go/releases/tag/dataform%2Fv1.0.0) (2026-05-08)
+
 ## [0.19.0](https://github.com/googleapis/google-cloud-go/releases/tag/dataform%2Fv0.19.0) (2026-05-07)
 
 ## [0.18.0](https://github.com/googleapis/google-cloud-go/releases/tag/dataform%2Fv0.18.0) (2026-04-30)

--- a/dataform/apiv1/.repo-metadata.json
+++ b/dataform/apiv1/.repo-metadata.json
@@ -6,5 +6,5 @@
     "distribution_name": "cloud.google.com/go/dataform/apiv1",
     "language": "go",
     "library_type": "GAPIC_AUTO",
-    "release_level": "preview"
+    "release_level": "stable"
 }

--- a/dataform/apiv1/doc.go
+++ b/dataform/apiv1/doc.go
@@ -20,8 +20,6 @@
 // Service to develop, version control, and operationalize SQL pipelines in
 // BigQuery.
 //
-//	NOTE: This package is in beta. It is not stable, and may be subject to changes.
-//
 // # General documentation
 //
 // For information that is relevant for all client libraries please reference

--- a/dataform/internal/version.go
+++ b/dataform/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "0.19.0"
+const Version = "1.0.0"

--- a/datamanager/CHANGES.md
+++ b/datamanager/CHANGES.md
@@ -1,5 +1,7 @@
 # Changes
 
+## [1.0.0](https://github.com/googleapis/google-cloud-go/releases/tag/datamanager%2Fv1.0.0) (2026-05-08)
+
 ## [0.8.0](https://github.com/googleapis/google-cloud-go/releases/tag/datamanager%2Fv0.8.0) (2026-05-07)
 
 ## [0.7.0](https://github.com/googleapis/google-cloud-go/releases/tag/datamanager%2Fv0.7.0) (2026-04-30)

--- a/datamanager/apiv1/.repo-metadata.json
+++ b/datamanager/apiv1/.repo-metadata.json
@@ -6,5 +6,5 @@
     "distribution_name": "cloud.google.com/go/datamanager/apiv1",
     "language": "go",
     "library_type": "GAPIC_AUTO",
-    "release_level": "preview"
+    "release_level": "stable"
 }

--- a/datamanager/apiv1/doc.go
+++ b/datamanager/apiv1/doc.go
@@ -20,8 +20,6 @@
 // A unified ingestion API for data partners, agencies and advertisers to
 // connect first-party data across Google advertising products.
 //
-//	NOTE: This package is in beta. It is not stable, and may be subject to changes.
-//
 // # General documentation
 //
 // For information that is relevant for all client libraries please reference

--- a/datamanager/internal/version.go
+++ b/datamanager/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "0.8.0"
+const Version = "1.0.0"

--- a/developerconnect/CHANGES.md
+++ b/developerconnect/CHANGES.md
@@ -1,5 +1,7 @@
 # Changes
 
+## [1.0.0](https://github.com/googleapis/google-cloud-go/releases/tag/developerconnect%2Fv1.0.0) (2026-05-08)
+
 ## [0.10.0](https://github.com/googleapis/google-cloud-go/releases/tag/developerconnect%2Fv0.10.0) (2026-05-07)
 
 ## [0.9.0](https://github.com/googleapis/google-cloud-go/releases/tag/developerconnect%2Fv0.9.0) (2026-04-30)

--- a/developerconnect/apiv1/.repo-metadata.json
+++ b/developerconnect/apiv1/.repo-metadata.json
@@ -6,5 +6,5 @@
     "distribution_name": "cloud.google.com/go/developerconnect/apiv1",
     "language": "go",
     "library_type": "GAPIC_AUTO",
-    "release_level": "preview"
+    "release_level": "stable"
 }

--- a/developerconnect/apiv1/doc.go
+++ b/developerconnect/apiv1/doc.go
@@ -17,9 +17,7 @@
 // Package developerconnect is an auto-generated package for the
 // Developer Connect API.
 //
-// Connect third-party source code management to Google
-//
-//	NOTE: This package is in beta. It is not stable, and may be subject to changes.
+// # Connect third-party source code management to Google
 //
 // # General documentation
 //

--- a/developerconnect/internal/version.go
+++ b/developerconnect/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "0.10.0"
+const Version = "1.0.0"

--- a/devicestreaming/CHANGES.md
+++ b/devicestreaming/CHANGES.md
@@ -1,5 +1,7 @@
 # Changes
 
+## [1.0.0](https://github.com/googleapis/google-cloud-go/releases/tag/devicestreaming%2Fv1.0.0) (2026-05-08)
+
 ## [0.6.0](https://github.com/googleapis/google-cloud-go/releases/tag/devicestreaming%2Fv0.6.0) (2026-05-07)
 
 ## [0.5.0](https://github.com/googleapis/google-cloud-go/releases/tag/devicestreaming%2Fv0.5.0) (2026-04-30)

--- a/devicestreaming/apiv1/.repo-metadata.json
+++ b/devicestreaming/apiv1/.repo-metadata.json
@@ -6,5 +6,5 @@
     "distribution_name": "cloud.google.com/go/devicestreaming/apiv1",
     "language": "go",
     "library_type": "GAPIC_AUTO",
-    "release_level": "preview"
+    "release_level": "stable"
 }

--- a/devicestreaming/apiv1/doc.go
+++ b/devicestreaming/apiv1/doc.go
@@ -19,8 +19,6 @@
 //
 // The Cloud API for device streaming usage.
 //
-//	NOTE: This package is in beta. It is not stable, and may be subject to changes.
-//
 // # General documentation
 //
 // For information that is relevant for all client libraries please reference

--- a/devicestreaming/internal/version.go
+++ b/devicestreaming/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "0.6.0"
+const Version = "1.0.0"

--- a/financialservices/CHANGES.md
+++ b/financialservices/CHANGES.md
@@ -1,5 +1,7 @@
 # Changes
 
+## [1.0.0](https://github.com/googleapis/google-cloud-go/releases/tag/financialservices%2Fv1.0.0) (2026-05-08)
+
 ## [0.6.0](https://github.com/googleapis/google-cloud-go/releases/tag/financialservices%2Fv0.6.0) (2026-05-07)
 
 ## [0.5.0](https://github.com/googleapis/google-cloud-go/releases/tag/financialservices%2Fv0.5.0) (2026-04-30)

--- a/financialservices/apiv1/.repo-metadata.json
+++ b/financialservices/apiv1/.repo-metadata.json
@@ -6,5 +6,5 @@
     "distribution_name": "cloud.google.com/go/financialservices/apiv1",
     "language": "go",
     "library_type": "GAPIC_AUTO",
-    "release_level": "preview"
+    "release_level": "stable"
 }

--- a/financialservices/apiv1/doc.go
+++ b/financialservices/apiv1/doc.go
@@ -17,8 +17,6 @@
 // Package financialservices is an auto-generated package for the
 // Financial Services API.
 //
-//	NOTE: This package is in beta. It is not stable, and may be subject to changes.
-//
 // # General documentation
 //
 // For information that is relevant for all client libraries please reference

--- a/financialservices/internal/version.go
+++ b/financialservices/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "0.6.0"
+const Version = "1.0.0"

--- a/geminidataanalytics/CHANGES.md
+++ b/geminidataanalytics/CHANGES.md
@@ -1,5 +1,7 @@
 # Changes
 
+## [1.0.0](https://github.com/googleapis/google-cloud-go/releases/tag/geminidataanalytics%2Fv1.0.0) (2026-05-08)
+
 ## [0.13.0](https://github.com/googleapis/google-cloud-go/releases/tag/geminidataanalytics%2Fv0.13.0) (2026-05-07)
 
 ### Features

--- a/geminidataanalytics/apiv1/.repo-metadata.json
+++ b/geminidataanalytics/apiv1/.repo-metadata.json
@@ -6,5 +6,5 @@
     "distribution_name": "cloud.google.com/go/geminidataanalytics/apiv1",
     "language": "go",
     "library_type": "GAPIC_AUTO",
-    "release_level": "preview"
+    "release_level": "stable"
 }

--- a/geminidataanalytics/apiv1/doc.go
+++ b/geminidataanalytics/apiv1/doc.go
@@ -21,8 +21,6 @@
 // analytics applications. Leverage AI-powered chat interfaces to allow users
 // to interact with and analyze structured data using natural language.
 //
-//	NOTE: This package is in beta. It is not stable, and may be subject to changes.
-//
 // # General documentation
 //
 // For information that is relevant for all client libraries please reference

--- a/geminidataanalytics/internal/version.go
+++ b/geminidataanalytics/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "0.13.0"
+const Version = "1.0.0"

--- a/gkeconnect/CHANGES.md
+++ b/gkeconnect/CHANGES.md
@@ -1,5 +1,7 @@
 # Changes
 
+## [1.0.0](https://github.com/googleapis/google-cloud-go/releases/tag/gkeconnect%2Fv1.0.0) (2026-05-08)
+
 ## [0.16.0](https://github.com/googleapis/google-cloud-go/releases/tag/gkeconnect%2Fv0.16.0) (2026-04-30)
 
 ## [0.15.0](https://github.com/googleapis/google-cloud-go/releases/tag/gkeconnect%2Fv0.15.0) (2026-04-13)

--- a/gkeconnect/gateway/apiv1/.repo-metadata.json
+++ b/gkeconnect/gateway/apiv1/.repo-metadata.json
@@ -6,5 +6,5 @@
     "distribution_name": "cloud.google.com/go/gkeconnect/gateway/apiv1",
     "language": "go",
     "library_type": "GAPIC_AUTO",
-    "release_level": "preview"
+    "release_level": "stable"
 }

--- a/gkeconnect/gateway/apiv1/doc.go
+++ b/gkeconnect/gateway/apiv1/doc.go
@@ -20,8 +20,6 @@
 // The Connect Gateway service allows connectivity from external parties to
 // connected Kubernetes clusters.
 //
-//	NOTE: This package is in beta. It is not stable, and may be subject to changes.
-//
 // # General documentation
 //
 // For information that is relevant for all client libraries please reference

--- a/gkeconnect/internal/version.go
+++ b/gkeconnect/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "0.16.0"
+const Version = "1.0.0"

--- a/gkerecommender/CHANGES.md
+++ b/gkerecommender/CHANGES.md
@@ -1,5 +1,7 @@
 # Changes
 
+## [1.0.0](https://github.com/googleapis/google-cloud-go/releases/tag/gkerecommender%2Fv1.0.0) (2026-05-08)
+
 ## [0.6.0](https://github.com/googleapis/google-cloud-go/releases/tag/gkerecommender%2Fv0.6.0) (2026-05-07)
 
 ## [0.5.0](https://github.com/googleapis/google-cloud-go/releases/tag/gkerecommender%2Fv0.5.0) (2026-04-30)

--- a/gkerecommender/apiv1/.repo-metadata.json
+++ b/gkerecommender/apiv1/.repo-metadata.json
@@ -6,5 +6,5 @@
     "distribution_name": "cloud.google.com/go/gkerecommender/apiv1",
     "language": "go",
     "library_type": "GAPIC_AUTO",
-    "release_level": "preview"
+    "release_level": "stable"
 }

--- a/gkerecommender/apiv1/doc.go
+++ b/gkerecommender/apiv1/doc.go
@@ -17,9 +17,7 @@
 // Package gkerecommender is an auto-generated package for the
 // GKE Recommender API.
 //
-// GKE Recommender API
-//
-//	NOTE: This package is in beta. It is not stable, and may be subject to changes.
+// # GKE Recommender API
 //
 // # General documentation
 //

--- a/gkerecommender/internal/version.go
+++ b/gkerecommender/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "0.6.0"
+const Version = "1.0.0"

--- a/hypercomputecluster/CHANGES.md
+++ b/hypercomputecluster/CHANGES.md
@@ -1,5 +1,7 @@
 # Changes
 
+## [1.0.0](https://github.com/googleapis/google-cloud-go/releases/tag/hypercomputecluster%2Fv1.0.0) (2026-05-08)
+
 ## [0.7.0](https://github.com/googleapis/google-cloud-go/releases/tag/hypercomputecluster%2Fv0.7.0) (2026-05-07)
 
 ## [0.6.0](https://github.com/googleapis/google-cloud-go/releases/tag/hypercomputecluster%2Fv0.6.0) (2026-04-30)

--- a/hypercomputecluster/apiv1/.repo-metadata.json
+++ b/hypercomputecluster/apiv1/.repo-metadata.json
@@ -6,5 +6,5 @@
     "distribution_name": "cloud.google.com/go/hypercomputecluster/apiv1",
     "language": "go",
     "library_type": "GAPIC_AUTO",
-    "release_level": "preview"
+    "release_level": "stable"
 }

--- a/hypercomputecluster/apiv1/doc.go
+++ b/hypercomputecluster/apiv1/doc.go
@@ -20,8 +20,6 @@
 // The Cluster Director API allows you to deploy, manage, and monitor
 // clusters that run AI, ML, or HPC workloads.
 //
-//	NOTE: This package is in beta. It is not stable, and may be subject to changes.
-//
 // # General documentation
 //
 // For information that is relevant for all client libraries please reference

--- a/hypercomputecluster/internal/version.go
+++ b/hypercomputecluster/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "0.7.0"
+const Version = "1.0.0"

--- a/identitytoolkit/CHANGES.md
+++ b/identitytoolkit/CHANGES.md
@@ -1,5 +1,7 @@
 # Changes
 
+## [1.0.0](https://github.com/googleapis/google-cloud-go/releases/tag/identitytoolkit%2Fv1.0.0) (2026-05-08)
+
 ## [0.6.0](https://github.com/googleapis/google-cloud-go/releases/tag/identitytoolkit%2Fv0.6.0) (2026-04-30)
 
 ## [0.5.0](https://github.com/googleapis/google-cloud-go/releases/tag/identitytoolkit%2Fv0.5.0) (2026-04-13)

--- a/identitytoolkit/apiv2/.repo-metadata.json
+++ b/identitytoolkit/apiv2/.repo-metadata.json
@@ -6,5 +6,5 @@
     "distribution_name": "cloud.google.com/go/identitytoolkit/apiv2",
     "language": "go",
     "library_type": "GAPIC_AUTO",
-    "release_level": "preview"
+    "release_level": "stable"
 }

--- a/identitytoolkit/apiv2/doc.go
+++ b/identitytoolkit/apiv2/doc.go
@@ -20,8 +20,6 @@
 // The Google Identity Toolkit API lets you use open standards to verify a
 // user’s identity.
 //
-//	NOTE: This package is in beta. It is not stable, and may be subject to changes.
-//
 // # General documentation
 //
 // For information that is relevant for all client libraries please reference

--- a/identitytoolkit/internal/version.go
+++ b/identitytoolkit/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "0.6.0"
+const Version = "1.0.0"

--- a/internal/generated/snippets/ai/generativelanguage/apiv1/snippet_metadata.google.ai.generativelanguage.v1.json
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1/snippet_metadata.google.ai.generativelanguage.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/ai/generativelanguage/apiv1",
-    "version": "0.20.0"
+    "version": "1.0.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/ai/generativelanguage/apiv1alpha/snippet_metadata.google.ai.generativelanguage.v1alpha.json
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1alpha/snippet_metadata.google.ai.generativelanguage.v1alpha.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/ai/generativelanguage/apiv1alpha",
-    "version": "0.20.0"
+    "version": "1.0.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta/snippet_metadata.google.ai.generativelanguage.v1beta.json
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta/snippet_metadata.google.ai.generativelanguage.v1beta.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/ai/generativelanguage/apiv1beta",
-    "version": "0.20.0"
+    "version": "1.0.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/ai/generativelanguage/apiv1beta2/snippet_metadata.google.ai.generativelanguage.v1beta2.json
+++ b/internal/generated/snippets/ai/generativelanguage/apiv1beta2/snippet_metadata.google.ai.generativelanguage.v1beta2.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/ai/generativelanguage/apiv1beta2",
-    "version": "0.20.0"
+    "version": "1.0.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/apigeeregistry/apiv1/snippet_metadata.google.cloud.apigeeregistry.v1.json
+++ b/internal/generated/snippets/apigeeregistry/apiv1/snippet_metadata.google.cloud.apigeeregistry.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/apigeeregistry/apiv1",
-    "version": "0.15.0"
+    "version": "1.0.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/apihub/apiv1/snippet_metadata.google.cloud.apihub.v1.json
+++ b/internal/generated/snippets/apihub/apiv1/snippet_metadata.google.cloud.apihub.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/apihub/apiv1",
-    "version": "0.7.0"
+    "version": "1.0.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/apiregistry/apiv1/snippet_metadata.google.cloud.apiregistry.v1.json
+++ b/internal/generated/snippets/apiregistry/apiv1/snippet_metadata.google.cloud.apiregistry.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/apiregistry/apiv1",
-    "version": "0.7.0"
+    "version": "1.0.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/apiregistry/apiv1beta/snippet_metadata.google.cloud.apiregistry.v1beta.json
+++ b/internal/generated/snippets/apiregistry/apiv1beta/snippet_metadata.google.cloud.apiregistry.v1beta.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/apiregistry/apiv1beta",
-    "version": "0.7.0"
+    "version": "1.0.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/apphub/apiv1/snippet_metadata.google.cloud.apphub.v1.json
+++ b/internal/generated/snippets/apphub/apiv1/snippet_metadata.google.cloud.apphub.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/apphub/apiv1",
-    "version": "0.9.0"
+    "version": "1.0.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/apps/events/subscriptions/apiv1/snippet_metadata.google.apps.events.subscriptions.v1.json
+++ b/internal/generated/snippets/apps/events/subscriptions/apiv1/snippet_metadata.google.apps.events.subscriptions.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/apps/events/subscriptions/apiv1",
-    "version": "0.13.0"
+    "version": "1.0.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/apps/events/subscriptions/apiv1beta/snippet_metadata.google.apps.events.subscriptions.v1beta.json
+++ b/internal/generated/snippets/apps/events/subscriptions/apiv1beta/snippet_metadata.google.apps.events.subscriptions.v1beta.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/apps/events/subscriptions/apiv1beta",
-    "version": "0.13.0"
+    "version": "1.0.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/apps/meet/apiv2/snippet_metadata.google.apps.meet.v2.json
+++ b/internal/generated/snippets/apps/meet/apiv2/snippet_metadata.google.apps.meet.v2.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/apps/meet/apiv2",
-    "version": "0.13.0"
+    "version": "1.0.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/apps/meet/apiv2beta/snippet_metadata.google.apps.meet.v2beta.json
+++ b/internal/generated/snippets/apps/meet/apiv2beta/snippet_metadata.google.apps.meet.v2beta.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/apps/meet/apiv2beta",
-    "version": "0.13.0"
+    "version": "1.0.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/auditmanager/apiv1/snippet_metadata.google.cloud.auditmanager.v1.json
+++ b/internal/generated/snippets/auditmanager/apiv1/snippet_metadata.google.cloud.auditmanager.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/auditmanager/apiv1",
-    "version": "0.7.0"
+    "version": "1.0.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/biglake/apiv1/snippet_metadata.google.cloud.biglake.v1.json
+++ b/internal/generated/snippets/biglake/apiv1/snippet_metadata.google.cloud.biglake.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/biglake/apiv1",
-    "version": "0.5.0"
+    "version": "1.0.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/biglake/hive/apiv1beta/snippet_metadata.google.cloud.biglake.hive.v1beta.json
+++ b/internal/generated/snippets/biglake/hive/apiv1beta/snippet_metadata.google.cloud.biglake.hive.v1beta.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/biglake/hive/apiv1beta",
-    "version": "0.5.0"
+    "version": "1.0.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/ces/apiv1/snippet_metadata.google.cloud.ces.v1.json
+++ b/internal/generated/snippets/ces/apiv1/snippet_metadata.google.cloud.ces.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/ces/apiv1",
-    "version": "0.9.0"
+    "version": "1.0.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/ces/apiv1beta/snippet_metadata.google.cloud.ces.v1beta.json
+++ b/internal/generated/snippets/ces/apiv1beta/snippet_metadata.google.cloud.ces.v1beta.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/ces/apiv1beta",
-    "version": "0.9.0"
+    "version": "1.0.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/chat/apiv1/snippet_metadata.google.chat.v1.json
+++ b/internal/generated/snippets/chat/apiv1/snippet_metadata.google.chat.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/chat/apiv1",
-    "version": "0.23.0"
+    "version": "1.0.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/chronicle/apiv1/snippet_metadata.google.cloud.chronicle.v1.json
+++ b/internal/generated/snippets/chronicle/apiv1/snippet_metadata.google.cloud.chronicle.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/chronicle/apiv1",
-    "version": "0.7.0"
+    "version": "1.0.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/cloudprofiler/apiv2/snippet_metadata.google.devtools.cloudprofiler.v2.json
+++ b/internal/generated/snippets/cloudprofiler/apiv2/snippet_metadata.google.devtools.cloudprofiler.v2.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/cloudprofiler/apiv2",
-    "version": "0.9.0"
+    "version": "1.0.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/cloudsecuritycompliance/apiv1/snippet_metadata.google.cloud.cloudsecuritycompliance.v1.json
+++ b/internal/generated/snippets/cloudsecuritycompliance/apiv1/snippet_metadata.google.cloud.cloudsecuritycompliance.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/cloudsecuritycompliance/apiv1",
-    "version": "0.6.0"
+    "version": "1.0.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/configdelivery/apiv1/snippet_metadata.google.cloud.configdelivery.v1.json
+++ b/internal/generated/snippets/configdelivery/apiv1/snippet_metadata.google.cloud.configdelivery.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/configdelivery/apiv1",
-    "version": "0.6.0"
+    "version": "1.0.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/configdelivery/apiv1beta/snippet_metadata.google.cloud.configdelivery.v1beta.json
+++ b/internal/generated/snippets/configdelivery/apiv1beta/snippet_metadata.google.cloud.configdelivery.v1beta.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/configdelivery/apiv1beta",
-    "version": "0.6.0"
+    "version": "1.0.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/dataform/apiv1/snippet_metadata.google.cloud.dataform.v1.json
+++ b/internal/generated/snippets/dataform/apiv1/snippet_metadata.google.cloud.dataform.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/dataform/apiv1",
-    "version": "0.19.0"
+    "version": "1.0.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/dataform/apiv1beta1/snippet_metadata.google.cloud.dataform.v1beta1.json
+++ b/internal/generated/snippets/dataform/apiv1beta1/snippet_metadata.google.cloud.dataform.v1beta1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/dataform/apiv1beta1",
-    "version": "0.19.0"
+    "version": "1.0.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/datamanager/apiv1/snippet_metadata.google.ads.datamanager.v1.json
+++ b/internal/generated/snippets/datamanager/apiv1/snippet_metadata.google.ads.datamanager.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/datamanager/apiv1",
-    "version": "0.8.0"
+    "version": "1.0.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/developerconnect/apiv1/snippet_metadata.google.cloud.developerconnect.v1.json
+++ b/internal/generated/snippets/developerconnect/apiv1/snippet_metadata.google.cloud.developerconnect.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/developerconnect/apiv1",
-    "version": "0.10.0"
+    "version": "1.0.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/devicestreaming/apiv1/snippet_metadata.google.cloud.devicestreaming.v1.json
+++ b/internal/generated/snippets/devicestreaming/apiv1/snippet_metadata.google.cloud.devicestreaming.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/devicestreaming/apiv1",
-    "version": "0.6.0"
+    "version": "1.0.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/financialservices/apiv1/snippet_metadata.google.cloud.financialservices.v1.json
+++ b/internal/generated/snippets/financialservices/apiv1/snippet_metadata.google.cloud.financialservices.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/financialservices/apiv1",
-    "version": "0.6.0"
+    "version": "1.0.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/geminidataanalytics/apiv1/snippet_metadata.google.cloud.geminidataanalytics.v1.json
+++ b/internal/generated/snippets/geminidataanalytics/apiv1/snippet_metadata.google.cloud.geminidataanalytics.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/geminidataanalytics/apiv1",
-    "version": "0.13.0"
+    "version": "1.0.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/geminidataanalytics/apiv1beta/snippet_metadata.google.cloud.geminidataanalytics.v1beta.json
+++ b/internal/generated/snippets/geminidataanalytics/apiv1beta/snippet_metadata.google.cloud.geminidataanalytics.v1beta.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/geminidataanalytics/apiv1beta",
-    "version": "0.13.0"
+    "version": "1.0.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/gkeconnect/gateway/apiv1/snippet_metadata.google.cloud.gkeconnect.gateway.v1.json
+++ b/internal/generated/snippets/gkeconnect/gateway/apiv1/snippet_metadata.google.cloud.gkeconnect.gateway.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/gkeconnect/gateway/apiv1",
-    "version": "0.16.0"
+    "version": "1.0.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/gkeconnect/gateway/apiv1beta1/snippet_metadata.google.cloud.gkeconnect.gateway.v1beta1.json
+++ b/internal/generated/snippets/gkeconnect/gateway/apiv1beta1/snippet_metadata.google.cloud.gkeconnect.gateway.v1beta1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/gkeconnect/gateway/apiv1beta1",
-    "version": "0.16.0"
+    "version": "1.0.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/gkerecommender/apiv1/snippet_metadata.google.cloud.gkerecommender.v1.json
+++ b/internal/generated/snippets/gkerecommender/apiv1/snippet_metadata.google.cloud.gkerecommender.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/gkerecommender/apiv1",
-    "version": "0.6.0"
+    "version": "1.0.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/hypercomputecluster/apiv1/snippet_metadata.google.cloud.hypercomputecluster.v1.json
+++ b/internal/generated/snippets/hypercomputecluster/apiv1/snippet_metadata.google.cloud.hypercomputecluster.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/hypercomputecluster/apiv1",
-    "version": "0.7.0"
+    "version": "1.0.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/hypercomputecluster/apiv1beta/snippet_metadata.google.cloud.hypercomputecluster.v1beta.json
+++ b/internal/generated/snippets/hypercomputecluster/apiv1beta/snippet_metadata.google.cloud.hypercomputecluster.v1beta.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/hypercomputecluster/apiv1beta",
-    "version": "0.7.0"
+    "version": "1.0.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/identitytoolkit/apiv2/snippet_metadata.google.cloud.identitytoolkit.v2.json
+++ b/internal/generated/snippets/identitytoolkit/apiv2/snippet_metadata.google.cloud.identitytoolkit.v2.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/identitytoolkit/apiv2",
-    "version": "0.6.0"
+    "version": "1.0.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/licensemanager/apiv1/snippet_metadata.google.cloud.licensemanager.v1.json
+++ b/internal/generated/snippets/licensemanager/apiv1/snippet_metadata.google.cloud.licensemanager.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/licensemanager/apiv1",
-    "version": "0.6.0"
+    "version": "1.0.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/locationfinder/apiv1/snippet_metadata.google.cloud.locationfinder.v1.json
+++ b/internal/generated/snippets/locationfinder/apiv1/snippet_metadata.google.cloud.locationfinder.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/locationfinder/apiv1",
-    "version": "0.6.0"
+    "version": "1.0.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/longrunning/autogen/snippet_metadata.google.longrunning.json
+++ b/internal/generated/snippets/longrunning/autogen/snippet_metadata.google.longrunning.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/longrunning/autogen",
-    "version": "0.13.0"
+    "version": "1.0.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/lustre/apiv1/snippet_metadata.google.cloud.lustre.v1.json
+++ b/internal/generated/snippets/lustre/apiv1/snippet_metadata.google.cloud.lustre.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/lustre/apiv1",
-    "version": "0.7.0"
+    "version": "1.0.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/maintenance/api/apiv1/snippet_metadata.google.cloud.maintenance.api.v1.json
+++ b/internal/generated/snippets/maintenance/api/apiv1/snippet_metadata.google.cloud.maintenance.api.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/maintenance/api/apiv1",
-    "version": "0.8.0"
+    "version": "1.0.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/maintenance/api/apiv1beta/snippet_metadata.google.cloud.maintenance.api.v1beta.json
+++ b/internal/generated/snippets/maintenance/api/apiv1beta/snippet_metadata.google.cloud.maintenance.api.v1beta.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/maintenance/api/apiv1beta",
-    "version": "0.8.0"
+    "version": "1.0.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/managedkafka/apiv1/snippet_metadata.google.cloud.managedkafka.v1.json
+++ b/internal/generated/snippets/managedkafka/apiv1/snippet_metadata.google.cloud.managedkafka.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/managedkafka/apiv1",
-    "version": "0.13.0"
+    "version": "1.0.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/managedkafka/schemaregistry/apiv1/snippet_metadata.google.cloud.managedkafka.schemaregistry.v1.json
+++ b/internal/generated/snippets/managedkafka/schemaregistry/apiv1/snippet_metadata.google.cloud.managedkafka.schemaregistry.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/managedkafka/schemaregistry/apiv1",
-    "version": "0.13.0"
+    "version": "1.0.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/memorystore/apiv1/snippet_metadata.google.cloud.memorystore.v1.json
+++ b/internal/generated/snippets/memorystore/apiv1/snippet_metadata.google.cloud.memorystore.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/memorystore/apiv1",
-    "version": "0.9.0"
+    "version": "1.0.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/memorystore/apiv1beta/snippet_metadata.google.cloud.memorystore.v1beta.json
+++ b/internal/generated/snippets/memorystore/apiv1beta/snippet_metadata.google.cloud.memorystore.v1beta.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/memorystore/apiv1beta",
-    "version": "0.9.0"
+    "version": "1.0.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/modelarmor/apiv1/snippet_metadata.google.cloud.modelarmor.v1.json
+++ b/internal/generated/snippets/modelarmor/apiv1/snippet_metadata.google.cloud.modelarmor.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/modelarmor/apiv1",
-    "version": "0.11.0"
+    "version": "1.0.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/modelarmor/apiv1beta/snippet_metadata.google.cloud.modelarmor.v1beta.json
+++ b/internal/generated/snippets/modelarmor/apiv1beta/snippet_metadata.google.cloud.modelarmor.v1beta.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/modelarmor/apiv1beta",
-    "version": "0.11.0"
+    "version": "1.0.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/networkservices/apiv1/snippet_metadata.google.cloud.networkservices.v1.json
+++ b/internal/generated/snippets/networkservices/apiv1/snippet_metadata.google.cloud.networkservices.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/networkservices/apiv1",
-    "version": "0.11.0"
+    "version": "1.0.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/oracledatabase/apiv1/snippet_metadata.google.cloud.oracledatabase.v1.json
+++ b/internal/generated/snippets/oracledatabase/apiv1/snippet_metadata.google.cloud.oracledatabase.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/oracledatabase/apiv1",
-    "version": "0.11.0"
+    "version": "1.0.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/parallelstore/apiv1/snippet_metadata.google.cloud.parallelstore.v1.json
+++ b/internal/generated/snippets/parallelstore/apiv1/snippet_metadata.google.cloud.parallelstore.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/parallelstore/apiv1",
-    "version": "0.17.0"
+    "version": "1.0.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/parallelstore/apiv1beta/snippet_metadata.google.cloud.parallelstore.v1beta.json
+++ b/internal/generated/snippets/parallelstore/apiv1beta/snippet_metadata.google.cloud.parallelstore.v1beta.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/parallelstore/apiv1beta",
-    "version": "0.17.0"
+    "version": "1.0.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/parametermanager/apiv1/snippet_metadata.google.cloud.parametermanager.v1.json
+++ b/internal/generated/snippets/parametermanager/apiv1/snippet_metadata.google.cloud.parametermanager.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/parametermanager/apiv1",
-    "version": "0.8.0"
+    "version": "1.0.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/policysimulator/apiv1/snippet_metadata.google.cloud.policysimulator.v1.json
+++ b/internal/generated/snippets/policysimulator/apiv1/snippet_metadata.google.cloud.policysimulator.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/policysimulator/apiv1",
-    "version": "0.9.0"
+    "version": "1.0.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/privilegedaccessmanager/apiv1/snippet_metadata.google.cloud.privilegedaccessmanager.v1.json
+++ b/internal/generated/snippets/privilegedaccessmanager/apiv1/snippet_metadata.google.cloud.privilegedaccessmanager.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/privilegedaccessmanager/apiv1",
-    "version": "0.8.0"
+    "version": "1.0.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/securityposture/apiv1/snippet_metadata.google.cloud.securityposture.v1.json
+++ b/internal/generated/snippets/securityposture/apiv1/snippet_metadata.google.cloud.securityposture.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/securityposture/apiv1",
-    "version": "0.7.0"
+    "version": "1.0.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/storagebatchoperations/apiv1/snippet_metadata.google.cloud.storagebatchoperations.v1.json
+++ b/internal/generated/snippets/storagebatchoperations/apiv1/snippet_metadata.google.cloud.storagebatchoperations.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/storagebatchoperations/apiv1",
-    "version": "0.9.0"
+    "version": "1.0.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/streetview/publish/apiv1/snippet_metadata.google.streetview.publish.v1.json
+++ b/internal/generated/snippets/streetview/publish/apiv1/snippet_metadata.google.streetview.publish.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/streetview/publish/apiv1",
-    "version": "0.7.0"
+    "version": "1.0.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/vectorsearch/apiv1/snippet_metadata.google.cloud.vectorsearch.v1.json
+++ b/internal/generated/snippets/vectorsearch/apiv1/snippet_metadata.google.cloud.vectorsearch.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/vectorsearch/apiv1",
-    "version": "0.11.0"
+    "version": "1.0.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/vectorsearch/apiv1beta/snippet_metadata.google.cloud.vectorsearch.v1beta.json
+++ b/internal/generated/snippets/vectorsearch/apiv1beta/snippet_metadata.google.cloud.vectorsearch.v1beta.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/vectorsearch/apiv1beta",
-    "version": "0.11.0"
+    "version": "1.0.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/visionai/apiv1/snippet_metadata.google.cloud.visionai.v1.json
+++ b/internal/generated/snippets/visionai/apiv1/snippet_metadata.google.cloud.visionai.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/visionai/apiv1",
-    "version": "0.10.0"
+    "version": "1.0.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/workloadmanager/apiv1/snippet_metadata.google.cloud.workloadmanager.v1.json
+++ b/internal/generated/snippets/workloadmanager/apiv1/snippet_metadata.google.cloud.workloadmanager.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/workloadmanager/apiv1",
-    "version": "0.6.0"
+    "version": "1.0.0"
   },
   "snippets": [
     {

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -2872,7 +2872,7 @@ libraries:
           path: google/cloud/vision/v1p1beta1
       module_path_version: v2
   - name: visionai
-    version: 0.10.0
+    version: 1.0.0
     apis:
       - path: google/cloud/visionai/v1
     go:

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -2964,7 +2964,7 @@ libraries:
             - F_proto_cloneof
           path: google/cloud/workflows/v1beta
   - name: workloadmanager
-    version: 0.6.0
+    version: 1.0.0
     apis:
       - path: google/cloud/workloadmanager/v1
     go:

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -1478,7 +1478,7 @@ libraries:
             - F_proto_cloneof
           path: google/cloud/iap/v1
   - name: identitytoolkit
-    version: 0.6.0
+    version: 1.0.0
     apis:
       - path: google/cloud/identitytoolkit/v2
     go:

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -253,7 +253,7 @@ libraries:
             - F_proto_cloneof
           path: google/cloud/appoptimize/v1beta
   - name: apps
-    version: 0.13.0
+    version: 1.0.0
     apis:
       - path: google/apps/meet/v2
       - path: google/apps/events/subscriptions/v1

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -1862,7 +1862,7 @@ libraries:
             - F_proto_cloneof
           path: google/cloud/networksecurity/v1beta1
   - name: networkservices
-    version: 0.11.0
+    version: 1.0.0
     apis:
       - path: google/cloud/networkservices/v1
     go:

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -1416,7 +1416,7 @@ libraries:
             - F_proto_cloneof
           path: google/cloud/gsuiteaddons/v1
   - name: hypercomputecluster
-    version: 0.7.0
+    version: 1.0.0
     apis:
       - path: google/cloud/hypercomputecluster/v1
       - path: google/cloud/hypercomputecluster/v1beta

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -1599,7 +1599,7 @@ libraries:
           import_path: longrunning/autogen
           path: google/longrunning
   - name: lustre
-    version: 0.7.0
+    version: 1.0.0
     apis:
       - path: google/cloud/lustre/v1
     go:

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -1773,7 +1773,7 @@ libraries:
             - F_proto_cloneof
           path: google/cloud/migrationcenter/v1
   - name: modelarmor
-    version: 0.11.0
+    version: 1.0.0
     apis:
       - path: google/cloud/modelarmor/v1
       - path: google/cloud/modelarmor/v1beta

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -346,7 +346,7 @@ libraries:
             - F_proto_cloneof
           path: google/cloud/assuredworkloads/v1beta1
   - name: auditmanager
-    version: 0.7.0
+    version: 1.0.0
     apis:
       - path: google/cloud/auditmanager/v1
     go:

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -207,7 +207,7 @@ libraries:
           import_path: apikeys/apiv2
           path: google/api/apikeys/v2
   - name: apiregistry
-    version: 0.7.0
+    version: 1.0.0
     apis:
       - path: google/cloud/apiregistry/v1
       - path: google/cloud/apiregistry/v1beta

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -2792,7 +2792,7 @@ libraries:
           path: google/cloud/translate/v3
           proto_package: google.cloud.translation.v3
   - name: vectorsearch
-    version: 0.11.0
+    version: 1.0.0
     apis:
       - path: google/cloud/vectorsearch/v1
       - path: google/cloud/vectorsearch/v1beta

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -186,7 +186,7 @@ libraries:
             - F_proto_cloneof
           path: google/cloud/apigeeregistry/v1
   - name: apihub
-    version: 0.7.0
+    version: 1.0.0
     apis:
       - path: google/cloud/apihub/v1
     go:

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -2357,7 +2357,7 @@ libraries:
             - F_proto_cloneof
           path: google/cloud/securitycentermanagement/v1
   - name: securityposture
-    version: 0.7.0
+    version: 1.0.0
     apis:
       - path: google/cloud/securityposture/v1
     go:

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -763,7 +763,7 @@ libraries:
             - F_proto_cloneof
           path: google/cloud/clouddms/v1
   - name: cloudprofiler
-    version: 0.9.0
+    version: 1.0.0
     apis:
       - path: google/devtools/cloudprofiler/v2
     go:

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -891,7 +891,7 @@ libraries:
             - F_proto_cloneof
           path: google/cloud/config/v1
   - name: configdelivery
-    version: 0.6.0
+    version: 1.0.0
     apis:
       - path: google/cloud/configdelivery/v1
       - path: google/cloud/configdelivery/v1beta

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -1728,7 +1728,7 @@ libraries:
             - F_proto_cloneof
           path: google/cloud/memcache/v1beta2
   - name: memorystore
-    version: 0.9.0
+    version: 1.0.0
     apis:
       - path: google/cloud/memorystore/v1
       - path: google/cloud/memorystore/v1beta

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -1116,7 +1116,7 @@ libraries:
             - F_proto_cloneof
           path: google/cloud/developerconnect/v1
   - name: devicestreaming
-    version: 0.6.0
+    version: 1.0.0
     apis:
       - path: google/cloud/devicestreaming/v1
     go:

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -1902,7 +1902,7 @@ libraries:
             - F_proto_cloneof
           path: google/cloud/optimization/v1
   - name: oracledatabase
-    version: 0.11.0
+    version: 1.0.0
     apis:
       - path: google/cloud/oracledatabase/v1
     go:

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -982,7 +982,7 @@ libraries:
             - F_proto_cloneof
           path: google/dataflow/v1beta3
   - name: dataform
-    version: 0.19.0
+    version: 1.0.0
     apis:
       - path: google/cloud/dataform/v1
       - path: google/cloud/dataform/v1beta1

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -1106,7 +1106,7 @@ libraries:
             - F_proto_cloneof
           path: google/cloud/deploy/v1
   - name: developerconnect
-    version: 0.10.0
+    version: 1.0.0
     apis:
       - path: google/cloud/developerconnect/v1
     go:

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -1391,7 +1391,7 @@ libraries:
             - F_proto_cloneof
           path: google/cloud/gkemulticloud/v1
   - name: gkerecommender
-    version: 0.6.0
+    version: 1.0.0
     apis:
       - path: google/cloud/gkerecommender/v1
     go:

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -1634,7 +1634,7 @@ libraries:
             - F_proto_cloneof
           path: google/cloud/managedidentities/v1
   - name: managedkafka
-    version: 0.13.0
+    version: 1.0.0
     apis:
       - path: google/cloud/managedkafka/v1
       - path: google/cloud/managedkafka/schemaregistry/v1

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -791,7 +791,7 @@ libraries:
           import_path: cloudquotas/apiv1beta
           path: google/api/cloudquotas/v1beta
   - name: cloudsecuritycompliance
-    version: 0.6.0
+    version: 1.0.0
     apis:
       - path: google/cloud/cloudsecuritycompliance/v1
     go:

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -1277,7 +1277,7 @@ libraries:
             - F_proto_cloneof
           path: google/cloud/filestore/v1
   - name: financialservices
-    version: 0.6.0
+    version: 1.0.0
     apis:
       - path: google/cloud/financialservices/v1
     go:

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -2689,7 +2689,7 @@ libraries:
             - F_proto_cloneof
           path: google/storagetransfer/v1
   - name: streetview
-    version: 0.7.0
+    version: 1.0.0
     apis:
       - path: google/streetview/publish/v1
     go:

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -67,7 +67,7 @@ libraries:
     skip_generate: true
     skip_release: true
   - name: ai
-    version: 0.20.0
+    version: 1.0.0
     apis:
       - path: google/ai/generativelanguage/v1
       - path: google/ai/generativelanguage/v1beta2

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -676,7 +676,7 @@ libraries:
             - F_proto_cloneof
           path: google/cloud/certificatemanager/v1
   - name: ces
-    version: 0.9.0
+    version: 1.0.0
     apis:
       - path: google/cloud/ces/v1
       - path: google/cloud/ces/v1beta

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -1994,7 +1994,7 @@ libraries:
           path: google/cloud/oslogin/common
           proto_only: true
   - name: parallelstore
-    version: 0.17.0
+    version: 1.0.0
     apis:
       - path: google/cloud/parallelstore/v1
       - path: google/cloud/parallelstore/v1beta

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -1356,7 +1356,7 @@ libraries:
             - F_proto_cloneof
           path: google/cloud/gkebackup/v1
   - name: gkeconnect
-    version: 0.16.0
+    version: 1.0.0
     apis:
       - path: google/cloud/gkeconnect/gateway/v1
       - path: google/cloud/gkeconnect/gateway/v1beta1

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -1545,7 +1545,7 @@ libraries:
             - F_proto_cloneof
           path: google/cloud/language/v1beta2
   - name: licensemanager
-    version: 0.6.0
+    version: 1.0.0
     apis:
       - path: google/cloud/licensemanager/v1
     go:

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -2009,7 +2009,7 @@ libraries:
             - F_proto_cloneof
           path: google/cloud/parallelstore/v1beta
   - name: parametermanager
-    version: 0.8.0
+    version: 1.0.0
     apis:
       - path: google/cloud/parametermanager/v1
     go:

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -444,7 +444,7 @@ libraries:
             - F_proto_cloneof
           path: google/cloud/beyondcorp/clientgateways/v1
   - name: biglake
-    version: 0.5.0
+    version: 1.0.0
     apis:
       - path: google/cloud/biglake/v1
       - path: google/cloud/biglake/hive/v1beta

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -1017,7 +1017,7 @@ libraries:
             - F_proto_cloneof
           path: google/cloud/datalabeling/v1beta1
   - name: datamanager
-    version: 0.8.0
+    version: 1.0.0
     apis:
       - path: google/ads/datamanager/v1
     go:

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -2064,7 +2064,7 @@ libraries:
             - F_proto_cloneof
           path: google/cloud/privatecatalog/v1beta1
   - name: privilegedaccessmanager
-    version: 0.8.0
+    version: 1.0.0
     apis:
       - path: google/cloud/privilegedaccessmanager/v1
     go:

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -711,7 +711,7 @@ libraries:
             - F_proto_cloneof
           path: google/chat/v1
   - name: chronicle
-    version: 0.7.0
+    version: 1.0.0
     apis:
       - path: google/cloud/chronicle/v1
     go:

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -232,7 +232,7 @@ libraries:
             - F_proto_cloneof
           path: google/appengine/v1
   - name: apphub
-    version: 0.9.0
+    version: 1.0.0
     apis:
       - path: google/cloud/apphub/v1
     go:

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -2029,7 +2029,7 @@ libraries:
             - F_proto_cloneof
           path: google/cloud/phishingprotection/v1beta1
   - name: policysimulator
-    version: 0.9.0
+    version: 1.0.0
     apis:
       - path: google/cloud/policysimulator/v1
     go:

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -1565,7 +1565,7 @@ libraries:
             - F_proto_cloneof
           path: google/cloud/lifesciences/v2beta
   - name: locationfinder
-    version: 0.6.0
+    version: 1.0.0
     apis:
       - path: google/cloud/locationfinder/v1
     go:

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -1331,7 +1331,7 @@ libraries:
             - F_proto_cloneof
           path: google/cloud/functions/v2beta
   - name: geminidataanalytics
-    version: 0.13.0
+    version: 1.0.0
     apis:
       - path: google/cloud/geminidataanalytics/v1
       - path: google/cloud/geminidataanalytics/v1beta

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -701,7 +701,7 @@ libraries:
             - F_proto_cloneof
           path: google/cloud/channel/v1
   - name: chat
-    version: 0.23.0
+    version: 1.0.0
     apis:
       - path: google/chat/v1
     go:

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -176,7 +176,7 @@ libraries:
             - F_proto_cloneof
           path: google/cloud/apigeeconnect/v1
   - name: apigeeregistry
-    version: 0.15.0
+    version: 1.0.0
     apis:
       - path: google/cloud/apigeeregistry/v1
     go:

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -1609,7 +1609,7 @@ libraries:
             - F_proto_cloneof
           path: google/cloud/lustre/v1
   - name: maintenance
-    version: 0.8.0
+    version: 1.0.0
     apis:
       - path: google/cloud/maintenance/api/v1
       - path: google/cloud/maintenance/api/v1beta

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -2659,7 +2659,7 @@ libraries:
             - F_proto_cloneof
           path: google/storage/control/v2
   - name: storagebatchoperations
-    version: 0.9.0
+    version: 1.0.0
     apis:
       - path: google/cloud/storagebatchoperations/v1
     go:

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -1587,7 +1587,7 @@ libraries:
           path: google/logging/v2
       nested_module: logadmin
   - name: longrunning
-    version: 0.13.0
+    version: 1.0.0
     apis:
       - path: google/longrunning
     go:

--- a/licensemanager/CHANGES.md
+++ b/licensemanager/CHANGES.md
@@ -1,5 +1,7 @@
 # Changes
 
+## [1.0.0](https://github.com/googleapis/google-cloud-go/releases/tag/licensemanager%2Fv1.0.0) (2026-05-08)
+
 ## [0.6.0](https://github.com/googleapis/google-cloud-go/releases/tag/licensemanager%2Fv0.6.0) (2026-05-07)
 
 ## [0.5.0](https://github.com/googleapis/google-cloud-go/releases/tag/licensemanager%2Fv0.5.0) (2026-04-30)

--- a/licensemanager/apiv1/.repo-metadata.json
+++ b/licensemanager/apiv1/.repo-metadata.json
@@ -6,5 +6,5 @@
     "distribution_name": "cloud.google.com/go/licensemanager/apiv1",
     "language": "go",
     "library_type": "GAPIC_AUTO",
-    "release_level": "preview"
+    "release_level": "stable"
 }

--- a/licensemanager/apiv1/doc.go
+++ b/licensemanager/apiv1/doc.go
@@ -20,8 +20,6 @@
 // License Manager is a tool to manage and track third-party licenses on
 // Google Cloud.
 //
-//	NOTE: This package is in beta. It is not stable, and may be subject to changes.
-//
 // # General documentation
 //
 // For information that is relevant for all client libraries please reference

--- a/licensemanager/internal/version.go
+++ b/licensemanager/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "0.6.0"
+const Version = "1.0.0"

--- a/locationfinder/CHANGES.md
+++ b/locationfinder/CHANGES.md
@@ -1,5 +1,7 @@
 # Changes
 
+## [1.0.0](https://github.com/googleapis/google-cloud-go/releases/tag/locationfinder%2Fv1.0.0) (2026-05-08)
+
 ## [0.6.0](https://github.com/googleapis/google-cloud-go/releases/tag/locationfinder%2Fv0.6.0) (2026-05-07)
 
 ## [0.5.0](https://github.com/googleapis/google-cloud-go/releases/tag/locationfinder%2Fv0.5.0) (2026-04-30)

--- a/locationfinder/apiv1/.repo-metadata.json
+++ b/locationfinder/apiv1/.repo-metadata.json
@@ -6,5 +6,5 @@
     "distribution_name": "cloud.google.com/go/locationfinder/apiv1",
     "language": "go",
     "library_type": "GAPIC_AUTO",
-    "release_level": "preview"
+    "release_level": "stable"
 }

--- a/locationfinder/apiv1/doc.go
+++ b/locationfinder/apiv1/doc.go
@@ -17,8 +17,6 @@
 // Package locationfinder is an auto-generated package for the
 // Cloud Location Finder API.
 //
-//	NOTE: This package is in beta. It is not stable, and may be subject to changes.
-//
 // # General documentation
 //
 // For information that is relevant for all client libraries please reference

--- a/locationfinder/internal/version.go
+++ b/locationfinder/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "0.6.0"
+const Version = "1.0.0"

--- a/longrunning/CHANGES.md
+++ b/longrunning/CHANGES.md
@@ -1,5 +1,7 @@
 # Changes
 
+## [1.0.0](https://github.com/googleapis/google-cloud-go/releases/tag/longrunning%2Fv1.0.0) (2026-05-08)
+
 ## [0.13.0](https://github.com/googleapis/google-cloud-go/releases/tag/longrunning%2Fv0.13.0) (2026-05-07)
 
 ## [0.12.0](https://github.com/googleapis/google-cloud-go/releases/tag/longrunning%2Fv0.12.0) (2026-04-30)

--- a/longrunning/internal/version.go
+++ b/longrunning/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "0.13.0"
+const Version = "1.0.0"

--- a/lustre/CHANGES.md
+++ b/lustre/CHANGES.md
@@ -1,5 +1,7 @@
 # Changes
 
+## [1.0.0](https://github.com/googleapis/google-cloud-go/releases/tag/lustre%2Fv1.0.0) (2026-05-08)
+
 ## [0.7.0](https://github.com/googleapis/google-cloud-go/releases/tag/lustre%2Fv0.7.0) (2026-05-07)
 
 ## [0.6.0](https://github.com/googleapis/google-cloud-go/releases/tag/lustre%2Fv0.6.0) (2026-04-30)

--- a/lustre/apiv1/.repo-metadata.json
+++ b/lustre/apiv1/.repo-metadata.json
@@ -6,5 +6,5 @@
     "distribution_name": "cloud.google.com/go/lustre/apiv1",
     "language": "go",
     "library_type": "GAPIC_AUTO",
-    "release_level": "preview"
+    "release_level": "stable"
 }

--- a/lustre/apiv1/doc.go
+++ b/lustre/apiv1/doc.go
@@ -17,8 +17,6 @@
 // Package lustre is an auto-generated package for the
 // Google Cloud Managed Lustre API.
 //
-//	NOTE: This package is in beta. It is not stable, and may be subject to changes.
-//
 // # General documentation
 //
 // For information that is relevant for all client libraries please reference

--- a/lustre/internal/version.go
+++ b/lustre/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "0.7.0"
+const Version = "1.0.0"

--- a/maintenance/CHANGES.md
+++ b/maintenance/CHANGES.md
@@ -1,5 +1,7 @@
 # Changes
 
+## [1.0.0](https://github.com/googleapis/google-cloud-go/releases/tag/maintenance%2Fv1.0.0) (2026-05-08)
+
 ## [0.8.0](https://github.com/googleapis/google-cloud-go/releases/tag/maintenance%2Fv0.8.0) (2026-05-07)
 
 ## [0.7.0](https://github.com/googleapis/google-cloud-go/releases/tag/maintenance%2Fv0.7.0) (2026-04-30)

--- a/maintenance/api/apiv1/.repo-metadata.json
+++ b/maintenance/api/apiv1/.repo-metadata.json
@@ -6,5 +6,5 @@
     "distribution_name": "cloud.google.com/go/maintenance/api/apiv1",
     "language": "go",
     "library_type": "GAPIC_AUTO",
-    "release_level": "preview"
+    "release_level": "stable"
 }

--- a/maintenance/api/apiv1/doc.go
+++ b/maintenance/api/apiv1/doc.go
@@ -23,8 +23,6 @@
 // controls to manage certain maintenance activities, such as maintenance
 // windows, rescheduling, and on-demand updates.
 //
-//	NOTE: This package is in beta. It is not stable, and may be subject to changes.
-//
 // # General documentation
 //
 // For information that is relevant for all client libraries please reference

--- a/maintenance/internal/version.go
+++ b/maintenance/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "0.8.0"
+const Version = "1.0.0"

--- a/managedkafka/CHANGES.md
+++ b/managedkafka/CHANGES.md
@@ -1,5 +1,7 @@
 # Changes
 
+## [1.0.0](https://github.com/googleapis/google-cloud-go/releases/tag/managedkafka%2Fv1.0.0) (2026-05-08)
+
 ## [0.13.0](https://github.com/googleapis/google-cloud-go/releases/tag/managedkafka%2Fv0.13.0) (2026-05-07)
 
 ## [0.12.0](https://github.com/googleapis/google-cloud-go/releases/tag/managedkafka%2Fv0.12.0) (2026-04-30)

--- a/managedkafka/apiv1/.repo-metadata.json
+++ b/managedkafka/apiv1/.repo-metadata.json
@@ -6,5 +6,5 @@
     "distribution_name": "cloud.google.com/go/managedkafka/apiv1",
     "language": "go",
     "library_type": "GAPIC_AUTO",
-    "release_level": "preview"
+    "release_level": "stable"
 }

--- a/managedkafka/apiv1/doc.go
+++ b/managedkafka/apiv1/doc.go
@@ -19,8 +19,6 @@
 //
 // Manage Apache Kafka clusters and resources.
 //
-//	NOTE: This package is in beta. It is not stable, and may be subject to changes.
-//
 // # General documentation
 //
 // For information that is relevant for all client libraries please reference

--- a/managedkafka/internal/version.go
+++ b/managedkafka/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "0.13.0"
+const Version = "1.0.0"

--- a/managedkafka/schemaregistry/apiv1/.repo-metadata.json
+++ b/managedkafka/schemaregistry/apiv1/.repo-metadata.json
@@ -6,5 +6,5 @@
     "distribution_name": "cloud.google.com/go/managedkafka/schemaregistry/apiv1",
     "language": "go",
     "library_type": "GAPIC_AUTO",
-    "release_level": "preview"
+    "release_level": "stable"
 }

--- a/managedkafka/schemaregistry/apiv1/doc.go
+++ b/managedkafka/schemaregistry/apiv1/doc.go
@@ -19,8 +19,6 @@
 //
 // Manage Apache Kafka clusters and resources.
 //
-//	NOTE: This package is in beta. It is not stable, and may be subject to changes.
-//
 // # General documentation
 //
 // For information that is relevant for all client libraries please reference

--- a/memorystore/CHANGES.md
+++ b/memorystore/CHANGES.md
@@ -1,6 +1,8 @@
 # Changes
 
 
+## [1.0.0](https://github.com/googleapis/google-cloud-go/releases/tag/memorystore%2Fv1.0.0) (2026-05-08)
+
 ## [0.9.0](https://github.com/googleapis/google-cloud-go/releases/tag/memorystore%2Fv0.9.0) (2026-05-07)
 
 ### Features

--- a/memorystore/apiv1/.repo-metadata.json
+++ b/memorystore/apiv1/.repo-metadata.json
@@ -6,5 +6,5 @@
     "distribution_name": "cloud.google.com/go/memorystore/apiv1",
     "language": "go",
     "library_type": "GAPIC_AUTO",
-    "release_level": "preview"
+    "release_level": "stable"
 }

--- a/memorystore/apiv1/doc.go
+++ b/memorystore/apiv1/doc.go
@@ -17,8 +17,6 @@
 // Package memorystore is an auto-generated package for the
 // Memorystore API.
 //
-//	NOTE: This package is in beta. It is not stable, and may be subject to changes.
-//
 // # General documentation
 //
 // For information that is relevant for all client libraries please reference

--- a/memorystore/internal/version.go
+++ b/memorystore/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "0.9.0"
+const Version = "1.0.0"

--- a/modelarmor/CHANGES.md
+++ b/modelarmor/CHANGES.md
@@ -1,5 +1,7 @@
 # Changes
 
+## [1.0.0](https://github.com/googleapis/google-cloud-go/releases/tag/modelarmor%2Fv1.0.0) (2026-05-08)
+
 ## [0.11.0](https://github.com/googleapis/google-cloud-go/releases/tag/modelarmor%2Fv0.11.0) (2026-05-07)
 
 ## [0.10.0](https://github.com/googleapis/google-cloud-go/releases/tag/modelarmor%2Fv0.10.0) (2026-04-30)

--- a/modelarmor/apiv1/.repo-metadata.json
+++ b/modelarmor/apiv1/.repo-metadata.json
@@ -6,5 +6,5 @@
     "distribution_name": "cloud.google.com/go/modelarmor/apiv1",
     "language": "go",
     "library_type": "GAPIC_AUTO",
-    "release_level": "preview"
+    "release_level": "stable"
 }

--- a/modelarmor/apiv1/doc.go
+++ b/modelarmor/apiv1/doc.go
@@ -21,8 +21,6 @@
 // content, and data leakage in generative AI applications by letting you
 // define policies that filter user prompts and model responses.
 //
-//	NOTE: This package is in beta. It is not stable, and may be subject to changes.
-//
 // # General documentation
 //
 // For information that is relevant for all client libraries please reference

--- a/modelarmor/internal/version.go
+++ b/modelarmor/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "0.11.0"
+const Version = "1.0.0"

--- a/networkservices/CHANGES.md
+++ b/networkservices/CHANGES.md
@@ -1,5 +1,7 @@
 # Changes
 
+## [1.0.0](https://github.com/googleapis/google-cloud-go/releases/tag/networkservices%2Fv1.0.0) (2026-05-08)
+
 ## [0.11.0](https://github.com/googleapis/google-cloud-go/releases/tag/networkservices%2Fv0.11.0) (2026-05-07)
 
 ## [0.10.0](https://github.com/googleapis/google-cloud-go/releases/tag/networkservices%2Fv0.10.0) (2026-04-30)

--- a/networkservices/apiv1/.repo-metadata.json
+++ b/networkservices/apiv1/.repo-metadata.json
@@ -6,5 +6,5 @@
     "distribution_name": "cloud.google.com/go/networkservices/apiv1",
     "language": "go",
     "library_type": "GAPIC_AUTO",
-    "release_level": "preview"
+    "release_level": "stable"
 }

--- a/networkservices/apiv1/doc.go
+++ b/networkservices/apiv1/doc.go
@@ -17,8 +17,6 @@
 // Package networkservices is an auto-generated package for the
 // Network Services API.
 //
-//	NOTE: This package is in beta. It is not stable, and may be subject to changes.
-//
 // # General documentation
 //
 // For information that is relevant for all client libraries please reference

--- a/networkservices/internal/version.go
+++ b/networkservices/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "0.11.0"
+const Version = "1.0.0"

--- a/oracledatabase/CHANGES.md
+++ b/oracledatabase/CHANGES.md
@@ -1,5 +1,7 @@
 # Changes
 
+## [1.0.0](https://github.com/googleapis/google-cloud-go/releases/tag/oracledatabase%2Fv1.0.0) (2026-05-08)
+
 ## [0.11.0](https://github.com/googleapis/google-cloud-go/releases/tag/oracledatabase%2Fv0.11.0) (2026-05-07)
 
 ## [0.10.0](https://github.com/googleapis/google-cloud-go/releases/tag/oracledatabase%2Fv0.10.0) (2026-04-30)

--- a/oracledatabase/apiv1/.repo-metadata.json
+++ b/oracledatabase/apiv1/.repo-metadata.json
@@ -6,5 +6,5 @@
     "distribution_name": "cloud.google.com/go/oracledatabase/apiv1",
     "language": "go",
     "library_type": "GAPIC_AUTO",
-    "release_level": "preview"
+    "release_level": "stable"
 }

--- a/oracledatabase/apiv1/doc.go
+++ b/oracledatabase/apiv1/doc.go
@@ -20,8 +20,6 @@
 // The Oracle Database@Google Cloud API provides a set of APIs to manage
 // Oracle database services, such as Exadata and Autonomous Databases.
 //
-//	NOTE: This package is in beta. It is not stable, and may be subject to changes.
-//
 // # General documentation
 //
 // For information that is relevant for all client libraries please reference

--- a/oracledatabase/internal/version.go
+++ b/oracledatabase/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "0.11.0"
+const Version = "1.0.0"

--- a/parallelstore/CHANGES.md
+++ b/parallelstore/CHANGES.md
@@ -1,6 +1,8 @@
 # Changes
 
 
+## [1.0.0](https://github.com/googleapis/google-cloud-go/releases/tag/parallelstore%2Fv1.0.0) (2026-05-08)
+
 ## [0.17.0](https://github.com/googleapis/google-cloud-go/releases/tag/parallelstore%2Fv0.17.0) (2026-05-07)
 
 ## [0.16.0](https://github.com/googleapis/google-cloud-go/releases/tag/parallelstore%2Fv0.16.0) (2026-04-30)

--- a/parallelstore/apiv1/.repo-metadata.json
+++ b/parallelstore/apiv1/.repo-metadata.json
@@ -6,5 +6,5 @@
     "distribution_name": "cloud.google.com/go/parallelstore/apiv1",
     "language": "go",
     "library_type": "GAPIC_AUTO",
-    "release_level": "preview"
+    "release_level": "stable"
 }

--- a/parallelstore/apiv1/doc.go
+++ b/parallelstore/apiv1/doc.go
@@ -17,8 +17,6 @@
 // Package parallelstore is an auto-generated package for the
 // Parallelstore API.
 //
-//	NOTE: This package is in beta. It is not stable, and may be subject to changes.
-//
 // # General documentation
 //
 // For information that is relevant for all client libraries please reference

--- a/parallelstore/internal/version.go
+++ b/parallelstore/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "0.17.0"
+const Version = "1.0.0"

--- a/parametermanager/CHANGES.md
+++ b/parametermanager/CHANGES.md
@@ -1,5 +1,7 @@
 # Changes
 
+## [1.0.0](https://github.com/googleapis/google-cloud-go/releases/tag/parametermanager%2Fv1.0.0) (2026-05-08)
+
 ## [0.8.0](https://github.com/googleapis/google-cloud-go/releases/tag/parametermanager%2Fv0.8.0) (2026-05-07)
 
 ## [0.7.0](https://github.com/googleapis/google-cloud-go/releases/tag/parametermanager%2Fv0.7.0) (2026-04-30)

--- a/parametermanager/apiv1/.repo-metadata.json
+++ b/parametermanager/apiv1/.repo-metadata.json
@@ -6,5 +6,5 @@
     "distribution_name": "cloud.google.com/go/parametermanager/apiv1",
     "language": "go",
     "library_type": "GAPIC_AUTO",
-    "release_level": "preview"
+    "release_level": "stable"
 }

--- a/parametermanager/apiv1/doc.go
+++ b/parametermanager/apiv1/doc.go
@@ -22,8 +22,6 @@
 // management of sensitive application parameters effortless for customers
 // without diminishing focus on security.
 //
-//	NOTE: This package is in beta. It is not stable, and may be subject to changes.
-//
 // # General documentation
 //
 // For information that is relevant for all client libraries please reference

--- a/parametermanager/internal/version.go
+++ b/parametermanager/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "0.8.0"
+const Version = "1.0.0"

--- a/policysimulator/CHANGES.md
+++ b/policysimulator/CHANGES.md
@@ -1,5 +1,7 @@
 # Changes
 
+## [1.0.0](https://github.com/googleapis/google-cloud-go/releases/tag/policysimulator%2Fv1.0.0) (2026-05-08)
+
 ## [0.9.0](https://github.com/googleapis/google-cloud-go/releases/tag/policysimulator%2Fv0.9.0) (2026-05-07)
 
 ## [0.8.0](https://github.com/googleapis/google-cloud-go/releases/tag/policysimulator%2Fv0.8.0) (2026-04-30)

--- a/policysimulator/apiv1/.repo-metadata.json
+++ b/policysimulator/apiv1/.repo-metadata.json
@@ -6,5 +6,5 @@
     "distribution_name": "cloud.google.com/go/policysimulator/apiv1",
     "language": "go",
     "library_type": "GAPIC_AUTO",
-    "release_level": "preview"
+    "release_level": "stable"
 }

--- a/policysimulator/apiv1/doc.go
+++ b/policysimulator/apiv1/doc.go
@@ -25,8 +25,6 @@
 // and compares those results to determine how your members’ access might
 // change under the proposed policy.
 //
-//	NOTE: This package is in beta. It is not stable, and may be subject to changes.
-//
 // # General documentation
 //
 // For information that is relevant for all client libraries please reference

--- a/policysimulator/internal/version.go
+++ b/policysimulator/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "0.9.0"
+const Version = "1.0.0"

--- a/privilegedaccessmanager/CHANGES.md
+++ b/privilegedaccessmanager/CHANGES.md
@@ -1,5 +1,7 @@
 # Changes
 
+## [1.0.0](https://github.com/googleapis/google-cloud-go/releases/tag/privilegedaccessmanager%2Fv1.0.0) (2026-05-08)
+
 ## [0.8.0](https://github.com/googleapis/google-cloud-go/releases/tag/privilegedaccessmanager%2Fv0.8.0) (2026-05-07)
 
 ## [0.7.0](https://github.com/googleapis/google-cloud-go/releases/tag/privilegedaccessmanager%2Fv0.7.0) (2026-04-30)

--- a/privilegedaccessmanager/apiv1/.repo-metadata.json
+++ b/privilegedaccessmanager/apiv1/.repo-metadata.json
@@ -6,5 +6,5 @@
     "distribution_name": "cloud.google.com/go/privilegedaccessmanager/apiv1",
     "language": "go",
     "library_type": "GAPIC_AUTO",
-    "release_level": "preview"
+    "release_level": "stable"
 }

--- a/privilegedaccessmanager/apiv1/doc.go
+++ b/privilegedaccessmanager/apiv1/doc.go
@@ -31,8 +31,6 @@
 // access for operators for data ingestion and audits, JIT access to service
 // accounts for automated tasks, and more.
 //
-//	NOTE: This package is in beta. It is not stable, and may be subject to changes.
-//
 // # General documentation
 //
 // For information that is relevant for all client libraries please reference

--- a/privilegedaccessmanager/internal/version.go
+++ b/privilegedaccessmanager/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "0.8.0"
+const Version = "1.0.0"

--- a/securityposture/CHANGES.md
+++ b/securityposture/CHANGES.md
@@ -1,5 +1,7 @@
 # Changes
 
+## [1.0.0](https://github.com/googleapis/google-cloud-go/releases/tag/securityposture%2Fv1.0.0) (2026-05-08)
+
 ## [0.7.0](https://github.com/googleapis/google-cloud-go/releases/tag/securityposture%2Fv0.7.0) (2026-05-07)
 
 ## [0.6.0](https://github.com/googleapis/google-cloud-go/releases/tag/securityposture%2Fv0.6.0) (2026-04-30)

--- a/securityposture/apiv1/.repo-metadata.json
+++ b/securityposture/apiv1/.repo-metadata.json
@@ -6,5 +6,5 @@
     "distribution_name": "cloud.google.com/go/securityposture/apiv1",
     "language": "go",
     "library_type": "GAPIC_AUTO",
-    "release_level": "preview"
+    "release_level": "stable"
 }

--- a/securityposture/apiv1/doc.go
+++ b/securityposture/apiv1/doc.go
@@ -22,8 +22,6 @@
 // measures in a unified way and helps simplify governance and reduces
 // administrative toil.
 //
-//	NOTE: This package is in beta. It is not stable, and may be subject to changes.
-//
 // # General documentation
 //
 // For information that is relevant for all client libraries please reference

--- a/securityposture/internal/version.go
+++ b/securityposture/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "0.7.0"
+const Version = "1.0.0"

--- a/storagebatchoperations/CHANGES.md
+++ b/storagebatchoperations/CHANGES.md
@@ -1,5 +1,7 @@
 # Changes
 
+## [1.0.0](https://github.com/googleapis/google-cloud-go/releases/tag/storagebatchoperations%2Fv1.0.0) (2026-05-08)
+
 ## [0.9.0](https://github.com/googleapis/google-cloud-go/releases/tag/storagebatchoperations%2Fv0.9.0) (2026-05-07)
 
 ## [0.8.0](https://github.com/googleapis/google-cloud-go/releases/tag/storagebatchoperations%2Fv0.8.0) (2026-04-30)

--- a/storagebatchoperations/apiv1/.repo-metadata.json
+++ b/storagebatchoperations/apiv1/.repo-metadata.json
@@ -6,5 +6,5 @@
     "distribution_name": "cloud.google.com/go/storagebatchoperations/apiv1",
     "language": "go",
     "library_type": "GAPIC_AUTO",
-    "release_level": "preview"
+    "release_level": "stable"
 }

--- a/storagebatchoperations/apiv1/doc.go
+++ b/storagebatchoperations/apiv1/doc.go
@@ -17,8 +17,6 @@
 // Package storagebatchoperations is an auto-generated package for the
 // Storage Batch Operations API.
 //
-//	NOTE: This package is in beta. It is not stable, and may be subject to changes.
-//
 // # General documentation
 //
 // For information that is relevant for all client libraries please reference

--- a/storagebatchoperations/internal/version.go
+++ b/storagebatchoperations/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "0.9.0"
+const Version = "1.0.0"

--- a/streetview/CHANGES.md
+++ b/streetview/CHANGES.md
@@ -1,5 +1,7 @@
 # Changes
 
+## [1.0.0](https://github.com/googleapis/google-cloud-go/releases/tag/streetview%2Fv1.0.0) (2026-05-08)
+
 ## [0.7.0](https://github.com/googleapis/google-cloud-go/releases/tag/streetview%2Fv0.7.0) (2026-05-07)
 
 ## [0.6.0](https://github.com/googleapis/google-cloud-go/releases/tag/streetview%2Fv0.6.0) (2026-04-30)

--- a/streetview/internal/version.go
+++ b/streetview/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "0.7.0"
+const Version = "1.0.0"

--- a/streetview/publish/apiv1/.repo-metadata.json
+++ b/streetview/publish/apiv1/.repo-metadata.json
@@ -6,5 +6,5 @@
     "distribution_name": "cloud.google.com/go/streetview/publish/apiv1",
     "language": "go",
     "library_type": "GAPIC_AUTO",
-    "release_level": "preview"
+    "release_level": "stable"
 }

--- a/streetview/publish/apiv1/doc.go
+++ b/streetview/publish/apiv1/doc.go
@@ -21,8 +21,6 @@
 // connectivity metadata. Apps can offer an interface for positioning,
 // connecting, and uploading user-generated Street View images.
 //
-//	NOTE: This package is in beta. It is not stable, and may be subject to changes.
-//
 // # General documentation
 //
 // For information that is relevant for all client libraries please reference

--- a/vectorsearch/CHANGES.md
+++ b/vectorsearch/CHANGES.md
@@ -1,5 +1,7 @@
 # Changes
 
+## [1.0.0](https://github.com/googleapis/google-cloud-go/releases/tag/vectorsearch%2Fv1.0.0) (2026-05-08)
+
 ## [0.11.0](https://github.com/googleapis/google-cloud-go/releases/tag/vectorsearch%2Fv0.11.0) (2026-05-07)
 
 ### Features

--- a/vectorsearch/apiv1/.repo-metadata.json
+++ b/vectorsearch/apiv1/.repo-metadata.json
@@ -6,5 +6,5 @@
     "distribution_name": "cloud.google.com/go/vectorsearch/apiv1",
     "language": "go",
     "library_type": "GAPIC_AUTO",
-    "release_level": "preview"
+    "release_level": "stable"
 }

--- a/vectorsearch/apiv1/doc.go
+++ b/vectorsearch/apiv1/doc.go
@@ -27,8 +27,6 @@
 // approximate nearest neighbor (ANN) searches to find semantically similar
 // items at scale.
 //
-//	NOTE: This package is in beta. It is not stable, and may be subject to changes.
-//
 // # General documentation
 //
 // For information that is relevant for all client libraries please reference

--- a/vectorsearch/internal/version.go
+++ b/vectorsearch/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "0.11.0"
+const Version = "1.0.0"

--- a/visionai/CHANGES.md
+++ b/visionai/CHANGES.md
@@ -1,5 +1,7 @@
 # Changes
 
+## [1.0.0](https://github.com/googleapis/google-cloud-go/releases/tag/visionai%2Fv1.0.0) (2026-05-08)
+
 ## [0.10.0](https://github.com/googleapis/google-cloud-go/releases/tag/visionai%2Fv0.10.0) (2026-05-07)
 
 ## [0.9.0](https://github.com/googleapis/google-cloud-go/releases/tag/visionai%2Fv0.9.0) (2026-04-30)

--- a/visionai/apiv1/.repo-metadata.json
+++ b/visionai/apiv1/.repo-metadata.json
@@ -6,5 +6,5 @@
     "distribution_name": "cloud.google.com/go/visionai/apiv1",
     "language": "go",
     "library_type": "GAPIC_AUTO",
-    "release_level": "preview"
+    "release_level": "stable"
 }

--- a/visionai/apiv1/doc.go
+++ b/visionai/apiv1/doc.go
@@ -17,8 +17,6 @@
 // Package visionai is an auto-generated package for the
 // Vision AI API.
 //
-//	NOTE: This package is in beta. It is not stable, and may be subject to changes.
-//
 // # General documentation
 //
 // For information that is relevant for all client libraries please reference

--- a/visionai/internal/version.go
+++ b/visionai/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "0.10.0"
+const Version = "1.0.0"

--- a/workloadmanager/CHANGES.md
+++ b/workloadmanager/CHANGES.md
@@ -1,5 +1,7 @@
 # Changes
 
+## [1.0.0](https://github.com/googleapis/google-cloud-go/releases/tag/workloadmanager%2Fv1.0.0) (2026-05-08)
+
 ## [0.6.0](https://github.com/googleapis/google-cloud-go/releases/tag/workloadmanager%2Fv0.6.0) (2026-05-07)
 
 ## [0.5.0](https://github.com/googleapis/google-cloud-go/releases/tag/workloadmanager%2Fv0.5.0) (2026-04-30)

--- a/workloadmanager/apiv1/.repo-metadata.json
+++ b/workloadmanager/apiv1/.repo-metadata.json
@@ -6,5 +6,5 @@
     "distribution_name": "cloud.google.com/go/workloadmanager/apiv1",
     "language": "go",
     "library_type": "GAPIC_AUTO",
-    "release_level": "preview"
+    "release_level": "stable"
 }

--- a/workloadmanager/apiv1/doc.go
+++ b/workloadmanager/apiv1/doc.go
@@ -21,8 +21,6 @@
 // workloads to automate the deployment and validation of your workloads
 // against best practices and recommendations.
 //
-//	NOTE: This package is in beta. It is not stable, and may be subject to changes.
-//
 // # General documentation
 //
 // For information that is relevant for all client libraries please reference

--- a/workloadmanager/internal/version.go
+++ b/workloadmanager/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "0.6.0"
+const Version = "1.0.0"


### PR DESCRIPTION
PR created by the bulk promotion script to bump stable 0.x libraries to 1.0.0.

Fixes https://github.com/googleapis/librarian/issues/5303.

<details><summary>ai: v1.0.0</summary>

## [v1.0.0](https://github.com/suztomo/google-cloud-go/compare/ai/v0.20.0...ai/v1.0.0) (2026-05-08)

</details>

<details><summary>apigeeregistry: v1.0.0</summary>

## [v1.0.0](https://github.com/suztomo/google-cloud-go/compare/apigeeregistry/v0.15.0...apigeeregistry/v1.0.0) (2026-05-08)

</details>

<details><summary>apihub: v1.0.0</summary>

## [v1.0.0](https://github.com/suztomo/google-cloud-go/compare/apihub/v0.7.0...apihub/v1.0.0) (2026-05-08)

</details>

<details><summary>apiregistry: v1.0.0</summary>

## [v1.0.0](https://github.com/suztomo/google-cloud-go/compare/apiregistry/v0.7.0...apiregistry/v1.0.0) (2026-05-08)

</details>

<details><summary>apphub: v1.0.0</summary>

## [v1.0.0](https://github.com/suztomo/google-cloud-go/compare/apphub/v0.9.0...apphub/v1.0.0) (2026-05-08)

</details>

<details><summary>apps: v1.0.0</summary>

## [v1.0.0](https://github.com/suztomo/google-cloud-go/compare/apps/v0.13.0...apps/v1.0.0) (2026-05-08)

</details>

<details><summary>auditmanager: v1.0.0</summary>

## [v1.0.0](https://github.com/suztomo/google-cloud-go/compare/auditmanager/v0.7.0...auditmanager/v1.0.0) (2026-05-08)

</details>

<details><summary>biglake: v1.0.0</summary>

## [v1.0.0](https://github.com/suztomo/google-cloud-go/compare/biglake/v0.5.0...biglake/v1.0.0) (2026-05-08)

</details>

<details><summary>ces: v1.0.0</summary>

## [v1.0.0](https://github.com/suztomo/google-cloud-go/compare/ces/v0.9.0...ces/v1.0.0) (2026-05-08)

</details>

<details><summary>chat: v1.0.0</summary>

## [v1.0.0](https://github.com/suztomo/google-cloud-go/compare/chat/v0.23.0...chat/v1.0.0) (2026-05-08)

</details>

<details><summary>chronicle: v1.0.0</summary>

## [v1.0.0](https://github.com/suztomo/google-cloud-go/compare/chronicle/v0.7.0...chronicle/v1.0.0) (2026-05-08)

</details>

<details><summary>cloudprofiler: v1.0.0</summary>

## [v1.0.0](https://github.com/suztomo/google-cloud-go/compare/cloudprofiler/v0.9.0...cloudprofiler/v1.0.0) (2026-05-08)

</details>

<details><summary>cloudsecuritycompliance: v1.0.0</summary>

## [v1.0.0](https://github.com/suztomo/google-cloud-go/compare/cloudsecuritycompliance/v0.6.0...cloudsecuritycompliance/v1.0.0) (2026-05-08)

</details>

<details><summary>configdelivery: v1.0.0</summary>

## [v1.0.0](https://github.com/suztomo/google-cloud-go/compare/configdelivery/v0.6.0...configdelivery/v1.0.0) (2026-05-08)

</details>

<details><summary>dataform: v1.0.0</summary>

## [v1.0.0](https://github.com/suztomo/google-cloud-go/compare/dataform/v0.19.0...dataform/v1.0.0) (2026-05-08)

</details>

<details><summary>datamanager: v1.0.0</summary>

## [v1.0.0](https://github.com/suztomo/google-cloud-go/compare/datamanager/v0.8.0...datamanager/v1.0.0) (2026-05-08)

</details>

<details><summary>developerconnect: v1.0.0</summary>

## [v1.0.0](https://github.com/suztomo/google-cloud-go/compare/developerconnect/v0.10.0...developerconnect/v1.0.0) (2026-05-08)

</details>

<details><summary>devicestreaming: v1.0.0</summary>

## [v1.0.0](https://github.com/suztomo/google-cloud-go/compare/devicestreaming/v0.6.0...devicestreaming/v1.0.0) (2026-05-08)

</details>

<details><summary>financialservices: v1.0.0</summary>

## [v1.0.0](https://github.com/suztomo/google-cloud-go/compare/financialservices/v0.6.0...financialservices/v1.0.0) (2026-05-08)

</details>

<details><summary>geminidataanalytics: v1.0.0</summary>

## [v1.0.0](https://github.com/suztomo/google-cloud-go/compare/geminidataanalytics/v0.13.0...geminidataanalytics/v1.0.0) (2026-05-08)

</details>

<details><summary>gkeconnect: v1.0.0</summary>

## [v1.0.0](https://github.com/suztomo/google-cloud-go/compare/gkeconnect/v0.16.0...gkeconnect/v1.0.0) (2026-05-08)

</details>

<details><summary>gkerecommender: v1.0.0</summary>

## [v1.0.0](https://github.com/suztomo/google-cloud-go/compare/gkerecommender/v0.6.0...gkerecommender/v1.0.0) (2026-05-08)

</details>

<details><summary>hypercomputecluster: v1.0.0</summary>

## [v1.0.0](https://github.com/suztomo/google-cloud-go/compare/hypercomputecluster/v0.7.0...hypercomputecluster/v1.0.0) (2026-05-08)

</details>

<details><summary>identitytoolkit: v1.0.0</summary>

## [v1.0.0](https://github.com/suztomo/google-cloud-go/compare/identitytoolkit/v0.6.0...identitytoolkit/v1.0.0) (2026-05-08)

</details>

<details><summary>licensemanager: v1.0.0</summary>

## [v1.0.0](https://github.com/suztomo/google-cloud-go/compare/licensemanager/v0.6.0...licensemanager/v1.0.0) (2026-05-08)

</details>

<details><summary>locationfinder: v1.0.0</summary>

## [v1.0.0](https://github.com/suztomo/google-cloud-go/compare/locationfinder/v0.6.0...locationfinder/v1.0.0) (2026-05-08)

</details>

<details><summary>longrunning: v1.0.0</summary>

## [v1.0.0](https://github.com/suztomo/google-cloud-go/compare/longrunning/v0.13.0...longrunning/v1.0.0) (2026-05-08)

</details>

<details><summary>lustre: v1.0.0</summary>

## [v1.0.0](https://github.com/suztomo/google-cloud-go/compare/lustre/v0.7.0...lustre/v1.0.0) (2026-05-08)

</details>

<details><summary>maintenance: v1.0.0</summary>

## [v1.0.0](https://github.com/suztomo/google-cloud-go/compare/maintenance/v0.8.0...maintenance/v1.0.0) (2026-05-08)

</details>

<details><summary>managedkafka: v1.0.0</summary>

## [v1.0.0](https://github.com/suztomo/google-cloud-go/compare/managedkafka/v0.13.0...managedkafka/v1.0.0) (2026-05-08)

</details>

<details><summary>memorystore: v1.0.0</summary>

## [v1.0.0](https://github.com/suztomo/google-cloud-go/compare/memorystore/v0.9.0...memorystore/v1.0.0) (2026-05-08)

</details>

<details><summary>modelarmor: v1.0.0</summary>

## [v1.0.0](https://github.com/suztomo/google-cloud-go/compare/modelarmor/v0.11.0...modelarmor/v1.0.0) (2026-05-08)

</details>

<details><summary>networkservices: v1.0.0</summary>

## [v1.0.0](https://github.com/suztomo/google-cloud-go/compare/networkservices/v0.11.0...networkservices/v1.0.0) (2026-05-08)

</details>

<details><summary>oracledatabase: v1.0.0</summary>

## [v1.0.0](https://github.com/suztomo/google-cloud-go/compare/oracledatabase/v0.11.0...oracledatabase/v1.0.0) (2026-05-08)

</details>

<details><summary>parallelstore: v1.0.0</summary>

## [v1.0.0](https://github.com/suztomo/google-cloud-go/compare/parallelstore/v0.17.0...parallelstore/v1.0.0) (2026-05-08)

</details>

<details><summary>parametermanager: v1.0.0</summary>

## [v1.0.0](https://github.com/suztomo/google-cloud-go/compare/parametermanager/v0.8.0...parametermanager/v1.0.0) (2026-05-08)

</details>

<details><summary>policysimulator: v1.0.0</summary>

## [v1.0.0](https://github.com/suztomo/google-cloud-go/compare/policysimulator/v0.9.0...policysimulator/v1.0.0) (2026-05-08)

</details>

<details><summary>privilegedaccessmanager: v1.0.0</summary>

## [v1.0.0](https://github.com/suztomo/google-cloud-go/compare/privilegedaccessmanager/v0.8.0...privilegedaccessmanager/v1.0.0) (2026-05-08)

</details>

<details><summary>securityposture: v1.0.0</summary>

## [v1.0.0](https://github.com/suztomo/google-cloud-go/compare/securityposture/v0.7.0...securityposture/v1.0.0) (2026-05-08)

</details>

<details><summary>storagebatchoperations: v1.0.0</summary>

## [v1.0.0](https://github.com/suztomo/google-cloud-go/compare/storagebatchoperations/v0.9.0...storagebatchoperations/v1.0.0) (2026-05-08)

</details>

<details><summary>streetview: v1.0.0</summary>

## [v1.0.0](https://github.com/suztomo/google-cloud-go/compare/streetview/v0.7.0...streetview/v1.0.0) (2026-05-08)

</details>

<details><summary>vectorsearch: v1.0.0</summary>

## [v1.0.0](https://github.com/suztomo/google-cloud-go/compare/vectorsearch/v0.11.0...vectorsearch/v1.0.0) (2026-05-08)

</details>

<details><summary>visionai: v1.0.0</summary>

## [v1.0.0](https://github.com/suztomo/google-cloud-go/compare/visionai/v0.10.0...visionai/v1.0.0) (2026-05-08)

</details>

<details><summary>workloadmanager: v1.0.0</summary>

## [v1.0.0](https://github.com/suztomo/google-cloud-go/compare/workloadmanager/v0.6.0...workloadmanager/v1.0.0) (2026-05-08)

</details>

