### PR TITLE
chore(.github): use librarian action

### DIFF
--- a/.github/workflows/generation_check.yaml
+++ b/.github/workflows/generation_check.yaml
@@ -5,8 +5,6 @@ on:
     branches:
       - main
   pull_request:
-    paths:
-      - 'librarian.yaml'
   # Allows manual triggering for debugging purpose.
   workflow_dispatch:
 permissions:
@@ -17,15 +15,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v4
+        id: changes
+        with:
+          filters: |
+            librarian:
+              - 'librarian.yaml'
       # Version of librarian is pulled from librarian.yaml,
       # main corresponds to the action's source definition.
       - uses: googleapis/librarian@main
+        if: 
         with:
           protoc-version: '33.2'
           protoc-checksum: '8c0a8577311720cc83488f813aeb5046d69cb9824cbf39cb7447e0c5132d677952d5bb7c1130d9df381835eee7352828878d409873ebb407d7a4649ea2a4aee5'
       - name: Install tools
         run: librarian install
       - name: Regenerate
+        if: steps.changes.outputs.librarian == 'true'
         run: |
           librarian generate --all
           git diff --exit-code

--- a/.github/workflows/generation_check.yaml
+++ b/.github/workflows/generation_check.yaml
@@ -24,7 +24,7 @@ jobs:
       # Version of librarian is pulled from librarian.yaml,
       # main corresponds to the action's source definition.
       - uses: googleapis/librarian@main
-        if: 
+        if: steps.changes.outputs.librarian == 'true'
         with:
           protoc-version: '33.2'
           protoc-checksum: '8c0a8577311720cc83488f813aeb5046d69cb9824cbf39cb7447e0c5132d677952d5bb7c1130d9df381835eee7352828878d409873ebb407d7a4649ea2a4aee5'

--- a/.github/workflows/generation_check.yaml
+++ b/.github/workflows/generation_check.yaml
@@ -29,6 +29,7 @@ jobs:
           protoc-version: '33.2'
           protoc-checksum: '8c0a8577311720cc83488f813aeb5046d69cb9824cbf39cb7447e0c5132d677952d5bb7c1130d9df381835eee7352828878d409873ebb407d7a4649ea2a4aee5'
       - name: Install tools
+        if: steps.changes.outputs.librarian == 'true'
         run: librarian install
       - name: Regenerate
         if: steps.changes.outputs.librarian == 'true'

--- a/.github/workflows/generation_check.yaml
+++ b/.github/workflows/generation_check.yaml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      # Version of librarian is pulled from librarian.yaml,
+      # main corresponds to the action's source definition.
       - uses: googleapis/librarian@main
         with:
           protoc-version: '33.2'

--- a/.github/workflows/generation_check.yaml
+++ b/.github/workflows/generation_check.yaml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    paths:
+      - 'librarian.yaml'
   # Allows manual triggering for debugging purpose.
   workflow_dispatch:
 permissions:
@@ -14,24 +17,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: googleapis/librarian@main
         with:
-          go-version: '1.26.x'
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
-        with:
-          version: "33.2"
+          protoc-version: '33.2'
+          protoc-checksum: '8c0a8577311720cc83488f813aeb5046d69cb9824cbf39cb7447e0c5132d677952d5bb7c1130d9df381835eee7352828878d409873ebb407d7a4649ea2a4aee5'
       - name: Install tools
-        run: |
-          version=$(go run github.com/googleapis/librarian/cmd/librarian@latest config get version)
-          go run "github.com/googleapis/librarian/cmd/librarian@${version}" install
+        run: librarian install
       - name: Regenerate
         run: |
-          version=$(go run github.com/googleapis/librarian/cmd/librarian@latest config get version)
-          go run "github.com/googleapis/librarian/cmd/librarian@${version}" generate -all
+          librarian generate --all
           git diff --exit-code
       - name: Create issue on diff
-        if: failure()
+        if: failure() && github.event_name == 'push' && github.ref == 'refs/heads/main'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/generation_check.yaml
+++ b/.github/workflows/generation_check.yaml
@@ -24,15 +24,15 @@ jobs:
       # Version of librarian is pulled from librarian.yaml,
       # main corresponds to the action's source definition.
       - uses: googleapis/librarian@main
-        if: steps.changes.outputs.librarian == 'true'
+        if: steps.changes.outputs.librarian == 'true' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
         with:
           protoc-version: '33.2'
           protoc-checksum: '8c0a8577311720cc83488f813aeb5046d69cb9824cbf39cb7447e0c5132d677952d5bb7c1130d9df381835eee7352828878d409873ebb407d7a4649ea2a4aee5'
       - name: Install tools
-        if: steps.changes.outputs.librarian == 'true'
+        if: steps.changes.outputs.librarian == 'true' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
         run: librarian install
       - name: Regenerate
-        if: steps.changes.outputs.librarian == 'true'
+        if: steps.changes.outputs.librarian == 'true' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
         run: |
           librarian generate --all
           git diff --exit-code

--- a/.github/workflows/librarian_tidy.yml
+++ b/.github/workflows/librarian_tidy.yml
@@ -15,21 +15,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Install Go
-        uses: actions/setup-go@v6
-        with:
-          go-version: '1.26.x'
+      - name: Install librarian
+        uses: googleapis/librarian@main
 
       - name: Run librarian tidy
-        run: |
-          V=$(go run github.com/googleapis/librarian/cmd/librarian@latest config get version)
-          go run github.com/googleapis/librarian/cmd/librarian@${V} tidy
-          git diff
+        run: librarian tidy
 
       - name: Check for diff
         run: |
           if ! git diff --exit-code; then
-            V=$(go run github.com/googleapis/librarian/cmd/librarian@latest config get version)
+            V=$(librarian config get version)
             echo "librarian.yaml is not tidy. Please run:"
             echo ""
             echo "  go run github.com/googleapis/librarian/cmd/librarian@${V} tidy"

--- a/.github/workflows/librarian_tidy.yml
+++ b/.github/workflows/librarian_tidy.yml
@@ -2,8 +2,6 @@ name: librarian tidy
 
 on:
   pull_request:
-    paths:
-      - 'librarian.yaml'
 
 permissions:
   contents: read
@@ -14,15 +12,22 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-
+      - uses: dorny/paths-filter@v4
+        id: changes
+        with:
+          filters: |
+            librarian:
+              - 'librarian.yaml'
       # Version of librarian is pulled from librarian.yaml,
       # main corresponds to the action's source definition.
       - uses: googleapis/librarian@main
 
       - name: Run librarian tidy
+        if: steps.changes.outputs.librarian == 'true'
         run: librarian tidy
 
       - name: Check for diff
+        if: steps.changes.outputs.librarian == 'true'
         run: |
           if ! git diff --exit-code; then
             V=$(librarian config get version)

--- a/.github/workflows/librarian_tidy.yml
+++ b/.github/workflows/librarian_tidy.yml
@@ -15,8 +15,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Install librarian
-        uses: googleapis/librarian@main
+      # Version of librarian is pulled from librarian.yaml,
+      # main corresponds to the action's source definition.
+      - uses: googleapis/librarian@main
 
       - name: Run librarian tidy
         run: librarian tidy

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -11,10 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-
-
-
 language: go
 version: v0.15.0
 repo: googleapis/google-cloud-go

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -11,6 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+
+
+
 language: go
 version: v0.15.0
 repo: googleapis/google-cloud-go


### PR DESCRIPTION
Switch to using the packaged `googleapis/librarian` action to simplify action call sites.

Also configure the `generation_check` to also run on pull requests that edit the `librarian.yaml` (to start, may expand to other files), and only file a bug if processing a push event on main (post-submit check).

Note: The version of librarian is automatically pulled from `librarian.yaml`,  `@main` just corresponds to the action's source definition.