### PR TITLE
chore: librarian release pull request: 20260521T182442Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -807,7 +807,7 @@ libraries:
       - internal/generated/snippets/commerce/
     tag_format: '{id}/v{version}'
   - id: compute
-    version: 1.63.0
+    version: 1.64.0
     last_generated_commit: ""
     apis:
       - path: google/cloud/compute/v1
@@ -999,7 +999,7 @@ libraries:
       - internal/generated/snippets/datalabeling/
     tag_format: '{id}/v{version}'
   - id: datamanager
-    version: 1.0.0
+    version: 1.1.0
     last_generated_commit: ""
     apis:
       - path: google/ads/datamanager/v1
@@ -2755,7 +2755,7 @@ libraries:
       - internal/generated/snippets/streetview/
     tag_format: '{id}/v{version}'
   - id: support
-    version: 1.10.0
+    version: 1.11.0
     last_generated_commit: ""
     apis:
       - path: google/cloud/support/v2

--- a/compute/CHANGES.md
+++ b/compute/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+## [1.64.0](https://github.com/googleapis/google-cloud-go/releases/tag/compute%2Fv1.64.0) (2026-05-21)
+
+### Features
+
+* update API sources and regenerate (#14621) ([6641db8](https://github.com/googleapis/google-cloud-go/commit/6641db88e5a1c62a967d0505d35c3bc1dedefe9f))
+
 ## [1.63.0](https://github.com/googleapis/google-cloud-go/releases/tag/compute%2Fv1.63.0) (2026-05-14)
 
 ### Features

--- a/compute/internal/version.go
+++ b/compute/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "1.63.0"
+const Version = "1.64.0"

--- a/datamanager/CHANGES.md
+++ b/datamanager/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+## [1.1.0](https://github.com/googleapis/google-cloud-go/releases/tag/datamanager%2Fv1.1.0) (2026-05-21)
+
+### Features
+
+* update API sources and regenerate (#14621) ([6641db8](https://github.com/googleapis/google-cloud-go/commit/6641db88e5a1c62a967d0505d35c3bc1dedefe9f))
+
 ## [1.0.0](https://github.com/googleapis/google-cloud-go/releases/tag/datamanager%2Fv1.0.0) (2026-05-08)
 
 ## [0.8.0](https://github.com/googleapis/google-cloud-go/releases/tag/datamanager%2Fv0.8.0) (2026-05-07)

--- a/datamanager/internal/version.go
+++ b/datamanager/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "1.0.0"
+const Version = "1.1.0"

--- a/internal/generated/snippets/compute/apiv1/snippet_metadata.google.cloud.compute.v1.json
+++ b/internal/generated/snippets/compute/apiv1/snippet_metadata.google.cloud.compute.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/compute/apiv1",
-    "version": "1.63.0"
+    "version": "1.64.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/compute/apiv1beta/snippet_metadata.google.cloud.compute.v1beta.json
+++ b/internal/generated/snippets/compute/apiv1beta/snippet_metadata.google.cloud.compute.v1beta.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/compute/apiv1beta",
-    "version": "1.63.0"
+    "version": "1.64.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/datamanager/apiv1/snippet_metadata.google.ads.datamanager.v1.json
+++ b/internal/generated/snippets/datamanager/apiv1/snippet_metadata.google.ads.datamanager.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/datamanager/apiv1",
-    "version": "1.0.0"
+    "version": "1.1.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/support/apiv2/snippet_metadata.google.cloud.support.v2.json
+++ b/internal/generated/snippets/support/apiv2/snippet_metadata.google.cloud.support.v2.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/support/apiv2",
-    "version": "1.10.0"
+    "version": "1.11.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/support/apiv2beta/snippet_metadata.google.cloud.support.v2beta.json
+++ b/internal/generated/snippets/support/apiv2beta/snippet_metadata.google.cloud.support.v2beta.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/support/apiv2beta",
-    "version": "1.10.0"
+    "version": "1.11.0"
   },
   "snippets": [
     {

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -479,7 +479,7 @@ libraries:
     apis:
       - path: google/cloud/commerce/consumer/procurement/v1
   - name: compute
-    version: 1.63.0
+    version: 1.64.0
     apis:
       - path: google/cloud/compute/v1
         go:
@@ -571,7 +571,7 @@ libraries:
     apis:
       - path: google/cloud/datalabeling/v1beta1
   - name: datamanager
-    version: 1.0.0
+    version: 1.1.0
     apis:
       - path: google/ads/datamanager/v1
         go:
@@ -1337,7 +1337,7 @@ libraries:
     apis:
       - path: google/streetview/publish/v1
   - name: support
-    version: 1.10.0
+    version: 1.11.0
     apis:
       - path: google/cloud/support/v2
       - path: google/cloud/support/v2beta

--- a/support/CHANGES.md
+++ b/support/CHANGES.md
@@ -1,6 +1,12 @@
 # Changes
 
 
+## [1.11.0](https://github.com/googleapis/google-cloud-go/releases/tag/support%2Fv1.11.0) (2026-05-21)
+
+### Features
+
+* update API sources and regenerate (#14621) ([6641db8](https://github.com/googleapis/google-cloud-go/commit/6641db88e5a1c62a967d0505d35c3bc1dedefe9f))
+
 ## [1.10.0](https://github.com/googleapis/google-cloud-go/releases/tag/support%2Fv1.10.0) (2026-05-07)
 
 ## [1.9.0](https://github.com/googleapis/google-cloud-go/releases/tag/support%2Fv1.9.0) (2026-04-30)

--- a/support/internal/version.go
+++ b/support/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "1.10.0"
+const Version = "1.11.0"


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.14.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go@sha256:b04b076f5eedbb5546bd6fc1404969dd3698c8b19c0f34ae815a84ae735a606a
<details><summary>compute: v1.64.0</summary>

## [v1.64.0](https://github.com/googleapis/google-cloud-go/compare/compute/v1.63.0...compute/v1.64.0) (2026-05-21)

### Features

* update API sources and regenerate (#14621) ([6641db88](https://github.com/googleapis/google-cloud-go/commit/6641db88))

</details>


<details><summary>datamanager: v1.1.0</summary>

## [v1.1.0](https://github.com/googleapis/google-cloud-go/compare/datamanager/v1.0.0...datamanager/v1.1.0) (2026-05-21)

### Features

* update API sources and regenerate (#14621) ([6641db88](https://github.com/googleapis/google-cloud-go/commit/6641db88))

</details>


<details><summary>support: v1.11.0</summary>

## [v1.11.0](https://github.com/googleapis/google-cloud-go/compare/support/v1.10.0...support/v1.11.0) (2026-05-21)

### Features

* update API sources and regenerate (#14621) ([6641db88](https://github.com/googleapis/google-cloud-go/commit/6641db88))

</details>