### PR TITLE
chore: configure default_enabled_generator_features in librarian.yaml

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 language: go
-version: v0.13.2-0.20260514223035-a22d6b5a1329
+version: v0.13.2-0.20260518181009-04b8e642ea4c
 repo: googleapis/google-cloud-go
 sources:
   googleapis:

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -32,32 +32,24 @@ default:
   tag_format: '{name}/v{version}'
   go:
     toolchain: go1.25.0
+    default_enabled_generator_features:
+      - F_open_telemetry_attributes
+      - F_proto_cloneof
 libraries:
   - name: accessapproval
     version: 1.13.0
     apis:
       - path: google/cloud/accessapproval/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: accesscontextmanager
     version: 1.14.0
     apis:
       - path: google/identity/accesscontextmanager/v1
         go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
           import_path: accesscontextmanager/apiv1
   - name: advisorynotifications
     version: 1.10.0
     apis:
       - path: google/cloud/advisorynotifications/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: agentplatform
     version: 0.20.0
     skip_generate: true
@@ -66,208 +58,95 @@ libraries:
     version: 1.0.0
     apis:
       - path: google/ai/generativelanguage/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/ai/generativelanguage/v1beta2
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/ai/generativelanguage/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/ai/generativelanguage/v1alpha
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: aiplatform
     version: 1.125.0
     apis:
       - path: google/cloud/aiplatform/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/aiplatform/v1beta1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
     skip_generate: true
   - name: alloydb
     version: 1.26.0
     apis:
       - path: google/cloud/alloydb/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/alloydb/connectors/v1
         go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
           proto_only: true
       - path: google/cloud/alloydb/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/alloydb/connectors/v1beta
         go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
           proto_only: true
       - path: google/cloud/alloydb/v1alpha
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/alloydb/connectors/v1alpha
         go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
           proto_only: true
   - name: analytics
     version: 0.35.0
     apis:
       - path: google/analytics/admin/v1alpha
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: apigateway
     version: 1.12.0
     apis:
       - path: google/cloud/apigateway/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: apigeeconnect
     version: 1.12.0
     apis:
       - path: google/cloud/apigeeconnect/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: apigeeregistry
     version: 1.0.0
     apis:
       - path: google/cloud/apigeeregistry/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: apihub
     version: 1.0.0
     apis:
       - path: google/cloud/apihub/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: apikeys
     version: 1.7.0
     apis:
       - path: google/api/apikeys/v2
         go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
           import_path: apikeys/apiv2
   - name: apiregistry
     version: 1.0.0
     apis:
       - path: google/cloud/apiregistry/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/apiregistry/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: appengine
     version: 1.14.0
     apis:
       - path: google/appengine/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: apphub
     version: 1.0.0
     apis:
       - path: google/cloud/apphub/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: appoptimize
     version: 0.4.0
     apis:
       - path: google/cloud/appoptimize/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
     copyright_year: "2026"
   - name: apps
     version: 1.0.0
     apis:
       - path: google/apps/meet/v2
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/apps/events/subscriptions/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/apps/meet/v2beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/apps/events/subscriptions/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: area120
     version: 0.15.0
     apis:
       - path: google/area120/tables/v1alpha1
         go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
           no_metadata: true
   - name: artifactregistry
     version: 1.25.0
     apis:
       - path: google/devtools/artifactregistry/v1
         go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
           import_path: artifactregistry/apiv1
       - path: google/devtools/artifactregistry/v1beta2
         go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
           import_path: artifactregistry/apiv1beta2
   - name: asset
     version: 1.27.0
@@ -296,23 +175,11 @@ libraries:
     version: 1.18.0
     apis:
       - path: google/cloud/assuredworkloads/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/assuredworkloads/v1beta1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: auditmanager
     version: 1.0.0
     apis:
       - path: google/cloud/auditmanager/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: auth
     version: 0.20.0
     keep:
@@ -328,82 +195,34 @@ libraries:
     version: 1.20.0
     apis:
       - path: google/cloud/automl/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/automl/v1beta1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: backupdr
     version: 1.14.0
     apis:
       - path: google/cloud/backupdr/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: baremetalsolution
     version: 1.9.0
     apis:
       - path: google/cloud/baremetalsolution/v2
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: batch
     version: 1.19.0
     apis:
       - path: google/cloud/batch/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
     keep:
       - apiv1/iam_policy_client.go
   - name: beyondcorp
     version: 1.7.0
     apis:
       - path: google/cloud/beyondcorp/appconnections/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/beyondcorp/appconnectors/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/beyondcorp/appgateways/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/beyondcorp/clientconnectorservices/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/beyondcorp/clientgateways/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: biglake
     version: 1.0.0
     apis:
       - path: google/cloud/biglake/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/biglake/hive/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
     copyright_year: "2026"
   - name: bigquery
     version: 1.77.0
@@ -546,16 +365,10 @@ libraries:
     apis:
       - path: google/bigtable/v2
         go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
           no_metadata: true
           proto_only: true
       - path: google/bigtable/admin/v2
         go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
           no_metadata: true
           proto_only: true
     keep:
@@ -565,154 +378,75 @@ libraries:
     version: 1.26.0
     apis:
       - path: google/cloud/billing/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/billing/budgets/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/billing/budgets/v1beta1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: binaryauthorization
     version: 1.15.0
     apis:
       - path: google/cloud/binaryauthorization/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/binaryauthorization/v1beta1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: capacityplanner
     version: 0.6.0
     apis:
       - path: google/cloud/capacityplanner/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: certificatemanager
     version: 1.14.0
     apis:
       - path: google/cloud/certificatemanager/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: ces
     version: 1.0.0
     apis:
       - path: google/cloud/ces/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/ces/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: channel
     version: 1.26.0
     apis:
       - path: google/cloud/channel/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: chat
     version: 1.1.0
     apis:
       - path: google/chat/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: chronicle
     version: 1.0.0
     apis:
       - path: google/cloud/chronicle/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: cloudbuild
     version: 1.30.0
     apis:
       - path: google/devtools/cloudbuild/v2
         go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
           import_path: cloudbuild/apiv2
       - path: google/devtools/cloudbuild/v1
         go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
           import_path: cloudbuild/apiv1/v2
   - name: cloudcontrolspartner
     version: 1.10.0
     apis:
       - path: google/cloud/cloudcontrolspartner/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/cloudcontrolspartner/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: clouddms
     version: 1.13.0
     apis:
       - path: google/cloud/clouddms/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: cloudprofiler
     version: 1.0.0
     apis:
       - path: google/devtools/cloudprofiler/v2
         go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
           import_path: cloudprofiler/apiv2
   - name: cloudquotas
     version: 1.11.0
     apis:
       - path: google/api/cloudquotas/v1
         go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
           import_path: cloudquotas/apiv1
       - path: google/api/cloudquotas/v1beta
         go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
           import_path: cloudquotas/apiv1beta
   - name: cloudsecuritycompliance
     version: 1.0.0
     apis:
       - path: google/cloud/cloudsecuritycompliance/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: cloudtasks
     version: 1.18.0
     apis:
@@ -744,10 +478,6 @@ libraries:
     version: 1.7.0
     apis:
       - path: google/cloud/commerce/consumer/procurement/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: compute
     version: 1.63.0
     apis:
@@ -777,60 +507,29 @@ libraries:
     version: 1.16.0
     apis:
       - path: google/cloud/confidentialcomputing/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/confidentialcomputing/v1alpha1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: config
     version: 1.11.0
     apis:
       - path: google/cloud/config/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: configdelivery
     version: 1.0.0
     apis:
       - path: google/cloud/configdelivery/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/configdelivery/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: contactcenterinsights
     version: 1.22.0
     apis:
       - path: google/cloud/contactcenterinsights/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: container
     version: 1.52.0
     apis:
       - path: google/container/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: containeranalysis
     version: 0.19.0
     apis:
       - path: google/devtools/containeranalysis/v1beta1
         go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
           import_path: containeranalysis/apiv1beta1
           nested_protos:
             - grafeas/grafeas.proto
@@ -844,25 +543,9 @@ libraries:
     version: 1.32.0
     apis:
       - path: google/cloud/datacatalog/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/datacatalog/lineage/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/datacatalog/lineage/configmanagement/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/datacatalog/v1beta1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
     keep:
       - apiv1/iam_policy_client.go
   - name: dataflow
@@ -878,56 +561,30 @@ libraries:
     version: 1.0.0
     apis:
       - path: google/cloud/dataform/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/dataform/v1beta1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: datafusion
     version: 1.13.0
     apis:
       - path: google/cloud/datafusion/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: datalabeling
     version: 0.14.0
     apis:
       - path: google/cloud/datalabeling/v1beta1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: datamanager
     version: 1.0.0
     apis:
       - path: google/ads/datamanager/v1
         go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
           import_path: datamanager/apiv1
   - name: dataplex
     version: 1.34.0
     apis:
       - path: google/cloud/dataplex/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: dataproc
     version: 2.22.0
     apis:
       - path: google/cloud/dataproc/v1
         go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
           import_path: dataproc/v2/apiv1
     go:
       module_path_version: v2
@@ -935,10 +592,6 @@ libraries:
     version: 0.13.0
     apis:
       - path: google/cloud/dataqna/v1alpha
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: datastore
     version: 1.23.0
     apis:
@@ -960,129 +613,58 @@ libraries:
     version: 1.20.0
     apis:
       - path: google/cloud/datastream/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/datastream/v1alpha1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
     keep:
       - apiv1/iam_policy_client.go
   - name: deploy
     version: 1.32.0
     apis:
       - path: google/cloud/deploy/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: developerconnect
     version: 1.0.0
     apis:
       - path: google/cloud/developerconnect/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: devicestreaming
     version: 1.0.0
     apis:
       - path: google/cloud/devicestreaming/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: dialogflow
     version: 1.82.0
     apis:
       - path: google/cloud/dialogflow/v2
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/dialogflow/cx/v3
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/dialogflow/cx/v3beta1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/dialogflow/v2beta1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: discoveryengine
     version: 1.29.0
     apis:
       - path: google/cloud/discoveryengine/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/discoveryengine/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/discoveryengine/v1alpha
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: dlp
     version: 1.34.0
     apis:
       - path: google/privacy/dlp/v2
         go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
           import_path: dlp/apiv2
           no_metadata: true
   - name: documentai
     version: 1.48.0
     apis:
       - path: google/cloud/documentai/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/documentai/v1beta3
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: domains
     version: 0.15.0
     apis:
       - path: google/cloud/domains/v1beta1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: edgecontainer
     version: 1.9.0
     apis:
       - path: google/cloud/edgecontainer/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: edgenetwork
     version: 1.8.0
     apis:
       - path: google/cloud/edgenetwork/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: errorreporting
     version: 0.9.0
     apis:
@@ -1107,31 +689,15 @@ libraries:
     version: 1.23.0
     apis:
       - path: google/cloud/eventarc/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/eventarc/publishing/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: filestore
     version: 1.15.0
     apis:
       - path: google/cloud/filestore/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: financialservices
     version: 1.0.0
     apis:
       - path: google/cloud/financialservices/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: firestore
     version: 1.22.0
     apis:
@@ -1158,78 +724,34 @@ libraries:
     version: 1.24.0
     apis:
       - path: google/cloud/functions/v2
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/functions/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/functions/v2beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: geminidataanalytics
     version: 1.1.0
     apis:
       - path: google/cloud/geminidataanalytics/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/geminidataanalytics/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: gkebackup
     version: 1.13.0
     apis:
       - path: google/cloud/gkebackup/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: gkeconnect
     version: 1.0.0
     apis:
       - path: google/cloud/gkeconnect/gateway/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/gkeconnect/gateway/v1beta1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: gkehub
     version: 0.21.0
     apis:
       - path: google/cloud/gkehub/v1beta1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: gkemulticloud
     version: 1.11.0
     apis:
       - path: google/cloud/gkemulticloud/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: gkerecommender
     version: 1.0.0
     apis:
       - path: google/cloud/gkerecommender/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: grafeas
     version: 0.5.0
     keep:
@@ -1239,23 +761,11 @@ libraries:
     version: 1.12.0
     apis:
       - path: google/cloud/gsuiteaddons/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: hypercomputecluster
     version: 1.0.0
     apis:
       - path: google/cloud/hypercomputecluster/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/hypercomputecluster/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: iam
     version: 1.11.0
     apis:
@@ -1296,34 +806,18 @@ libraries:
     version: 1.17.0
     apis:
       - path: google/cloud/iap/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: identitytoolkit
     version: 1.0.0
     apis:
       - path: google/cloud/identitytoolkit/v2
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: ids
     version: 1.10.0
     apis:
       - path: google/cloud/ids/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: iot
     version: 1.13.0
     apis:
       - path: google/cloud/iot/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: kms
     version: 1.31.0
     apis:
@@ -1343,44 +837,20 @@ libraries:
     version: 1.18.0
     apis:
       - path: google/cloud/language/v2
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/language/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/language/v1beta2
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: licensemanager
     version: 1.0.0
     apis:
       - path: google/cloud/licensemanager/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: lifesciences
     version: 0.15.0
     apis:
       - path: google/cloud/lifesciences/v2beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: locationfinder
     version: 1.0.0
     apis:
       - path: google/cloud/locationfinder/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: logging
     version: 1.18.0
     apis:
@@ -1398,101 +868,40 @@ libraries:
       - path: google/longrunning
         go:
           client_package: longrunning
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
           import_path: longrunning/autogen
   - name: lustre
     version: 1.0.0
     apis:
       - path: google/cloud/lustre/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: maintenance
     version: 1.0.0
     apis:
       - path: google/cloud/maintenance/api/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/maintenance/api/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: managedidentities
     version: 1.12.0
     apis:
       - path: google/cloud/managedidentities/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: managedkafka
     version: 1.0.0
     apis:
       - path: google/cloud/managedkafka/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/managedkafka/schemaregistry/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: maps
     version: 1.35.0
     apis:
       - path: google/maps/geocode/v4
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/maps/routing/v2
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/maps/addressvalidation/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/maps/areainsights/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/maps/fleetengine/v1
         go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
           proto_package: maps.fleetengine.v1
       - path: google/maps/places/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/maps/routeoptimization/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/maps/solar/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/maps/fleetengine/delivery/v1
         go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
           proto_package: maps.fleetengine.delivery.v1
       - path: google/maps/mapmanagement/v2beta
     title_override: Google Maps Platform
@@ -1500,75 +909,31 @@ libraries:
     version: 0.13.0
     apis:
       - path: google/cloud/mediatranslation/v1beta1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: memcache
     version: 1.16.0
     apis:
       - path: google/cloud/memcache/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/memcache/v1beta2
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: memorystore
     version: 1.0.0
     apis:
       - path: google/cloud/memorystore/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/memorystore/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: metastore
     version: 1.19.0
     apis:
       - path: google/cloud/metastore/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/metastore/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/metastore/v1alpha
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: migrationcenter
     version: 1.6.0
     apis:
       - path: google/cloud/migrationcenter/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: modelarmor
     version: 1.0.0
     apis:
       - path: google/cloud/modelarmor/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/modelarmor/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: monitoring
     version: 1.29.0
     apis:
@@ -1595,94 +960,42 @@ libraries:
     version: 1.17.0
     apis:
       - path: google/cloud/netapp/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: networkconnectivity
     version: 1.26.0
     apis:
       - path: google/cloud/networkconnectivity/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/networkconnectivity/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/networkconnectivity/v1alpha1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: networkmanagement
     version: 1.28.0
     apis:
       - path: google/cloud/networkmanagement/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: networksecurity
     version: 0.16.0
     apis:
       - path: google/cloud/networksecurity/v1beta1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: networkservices
     version: 1.0.0
     apis:
       - path: google/cloud/networkservices/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: notebooks
     version: 1.17.0
     apis:
       - path: google/cloud/notebooks/v2
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/notebooks/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/notebooks/v1beta1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: optimization
     version: 1.11.0
     apis:
       - path: google/cloud/optimization/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: oracledatabase
     version: 1.0.0
     apis:
       - path: google/cloud/oracledatabase/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: orchestration
     version: 1.16.0
     apis:
       - path: google/cloud/orchestration/airflow/service/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: orgpolicy
     version: 1.20.0
     apis:
@@ -1703,118 +1016,53 @@ libraries:
     version: 1.21.0
     apis:
       - path: google/cloud/osconfig/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/osconfig/agentendpoint/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/osconfig/agentendpoint/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/osconfig/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/osconfig/v1alpha
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: oslogin
     version: 1.18.0
     apis:
       - path: google/cloud/oslogin/v1
         go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
           no_metadata: true
       - path: google/cloud/oslogin/v1beta
         go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
           no_metadata: true
       - path: google/cloud/oslogin/common
         go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
           import_path: oslogin/common
           proto_only: true
   - name: parallelstore
     version: 1.0.0
     apis:
       - path: google/cloud/parallelstore/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/parallelstore/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: parametermanager
     version: 1.0.0
     apis:
       - path: google/cloud/parametermanager/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: phishingprotection
     version: 0.13.0
     apis:
       - path: google/cloud/phishingprotection/v1beta1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: policysimulator
     version: 1.0.0
     apis:
       - path: google/cloud/policysimulator/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: policytroubleshooter
     version: 1.15.0
     apis:
       - path: google/cloud/policytroubleshooter/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/policytroubleshooter/iam/v3
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: privatecatalog
     version: 0.15.0
     apis:
       - path: google/cloud/privatecatalog/v1beta1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: privilegedaccessmanager
     version: 1.0.0
     apis:
       - path: google/cloud/privilegedaccessmanager/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: profiler
     version: 0.6.0
     keep:
@@ -1846,33 +1094,19 @@ libraries:
     version: 1.8.2
     apis:
       - path: google/cloud/pubsublite/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
     skip_release: true
   - name: rapidmigrationassessment
     version: 1.6.0
     apis:
       - path: google/cloud/rapidmigrationassessment/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: recaptchaenterprise
     version: 2.26.0
     apis:
       - path: google/cloud/recaptchaenterprise/v1
         go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
           import_path: recaptchaenterprise/v2/apiv1
       - path: google/cloud/recaptchaenterprise/v1beta1
         go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
           import_path: recaptchaenterprise/v2/apiv1beta1
     go:
       module_path_version: v2
@@ -1880,10 +1114,6 @@ libraries:
     version: 0.14.0
     apis:
       - path: google/cloud/recommendationengine/v1beta1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: recommender
     version: 1.18.0
     apis:
@@ -1903,20 +1133,8 @@ libraries:
     version: 1.23.0
     apis:
       - path: google/cloud/redis/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/redis/cluster/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/redis/v1beta1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: resourcemanager
     version: 1.15.0
     apis:
@@ -1936,20 +1154,8 @@ libraries:
     version: 1.31.0
     apis:
       - path: google/cloud/retail/v2
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/retail/v2beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/retail/v2alpha
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: root-module
     version: 0.123.0
     keep:
@@ -1961,33 +1167,17 @@ libraries:
     version: 1.21.0
     apis:
       - path: google/cloud/run/v2
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
     keep:
       - apiv2/locations_client.go
   - name: saasplatform
     version: 0.7.0
     apis:
       - path: google/cloud/saasplatform/saasservicemgmt/v1beta1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: scheduler
     version: 1.16.0
     apis:
       - path: google/cloud/scheduler/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/scheduler/v1beta1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: secretmanager
     version: 1.20.0
     apis:
@@ -2007,271 +1197,91 @@ libraries:
     version: 1.9.0
     apis:
       - path: google/cloud/securesourcemanager/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: security
     version: 1.24.0
     apis:
       - path: google/cloud/security/privateca/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/security/publicca/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/security/publicca/v1beta1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: securitycenter
     version: 1.44.0
     apis:
       - path: google/cloud/securitycenter/v2
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/securitycenter/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/securitycenter/v1p1beta1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/securitycenter/settings/v1beta1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/securitycenter/v1beta1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: securitycentermanagement
     version: 1.6.0
     apis:
       - path: google/cloud/securitycentermanagement/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: securityposture
     version: 1.0.0
     apis:
       - path: google/cloud/securityposture/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: servicecontrol
     version: 1.18.0
     apis:
       - path: google/api/servicecontrol/v1
         go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
           import_path: servicecontrol/apiv1
   - name: servicedirectory
     version: 1.17.0
     apis:
       - path: google/cloud/servicedirectory/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/servicedirectory/v1beta1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: servicehealth
     version: 1.7.0
     apis:
       - path: google/cloud/servicehealth/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: servicemanagement
     version: 1.15.0
     apis:
       - path: google/api/servicemanagement/v1
         go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
           import_path: servicemanagement/apiv1
   - name: serviceusage
     version: 1.14.0
     apis:
       - path: google/api/serviceusage/v1
         go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
           import_path: serviceusage/apiv1
   - name: shell
     version: 1.12.0
     apis:
       - path: google/cloud/shell/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: shopping
     version: 1.11.0
     apis:
       - path: google/shopping/css/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/shopping/merchant/promotions/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/shopping/merchant/quota/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/shopping/merchant/conversions/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/shopping/merchant/accounts/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/shopping/merchant/datasources/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/shopping/merchant/reports/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/shopping/merchant/notifications/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/shopping/merchant/lfp/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/shopping/merchant/ordertracking/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/shopping/merchant/issueresolution/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/shopping/merchant/products/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/shopping/merchant/inventories/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/shopping/merchant/notifications/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/shopping/merchant/ordertracking/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/shopping/merchant/products/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/shopping/merchant/accounts/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/shopping/merchant/quota/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/shopping/merchant/promotions/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/shopping/merchant/inventories/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/shopping/merchant/reports/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/shopping/merchant/issueresolution/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/shopping/merchant/reviews/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/shopping/merchant/lfp/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/shopping/merchant/datasources/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/shopping/merchant/conversions/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/shopping/merchant/productstudio/v1alpha
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/shopping/type
         go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
           import_path: shopping/type
           proto_only: true
   - name: spanner
@@ -2279,31 +1289,14 @@ libraries:
     apis:
       - path: google/spanner/v1
         go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
           no_metadata: true
       - path: google/spanner/adapter/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/spanner/executor/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/spanner/admin/database/v1
         go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
           no_metadata: true
       - path: google/spanner/admin/instance/v1
         go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
           no_metadata: true
     keep:
       - README.md
@@ -2312,34 +1305,15 @@ libraries:
     version: 1.35.0
     apis:
       - path: google/cloud/speech/v2
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/speech/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/speech/v1p1beta1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: storage
     version: 1.62.2
     apis:
       - path: google/storage/v2
         go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
           import_path: storage/internal/apiv2
       - path: google/storage/control/v2
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
     keep:
       - README.md
     skip_release: true
@@ -2350,84 +1324,40 @@ libraries:
     version: 1.0.0
     apis:
       - path: google/cloud/storagebatchoperations/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: storageinsights
     version: 1.7.0
     apis:
       - path: google/cloud/storageinsights/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: storagetransfer
     version: 1.18.0
     apis:
       - path: google/storagetransfer/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: streetview
     version: 1.0.0
     apis:
       - path: google/streetview/publish/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: support
     version: 1.10.0
     apis:
       - path: google/cloud/support/v2
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/support/v2beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: talent
     version: 1.13.0
     apis:
       - path: google/cloud/talent/v4
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/talent/v4beta1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: telcoautomation
     version: 1.6.0
     apis:
       - path: google/cloud/telcoautomation/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: texttospeech
     version: 1.21.0
     apis:
       - path: google/cloud/texttospeech/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: tpu
     version: 1.13.0
     apis:
       - path: google/cloud/tpu/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: trace
     version: 1.16.0
     apis:
@@ -2453,23 +1383,12 @@ libraries:
     apis:
       - path: google/cloud/translate/v3
         go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
           proto_package: google.cloud.translation.v3
   - name: vectorsearch
     version: 1.0.0
     apis:
       - path: google/cloud/vectorsearch/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/vectorsearch/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: vertexai
     version: 0.19.0
     keep:
@@ -2480,52 +1399,22 @@ libraries:
     version: 1.32.0
     apis:
       - path: google/cloud/video/livestream/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/video/transcoder/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/video/stitcher/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: videointelligence
     version: 1.16.0
     apis:
       - path: google/cloud/videointelligence/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/videointelligence/v1p3beta1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/videointelligence/v1beta2
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: vision
     version: 2.14.0
     apis:
       - path: google/cloud/vision/v1
         go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
           import_path: vision/v2/apiv1
       - path: google/cloud/vision/v1p1beta1
         go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
           import_path: vision/v2/apiv1p1beta1
           no_metadata: true
     go:
@@ -2534,98 +1423,42 @@ libraries:
     version: 1.0.0
     apis:
       - path: google/cloud/visionai/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: vmmigration
     version: 1.15.0
     apis:
       - path: google/cloud/vmmigration/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
     keep:
       - apiv1/iam_policy_client.go
   - name: vmwareengine
     version: 1.8.0
     apis:
       - path: google/cloud/vmwareengine/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: vpcaccess
     version: 1.13.0
     apis:
       - path: google/cloud/vpcaccess/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: webrisk
     version: 1.16.0
     apis:
       - path: google/cloud/webrisk/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/webrisk/v1beta1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: websecurityscanner
     version: 1.12.0
     apis:
       - path: google/cloud/websecurityscanner/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: workflows
     version: 1.19.0
     apis:
       - path: google/cloud/workflows/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/workflows/executions/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/workflows/executions/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/workflows/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: workloadmanager
     version: 1.0.0
     apis:
       - path: google/cloud/workloadmanager/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: workstations
     version: 1.6.0
     apis:
       - path: google/cloud/workstations/v1
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/workstations/v1beta
-        go:
-          enabled_generator_features:
-            - F_open_telemetry_attributes
-            - F_proto_cloneof

--- a/maps/mapmanagement/apiv2beta/map_management_client.go
+++ b/maps/mapmanagement/apiv2beta/map_management_client.go
@@ -27,6 +27,7 @@ import (
 
 	mapmanagementpb "cloud.google.com/go/maps/mapmanagement/apiv2beta/mapmanagementpb"
 	gax "github.com/googleapis/gax-go/v2"
+	"github.com/googleapis/gax-go/v2/callctx"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
 	"google.golang.org/api/option/internaloption"
@@ -302,6 +303,16 @@ type gRPCClient struct {
 // and v2beta endpoints.
 func NewClient(ctx context.Context, opts ...option.ClientOption) (*Client, error) {
 	clientOpts := defaultGRPCClientOptions()
+	if gax.IsFeatureEnabled("TRACING") || gax.IsFeatureEnabled("LOGGING") {
+		clientOpts = append(clientOpts, internaloption.WithTelemetryAttributes(map[string]string{
+			"gcp.client.service":  "mapmanagement",
+			"gcp.client.version":  getVersionClient(),
+			"gcp.client.repo":     "googleapis/google-cloud-go",
+			"gcp.client.artifact": "cloud.google.com/go/maps/mapmanagement/apiv2beta",
+			"gcp.client.language": "go",
+			"url.domain":          "mapmanagement.googleapis.com",
+		}))
+	}
 	if newClientHook != nil {
 		hookOpts, err := newClientHook(ctx, clientHookParams{})
 		if err != nil {
@@ -323,6 +334,34 @@ func NewClient(ctx context.Context, opts ...option.ClientOption) (*Client, error
 		logger:      internaloption.GetLogger(opts),
 	}
 	c.setGoogleClientInfo()
+	if gax.IsFeatureEnabled("METRICS") {
+		metrics := gax.NewClientMetrics(
+			gax.WithTelemetryLogger(c.logger),
+			gax.WithTelemetryAttributes(map[string]string{
+				gax.ClientService:  "mapmanagement",
+				gax.ClientVersion:  getVersionClient(),
+				gax.ClientArtifact: "cloud.google.com/go/maps/mapmanagement/apiv2beta",
+				gax.RPCSystem:      "grpc",
+				gax.URLDomain:      "mapmanagement.googleapis.com",
+			}),
+		)
+
+		client.CallOptions.CreateMapConfig = append(client.CallOptions.CreateMapConfig, gax.WithClientMetrics(metrics))
+		client.CallOptions.GetMapConfig = append(client.CallOptions.GetMapConfig, gax.WithClientMetrics(metrics))
+		client.CallOptions.ListMapConfigs = append(client.CallOptions.ListMapConfigs, gax.WithClientMetrics(metrics))
+		client.CallOptions.UpdateMapConfig = append(client.CallOptions.UpdateMapConfig, gax.WithClientMetrics(metrics))
+		client.CallOptions.DeleteMapConfig = append(client.CallOptions.DeleteMapConfig, gax.WithClientMetrics(metrics))
+		client.CallOptions.CreateStyleConfig = append(client.CallOptions.CreateStyleConfig, gax.WithClientMetrics(metrics))
+		client.CallOptions.GetStyleConfig = append(client.CallOptions.GetStyleConfig, gax.WithClientMetrics(metrics))
+		client.CallOptions.ListStyleConfigs = append(client.CallOptions.ListStyleConfigs, gax.WithClientMetrics(metrics))
+		client.CallOptions.UpdateStyleConfig = append(client.CallOptions.UpdateStyleConfig, gax.WithClientMetrics(metrics))
+		client.CallOptions.DeleteStyleConfig = append(client.CallOptions.DeleteStyleConfig, gax.WithClientMetrics(metrics))
+		client.CallOptions.CreateMapContextConfig = append(client.CallOptions.CreateMapContextConfig, gax.WithClientMetrics(metrics))
+		client.CallOptions.GetMapContextConfig = append(client.CallOptions.GetMapContextConfig, gax.WithClientMetrics(metrics))
+		client.CallOptions.ListMapContextConfigs = append(client.CallOptions.ListMapContextConfigs, gax.WithClientMetrics(metrics))
+		client.CallOptions.UpdateMapContextConfig = append(client.CallOptions.UpdateMapContextConfig, gax.WithClientMetrics(metrics))
+		client.CallOptions.DeleteMapContextConfig = append(client.CallOptions.DeleteMapContextConfig, gax.WithClientMetrics(metrics))
+	}
 
 	client.internalClient = c
 
@@ -392,6 +431,16 @@ type restClient struct {
 // and v2beta endpoints.
 func NewRESTClient(ctx context.Context, opts ...option.ClientOption) (*Client, error) {
 	clientOpts := append(defaultRESTClientOptions(), opts...)
+	if gax.IsFeatureEnabled("TRACING") || gax.IsFeatureEnabled("LOGGING") {
+		clientOpts = append(clientOpts, internaloption.WithTelemetryAttributes(map[string]string{
+			"gcp.client.service":  "mapmanagement",
+			"gcp.client.version":  getVersionClient(),
+			"gcp.client.repo":     "googleapis/google-cloud-go",
+			"gcp.client.artifact": "cloud.google.com/go/maps/mapmanagement/apiv2beta",
+			"gcp.client.language": "go",
+			"url.domain":          "mapmanagement.googleapis.com",
+		}))
+	}
 	httpClient, endpoint, err := httptransport.NewClient(ctx, clientOpts...)
 	if err != nil {
 		return nil, err
@@ -405,6 +454,35 @@ func NewRESTClient(ctx context.Context, opts ...option.ClientOption) (*Client, e
 		logger:      internaloption.GetLogger(opts),
 	}
 	c.setGoogleClientInfo()
+
+	if gax.IsFeatureEnabled("METRICS") {
+		metrics := gax.NewClientMetrics(
+			gax.WithTelemetryLogger(c.logger),
+			gax.WithTelemetryAttributes(map[string]string{
+				gax.ClientService:  "mapmanagement",
+				gax.ClientVersion:  getVersionClient(),
+				gax.ClientArtifact: "cloud.google.com/go/maps/mapmanagement/apiv2beta",
+				gax.RPCSystem:      "http",
+				gax.URLDomain:      "mapmanagement.googleapis.com",
+			}),
+		)
+
+		callOpts.CreateMapConfig = append(callOpts.CreateMapConfig, gax.WithClientMetrics(metrics))
+		callOpts.GetMapConfig = append(callOpts.GetMapConfig, gax.WithClientMetrics(metrics))
+		callOpts.ListMapConfigs = append(callOpts.ListMapConfigs, gax.WithClientMetrics(metrics))
+		callOpts.UpdateMapConfig = append(callOpts.UpdateMapConfig, gax.WithClientMetrics(metrics))
+		callOpts.DeleteMapConfig = append(callOpts.DeleteMapConfig, gax.WithClientMetrics(metrics))
+		callOpts.CreateStyleConfig = append(callOpts.CreateStyleConfig, gax.WithClientMetrics(metrics))
+		callOpts.GetStyleConfig = append(callOpts.GetStyleConfig, gax.WithClientMetrics(metrics))
+		callOpts.ListStyleConfigs = append(callOpts.ListStyleConfigs, gax.WithClientMetrics(metrics))
+		callOpts.UpdateStyleConfig = append(callOpts.UpdateStyleConfig, gax.WithClientMetrics(metrics))
+		callOpts.DeleteStyleConfig = append(callOpts.DeleteStyleConfig, gax.WithClientMetrics(metrics))
+		callOpts.CreateMapContextConfig = append(callOpts.CreateMapContextConfig, gax.WithClientMetrics(metrics))
+		callOpts.GetMapContextConfig = append(callOpts.GetMapContextConfig, gax.WithClientMetrics(metrics))
+		callOpts.ListMapContextConfigs = append(callOpts.ListMapContextConfigs, gax.WithClientMetrics(metrics))
+		callOpts.UpdateMapContextConfig = append(callOpts.UpdateMapContextConfig, gax.WithClientMetrics(metrics))
+		callOpts.DeleteMapContextConfig = append(callOpts.DeleteMapContextConfig, gax.WithClientMetrics(metrics))
+	}
 
 	return &Client{internalClient: c, CallOptions: callOpts}, nil
 }
@@ -451,6 +529,12 @@ func (c *gRPCClient) CreateMapConfig(ctx context.Context, req *mapmanagementpb.C
 
 	hds = append(c.xGoogHeaders, hds...)
 	ctx = gax.InsertMetadataIntoOutgoingContext(ctx, hds...)
+	if gax.IsFeatureEnabled("TRACING") || gax.IsFeatureEnabled("LOGGING") {
+		ctx = callctx.WithTelemetryContext(ctx, "resource_name", fmt.Sprintf("//mapmanagement.googleapis.com/%v", req.GetParent()))
+	}
+	if gax.IsFeatureEnabled("METRICS") || gax.IsFeatureEnabled("TRACING") || gax.IsFeatureEnabled("LOGGING") {
+		ctx = callctx.WithTelemetryContext(ctx, "rpc_method", "google.maps.mapmanagement.v2beta.MapManagement/CreateMapConfig")
+	}
 	opts = append((*c.CallOptions).CreateMapConfig[0:len((*c.CallOptions).CreateMapConfig):len((*c.CallOptions).CreateMapConfig)], opts...)
 	var resp *mapmanagementpb.MapConfig
 	err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
@@ -469,6 +553,12 @@ func (c *gRPCClient) GetMapConfig(ctx context.Context, req *mapmanagementpb.GetM
 
 	hds = append(c.xGoogHeaders, hds...)
 	ctx = gax.InsertMetadataIntoOutgoingContext(ctx, hds...)
+	if gax.IsFeatureEnabled("TRACING") || gax.IsFeatureEnabled("LOGGING") {
+		ctx = callctx.WithTelemetryContext(ctx, "resource_name", fmt.Sprintf("//mapmanagement.googleapis.com/%v", req.GetName()))
+	}
+	if gax.IsFeatureEnabled("METRICS") || gax.IsFeatureEnabled("TRACING") || gax.IsFeatureEnabled("LOGGING") {
+		ctx = callctx.WithTelemetryContext(ctx, "rpc_method", "google.maps.mapmanagement.v2beta.MapManagement/GetMapConfig")
+	}
 	opts = append((*c.CallOptions).GetMapConfig[0:len((*c.CallOptions).GetMapConfig):len((*c.CallOptions).GetMapConfig)], opts...)
 	var resp *mapmanagementpb.MapConfig
 	err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
@@ -487,9 +577,15 @@ func (c *gRPCClient) ListMapConfigs(ctx context.Context, req *mapmanagementpb.Li
 
 	hds = append(c.xGoogHeaders, hds...)
 	ctx = gax.InsertMetadataIntoOutgoingContext(ctx, hds...)
+	if gax.IsFeatureEnabled("TRACING") || gax.IsFeatureEnabled("LOGGING") {
+		ctx = callctx.WithTelemetryContext(ctx, "resource_name", fmt.Sprintf("//mapmanagement.googleapis.com/%v", req.GetParent()))
+	}
+	if gax.IsFeatureEnabled("METRICS") || gax.IsFeatureEnabled("TRACING") || gax.IsFeatureEnabled("LOGGING") {
+		ctx = callctx.WithTelemetryContext(ctx, "rpc_method", "google.maps.mapmanagement.v2beta.MapManagement/ListMapConfigs")
+	}
 	opts = append((*c.CallOptions).ListMapConfigs[0:len((*c.CallOptions).ListMapConfigs):len((*c.CallOptions).ListMapConfigs)], opts...)
 	it := &MapConfigIterator{}
-	req = proto.Clone(req).(*mapmanagementpb.ListMapConfigsRequest)
+	req = proto.CloneOf(req)
 	it.InternalFetch = func(pageSize int, pageToken string) ([]*mapmanagementpb.MapConfig, string, error) {
 		resp := &mapmanagementpb.ListMapConfigsResponse{}
 		if pageToken != "" {
@@ -533,6 +629,9 @@ func (c *gRPCClient) UpdateMapConfig(ctx context.Context, req *mapmanagementpb.U
 
 	hds = append(c.xGoogHeaders, hds...)
 	ctx = gax.InsertMetadataIntoOutgoingContext(ctx, hds...)
+	if gax.IsFeatureEnabled("METRICS") || gax.IsFeatureEnabled("TRACING") || gax.IsFeatureEnabled("LOGGING") {
+		ctx = callctx.WithTelemetryContext(ctx, "rpc_method", "google.maps.mapmanagement.v2beta.MapManagement/UpdateMapConfig")
+	}
 	opts = append((*c.CallOptions).UpdateMapConfig[0:len((*c.CallOptions).UpdateMapConfig):len((*c.CallOptions).UpdateMapConfig)], opts...)
 	var resp *mapmanagementpb.MapConfig
 	err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
@@ -551,6 +650,12 @@ func (c *gRPCClient) DeleteMapConfig(ctx context.Context, req *mapmanagementpb.D
 
 	hds = append(c.xGoogHeaders, hds...)
 	ctx = gax.InsertMetadataIntoOutgoingContext(ctx, hds...)
+	if gax.IsFeatureEnabled("TRACING") || gax.IsFeatureEnabled("LOGGING") {
+		ctx = callctx.WithTelemetryContext(ctx, "resource_name", fmt.Sprintf("//mapmanagement.googleapis.com/%v", req.GetName()))
+	}
+	if gax.IsFeatureEnabled("METRICS") || gax.IsFeatureEnabled("TRACING") || gax.IsFeatureEnabled("LOGGING") {
+		ctx = callctx.WithTelemetryContext(ctx, "rpc_method", "google.maps.mapmanagement.v2beta.MapManagement/DeleteMapConfig")
+	}
 	opts = append((*c.CallOptions).DeleteMapConfig[0:len((*c.CallOptions).DeleteMapConfig):len((*c.CallOptions).DeleteMapConfig)], opts...)
 	err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
 		var err error
@@ -565,6 +670,12 @@ func (c *gRPCClient) CreateStyleConfig(ctx context.Context, req *mapmanagementpb
 
 	hds = append(c.xGoogHeaders, hds...)
 	ctx = gax.InsertMetadataIntoOutgoingContext(ctx, hds...)
+	if gax.IsFeatureEnabled("TRACING") || gax.IsFeatureEnabled("LOGGING") {
+		ctx = callctx.WithTelemetryContext(ctx, "resource_name", fmt.Sprintf("//mapmanagement.googleapis.com/%v", req.GetParent()))
+	}
+	if gax.IsFeatureEnabled("METRICS") || gax.IsFeatureEnabled("TRACING") || gax.IsFeatureEnabled("LOGGING") {
+		ctx = callctx.WithTelemetryContext(ctx, "rpc_method", "google.maps.mapmanagement.v2beta.MapManagement/CreateStyleConfig")
+	}
 	opts = append((*c.CallOptions).CreateStyleConfig[0:len((*c.CallOptions).CreateStyleConfig):len((*c.CallOptions).CreateStyleConfig)], opts...)
 	var resp *mapmanagementpb.StyleConfig
 	err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
@@ -583,6 +694,12 @@ func (c *gRPCClient) GetStyleConfig(ctx context.Context, req *mapmanagementpb.Ge
 
 	hds = append(c.xGoogHeaders, hds...)
 	ctx = gax.InsertMetadataIntoOutgoingContext(ctx, hds...)
+	if gax.IsFeatureEnabled("TRACING") || gax.IsFeatureEnabled("LOGGING") {
+		ctx = callctx.WithTelemetryContext(ctx, "resource_name", fmt.Sprintf("//mapmanagement.googleapis.com/%v", req.GetName()))
+	}
+	if gax.IsFeatureEnabled("METRICS") || gax.IsFeatureEnabled("TRACING") || gax.IsFeatureEnabled("LOGGING") {
+		ctx = callctx.WithTelemetryContext(ctx, "rpc_method", "google.maps.mapmanagement.v2beta.MapManagement/GetStyleConfig")
+	}
 	opts = append((*c.CallOptions).GetStyleConfig[0:len((*c.CallOptions).GetStyleConfig):len((*c.CallOptions).GetStyleConfig)], opts...)
 	var resp *mapmanagementpb.StyleConfig
 	err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
@@ -601,9 +718,15 @@ func (c *gRPCClient) ListStyleConfigs(ctx context.Context, req *mapmanagementpb.
 
 	hds = append(c.xGoogHeaders, hds...)
 	ctx = gax.InsertMetadataIntoOutgoingContext(ctx, hds...)
+	if gax.IsFeatureEnabled("TRACING") || gax.IsFeatureEnabled("LOGGING") {
+		ctx = callctx.WithTelemetryContext(ctx, "resource_name", fmt.Sprintf("//mapmanagement.googleapis.com/%v", req.GetParent()))
+	}
+	if gax.IsFeatureEnabled("METRICS") || gax.IsFeatureEnabled("TRACING") || gax.IsFeatureEnabled("LOGGING") {
+		ctx = callctx.WithTelemetryContext(ctx, "rpc_method", "google.maps.mapmanagement.v2beta.MapManagement/ListStyleConfigs")
+	}
 	opts = append((*c.CallOptions).ListStyleConfigs[0:len((*c.CallOptions).ListStyleConfigs):len((*c.CallOptions).ListStyleConfigs)], opts...)
 	it := &StyleConfigIterator{}
-	req = proto.Clone(req).(*mapmanagementpb.ListStyleConfigsRequest)
+	req = proto.CloneOf(req)
 	it.InternalFetch = func(pageSize int, pageToken string) ([]*mapmanagementpb.StyleConfig, string, error) {
 		resp := &mapmanagementpb.ListStyleConfigsResponse{}
 		if pageToken != "" {
@@ -647,6 +770,9 @@ func (c *gRPCClient) UpdateStyleConfig(ctx context.Context, req *mapmanagementpb
 
 	hds = append(c.xGoogHeaders, hds...)
 	ctx = gax.InsertMetadataIntoOutgoingContext(ctx, hds...)
+	if gax.IsFeatureEnabled("METRICS") || gax.IsFeatureEnabled("TRACING") || gax.IsFeatureEnabled("LOGGING") {
+		ctx = callctx.WithTelemetryContext(ctx, "rpc_method", "google.maps.mapmanagement.v2beta.MapManagement/UpdateStyleConfig")
+	}
 	opts = append((*c.CallOptions).UpdateStyleConfig[0:len((*c.CallOptions).UpdateStyleConfig):len((*c.CallOptions).UpdateStyleConfig)], opts...)
 	var resp *mapmanagementpb.StyleConfig
 	err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
@@ -665,6 +791,12 @@ func (c *gRPCClient) DeleteStyleConfig(ctx context.Context, req *mapmanagementpb
 
 	hds = append(c.xGoogHeaders, hds...)
 	ctx = gax.InsertMetadataIntoOutgoingContext(ctx, hds...)
+	if gax.IsFeatureEnabled("TRACING") || gax.IsFeatureEnabled("LOGGING") {
+		ctx = callctx.WithTelemetryContext(ctx, "resource_name", fmt.Sprintf("//mapmanagement.googleapis.com/%v", req.GetName()))
+	}
+	if gax.IsFeatureEnabled("METRICS") || gax.IsFeatureEnabled("TRACING") || gax.IsFeatureEnabled("LOGGING") {
+		ctx = callctx.WithTelemetryContext(ctx, "rpc_method", "google.maps.mapmanagement.v2beta.MapManagement/DeleteStyleConfig")
+	}
 	opts = append((*c.CallOptions).DeleteStyleConfig[0:len((*c.CallOptions).DeleteStyleConfig):len((*c.CallOptions).DeleteStyleConfig)], opts...)
 	err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
 		var err error
@@ -679,6 +811,12 @@ func (c *gRPCClient) CreateMapContextConfig(ctx context.Context, req *mapmanagem
 
 	hds = append(c.xGoogHeaders, hds...)
 	ctx = gax.InsertMetadataIntoOutgoingContext(ctx, hds...)
+	if gax.IsFeatureEnabled("TRACING") || gax.IsFeatureEnabled("LOGGING") {
+		ctx = callctx.WithTelemetryContext(ctx, "resource_name", fmt.Sprintf("//mapmanagement.googleapis.com/%v", req.GetParent()))
+	}
+	if gax.IsFeatureEnabled("METRICS") || gax.IsFeatureEnabled("TRACING") || gax.IsFeatureEnabled("LOGGING") {
+		ctx = callctx.WithTelemetryContext(ctx, "rpc_method", "google.maps.mapmanagement.v2beta.MapManagement/CreateMapContextConfig")
+	}
 	opts = append((*c.CallOptions).CreateMapContextConfig[0:len((*c.CallOptions).CreateMapContextConfig):len((*c.CallOptions).CreateMapContextConfig)], opts...)
 	var resp *mapmanagementpb.MapContextConfig
 	err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
@@ -697,6 +835,12 @@ func (c *gRPCClient) GetMapContextConfig(ctx context.Context, req *mapmanagement
 
 	hds = append(c.xGoogHeaders, hds...)
 	ctx = gax.InsertMetadataIntoOutgoingContext(ctx, hds...)
+	if gax.IsFeatureEnabled("TRACING") || gax.IsFeatureEnabled("LOGGING") {
+		ctx = callctx.WithTelemetryContext(ctx, "resource_name", fmt.Sprintf("//mapmanagement.googleapis.com/%v", req.GetName()))
+	}
+	if gax.IsFeatureEnabled("METRICS") || gax.IsFeatureEnabled("TRACING") || gax.IsFeatureEnabled("LOGGING") {
+		ctx = callctx.WithTelemetryContext(ctx, "rpc_method", "google.maps.mapmanagement.v2beta.MapManagement/GetMapContextConfig")
+	}
 	opts = append((*c.CallOptions).GetMapContextConfig[0:len((*c.CallOptions).GetMapContextConfig):len((*c.CallOptions).GetMapContextConfig)], opts...)
 	var resp *mapmanagementpb.MapContextConfig
 	err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
@@ -715,9 +859,15 @@ func (c *gRPCClient) ListMapContextConfigs(ctx context.Context, req *mapmanageme
 
 	hds = append(c.xGoogHeaders, hds...)
 	ctx = gax.InsertMetadataIntoOutgoingContext(ctx, hds...)
+	if gax.IsFeatureEnabled("TRACING") || gax.IsFeatureEnabled("LOGGING") {
+		ctx = callctx.WithTelemetryContext(ctx, "resource_name", fmt.Sprintf("//mapmanagement.googleapis.com/%v", req.GetParent()))
+	}
+	if gax.IsFeatureEnabled("METRICS") || gax.IsFeatureEnabled("TRACING") || gax.IsFeatureEnabled("LOGGING") {
+		ctx = callctx.WithTelemetryContext(ctx, "rpc_method", "google.maps.mapmanagement.v2beta.MapManagement/ListMapContextConfigs")
+	}
 	opts = append((*c.CallOptions).ListMapContextConfigs[0:len((*c.CallOptions).ListMapContextConfigs):len((*c.CallOptions).ListMapContextConfigs)], opts...)
 	it := &MapContextConfigIterator{}
-	req = proto.Clone(req).(*mapmanagementpb.ListMapContextConfigsRequest)
+	req = proto.CloneOf(req)
 	it.InternalFetch = func(pageSize int, pageToken string) ([]*mapmanagementpb.MapContextConfig, string, error) {
 		resp := &mapmanagementpb.ListMapContextConfigsResponse{}
 		if pageToken != "" {
@@ -761,6 +911,9 @@ func (c *gRPCClient) UpdateMapContextConfig(ctx context.Context, req *mapmanagem
 
 	hds = append(c.xGoogHeaders, hds...)
 	ctx = gax.InsertMetadataIntoOutgoingContext(ctx, hds...)
+	if gax.IsFeatureEnabled("METRICS") || gax.IsFeatureEnabled("TRACING") || gax.IsFeatureEnabled("LOGGING") {
+		ctx = callctx.WithTelemetryContext(ctx, "rpc_method", "google.maps.mapmanagement.v2beta.MapManagement/UpdateMapContextConfig")
+	}
 	opts = append((*c.CallOptions).UpdateMapContextConfig[0:len((*c.CallOptions).UpdateMapContextConfig):len((*c.CallOptions).UpdateMapContextConfig)], opts...)
 	var resp *mapmanagementpb.MapContextConfig
 	err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
@@ -779,6 +932,12 @@ func (c *gRPCClient) DeleteMapContextConfig(ctx context.Context, req *mapmanagem
 
 	hds = append(c.xGoogHeaders, hds...)
 	ctx = gax.InsertMetadataIntoOutgoingContext(ctx, hds...)
+	if gax.IsFeatureEnabled("TRACING") || gax.IsFeatureEnabled("LOGGING") {
+		ctx = callctx.WithTelemetryContext(ctx, "resource_name", fmt.Sprintf("//mapmanagement.googleapis.com/%v", req.GetName()))
+	}
+	if gax.IsFeatureEnabled("METRICS") || gax.IsFeatureEnabled("TRACING") || gax.IsFeatureEnabled("LOGGING") {
+		ctx = callctx.WithTelemetryContext(ctx, "rpc_method", "google.maps.mapmanagement.v2beta.MapManagement/DeleteMapContextConfig")
+	}
 	opts = append((*c.CallOptions).DeleteMapContextConfig[0:len((*c.CallOptions).DeleteMapContextConfig):len((*c.CallOptions).DeleteMapContextConfig)], opts...)
 	err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
 		var err error
@@ -814,6 +973,13 @@ func (c *restClient) CreateMapConfig(ctx context.Context, req *mapmanagementpb.C
 	hds = append(c.xGoogHeaders, hds...)
 	hds = append(hds, "Content-Type", "application/json")
 	headers := gax.BuildHeaders(ctx, hds...)
+	if gax.IsFeatureEnabled("TRACING") || gax.IsFeatureEnabled("LOGGING") {
+		ctx = callctx.WithTelemetryContext(ctx, "resource_name", fmt.Sprintf("//mapmanagement.googleapis.com/%v", req.GetParent()))
+	}
+	if gax.IsFeatureEnabled("METRICS") || gax.IsFeatureEnabled("TRACING") || gax.IsFeatureEnabled("LOGGING") {
+		ctx = callctx.WithTelemetryContext(ctx, "rpc_method", "google.maps.mapmanagement.v2beta.MapManagement/CreateMapConfig")
+		ctx = callctx.WithTelemetryContext(ctx, "url_template", "/v2beta/{parent=projects/*}/mapConfigs")
+	}
 	opts = append((*c.CallOptions).CreateMapConfig[0:len((*c.CallOptions).CreateMapConfig):len((*c.CallOptions).CreateMapConfig)], opts...)
 	unm := protojson.UnmarshalOptions{AllowPartial: true, DiscardUnknown: true}
 	resp := &mapmanagementpb.MapConfig{}
@@ -864,6 +1030,13 @@ func (c *restClient) GetMapConfig(ctx context.Context, req *mapmanagementpb.GetM
 	hds = append(c.xGoogHeaders, hds...)
 	hds = append(hds, "Content-Type", "application/json")
 	headers := gax.BuildHeaders(ctx, hds...)
+	if gax.IsFeatureEnabled("TRACING") || gax.IsFeatureEnabled("LOGGING") {
+		ctx = callctx.WithTelemetryContext(ctx, "resource_name", fmt.Sprintf("//mapmanagement.googleapis.com/%v", req.GetName()))
+	}
+	if gax.IsFeatureEnabled("METRICS") || gax.IsFeatureEnabled("TRACING") || gax.IsFeatureEnabled("LOGGING") {
+		ctx = callctx.WithTelemetryContext(ctx, "rpc_method", "google.maps.mapmanagement.v2beta.MapManagement/GetMapConfig")
+		ctx = callctx.WithTelemetryContext(ctx, "url_template", "/v2beta/{name=projects/*/mapConfigs/*}")
+	}
 	opts = append((*c.CallOptions).GetMapConfig[0:len((*c.CallOptions).GetMapConfig):len((*c.CallOptions).GetMapConfig)], opts...)
 	unm := protojson.UnmarshalOptions{AllowPartial: true, DiscardUnknown: true}
 	resp := &mapmanagementpb.MapConfig{}
@@ -898,7 +1071,7 @@ func (c *restClient) GetMapConfig(ctx context.Context, req *mapmanagementpb.GetM
 // ListMapConfigs lists MapConfigs for a project.
 func (c *restClient) ListMapConfigs(ctx context.Context, req *mapmanagementpb.ListMapConfigsRequest, opts ...gax.CallOption) *MapConfigIterator {
 	it := &MapConfigIterator{}
-	req = proto.Clone(req).(*mapmanagementpb.ListMapConfigsRequest)
+	req = proto.CloneOf(req)
 	unm := protojson.UnmarshalOptions{AllowPartial: true, DiscardUnknown: true}
 	it.InternalFetch = func(pageSize int, pageToken string) ([]*mapmanagementpb.MapConfig, string, error) {
 		resp := &mapmanagementpb.ListMapConfigsResponse{}
@@ -1006,6 +1179,10 @@ func (c *restClient) UpdateMapConfig(ctx context.Context, req *mapmanagementpb.U
 	hds = append(c.xGoogHeaders, hds...)
 	hds = append(hds, "Content-Type", "application/json")
 	headers := gax.BuildHeaders(ctx, hds...)
+	if gax.IsFeatureEnabled("METRICS") || gax.IsFeatureEnabled("TRACING") || gax.IsFeatureEnabled("LOGGING") {
+		ctx = callctx.WithTelemetryContext(ctx, "rpc_method", "google.maps.mapmanagement.v2beta.MapManagement/UpdateMapConfig")
+		ctx = callctx.WithTelemetryContext(ctx, "url_template", "/v2beta/{map_config.name=projects/*/mapConfigs/*}")
+	}
 	opts = append((*c.CallOptions).UpdateMapConfig[0:len((*c.CallOptions).UpdateMapConfig):len((*c.CallOptions).UpdateMapConfig)], opts...)
 	unm := protojson.UnmarshalOptions{AllowPartial: true, DiscardUnknown: true}
 	resp := &mapmanagementpb.MapConfig{}
@@ -1059,6 +1236,13 @@ func (c *restClient) DeleteMapConfig(ctx context.Context, req *mapmanagementpb.D
 	hds = append(c.xGoogHeaders, hds...)
 	hds = append(hds, "Content-Type", "application/json")
 	headers := gax.BuildHeaders(ctx, hds...)
+	if gax.IsFeatureEnabled("TRACING") || gax.IsFeatureEnabled("LOGGING") {
+		ctx = callctx.WithTelemetryContext(ctx, "resource_name", fmt.Sprintf("//mapmanagement.googleapis.com/%v", req.GetName()))
+	}
+	if gax.IsFeatureEnabled("METRICS") || gax.IsFeatureEnabled("TRACING") || gax.IsFeatureEnabled("LOGGING") {
+		ctx = callctx.WithTelemetryContext(ctx, "rpc_method", "google.maps.mapmanagement.v2beta.MapManagement/DeleteMapConfig")
+		ctx = callctx.WithTelemetryContext(ctx, "url_template", "/v2beta/{name=projects/*/mapConfigs/*}")
+	}
 	return gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
 		if settings.Path != "" {
 			baseUrl.Path = settings.Path
@@ -1101,6 +1285,13 @@ func (c *restClient) CreateStyleConfig(ctx context.Context, req *mapmanagementpb
 	hds = append(c.xGoogHeaders, hds...)
 	hds = append(hds, "Content-Type", "application/json")
 	headers := gax.BuildHeaders(ctx, hds...)
+	if gax.IsFeatureEnabled("TRACING") || gax.IsFeatureEnabled("LOGGING") {
+		ctx = callctx.WithTelemetryContext(ctx, "resource_name", fmt.Sprintf("//mapmanagement.googleapis.com/%v", req.GetParent()))
+	}
+	if gax.IsFeatureEnabled("METRICS") || gax.IsFeatureEnabled("TRACING") || gax.IsFeatureEnabled("LOGGING") {
+		ctx = callctx.WithTelemetryContext(ctx, "rpc_method", "google.maps.mapmanagement.v2beta.MapManagement/CreateStyleConfig")
+		ctx = callctx.WithTelemetryContext(ctx, "url_template", "/v2beta/{parent=projects/*}/styleConfigs")
+	}
 	opts = append((*c.CallOptions).CreateStyleConfig[0:len((*c.CallOptions).CreateStyleConfig):len((*c.CallOptions).CreateStyleConfig)], opts...)
 	unm := protojson.UnmarshalOptions{AllowPartial: true, DiscardUnknown: true}
 	resp := &mapmanagementpb.StyleConfig{}
@@ -1151,6 +1342,13 @@ func (c *restClient) GetStyleConfig(ctx context.Context, req *mapmanagementpb.Ge
 	hds = append(c.xGoogHeaders, hds...)
 	hds = append(hds, "Content-Type", "application/json")
 	headers := gax.BuildHeaders(ctx, hds...)
+	if gax.IsFeatureEnabled("TRACING") || gax.IsFeatureEnabled("LOGGING") {
+		ctx = callctx.WithTelemetryContext(ctx, "resource_name", fmt.Sprintf("//mapmanagement.googleapis.com/%v", req.GetName()))
+	}
+	if gax.IsFeatureEnabled("METRICS") || gax.IsFeatureEnabled("TRACING") || gax.IsFeatureEnabled("LOGGING") {
+		ctx = callctx.WithTelemetryContext(ctx, "rpc_method", "google.maps.mapmanagement.v2beta.MapManagement/GetStyleConfig")
+		ctx = callctx.WithTelemetryContext(ctx, "url_template", "/v2beta/{name=projects/*/styleConfigs/*}")
+	}
 	opts = append((*c.CallOptions).GetStyleConfig[0:len((*c.CallOptions).GetStyleConfig):len((*c.CallOptions).GetStyleConfig)], opts...)
 	unm := protojson.UnmarshalOptions{AllowPartial: true, DiscardUnknown: true}
 	resp := &mapmanagementpb.StyleConfig{}
@@ -1185,7 +1383,7 @@ func (c *restClient) GetStyleConfig(ctx context.Context, req *mapmanagementpb.Ge
 // ListStyleConfigs lists StyleConfigs.
 func (c *restClient) ListStyleConfigs(ctx context.Context, req *mapmanagementpb.ListStyleConfigsRequest, opts ...gax.CallOption) *StyleConfigIterator {
 	it := &StyleConfigIterator{}
-	req = proto.Clone(req).(*mapmanagementpb.ListStyleConfigsRequest)
+	req = proto.CloneOf(req)
 	unm := protojson.UnmarshalOptions{AllowPartial: true, DiscardUnknown: true}
 	it.InternalFetch = func(pageSize int, pageToken string) ([]*mapmanagementpb.StyleConfig, string, error) {
 		resp := &mapmanagementpb.ListStyleConfigsResponse{}
@@ -1299,6 +1497,10 @@ func (c *restClient) UpdateStyleConfig(ctx context.Context, req *mapmanagementpb
 	hds = append(c.xGoogHeaders, hds...)
 	hds = append(hds, "Content-Type", "application/json")
 	headers := gax.BuildHeaders(ctx, hds...)
+	if gax.IsFeatureEnabled("METRICS") || gax.IsFeatureEnabled("TRACING") || gax.IsFeatureEnabled("LOGGING") {
+		ctx = callctx.WithTelemetryContext(ctx, "rpc_method", "google.maps.mapmanagement.v2beta.MapManagement/UpdateStyleConfig")
+		ctx = callctx.WithTelemetryContext(ctx, "url_template", "/v2beta/{style_config.name=projects/*/styleConfigs/*}")
+	}
 	opts = append((*c.CallOptions).UpdateStyleConfig[0:len((*c.CallOptions).UpdateStyleConfig):len((*c.CallOptions).UpdateStyleConfig)], opts...)
 	unm := protojson.UnmarshalOptions{AllowPartial: true, DiscardUnknown: true}
 	resp := &mapmanagementpb.StyleConfig{}
@@ -1349,6 +1551,13 @@ func (c *restClient) DeleteStyleConfig(ctx context.Context, req *mapmanagementpb
 	hds = append(c.xGoogHeaders, hds...)
 	hds = append(hds, "Content-Type", "application/json")
 	headers := gax.BuildHeaders(ctx, hds...)
+	if gax.IsFeatureEnabled("TRACING") || gax.IsFeatureEnabled("LOGGING") {
+		ctx = callctx.WithTelemetryContext(ctx, "resource_name", fmt.Sprintf("//mapmanagement.googleapis.com/%v", req.GetName()))
+	}
+	if gax.IsFeatureEnabled("METRICS") || gax.IsFeatureEnabled("TRACING") || gax.IsFeatureEnabled("LOGGING") {
+		ctx = callctx.WithTelemetryContext(ctx, "rpc_method", "google.maps.mapmanagement.v2beta.MapManagement/DeleteStyleConfig")
+		ctx = callctx.WithTelemetryContext(ctx, "url_template", "/v2beta/{name=projects/*/styleConfigs/*}")
+	}
 	return gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
 		if settings.Path != "" {
 			baseUrl.Path = settings.Path
@@ -1391,6 +1600,13 @@ func (c *restClient) CreateMapContextConfig(ctx context.Context, req *mapmanagem
 	hds = append(c.xGoogHeaders, hds...)
 	hds = append(hds, "Content-Type", "application/json")
 	headers := gax.BuildHeaders(ctx, hds...)
+	if gax.IsFeatureEnabled("TRACING") || gax.IsFeatureEnabled("LOGGING") {
+		ctx = callctx.WithTelemetryContext(ctx, "resource_name", fmt.Sprintf("//mapmanagement.googleapis.com/%v", req.GetParent()))
+	}
+	if gax.IsFeatureEnabled("METRICS") || gax.IsFeatureEnabled("TRACING") || gax.IsFeatureEnabled("LOGGING") {
+		ctx = callctx.WithTelemetryContext(ctx, "rpc_method", "google.maps.mapmanagement.v2beta.MapManagement/CreateMapContextConfig")
+		ctx = callctx.WithTelemetryContext(ctx, "url_template", "/v2beta/{parent=projects/*/mapConfigs/*}/mapContextConfigs")
+	}
 	opts = append((*c.CallOptions).CreateMapContextConfig[0:len((*c.CallOptions).CreateMapContextConfig):len((*c.CallOptions).CreateMapContextConfig)], opts...)
 	unm := protojson.UnmarshalOptions{AllowPartial: true, DiscardUnknown: true}
 	resp := &mapmanagementpb.MapContextConfig{}
@@ -1441,6 +1657,13 @@ func (c *restClient) GetMapContextConfig(ctx context.Context, req *mapmanagement
 	hds = append(c.xGoogHeaders, hds...)
 	hds = append(hds, "Content-Type", "application/json")
 	headers := gax.BuildHeaders(ctx, hds...)
+	if gax.IsFeatureEnabled("TRACING") || gax.IsFeatureEnabled("LOGGING") {
+		ctx = callctx.WithTelemetryContext(ctx, "resource_name", fmt.Sprintf("//mapmanagement.googleapis.com/%v", req.GetName()))
+	}
+	if gax.IsFeatureEnabled("METRICS") || gax.IsFeatureEnabled("TRACING") || gax.IsFeatureEnabled("LOGGING") {
+		ctx = callctx.WithTelemetryContext(ctx, "rpc_method", "google.maps.mapmanagement.v2beta.MapManagement/GetMapContextConfig")
+		ctx = callctx.WithTelemetryContext(ctx, "url_template", "/v2beta/{name=projects/*/mapConfigs/*/mapContextConfigs/*}")
+	}
 	opts = append((*c.CallOptions).GetMapContextConfig[0:len((*c.CallOptions).GetMapContextConfig):len((*c.CallOptions).GetMapContextConfig)], opts...)
 	unm := protojson.UnmarshalOptions{AllowPartial: true, DiscardUnknown: true}
 	resp := &mapmanagementpb.MapContextConfig{}
@@ -1475,7 +1698,7 @@ func (c *restClient) GetMapContextConfig(ctx context.Context, req *mapmanagement
 // ListMapContextConfigs lists MapContextConfigs.
 func (c *restClient) ListMapContextConfigs(ctx context.Context, req *mapmanagementpb.ListMapContextConfigsRequest, opts ...gax.CallOption) *MapContextConfigIterator {
 	it := &MapContextConfigIterator{}
-	req = proto.Clone(req).(*mapmanagementpb.ListMapContextConfigsRequest)
+	req = proto.CloneOf(req)
 	unm := protojson.UnmarshalOptions{AllowPartial: true, DiscardUnknown: true}
 	it.InternalFetch = func(pageSize int, pageToken string) ([]*mapmanagementpb.MapContextConfig, string, error) {
 		resp := &mapmanagementpb.ListMapContextConfigsResponse{}
@@ -1583,6 +1806,10 @@ func (c *restClient) UpdateMapContextConfig(ctx context.Context, req *mapmanagem
 	hds = append(c.xGoogHeaders, hds...)
 	hds = append(hds, "Content-Type", "application/json")
 	headers := gax.BuildHeaders(ctx, hds...)
+	if gax.IsFeatureEnabled("METRICS") || gax.IsFeatureEnabled("TRACING") || gax.IsFeatureEnabled("LOGGING") {
+		ctx = callctx.WithTelemetryContext(ctx, "rpc_method", "google.maps.mapmanagement.v2beta.MapManagement/UpdateMapContextConfig")
+		ctx = callctx.WithTelemetryContext(ctx, "url_template", "/v2beta/{map_context_config.name=projects/*/mapConfigs/*/mapContextConfigs/*}")
+	}
 	opts = append((*c.CallOptions).UpdateMapContextConfig[0:len((*c.CallOptions).UpdateMapContextConfig):len((*c.CallOptions).UpdateMapContextConfig)], opts...)
 	unm := protojson.UnmarshalOptions{AllowPartial: true, DiscardUnknown: true}
 	resp := &mapmanagementpb.MapContextConfig{}
@@ -1633,6 +1860,13 @@ func (c *restClient) DeleteMapContextConfig(ctx context.Context, req *mapmanagem
 	hds = append(c.xGoogHeaders, hds...)
 	hds = append(hds, "Content-Type", "application/json")
 	headers := gax.BuildHeaders(ctx, hds...)
+	if gax.IsFeatureEnabled("TRACING") || gax.IsFeatureEnabled("LOGGING") {
+		ctx = callctx.WithTelemetryContext(ctx, "resource_name", fmt.Sprintf("//mapmanagement.googleapis.com/%v", req.GetName()))
+	}
+	if gax.IsFeatureEnabled("METRICS") || gax.IsFeatureEnabled("TRACING") || gax.IsFeatureEnabled("LOGGING") {
+		ctx = callctx.WithTelemetryContext(ctx, "rpc_method", "google.maps.mapmanagement.v2beta.MapManagement/DeleteMapContextConfig")
+		ctx = callctx.WithTelemetryContext(ctx, "url_template", "/v2beta/{name=projects/*/mapConfigs/*/mapContextConfigs/*}")
+	}
 	return gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
 		if settings.Path != "" {
 			baseUrl.Path = settings.Path


### PR DESCRIPTION
This change adds default_enabled_generator_features under default.go and removes redundant enabled_generator_features from individual APIs where they match the default.

The companion pull request is https://github.com/googleapis/librarian/pull/6029. The librarian change needs to happen first. After that, I'll update the librarian version in `librarian.yaml` in google-cloud-go with a pseudo version. => It is `v0.13.2-0.20260518181009-04b8e642ea4c`. 

I regenerated the code using the pseudo version:

```
suztomo@suztomo:~/librarian-2026/google-cloud-go$ echo $V
v0.13.2-0.20260518181009-04b8e642ea4c
suztomo@suztomo:~/librarian-2026/google-cloud-go$ go run github.com/googleapis/librarian/cmd/librarian@${V} generate --all
```

This fixes `maps/mapmanagement/apiv2beta/map_management_client.go` being generated without the `F_open_telemetry_attributes` option (details: https://github.com/googleapis/librarian/issues/5246#issuecomment-4423214986).

Fixes https://github.com/googleapis/librarian/issues/5246
