### PR TITLE
chore: librarian release pull request: 20260514T191310Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -657,7 +657,7 @@ libraries:
       - internal/generated/snippets/channel/
     tag_format: '{id}/v{version}'
   - id: chat
-    version: 1.0.0
+    version: 1.1.0
     last_generated_commit: ""
     apis:
       - path: google/chat/v1
@@ -807,7 +807,7 @@ libraries:
       - internal/generated/snippets/commerce/
     tag_format: '{id}/v{version}'
   - id: compute
-    version: 1.62.0
+    version: 1.63.0
     last_generated_commit: ""
     apis:
       - path: google/cloud/compute/v1
@@ -893,7 +893,7 @@ libraries:
       - internal/generated/snippets/contactcenterinsights/
     tag_format: '{id}/v{version}'
   - id: container
-    version: 1.51.0
+    version: 1.52.0
     last_generated_commit: ""
     apis:
       - path: google/container/v1
@@ -921,7 +921,7 @@ libraries:
       - internal/generated/snippets/containeranalysis/
     tag_format: '{id}/v{version}'
   - id: datacatalog
-    version: 1.31.0
+    version: 1.32.0
     last_generated_commit: ""
     apis:
       - path: google/cloud/datacatalog/lineage/v1
@@ -1027,7 +1027,7 @@ libraries:
       - internal/generated/snippets/dataplex/
     tag_format: '{id}/v{version}'
   - id: dataproc
-    version: 2.21.0
+    version: 2.22.0
     last_generated_commit: ""
     apis:
       - path: google/cloud/dataproc/v1
@@ -1346,7 +1346,7 @@ libraries:
       - internal/generated/snippets/functions/
     tag_format: '{id}/v{version}'
   - id: geminidataanalytics
-    version: 1.0.0
+    version: 1.1.0
     last_generated_commit: ""
     apis:
       - path: google/cloud/geminidataanalytics/v1beta

--- a/chat/CHANGES.md
+++ b/chat/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+## [1.1.0](https://github.com/googleapis/google-cloud-go/releases/tag/chat%2Fv1.1.0) (2026-05-14)
+
+### Features
+
+* update API sources and regenerate (#14581) ([df96b2e](https://github.com/googleapis/google-cloud-go/commit/df96b2ecb3930d6fb2e6e542e11521ee8e9d5935))
+
 ## [1.0.0](https://github.com/googleapis/google-cloud-go/releases/tag/chat%2Fv1.0.0) (2026-05-08)
 
 ## [0.23.0](https://github.com/googleapis/google-cloud-go/releases/tag/chat%2Fv0.23.0) (2026-05-07)

--- a/chat/internal/version.go
+++ b/chat/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "1.0.0"
+const Version = "1.1.0"

--- a/compute/CHANGES.md
+++ b/compute/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+## [1.63.0](https://github.com/googleapis/google-cloud-go/releases/tag/compute%2Fv1.63.0) (2026-05-14)
+
+### Features
+
+* update API sources and regenerate (#14581) ([df96b2e](https://github.com/googleapis/google-cloud-go/commit/df96b2ecb3930d6fb2e6e542e11521ee8e9d5935))
+
 ## [1.62.0](https://github.com/googleapis/google-cloud-go/releases/tag/compute%2Fv1.62.0) (2026-05-07)
 
 ### Features

--- a/compute/internal/version.go
+++ b/compute/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "1.62.0"
+const Version = "1.63.0"

--- a/container/CHANGES.md
+++ b/container/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+## [1.52.0](https://github.com/googleapis/google-cloud-go/releases/tag/container%2Fv1.52.0) (2026-05-14)
+
+### Features
+
+* update API sources and regenerate (#14581) ([df96b2e](https://github.com/googleapis/google-cloud-go/commit/df96b2ecb3930d6fb2e6e542e11521ee8e9d5935))
+
 ## [1.51.0](https://github.com/googleapis/google-cloud-go/releases/tag/container%2Fv1.51.0) (2026-05-07)
 
 ## [1.50.0](https://github.com/googleapis/google-cloud-go/releases/tag/container%2Fv1.50.0) (2026-04-30)

--- a/container/internal/version.go
+++ b/container/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "1.51.0"
+const Version = "1.52.0"

--- a/datacatalog/CHANGES.md
+++ b/datacatalog/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+## [1.32.0](https://github.com/googleapis/google-cloud-go/releases/tag/datacatalog%2Fv1.32.0) (2026-05-14)
+
+### Features
+
+* update API sources and regenerate (#14581) ([df96b2e](https://github.com/googleapis/google-cloud-go/commit/df96b2ecb3930d6fb2e6e542e11521ee8e9d5935))
+
 ## [1.31.0](https://github.com/googleapis/google-cloud-go/releases/tag/datacatalog%2Fv1.31.0) (2026-05-07)
 
 ## [1.30.0](https://github.com/googleapis/google-cloud-go/releases/tag/datacatalog%2Fv1.30.0) (2026-04-30)

--- a/datacatalog/internal/version.go
+++ b/datacatalog/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "1.31.0"
+const Version = "1.32.0"

--- a/dataproc/CHANGES.md
+++ b/dataproc/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+## [2.22.0](https://github.com/googleapis/google-cloud-go/releases/tag/dataproc%2Fv2.22.0) (2026-05-14)
+
+### Features
+
+* update API sources and regenerate (#14581) ([df96b2e](https://github.com/googleapis/google-cloud-go/commit/df96b2ecb3930d6fb2e6e542e11521ee8e9d5935))
+
 ## [2.21.0](https://github.com/googleapis/google-cloud-go/releases/tag/dataproc%2Fv2.21.0) (2026-05-07)
 
 ### Features

--- a/dataproc/internal/version.go
+++ b/dataproc/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "2.21.0"
+const Version = "2.22.0"

--- a/geminidataanalytics/CHANGES.md
+++ b/geminidataanalytics/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+## [1.1.0](https://github.com/googleapis/google-cloud-go/releases/tag/geminidataanalytics%2Fv1.1.0) (2026-05-14)
+
+### Features
+
+* update API sources and regenerate (#14581) ([df96b2e](https://github.com/googleapis/google-cloud-go/commit/df96b2ecb3930d6fb2e6e542e11521ee8e9d5935))
+
 ## [1.0.0](https://github.com/googleapis/google-cloud-go/releases/tag/geminidataanalytics%2Fv1.0.0) (2026-05-08)
 
 ## [0.13.0](https://github.com/googleapis/google-cloud-go/releases/tag/geminidataanalytics%2Fv0.13.0) (2026-05-07)

--- a/geminidataanalytics/internal/version.go
+++ b/geminidataanalytics/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "1.0.0"
+const Version = "1.1.0"

--- a/internal/generated/snippets/chat/apiv1/snippet_metadata.google.chat.v1.json
+++ b/internal/generated/snippets/chat/apiv1/snippet_metadata.google.chat.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/chat/apiv1",
-    "version": "1.0.0"
+    "version": "1.1.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/compute/apiv1/snippet_metadata.google.cloud.compute.v1.json
+++ b/internal/generated/snippets/compute/apiv1/snippet_metadata.google.cloud.compute.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/compute/apiv1",
-    "version": "1.62.0"
+    "version": "1.63.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/compute/apiv1beta/snippet_metadata.google.cloud.compute.v1beta.json
+++ b/internal/generated/snippets/compute/apiv1beta/snippet_metadata.google.cloud.compute.v1beta.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/compute/apiv1beta",
-    "version": "1.62.0"
+    "version": "1.63.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/container/apiv1/snippet_metadata.google.container.v1.json
+++ b/internal/generated/snippets/container/apiv1/snippet_metadata.google.container.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/container/apiv1",
-    "version": "1.51.0"
+    "version": "1.52.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/datacatalog/apiv1/snippet_metadata.google.cloud.datacatalog.v1.json
+++ b/internal/generated/snippets/datacatalog/apiv1/snippet_metadata.google.cloud.datacatalog.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/datacatalog/apiv1",
-    "version": "1.31.0"
+    "version": "1.32.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/datacatalog/apiv1beta1/snippet_metadata.google.cloud.datacatalog.v1beta1.json
+++ b/internal/generated/snippets/datacatalog/apiv1beta1/snippet_metadata.google.cloud.datacatalog.v1beta1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/datacatalog/apiv1beta1",
-    "version": "1.31.0"
+    "version": "1.32.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/datacatalog/lineage/apiv1/snippet_metadata.google.cloud.datacatalog.lineage.v1.json
+++ b/internal/generated/snippets/datacatalog/lineage/apiv1/snippet_metadata.google.cloud.datacatalog.lineage.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/datacatalog/lineage/apiv1",
-    "version": "1.31.0"
+    "version": "1.32.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/datacatalog/lineage/configmanagement/apiv1/snippet_metadata.google.cloud.datacatalog.lineage.configmanagement.v1.json
+++ b/internal/generated/snippets/datacatalog/lineage/configmanagement/apiv1/snippet_metadata.google.cloud.datacatalog.lineage.configmanagement.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/datacatalog/lineage/configmanagement/apiv1",
-    "version": "1.31.0"
+    "version": "1.32.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/dataproc/apiv1/snippet_metadata.google.cloud.dataproc.v1.json
+++ b/internal/generated/snippets/dataproc/apiv1/snippet_metadata.google.cloud.dataproc.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/dataproc/v2/apiv1",
-    "version": "2.21.0"
+    "version": "2.22.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/geminidataanalytics/apiv1/snippet_metadata.google.cloud.geminidataanalytics.v1.json
+++ b/internal/generated/snippets/geminidataanalytics/apiv1/snippet_metadata.google.cloud.geminidataanalytics.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/geminidataanalytics/apiv1",
-    "version": "1.0.0"
+    "version": "1.1.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/geminidataanalytics/apiv1beta/snippet_metadata.google.cloud.geminidataanalytics.v1beta.json
+++ b/internal/generated/snippets/geminidataanalytics/apiv1beta/snippet_metadata.google.cloud.geminidataanalytics.v1beta.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/geminidataanalytics/apiv1beta",
-    "version": "1.0.0"
+    "version": "1.1.0"
   },
   "snippets": [
     {

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -703,7 +703,7 @@ libraries:
             - F_proto_cloneof
           path: google/cloud/channel/v1
   - name: chat
-    version: 1.0.0
+    version: 1.1.0
     apis:
       - path: google/chat/v1
     go:
@@ -842,7 +842,7 @@ libraries:
             - F_proto_cloneof
           path: google/cloud/commerce/consumer/procurement/v1
   - name: compute
-    version: 1.62.0
+    version: 1.63.0
     apis:
       - path: google/cloud/compute/v1
       - path: google/cloud/compute/v1beta
@@ -918,7 +918,7 @@ libraries:
             - F_proto_cloneof
           path: google/cloud/contactcenterinsights/v1
   - name: container
-    version: 1.51.0
+    version: 1.52.0
     apis:
       - path: google/container/v1
     go:
@@ -946,7 +946,7 @@ libraries:
           no_metadata: true
           path: google/devtools/containeranalysis/v1beta1
   - name: datacatalog
-    version: 1.31.0
+    version: 1.32.0
     apis:
       - path: google/cloud/datacatalog/v1
       - path: google/cloud/datacatalog/lineage/v1
@@ -1040,7 +1040,7 @@ libraries:
             - F_proto_cloneof
           path: google/cloud/dataplex/v1
   - name: dataproc
-    version: 2.21.0
+    version: 2.22.0
     apis:
       - path: google/cloud/dataproc/v1
     go:
@@ -1333,7 +1333,7 @@ libraries:
             - F_proto_cloneof
           path: google/cloud/functions/v2beta
   - name: geminidataanalytics
-    version: 1.0.0
+    version: 1.1.0
     apis:
       - path: google/cloud/geminidataanalytics/v1
       - path: google/cloud/geminidataanalytics/v1beta


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.13.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go@sha256:b04b076f5eedbb5546bd6fc1404969dd3698c8b19c0f34ae815a84ae735a606a
<details><summary>chat: v1.1.0</summary>

## [v1.1.0](https://github.com/googleapis/google-cloud-go/compare/chat/v1.0.0...chat/v1.1.0) (2026-05-14)

### Features

* update API sources and regenerate (#14581) ([df96b2ec](https://github.com/googleapis/google-cloud-go/commit/df96b2ec))

</details>


<details><summary>compute: v1.63.0</summary>

## [v1.63.0](https://github.com/googleapis/google-cloud-go/compare/compute/v1.62.0...compute/v1.63.0) (2026-05-14)

### Features

* update API sources and regenerate (#14581) ([df96b2ec](https://github.com/googleapis/google-cloud-go/commit/df96b2ec))

</details>


<details><summary>container: v1.52.0</summary>

## [v1.52.0](https://github.com/googleapis/google-cloud-go/compare/container/v1.51.0...container/v1.52.0) (2026-05-14)

### Features

* update API sources and regenerate (#14581) ([df96b2ec](https://github.com/googleapis/google-cloud-go/commit/df96b2ec))

</details>


<details><summary>datacatalog: v1.32.0</summary>

## [v1.32.0](https://github.com/googleapis/google-cloud-go/compare/datacatalog/v1.31.0...datacatalog/v1.32.0) (2026-05-14)

### Features

* update API sources and regenerate (#14581) ([df96b2ec](https://github.com/googleapis/google-cloud-go/commit/df96b2ec))

</details>


<details><summary>dataproc: v2.22.0</summary>

## [v2.22.0](https://github.com/googleapis/google-cloud-go/compare/dataproc/v2.21.0...dataproc/v2.22.0) (2026-05-14)

### Features

* update API sources and regenerate (#14581) ([df96b2ec](https://github.com/googleapis/google-cloud-go/commit/df96b2ec))

</details>


<details><summary>geminidataanalytics: v1.1.0</summary>

## [v1.1.0](https://github.com/googleapis/google-cloud-go/compare/geminidataanalytics/v1.0.0...geminidataanalytics/v1.1.0) (2026-05-14)

### Features

* update API sources and regenerate (#14581) ([df96b2ec](https://github.com/googleapis/google-cloud-go/commit/df96b2ec))

</details>