### PR TITLE
refactor(pubsub/v2): use strings.ReplaceAll

### DIFF
--- a/pubsub/v2/integration_test.go
+++ b/pubsub/v2/integration_test.go
@@ -480,8 +480,7 @@ func TestIntegration_OrderedKeys_JSON(t *testing.T) {
 		scanner := bufio.NewScanner(inFile)
 		for scanner.Scan() {
 			line := scanner.Text()
-			// TODO: use strings.ReplaceAll once we only support 1.11+.
-			line = strings.Replace(line, "\"", "", -1)
+			line = strings.ReplaceAll(line, "\"", "")
 			parts := strings.Split(line, ",")
 			key := parts[0]
 			msg := parts[1]


### PR DESCRIPTION
Per comment, we can cleanup this old todo since our minimum version greatly exceeds the specified version. 