### PR TITLE
chore: librarian release pull request: 20260518T160342Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -2681,7 +2681,7 @@ libraries:
       - internal/generated/snippets/speech/
     tag_format: '{id}/v{version}'
   - id: storage
-    version: 1.62.1
+    version: 1.63.0
     last_generated_commit: ""
     apis:
       - path: google/storage/control/v2

--- a/internal/generated/snippets/storage/control/apiv2/snippet_metadata.google.storage.control.v2.json
+++ b/internal/generated/snippets/storage/control/apiv2/snippet_metadata.google.storage.control.v2.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/storage/control/apiv2",
-    "version": "1.62.1"
+    "version": "1.63.0"
   },
   "snippets": [
     {

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -2327,7 +2327,7 @@ libraries:
             - F_open_telemetry_attributes
             - F_proto_cloneof
   - name: storage
-    version: 1.62.1
+    version: 1.63.0
     apis:
       - path: google/storage/v2
         go:

--- a/storage/CHANGES.md
+++ b/storage/CHANGES.md
@@ -1,6 +1,18 @@
 # Changes
 
 
+## [1.63.0](https://github.com/googleapis/google-cloud-go/releases/tag/storage%2Fv1.63.0) (2026-05-18)
+
+### Features
+
+* enable open telemetry attrs (#14426) ([74eab64](https://github.com/googleapis/google-cloud-go/commit/74eab64d1b4e22d8c79b0de4e5fc9a36bc4c6c19))
+
+### Bug Fixes
+
+* Set default chunkRetryDeadline to 32s in NewWriterFromAppendableObject (#14458) ([ec7c7d6](https://github.com/googleapis/google-cloud-go/commit/ec7c7d66eb0bf6e52a3ae1f529cb8e5de6f8dc86))
+* refactor userProject metadata propagation in ListObjects  (#14533) ([fbb543e](https://github.com/googleapis/google-cloud-go/commit/fbb543e3bb0d9b45c8e9aa167b6551c154f23169))
+* restore metadata operations timeout in gRPC (#14575) ([275ff56](https://github.com/googleapis/google-cloud-go/commit/275ff562aee8c0201b9e5bf2913bb85bcdbe947a))
+
 ## [1.62.1](https://github.com/googleapis/google-cloud-go/releases/tag/storage%2Fv1.62.1) (2026-04-13)
 
 ### Bug Fixes

--- a/storage/internal/version.go
+++ b/storage/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "1.62.1"
+const Version = "1.63.0"


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.13.2-0.20260514223035-a22d6b5a1329
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go@sha256:b04b076f5eedbb5546bd6fc1404969dd3698c8b19c0f34ae815a84ae735a606a
<details><summary>storage: v1.63.0</summary>

## [v1.63.0](https://github.com/googleapis/google-cloud-go/compare/storage/v1.62.1...storage/v1.63.0) (2026-05-18)

### Features

* enable open telemetry attrs (#14426) ([74eab64d](https://github.com/googleapis/google-cloud-go/commit/74eab64d))

### Bug Fixes

* restore metadata operations timeout in gRPC (#14575) ([275ff562](https://github.com/googleapis/google-cloud-go/commit/275ff562))

* Set default chunkRetryDeadline to 32s in NewWriterFromAppendableObject (#14458) ([ec7c7d66](https://github.com/googleapis/google-cloud-go/commit/ec7c7d66))

* refactor userProject metadata propagation in ListObjects  (#14533) ([fbb543e3](https://github.com/googleapis/google-cloud-go/commit/fbb543e3))

</details>