### PR TITLE
feat(spanner): add option for auto-tagging transactions

### DIFF
--- a/spanner/autotagging_test.go
+++ b/spanner/autotagging_test.go
@@ -1,0 +1,364 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package spanner
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
+	. "cloud.google.com/go/spanner/internal/testutil"
+)
+
+func TestAutoTagging_ReadOnlyTransaction(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	server, client, teardown := setupMockedTestServerWithConfig(t, ClientConfig{
+		DisableNativeMetrics: true,
+		EnableAutoTagging:    true,
+		AutoTaggingPackages:  []string{"cloud.google.com/go/spanner.TestAutoTagging"},
+	})
+	defer teardown()
+
+	ro := client.ReadOnlyTransaction()
+	defer ro.Close()
+
+	iter := ro.Query(ctx, NewStatement(SelectSingerIDAlbumIDAlbumTitleFromAlbums))
+	_ = iter.Do(func(row *Row) error { return nil })
+
+	// Verify request_tag is populated and transaction_tag is empty
+	reqs := drainRequestsFromServer(server.TestSpanner)
+	found := false
+	for _, s := range reqs {
+		if req, ok := s.(*sppb.ExecuteSqlRequest); ok {
+			found = true
+			if req.RequestOptions == nil || req.RequestOptions.RequestTag == "" {
+				t.Errorf("Expected request_tag to be populated, got empty")
+			} else if !strings.Contains(req.RequestOptions.RequestTag, "TestAutoTagging") {
+				t.Errorf("Expected request_tag to contain TestAutoTagging, got %q", req.RequestOptions.RequestTag)
+			}
+			if req.RequestOptions != nil && req.RequestOptions.TransactionTag != "" {
+				t.Errorf("Expected transaction_tag to be empty, got %q", req.RequestOptions.TransactionTag)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("No ExecuteSqlRequest found")
+	}
+}
+
+func TestAutoTagging_ReadWriteTransaction(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	server, client, teardown := setupMockedTestServerWithConfig(t, ClientConfig{
+		DisableNativeMetrics: true,
+		EnableAutoTagging:    true,
+		AutoTaggingPackages:  []string{"cloud.google.com/go/spanner.TestAutoTagging"},
+	})
+	defer teardown()
+
+	_, _ = client.ReadWriteTransaction(ctx, func(ctx context.Context, txn *ReadWriteTransaction) error {
+		_, _ = txn.Update(ctx, NewStatement(UpdateBarSetFoo))
+		return nil
+	})
+
+	reqs := drainRequestsFromServer(server.TestSpanner)
+	hasStmt, hasCommit := false, false
+	for _, s := range reqs {
+		if req, ok := s.(*sppb.ExecuteSqlRequest); ok {
+			hasStmt = true
+			if req.RequestOptions != nil && req.RequestOptions.RequestTag != "" {
+				t.Errorf("Expected request_tag to be empty in RW tx, got %q", req.RequestOptions.RequestTag)
+			}
+			if req.RequestOptions == nil || !strings.Contains(req.RequestOptions.TransactionTag, "TestAutoTagging") {
+				t.Errorf("Expected transaction_tag to be populated in RW tx statement, got %v", req.RequestOptions)
+			}
+		}
+		if req, ok := s.(*sppb.CommitRequest); ok {
+			hasCommit = true
+			if req.RequestOptions == nil || !strings.Contains(req.RequestOptions.TransactionTag, "TestAutoTagging") {
+				t.Errorf("Expected transaction_tag to be populated in CommitRequest, got %v", req.RequestOptions)
+			}
+		}
+	}
+	if !hasStmt || !hasCommit {
+		t.Errorf("Missing statement (%v) or commit (%v) request", hasStmt, hasCommit)
+	}
+}
+
+func TestAutoTagging_CachingEfficiency(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	server, client, teardown := setupMockedTestServerWithConfig(t, ClientConfig{
+		DisableNativeMetrics: true,
+		EnableAutoTagging:    true,
+		AutoTaggingPackages:  []string{"cloud.google.com/go/spanner.TestAutoTagging"},
+	})
+	defer teardown()
+
+	ro := client.ReadOnlyTransaction()
+	defer ro.Close()
+
+	// Execute first statement
+	_ = ro.Query(ctx, NewStatement(SelectSingerIDAlbumIDAlbumTitleFromAlbums)).Do(func(r *Row) error { return nil })
+	// Check cached value
+	cached := ro.cachedRequestTag
+
+	if cached == "" {
+		t.Fatalf("Expected tag to be cached at ReadOnlyTransaction creation")
+	}
+
+	// Second statement should use cached tag without re-walking
+	_ = ro.Query(ctx, NewStatement(SelectSingerIDAlbumIDAlbumTitleFromAlbums)).Do(func(r *Row) error { return nil })
+
+	reqs := drainRequestsFromServer(server.TestSpanner)
+	count := 0
+	for _, s := range reqs {
+		if req, ok := s.(*sppb.ExecuteSqlRequest); ok {
+			count++
+			if req.RequestOptions.RequestTag != cached {
+				t.Errorf("Expected request_tag %q, got %q", cached, req.RequestOptions.RequestTag)
+			}
+		}
+	}
+	if count < 2 {
+		t.Errorf("Expected at least 2 queries, got %d", count)
+	}
+}
+
+func TestAutoTagging_VarargsAndLimits(t *testing.T) {
+	tag := getCallStackTag([]string{"github.com/unknown", "cloud.google.com/go/spanner.TestAutoTagging"}, 10)
+	if !strings.Contains(tag, "TestAutoTagging") {
+		t.Errorf("Expected matching tag from multiple packages, got %q", tag)
+	}
+}
+
+func TestAutoTagging_Truncation(t *testing.T) {
+	longMethod := "cloud.google.com/go/spanner.TestAutoTaggingThisIsAnExtremelyLongFunctionNameThatExceedsFiftyCharactersInLength"
+	tag := formatFrameTag(longMethod)
+	if len(tag) > 50 {
+		tag = tag[len(tag)-50:]
+	}
+	tag = strings.TrimLeft(tag, "0123456789_-")
+	if len(tag) != 50 {
+		t.Errorf("Expected length 50, got %d", len(tag))
+	}
+}
+
+func TestAutoTagging_GlobalOverrides(t *testing.T) {
+	_ = os.Setenv("SPANNER_DISABLE_AUTO_TAGGING", "true")
+	defer os.Unsetenv("SPANNER_DISABLE_AUTO_TAGGING")
+
+	_, client, teardown := setupMockedTestServerWithConfig(t, ClientConfig{
+		DisableNativeMetrics: true,
+		EnableAutoTagging:    true,
+	})
+	defer teardown()
+
+	if client.enableAutoTagging {
+		t.Errorf("Expected auto tagging to be disabled by global env override")
+	}
+
+	_ = os.Setenv("SPANNER_DISABLE_AUTO_TAGGING", "false")
+	_ = os.Setenv("SPANNER_ENABLE_AUTO_TAGGING", "true")
+	defer os.Unsetenv("SPANNER_ENABLE_AUTO_TAGGING")
+
+	_, client2, teardown2 := setupMockedTestServerWithConfig(t, ClientConfig{
+		DisableNativeMetrics: true,
+		EnableAutoTagging:    false,
+	})
+	defer teardown2()
+
+	if !client2.enableAutoTagging {
+		t.Errorf("Expected auto tagging to be enabled by global env override")
+	}
+}
+
+func TestAutoTagging_IsEligibleFrame(t *testing.T) {
+	tests := []struct {
+		fn       string
+		packages []string
+		want     bool
+	}{
+		{"runtime.gopanic", nil, false},
+		{"reflect.Value.Call", nil, false},
+		{"sync.(*Mutex).Lock", nil, false},
+		{"cloud.google.com/go/spanner.(*Client).Single", nil, false},
+		{"github.com/myorg/myapp/db.FetchData", nil, true},
+		{"github.com/myorg/myapp/db.FetchData", []string{"github.com/myorg/myapp"}, true},
+		{"github.com/otherorg/otherapp.DoWork", []string{"github.com/myorg/myapp"}, false},
+	}
+
+	for _, tc := range tests {
+		got := isEligibleFrame(tc.fn, tc.packages)
+		if got != tc.want {
+			t.Errorf("isEligibleFrame(%q, %v) = %v, want %v", tc.fn, tc.packages, got, tc.want)
+		}
+	}
+}
+
+func TestAutoTagging_SingleUse(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	server, client, teardown := setupMockedTestServerWithConfig(t, ClientConfig{
+		DisableNativeMetrics: true,
+		EnableAutoTagging:    true,
+		AutoTaggingPackages:  []string{"cloud.google.com/go/spanner.TestAutoTagging"},
+	})
+	defer teardown()
+
+	_, _ = client.Single().ReadRow(ctx, "Albums", Key{"foo"}, []string{"SingerId", "AlbumId"})
+
+	reqs := drainRequestsFromServer(server.TestSpanner)
+	found := false
+	for _, s := range reqs {
+		if req, ok := s.(*sppb.ReadRequest); ok {
+			found = true
+			if req.RequestOptions == nil || req.RequestOptions.RequestTag == "" {
+				t.Errorf("Expected request_tag to be populated in Single(), got empty")
+			} else if !strings.Contains(req.RequestOptions.RequestTag, "TestAutoTagging") {
+				t.Errorf("Expected request_tag to contain TestAutoTagging, got %q", req.RequestOptions.RequestTag)
+			}
+			if req.RequestOptions != nil && req.RequestOptions.TransactionTag != "" {
+				t.Errorf("Expected transaction_tag to be empty, got %q", req.RequestOptions.TransactionTag)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("No ReadRequest found for Single()")
+	}
+}
+
+func TestAutoTagging_Apply(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	server, client, teardown := setupMockedTestServerWithConfig(t, ClientConfig{
+		DisableNativeMetrics: true,
+		EnableAutoTagging:    true,
+		AutoTaggingPackages:  []string{"cloud.google.com/go/spanner.TestAutoTagging"},
+	})
+	defer teardown()
+
+	ms := []*Mutation{Insert("Albums", []string{"SingerId"}, []interface{}{int64(1)})}
+	_, _ = client.Apply(ctx, ms)
+
+	reqs := drainRequestsFromServer(server.TestSpanner)
+	found := false
+	for _, s := range reqs {
+		if req, ok := s.(*sppb.CommitRequest); ok {
+			found = true
+			if req.RequestOptions == nil || !strings.Contains(req.RequestOptions.TransactionTag, "TestAutoTagging") {
+				t.Errorf("Expected transaction_tag to be populated in Apply CommitRequest, got %v", req.RequestOptions)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("No CommitRequest found for Apply()")
+	}
+}
+
+func TestAutoTagging_ApplyAtLeastOnce(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	server, client, teardown := setupMockedTestServerWithConfig(t, ClientConfig{
+		DisableNativeMetrics: true,
+		EnableAutoTagging:    true,
+		AutoTaggingPackages:  []string{"cloud.google.com/go/spanner.TestAutoTagging"},
+	})
+	defer teardown()
+
+	ms := []*Mutation{Insert("Albums", []string{"SingerId"}, []interface{}{int64(1)})}
+	_, _ = client.Apply(ctx, ms, ApplyAtLeastOnce())
+
+	reqs := drainRequestsFromServer(server.TestSpanner)
+	found := false
+	for _, s := range reqs {
+		if req, ok := s.(*sppb.CommitRequest); ok {
+			found = true
+			if req.RequestOptions == nil || !strings.Contains(req.RequestOptions.TransactionTag, "TestAutoTagging") {
+				t.Errorf("Expected transaction_tag to be populated in ApplyAtLeastOnce CommitRequest, got %v", req.RequestOptions)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("No CommitRequest found for ApplyAtLeastOnce()")
+	}
+}
+
+func TestAutoTagging_BatchWrite(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	server, client, teardown := setupMockedTestServerWithConfig(t, ClientConfig{
+		DisableNativeMetrics: true,
+		EnableAutoTagging:    true,
+		AutoTaggingPackages:  []string{"cloud.google.com/go/spanner.TestAutoTagging"},
+	})
+	defer teardown()
+
+	mgs := []*MutationGroup{{Mutations: []*Mutation{Insert("Albums", []string{"SingerId"}, []interface{}{int64(1)})}}}
+	iter := client.BatchWrite(ctx, mgs)
+	_, _ = iter.Next()
+
+	reqs := drainRequestsFromServer(server.TestSpanner)
+	found := false
+	for _, s := range reqs {
+		if req, ok := s.(*sppb.BatchWriteRequest); ok {
+			found = true
+			if req.RequestOptions == nil || !strings.Contains(req.RequestOptions.TransactionTag, "TestAutoTagging") {
+				t.Errorf("Expected transaction_tag to be populated in BatchWriteRequest, got %v", req.RequestOptions)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("No BatchWriteRequest found for BatchWrite()")
+	}
+}
+
+func TestAutoTagging_BatchReadOnly(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	server, client, teardown := setupMockedTestServerWithConfig(t, ClientConfig{
+		DisableNativeMetrics: true,
+		EnableAutoTagging:    true,
+		AutoTaggingPackages:  []string{"cloud.google.com/go/spanner.TestAutoTagging"},
+	})
+	defer teardown()
+
+	txn, err := client.BatchReadOnlyTransaction(ctx, StrongRead())
+	if err != nil {
+		t.Fatalf("BatchReadOnlyTransaction failed: %v", err)
+	}
+	defer txn.Close()
+
+	_, _ = txn.PartitionQuery(ctx, NewStatement(SelectSingerIDAlbumIDAlbumTitleFromAlbums), PartitionOptions{})
+
+	reqs := drainRequestsFromServer(server.TestSpanner)
+	found := false
+	for _, s := range reqs {
+		if req, ok := s.(*sppb.PartitionQueryRequest); ok {
+			found = true
+			if req.Transaction == nil {
+				t.Errorf("Expected Transaction selector in PartitionQueryRequest")
+			}
+		}
+	}
+	if !found {
+		t.Errorf("No PartitionQueryRequest found")
+	}
+}

--- a/spanner/client.go
+++ b/spanner/client.go
@@ -117,21 +117,24 @@ func parseDatabaseName(db string) (project, instance, database string, err error
 // Client is a client for reading and writing data to a Cloud Spanner database.
 // A client is safe to use concurrently, except for its Close method.
 type Client struct {
-	sc                   *sessionClient
-	sm                   *sessionManager
-	logger               *log.Logger
-	qo                   QueryOptions
-	ro                   ReadOptions
-	ao                   []ApplyOption
-	txo                  TransactionOptions
-	bwo                  BatchWriteOptions
-	ct                   *commonTags
-	disableRouteToLeader bool
-	dro                  *sppb.DirectedReadOptions
-	otConfig             *openTelemetryConfig
-	metricsTracerFactory *builtinMetricsTracerFactory
-	clientContext        *sppb.RequestOptions_ClientContext
-	locationRouter       *locationRouter
+	sc                     *sessionClient
+	sm                     *sessionManager
+	logger                 *log.Logger
+	qo                     QueryOptions
+	ro                     ReadOptions
+	ao                     []ApplyOption
+	txo                    TransactionOptions
+	bwo                    BatchWriteOptions
+	ct                     *commonTags
+	disableRouteToLeader   bool
+	dro                    *sppb.DirectedReadOptions
+	otConfig               *openTelemetryConfig
+	metricsTracerFactory   *builtinMetricsTracerFactory
+	clientContext          *sppb.RequestOptions_ClientContext
+	locationRouter         *locationRouter
+	enableAutoTagging      bool
+	autoTaggingPackages    []string
+	autoTaggingTracerLimit int
 }
 
 // DatabaseName returns the full name of a database, e.g.,
@@ -380,6 +383,22 @@ type ClientConfig struct {
 	//
 	// Default: false
 	EnableDirectAccess bool
+
+	// EnableAutoTagging is an opt-in flag that automatically adds transaction tags to all
+	// read/write transactions and request tags to all statements in read-only transactions
+	// based on the name of the method that started the transaction.
+	EnableAutoTagging bool
+
+	// AutoTaggingPackages is an optional list of target package name prefixes.
+	// Use this to indicate which package names are part of the application.
+	// A tag name will be based on the first method that is found in the call stack
+	// that is part of the application. If no package names are specified in this option,
+	// auto-tagging will look for the first method that it can find that is not part of the
+	// Spanner client or a system package.
+	AutoTaggingPackages []string
+
+	// AutoTaggingTracerLimit specifies depth limit for stack-trace walking.
+	AutoTaggingTracerLimit int
 }
 
 type openTelemetryConfig struct {
@@ -709,22 +728,33 @@ Multiplexed session enabled: true
 			projectID, config.NumChannels, !config.DisableRouteToLeader, isDirectPathEnabled,
 			config.EnableEndToEndTracing, !config.DisableNativeMetrics, isGRPCBuiltInMetricsEnabled)
 	}
+	if strings.EqualFold(os.Getenv("SPANNER_DISABLE_AUTO_TAGGING"), "true") {
+		config.EnableAutoTagging = false
+	} else if strings.EqualFold(os.Getenv("SPANNER_ENABLE_AUTO_TAGGING"), "true") {
+		config.EnableAutoTagging = true
+	}
+	if config.EnableAutoTagging && config.AutoTaggingTracerLimit == 0 {
+		config.AutoTaggingTracerLimit = 50
+	}
 	c = &Client{
-		sc:                   sc,
-		sm:                   sp,
-		logger:               config.Logger,
-		qo:                   getQueryOptions(config.QueryOptions),
-		ro:                   config.ReadOptions,
-		ao:                   config.ApplyOptions,
-		txo:                  config.TransactionOptions,
-		bwo:                  config.BatchWriteOptions,
-		ct:                   getCommonTags(sc),
-		disableRouteToLeader: config.DisableRouteToLeader,
-		dro:                  config.DirectedReadOptions,
-		otConfig:             otConfig,
-		metricsTracerFactory: metricsTracerFactory,
-		clientContext:        config.ClientContext,
-		locationRouter:       locationRouter,
+		sc:                     sc,
+		sm:                     sp,
+		logger:                 config.Logger,
+		qo:                     getQueryOptions(config.QueryOptions),
+		ro:                     config.ReadOptions,
+		ao:                     config.ApplyOptions,
+		txo:                    config.TransactionOptions,
+		bwo:                    config.BatchWriteOptions,
+		ct:                     getCommonTags(sc),
+		disableRouteToLeader:   config.DisableRouteToLeader,
+		dro:                    config.DirectedReadOptions,
+		otConfig:               otConfig,
+		metricsTracerFactory:   metricsTracerFactory,
+		clientContext:          config.ClientContext,
+		locationRouter:         locationRouter,
+		enableAutoTagging:      config.EnableAutoTagging,
+		autoTaggingPackages:    config.AutoTaggingPackages,
+		autoTaggingTracerLimit: config.AutoTaggingTracerLimit,
 	}
 	return c, nil
 }
@@ -948,6 +978,9 @@ func (c *Client) Single() *ReadOnlyTransaction {
 	t.txReadOnly.ro.DirectedReadOptions = c.dro
 	t.txReadOnly.ro.LockHint = sppb.ReadRequest_LOCK_HINT_UNSPECIFIED
 	t.txReadOnly.clientContext = c.clientContext
+	if c.enableAutoTagging {
+		t.cachedRequestTag = getCallStackTag(c.autoTaggingPackages, c.autoTaggingTracerLimit)
+	}
 
 	t.ct = c.ct
 	t.otConfig = c.otConfig
@@ -977,6 +1010,9 @@ func (c *Client) ReadOnlyTransaction() *ReadOnlyTransaction {
 	t.txReadOnly.ro.DirectedReadOptions = c.dro
 	t.txReadOnly.ro.LockHint = sppb.ReadRequest_LOCK_HINT_UNSPECIFIED
 	t.txReadOnly.clientContext = c.clientContext
+	if c.enableAutoTagging {
+		t.cachedRequestTag = getCallStackTag(c.autoTaggingPackages, c.autoTaggingTracerLimit)
+	}
 
 	t.ct = c.ct
 	t.otConfig = c.otConfig
@@ -1050,6 +1086,9 @@ func (c *Client) BatchReadOnlyTransaction(ctx context.Context, tb TimestampBound
 	t.txReadOnly.ro.DirectedReadOptions = c.dro
 	t.txReadOnly.ro.LockHint = sppb.ReadRequest_LOCK_HINT_UNSPECIFIED
 	t.txReadOnly.clientContext = c.clientContext
+	if c.enableAutoTagging {
+		t.cachedRequestTag = getCallStackTag(c.autoTaggingPackages, c.autoTaggingTracerLimit)
+	}
 
 	t.ct = c.ct
 	t.otConfig = c.otConfig
@@ -1088,6 +1127,9 @@ func (c *Client) BatchReadOnlyTransactionFromID(tid BatchReadOnlyTransactionID) 
 	t.txReadOnly.ro.DirectedReadOptions = c.dro
 	t.txReadOnly.ro.LockHint = sppb.ReadRequest_LOCK_HINT_UNSPECIFIED
 	t.txReadOnly.clientContext = c.clientContext
+	if c.enableAutoTagging {
+		t.cachedRequestTag = getCallStackTag(c.autoTaggingPackages, c.autoTaggingTracerLimit)
+	}
 
 	t.ct = c.ct
 	t.otConfig = c.otConfig
@@ -1145,6 +1187,9 @@ func (c *Client) ReadWriteTransactionWithOptions(ctx context.Context, f func(con
 func (c *Client) rwTransaction(ctx context.Context, f func(context.Context, *ReadWriteTransaction) error, options TransactionOptions) (resp CommitResponse, err error) {
 	if err := checkNestedTxn(ctx); err != nil {
 		return resp, err
+	}
+	if c.enableAutoTagging && options.TransactionTag == "" {
+		options.TransactionTag = getCallStackTag(c.autoTaggingPackages, c.autoTaggingTracerLimit)
 	}
 	var (
 		sh      *sessionHandle
@@ -1319,6 +1364,9 @@ func (c *Client) Apply(ctx context.Context, ms []*Mutation, opts ...ApplyOption)
 		}, TransactionOptions{CommitPriority: ao.priority, TransactionTag: ao.transactionTag, ExcludeTxnFromChangeStreams: ao.excludeTxnFromChangeStreams, CommitOptions: ao.commitOptions, IsolationLevel: ao.isolationLevel})
 		return resp.CommitTs, err
 	}
+	if c.enableAutoTagging && ao.transactionTag == "" {
+		ao.transactionTag = getCallStackTag(c.autoTaggingPackages, c.autoTaggingTracerLimit)
+	}
 	t := &writeOnlyTransaction{sm: c.sm, commitPriority: ao.priority, transactionTag: ao.transactionTag, disableRouteToLeader: c.disableRouteToLeader, excludeTxnFromChangeStreams: ao.excludeTxnFromChangeStreams, commitOptions: ao.commitOptions, isolationLevel: ao.isolationLevel, clientContext: c.clientContext}
 	return t.applyAtLeastOnce(ctx, ms...)
 }
@@ -1486,6 +1534,9 @@ func (c *Client) BatchWriteWithOptions(ctx context.Context, mgs []*MutationGroup
 	}()
 
 	opts = c.bwo.merge(opts)
+	if c.enableAutoTagging && opts.TransactionTag == "" {
+		opts.TransactionTag = getCallStackTag(c.autoTaggingPackages, c.autoTaggingTracerLimit)
+	}
 
 	mgsPb, err := mutationGroupsProto(mgs)
 	if err != nil {

--- a/spanner/transaction.go
+++ b/spanner/transaction.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"runtime"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -356,6 +358,11 @@ func (t *txReadOnly) ReadWithOptions(ctx context.Context, table string, keys Key
 			lockHint = opts.LockHint
 		}
 		clientContext = mergeClientContext(clientContext, opts.ClientContext)
+	}
+	if requestTag == "" {
+		if rot, ok := t.txReadEnv.(*ReadOnlyTransaction); ok && rot.cachedRequestTag != "" {
+			requestTag = rot.cachedRequestTag
+		}
 	}
 	var setTransactionID func(transactionID)
 	if _, ok := ts.Selector.(*sppb.TransactionSelector_Begin); ok {
@@ -790,6 +797,12 @@ func (t *txReadOnly) prepareExecuteSQL(ctx context.Context, stmt Statement, opti
 	if options.Mode != nil {
 		mode = *options.Mode
 	}
+	requestTag := options.RequestTag
+	if requestTag == "" {
+		if rot, ok := t.txReadEnv.(*ReadOnlyTransaction); ok && rot.cachedRequestTag != "" {
+			requestTag = rot.cachedRequestTag
+		}
+	}
 	req := &sppb.ExecuteSqlRequest{
 		Session:             sid,
 		Transaction:         ts,
@@ -799,7 +812,7 @@ func (t *txReadOnly) prepareExecuteSQL(ctx context.Context, stmt Statement, opti
 		Params:              params,
 		ParamTypes:          paramTypes,
 		QueryOptions:        options.Options,
-		RequestOptions:      createRequestOptions(options.Priority, options.RequestTag, t.txOpts.TransactionTag, mergeClientContext(t.clientContext, options.ClientContext)),
+		RequestOptions:      createRequestOptions(options.Priority, requestTag, t.txOpts.TransactionTag, mergeClientContext(t.clientContext, options.ClientContext)),
 		DataBoostEnabled:    options.DataBoostEnabled,
 		DirectedReadOptions: options.DirectedReadOptions,
 		LastStatement:       options.LastStatement,
@@ -886,6 +899,7 @@ type ReadOnlyTransaction struct {
 	beginTransactionOption BeginTransactionOption
 	// isLongRunningTransaction indicates whether the transaction is long-running or not.
 	isLongRunningTransaction bool
+	cachedRequestTag         string
 }
 
 // errTxInitTimeout returns error for timeout in waiting for initialization of
@@ -2320,4 +2334,67 @@ type transactionBeginOptions struct {
 	previousTx    transactionID
 	mutation      *sppb.Mutation
 	clientContext *sppb.RequestOptions_ClientContext
+}
+
+func getCallStackTag(packages []string, limit int) string {
+	if limit <= 0 {
+		limit = 50
+	}
+	pc := make([]uintptr, limit)
+	// Skip runtime.Callers and getCallStackTag frames
+	n := runtime.Callers(2, pc)
+	if n == 0 {
+		return ""
+	}
+	pc = pc[:n]
+	frames := runtime.CallersFrames(pc)
+	for {
+		frame, more := frames.Next()
+		if frame.Function != "" && isEligibleFrame(frame.Function, packages) {
+			tag := formatFrameTag(frame.Function)
+			if len(tag) > 50 {
+				tag = tag[len(tag)-50:]
+			}
+			// Tags must start with a letter and contain only letters, numbers, underscores, and hyphens.
+			tag = strings.TrimLeft(tag, "0123456789_-")
+			if tag != "" {
+				return tag
+			}
+		}
+		if !more {
+			break
+		}
+	}
+	return ""
+}
+
+func isEligibleFrame(fn string, packages []string) bool {
+	if strings.HasPrefix(fn, "runtime.") || strings.HasPrefix(fn, "reflect.") || strings.HasPrefix(fn, "sync.") {
+		return false
+	}
+	if len(packages) > 0 {
+		for _, pkg := range packages {
+			if strings.HasPrefix(fn, pkg) || strings.Contains(fn, "/"+pkg) {
+				return true
+			}
+		}
+		return false
+	}
+	if strings.Contains(fn, "cloud.google.com/go/spanner") {
+		return false
+	}
+	return true
+}
+
+func formatFrameTag(fn string) string {
+	idx := strings.LastIndex(fn, "/")
+	if idx >= 0 {
+		fn = fn[idx+1:]
+	}
+	return strings.Map(func(r rune) rune {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_' || r == '-' {
+			return r
+		}
+		return '_'
+	}, fn)
 }


### PR DESCRIPTION
Adds an option that automatically adds transaction tags to all read/write transactions that do not already include an explicit transaction tag. For read-only transactions, this option automatically adds a request tag to each statement that is executed in the read-only transaction. The tag name is equal to the type name + method name of the method that started the transaction. Tags are limited to max 50 characters. If the combination of type name + method name exceeds 50 characters, then the last 50 characters are used as the tag.

This option can be enabled with `EnableAutoTagging: true` in the `ClientConfig` or by setting the environment variable `SPANNER_ENABLE_AUTO_TAGGING=true`.