### PR TITLE
test(spanner): retry query after database recreation in integration test

### DIFF
--- a/spanner/integration_test.go
+++ b/spanner/integration_test.go
@@ -2202,12 +2202,15 @@ func TestIntegration_DbRemovalRecovery(t *testing.T) {
 	}
 
 	// Now, send the query again.
-	iter = client.Single().Query(ctx, Statement{SQL: "SELECT SingerId FROM Singers"})
-	defer iter.Stop()
-	_, err = iter.Next()
-	if err != nil && err != iterator.Done {
-		t.Errorf("failed to send query to database %v: %v", dbPath, err)
-	}
+	waitFor(t, func() error {
+		iter := client.Single().Query(ctx, Statement{SQL: "SELECT SingerId FROM Singers"})
+		defer iter.Stop()
+		_, err := iter.Next()
+		if err != nil && err != iterator.Done {
+			return err
+		}
+		return nil
+	})
 	verifyDirectPathRemoteAddress(t)
 }
 

--- a/spanner/session_test.go
+++ b/spanner/session_test.go
@@ -98,7 +98,9 @@ func TestMultiplexSessionWorker(t *testing.T) {
 	server.TestSpanner.Unfreeze()
 
 	waitFor(t, func() error {
-		if server.TestSpanner.TotalSessionsCreated() != 2 {
+		sp.mu.Lock()
+		defer sp.mu.Unlock()
+		if server.TestSpanner.TotalSessionsCreated() != 2 || sp.multiplexedSession.id == oldMultiplexedSession {
 			return errInvalidSession
 		}
 		return nil


### PR DESCRIPTION
In TestIntegration_DbRemovalRecovery, immediately querying a newly recreated database can occasionally fail with a NotFound ("Database not found") error due to brief propagation delays in Spanner's internal location directory caches.

This change wraps the post-recreation query inside the existing waitFor helper loop, allowing the test to retry and tolerate temporary propagation windows.