### PR TITLE
feat(bigtable): add traffic diverter and table shim  for bigtable

### DIFF
--- a/bigtable/internal/transport/diverter.go
+++ b/bigtable/internal/transport/diverter.go
@@ -1,0 +1,50 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"math"
+	"math/rand/v2"
+	"sync/atomic"
+)
+
+// Diverter decides whether to use the session-based protocol or classic protocol.
+type Diverter struct {
+	sessionLoadBits atomic.Uint64
+}
+
+// NewDiverter creates a new Diverter with the given session load ratio (0.0 to 1.0).
+func NewDiverter(sessionLoad float64) *Diverter {
+	d := &Diverter{}
+	d.sessionLoadBits.Store(math.Float64bits(sessionLoad))
+	return d
+}
+
+// SetSessionLoad updates the session load ratio.
+func (d *Diverter) SetSessionLoad(load float64) {
+	d.sessionLoadBits.Store(math.Float64bits(load))
+}
+
+// UseSession returns true if the next call should use the session protocol.
+func (d *Diverter) UseSession() bool {
+	load := math.Float64frombits(d.sessionLoadBits.Load())
+	if load <= 0 {
+		return false
+	}
+	if load >= 1 {
+		return true
+	}
+	return rand.Float64() <= load
+}

--- a/bigtable/internal/transport/diverter_test.go
+++ b/bigtable/internal/transport/diverter_test.go
@@ -1,0 +1,114 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestDiverterZeroAndOne(t *testing.T) {
+	tests := []struct {
+		name         string
+		sessionLoad  float64
+		expectedRes  bool
+	}{
+		{
+			name:        "Load is zero",
+			sessionLoad: 0.0,
+			expectedRes: false,
+		},
+		{
+			name:        "Load is negative",
+			sessionLoad: -0.5,
+			expectedRes: false,
+		},
+		{
+			name:        "Load is one",
+			sessionLoad: 1.0,
+			expectedRes: true,
+		},
+		{
+			name:        "Load is greater than one",
+			sessionLoad: 1.5,
+			expectedRes: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			d := NewDiverter(tc.sessionLoad)
+			for i := 0; i < 1000; i++ {
+				if got := d.UseSession(); got != tc.expectedRes {
+					t.Errorf("UseSession() = %v, want %v for load %f", got, tc.expectedRes, tc.sessionLoad)
+				}
+			}
+		})
+	}
+}
+
+func TestDiverterSetSessionLoad(t *testing.T) {
+	d := NewDiverter(0.0)
+	if got := d.UseSession(); got != false {
+		t.Errorf("Expected initial UseSession() to be false, got %v", got)
+	}
+
+	d.SetSessionLoad(1.0)
+	if got := d.UseSession(); got != true {
+		t.Errorf("Expected UseSession() to be true after SetSessionLoad(1.0), got %v", got)
+	}
+}
+
+func TestDiverterProbabilistic(t *testing.T) {
+	load := 0.4
+	d := NewDiverter(load)
+	iterations := 10000
+	trueCount := 0
+
+	for i := 0; i < iterations; i++ {
+		if d.UseSession() {
+			trueCount++
+		}
+	}
+
+	expected := int(float64(iterations) * load)
+	tolerance := 300 // Allow a variance range of +/- 3% of total iterations
+
+	if trueCount < expected-tolerance || trueCount > expected+tolerance {
+		t.Errorf("Expected approximately %d true results (with tolerance %d), got %d", expected, tolerance, trueCount)
+	}
+}
+
+func TestDiverterConcurrentAccess(t *testing.T) {
+	d := NewDiverter(0.5)
+	var wg sync.WaitGroup
+	numWorkers := 20
+	iterations := 1000
+
+	for i := 0; i < numWorkers; i++ {
+		wg.Add(1)
+		go func(workerID int) {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				if j%10 == 0 {
+					d.SetSessionLoad(float64(workerID) / float64(numWorkers))
+				}
+				_ = d.UseSession()
+			}
+		}(i)
+	}
+
+	wg.Wait()
+}

--- a/bigtable/internal/transport/diverter_test.go
+++ b/bigtable/internal/transport/diverter_test.go
@@ -21,9 +21,9 @@ import (
 
 func TestDiverterZeroAndOne(t *testing.T) {
 	tests := []struct {
-		name         string
-		sessionLoad  float64
-		expectedRes  bool
+		name        string
+		sessionLoad float64
+		expectedRes bool
 	}{
 		{
 			name:        "Load is zero",

--- a/bigtable/table_shim.go
+++ b/bigtable/table_shim.go
@@ -1,3 +1,17 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package bigtable
 
 import (

--- a/bigtable/table_shim.go
+++ b/bigtable/table_shim.go
@@ -39,15 +39,7 @@ func NewTableShim(classic, session TableAPI, diverter *internal.Diverter) TableA
 // ReadRow implements TableAPI.
 func (t *TableShim) ReadRow(ctx context.Context, row string, opts ...ReadOption) (Row, error) {
 	if t.diverter.UseSession() {
-		rowRes, err := t.session.ReadRow(ctx, row, opts...)
-		if err != nil {
-			// Do not fall back to classic if the session call failed because the context was cancelled or timed out.
-			if ctx.Err() != nil {
-				return nil, err
-			}
-			return t.classic.ReadRow(ctx, row, opts...)
-		}
-		return rowRes, nil
+		return t.session.ReadRow(ctx, row, opts...)
 	}
 	return t.classic.ReadRow(ctx, row, opts...)
 }
@@ -55,15 +47,7 @@ func (t *TableShim) ReadRow(ctx context.Context, row string, opts ...ReadOption)
 // Apply implements TableAPI.
 func (t *TableShim) Apply(ctx context.Context, row string, m *Mutation, opts ...ApplyOption) error {
 	if t.diverter.UseSession() {
-		err := t.session.Apply(ctx, row, m, opts...)
-		if err != nil {
-			// Do not fall back to classic if the session call failed because the context was cancelled or timed out.
-			if ctx.Err() != nil {
-				return err
-			}
-			return t.classic.Apply(ctx, row, m, opts...)
-		}
-		return nil
+		return t.session.Apply(ctx, row, m, opts...)
 	}
 	return t.classic.Apply(ctx, row, m, opts...)
 }

--- a/bigtable/table_shim.go
+++ b/bigtable/table_shim.go
@@ -1,0 +1,75 @@
+package bigtable
+
+import (
+	"context"
+
+	internal "cloud.google.com/go/bigtable/internal/transport"
+)
+
+// TableShim wraps a classic and a session-based TableAPI and diverts traffic between them.
+type TableShim struct {
+	classic  TableAPI
+	session  TableAPI
+	diverter *internal.Diverter
+}
+
+// NewTableShim creates a new TableShim.
+func NewTableShim(classic, session TableAPI, diverter *internal.Diverter) TableAPI {
+	return &TableShim{
+		classic:  classic,
+		session:  session,
+		diverter: diverter,
+	}
+}
+
+// ReadRow implements TableAPI.
+func (t *TableShim) ReadRow(ctx context.Context, row string, opts ...ReadOption) (Row, error) {
+	if t.diverter.UseSession() {
+		rowRes, err := t.session.ReadRow(ctx, row, opts...)
+		if err != nil {
+			// Do not fall back to classic if the session call failed because the context was cancelled or timed out.
+			if ctx.Err() != nil {
+				return nil, err
+			}
+			return t.classic.ReadRow(ctx, row, opts...)
+		}
+		return rowRes, nil
+	}
+	return t.classic.ReadRow(ctx, row, opts...)
+}
+
+// Apply implements TableAPI.
+func (t *TableShim) Apply(ctx context.Context, row string, m *Mutation, opts ...ApplyOption) error {
+	if t.diverter.UseSession() {
+		err := t.session.Apply(ctx, row, m, opts...)
+		if err != nil {
+			// Do not fall back to classic if the session call failed because the context was cancelled or timed out.
+			if ctx.Err() != nil {
+				return err
+			}
+			return t.classic.Apply(ctx, row, m, opts...)
+		}
+		return nil
+	}
+	return t.classic.Apply(ctx, row, m, opts...)
+}
+
+// ReadRows implements TableAPI. It delegates to classic as session support is not yet implemented.
+func (t *TableShim) ReadRows(ctx context.Context, arg RowSet, f func(Row) bool, opts ...ReadOption) error {
+	return t.classic.ReadRows(ctx, arg, f, opts...)
+}
+
+// SampleRowKeys implements TableAPI. It delegates to classic.
+func (t *TableShim) SampleRowKeys(ctx context.Context) ([]string, error) {
+	return t.classic.SampleRowKeys(ctx)
+}
+
+// ApplyBulk implements TableAPI. It delegates to classic.
+func (t *TableShim) ApplyBulk(ctx context.Context, rowKeys []string, muts []*Mutation, opts ...ApplyOption) ([]error, error) {
+	return t.classic.ApplyBulk(ctx, rowKeys, muts, opts...)
+}
+
+// ApplyReadModifyWrite implements TableAPI. It delegates to classic.
+func (t *TableShim) ApplyReadModifyWrite(ctx context.Context, row string, m *ReadModifyWrite) (Row, error) {
+	return t.classic.ApplyReadModifyWrite(ctx, row, m)
+}

--- a/bigtable/table_shim_test.go
+++ b/bigtable/table_shim_test.go
@@ -147,7 +147,7 @@ func TestTableShim_ReadRow(t *testing.T) {
 		}
 	})
 
-	t.Run("Session fails and falls back to classic when context is NOT cancelled", func(t *testing.T) {
+	t.Run("Session fails and returns error directly without falling back to classic", func(t *testing.T) {
 		classicCalled := false
 		sessionCalled := false
 
@@ -167,50 +167,12 @@ func TestTableShim_ReadRow(t *testing.T) {
 		diverter := internal.NewDiverter(1.0)
 		shim := NewTableShim(classic, session, diverter)
 
-		res, err := shim.ReadRow(context.Background(), "row1")
-		if err != nil {
-			t.Errorf("Unexpected error: %v", err)
-		}
-		if res.Key() != "row1" {
-			t.Errorf("Expected row key row1, got %s", res.Key())
-		}
-		if !classicCalled {
-			t.Error("Expected classic to be called on fallback")
-		}
-		if !sessionCalled {
-			t.Error("Expected session to be called first")
-		}
-	})
-
-	t.Run("Session fails and does NOT fall back when context IS cancelled", func(t *testing.T) {
-		classicCalled := false
-		sessionCalled := false
-
-		classic := &mockTableAPI{
-			readRowFunc: func(ctx context.Context, row string, opts ...ReadOption) (Row, error) {
-				classicCalled = true
-				return dummyRow, nil
-			},
-		}
-		session := &mockTableAPI{
-			readRowFunc: func(ctx context.Context, row string, opts ...ReadOption) (Row, error) {
-				sessionCalled = true
-				return nil, dummyErr
-			},
-		}
-
-		diverter := internal.NewDiverter(1.0)
-		shim := NewTableShim(classic, session, diverter)
-
-		ctx, cancel := context.WithCancel(context.Background())
-		cancel() // Cancel the context immediately
-
-		_, err := shim.ReadRow(ctx, "row1")
+		_, err := shim.ReadRow(context.Background(), "row1")
 		if err != dummyErr {
 			t.Errorf("Expected session error %v, got %v", dummyErr, err)
 		}
 		if classicCalled {
-			t.Error("Expected classic NOT to be called when context is cancelled")
+			t.Error("Expected classic NOT to be called")
 		}
 		if !sessionCalled {
 			t.Error("Expected session to be called")
@@ -285,7 +247,7 @@ func TestTableShim_Apply(t *testing.T) {
 		}
 	})
 
-	t.Run("Session fails and falls back to classic when context is NOT cancelled", func(t *testing.T) {
+	t.Run("Session fails and returns error directly without falling back to classic", func(t *testing.T) {
 		classicCalled := false
 		sessionCalled := false
 
@@ -306,46 +268,11 @@ func TestTableShim_Apply(t *testing.T) {
 		shim := NewTableShim(classic, session, diverter)
 
 		err := shim.Apply(context.Background(), "row1", NewMutation())
-		if err != nil {
-			t.Errorf("Unexpected error: %v", err)
-		}
-		if !classicCalled {
-			t.Error("Expected classic to be called on fallback")
-		}
-		if !sessionCalled {
-			t.Error("Expected session to be called first")
-		}
-	})
-
-	t.Run("Session fails and does NOT fall back when context IS cancelled", func(t *testing.T) {
-		classicCalled := false
-		sessionCalled := false
-
-		classic := &mockTableAPI{
-			applyFunc: func(ctx context.Context, row string, m *Mutation, opts ...ApplyOption) error {
-				classicCalled = true
-				return nil
-			},
-		}
-		session := &mockTableAPI{
-			applyFunc: func(ctx context.Context, row string, m *Mutation, opts ...ApplyOption) error {
-				sessionCalled = true
-				return dummyErr
-			},
-		}
-
-		diverter := internal.NewDiverter(1.0)
-		shim := NewTableShim(classic, session, diverter)
-
-		ctx, cancel := context.WithCancel(context.Background())
-		cancel() // Cancel the context immediately
-
-		err := shim.Apply(ctx, "row1", NewMutation())
 		if err != dummyErr {
 			t.Errorf("Expected session error %v, got %v", dummyErr, err)
 		}
 		if classicCalled {
-			t.Error("Expected classic NOT to be called when context is cancelled")
+			t.Error("Expected classic NOT to be called")
 		}
 		if !sessionCalled {
 			t.Error("Expected session to be called")

--- a/bigtable/table_shim_test.go
+++ b/bigtable/table_shim_test.go
@@ -1,0 +1,430 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bigtable
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	internal "cloud.google.com/go/bigtable/internal/transport"
+)
+
+type mockTableAPI struct {
+	readRowFunc              func(ctx context.Context, row string, opts ...ReadOption) (Row, error)
+	applyFunc                func(ctx context.Context, row string, m *Mutation, opts ...ApplyOption) error
+	readRowsFunc             func(ctx context.Context, arg RowSet, f func(Row) bool, opts ...ReadOption) error
+	sampleRowKeysFunc        func(ctx context.Context) ([]string, error)
+	applyBulkFunc            func(ctx context.Context, rowKeys []string, muts []*Mutation, opts ...ApplyOption) ([]error, error)
+	applyReadModifyWriteFunc func(ctx context.Context, row string, m *ReadModifyWrite) (Row, error)
+}
+
+func (m *mockTableAPI) ReadRows(ctx context.Context, arg RowSet, f func(Row) bool, opts ...ReadOption) error {
+	if m.readRowsFunc != nil {
+		return m.readRowsFunc(ctx, arg, f, opts...)
+	}
+	return nil
+}
+
+func (m *mockTableAPI) ReadRow(ctx context.Context, row string, opts ...ReadOption) (Row, error) {
+	if m.readRowFunc != nil {
+		return m.readRowFunc(ctx, row, opts...)
+	}
+	return nil, nil
+}
+
+func (m *mockTableAPI) SampleRowKeys(ctx context.Context) ([]string, error) {
+	if m.sampleRowKeysFunc != nil {
+		return m.sampleRowKeysFunc(ctx)
+	}
+	return nil, nil
+}
+
+func (m *mockTableAPI) Apply(ctx context.Context, row string, mutation *Mutation, opts ...ApplyOption) error {
+	if m.applyFunc != nil {
+		return m.applyFunc(ctx, row, mutation, opts...)
+	}
+	return nil
+}
+
+func (m *mockTableAPI) ApplyBulk(ctx context.Context, rowKeys []string, muts []*Mutation, opts ...ApplyOption) ([]error, error) {
+	if m.applyBulkFunc != nil {
+		return m.applyBulkFunc(ctx, rowKeys, muts, opts...)
+	}
+	return nil, nil
+}
+
+func (m *mockTableAPI) ApplyReadModifyWrite(ctx context.Context, row string, rmw *ReadModifyWrite) (Row, error) {
+	if m.applyReadModifyWriteFunc != nil {
+		return m.applyReadModifyWriteFunc(ctx, row, rmw)
+	}
+	return nil, nil
+}
+
+func TestTableShim_ReadRow(t *testing.T) {
+	dummyRow := Row{"fam": []ReadItem{{Row: "row1"}}}
+	dummyErr := errors.New("dummy error")
+
+	t.Run("Classic only when UseSession is false", func(t *testing.T) {
+		classicCalled := false
+		sessionCalled := false
+
+		classic := &mockTableAPI{
+			readRowFunc: func(ctx context.Context, row string, opts ...ReadOption) (Row, error) {
+				classicCalled = true
+				return dummyRow, nil
+			},
+		}
+		session := &mockTableAPI{
+			readRowFunc: func(ctx context.Context, row string, opts ...ReadOption) (Row, error) {
+				sessionCalled = true
+				return nil, dummyErr
+			},
+		}
+
+		diverter := internal.NewDiverter(0.0) // 0% load
+		shim := NewTableShim(classic, session, diverter)
+
+		res, err := shim.ReadRow(context.Background(), "row1")
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+		if res.Key() != "row1" {
+			t.Errorf("Expected row key row1, got %s", res.Key())
+		}
+		if !classicCalled {
+			t.Error("Expected classic to be called")
+		}
+		if sessionCalled {
+			t.Error("Expected session NOT to be called")
+		}
+	})
+
+	t.Run("Session only when UseSession is true and succeeds", func(t *testing.T) {
+		classicCalled := false
+		sessionCalled := false
+
+		classic := &mockTableAPI{
+			readRowFunc: func(ctx context.Context, row string, opts ...ReadOption) (Row, error) {
+				classicCalled = true
+				return nil, dummyErr
+			},
+		}
+		session := &mockTableAPI{
+			readRowFunc: func(ctx context.Context, row string, opts ...ReadOption) (Row, error) {
+				sessionCalled = true
+				return dummyRow, nil
+			},
+		}
+
+		diverter := internal.NewDiverter(1.0) // 100% load
+		shim := NewTableShim(classic, session, diverter)
+
+		res, err := shim.ReadRow(context.Background(), "row1")
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+		if res.Key() != "row1" {
+			t.Errorf("Expected row key row1, got %s", res.Key())
+		}
+		if classicCalled {
+			t.Error("Expected classic NOT to be called")
+		}
+		if !sessionCalled {
+			t.Error("Expected session to be called")
+		}
+	})
+
+	t.Run("Session fails and falls back to classic when context is NOT cancelled", func(t *testing.T) {
+		classicCalled := false
+		sessionCalled := false
+
+		classic := &mockTableAPI{
+			readRowFunc: func(ctx context.Context, row string, opts ...ReadOption) (Row, error) {
+				classicCalled = true
+				return dummyRow, nil
+			},
+		}
+		session := &mockTableAPI{
+			readRowFunc: func(ctx context.Context, row string, opts ...ReadOption) (Row, error) {
+				sessionCalled = true
+				return nil, dummyErr
+			},
+		}
+
+		diverter := internal.NewDiverter(1.0)
+		shim := NewTableShim(classic, session, diverter)
+
+		res, err := shim.ReadRow(context.Background(), "row1")
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+		if res.Key() != "row1" {
+			t.Errorf("Expected row key row1, got %s", res.Key())
+		}
+		if !classicCalled {
+			t.Error("Expected classic to be called on fallback")
+		}
+		if !sessionCalled {
+			t.Error("Expected session to be called first")
+		}
+	})
+
+	t.Run("Session fails and does NOT fall back when context IS cancelled", func(t *testing.T) {
+		classicCalled := false
+		sessionCalled := false
+
+		classic := &mockTableAPI{
+			readRowFunc: func(ctx context.Context, row string, opts ...ReadOption) (Row, error) {
+				classicCalled = true
+				return dummyRow, nil
+			},
+		}
+		session := &mockTableAPI{
+			readRowFunc: func(ctx context.Context, row string, opts ...ReadOption) (Row, error) {
+				sessionCalled = true
+				return nil, dummyErr
+			},
+		}
+
+		diverter := internal.NewDiverter(1.0)
+		shim := NewTableShim(classic, session, diverter)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // Cancel the context immediately
+
+		_, err := shim.ReadRow(ctx, "row1")
+		if err != dummyErr {
+			t.Errorf("Expected session error %v, got %v", dummyErr, err)
+		}
+		if classicCalled {
+			t.Error("Expected classic NOT to be called when context is cancelled")
+		}
+		if !sessionCalled {
+			t.Error("Expected session to be called")
+		}
+	})
+}
+
+func TestTableShim_Apply(t *testing.T) {
+	dummyErr := errors.New("dummy error")
+
+	t.Run("Classic only when UseSession is false", func(t *testing.T) {
+		classicCalled := false
+		sessionCalled := false
+
+		classic := &mockTableAPI{
+			applyFunc: func(ctx context.Context, row string, m *Mutation, opts ...ApplyOption) error {
+				classicCalled = true
+				return nil
+			},
+		}
+		session := &mockTableAPI{
+			applyFunc: func(ctx context.Context, row string, m *Mutation, opts ...ApplyOption) error {
+				sessionCalled = true
+				return dummyErr
+			},
+		}
+
+		diverter := internal.NewDiverter(0.0)
+		shim := NewTableShim(classic, session, diverter)
+
+		err := shim.Apply(context.Background(), "row1", NewMutation())
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+		if !classicCalled {
+			t.Error("Expected classic to be called")
+		}
+		if sessionCalled {
+			t.Error("Expected session NOT to be called")
+		}
+	})
+
+	t.Run("Session only when UseSession is true and succeeds", func(t *testing.T) {
+		classicCalled := false
+		sessionCalled := false
+
+		classic := &mockTableAPI{
+			applyFunc: func(ctx context.Context, row string, m *Mutation, opts ...ApplyOption) error {
+				classicCalled = true
+				return dummyErr
+			},
+		}
+		session := &mockTableAPI{
+			applyFunc: func(ctx context.Context, row string, m *Mutation, opts ...ApplyOption) error {
+				sessionCalled = true
+				return nil
+			},
+		}
+
+		diverter := internal.NewDiverter(1.0)
+		shim := NewTableShim(classic, session, diverter)
+
+		err := shim.Apply(context.Background(), "row1", NewMutation())
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+		if classicCalled {
+			t.Error("Expected classic NOT to be called")
+		}
+		if !sessionCalled {
+			t.Error("Expected session to be called")
+		}
+	})
+
+	t.Run("Session fails and falls back to classic when context is NOT cancelled", func(t *testing.T) {
+		classicCalled := false
+		sessionCalled := false
+
+		classic := &mockTableAPI{
+			applyFunc: func(ctx context.Context, row string, m *Mutation, opts ...ApplyOption) error {
+				classicCalled = true
+				return nil
+			},
+		}
+		session := &mockTableAPI{
+			applyFunc: func(ctx context.Context, row string, m *Mutation, opts ...ApplyOption) error {
+				sessionCalled = true
+				return dummyErr
+			},
+		}
+
+		diverter := internal.NewDiverter(1.0)
+		shim := NewTableShim(classic, session, diverter)
+
+		err := shim.Apply(context.Background(), "row1", NewMutation())
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+		if !classicCalled {
+			t.Error("Expected classic to be called on fallback")
+		}
+		if !sessionCalled {
+			t.Error("Expected session to be called first")
+		}
+	})
+
+	t.Run("Session fails and does NOT fall back when context IS cancelled", func(t *testing.T) {
+		classicCalled := false
+		sessionCalled := false
+
+		classic := &mockTableAPI{
+			applyFunc: func(ctx context.Context, row string, m *Mutation, opts ...ApplyOption) error {
+				classicCalled = true
+				return nil
+			},
+		}
+		session := &mockTableAPI{
+			applyFunc: func(ctx context.Context, row string, m *Mutation, opts ...ApplyOption) error {
+				sessionCalled = true
+				return dummyErr
+			},
+		}
+
+		diverter := internal.NewDiverter(1.0)
+		shim := NewTableShim(classic, session, diverter)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // Cancel the context immediately
+
+		err := shim.Apply(ctx, "row1", NewMutation())
+		if err != dummyErr {
+			t.Errorf("Expected session error %v, got %v", dummyErr, err)
+		}
+		if classicCalled {
+			t.Error("Expected classic NOT to be called when context is cancelled")
+		}
+		if !sessionCalled {
+			t.Error("Expected session to be called")
+		}
+	})
+}
+
+func TestTableShim_DelegatedMethods(t *testing.T) {
+	classicCalled := false
+	sessionCalled := false
+
+	classic := &mockTableAPI{
+		readRowsFunc: func(ctx context.Context, arg RowSet, f func(Row) bool, opts ...ReadOption) error {
+			classicCalled = true
+			return nil
+		},
+		sampleRowKeysFunc: func(ctx context.Context) ([]string, error) {
+			classicCalled = true
+			return nil, nil
+		},
+		applyBulkFunc: func(ctx context.Context, rowKeys []string, muts []*Mutation, opts ...ApplyOption) ([]error, error) {
+			classicCalled = true
+			return nil, nil
+		},
+		applyReadModifyWriteFunc: func(ctx context.Context, row string, m *ReadModifyWrite) (Row, error) {
+			classicCalled = true
+			return nil, nil
+		},
+	}
+	session := &mockTableAPI{
+		readRowsFunc: func(ctx context.Context, arg RowSet, f func(Row) bool, opts ...ReadOption) error {
+			sessionCalled = true
+			return nil
+		},
+		sampleRowKeysFunc: func(ctx context.Context) ([]string, error) {
+			sessionCalled = true
+			return nil, nil
+		},
+		applyBulkFunc: func(ctx context.Context, rowKeys []string, muts []*Mutation, opts ...ApplyOption) ([]error, error) {
+			sessionCalled = true
+			return nil, nil
+		},
+		applyReadModifyWriteFunc: func(ctx context.Context, row string, m *ReadModifyWrite) (Row, error) {
+			sessionCalled = true
+			return nil, nil
+		},
+	}
+
+	diverter := internal.NewDiverter(1.0) // Even with 100% session load, these delegate to classic
+	shim := NewTableShim(classic, session, diverter)
+
+	// ReadRows
+	classicCalled = false
+	_ = shim.ReadRows(context.Background(), RowRange{}, func(r Row) bool { return true })
+	if !classicCalled || sessionCalled {
+		t.Errorf("ReadRows: expected classic called: %v, session called: %v", classicCalled, sessionCalled)
+	}
+
+	// SampleRowKeys
+	classicCalled = false
+	sessionCalled = false
+	_, _ = shim.SampleRowKeys(context.Background())
+	if !classicCalled || sessionCalled {
+		t.Errorf("SampleRowKeys: expected classic called: %v, session called: %v", classicCalled, sessionCalled)
+	}
+
+	// ApplyBulk
+	classicCalled = false
+	sessionCalled = false
+	_, _ = shim.ApplyBulk(context.Background(), nil, nil)
+	if !classicCalled || sessionCalled {
+		t.Errorf("ApplyBulk: expected classic called: %v, session called: %v", classicCalled, sessionCalled)
+	}
+
+	// ApplyReadModifyWrite
+	classicCalled = false
+	sessionCalled = false
+	_, _ = shim.ApplyReadModifyWrite(context.Background(), "row1", nil)
+	if !classicCalled || sessionCalled {
+		t.Errorf("ApplyReadModifyWrite: expected classic called: %v, session called: %v", classicCalled, sessionCalled)
+	}
+}


### PR DESCRIPTION
We will read the ClientConfig and call Diverter for how much load we will use for session.
We will use TableShim for diverting traffic between classic and session impl.