### PR TITLE
chore: update librarian to v0.15.0

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 language: go
-version: v0.14.0
+version: v0.15.0
 repo: googleapis/google-cloud-go
 sources:
   googleapis:


### PR DESCRIPTION
After upgrading the Librarian version in librarian.yaml, I ran `$ go run github.com/googleapis/librarian/cmd/librarian@${V} generate --all` where V is `v0.15.0`. There's no code change this week.