### PR TITLE
fix: go toolchain 1.25.8

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -31,7 +31,7 @@ tools:
 default:
   tag_format: '{name}/v{version}'
   go:
-    toolchain: go1.25.0
+    toolchain: go1.25.8
     default_enabled_generator_features:
       - F_open_telemetry_attributes
       - F_proto_cloneof


### PR DESCRIPTION
The previous dependency version bump commit broke the build:
https://github.com/googleapis/google-cloud-go/commit/e190be41b1285c72d0ac7f3172db84625b737fea

```
$ go run "github.com/googleapis/librarian/cmd/librarian@${version}" generate -all
2026/05/27 14:27:34 librarian: generate library "auth" (go): /usr/lib/go-1.26/bin/go mod tidy: go: go.mod requires go >= 1.25.8 (running go 1.25.0; GOTOOLCHAIN=go1.25.0)
: exit status 1
```

where the version is v0.15.0. The go toolchain version is in the librarian.yaml file.

For https://github.com/googleapis/google-cloud-go/issues/14655.