### PR TITLE
chore: librarian release pull request: 20260519T161341Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1055,7 +1055,7 @@ libraries:
       - internal/generated/snippets/dataqna/
     tag_format: '{id}/v{version}'
   - id: datastore
-    version: 1.23.0
+    version: 1.24.0
     last_generated_commit: ""
     apis:
       - path: google/datastore/admin/v1

--- a/datastore/CHANGES.md
+++ b/datastore/CHANGES.md
@@ -1,5 +1,13 @@
 # Changes
 
+## [1.24.0](https://github.com/googleapis/google-cloud-go/releases/tag/datastore%2Fv1.24.0) (2026-05-19)
+
+### Bug Fixes
+
+* add retries to emulator (#14591) ([d944830](https://github.com/googleapis/google-cloud-go/commit/d9448309a64e756a5facdfbd6ffa9d51f27c0610))
+* detach rollback context from transaction cancellation (#14602) ([0a8d10d](https://github.com/googleapis/google-cloud-go/commit/0a8d10d18d7e2b0008e82c5e2936f95e82bfbbc5))
+* fix context leak in Iterator and Transaction spans (#14478) ([78de20d](https://github.com/googleapis/google-cloud-go/commit/78de20dabebc4d7b98e429b4c5fb04aa7c90fb66))
+
 ## [1.23.0](https://github.com/googleapis/google-cloud-go/releases/tag/datastore%2Fv1.23.0) (2026-04-27)
 
 ## [1.22.0](https://github.com/googleapis/google-cloud-go/releases/tag/datastore%2Fv1.22.0) (2026-02-04)

--- a/datastore/internal/version.go
+++ b/datastore/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "1.23.0"
+const Version = "1.24.0"

--- a/internal/generated/snippets/datastore/admin/apiv1/snippet_metadata.google.datastore.admin.v1.json
+++ b/internal/generated/snippets/datastore/admin/apiv1/snippet_metadata.google.datastore.admin.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/datastore/admin/apiv1",
-    "version": "1.23.0"
+    "version": "1.24.0"
   },
   "snippets": [
     {

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -593,7 +593,7 @@ libraries:
     apis:
       - path: google/cloud/dataqna/v1alpha
   - name: datastore
-    version: 1.23.0
+    version: 1.24.0
     apis:
       - path: google/datastore/v1
         go:


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.13.2-0.20260518181009-04b8e642ea4c
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go@sha256:b04b076f5eedbb5546bd6fc1404969dd3698c8b19c0f34ae815a84ae735a606a
<details><summary>datastore: v1.24.0</summary>

## [v1.24.0](https://github.com/googleapis/google-cloud-go/compare/datastore/v1.23.0...datastore/v1.24.0) (2026-05-19)

### Bug Fixes

* detach rollback context from transaction cancellation (#14602) ([0a8d10d1](https://github.com/googleapis/google-cloud-go/commit/0a8d10d1))

* fix context leak in Iterator and Transaction spans (#14478) ([78de20da](https://github.com/googleapis/google-cloud-go/commit/78de20da))

* add retries to emulator (#14591) ([d9448309](https://github.com/googleapis/google-cloud-go/commit/d9448309))

</details>