### PR TITLE
fix(internal/librariangen): release preview support

### DIFF
--- a/internal/librariangen/release/release.go
+++ b/internal/librariangen/release/release.go
@@ -66,19 +66,30 @@ func Stage(ctx context.Context, cfg *Config) error {
 			continue
 		}
 		moduleConfig := repoConfig.GetModuleConfig(lib.ID)
+		var previewModule string
+		if strings.HasSuffix(lib.ID, "-preview") {
+			previewModule = strings.TrimSuffix(lib.ID, "-preview")
+		}
 
 		var moduleDir string
 		if isRootRepoModule(lib) {
 			moduleDir = cfg.OutputDir
 		} else {
 			moduleDir = filepath.Join(cfg.OutputDir, lib.ID)
+			if previewModule != "" {
+				moduleDir = filepath.Join(cfg.OutputDir, "preview", "internal", previewModule)
+			}
 		}
 		slog.Info("librariangen: processing library for release", "id", lib.ID, "version", lib.Version)
-		if err := updateChangelog(cfg, lib, now().UTC()); err != nil {
+		if err := updateChangelog(cfg, lib, now().UTC(), previewModule); err != nil {
 			return writeErrorResponse(cfg.LibrarianDir, fmt.Errorf("librariangen: failed to update changelog for %s: %w", lib.ID, err))
 		}
 		if err := module.GenerateInternalVersionFile(moduleDir, lib.Version); err != nil {
 			return writeErrorResponse(cfg.LibrarianDir, fmt.Errorf("librariangen: failed to update version for %s: %w", lib.ID, err))
+		}
+		if previewModule != "" {
+			// Skip snippet updates for preview modules, which don't have snippets.
+			continue
 		}
 		if err := module.UpdateSnippetsMetadata(lib, cfg.RepoDir, cfg.OutputDir, moduleConfig); err != nil {
 			return writeErrorResponse(cfg.LibrarianDir, fmt.Errorf("librariangen: failed to update snippet version for %s: %w", lib.ID, err))
@@ -99,10 +110,12 @@ var changelogSections = []struct {
 	{Type: "docs", Section: "Documentation"},
 }
 
-func updateChangelog(cfg *Config, lib *request.Library, t time.Time) error {
+func updateChangelog(cfg *Config, lib *request.Library, t time.Time, previewModule string) error {
 	var relativeChangelogPath string
 	if isRootRepoModule(lib) {
 		relativeChangelogPath = "CHANGES.md"
+	} else if previewModule != "" {
+		relativeChangelogPath = filepath.Join("preview", "internal", previewModule, "CHANGES.md")
 	} else {
 		relativeChangelogPath = filepath.Join(lib.ID, "CHANGES.md")
 	}
@@ -122,7 +135,11 @@ func updateChangelog(cfg *Config, lib *request.Library, t time.Time) error {
 
 	var newEntry bytes.Buffer
 
-	tag := strings.NewReplacer("{id}", lib.ID, "{version}", lib.Version).Replace(lib.TagFormat)
+	moduleName := lib.ID
+	if previewModule != "" {
+		moduleName = previewModule
+	}
+	tag := strings.NewReplacer("{id}", moduleName, "{version}", lib.Version).Replace(lib.TagFormat)
 	encodedTag := strings.ReplaceAll(tag, "/", "%2F")
 	releaseURL := "https://github.com/googleapis/google-cloud-go/releases/tag/" + encodedTag
 	date := t.Format("2006-01-02")

--- a/internal/librariangen/release/release_test.go
+++ b/internal/librariangen/release/release_test.go
@@ -146,6 +146,29 @@ func TestStage(t *testing.T) {
 			wantSnippetVersion:  `"version": "1.16.0"`,
 		},
 		{
+			name: "success-preview",
+			requestJSON: `{ 
+				"libraries": [{ 
+					"id": "secretmanager-preview", "version": "1.16.0-preview.1", "release_triggered": true,
+					"source_roots": ["preview/internal/secretmanager"],
+					"apis": [{"path": "google/cloud/secretmanager/v1"}],
+					"changes": [
+						{"type": "feat", "subject": "another feature", "commit_hash": "zxcvbn098765"},
+						{"type": "fix", "subject": "correct typo in documentation", "commit_hash": "123456abcdef"},
+						{"type": "feat", "subject": "add new GetSecret API", "commit_hash": "abcdef123456"}
+					],
+					"tag_format": "{id}/v{version}"
+				}]
+			}`,
+			initialRepoContent: map[string]string{
+				"preview/internal/secretmanager/CHANGES.md":          "# Changes\n\n## [1.15.0]\n- Old stuff.",
+				"preview/internal/secretmanager/internal/version.go": `package internal; const Version = "1.15.0"`,
+			},
+			moduleRootPath:      "preview/internal/secretmanager",
+			wantChangelogSubstr: "## [1.16.0-preview.1](https://github.com/googleapis/google-cloud-go/releases/tag/secretmanager%2Fv1.16.0-preview.1) (2025-09-11)\n\n### Features\n\n* add new GetSecret API ([abcdef1](https://github.com/googleapis/google-cloud-go/commit/abcdef123456))\n* another feature ([zxcvbn0](https://github.com/googleapis/google-cloud-go/commit/zxcvbn098765))\n\n### Bug Fixes\n\n* correct typo in documentation ([123456a](https://github.com/googleapis/google-cloud-go/commit/123456abcdef))\n\n",
+			wantVersion:         "1.16.0-preview.1",
+		},
+		{
 			name:                "release not triggered",
 			requestJSON:         `{ "libraries": [{"id": "secretmanager", "version": "1.16.0", "release_triggered": false}] }`,
 			releaseNotTriggered: true,


### PR DESCRIPTION
Adds support for doing version bumps and changelog updates for preview libraries.

Tested locally + unit test.

Toward https://github.com/googleapis/librarian/issues/5894