### PR TITLE
chore: librarian release pull request: 20260515T100034Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -2681,7 +2681,7 @@ libraries:
       - internal/generated/snippets/speech/
     tag_format: '{id}/v{version}'
   - id: storage
-    version: 1.62.1
+    version: 1.62.2
     last_generated_commit: ""
     apis:
       - path: google/storage/control/v2

--- a/internal/generated/snippets/storage/control/apiv2/snippet_metadata.google.storage.control.v2.json
+++ b/internal/generated/snippets/storage/control/apiv2/snippet_metadata.google.storage.control.v2.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/storage/control/apiv2",
-    "version": "1.62.1"
+    "version": "1.62.2"
   },
   "snippets": [
     {

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -37,27 +37,14 @@ libraries:
     version: 1.13.0
     apis:
       - path: google/cloud/accessapproval/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: accesscontextmanager
     version: 1.14.0
     apis:
       - path: google/identity/accesscontextmanager/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
-          import_path: accesscontextmanager/apiv1
   - name: advisorynotifications
     version: 1.10.0
     apis:
       - path: google/cloud/advisorynotifications/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: agentplatform
     version: 0.20.0
     skip_generate: true
@@ -66,253 +53,97 @@ libraries:
     version: 1.0.0
     apis:
       - path: google/ai/generativelanguage/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/ai/generativelanguage/v1beta2
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/ai/generativelanguage/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/ai/generativelanguage/v1alpha
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: aiplatform
     version: 1.125.0
     apis:
       - path: google/cloud/aiplatform/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/aiplatform/v1beta1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
     skip_generate: true
   - name: alloydb
     version: 1.26.0
     apis:
       - path: google/cloud/alloydb/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/alloydb/connectors/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
-          proto_only: true
       - path: google/cloud/alloydb/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/alloydb/connectors/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
-          proto_only: true
       - path: google/cloud/alloydb/v1alpha
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/alloydb/connectors/v1alpha
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
-          proto_only: true
   - name: analytics
     version: 0.35.0
     apis:
       - path: google/analytics/admin/v1alpha
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: apigateway
     version: 1.12.0
     apis:
       - path: google/cloud/apigateway/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: apigeeconnect
     version: 1.12.0
     apis:
       - path: google/cloud/apigeeconnect/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: apigeeregistry
     version: 1.0.0
     apis:
       - path: google/cloud/apigeeregistry/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: apihub
     version: 1.0.0
     apis:
       - path: google/cloud/apihub/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: apikeys
     version: 1.7.0
     apis:
       - path: google/api/apikeys/v2
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
-          import_path: apikeys/apiv2
   - name: apiregistry
     version: 1.0.0
     apis:
       - path: google/cloud/apiregistry/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/apiregistry/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: appengine
     version: 1.14.0
     apis:
       - path: google/appengine/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: apphub
     version: 1.0.0
     apis:
       - path: google/cloud/apphub/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: appoptimize
     version: 0.4.0
     apis:
       - path: google/cloud/appoptimize/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
     copyright_year: "2026"
   - name: apps
     version: 1.0.0
     apis:
       - path: google/apps/meet/v2
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/apps/events/subscriptions/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/apps/meet/v2beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/apps/events/subscriptions/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: area120
     version: 0.15.0
     apis:
       - path: google/area120/tables/v1alpha1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
-          no_metadata: true
   - name: artifactregistry
     version: 1.25.0
     apis:
       - path: google/devtools/artifactregistry/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
-          import_path: artifactregistry/apiv1
       - path: google/devtools/artifactregistry/v1beta2
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
-          import_path: artifactregistry/apiv1beta2
   - name: asset
     version: 1.27.0
     apis:
       - path: google/cloud/asset/v1
-        go:
-          enabled_generator_features:
-            - F_mtls_hard_bound_tokens
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
-          no_metadata: true
       - path: google/cloud/asset/v1p5beta1
-        go:
-          enabled_generator_features:
-            - F_mtls_hard_bound_tokens
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
-          no_metadata: true
       - path: google/cloud/asset/v1p2beta1
-        go:
-          enabled_generator_features:
-            - F_mtls_hard_bound_tokens
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: assuredworkloads
     version: 1.18.0
     apis:
       - path: google/cloud/assuredworkloads/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/assuredworkloads/v1beta1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: auditmanager
     version: 1.0.0
     apis:
       - path: google/cloud/auditmanager/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: auth
     version: 0.20.0
     keep:
@@ -328,200 +159,57 @@ libraries:
     version: 1.20.0
     apis:
       - path: google/cloud/automl/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/automl/v1beta1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: backupdr
     version: 1.14.0
     apis:
       - path: google/cloud/backupdr/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: baremetalsolution
     version: 1.9.0
     apis:
       - path: google/cloud/baremetalsolution/v2
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: batch
     version: 1.19.0
     apis:
       - path: google/cloud/batch/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
     keep:
       - apiv1/iam_policy_client.go
   - name: beyondcorp
     version: 1.7.0
     apis:
       - path: google/cloud/beyondcorp/appconnections/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/beyondcorp/appconnectors/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/beyondcorp/appgateways/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/beyondcorp/clientconnectorservices/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/beyondcorp/clientgateways/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: biglake
     version: 1.0.0
     apis:
       - path: google/cloud/biglake/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/biglake/hive/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
     copyright_year: "2026"
   - name: bigquery
     version: 1.77.0
     apis:
       - path: google/cloud/bigquery/migration/v2
-        go:
-          enabled_generator_features:
-            - F_dynamic_resource_heuristics
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/bigquery/datapolicies/v2
-        go:
-          enabled_generator_features:
-            - F_dynamic_resource_heuristics
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/bigquery/datatransfer/v1
-        go:
-          enabled_generator_features:
-            - F_dynamic_resource_heuristics
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/bigquery/biglake/v1
-        go:
-          enabled_generator_features:
-            - F_dynamic_resource_heuristics
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/bigquery/storage/v1
-        go:
-          enabled_generator_features:
-            - F_dynamic_resource_heuristics
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/bigquery/connection/v1
-        go:
-          enabled_generator_features:
-            - F_dynamic_resource_heuristics
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/bigquery/reservation/v1
-        go:
-          enabled_generator_features:
-            - F_dynamic_resource_heuristics
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/bigquery/analyticshub/v1
-        go:
-          enabled_generator_features:
-            - F_dynamic_resource_heuristics
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/bigquery/datapolicies/v1
-        go:
-          enabled_generator_features:
-            - F_dynamic_resource_heuristics
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/bigquery/datapolicies/v2beta1
-        go:
-          enabled_generator_features:
-            - F_dynamic_resource_heuristics
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/bigquery/migration/v2alpha
-        go:
-          enabled_generator_features:
-            - F_dynamic_resource_heuristics
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/bigquery/storage/v1beta2
-        go:
-          enabled_generator_features:
-            - F_dynamic_resource_heuristics
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/bigquery/datapolicies/v1beta1
-        go:
-          enabled_generator_features:
-            - F_dynamic_resource_heuristics
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/bigquery/dataexchange/v1beta1
-        go:
-          enabled_generator_features:
-            - F_dynamic_resource_heuristics
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/bigquery/connection/v1beta1
-        go:
-          enabled_generator_features:
-            - F_dynamic_resource_heuristics
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/bigquery/storage/v1beta1
-        go:
-          enabled_generator_features:
-            - F_dynamic_resource_heuristics
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/bigquery/storage/v1beta
-        go:
-          enabled_generator_features:
-            - F_dynamic_resource_heuristics
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/bigquery/biglake/v1alpha1
-        go:
-          enabled_generator_features:
-            - F_dynamic_resource_heuristics
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/bigquery/storage/v1alpha
-        go:
-          enabled_generator_features:
-            - F_dynamic_resource_heuristics
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
     keep:
       - README.md
     skip_release: true
@@ -531,13 +219,6 @@ libraries:
     version: 0.0.0
     apis:
       - path: google/cloud/bigquery/v2
-        go:
-          enabled_generator_features:
-            - F_dynamic_resource_heuristics
-            - F_open_telemetry_attributes
-            - F_wrapper_types_for_page_size
-            - F_proto_cloneof
-          import_path: bigquery/v2/apiv2
     keep:
       - README.md
     skip_release: true
@@ -545,19 +226,7 @@ libraries:
     version: 1.47.0
     apis:
       - path: google/bigtable/v2
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
-          no_metadata: true
-          proto_only: true
       - path: google/bigtable/admin/v2
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
-          no_metadata: true
-          proto_only: true
     keep:
       - README.md
     skip_release: true
@@ -565,206 +234,80 @@ libraries:
     version: 1.26.0
     apis:
       - path: google/cloud/billing/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/billing/budgets/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/billing/budgets/v1beta1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: binaryauthorization
     version: 1.15.0
     apis:
       - path: google/cloud/binaryauthorization/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/binaryauthorization/v1beta1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: capacityplanner
     version: 0.6.0
     apis:
       - path: google/cloud/capacityplanner/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: certificatemanager
     version: 1.14.0
     apis:
       - path: google/cloud/certificatemanager/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: ces
     version: 1.0.0
     apis:
       - path: google/cloud/ces/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/ces/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: channel
     version: 1.26.0
     apis:
       - path: google/cloud/channel/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: chat
     version: 1.1.0
     apis:
       - path: google/chat/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: chronicle
     version: 1.0.0
     apis:
       - path: google/cloud/chronicle/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: cloudbuild
     version: 1.30.0
     apis:
       - path: google/devtools/cloudbuild/v2
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
-          import_path: cloudbuild/apiv2
       - path: google/devtools/cloudbuild/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
-          import_path: cloudbuild/apiv1/v2
   - name: cloudcontrolspartner
     version: 1.10.0
     apis:
       - path: google/cloud/cloudcontrolspartner/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/cloudcontrolspartner/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: clouddms
     version: 1.13.0
     apis:
       - path: google/cloud/clouddms/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: cloudprofiler
     version: 1.0.0
     apis:
       - path: google/devtools/cloudprofiler/v2
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
-          import_path: cloudprofiler/apiv2
   - name: cloudquotas
     version: 1.11.0
     apis:
       - path: google/api/cloudquotas/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
-          import_path: cloudquotas/apiv1
       - path: google/api/cloudquotas/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
-          import_path: cloudquotas/apiv1beta
   - name: cloudsecuritycompliance
     version: 1.0.0
     apis:
       - path: google/cloud/cloudsecuritycompliance/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: cloudtasks
     version: 1.18.0
     apis:
       - path: google/cloud/tasks/v2
-        go:
-          client_package: cloudtasks
-          enabled_generator_features:
-            - F_mtls_hard_bound_tokens
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
-          import_path: cloudtasks/apiv2
       - path: google/cloud/tasks/v2beta3
-        go:
-          client_package: cloudtasks
-          enabled_generator_features:
-            - F_mtls_hard_bound_tokens
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
-          import_path: cloudtasks/apiv2beta3
       - path: google/cloud/tasks/v2beta2
-        go:
-          client_package: cloudtasks
-          enabled_generator_features:
-            - F_mtls_hard_bound_tokens
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
-          import_path: cloudtasks/apiv2beta2
   - name: commerce
     version: 1.7.0
     apis:
       - path: google/cloud/commerce/consumer/procurement/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: compute
     version: 1.63.0
     apis:
       - path: google/cloud/compute/v1
-        go:
-          diregapic: true
-          enabled_generator_features:
-            - F_dynamic_resource_heuristics
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/compute/v1beta
-        go:
-          diregapic: true
-          enabled_generator_features:
-            - F_dynamic_resource_heuristics
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
     go:
       nested_module: metadata
   - name: compute/metadata
@@ -777,64 +320,28 @@ libraries:
     version: 1.16.0
     apis:
       - path: google/cloud/confidentialcomputing/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/confidentialcomputing/v1alpha1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: config
     version: 1.11.0
     apis:
       - path: google/cloud/config/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: configdelivery
     version: 1.0.0
     apis:
       - path: google/cloud/configdelivery/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/configdelivery/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: contactcenterinsights
     version: 1.22.0
     apis:
       - path: google/cloud/contactcenterinsights/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: container
     version: 1.52.0
     apis:
       - path: google/container/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: containeranalysis
     version: 0.19.0
     apis:
       - path: google/devtools/containeranalysis/v1beta1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
-          import_path: containeranalysis/apiv1beta1
-          nested_protos:
-            - grafeas/grafeas.proto
-          no_metadata: true
     keep:
       - apiv1beta1/grafeas/grafeaspb/grafeas.pb.go
     go:
@@ -844,313 +351,131 @@ libraries:
     version: 1.32.0
     apis:
       - path: google/cloud/datacatalog/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/datacatalog/lineage/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/datacatalog/lineage/configmanagement/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/datacatalog/v1beta1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
     keep:
       - apiv1/iam_policy_client.go
   - name: dataflow
     version: 0.16.0
     apis:
       - path: google/dataflow/v1beta3
-        go:
-          enabled_generator_features:
-            - F_mtls_hard_bound_tokens
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: dataform
     version: 1.0.0
     apis:
       - path: google/cloud/dataform/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/dataform/v1beta1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: datafusion
     version: 1.13.0
     apis:
       - path: google/cloud/datafusion/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: datalabeling
     version: 0.14.0
     apis:
       - path: google/cloud/datalabeling/v1beta1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: datamanager
     version: 1.0.0
     apis:
       - path: google/ads/datamanager/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
-          import_path: datamanager/apiv1
   - name: dataplex
     version: 1.34.0
     apis:
       - path: google/cloud/dataplex/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: dataproc
     version: 2.22.0
     apis:
       - path: google/cloud/dataproc/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
-          import_path: dataproc/v2/apiv1
     go:
       module_path_version: v2
   - name: dataqna
     version: 0.13.0
     apis:
       - path: google/cloud/dataqna/v1alpha
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: datastore
     version: 1.23.0
     apis:
       - path: google/datastore/v1
-        go:
-          enabled_generator_features:
-            - F_mtls_hard_bound_tokens
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
-          proto_only: true
       - path: google/datastore/admin/v1
-        go:
-          enabled_generator_features:
-            - F_mtls_hard_bound_tokens
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
     skip_release: true
   - name: datastream
     version: 1.20.0
     apis:
       - path: google/cloud/datastream/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/datastream/v1alpha1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
     keep:
       - apiv1/iam_policy_client.go
   - name: deploy
     version: 1.32.0
     apis:
       - path: google/cloud/deploy/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: developerconnect
     version: 1.0.0
     apis:
       - path: google/cloud/developerconnect/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: devicestreaming
     version: 1.0.0
     apis:
       - path: google/cloud/devicestreaming/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: dialogflow
     version: 1.82.0
     apis:
       - path: google/cloud/dialogflow/v2
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/dialogflow/cx/v3
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/dialogflow/cx/v3beta1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/dialogflow/v2beta1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: discoveryengine
     version: 1.29.0
     apis:
       - path: google/cloud/discoveryengine/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/discoveryengine/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/discoveryengine/v1alpha
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: dlp
     version: 1.34.0
     apis:
       - path: google/privacy/dlp/v2
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
-          import_path: dlp/apiv2
-          no_metadata: true
   - name: documentai
     version: 1.48.0
     apis:
       - path: google/cloud/documentai/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/documentai/v1beta3
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: domains
     version: 0.15.0
     apis:
       - path: google/cloud/domains/v1beta1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: edgecontainer
     version: 1.9.0
     apis:
       - path: google/cloud/edgecontainer/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: edgenetwork
     version: 1.8.0
     apis:
       - path: google/cloud/edgenetwork/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: errorreporting
     version: 0.9.0
     apis:
       - path: google/devtools/clouderrorreporting/v1beta1
-        go:
-          client_package: errorreporting
-          enabled_generator_features:
-            - F_mtls_hard_bound_tokens
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
-          import_path: errorreporting/apiv1beta1
   - name: essentialcontacts
     version: 1.12.0
     apis:
       - path: google/cloud/essentialcontacts/v1
-        go:
-          enabled_generator_features:
-            - F_mtls_hard_bound_tokens
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: eventarc
     version: 1.23.0
     apis:
       - path: google/cloud/eventarc/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/eventarc/publishing/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: filestore
     version: 1.15.0
     apis:
       - path: google/cloud/filestore/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: financialservices
     version: 1.0.0
     apis:
       - path: google/cloud/financialservices/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: firestore
     version: 1.22.0
     apis:
       - path: google/firestore/v1
-        go:
-          enabled_generator_features:
-            - F_mtls_hard_bound_tokens
-            - F_open_telemetry_attributes
-            - F_ordered_routing_headers
-            - F_proto_cloneof
       - path: google/firestore/admin/v1
-        go:
-          client_package: apiv1
-          enabled_generator_features:
-            - F_mtls_hard_bound_tokens
-            - F_open_telemetry_attributes
-            - F_ordered_routing_headers
-            - F_proto_cloneof
-          import_path: firestore/apiv1/admin
     keep:
       - README.md
     skip_release: true
@@ -1158,78 +483,34 @@ libraries:
     version: 1.24.0
     apis:
       - path: google/cloud/functions/v2
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/functions/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/functions/v2beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: geminidataanalytics
     version: 1.1.0
     apis:
       - path: google/cloud/geminidataanalytics/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/geminidataanalytics/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: gkebackup
     version: 1.13.0
     apis:
       - path: google/cloud/gkebackup/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: gkeconnect
     version: 1.0.0
     apis:
       - path: google/cloud/gkeconnect/gateway/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/gkeconnect/gateway/v1beta1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: gkehub
     version: 0.21.0
     apis:
       - path: google/cloud/gkehub/v1beta1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: gkemulticloud
     version: 1.11.0
     apis:
       - path: google/cloud/gkemulticloud/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: gkerecommender
     version: 1.0.0
     apis:
       - path: google/cloud/gkerecommender/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: grafeas
     version: 0.5.0
     keep:
@@ -1239,582 +520,226 @@ libraries:
     version: 1.12.0
     apis:
       - path: google/cloud/gsuiteaddons/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: hypercomputecluster
     version: 1.0.0
     apis:
       - path: google/cloud/hypercomputecluster/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/hypercomputecluster/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: iam
     version: 1.11.0
     apis:
       - path: google/iam/v3
-        go:
-          enabled_generator_features:
-            - F_mtls_hard_bound_tokens
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/iam/v2
-        go:
-          enabled_generator_features:
-            - F_mtls_hard_bound_tokens
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/iam/v1
-        go:
-          enabled_generator_features:
-            - F_mtls_hard_bound_tokens
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/iam/credentials/v1
-        go:
-          enabled_generator_features:
-            - F_mtls_hard_bound_tokens
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
-          no_metadata: true
       - path: google/iam/v3beta
-        go:
-          enabled_generator_features:
-            - F_mtls_hard_bound_tokens
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
     go:
       nested_module: admin
   - name: iap
     version: 1.17.0
     apis:
       - path: google/cloud/iap/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: identitytoolkit
     version: 1.0.0
     apis:
       - path: google/cloud/identitytoolkit/v2
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: ids
     version: 1.10.0
     apis:
       - path: google/cloud/ids/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: iot
     version: 1.13.0
     apis:
       - path: google/cloud/iot/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: kms
     version: 1.31.0
     apis:
       - path: google/cloud/kms/v1
-        go:
-          enabled_generator_features:
-            - F_mtls_hard_bound_tokens
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/kms/inventory/v1
-        go:
-          enabled_generator_features:
-            - F_mtls_hard_bound_tokens
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: language
     version: 1.18.0
     apis:
       - path: google/cloud/language/v2
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/language/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/language/v1beta2
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: licensemanager
     version: 1.0.0
     apis:
       - path: google/cloud/licensemanager/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: lifesciences
     version: 0.15.0
     apis:
       - path: google/cloud/lifesciences/v2beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: locationfinder
     version: 1.0.0
     apis:
       - path: google/cloud/locationfinder/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: logging
     version: 1.18.0
     apis:
       - path: google/logging/v2
-        go:
-          enabled_generator_features:
-            - F_mtls_hard_bound_tokens
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
     go:
       nested_module: logadmin
   - name: longrunning
     version: 1.0.0
     apis:
       - path: google/longrunning
-        go:
-          client_package: longrunning
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
-          import_path: longrunning/autogen
   - name: lustre
     version: 1.0.0
     apis:
       - path: google/cloud/lustre/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: maintenance
     version: 1.0.0
     apis:
       - path: google/cloud/maintenance/api/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/maintenance/api/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: managedidentities
     version: 1.12.0
     apis:
       - path: google/cloud/managedidentities/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: managedkafka
     version: 1.0.0
     apis:
       - path: google/cloud/managedkafka/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/managedkafka/schemaregistry/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: maps
     version: 1.35.0
     apis:
       - path: google/maps/geocode/v4
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/maps/routing/v2
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/maps/addressvalidation/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/maps/areainsights/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/maps/fleetengine/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
-          proto_package: maps.fleetengine.v1
       - path: google/maps/places/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/maps/routeoptimization/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/maps/solar/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/maps/fleetengine/delivery/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
-          proto_package: maps.fleetengine.delivery.v1
       - path: google/maps/mapmanagement/v2beta
     title_override: Google Maps Platform
   - name: mediatranslation
     version: 0.13.0
     apis:
       - path: google/cloud/mediatranslation/v1beta1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: memcache
     version: 1.16.0
     apis:
       - path: google/cloud/memcache/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/memcache/v1beta2
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: memorystore
     version: 1.0.0
     apis:
       - path: google/cloud/memorystore/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/memorystore/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: metastore
     version: 1.19.0
     apis:
       - path: google/cloud/metastore/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/metastore/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/metastore/v1alpha
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: migrationcenter
     version: 1.6.0
     apis:
       - path: google/cloud/migrationcenter/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: modelarmor
     version: 1.0.0
     apis:
       - path: google/cloud/modelarmor/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/modelarmor/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: monitoring
     version: 1.29.0
     apis:
       - path: google/monitoring/v3
-        go:
-          enabled_generator_features:
-            - F_mtls_hard_bound_tokens
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
-          import_path: monitoring/apiv3/v2
       - path: google/monitoring/dashboard/v1
-        go:
-          enabled_generator_features:
-            - F_mtls_hard_bound_tokens
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/monitoring/metricsscope/v1
-        go:
-          enabled_generator_features:
-            - F_mtls_hard_bound_tokens
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: netapp
     version: 1.17.0
     apis:
       - path: google/cloud/netapp/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: networkconnectivity
     version: 1.26.0
     apis:
       - path: google/cloud/networkconnectivity/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/networkconnectivity/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/networkconnectivity/v1alpha1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: networkmanagement
     version: 1.28.0
     apis:
       - path: google/cloud/networkmanagement/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: networksecurity
     version: 0.16.0
     apis:
       - path: google/cloud/networksecurity/v1beta1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: networkservices
     version: 1.0.0
     apis:
       - path: google/cloud/networkservices/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: notebooks
     version: 1.17.0
     apis:
       - path: google/cloud/notebooks/v2
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/notebooks/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/notebooks/v1beta1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: optimization
     version: 1.11.0
     apis:
       - path: google/cloud/optimization/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: oracledatabase
     version: 1.0.0
     apis:
       - path: google/cloud/oracledatabase/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: orchestration
     version: 1.16.0
     apis:
       - path: google/cloud/orchestration/airflow/service/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: orgpolicy
     version: 1.20.0
     apis:
       - path: google/cloud/orgpolicy/v2
-        go:
-          enabled_generator_features:
-            - F_mtls_hard_bound_tokens
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/orgpolicy/v1
-        go:
-          enabled_generator_features:
-            - F_mtls_hard_bound_tokens
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
-          proto_only: true
   - name: osconfig
     version: 1.21.0
     apis:
       - path: google/cloud/osconfig/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/osconfig/agentendpoint/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/osconfig/agentendpoint/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/osconfig/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/osconfig/v1alpha
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: oslogin
     version: 1.18.0
     apis:
       - path: google/cloud/oslogin/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
-          no_metadata: true
       - path: google/cloud/oslogin/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
-          no_metadata: true
       - path: google/cloud/oslogin/common
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
-          import_path: oslogin/common
-          proto_only: true
   - name: parallelstore
     version: 1.0.0
     apis:
       - path: google/cloud/parallelstore/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/parallelstore/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: parametermanager
     version: 1.0.0
     apis:
       - path: google/cloud/parametermanager/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: phishingprotection
     version: 0.13.0
     apis:
       - path: google/cloud/phishingprotection/v1beta1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: policysimulator
     version: 1.0.0
     apis:
       - path: google/cloud/policysimulator/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: policytroubleshooter
     version: 1.15.0
     apis:
       - path: google/cloud/policytroubleshooter/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/policytroubleshooter/iam/v3
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: privatecatalog
     version: 0.15.0
     apis:
       - path: google/cloud/privatecatalog/v1beta1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: privilegedaccessmanager
     version: 1.0.0
     apis:
       - path: google/cloud/privilegedaccessmanager/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: profiler
     version: 0.6.0
     keep:
@@ -1832,13 +757,6 @@ libraries:
     version: 2.6.0
     apis:
       - path: google/pubsub/v1
-        go:
-          enabled_generator_features:
-            - F_mtls_hard_bound_tokens
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
-          import_path: pubsub/v2/apiv1
-          no_metadata: true
     keep:
       - README.md
     skip_release: true
@@ -1846,110 +764,44 @@ libraries:
     version: 1.8.2
     apis:
       - path: google/cloud/pubsublite/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
     skip_release: true
   - name: rapidmigrationassessment
     version: 1.6.0
     apis:
       - path: google/cloud/rapidmigrationassessment/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: recaptchaenterprise
     version: 2.26.0
     apis:
       - path: google/cloud/recaptchaenterprise/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
-          import_path: recaptchaenterprise/v2/apiv1
       - path: google/cloud/recaptchaenterprise/v1beta1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
-          import_path: recaptchaenterprise/v2/apiv1beta1
     go:
       module_path_version: v2
   - name: recommendationengine
     version: 0.14.0
     apis:
       - path: google/cloud/recommendationengine/v1beta1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: recommender
     version: 1.18.0
     apis:
       - path: google/cloud/recommender/v1
-        go:
-          enabled_generator_features:
-            - F_mtls_hard_bound_tokens
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/recommender/v1beta1
-        go:
-          enabled_generator_features:
-            - F_mtls_hard_bound_tokens
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: redis
     version: 1.23.0
     apis:
       - path: google/cloud/redis/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/redis/cluster/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/redis/v1beta1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: resourcemanager
     version: 1.15.0
     apis:
       - path: google/cloud/resourcemanager/v3
-        go:
-          enabled_generator_features:
-            - F_mtls_hard_bound_tokens
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/resourcemanager/v2
-        go:
-          enabled_generator_features:
-            - F_mtls_hard_bound_tokens
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: retail
     version: 1.31.0
     apis:
       - path: google/cloud/retail/v2
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/retail/v2beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/retail/v2alpha
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: root-module
     version: 0.123.0
     keep:
@@ -1961,350 +813,112 @@ libraries:
     version: 1.21.0
     apis:
       - path: google/cloud/run/v2
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
     keep:
       - apiv2/locations_client.go
   - name: saasplatform
     version: 0.7.0
     apis:
       - path: google/cloud/saasplatform/saasservicemgmt/v1beta1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: scheduler
     version: 1.16.0
     apis:
       - path: google/cloud/scheduler/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/scheduler/v1beta1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: secretmanager
     version: 1.20.0
     apis:
       - path: google/cloud/secretmanager/v1
-        go:
-          enabled_generator_features:
-            - F_mtls_hard_bound_tokens
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/secretmanager/v1beta2
-        go:
-          enabled_generator_features:
-            - F_mtls_hard_bound_tokens
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: securesourcemanager
     version: 1.9.0
     apis:
       - path: google/cloud/securesourcemanager/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: security
     version: 1.24.0
     apis:
       - path: google/cloud/security/privateca/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/security/publicca/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/security/publicca/v1beta1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: securitycenter
     version: 1.44.0
     apis:
       - path: google/cloud/securitycenter/v2
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/securitycenter/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/securitycenter/v1p1beta1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/securitycenter/settings/v1beta1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/securitycenter/v1beta1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: securitycentermanagement
     version: 1.6.0
     apis:
       - path: google/cloud/securitycentermanagement/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: securityposture
     version: 1.0.0
     apis:
       - path: google/cloud/securityposture/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: servicecontrol
     version: 1.18.0
     apis:
       - path: google/api/servicecontrol/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
-          import_path: servicecontrol/apiv1
   - name: servicedirectory
     version: 1.17.0
     apis:
       - path: google/cloud/servicedirectory/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/servicedirectory/v1beta1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: servicehealth
     version: 1.7.0
     apis:
       - path: google/cloud/servicehealth/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: servicemanagement
     version: 1.15.0
     apis:
       - path: google/api/servicemanagement/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
-          import_path: servicemanagement/apiv1
   - name: serviceusage
     version: 1.14.0
     apis:
       - path: google/api/serviceusage/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
-          import_path: serviceusage/apiv1
   - name: shell
     version: 1.12.0
     apis:
       - path: google/cloud/shell/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: shopping
     version: 1.11.0
     apis:
       - path: google/shopping/css/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/shopping/merchant/promotions/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/shopping/merchant/quota/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/shopping/merchant/conversions/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/shopping/merchant/accounts/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/shopping/merchant/datasources/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/shopping/merchant/reports/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/shopping/merchant/notifications/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/shopping/merchant/lfp/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/shopping/merchant/ordertracking/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/shopping/merchant/issueresolution/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/shopping/merchant/products/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/shopping/merchant/inventories/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/shopping/merchant/notifications/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/shopping/merchant/ordertracking/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/shopping/merchant/products/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/shopping/merchant/accounts/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/shopping/merchant/quota/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/shopping/merchant/promotions/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/shopping/merchant/inventories/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/shopping/merchant/reports/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/shopping/merchant/issueresolution/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/shopping/merchant/reviews/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/shopping/merchant/lfp/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/shopping/merchant/datasources/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/shopping/merchant/conversions/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/shopping/merchant/productstudio/v1alpha
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/shopping/type
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
-          import_path: shopping/type
-          proto_only: true
   - name: spanner
     version: 1.91.0
     apis:
       - path: google/spanner/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
-          no_metadata: true
       - path: google/spanner/adapter/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/spanner/executor/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/spanner/admin/database/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
-          no_metadata: true
       - path: google/spanner/admin/instance/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
-          no_metadata: true
     keep:
       - README.md
     skip_release: true
@@ -2312,34 +926,13 @@ libraries:
     version: 1.35.0
     apis:
       - path: google/cloud/speech/v2
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/speech/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/speech/v1p1beta1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: storage
-    version: 1.62.1
+    version: 1.62.2
     apis:
       - path: google/storage/v2
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
-          import_path: storage/internal/apiv2
       - path: google/storage/control/v2
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
     keep:
       - README.md
     skip_release: true
@@ -2350,126 +943,54 @@ libraries:
     version: 1.0.0
     apis:
       - path: google/cloud/storagebatchoperations/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: storageinsights
     version: 1.7.0
     apis:
       - path: google/cloud/storageinsights/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: storagetransfer
     version: 1.18.0
     apis:
       - path: google/storagetransfer/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: streetview
     version: 1.0.0
     apis:
       - path: google/streetview/publish/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: support
     version: 1.10.0
     apis:
       - path: google/cloud/support/v2
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/support/v2beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: talent
     version: 1.13.0
     apis:
       - path: google/cloud/talent/v4
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/talent/v4beta1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: telcoautomation
     version: 1.6.0
     apis:
       - path: google/cloud/telcoautomation/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: texttospeech
     version: 1.21.0
     apis:
       - path: google/cloud/texttospeech/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: tpu
     version: 1.13.0
     apis:
       - path: google/cloud/tpu/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: trace
     version: 1.16.0
     apis:
       - path: google/devtools/cloudtrace/v2
-        go:
-          client_package: trace
-          enabled_generator_features:
-            - F_mtls_hard_bound_tokens
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
-          import_path: trace/apiv2
       - path: google/devtools/cloudtrace/v1
-        go:
-          client_package: trace
-          enabled_generator_features:
-            - F_mtls_hard_bound_tokens
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
-          import_path: trace/apiv1
-          no_metadata: true
   - name: translate
     version: 1.17.0
     apis:
       - path: google/cloud/translate/v3
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
-          proto_package: google.cloud.translation.v3
   - name: vectorsearch
     version: 1.0.0
     apis:
       - path: google/cloud/vectorsearch/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/vectorsearch/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: vertexai
     version: 0.19.0
     keep:
@@ -2480,152 +1001,61 @@ libraries:
     version: 1.32.0
     apis:
       - path: google/cloud/video/livestream/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/video/transcoder/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/video/stitcher/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: videointelligence
     version: 1.16.0
     apis:
       - path: google/cloud/videointelligence/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/videointelligence/v1p3beta1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/videointelligence/v1beta2
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: vision
     version: 2.14.0
     apis:
       - path: google/cloud/vision/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
-          import_path: vision/v2/apiv1
       - path: google/cloud/vision/v1p1beta1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
-          import_path: vision/v2/apiv1p1beta1
-          no_metadata: true
     go:
       module_path_version: v2
   - name: visionai
     version: 1.0.0
     apis:
       - path: google/cloud/visionai/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: vmmigration
     version: 1.15.0
     apis:
       - path: google/cloud/vmmigration/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
     keep:
       - apiv1/iam_policy_client.go
   - name: vmwareengine
     version: 1.8.0
     apis:
       - path: google/cloud/vmwareengine/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: vpcaccess
     version: 1.13.0
     apis:
       - path: google/cloud/vpcaccess/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: webrisk
     version: 1.16.0
     apis:
       - path: google/cloud/webrisk/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/webrisk/v1beta1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: websecurityscanner
     version: 1.12.0
     apis:
       - path: google/cloud/websecurityscanner/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: workflows
     version: 1.19.0
     apis:
       - path: google/cloud/workflows/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/workflows/executions/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/workflows/executions/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/workflows/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: workloadmanager
     version: 1.0.0
     apis:
       - path: google/cloud/workloadmanager/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: workstations
     version: 1.6.0
     apis:
       - path: google/cloud/workstations/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/workstations/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof

--- a/storage/CHANGES.md
+++ b/storage/CHANGES.md
@@ -82,6 +82,12 @@
 
 * Update documentation for `BidiReadObject`, `ReadObjectRequest`, and `ObjectContexts` ([611f239](https://github.com/googleapis/google-cloud-go/commit/611f239219225fb03f6475c7238f497a349961e2))
 
+## [1.59.3](https://github.com/googleapis/google-cloud-go/releases/tag/storage%2Fv1.59.3) (2026-05-05)
+
+### Bug Fixes
+
+* handle MRD hang corner case (#14509) ([1ca3b6f](https://github.com/googleapis/google-cloud-go/commit/1ca3b6f02d35f87c336e34358e16985557c7fd58))
+
 ## [1.59.2](https://github.com/googleapis/google-cloud-go/releases/tag/storage%2Fv1.59.2) (2026-01-28)
 
 ### Bug Fixes

--- a/storage/CHANGES.md
+++ b/storage/CHANGES.md
@@ -1,6 +1,18 @@
 # Changes
 
 
+## [1.62.2](https://github.com/googleapis/google-cloud-go/releases/tag/storage%2Fv1.62.2) (2026-05-15)
+
+### Features
+
+* enable open telemetry attrs (#14426) ([74eab64](https://github.com/googleapis/google-cloud-go/commit/74eab64d1b4e22d8c79b0de4e5fc9a36bc4c6c19))
+
+### Bug Fixes
+
+* Set default chunkRetryDeadline to 32s in NewWriterFromAppendableObject (#14458) ([ec7c7d6](https://github.com/googleapis/google-cloud-go/commit/ec7c7d66eb0bf6e52a3ae1f529cb8e5de6f8dc86))
+* refactor userProject metadata propagation in ListObjects  (#14533) ([fbb543e](https://github.com/googleapis/google-cloud-go/commit/fbb543e3bb0d9b45c8e9aa167b6551c154f23169))
+* restore metadata operations timeout in gRPC (#14575) ([275ff56](https://github.com/googleapis/google-cloud-go/commit/275ff562aee8c0201b9e5bf2913bb85bcdbe947a))
+
 ## [1.62.1](https://github.com/googleapis/google-cloud-go/releases/tag/storage%2Fv1.62.1) (2026-04-13)
 
 ### Bug Fixes

--- a/storage/internal/version.go
+++ b/storage/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "1.62.1"
+const Version = "1.62.2"


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.13.1
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go@sha256:b04b076f5eedbb5546bd6fc1404969dd3698c8b19c0f34ae815a84ae735a606a
<details><summary>storage: v1.62.2</summary>

## [v1.62.2](https://github.com/googleapis/google-cloud-go/compare/storage/v1.62.1...storage/v1.62.2) (2026-05-15)

### Features

* enable open telemetry attrs (#14426) ([74eab64d](https://github.com/googleapis/google-cloud-go/commit/74eab64d))

### Bug Fixes

* restore metadata operations timeout in gRPC (#14575) ([275ff562](https://github.com/googleapis/google-cloud-go/commit/275ff562))

* Set default chunkRetryDeadline to 32s in NewWriterFromAppendableObject (#14458) ([ec7c7d66](https://github.com/googleapis/google-cloud-go/commit/ec7c7d66))

* refactor userProject metadata propagation in ListObjects  (#14533) ([fbb543e3](https://github.com/googleapis/google-cloud-go/commit/fbb543e3))

</details>