### PR TITLE
fix(internal/gapicgen): install protoc-gen-go-grpc in genbot image

### DIFF
--- a/internal/gapicgen/cmd/genbot/Dockerfile
+++ b/internal/gapicgen/cmd/genbot/Dockerfile
@@ -27,7 +27,8 @@ ENV PATH /usr/local/go/bin:$PATH
 RUN go version
 
 # Install Go tools.
-RUN go install github.com/golang/protobuf/protoc-gen-go@v1.5.3 && \
+RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.36.11 && \
+    go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.6.2 && \
     go install golang.org/x/lint/golint@latest && \
     go install golang.org/x/tools/cmd/goimports@latest && \
     go install honnef.co/go/tools/cmd/staticcheck@latest && \


### PR DESCRIPTION
This PR installs the `protoc-gen-go-grpc` plugin in the `genbot` Docker image to resolve:
build #52106 in prod:cloud-devrel/client-libraries/go/gapicgen/genbot fails with error "protoc-gen-go-grpc: program not found or is not executable"

### Cause of the bug:
In a previous PR (#14492 internal/gapicgen/generator/genproto.go ), the `genproto` regeneration was migrated to use split plugins (`--go_out` and `--go-grpc_out`) instead of the old `plugins=grpc` option. However, the Dockerfile was not updated to install the new `protoc-gen-go-grpc` plugin, leading to "plugin failed" errors during build when compiling protos that require gRPC.

### Solution:
- Added installation of `google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.6.2` to the Dockerfile (matching the version used in `gapic-showcase`).
- Updated `protoc-gen-go` installation to use the modern path `google.golang.org/protobuf/cmd/protoc-gen-go@v1.36.11` (aligned with the runtime version in `go.mod`).


