### PR TITLE
chore: release agentplatform@v0.21.0

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -56,7 +56,7 @@ libraries:
       - internal/generated/snippets/advisorynotifications/
     tag_format: '{id}/v{version}'
   - id: agentplatform
-    version: 0.20.0
+    version: 0.21.0
     last_generated_commit: ""
     apis: []
     source_roots:

--- a/agentplatform/CHANGES.md
+++ b/agentplatform/CHANGES.md
@@ -1,3 +1,18 @@
+## [0.21.0](https://github.com/googleapis/google-cloud-go/releases/tag/agentplatform%2Fv0.21.0) (2026-05-27)
+
+### Features
+
+* Add ListSkills and DeleteSkill methods in Vertex AI Skill Registry SDK ([942bbc1](https://github.com/googleapis/google-cloud-go/commit/942bbc15b99ffd078af4f731a6f249c3b4c48110))
+
+### Bug Fixes
+
+* Fix name collision on SandboxEnvironment.state by renaming enum to SandboxState ([14ea3de](https://github.com/googleapis/google-cloud-go/commit/14ea3de7de6e8e2c769f0d1828705e83097b9ba9))
+* Set the agentplatform's dedicated user-agent in header. ([66574db](https://github.com/googleapis/google-cloud-go/commit/66574dbbc932ce9ff36f2e2b58e7f01778dfd88e))
+
+### Documentation
+
+* update README to reflect Gemini Enterprise Agent Platform ([541569e](https://github.com/googleapis/google-cloud-go/commit/541569e80c1154b8742f147fa9667b6794be84eb))
+
 ## [0.20.0](https://github.com/googleapis/google-cloud-go/releases/tag/agentplatform%2Fv0.20.0) (2026-05-07)
 
 ### Features

--- a/agentplatform/internal/version.go
+++ b/agentplatform/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "0.20.0"
+const Version = "0.21.0"

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -51,7 +51,7 @@ libraries:
     apis:
       - path: google/cloud/advisorynotifications/v1
   - name: agentplatform
-    version: 0.20.0
+    version: 0.21.0
     skip_generate: true
     skip_release: true
   - name: ai


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.12.1
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go@sha256:b04b076f5eedbb5546bd6fc1404969dd3698c8b19c0f34ae815a84ae735a606a
<details><summary>agentplatform: v0.21.0</summary>

## [v0.21.0](https://github.com/googleapis/google-cloud-go/compare/agentplatform/v0.20.0...agentplatform/v0.21.0) (2026-05-27)

### Features

* Add ListSkills and DeleteSkill methods in Vertex AI Skill Registry SDK (PiperOrigin-RevId: 912730700) ([942bbc15](https://github.com/googleapis/google-cloud-go/commit/942bbc15))

### Bug Fixes

* Fix name collision on SandboxEnvironment.state by renaming enum to SandboxState (PiperOrigin-RevId: 912527667) ([14ea3de7](https://github.com/googleapis/google-cloud-go/commit/14ea3de7))

* Set the agentplatform&#39;s dedicated user-agent in header. (PiperOrigin-RevId: 915113335) ([66574dbb](https://github.com/googleapis/google-cloud-go/commit/66574dbb))

### Documentation

* update README to reflect Gemini Enterprise Agent Platform (PiperOrigin-RevId: 912137130) ([541569e8](https://github.com/googleapis/google-cloud-go/commit/541569e8))

</details>