### PR TITLE
fix(internal/gapicgen): use actual HEAD commit for recordGoogleapisHash

### DIFF
--- a/internal/gapicgen/generator/generator.go
+++ b/internal/gapicgen/generator/generator.go
@@ -133,12 +133,9 @@ func gatherChanges(googleapisDir, genprotoDir string) ([]*git.ChangeInfo, error)
 // recordGoogleapisHash parses the latest commit in googleapis and records it to
 // regen.txt in go-genproto.
 func recordGoogleapisHash(googleapisDir, genprotoDir string) error {
-	commits, err := git.CommitsSinceHash(googleapisDir, "HEAD", true)
+	hash, err := git.HeadHash(googleapisDir)
 	if err != nil {
 		return err
-	}
-	if len(commits) != 1 {
-		return fmt.Errorf("only expected one commit, got %d", len(commits))
 	}
 
 	f, err := os.OpenFile(filepath.Join(genprotoDir, "regen.txt"), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
@@ -146,7 +143,7 @@ func recordGoogleapisHash(googleapisDir, genprotoDir string) error {
 		return err
 	}
 	defer f.Close()
-	if _, err := f.WriteString(commits[0]); err != nil {
+	if _, err := f.WriteString(hash); err != nil {
 		return err
 	}
 	return nil

--- a/internal/gapicgen/generator/generator.go
+++ b/internal/gapicgen/generator/generator.go
@@ -137,8 +137,12 @@ func recordGoogleapisHash(googleapisDir, genprotoDir string) error {
 	if err != nil {
 		return err
 	}
+	if hash == "" {
+		return fmt.Errorf("git.HeadHash: empty output")
+	}
 
 	f, err := os.OpenFile(filepath.Join(genprotoDir, "regen.txt"), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+
 	if err != nil {
 		return err
 	}

--- a/internal/gapicgen/git/git.go
+++ b/internal/gapicgen/git/git.go
@@ -15,9 +15,11 @@
 package git
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"os"
+	"os/exec"
 	"strings"
 
 	"cloud.google.com/go/internal/gapicgen/execv"
@@ -220,6 +222,10 @@ func HeadHash(gitDir string) (string, error) {
 	c.Dir = gitDir
 	b, err := c.Output()
 	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return "", fmt.Errorf("git rev-parse HEAD failed: %w (stderr: %s)", err, string(exitErr.Stderr))
+		}
 		return "", err
 	}
 	return strings.TrimSpace(string(b)), nil

--- a/internal/gapicgen/git/git.go
+++ b/internal/gapicgen/git/git.go
@@ -213,3 +213,14 @@ func GetFileContentAtCommit(gitDir, hash, filePath string) ([]byte, error) {
 	}
 	return b, nil
 }
+
+// HeadHash returns the HEAD commit hash for the given gitDir.
+func HeadHash(gitDir string) (string, error) {
+	c := execv.Command("git", "rev-parse", "HEAD")
+	c.Dir = gitDir
+	b, err := c.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(b)), nil
+}


### PR DESCRIPTION
Fixes a bug where `recordGoogleapisHash` could write an empty string to `regen.txt`, breaking subsequent runs of the auto-regeneration bot.

### Cause of the bug:
During a refactoring in PR #3174, `recordGoogleapisHash` was changed to reuse `git.CommitsSinceHash(..., "HEAD", true)`. 
However, `CommitsSinceHash` applies a pathspec filter (e.g., excluding `preview/`). If the latest commit (HEAD) in `googleapis` at the time of the run only modified excluded files, `CommitsSinceHash` returned empty. 
Due to `strings.Split` behavior on empty strings, this was parsed as `[""]` and written to `regen.txt` as an empty string.
Subsequent runs read this empty string and executed `git diff-tree ..HEAD`, which returned no files, causing the bot to silently skip generation.

### Solution:
Introduced `git.HeadHash` which uses `git rev-parse HEAD` to get the actual HEAD commit hash of `googleapis` without any pathspec filtering. This ensures we always record a valid hash, marking that we have processed up to that commit. 

