### PR TITLE
feat(auth): add support for TPC universe domain during impersonation

### DIFF
--- a/auth/credentials/detect.go
+++ b/auth/credentials/detect.go
@@ -175,7 +175,8 @@ func DetectDefault(opts *DetectOptions) (*auth.Credentials, error) {
 			UseDefaultClient: true,
 		})
 		gceUniverseDomainProvider := &internal.ComputeUniverseDomainProvider{
-			MetadataClient: metadataClient,
+			MetadataClient:         metadataClient,
+			UniverseDomainOverride: opts.UniverseDomain,
 		}
 
 		tp := computeTokenProvider(opts, metadataClient)
@@ -379,6 +380,16 @@ func (o *DetectOptions) validate() error {
 		return errors.New("credentials: both credentials file and JSON were provided")
 	}
 	return nil
+}
+
+func (o *DetectOptions) universeDomain() string {
+	if o == nil {
+		return ""
+	}
+	if o.UniverseDomain != "" {
+		return o.UniverseDomain
+	}
+	return os.Getenv(internal.UniverseDomainEnvVar)
 }
 
 func (o *DetectOptions) tokenURL() string {

--- a/auth/credentials/detect_test.go
+++ b/auth/credentials/detect_test.go
@@ -869,9 +869,10 @@ func TestDefaultCredentials_Validate(t *testing.T) {
 func TestDefaultCredentials_UniverseDomain(t *testing.T) {
 	ctx := context.Background()
 	tests := []struct {
-		name string
-		opts *DetectOptions
-		want string
+		name  string
+		opts  *DetectOptions
+		want  string
+		setup func(*testing.T)
 	}{
 		{
 			name: "service account json",
@@ -1037,9 +1038,46 @@ func TestDefaultCredentials_UniverseDomain(t *testing.T) {
 			},
 			want: "foo.com",
 		},
+		{
+			name: "service account json with env var universe domain",
+			opts: &DetectOptions{
+				CredentialsFile: "../internal/testdata/sa.json",
+				Scopes:          []string{"https://www.googleapis.com/auth/cloud-platform"},
+			},
+			setup: func(t *testing.T) {
+				t.Setenv("GOOGLE_CLOUD_UNIVERSE_DOMAIN", "env-universe.com")
+			},
+			want: "env-universe.com",
+		},
+		{
+			name: "service account json with file and env var universe domain",
+			opts: &DetectOptions{
+				CredentialsFile: "../internal/testdata/sa_universe_domain.json",
+				Scopes:          []string{"https://www.googleapis.com/auth/cloud-platform"},
+			},
+			setup: func(t *testing.T) {
+				t.Setenv("GOOGLE_CLOUD_UNIVERSE_DOMAIN", "env-universe.com")
+			},
+			want: "example.com", // file wins
+		},
+		{
+			name: "service account json with options and env var universe domain",
+			opts: &DetectOptions{
+				CredentialsFile: "../internal/testdata/sa.json",
+				Scopes:          []string{"https://www.googleapis.com/auth/cloud-platform"},
+				UniverseDomain:  "foo.com",
+			},
+			setup: func(t *testing.T) {
+				t.Setenv("GOOGLE_CLOUD_UNIVERSE_DOMAIN", "env-universe.com")
+			},
+			want: "foo.com", // options win
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			if tt.setup != nil {
+				tt.setup(t)
+			}
 			creds, err := DetectDefault(tt.opts)
 			if err != nil {
 				t.Fatalf("%v", err)
@@ -1115,5 +1153,45 @@ func TestDefaultCredentials_OnGCE(t *testing.T) {
 	}
 	if !strings.Contains(logBuf.String(), "metadata request") {
 		t.Errorf("log output missing 'metadata request': got %q", logBuf.String())
+	}
+}
+
+func TestDefaultCredentials_OnGCE_UniverseDomainEnvVar(t *testing.T) {
+	t.Setenv("GOOGLE_CLOUD_UNIVERSE_DOMAIN", "env-universe.com")
+	ctx := context.Background()
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/computeMetadata/v1/project/project-id":
+			fmt.Fprint(w, "fake-project")
+		case "/computeMetadata/v1/instance/service-accounts/default/token":
+			w.Header().Set("Content-Type", "application/json")
+			resp := &tokResp{
+				AccessToken: "a_fake_token",
+				TokenType:   internal.TokenTypeBearer,
+				ExpiresIn:   60,
+			}
+			if err := json.NewEncoder(w).Encode(&resp); err != nil {
+				t.Fatal(err)
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+	t.Setenv("GCE_METADATA_HOST", strings.TrimPrefix(ts.URL, "http://"))
+	t.Setenv(credsfile.GoogleAppCredsEnvVar, "")
+	t.Setenv("HOME", "nothingToSeeHere")
+	t.Setenv("APPDATA", "nothingToSeeHere")
+
+	creds, err := DetectDefault(&DetectOptions{})
+	if err != nil {
+		t.Fatalf("DetectDefault() = %v, want nil", err)
+	}
+	ud, err := creds.UniverseDomain(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := "env-universe.com"; ud != want {
+		t.Errorf("creds.UniverseDomain() = %q, want %q", ud, want)
 	}
 }

--- a/auth/credentials/filetypes.go
+++ b/auth/credentials/filetypes.go
@@ -17,6 +17,7 @@ package credentials
 import (
 	"errors"
 	"fmt"
+	"os"
 
 	"cloud.google.com/go/auth"
 	"cloud.google.com/go/auth/credentials/internal/externalaccount"
@@ -126,7 +127,10 @@ func resolveUniverseDomain(optsUniverseDomain, fileUniverseDomain string) string
 	if optsUniverseDomain != "" {
 		return optsUniverseDomain
 	}
-	return fileUniverseDomain
+	if fileUniverseDomain != "" {
+		return fileUniverseDomain
+	}
+	return os.Getenv(internalauth.UniverseDomainEnvVar)
 }
 
 func handleServiceAccount(f *credsfile.ServiceAccountFile, opts *DetectOptions) (auth.TokenProvider, error) {

--- a/auth/credentials/impersonate/idtoken.go
+++ b/auth/credentials/impersonate/idtoken.go
@@ -101,6 +101,7 @@ func NewIDTokenCredentials(opts *IDTokenOptions) (*auth.Credentials, error) {
 				Scopes:           []string{defaultScope},
 				UseSelfSignedJWT: true,
 				Logger:           logger,
+				UniverseDomain:   opts.UniverseDomain,
 			})
 			if err != nil {
 				return nil, err

--- a/auth/credentials/impersonate/idtoken_test.go
+++ b/auth/credentials/impersonate/idtoken_test.go
@@ -33,6 +33,8 @@ func TestNewIDTokenCredentials(t *testing.T) {
 		config             IDTokenOptions
 		wantErr            bool
 		wantUniverseDomain string
+		setup              func(*testing.T)
+		skipTokenCall      bool
 	}{
 		{
 			name: "missing aud",
@@ -84,11 +86,41 @@ func TestNewIDTokenCredentials(t *testing.T) {
 			},
 			wantUniverseDomain: "example.com",
 		},
+		{
+			name: "universe domain from env var (detected)",
+			config: IDTokenOptions{
+				Audience:        "http://example.com/",
+				TargetPrincipal: "foo@project-id.iam.gserviceaccount.com",
+			},
+			setup: func(t *testing.T) {
+				t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "../../internal/testdata/sa.json")
+				t.Setenv("GOOGLE_CLOUD_UNIVERSE_DOMAIN", "env-universe.com")
+			},
+			wantUniverseDomain: "env-universe.com",
+			skipTokenCall:      true,
+		},
+		{
+			name: "universe domain from options (detected override)",
+			config: IDTokenOptions{
+				Audience:        "http://example.com/",
+				TargetPrincipal: "foo@project-id.iam.gserviceaccount.com",
+				UniverseDomain:  "options-universe.com",
+			},
+			setup: func(t *testing.T) {
+				t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "../../internal/testdata/sa.json")
+				t.Setenv("GOOGLE_CLOUD_UNIVERSE_DOMAIN", "env-universe.com")
+			},
+			wantUniverseDomain: "options-universe.com",
+			skipTokenCall:      true,
+		},
 	}
 
 	for _, tt := range tests {
 		name := tt.name
 		t.Run(name, func(t *testing.T) {
+			if tt.setup != nil {
+				tt.setup(t)
+			}
 			idTok := "id-token"
 			client := &http.Client{
 				Transport: RoundTripFn(func(req *http.Request) *http.Response {
@@ -128,7 +160,7 @@ func TestNewIDTokenCredentials(t *testing.T) {
 					}
 				}),
 			}
-			if tt.config.Credentials == nil {
+			if tt.config.Credentials == nil && !tt.skipTokenCall {
 				tt.config.Client = client
 			}
 			creds, err := NewIDTokenCredentials(&tt.config)
@@ -139,7 +171,7 @@ func TestNewIDTokenCredentials(t *testing.T) {
 				return
 			}
 			// Static config.Credentials is invalid for Token request, skip.
-			if tt.config.Credentials == nil {
+			if tt.config.Credentials == nil && !tt.skipTokenCall {
 				tok, err := creds.Token(ctx)
 				if err != nil {
 					t.Error(err)

--- a/auth/credentials/impersonate/impersonate.go
+++ b/auth/credentials/impersonate/impersonate.go
@@ -74,6 +74,7 @@ func NewCredentials(opts *CredentialsOptions) (*auth.Credentials, error) {
 				Scopes:           []string{defaultScope},
 				UseSelfSignedJWT: true,
 				Logger:           logger,
+				UniverseDomain:   opts.UniverseDomain,
 			})
 			if err != nil {
 				return nil, err

--- a/auth/credentials/impersonate/impersonate_test.go
+++ b/auth/credentials/impersonate/impersonate_test.go
@@ -36,6 +36,8 @@ func TestNewCredentials_serviceAccount(t *testing.T) {
 		config             CredentialsOptions
 		wantErr            error
 		wantUniverseDomain string
+		setup              func(*testing.T)
+		skipTokenCall      bool
 	}{
 		{
 			name:    "missing targetPrincipal",
@@ -97,11 +99,41 @@ func TestNewCredentials_serviceAccount(t *testing.T) {
 			wantErr:            nil,
 			wantUniverseDomain: "example.com",
 		},
+		{
+			name: "universe domain from env var (detected)",
+			config: CredentialsOptions{
+				TargetPrincipal: "foo@project-id.iam.gserviceaccount.com",
+				Scopes:          []string{"scope"},
+			},
+			setup: func(t *testing.T) {
+				t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "../../internal/testdata/sa.json")
+				t.Setenv("GOOGLE_CLOUD_UNIVERSE_DOMAIN", "env-universe.com")
+			},
+			wantUniverseDomain: "env-universe.com",
+			skipTokenCall:      true,
+		},
+		{
+			name: "universe domain from options (detected override)",
+			config: CredentialsOptions{
+				TargetPrincipal: "foo@project-id.iam.gserviceaccount.com",
+				Scopes:          []string{"scope"},
+				UniverseDomain:  "options-universe.com",
+			},
+			setup: func(t *testing.T) {
+				t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "../../internal/testdata/sa.json")
+				t.Setenv("GOOGLE_CLOUD_UNIVERSE_DOMAIN", "env-universe.com")
+			},
+			wantUniverseDomain: "options-universe.com",
+			skipTokenCall:      true,
+		},
 	}
 
 	for _, tt := range tests {
 		name := tt.name
 		t.Run(name, func(t *testing.T) {
+			if tt.setup != nil {
+				tt.setup(t)
+			}
 			saTok := "sa-token"
 			client := &http.Client{
 				Transport: RoundTripFn(func(req *http.Request) *http.Response {
@@ -142,7 +174,7 @@ func TestNewCredentials_serviceAccount(t *testing.T) {
 					}
 				}),
 			}
-			if tt.config.Credentials == nil {
+			if tt.config.Credentials == nil && !tt.skipTokenCall {
 				tt.config.Client = client
 			}
 			creds, err := NewCredentials(&tt.config)
@@ -150,8 +182,8 @@ func TestNewCredentials_serviceAccount(t *testing.T) {
 				if err != tt.wantErr {
 					t.Fatalf("err: %v", err)
 				}
-			} else if tt.config.Credentials != nil {
-				// config.Credentials is invalid for Token request, just assert universe domain.
+			} else if tt.config.Credentials != nil || tt.skipTokenCall {
+				// config.Credentials is invalid for Token request, or we want to skip Token call, just assert universe domain.
 				if got, _ := creds.UniverseDomain(ctx); got != tt.wantUniverseDomain {
 					t.Errorf("got %q, want %q", got, tt.wantUniverseDomain)
 				}

--- a/auth/internal/internal.go
+++ b/auth/internal/internal.go
@@ -185,15 +185,22 @@ func (p StaticProperty) GetProperty(context.Context) (string, error) {
 // ComputeUniverseDomainProvider fetches the credentials universe domain from
 // the google cloud metadata service.
 type ComputeUniverseDomainProvider struct {
-	MetadataClient     *metadata.Client
-	universeDomainOnce sync.Once
-	universeDomain     string
-	universeDomainErr  error
+	MetadataClient         *metadata.Client
+	UniverseDomainOverride string
+	universeDomainOnce     sync.Once
+	universeDomain         string
+	universeDomainErr      error
 }
 
 // GetProperty fetches the credentials universe domain from the google cloud
 // metadata service.
 func (c *ComputeUniverseDomainProvider) GetProperty(ctx context.Context) (string, error) {
+	if c.UniverseDomainOverride != "" {
+		return c.UniverseDomainOverride, nil
+	}
+	if envUD := os.Getenv(UniverseDomainEnvVar); envUD != "" {
+		return envUD, nil
+	}
 	c.universeDomainOnce.Do(func() {
 		c.universeDomain, c.universeDomainErr = getMetadataUniverseDomain(ctx, c.MetadataClient)
 	})


### PR DESCRIPTION
This change adds support for TPC (Trusted Partner Cloud) universe domains during service account and ID token impersonation.

Previously, when using the `credentials/impersonate` package in a TPC environment (where the universe domain is configured via the `GOOGLE_CLOUD_UNIVERSE_DOMAIN` environment variable), the library would fail. It would either timeout trying to reach the default `googleapis.com` endpoint to generate the impersonated token, or fail with a "universe domain mismatch" error during transport validation because the detected base credentials defaulted to `googleapis.com`.

To resolve this, we ensure that the universe domain is correctly resolved and propagated:
1. `credentials.DetectDefault` now respects the `GOOGLE_CLOUD_UNIVERSE_DOMAIN` environment variable for both file-based and GCE-based credentials if not explicitly overridden in options or the credentials file.
2. `impersonate.NewCredentials` and `NewIDTokenCredentials` now pass `opts.UniverseDomain` to `credentials.DetectDefault` to ensure the resolved base credentials use the correct universe domain.