### PR TITLE
fix(storage): add server closed idle connection to retriable errors

### DIFF
--- a/storage/invoke.go
+++ b/storage/invoke.go
@@ -206,7 +206,8 @@ func ShouldRetry(err error) bool {
 		// https://cloud.google.com/storage/docs/exponential-backoff.
 		return e.Code == 408 || e.Code == 429 || (e.Code >= 500 && e.Code < 600)
 	case *net.OpError, *url.Error:
-		// Retry socket-level errors ECONNREFUSED and ECONNRESET (from syscall).
+		// Retry socket-level errors ECONNREFUSED and ECONNRESET (from syscall)
+		// and transport-level errors like server closed idle connections.
 		// Unfortunately the error type is unexported, so we resort to string
 		// matching.
 		retriable := []string{"connection refused", "connection reset", "broken pipe", "client connection lost", "server closed idle connection"}

--- a/storage/invoke.go
+++ b/storage/invoke.go
@@ -209,7 +209,7 @@ func ShouldRetry(err error) bool {
 		// Retry socket-level errors ECONNREFUSED and ECONNRESET (from syscall).
 		// Unfortunately the error type is unexported, so we resort to string
 		// matching.
-		retriable := []string{"connection refused", "connection reset", "broken pipe", "client connection lost"}
+		retriable := []string{"connection refused", "connection reset", "broken pipe", "client connection lost", "server closed idle connection"}
 		for _, s := range retriable {
 			if strings.Contains(e.Error(), s) {
 				return true

--- a/storage/invoke_test.go
+++ b/storage/invoke_test.go
@@ -469,6 +469,16 @@ func TestShouldRetry(t *testing.T) {
 			inputErr:    fmt.Errorf("wrapped error: %w", &url.Error{Op: "blah", URL: "blah", Err: errors.New("http2: client connection lost")}),
 			shouldRetry: true,
 		},
+		{
+			desc:        "server closed idle connection",
+			inputErr:    &url.Error{Op: "blah", URL: "blah", Err: errors.New("http: server closed idle connection")},
+			shouldRetry: true,
+		},
+		{
+			desc:        "wrapped server closed idle connection",
+			inputErr:    fmt.Errorf("wrapped error: %w", &url.Error{Op: "blah", URL: "blah", Err: errors.New("http: server closed idle connection")}),
+			shouldRetry: true,
+		},
 	} {
 		t.Run(test.desc, func(s *testing.T) {
 			got := ShouldRetry(test.inputErr)

--- a/storage/invoke_test.go
+++ b/storage/invoke_test.go
@@ -479,6 +479,16 @@ func TestShouldRetry(t *testing.T) {
 			inputErr:    fmt.Errorf("wrapped error: %w", &url.Error{Op: "blah", URL: "blah", Err: errors.New("http: server closed idle connection")}),
 			shouldRetry: true,
 		},
+		{
+			desc:        "net.OpError with server closed idle connection",
+			inputErr:    &net.OpError{Op: "read", Net: "tcp", Err: errors.New("server closed idle connection")},
+			shouldRetry: true,
+		},
+		{
+			desc:        "wrapped net.OpError with server closed idle connection",
+			inputErr:    fmt.Errorf("wrapped error: %w", &net.OpError{Op: "read", Net: "tcp", Err: errors.New("server closed idle connection")}),
+			shouldRetry: true,
+		},
 	} {
 		t.Run(test.desc, func(s *testing.T) {
 			got := ShouldRetry(test.inputErr)


### PR DESCRIPTION
## Description
This PR adds `server closed idle connection` to the list of retriable socket-level network errors in the Cloud Storage client library.

When the standard Go HTTP transport attempts to reuse a TCP keep-alive connection that GCS has closed due to an idle timeout, it returns a `*url.Error` containing the error message:
`http: server closed idle connection`

Because GCS does not classify this specific string as retriable, the entire write/upload operation immediately fails without retrying, even when idempotent preconditions (such as `IfGenerationMatch` or `DoesNotExist`) are configured.

## Changes
* **`storage/invoke.go`**: Added `"server closed idle connection"` to the `retriable` slice inside `ShouldRetry(err error)`.
* **`storage/invoke_test.go`**: Added explicit unit tests to `TestShouldRetry` verifying that both direct and wrapped `"server closed idle connection"` errors are correctly identified as retriable.

## Verification
Added unit test cases in `storage/invoke_test.go` pass successfully:
```bash
go test -v -short -run TestShouldRetry
