### PR TITLE
chore: update librarian to v0.14.0

### DIFF
--- a/ai/generativelanguage/apiv1alpha/doc.go
+++ b/ai/generativelanguage/apiv1alpha/doc.go
@@ -25,7 +25,7 @@
 // like reasoning across text and images, content generation, dialogue
 // agents, summarization and classification systems, and more.
 //
-//	NOTE: This package is in beta. It is not stable, and may be subject to changes.
+//	NOTE: This package is in alpha. It is not stable, and is likely to change.
 //
 // # General documentation
 //

--- a/alloydb/apiv1alpha/doc.go
+++ b/alloydb/apiv1alpha/doc.go
@@ -29,7 +29,7 @@
 // read resources; scale existing PostgreSQL workloads with no application
 // changes; and modernize legacy proprietary databases.
 //
-//	NOTE: This package is in beta. It is not stable, and may be subject to changes.
+//	NOTE: This package is in alpha. It is not stable, and is likely to change.
 //
 // # General documentation
 //

--- a/bigquery/biglake/apiv1alpha1/doc.go
+++ b/bigquery/biglake/apiv1alpha1/doc.go
@@ -21,7 +21,7 @@
 // managed, and highly available metastore for open-source data that can be
 // used for querying Apache Iceberg tables in BigQuery.
 //
-//	NOTE: This package is in beta. It is not stable, and may be subject to changes.
+//	NOTE: This package is in alpha. It is not stable, and is likely to change.
 //
 // # General documentation
 //

--- a/bigquery/storage/apiv1alpha/doc.go
+++ b/bigquery/storage/apiv1alpha/doc.go
@@ -17,7 +17,7 @@
 // Package storage is an auto-generated package for the
 // BigQuery Storage API.
 //
-//	NOTE: This package is in beta. It is not stable, and may be subject to changes.
+//	NOTE: This package is in alpha. It is not stable, and is likely to change.
 //
 // # General documentation
 //

--- a/bigquery/v2/apiv2/doc.go
+++ b/bigquery/v2/apiv2/doc.go
@@ -19,7 +19,7 @@
 //
 // A data platform for customers to create, manage, share and query data.
 //
-//	NOTE: This package is in alpha. It is not stable, and is likely to change.
+//	NOTE: This package is in beta. It is not stable, and may be subject to changes.
 //
 // # General documentation
 //

--- a/confidentialcomputing/apiv1alpha1/doc.go
+++ b/confidentialcomputing/apiv1alpha1/doc.go
@@ -17,7 +17,7 @@
 // Package confidentialcomputing is an auto-generated package for the
 // Confidential Computing API.
 //
-//	NOTE: This package is in beta. It is not stable, and may be subject to changes.
+//	NOTE: This package is in alpha. It is not stable, and is likely to change.
 //
 // # General documentation
 //

--- a/discoveryengine/apiv1alpha/doc.go
+++ b/discoveryengine/apiv1alpha/doc.go
@@ -19,7 +19,7 @@
 //
 // Discovery Engine API.
 //
-//	NOTE: This package is in beta. It is not stable, and may be subject to changes.
+//	NOTE: This package is in alpha. It is not stable, and is likely to change.
 //
 // # General documentation
 //

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 language: go
-version: v0.13.2-0.20260518181009-04b8e642ea4c
+version: v0.14.0
 repo: googleapis/google-cloud-go
 sources:
   googleapis:

--- a/shopping/merchant/productstudio/apiv1alpha/doc.go
+++ b/shopping/merchant/productstudio/apiv1alpha/doc.go
@@ -19,7 +19,7 @@
 //
 // Programmatically manage your Merchant Center Accounts.
 //
-//	NOTE: This package is in beta. It is not stable, and may be subject to changes.
+//	NOTE: This package is in alpha. It is not stable, and is likely to change.
 //
 // # General documentation
 //


### PR DESCRIPTION
The changes are from librarian generate with V=v0.14.0:

```
suztomo@suztomo:~/librarian-2026/google-cloud-go$ go run github.com/googleapis/librarian/cmd/librarian@${V} generate --all
```