### PR TITLE
perf(spanner) optimize Spanner built-in metrics hot path

### DIFF
--- a/spanner/batch.go
+++ b/spanner/batch.go
@@ -25,6 +25,7 @@ import (
 	"cloud.google.com/go/internal/trace"
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
 	"github.com/googleapis/gax-go/v2"
+	oteltrace "go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/proto"
@@ -315,16 +316,23 @@ func (t *BatchReadOnlyTransaction) Execute(ctx context.Context, p *Partition) *R
 			if err != nil {
 				return client, err
 			}
-			md, err := client.Header()
-			if getGFELatencyMetricsFlag() && md != nil && t.ct != nil {
-				if err := createContextAndCaptureGFELatencyMetrics(ctx, t.ct, md, "Execute"); err != nil {
-					trace.TracePrintf(ctx, nil, "Error in recording GFE Latency. Try disabling and rerunning. Error: %v", err)
-				}
+			if shouldCaptureStreamingHeaderMetrics(t.ct, t.otConfig) {
+				client = wrapStreamingReadClient(
+					client,
+					oteltrace.SpanFromContext(ctx),
+					nil,
+					streamingHeaderMetrics{
+						ctx:      ctx,
+						ct:       t.ct,
+						otConfig: t.otConfig,
+						method:   "Execute",
+						traceErrf: func(err error) {
+							trace.TracePrintf(ctx, nil, "Error in recording GFE Latency. Try disabling and rerunning. Error: %v", err)
+						},
+					},
+				)
 			}
-			if metricErr := recordGFELatencyMetricsOT(ctx, md, "Execute", t.otConfig); metricErr != nil {
-				trace.TracePrintf(ctx, nil, "Error in recording GFE Latency through OpenTelemetry. Error: %v", metricErr)
-			}
-			return client, err
+			return client, nil
 		}
 	} else {
 		rpc = func(ctx context.Context, resumeToken []byte, opts ...gax.CallOption) (streamingReceiver, error) {
@@ -345,17 +353,23 @@ func (t *BatchReadOnlyTransaction) Execute(ctx context.Context, p *Partition) *R
 			if err != nil {
 				return client, err
 			}
-			md, err := client.Header()
-
-			if getGFELatencyMetricsFlag() && md != nil && t.ct != nil {
-				if err := createContextAndCaptureGFELatencyMetrics(ctx, t.ct, md, "Execute"); err != nil {
-					trace.TracePrintf(ctx, nil, "Error in recording GFE Latency. Try disabling and rerunning. Error: %v", err)
-				}
+			if shouldCaptureStreamingHeaderMetrics(t.ct, t.otConfig) {
+				client = wrapExecuteStreamingSqlClient(
+					client,
+					oteltrace.SpanFromContext(ctx),
+					nil,
+					streamingHeaderMetrics{
+						ctx:      ctx,
+						ct:       t.ct,
+						otConfig: t.otConfig,
+						method:   "Execute",
+						traceErrf: func(err error) {
+							trace.TracePrintf(ctx, nil, "Error in recording GFE Latency. Try disabling and rerunning. Error: %v", err)
+						},
+					},
+				)
 			}
-			if metricErr := recordGFELatencyMetricsOT(ctx, md, "Execute", t.otConfig); metricErr != nil {
-				trace.TracePrintf(ctx, nil, "Error in recording GFE Latency through OpenTelemetry. Error: %v", metricErr)
-			}
-			return client, err
+			return client, nil
 		}
 	}
 	return streamWithTransactionCallbacks(

--- a/spanner/client.go
+++ b/spanner/client.go
@@ -31,7 +31,6 @@ import (
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
 	"github.com/GoogleCloudPlatform/grpc-gcp-go/grpcgcp"
 	grpcgcppb "github.com/GoogleCloudPlatform/grpc-gcp-go/grpcgcp/grpc_gcp"
-	"github.com/googleapis/gax-go/v2"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/metric/noop"
@@ -521,6 +520,11 @@ func newClientWithConfig(ctx context.Context, database string, config ClientConf
 	if err != nil {
 		return nil, err
 	}
+	closeMetricsTracerFactory := func() {
+		if metricsTracerFactory != nil {
+			metricsTracerFactory.shutdown(context.Background())
+		}
+	}
 	if len(metricsTracerFactory.clientOpts) > 0 {
 		opts = append(opts, metricsTracerFactory.clientOpts...)
 	}
@@ -550,6 +554,7 @@ func newClientWithConfig(ctx context.Context, database string, config ClientConf
 		endpointClientOpts = append(endpointClientOpts, allOpts...)
 		primaryConn, err = gtransport.DialPool(ctx, allOpts...)
 		if err != nil {
+			closeMetricsTracerFactory()
 			return nil, err
 		}
 
@@ -557,12 +562,14 @@ func newClientWithConfig(ctx context.Context, database string, config ClientConf
 		fallbackConn, err = gtransport.DialPool(ctx, fallbackConnOpts...)
 		if err != nil {
 			primaryConn.Close()
+			closeMetricsTracerFactory()
 			return nil, err
 		}
 
 		if hasNumChannelsConfig && ((primaryConn.Num() != config.NumChannels) || (fallbackConn.Num() != config.NumChannels)) {
 			primaryConn.Close()
 			fallbackConn.Close()
+			closeMetricsTracerFactory()
 			return nil, spannerErrorf(codes.InvalidArgument, "Connection pool mismatch: NumChannels=%v, primaryConn.Num()=%v, fallbackConn.Num()=%v", config.NumChannels, primaryConn.Num(), fallbackConn.Num())
 		}
 
@@ -580,6 +587,7 @@ func newClientWithConfig(ctx context.Context, database string, config ClientConf
 		if err != nil {
 			primaryConn.Close()
 			fallbackConn.Close()
+			closeMetricsTracerFactory()
 			return nil, err
 		}
 
@@ -599,11 +607,13 @@ func newClientWithConfig(ctx context.Context, database string, config ClientConf
 		endpointClientOpts = append(endpointClientOpts, allOpts...)
 		pool, err = gtransport.DialPool(ctx, allOpts...)
 		if err != nil {
+			closeMetricsTracerFactory()
 			return nil, err
 		}
 
 		if hasNumChannelsConfig && pool.Num() != config.NumChannels {
 			pool.Close()
+			closeMetricsTracerFactory()
 			return nil, spannerErrorf(codes.InvalidArgument, "Connection pool mismatch: NumChannels=%v, WithGRPCConnectionPool=%v. Only set one of these options, or set both to the same value.", config.NumChannels, pool.Num())
 		}
 	}
@@ -652,6 +662,8 @@ func newClientWithConfig(ctx context.Context, database string, config ClientConf
 	otConfig, err := createOpenTelemetryConfig(ctx, config.OpenTelemetryMeterProvider, config.Logger, sc.id, database)
 	if err != nil {
 		// The error returned here will be due to database name parsing
+		sc.close()
+		closeMetricsTracerFactory()
 		return nil, err
 	}
 	// To prevent data race in unit tests (ex: TestClient_SessionNotFound)
@@ -689,6 +701,7 @@ func newClientWithConfig(ctx context.Context, database string, config ClientConf
 	// Create a session manager.
 	sp, err := newSessionManager(sc, config.SessionPoolConfig, sharedLocationAwareState)
 	if err != nil {
+		closeMetricsTracerFactory()
 		sc.close()
 		return nil, err
 	}
@@ -845,7 +858,7 @@ func metricsInterceptor() grpc.UnaryClientInterceptor {
 		statusCode, _ := status.FromError(err)
 		mt.currOp.currAttempt.setStatus(statusCode.Code().String())
 		mt.currOp.currAttempt.setDirectPathUsed(peer.NewContext(ctx, peerInfo))
-		latencies := parseServerTimingHeader(md)
+		latencies := parseServerTimingHeaderMetrics(md)
 		span := otrace.SpanFromContext(ctx)
 		setGFEAndAFESpanAttributes(span, latencies)
 		mt.currOp.currAttempt.setServerTimingMetrics(latencies)
@@ -1374,11 +1387,21 @@ type BatchWriteResponseIterator struct {
 // will return Done.
 func (r *BatchWriteResponseIterator) Next() (*sppb.BatchWriteResponse, error) {
 	mt := r.meterTracerFactory.createBuiltinMetricsTracer(r.ctx)
+	if r.err != nil {
+		return nil, r.err
+	}
+	mt.currOp.incrementAttemptCount()
+	mt.currOp.currAttempt = &attemptTracer{
+		startTime: time.Now(),
+	}
 	defer func() {
 		if mt.method != "" {
 			statusCode, _ := convertToGrpcStatusErr(r.err)
+			mt.currOp.currAttempt.setStatus(statusCode.String())
+			recordAttemptCompletion(&mt)
 			mt.currOp.setStatus(statusCode.String())
 			recordOperationCompletion(&mt)
+			mt.currOp.currAttempt = nil
 		}
 	}()
 	for {
@@ -1389,7 +1412,7 @@ func (r *BatchWriteResponseIterator) Next() (*sppb.BatchWriteResponse, error) {
 
 		// RPC not made yet.
 		if r.stream == nil {
-			r.stream, r.err = r.rpc(r.ctx)
+			r.stream, r.err = r.rpc(context.WithValue(r.ctx, metricsTracerKey, &mt))
 			continue
 		}
 
@@ -1499,21 +1522,28 @@ func (c *Client) BatchWriteWithOptions(ctx context.Context, mgs []*MutationGroup
 	}
 
 	rpc := func(ct context.Context) (sppb.Spanner_BatchWriteClient, error) {
-		var md metadata.MD
 		stream, rpcErr := sh.getClient().BatchWrite(contextWithOutgoingMetadata(ct, sh.getMetadata(), c.disableRouteToLeader), &sppb.BatchWriteRequest{
 			Session:                     sh.getID(),
 			MutationGroups:              mgsPb,
 			RequestOptions:              createRequestOptions(opts.Priority, "", opts.TransactionTag, mergeClientContext(c.clientContext, opts.ClientContext)),
 			ExcludeTxnFromChangeStreams: opts.ExcludeTxnFromChangeStreams,
-		}, gax.WithGRPCOptions(grpc.Header(&md)))
+		})
 
-		if getGFELatencyMetricsFlag() && md != nil && c.ct != nil {
-			if metricErr := createContextAndCaptureGFELatencyMetrics(ct, c.ct, md, "BatchWrite"); metricErr != nil {
-				trace.TracePrintf(ct, nil, "Error in recording GFE Latency. Try disabling and rerunning. Error: %v", err)
-			}
-		}
-		if metricErr := recordGFELatencyMetricsOT(ct, md, "BatchWrite", c.otConfig); metricErr != nil {
-			trace.TracePrintf(ct, nil, "Error in recording GFE Latency through OpenTelemetry. Error: %v", err)
+		if rpcErr == nil && stream != nil && shouldCaptureStreamingHeaderMetrics(c.ct, c.otConfig) {
+			stream = wrapBatchWriteClient(
+				stream,
+				otrace.SpanFromContext(ct),
+				nil,
+				streamingHeaderMetrics{
+					ctx:      ct,
+					ct:       c.ct,
+					otConfig: c.otConfig,
+					method:   "BatchWrite",
+					traceErrf: func(err error) {
+						trace.TracePrintf(ct, nil, "Error in recording GFE Latency. Try disabling and rerunning. Error: %v", err)
+					},
+				},
+			)
 		}
 		return stream, rpcErr
 	}
@@ -1546,31 +1576,112 @@ func logf(logger *log.Logger, format string, v ...interface{}) {
 	}
 }
 
-// parseServerTimingHeader extracts server timing metrics from gRPC metadata into a map
+type serverTimingMetrics struct {
+	gfeLatency time.Duration
+	afeLatency time.Duration
+	hasGFE     bool
+	hasAFE     bool
+}
+
+// parseServerTimingHeader extracts server timing metrics from gRPC metadata into a map.
+// This is used by legacy exported helpers/tests. Built-in metrics use
+// parseServerTimingHeaderMetrics to avoid allocating a map on the request path.
 func parseServerTimingHeader(md metadata.MD) map[string]time.Duration {
-	metrics := make(map[string]time.Duration)
+	timing := parseServerTimingHeaderMetrics(md)
+	metrics := make(map[string]time.Duration, 2)
+	if timing.hasGFE {
+		metrics[gfeTimingHeader] = timing.gfeLatency
+	}
+	if timing.hasAFE {
+		metrics[afeTimingHeader] = timing.afeLatency
+	}
+	return metrics
+}
+
+// parseServerTimingHeaderMetrics extracts only the server timing fields used by
+// built-in metrics. It avoids regexp result slices and map allocation.
+func parseServerTimingHeaderMetrics(md metadata.MD) serverTimingMetrics {
+	var metrics serverTimingMetrics
 	if md == nil {
 		return metrics
 	}
-
-	serverTiming := md.Get(serverTimingHeaderKey)
+	serverTiming := md[serverTimingHeaderKey]
 	if len(serverTiming) == 0 {
-		return metrics
+		serverTiming = md.Get(serverTimingHeaderKey)
 	}
-
 	for _, timing := range serverTiming {
-		matches := serverTimingPattern.FindAllStringSubmatch(timing, -1)
-		for _, match := range matches {
-			if len(match) == 3 { // full match + 2 capture groups
-				metricName := match[1]
-				duration, err := strconv.ParseFloat(match[2], 64)
-				if err == nil {
-					metrics[metricName] = time.Duration(duration*1000) * time.Microsecond
-				}
-			}
+		parseServerTimingHeaderValue(timing, &metrics)
+		if metrics.hasGFE && metrics.hasAFE {
+			break
 		}
 	}
 	return metrics
+}
+
+func parseServerTimingHeaderValue(timing string, metrics *serverTimingMetrics) {
+	for len(timing) > 0 {
+		timing = strings.TrimLeft(timing, " \t,")
+		nameEnd := strings.IndexByte(timing, ';')
+		if nameEnd < 0 {
+			return
+		}
+		name := strings.TrimSpace(timing[:nameEnd])
+		timing = timing[nameEnd+1:]
+		next := strings.IndexByte(timing, ',')
+		var params string
+		if next < 0 {
+			params = timing
+			timing = ""
+		} else {
+			params = timing[:next]
+			timing = timing[next+1:]
+		}
+		if name != gfeTimingHeader && name != afeTimingHeader {
+			continue
+		}
+		dur, ok := parseServerTimingDuration(params)
+		if !ok {
+			continue
+		}
+		if name == gfeTimingHeader {
+			metrics.gfeLatency = dur
+			metrics.hasGFE = true
+		} else {
+			metrics.afeLatency = dur
+			metrics.hasAFE = true
+		}
+	}
+}
+
+func parseServerTimingDuration(params string) (time.Duration, bool) {
+	for len(params) > 0 {
+		params = strings.TrimLeft(params, " \t;")
+		if strings.HasPrefix(params, "dur=") {
+			params = params[len("dur="):]
+			end := 0
+			for end < len(params) {
+				c := params[end]
+				if (c < '0' || c > '9') && c != '.' {
+					break
+				}
+				end++
+			}
+			if end == 0 {
+				return 0, false
+			}
+			duration, err := strconv.ParseFloat(params[:end], 64)
+			if err != nil {
+				return 0, false
+			}
+			return time.Duration(duration*1000) * time.Microsecond, true
+		}
+		next := strings.IndexByte(params, ';')
+		if next < 0 {
+			return 0, false
+		}
+		params = params[next+1:]
+	}
+	return 0, false
 }
 
 // enableLogClientOptions returns true if the environment variable for enabling has been set to true, or if the

--- a/spanner/grpc_client.go
+++ b/spanner/grpc_client.go
@@ -19,8 +19,8 @@ package spanner
 import (
 	"context"
 	"strings"
+	"sync"
 	"sync/atomic"
-	"time"
 
 	vkit "cloud.google.com/go/spanner/apiv1"
 	"cloud.google.com/go/spanner/apiv1/spannerpb"
@@ -30,6 +30,7 @@ import (
 	oteltrace "go.opentelemetry.io/otel/trace"
 	"google.golang.org/api/option"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
 )
@@ -37,6 +38,212 @@ import (
 type contextKey string
 
 const metricsTracerKey contextKey = "metricsTracer"
+
+type streamingHeaderMetrics struct {
+	ctx       context.Context
+	ct        *commonTags
+	otConfig  *openTelemetryConfig
+	method    string
+	traceErrf func(error)
+}
+
+func (h streamingHeaderMetrics) enabled() bool {
+	return (getGFELatencyMetricsFlag() && h.ct != nil) || (h.otConfig != nil && h.otConfig.enabled)
+}
+
+func (h streamingHeaderMetrics) capture(md metadata.MD) {
+	if getGFELatencyMetricsFlag() && md != nil && h.ct != nil {
+		if err := createContextAndCaptureGFELatencyMetrics(h.ctx, h.ct, md, h.method); err != nil && h.traceErrf != nil {
+			h.traceErrf(err)
+		}
+	}
+	if metricErr := recordGFELatencyMetricsOT(h.ctx, md, h.method, h.otConfig); metricErr != nil && h.traceErrf != nil {
+		h.traceErrf(metricErr)
+	}
+}
+
+type metricsExecuteStreamingSqlClient struct {
+	spannerpb.Spanner_ExecuteStreamingSqlClient
+	span          oteltrace.Span
+	mt            *builtinMetricsTracer
+	headerMetrics streamingHeaderMetrics
+	once          sync.Once
+}
+
+func wrapExecuteStreamingSqlClient(
+	client spannerpb.Spanner_ExecuteStreamingSqlClient,
+	span oteltrace.Span,
+	mt *builtinMetricsTracer,
+	headerMetrics streamingHeaderMetrics,
+) spannerpb.Spanner_ExecuteStreamingSqlClient {
+	if client == nil {
+		return nil
+	}
+	if metricsClient, ok := client.(*metricsExecuteStreamingSqlClient); ok {
+		if mt != nil {
+			metricsClient.mt = mt
+		}
+		if span != nil {
+			metricsClient.span = span
+		}
+		if headerMetrics.enabled() {
+			metricsClient.headerMetrics = headerMetrics
+		}
+		return metricsClient
+	}
+	return &metricsExecuteStreamingSqlClient{
+		Spanner_ExecuteStreamingSqlClient: client,
+		span:                              span,
+		mt:                                mt,
+		headerMetrics:                     headerMetrics,
+	}
+}
+
+func (c *metricsExecuteStreamingSqlClient) Recv() (*spannerpb.PartialResultSet, error) {
+	resp, err := c.Spanner_ExecuteStreamingSqlClient.Recv()
+	c.capture()
+	return resp, err
+}
+
+func (c *metricsExecuteStreamingSqlClient) finish() {
+	if finalizer, ok := c.Spanner_ExecuteStreamingSqlClient.(streamingFinalizer); ok {
+		finalizer.finish()
+	}
+}
+
+func (c *metricsExecuteStreamingSqlClient) capture() {
+	c.once.Do(func() {
+		md, _ := c.Spanner_ExecuteStreamingSqlClient.Header()
+		c.headerMetrics.capture(md)
+		if c.mt == nil || c.mt.currOp == nil || c.mt.currOp.currAttempt == nil {
+			return
+		}
+		latencies := parseServerTimingHeaderMetrics(md)
+		setGFEAndAFESpanAttributes(c.span, latencies)
+		c.mt.currOp.currAttempt.setServerTimingMetrics(latencies)
+		c.mt.currOp.currAttempt.setDirectPathUsed(c.Spanner_ExecuteStreamingSqlClient.Context())
+	})
+}
+
+type metricsStreamingReadClient struct {
+	spannerpb.Spanner_StreamingReadClient
+	span          oteltrace.Span
+	mt            *builtinMetricsTracer
+	headerMetrics streamingHeaderMetrics
+	once          sync.Once
+}
+
+func wrapStreamingReadClient(
+	client spannerpb.Spanner_StreamingReadClient,
+	span oteltrace.Span,
+	mt *builtinMetricsTracer,
+	headerMetrics streamingHeaderMetrics,
+) spannerpb.Spanner_StreamingReadClient {
+	if client == nil {
+		return nil
+	}
+	if metricsClient, ok := client.(*metricsStreamingReadClient); ok {
+		if mt != nil {
+			metricsClient.mt = mt
+		}
+		if span != nil {
+			metricsClient.span = span
+		}
+		if headerMetrics.enabled() {
+			metricsClient.headerMetrics = headerMetrics
+		}
+		return metricsClient
+	}
+	return &metricsStreamingReadClient{
+		Spanner_StreamingReadClient: client,
+		span:                        span,
+		mt:                          mt,
+		headerMetrics:               headerMetrics,
+	}
+}
+
+func (c *metricsStreamingReadClient) Recv() (*spannerpb.PartialResultSet, error) {
+	resp, err := c.Spanner_StreamingReadClient.Recv()
+	c.capture()
+	return resp, err
+}
+
+func (c *metricsStreamingReadClient) finish() {
+	if finalizer, ok := c.Spanner_StreamingReadClient.(streamingFinalizer); ok {
+		finalizer.finish()
+	}
+}
+
+func (c *metricsStreamingReadClient) capture() {
+	c.once.Do(func() {
+		md, _ := c.Spanner_StreamingReadClient.Header()
+		c.headerMetrics.capture(md)
+		if c.mt == nil || c.mt.currOp == nil || c.mt.currOp.currAttempt == nil {
+			return
+		}
+		latencies := parseServerTimingHeaderMetrics(md)
+		setGFEAndAFESpanAttributes(c.span, latencies)
+		c.mt.currOp.currAttempt.setServerTimingMetrics(latencies)
+		c.mt.currOp.currAttempt.setDirectPathUsed(c.Spanner_StreamingReadClient.Context())
+	})
+}
+
+type metricsBatchWriteClient struct {
+	spannerpb.Spanner_BatchWriteClient
+	span          oteltrace.Span
+	mt            *builtinMetricsTracer
+	headerMetrics streamingHeaderMetrics
+	once          sync.Once
+}
+
+func wrapBatchWriteClient(
+	client spannerpb.Spanner_BatchWriteClient,
+	span oteltrace.Span,
+	mt *builtinMetricsTracer,
+	headerMetrics streamingHeaderMetrics,
+) spannerpb.Spanner_BatchWriteClient {
+	if client == nil {
+		return nil
+	}
+	if metricsClient, ok := client.(*metricsBatchWriteClient); ok {
+		if mt != nil {
+			metricsClient.mt = mt
+		}
+		if span != nil {
+			metricsClient.span = span
+		}
+		if headerMetrics.enabled() {
+			metricsClient.headerMetrics = headerMetrics
+		}
+		return metricsClient
+	}
+	return &metricsBatchWriteClient{
+		Spanner_BatchWriteClient: client,
+		span:                     span,
+		mt:                       mt,
+		headerMetrics:            headerMetrics,
+	}
+}
+
+func (c *metricsBatchWriteClient) Recv() (*spannerpb.BatchWriteResponse, error) {
+	resp, err := c.Spanner_BatchWriteClient.Recv()
+	c.capture()
+	return resp, err
+}
+
+func (c *metricsBatchWriteClient) capture() {
+	c.once.Do(func() {
+		md, _ := c.Spanner_BatchWriteClient.Header()
+		c.headerMetrics.capture(md)
+		if c.mt == nil || c.mt.currOp == nil || c.mt.currOp.currAttempt == nil {
+			return
+		}
+		latencies := parseServerTimingHeaderMetrics(md)
+		setGFEAndAFESpanAttributes(c.span, latencies)
+		c.mt.currOp.currAttempt.setServerTimingMetrics(latencies)
+		c.mt.currOp.currAttempt.setDirectPathUsed(c.Spanner_BatchWriteClient.Context())
+	})
+}
 
 // spannerClient is an interface that defines the methods available from Cloud Spanner API.
 type spannerClient interface {
@@ -213,16 +420,15 @@ func setSpanAttributes[T any](span oteltrace.Span, req T) {
 	span.SetAttributes(attrs...)
 }
 
-func setGFEAndAFESpanAttributes(span oteltrace.Span, latencyMap map[string]time.Duration) {
+func setGFEAndAFESpanAttributes(span oteltrace.Span, latencies serverTimingMetrics) {
 	if !span.IsRecording() {
 		return
 	}
-	for t, v := range latencyMap {
-		if t == gfeTimingHeader || t == afeTimingHeader {
-			span.SetAttributes(
-				attribute.Float64(t[:3]+".latency_ms", float64(v.Nanoseconds())/1e6),
-			)
-		}
+	if latencies.hasGFE {
+		span.SetAttributes(attribute.Float64("gfe.latency_ms", float64(latencies.gfeLatency.Nanoseconds())/1e6))
+	}
+	if latencies.hasAFE {
+		span.SetAttributes(attribute.Float64("afe.latency_ms", float64(latencies.afeLatency.Nanoseconds())/1e6))
 	}
 }
 
@@ -245,15 +451,8 @@ func (g *grpcSpannerClient) ExecuteStreamingSql(ctx context.Context, req *spanne
 	// as it is already manually added when creating Stream iterators for ExecuteStreamingSql.
 	client, err := g.raw.ExecuteStreamingSql(peer.NewContext(ctx, &peer.Peer{}), req, opts...)
 	mt, ok := ctx.Value(metricsTracerKey).(*builtinMetricsTracer)
-	if !ok {
-		return client, err
-	}
-	if mt != nil && client != nil && mt.currOp.currAttempt != nil {
-		md, _ := client.Header()
-		latencyMap := parseServerTimingHeader(md)
-		setGFEAndAFESpanAttributes(span, latencyMap)
-		mt.currOp.currAttempt.setServerTimingMetrics(latencyMap)
-		mt.currOp.currAttempt.setDirectPathUsed(client.Context())
+	if ok && mt != nil && client != nil && mt.currOp.currAttempt != nil && (mt.builtInEnabled || span.IsRecording()) {
+		client = wrapExecuteStreamingSqlClient(client, span, mt, streamingHeaderMetrics{})
 	}
 	return client, err
 }
@@ -289,15 +488,8 @@ func (g *grpcSpannerClient) StreamingRead(ctx context.Context, req *spannerpb.Re
 	setSpanAttributes(span, req)
 	client, err := g.raw.StreamingRead(peer.NewContext(ctx, &peer.Peer{}), req, opts...)
 	mt, ok := ctx.Value(metricsTracerKey).(*builtinMetricsTracer)
-	if !ok {
-		return client, err
-	}
-	if mt != nil && client != nil && mt.currOp.currAttempt != nil {
-		md, _ := client.Header()
-		latencyMap := parseServerTimingHeader(md)
-		setGFEAndAFESpanAttributes(span, latencyMap)
-		mt.currOp.currAttempt.setServerTimingMetrics(latencyMap)
-		mt.currOp.currAttempt.setDirectPathUsed(client.Context())
+	if ok && mt != nil && client != nil && mt.currOp.currAttempt != nil && (mt.builtInEnabled || span.IsRecording()) {
+		client = wrapStreamingReadClient(client, span, mt, streamingHeaderMetrics{})
 	}
 	return client, err
 }
@@ -366,12 +558,8 @@ func (g *grpcSpannerClient) BatchWrite(ctx context.Context, req *spannerpb.Batch
 	if !ok {
 		return client, err
 	}
-	if mt != nil && client != nil && mt.currOp.currAttempt != nil {
-		md, _ := client.Header()
-		latencyMap := parseServerTimingHeader(md)
-		setGFEAndAFESpanAttributes(span, latencyMap)
-		mt.currOp.currAttempt.setServerTimingMetrics(latencyMap)
-		mt.currOp.currAttempt.setDirectPathUsed(client.Context())
+	if mt != nil && client != nil {
+		client = wrapBatchWriteClient(client, span, mt, streamingHeaderMetrics{})
 	}
 	return client, err
 }

--- a/spanner/metrics.go
+++ b/spanner/metrics.go
@@ -111,59 +111,6 @@ var (
 		800.0, 1000.0, 2000.0, 5000.0, 10000.0, 20000.0, 50000.0, 100000.0, 200000.0,
 		400000.0, 800000.0, 1600000.0, 3200000.0}
 
-	// All the built-in metrics have same attributes except 'status' and 'streaming'
-	// These attributes need to be added to only few of the metrics
-	metricsDetails = map[string]metricInfo{
-		metricNameOperationCount: {
-			additionalAttrs: []string{
-				metricLabelKeyStatus,
-			},
-			recordedPerAttempt: false,
-		},
-		metricNameOperationLatencies: {
-			additionalAttrs: []string{
-				metricLabelKeyStatus,
-			},
-			recordedPerAttempt: false,
-		},
-		metricNameAttemptLatencies: {
-			additionalAttrs: []string{
-				metricLabelKeyStatus,
-			},
-			recordedPerAttempt: true,
-		},
-		metricNameAttemptCount: {
-			additionalAttrs: []string{
-				metricLabelKeyStatus,
-			},
-			recordedPerAttempt: true,
-		},
-		metricNameAFELatencies: {
-			additionalAttrs: []string{
-				metricLabelKeyStatus,
-			},
-			recordedPerAttempt: true,
-		},
-		metricNameGFELatencies: {
-			additionalAttrs: []string{
-				metricLabelKeyStatus,
-			},
-			recordedPerAttempt: true,
-		},
-		metricNameGFEConnectivityErrorCount: {
-			additionalAttrs: []string{
-				metricLabelKeyStatus,
-			},
-			recordedPerAttempt: true,
-		},
-		metricNameAFEConnectivityErrorCount: {
-			additionalAttrs: []string{
-				metricLabelKeyStatus,
-			},
-			recordedPerAttempt: true,
-		},
-	}
-
 	// Generates unique client ID in the format go-<random UUID>@<hostname>
 	generateClientUID = func() (string, error) {
 		hostname := "localhost"
@@ -251,11 +198,6 @@ var (
 		"grpc.lb.locality",
 	}
 )
-
-type metricInfo struct {
-	additionalAttrs    []string
-	recordedPerAttempt bool
-}
 
 // builtinMetricsTracerFactory is responsible for creating and managing metrics tracers.
 type builtinMetricsTracerFactory struct {
@@ -357,6 +299,9 @@ func newBuiltinMetricsTracerFactory(ctx context.Context, dbpath, compression str
 	// Create meter and instruments
 	meter := meterProvider.Meter(builtInMetricsMeterName, metric.WithInstrumentationVersion(internal.Version))
 	err = tracerFactory.createInstruments(meter)
+	if err != nil {
+		return tracerFactory, err
+	}
 	return tracerFactory, err
 }
 
@@ -523,7 +468,8 @@ type builtinMetricsTracer struct {
 	instrumentOperationCount     metric.Int64Counter     // Counter for the number of operations.
 	instrumentAttemptCount       metric.Int64Counter     // Counter for the number of attempts.
 
-	method string // The method being traced.
+	method      string // The method being traced.
+	methodLabel string // The method label value used by metrics.
 
 	currOp *opTracer // The current operation tracer.
 }
@@ -549,7 +495,7 @@ type attemptTracer struct {
 	status    string    // The gRPC status code of the attempt.
 
 	directPathUsed      bool // Indicates if DirectPath was used for the attempt.
-	serverTimingMetrics map[string]time.Duration
+	serverTimingMetrics serverTimingMetrics
 }
 
 // setStartTime sets the start time for the operation.
@@ -581,13 +527,19 @@ func (o *opTracer) incrementAttemptCount() {
 func (a *attemptTracer) setDirectPathUsed(ctx context.Context) {
 	peerInfo, ok := peer.FromContext(ctx)
 	if ok {
+		a.setDirectPathUsedFromPeer(peerInfo)
+	}
+}
+
+func (a *attemptTracer) setDirectPathUsedFromPeer(peerInfo *peer.Peer) {
+	if peerInfo != nil {
 		if _, isALTS := peerInfo.AuthInfo.(alts.AuthInfo); isALTS {
 			a.directPathUsed = true
 		}
 	}
 }
 
-func (a *attemptTracer) setServerTimingMetrics(metrics map[string]time.Duration) {
+func (a *attemptTracer) setServerTimingMetrics(metrics serverTimingMetrics) {
 	a.serverTimingMetrics = metrics
 }
 
@@ -621,71 +573,20 @@ func (tf *builtinMetricsTracerFactory) createBuiltinMetricsTracer(ctx context.Co
 	}
 }
 
-// toOtelMetricAttrs:
-// - converts metric attributes values captured throughout the operation / attempt
-// to OpenTelemetry attributes format,
-// - combines these with common client attributes and returns
-func (mt *builtinMetricsTracer) toOtelMetricAttrs(metricName string) ([]attribute.KeyValue, error) {
-	if mt.currOp == nil || mt.currOp.currAttempt == nil {
-		return nil, fmt.Errorf("unable to create attributes list for unknown metric: %v", metricName)
+func (mt *builtinMetricsTracer) metricMethodLabel() string {
+	if mt.methodLabel == "" && mt.method != "" {
+		mt.methodLabel = strings.ReplaceAll(strings.TrimPrefix(mt.method, "/google.spanner.v1."), "/", ".")
 	}
-	// Get metric details
-	mDetails, found := metricsDetails[metricName]
-	if !found {
-		return nil, fmt.Errorf("unable to create attributes list for unknown metric: %v", metricName)
-	}
+	return mt.methodLabel
+}
 
-	rpcStatus := mt.currOp.status
-	if mDetails.recordedPerAttempt {
-		rpcStatus = mt.currOp.currAttempt.status
-	}
-
-	return []attribute.KeyValue{
-		attribute.String(metricLabelKeyMethod, strings.ReplaceAll(strings.TrimPrefix(mt.method, "/google.spanner.v1."), "/", ".")),
+func (mt *builtinMetricsTracer) metricAttributeSet(status string, directPathUsed bool) attribute.Set {
+	return attribute.NewSet(
+		attribute.String(metricLabelKeyMethod, mt.metricMethodLabel()),
 		attribute.String(metricLabelKeyDirectPathEnabled, strconv.FormatBool(mt.currOp.directPathEnabled)),
-		attribute.String(metricLabelKeyDirectPathUsed, strconv.FormatBool(mt.currOp.currAttempt.directPathUsed)),
-		attribute.String(metricLabelKeyStatus, rpcStatus),
-	}, nil
-}
-
-func (t *builtinMetricsTracer) recordGFELatency(latency time.Duration) {
-	if t.builtInEnabled {
-		attrs, err := t.toOtelMetricAttrs(metricNameGFELatencies)
-		if err != nil {
-			return
-		}
-		t.instrumentGFELatencies.Record(t.ctx, float64(latency.Milliseconds()), metric.WithAttributes(attrs...))
-	}
-}
-
-func (t *builtinMetricsTracer) recordAFELatency(latency time.Duration) {
-	if !t.isAFEBuiltInMetricEnabled {
-		return
-	}
-	attrs, err := t.toOtelMetricAttrs(metricNameAFELatencies)
-	if err != nil {
-		return
-	}
-	t.instrumentAFELatencies.Record(t.ctx, float64(latency.Milliseconds()), metric.WithAttributes(attrs...))
-}
-
-func (t *builtinMetricsTracer) recordGFEError() {
-	attrs, err := t.toOtelMetricAttrs(metricNameGFEConnectivityErrorCount)
-	if err != nil {
-		return
-	}
-	t.instrumentGFEErrorCount.Add(t.ctx, 1, metric.WithAttributes(attrs...))
-}
-
-func (t *builtinMetricsTracer) recordAFEError() {
-	if !t.isAFEBuiltInMetricEnabled {
-		return
-	}
-	attrs, err := t.toOtelMetricAttrs(metricNameAFEConnectivityErrorCount)
-	if err != nil {
-		return
-	}
-	t.instrumentAFEErrorCount.Add(t.ctx, 1, metric.WithAttributes(attrs...))
+		attribute.String(metricLabelKeyDirectPathUsed, strconv.FormatBool(directPathUsed)),
+		attribute.String(metricLabelKeyStatus, status),
+	)
 }
 
 // Convert error to grpc status error
@@ -710,33 +611,31 @@ func convertToGrpcStatusErr(err error) (codes.Code, error) {
 // Ignore errors seen while creating metric attributes since metric can still
 // be recorded with rest of the attributes
 func recordAttemptCompletion(mt *builtinMetricsTracer) {
+	if mt.currOp == nil || mt.currOp.currAttempt == nil {
+		return
+	}
 	if !mt.builtInEnabled {
 		return
 	}
-	// capture AFE metrics only if direct-path is enabled and used in current attempt
-	if mt.currOp.currAttempt.directPathUsed {
-		if dur, ok := mt.currOp.currAttempt.serverTimingMetrics[afeTimingHeader]; ok {
-			mt.recordAFELatency(dur)
-		} else {
-			mt.recordAFEError()
+	attempt := mt.currOp.currAttempt
+	attrSet := mt.metricAttributeSet(attempt.status, attempt.directPathUsed)
+
+	if attempt.directPathUsed {
+		if mt.isAFEBuiltInMetricEnabled {
+			if attempt.serverTimingMetrics.hasAFE {
+				mt.instrumentAFELatencies.Record(mt.ctx, float64(attempt.serverTimingMetrics.afeLatency.Milliseconds()), metric.WithAttributeSet(attrSet))
+			} else {
+				mt.instrumentAFEErrorCount.Add(mt.ctx, 1, metric.WithAttributeSet(attrSet))
+			}
 		}
 	} else {
-		if dur, ok := mt.currOp.currAttempt.serverTimingMetrics[gfeTimingHeader]; ok {
-			mt.recordGFELatency(dur)
+		if attempt.serverTimingMetrics.hasGFE {
+			mt.instrumentGFELatencies.Record(mt.ctx, float64(attempt.serverTimingMetrics.gfeLatency.Milliseconds()), metric.WithAttributeSet(attrSet))
 		} else {
-			mt.recordGFEError()
+			mt.instrumentGFEErrorCount.Add(mt.ctx, 1, metric.WithAttributeSet(attrSet))
 		}
 	}
-
-	// Calculate elapsed time
-	elapsedTime := convertToMs(time.Since(mt.currOp.currAttempt.startTime))
-
-	// Record attempt_latencies
-	attemptLatAttrs, err := mt.toOtelMetricAttrs(metricNameAttemptLatencies)
-	if err != nil {
-		return
-	}
-	mt.instrumentAttemptLatencies.Record(mt.ctx, elapsedTime, metric.WithAttributes(attemptLatAttrs...))
+	mt.instrumentAttemptLatencies.Record(mt.ctx, convertToMs(time.Since(attempt.startTime)), metric.WithAttributeSet(attrSet))
 }
 
 // recordOperationCompletion records as many operation specific metrics as it can
@@ -746,30 +645,14 @@ func recordOperationCompletion(mt *builtinMetricsTracer) {
 	if !mt.builtInEnabled {
 		return
 	}
-
-	// Calculate elapsed time
-	elapsedTimeMs := convertToMs(time.Since(mt.currOp.startTime))
-
-	// Record operation_count
-	opCntAttrs, err := mt.toOtelMetricAttrs(metricNameOperationCount)
-	if err != nil {
+	if mt.currOp == nil || mt.currOp.currAttempt == nil {
 		return
 	}
-	mt.instrumentOperationCount.Add(mt.ctx, 1, metric.WithAttributes(opCntAttrs...))
 
-	// Record operation_latencies
-	opLatAttrs, err := mt.toOtelMetricAttrs(metricNameOperationLatencies)
-	if err != nil {
-		return
-	}
-	mt.instrumentOperationLatencies.Record(mt.ctx, elapsedTimeMs, metric.WithAttributes(opLatAttrs...))
-
-	// Record attempt_count
-	attemptCntAttrs, err := mt.toOtelMetricAttrs(metricNameAttemptCount)
-	if err != nil {
-		return
-	}
-	mt.instrumentAttemptCount.Add(mt.ctx, mt.currOp.attemptCount, metric.WithAttributes(attemptCntAttrs...))
+	attrSet := mt.metricAttributeSet(mt.currOp.status, mt.currOp.currAttempt.directPathUsed)
+	mt.instrumentOperationCount.Add(mt.ctx, 1, metric.WithAttributeSet(attrSet))
+	mt.instrumentOperationLatencies.Record(mt.ctx, convertToMs(time.Since(mt.currOp.startTime)), metric.WithAttributeSet(attrSet))
+	mt.instrumentAttemptCount.Add(mt.ctx, mt.currOp.attemptCount, metric.WithAttributeSet(attrSet))
 }
 
 func convertToMs(d time.Duration) float64 {

--- a/spanner/ot_metrics.go
+++ b/spanner/ot_metrics.go
@@ -215,15 +215,18 @@ func recordGFELatencyMetricsOT(ctx context.Context, md metadata.MD, keyMethod st
 	if otConfig == nil || !otConfig.enabled || md == nil {
 		return nil
 	}
-	attr := otConfig.attributeMap
-	metrics := parseServerTimingHeader(md)
-	if len(metrics) == 0 && otConfig.gfeHeaderMissingCount != nil {
-		otConfig.gfeHeaderMissingCount.Add(ctx, 1, metric.WithAttributes(attr...))
+	timing := parseServerTimingHeaderMetrics(md)
+	if !timing.hasGFE {
+		if otConfig.gfeHeaderMissingCount != nil {
+			otConfig.gfeHeaderMissingCount.Add(ctx, 1, metric.WithAttributes(otConfig.attributeMap...))
+		}
 		return nil
 	}
-	attr = append(attr, attributeKeyMethod.String(keyMethod))
 	if otConfig.gfeLatency != nil {
-		otConfig.gfeLatency.Record(ctx, metrics[gfeTimingHeader].Milliseconds(), metric.WithAttributes(attr...))
+		var attr [8]attribute.KeyValue
+		n := copy(attr[:], otConfig.attributeMap)
+		attr[n] = attributeKeyMethod.String(keyMethod)
+		otConfig.gfeLatency.Record(ctx, timing.gfeLatency.Milliseconds(), metric.WithAttributes(attr[:n+1]...))
 	}
 	return nil
 }

--- a/spanner/transaction.go
+++ b/spanner/transaction.go
@@ -28,6 +28,7 @@ import (
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
 	"github.com/googleapis/gax-go/v2"
 	"github.com/googleapis/gax-go/v2/apierror"
+	oteltrace "go.opentelemetry.io/otel/trace"
 	"google.golang.org/api/iterator"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -103,6 +104,10 @@ type txReadOnly struct {
 	clientContext *sppb.RequestOptions_ClientContext
 
 	otConfig *openTelemetryConfig
+}
+
+func shouldCaptureStreamingHeaderMetrics(ct *commonTags, otConfig *openTelemetryConfig) bool {
+	return (getGFELatencyMetricsFlag() && ct != nil) || (otConfig != nil && otConfig.enabled)
 }
 
 func (t *txReadOnly) isDefaultInlinedBegin() bool {
@@ -393,16 +398,23 @@ func (t *txReadOnly) ReadWithOptions(ctx context.Context, table string, keys Key
 				}
 				return client, t.updateTxState(err)
 			}
-			md, err := client.Header()
-			if getGFELatencyMetricsFlag() && md != nil && t.ct != nil {
-				if err := createContextAndCaptureGFELatencyMetrics(ctx, t.ct, md, "ReadWithOptions"); err != nil {
-					trace.TracePrintf(ctx, nil, "Error in recording GFE Latency. Try disabling and rerunning. Error: %v", err)
-				}
+			if shouldCaptureStreamingHeaderMetrics(t.ct, t.otConfig) {
+				client = wrapStreamingReadClient(
+					client,
+					oteltrace.SpanFromContext(ctx),
+					nil,
+					streamingHeaderMetrics{
+						ctx:      ctx,
+						ct:       t.ct,
+						otConfig: t.otConfig,
+						method:   "ReadWithOptions",
+						traceErrf: func(err error) {
+							trace.TracePrintf(ctx, nil, "Error in recording GFE Latency. Try disabling and rerunning. Error: %v", err)
+						},
+					},
+				)
 			}
-			if metricErr := recordGFELatencyMetricsOT(ctx, md, "ReadWithOptions", t.otConfig); metricErr != nil {
-				trace.TracePrintf(ctx, nil, "Error in recording GFE Latency through OpenTelemetry. Error: %v", metricErr)
-			}
-			return client, err
+			return client, nil
 		},
 		setTransactionID,
 		func(err error) error {
@@ -748,16 +760,23 @@ func (t *txReadOnly) query(ctx context.Context, statement Statement, options Que
 				}
 				return client, t.updateTxState(err)
 			}
-			md, err := client.Header()
-			if getGFELatencyMetricsFlag() && md != nil && t.ct != nil {
-				if err := createContextAndCaptureGFELatencyMetrics(ctx, t.ct, md, "query"); err != nil {
-					trace.TracePrintf(ctx, nil, "Error in recording GFE Latency. Try disabling and rerunning. Error: %v", err)
-				}
+			if shouldCaptureStreamingHeaderMetrics(t.ct, t.otConfig) {
+				client = wrapExecuteStreamingSqlClient(
+					client,
+					oteltrace.SpanFromContext(ctx),
+					nil,
+					streamingHeaderMetrics{
+						ctx:      ctx,
+						ct:       t.ct,
+						otConfig: t.otConfig,
+						method:   "query",
+						traceErrf: func(err error) {
+							trace.TracePrintf(ctx, nil, "Error in recording GFE Latency. Try disabling and rerunning. Error: %v", err)
+						},
+					},
+				)
 			}
-			if metricErr := recordGFELatencyMetricsOT(ctx, md, "query", t.otConfig); metricErr != nil {
-				trace.TracePrintf(ctx, nil, "Error in recording GFE Latency through OpenTelemetry. Error: %v", metricErr)
-			}
-			return client, err
+			return client, nil
 		},
 		setTransactionID,
 		func(err error) error {


### PR DESCRIPTION
## Summary
- avoid eager `Header()` calls on streaming read/query paths used by built-in and legacy GFE latency metrics
- remove map/regexp allocations from server-timing parsing on the built-in metrics hot path
- record built-in metrics with `attribute.Set` and avoid per-metric attribute slice/map construction
- keep legacy OpenTelemetry GFE latency metrics intact while moving streaming header capture off the pre-`Recv` request path

## Why
When built-in metrics and legacy OpenTelemetry Spanner metrics are enabled, streaming query/read currently calls `Header()` before the first `Recv()`. Under load, goroutine profiles showed many requests blocked in `grpc.(*clientStream).Header`, increasing request latency even when server/GFE latency was low. This change defers header capture until after the first `Recv()` returns, preserving metrics but removing the blocking header wait from request dispatch.


