### PR TITLE
fix(datastore): add retries to emulator

### DIFF
--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"reflect"
 	"regexp"
+	"strings"
 	"time"
 
 	pb "cloud.google.com/go/datastore/apiv1/datastorepb"
@@ -46,22 +47,37 @@ const (
 // retryPolicy is based on https://github.com/googleapis/googleapis/blob/master/google/datastore/v1/datastore_grpc_service_config.json
 // but updated to include INTERNAL and RESOURCE_EXHAUSTED for the data plane.
 const retryPolicy = `{
-  "methodConfig": [{
-    "name": [
-      {"service": "google.datastore.v1.Datastore", "method": "Lookup"},
-      {"service": "google.datastore.v1.Datastore", "method": "RunQuery"},
-      {"service": "google.datastore.v1.Datastore", "method": "RunAggregationQuery"},
-      {"service": "google.datastore.v1.Datastore", "method": "ReserveIds"}
-    ],
-    "timeout": "60s",
-    "retryPolicy": {
-      "maxAttempts": 5,
-      "initialBackoff": "0.100s",
-      "maxBackoff": "60s",
-      "backoffMultiplier": 1.3,
-      "retryableStatusCodes": ["UNAVAILABLE", "DEADLINE_EXCEEDED", "INTERNAL", "RESOURCE_EXHAUSTED"]
+  "methodConfig": [
+    {
+      "name": [{"service": "google.datastore.v1.Datastore"}],
+      "timeout": "60s",
+			"waitForReady": true,
+      "retryPolicy": {
+        "maxAttempts": 5,
+        "initialBackoff": "0.100s",
+        "maxBackoff": "60s",
+        "backoffMultiplier": 1.3,
+        "retryableStatusCodes": ["UNAVAILABLE"]
+      }
+    },
+    {
+      "name": [
+        {"service": "google.datastore.v1.Datastore", "method": "Lookup"},
+        {"service": "google.datastore.v1.Datastore", "method": "RunQuery"},
+        {"service": "google.datastore.v1.Datastore", "method": "RunAggregationQuery"},
+        {"service": "google.datastore.v1.Datastore", "method": "ReserveIds"}
+      ],
+      "timeout": "60s",
+			"waitForReady": true,
+      "retryPolicy": {
+        "maxAttempts": 5,
+        "initialBackoff": "0.100s",
+        "maxBackoff": "60s",
+        "backoffMultiplier": 1.3,
+        "retryableStatusCodes": ["UNAVAILABLE", "DEADLINE_EXCEEDED", "INTERNAL", "RESOURCE_EXHAUSTED"]
+      }
     }
-  }]
+  ]
 }`
 
 // ScopeDatastore grants permissions to view and/or manage datastore entities
@@ -126,15 +142,28 @@ func NewClient(ctx context.Context, projectID string, opts ...option.ClientOptio
 // Call (*Client).Close() when done with the client.
 func NewClientWithDatabase(ctx context.Context, projectID, databaseID string, opts ...option.ClientOption) (*Client, error) {
 	var o []option.ClientOption
+	keepaliveParams := keepalive.ClientParameters{
+		Time:                1 * time.Minute,
+		Timeout:             20 * time.Second,
+		PermitWithoutStream: true,
+	}
+
 	// Environment variables for gcd emulator:
 	// https://cloud.google.com/datastore/docs/tools/datastore-emulator
 	// If the emulator is available, dial it without passing any credentials.
 	if addr := os.Getenv("DATASTORE_EMULATOR_HOST"); addr != "" {
-		addr = schemeRegexp.ReplaceAllString(addr, "")
+		// If it's already a valid gRPC target with a non-HTTP scheme (like unix:///), leave it.
+		// Otherwise, strip legacy schemes and force passthrough for performance.
+		if !(strings.Contains(addr, "://") && !strings.HasPrefix(addr, "http")) {
+			addr = schemeRegexp.ReplaceAllString(addr, "")
+			addr = "passthrough:///" + addr
+		}
 		o = []option.ClientOption{
-			option.WithEndpoint("passthrough:///" + addr),
+			option.WithEndpoint(addr),
 			option.WithoutAuthentication(),
 			option.WithGRPCDialOption(grpc.WithTransportCredentials(insecure.NewCredentials())),
+			option.WithGRPCDialOption(grpc.WithDefaultServiceConfig(retryPolicy)),
+			option.WithGRPCDialOption(grpc.WithKeepaliveParams(keepaliveParams)),
 		}
 		if projectID == DetectProjectID {
 			projectID, _ = detectProjectIDFn(ctx, opts...)
@@ -153,11 +182,7 @@ func NewClientWithDatabase(ctx context.Context, projectID, databaseID string, op
 			// Add the Service Config for retries
 			option.WithGRPCDialOption(grpc.WithDefaultServiceConfig(retryPolicy)),
 			// Add Keepalives to prune zombie connections
-			option.WithGRPCDialOption(grpc.WithKeepaliveParams(keepalive.ClientParameters{
-				Time:                1 * time.Minute,
-				Timeout:             20 * time.Second,
-				PermitWithoutStream: true,
-			})),
+			option.WithGRPCDialOption(grpc.WithKeepaliveParams(keepaliveParams)),
 		}
 	}
 	// Warn if we see the legacy emulator environment variables.


### PR DESCRIPTION
**Summary**
This PR refines the Datastore client's resilience logic to fix regressions identified during TAP testing, specifically regarding emulator startup races, Unix domain sockets, and IPv6 literals. It ensures that the resilience benefits for bug **[b/473841984](http://b/473841984)** are applied consistently to both production and emulator environments without breaking existing tests.

**Why these changes are needed**
1.  **Handling Emulator Startup Races**: Many tests (e.g., `exchange:datastore_test`) experience a "connection refused" error if an RPC is attempted immediately after starting the emulator process. By adding **`"waitForReady": true`** to the gRPC Service Config, the client will now block and wait for the emulator to finish binding its port instead of failing the RPC immediately.
2.  **Preventing Infinite Hangs**: With `waitForReady` enabled, an unreachable host could cause a test to hang indefinitely. This PR adds a canonical **`"timeout": "60s"`** to the generic `methodConfig` to ensure RPCs eventually fail with a clear error.
3.  **Robust Scheme Handling (Unix Sockets & IPv6)**: Internal test environments like `tin` often use **Unix domain sockets** (`unix:///`) or IPv6 literals (`[::1]`) for emulator addresses. Previous logic would mangle these into invalid targets (e.g., `passthrough:///unix:///...`), leading to "too many colons" errors or connection hangs. The updated logic defensively checks for existing valid schemes before applying the `passthrough:///` optimization.
4.  **Idempotent Retries for `Commit`**: A catch-all configuration block is added to the Service Config to ensure that **`UNAVAILABLE`** errors are retried for all methods, including `Commit` (used by `PutMulti`), which was previously omitted.

**Why PR #14411 was insufficient**
While PR #14411 introduced Keepalives and expanded retries for idempotent calls, it had several gaps:
*   It only applied the new configuration to the **production** code path, leaving the emulator path without resilience logic or standardized retries.
*   By removing the manual 100ms retry loop without adding `waitForReady: true` to the Service Config, it removed the "wait" period needed for emulators to become ready.
*   The aggressive prepending of `passthrough:///` did not account for `unix:///` schemes or bracketed IPv6 literals, causing dialer errors in specialized test environments. (Even though the passthrough was not added in PR #14411, the current google3 imported code did not have this logic. While trying to import [cl/906545069](http://cl/906545069) latest code with psssthrough, this issue was discovered. )

**Related Bug**
[b/473841984](http://b/473841984)