### PR TITLE
fix(internal/gapicgen): fix genproto regeneration failures

### DIFF
--- a/internal/gapicgen/execv/gocmd/gocmd.go
+++ b/internal/gapicgen/execv/gocmd/gocmd.go
@@ -117,7 +117,16 @@ func Vet(dir string) error {
 		return err
 	}
 
-	c = execv.Command("gofmt", "-s", "-w", "-l", ".")
-	c.Dir = dir
-	return c.Run()
+	// Run once to print diffs to stdout (which gets logged by execv).
+	// We ignore the error here because gofmt -d exits with 1 if there are diffs,
+	// but we still want to proceed to write them.
+	c1 := execv.Command("gofmt", "-s", "-d", "-l", ".")
+	c1.Dir = dir
+	_ = c1.Run()
+
+	// Run again to actually write the changes.
+	// We do not ignore the error here to ensure we catch any real failures.
+	c2 := execv.Command("gofmt", "-s", "-w", ".")
+	c2.Dir = dir
+	return c2.Run()
 }

--- a/internal/gapicgen/execv/gocmd/gocmd.go
+++ b/internal/gapicgen/execv/gocmd/gocmd.go
@@ -117,7 +117,7 @@ func Vet(dir string) error {
 		return err
 	}
 
-	c = execv.Command("gofmt", "-s", "-d", "-w", "-l", ".")
+	c = execv.Command("gofmt", "-s", "-w", "-l", ".")
 	c.Dir = dir
 	return c.Run()
 }

--- a/internal/gapicgen/generator/genproto.go
+++ b/internal/gapicgen/generator/genproto.go
@@ -168,7 +168,7 @@ func (g *GenprotoGenerator) Regen(ctx context.Context) error {
 	// if the last regenerated hash is earlier than the top commit, the git diff-tree
 	// command fails. This is is a bit of a rough edge. Using my local clone of
 	// googleapis rectified the issue.
-	pkgFiles, err := g.getUpdatedPackages(string(lastHash))
+	pkgFiles, err := g.getUpdatedPackages(strings.TrimSpace(string(lastHash)))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR fixes two issues in `gapicgen` that cause regeneration failures:

1. **Trim whitespace from `regen.txt`:**
   The `Regen` function now trims whitespace from the hash read from `regen.txt` before passing it to `git diff-tree`. This prevents "bad revision" errors if `regen.txt` contains trailing newlines or spaces (as happened recently with a manual update).

2. **Handle `gofmt` in `Vet` by running it twice:**
   Modified `gocmd.Vet` to run `gofmt` twice to preserve diff logging without failing the build on exit code 1:
   - First run: `gofmt -s -d -l .` to print formatting diffs to the logs. We explicitly ignore the error/exit code here because `gofmt -d` exits with 1 when differences are found.
   - Second run: `gofmt -s -w .` to actually write the formatting changes. We do not ignore the error here, ensuring we still catch real failures (like syntax errors or write permission issues).
   This avoids having to check for specific exit codes while ensuring the build only fails on real errors.


