### PR TITLE
test(pubsub/v2): increase modack extension for ack retry deadline test

### DIFF
--- a/pubsub/subscription_test.go
+++ b/pubsub/subscription_test.go
@@ -745,7 +745,8 @@ func TestExactlyOnceDelivery_AckRetryDeadlineExceeded(t *testing.T) {
 	}
 
 	s.ReceiveSettings = ReceiveSettings{
-		NumGoroutines: 1,
+		NumGoroutines:              1,
+		MinDurationPerAckExtension: 10 * time.Minute,
 	}
 	// Override the default timeout here so this test doesn't take 10 minutes.
 	exactlyOnceDeliveryRetryDeadline = 10 * time.Second

--- a/pubsub/subscription_test.go
+++ b/pubsub/subscription_test.go
@@ -745,8 +745,8 @@ func TestExactlyOnceDelivery_AckRetryDeadlineExceeded(t *testing.T) {
 	}
 
 	s.ReceiveSettings = ReceiveSettings{
-		NumGoroutines:              1,
-		MinDurationPerAckExtension: 10 * time.Minute,
+		NumGoroutines:      1,
+		MinExtensionPeriod: 10 * time.Minute,
 	}
 	// Override the default timeout here so this test doesn't take 10 minutes.
 	exactlyOnceDeliveryRetryDeadline = 10 * time.Second

--- a/pubsub/v2/subscriber_test.go
+++ b/pubsub/v2/subscriber_test.go
@@ -246,7 +246,8 @@ func TestExactlyOnceDelivery_AckRetryDeadlineExceeded(t *testing.T) {
 	}
 
 	s.ReceiveSettings = ReceiveSettings{
-		NumGoroutines: 1,
+		NumGoroutines:              1,
+		MinDurationPerAckExtension: 10 * time.Minute,
 	}
 	// Override the default timeout here so this test doesn't take 10 minutes.
 	exactlyOnceDeliveryRetryDeadline = 10 * time.Second


### PR DESCRIPTION
If the subscriber redelivers a message because the ack deadline expired, the second delivery will cause a context cancelled error instead of a context deadline exceeded error. This causes our tests to flake.

Fixes #14657