### PR TITLE
chore: librarian release pull request: 20260528T175942Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1013,7 +1013,7 @@ libraries:
       - internal/generated/snippets/datamanager/
     tag_format: '{id}/v{version}'
   - id: dataplex
-    version: 1.34.0
+    version: 1.35.0
     last_generated_commit: ""
     apis:
       - path: google/cloud/dataplex/v1
@@ -1346,7 +1346,7 @@ libraries:
       - internal/generated/snippets/functions/
     tag_format: '{id}/v{version}'
   - id: geminidataanalytics
-    version: 1.1.0
+    version: 1.2.0
     last_generated_commit: ""
     apis:
       - path: google/cloud/geminidataanalytics/v1beta
@@ -1714,7 +1714,7 @@ libraries:
       - internal/generated/snippets/managedkafka/
     tag_format: '{id}/v{version}'
   - id: maps
-    version: 1.35.0
+    version: 1.36.0
     last_generated_commit: ""
     apis:
       - path: google/maps/addressvalidation/v1
@@ -2354,7 +2354,7 @@ libraries:
       - internal/generated/snippets/run/
     tag_format: '{id}/v{version}'
   - id: saasplatform
-    version: 0.7.0
+    version: 0.8.0
     last_generated_commit: ""
     apis:
       - path: google/cloud/saasplatform/saasservicemgmt/v1beta1
@@ -2414,7 +2414,7 @@ libraries:
       - internal/generated/snippets/securesourcemanager/
     tag_format: '{id}/v{version}'
   - id: security
-    version: 1.24.0
+    version: 1.25.0
     last_generated_commit: ""
     apis:
       - path: google/cloud/security/privateca/v1

--- a/dataplex/CHANGES.md
+++ b/dataplex/CHANGES.md
@@ -1,6 +1,12 @@
 # Changes
 
 
+## [1.35.0](https://github.com/googleapis/google-cloud-go/releases/tag/dataplex%2Fv1.35.0) (2026-05-28)
+
+### Features
+
+* update API sources and regenerate (#14661) ([d0cd917](https://github.com/googleapis/google-cloud-go/commit/d0cd917ce0ad46a4d2c1cd4ea2ef8efa60b591d3))
+
 ## [1.34.0](https://github.com/googleapis/google-cloud-go/releases/tag/dataplex%2Fv1.34.0) (2026-05-07)
 
 ### Features

--- a/dataplex/internal/version.go
+++ b/dataplex/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "1.34.0"
+const Version = "1.35.0"

--- a/geminidataanalytics/CHANGES.md
+++ b/geminidataanalytics/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+## [1.2.0](https://github.com/googleapis/google-cloud-go/releases/tag/geminidataanalytics%2Fv1.2.0) (2026-05-28)
+
+### Features
+
+* update API sources and regenerate (#14661) ([d0cd917](https://github.com/googleapis/google-cloud-go/commit/d0cd917ce0ad46a4d2c1cd4ea2ef8efa60b591d3))
+
 ## [1.1.0](https://github.com/googleapis/google-cloud-go/releases/tag/geminidataanalytics%2Fv1.1.0) (2026-05-14)
 
 ### Features

--- a/geminidataanalytics/internal/version.go
+++ b/geminidataanalytics/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "1.1.0"
+const Version = "1.2.0"

--- a/internal/generated/snippets/dataplex/apiv1/snippet_metadata.google.cloud.dataplex.v1.json
+++ b/internal/generated/snippets/dataplex/apiv1/snippet_metadata.google.cloud.dataplex.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/dataplex/apiv1",
-    "version": "1.34.0"
+    "version": "1.35.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/geminidataanalytics/apiv1/snippet_metadata.google.cloud.geminidataanalytics.v1.json
+++ b/internal/generated/snippets/geminidataanalytics/apiv1/snippet_metadata.google.cloud.geminidataanalytics.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/geminidataanalytics/apiv1",
-    "version": "1.1.0"
+    "version": "1.2.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/geminidataanalytics/apiv1beta/snippet_metadata.google.cloud.geminidataanalytics.v1beta.json
+++ b/internal/generated/snippets/geminidataanalytics/apiv1beta/snippet_metadata.google.cloud.geminidataanalytics.v1beta.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/geminidataanalytics/apiv1beta",
-    "version": "1.1.0"
+    "version": "1.2.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/maps/addressvalidation/apiv1/snippet_metadata.google.maps.addressvalidation.v1.json
+++ b/internal/generated/snippets/maps/addressvalidation/apiv1/snippet_metadata.google.maps.addressvalidation.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/maps/addressvalidation/apiv1",
-    "version": "1.35.0"
+    "version": "1.36.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/maps/areainsights/apiv1/snippet_metadata.google.maps.areainsights.v1.json
+++ b/internal/generated/snippets/maps/areainsights/apiv1/snippet_metadata.google.maps.areainsights.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/maps/areainsights/apiv1",
-    "version": "1.35.0"
+    "version": "1.36.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/maps/fleetengine/apiv1/snippet_metadata.maps.fleetengine.v1.json
+++ b/internal/generated/snippets/maps/fleetengine/apiv1/snippet_metadata.maps.fleetengine.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/maps/fleetengine/apiv1",
-    "version": "1.35.0"
+    "version": "1.36.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/maps/geocode/apiv4/snippet_metadata.google.maps.geocode.v4.json
+++ b/internal/generated/snippets/maps/geocode/apiv4/snippet_metadata.google.maps.geocode.v4.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/maps/geocode/apiv4",
-    "version": "1.35.0"
+    "version": "1.36.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/maps/places/apiv1/snippet_metadata.google.maps.places.v1.json
+++ b/internal/generated/snippets/maps/places/apiv1/snippet_metadata.google.maps.places.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/maps/places/apiv1",
-    "version": "1.35.0"
+    "version": "1.36.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/maps/routeoptimization/apiv1/snippet_metadata.google.maps.routeoptimization.v1.json
+++ b/internal/generated/snippets/maps/routeoptimization/apiv1/snippet_metadata.google.maps.routeoptimization.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/maps/routeoptimization/apiv1",
-    "version": "1.35.0"
+    "version": "1.36.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/maps/routing/apiv2/snippet_metadata.google.maps.routing.v2.json
+++ b/internal/generated/snippets/maps/routing/apiv2/snippet_metadata.google.maps.routing.v2.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/maps/routing/apiv2",
-    "version": "1.35.0"
+    "version": "1.36.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/maps/solar/apiv1/snippet_metadata.google.maps.solar.v1.json
+++ b/internal/generated/snippets/maps/solar/apiv1/snippet_metadata.google.maps.solar.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/maps/solar/apiv1",
-    "version": "1.35.0"
+    "version": "1.36.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/snippet_metadata.google.cloud.saasplatform.saasservicemgmt.v1beta1.json
+++ b/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/snippet_metadata.google.cloud.saasplatform.saasservicemgmt.v1beta1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/saasplatform/saasservicemgmt/apiv1beta1",
-    "version": "0.7.0"
+    "version": "0.8.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/security/privateca/apiv1/snippet_metadata.google.cloud.security.privateca.v1.json
+++ b/internal/generated/snippets/security/privateca/apiv1/snippet_metadata.google.cloud.security.privateca.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/security/privateca/apiv1",
-    "version": "1.24.0"
+    "version": "1.25.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/security/publicca/apiv1/snippet_metadata.google.cloud.security.publicca.v1.json
+++ b/internal/generated/snippets/security/publicca/apiv1/snippet_metadata.google.cloud.security.publicca.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/security/publicca/apiv1",
-    "version": "1.24.0"
+    "version": "1.25.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/security/publicca/apiv1beta1/snippet_metadata.google.cloud.security.publicca.v1beta1.json
+++ b/internal/generated/snippets/security/publicca/apiv1beta1/snippet_metadata.google.cloud.security.publicca.v1beta1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/security/publicca/apiv1beta1",
-    "version": "1.24.0"
+    "version": "1.25.0"
   },
   "snippets": [
     {

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -577,7 +577,7 @@ libraries:
         go:
           import_path: datamanager/apiv1
   - name: dataplex
-    version: 1.34.0
+    version: 1.35.0
     apis:
       - path: google/cloud/dataplex/v1
   - name: dataproc
@@ -727,7 +727,7 @@ libraries:
       - path: google/cloud/functions/v1
       - path: google/cloud/functions/v2beta
   - name: geminidataanalytics
-    version: 1.1.0
+    version: 1.2.0
     apis:
       - path: google/cloud/geminidataanalytics/v1
       - path: google/cloud/geminidataanalytics/v1beta
@@ -888,7 +888,7 @@ libraries:
       - path: google/cloud/managedkafka/v1
       - path: google/cloud/managedkafka/schemaregistry/v1
   - name: maps
-    version: 1.35.0
+    version: 1.36.0
     apis:
       - path: google/maps/geocode/v4
       - path: google/maps/routing/v2
@@ -1174,7 +1174,7 @@ libraries:
     keep:
       - apiv2/locations_client.go
   - name: saasplatform
-    version: 0.7.0
+    version: 0.8.0
     apis:
       - path: google/cloud/saasplatform/saasservicemgmt/v1beta1
   - name: scheduler
@@ -1202,7 +1202,7 @@ libraries:
     apis:
       - path: google/cloud/securesourcemanager/v1
   - name: security
-    version: 1.24.0
+    version: 1.25.0
     apis:
       - path: google/cloud/security/privateca/v1
       - path: google/cloud/security/publicca/v1

--- a/maps/CHANGES.md
+++ b/maps/CHANGES.md
@@ -2,6 +2,16 @@
 
 
 
+## [1.36.0](https://github.com/googleapis/google-cloud-go/releases/tag/maps%2Fv1.36.0) (2026-05-28)
+
+### Features
+
+* update API sources and regenerate (#14661) ([d0cd917](https://github.com/googleapis/google-cloud-go/commit/d0cd917ce0ad46a4d2c1cd4ea2ef8efa60b591d3))
+
+### Documentation
+
+* correct the samples (#14632) ([7988942](https://github.com/googleapis/google-cloud-go/commit/7988942ceb456a93a5ca43dc2fde7320bde093bc))
+
 ## [1.35.0](https://github.com/googleapis/google-cloud-go/releases/tag/maps%2Fv1.35.0) (2026-05-07)
 
 ## [1.34.0](https://github.com/googleapis/google-cloud-go/releases/tag/maps%2Fv1.34.0) (2026-04-30)

--- a/maps/internal/version.go
+++ b/maps/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "1.35.0"
+const Version = "1.36.0"

--- a/saasplatform/CHANGES.md
+++ b/saasplatform/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+## [0.8.0](https://github.com/googleapis/google-cloud-go/releases/tag/saasplatform%2Fv0.8.0) (2026-05-28)
+
+### Features
+
+* update API sources and regenerate (#14661) ([d0cd917](https://github.com/googleapis/google-cloud-go/commit/d0cd917ce0ad46a4d2c1cd4ea2ef8efa60b591d3))
+
 ## [0.7.0](https://github.com/googleapis/google-cloud-go/releases/tag/saasplatform%2Fv0.7.0) (2026-05-07)
 
 ## [0.6.0](https://github.com/googleapis/google-cloud-go/releases/tag/saasplatform%2Fv0.6.0) (2026-04-30)

--- a/saasplatform/internal/version.go
+++ b/saasplatform/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "0.7.0"
+const Version = "0.8.0"

--- a/security/CHANGES.md
+++ b/security/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+## [1.25.0](https://github.com/googleapis/google-cloud-go/releases/tag/security%2Fv1.25.0) (2026-05-28)
+
+### Features
+
+* update API sources and regenerate (#14661) ([d0cd917](https://github.com/googleapis/google-cloud-go/commit/d0cd917ce0ad46a4d2c1cd4ea2ef8efa60b591d3))
+
 ## [1.24.0](https://github.com/googleapis/google-cloud-go/releases/tag/security%2Fv1.24.0) (2026-05-07)
 
 ## [1.23.0](https://github.com/googleapis/google-cloud-go/releases/tag/security%2Fv1.23.0) (2026-04-30)

--- a/security/internal/version.go
+++ b/security/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "1.24.0"
+const Version = "1.25.0"


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.15.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go@sha256:b04b076f5eedbb5546bd6fc1404969dd3698c8b19c0f34ae815a84ae735a606a
<details><summary>dataplex: v1.35.0</summary>

## [v1.35.0](https://github.com/googleapis/google-cloud-go/compare/dataplex/v1.34.0...dataplex/v1.35.0) (2026-05-28)

### Features

* update API sources and regenerate (#14661) ([d0cd917c](https://github.com/googleapis/google-cloud-go/commit/d0cd917c))

</details>


<details><summary>geminidataanalytics: v1.2.0</summary>

## [v1.2.0](https://github.com/googleapis/google-cloud-go/compare/geminidataanalytics/v1.1.0...geminidataanalytics/v1.2.0) (2026-05-28)

### Features

* update API sources and regenerate (#14661) ([d0cd917c](https://github.com/googleapis/google-cloud-go/commit/d0cd917c))

</details>


<details><summary>maps: v1.36.0</summary>

## [v1.36.0](https://github.com/googleapis/google-cloud-go/compare/maps/v1.35.0...maps/v1.36.0) (2026-05-28)

### Features

* update API sources and regenerate (#14661) ([d0cd917c](https://github.com/googleapis/google-cloud-go/commit/d0cd917c))

### Documentation

* correct the samples (#14632) ([7988942c](https://github.com/googleapis/google-cloud-go/commit/7988942c))

</details>


<details><summary>saasplatform: v0.8.0</summary>

## [v0.8.0](https://github.com/googleapis/google-cloud-go/compare/saasplatform/v0.7.0...saasplatform/v0.8.0) (2026-05-28)

### Features

* update API sources and regenerate (#14661) ([d0cd917c](https://github.com/googleapis/google-cloud-go/commit/d0cd917c))

</details>


<details><summary>security: v1.25.0</summary>

## [v1.25.0](https://github.com/googleapis/google-cloud-go/compare/security/v1.24.0...security/v1.25.0) (2026-05-28)

### Features

* update API sources and regenerate (#14661) ([d0cd917c](https://github.com/googleapis/google-cloud-go/commit/d0cd917c))

</details>