### PR TITLE
test(spanner): retry query after database recreation in integration test

### DIFF
--- a/spanner/integration_test.go
+++ b/spanner/integration_test.go
@@ -2202,15 +2202,23 @@ func TestIntegration_DbRemovalRecovery(t *testing.T) {
 	}
 
 	// Now, send the query again.
-	waitFor(t, func() error {
+	// In real Cloud Spanner, after dropping and recreating a database, GFE location/directory
+	// cache propagation across all zones and workers can take up to several minutes.
+	// Retry sending the query until the context deadline.
+	for {
 		iter := client.Single().Query(ctx, Statement{SQL: "SELECT SingerId FROM Singers"})
-		defer iter.Stop()
 		_, err := iter.Next()
-		if err != nil && err != iterator.Done {
-			return err
+		iter.Stop()
+		if err == nil || err == iterator.Done {
+			break
 		}
-		return nil
-	})
+
+		select {
+		case <-ctx.Done():
+			t.Fatalf("timeout waiting for recreated database to be reachable: %v", ctx.Err())
+		case <-time.After(time.Second):
+		}
+	}
 	verifyDirectPathRemoteAddress(t)
 }
 


### PR DESCRIPTION
In TestIntegration_DbRemovalRecovery, immediately querying a newly recreated database can occasionally fail with a NotFound ("Database not found") error due to brief propagation delays in Spanner's internal location directory caches.

This change replaces the single query attempt with a polling loop that retries until the 5-minute context deadline, allowing to propogate.