### PR TITLE
chore(.github): fail generation check workflow on diff

### DIFF
--- a/.github/workflows/generation_check.yaml
+++ b/.github/workflows/generation_check.yaml
@@ -29,6 +29,7 @@ jobs:
         run: |
           version=$(go run github.com/googleapis/librarian/cmd/librarian@latest config get version)
           go run "github.com/googleapis/librarian/cmd/librarian@${version}" generate -all
+          git diff --exit-code
       - name: Create issue on diff
         if: failure()
         env:


### PR DESCRIPTION
Add `git diff --exit-code` to the regeneration step so that the step fails when a diff is detected.

This triggers the subsequent issue creation step.