### PR TITLE
chore: librarian release pull request: 20260526T215744Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -548,7 +548,7 @@ libraries:
       - internal/generated/snippets/bigquery/v2
     tag_format: bigquery/v{version}
   - id: bigtable
-    version: 1.47.0
+    version: 1.48.0
     last_generated_commit: ""
     apis:
       - path: google/bigtable/admin/v2

--- a/bigtable/CHANGES.md
+++ b/bigtable/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+## [1.48.0](https://github.com/googleapis/google-cloud-go/releases/tag/bigtable%2Fv1.48.0) (2026-05-26)
+
+### Features
+
+* expose a client option to disable direct access: (#14626) ([f22b29f](https://github.com/googleapis/google-cloud-go/commit/f22b29f5d954a61b34e71995546c818883697aa6))
+
 ## [1.47.0](https://github.com/googleapis/google-cloud-go/releases/tag/bigtable%2Fv1.47.0) (2026-05-01)
 
 ## [1.46.0](https://github.com/googleapis/google-cloud-go/releases/tag/bigtable%2Fv1.46.0) (2026-04-09)

--- a/bigtable/internal/version.go
+++ b/bigtable/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "1.47.0"
+const Version = "1.48.0"

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -361,7 +361,7 @@ libraries:
       - README.md
     skip_release: true
   - name: bigtable
-    version: 1.47.0
+    version: 1.48.0
     apis:
       - path: google/bigtable/v2
         go:


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.15.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go@sha256:b04b076f5eedbb5546bd6fc1404969dd3698c8b19c0f34ae815a84ae735a606a
<details><summary>bigtable: v1.48.0</summary>

## [v1.48.0](https://github.com/googleapis/google-cloud-go/compare/bigtable/v1.47.0...bigtable/v1.48.0) (2026-05-26)

### Features

* expose a client option to disable direct access: (#14626) ([f22b29f5](https://github.com/googleapis/google-cloud-go/commit/f22b29f5))

</details>