### PR TITLE
feat(firestore): configure client to support 16MB documents

### DIFF
--- a/firestore/client.go
+++ b/firestore/client.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net/url"
 	"os"
 	"strings"
@@ -91,7 +92,14 @@ func newClient(ctx context.Context, projectID string, createClient func(ctx cont
 			return nil, fmt.Errorf("firestore: emulator is not supported for this client type")
 		}
 
-		conn, err := grpc.Dial(addr, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithPerRPCCredentials(emulatorCreds{}))
+		conn, err := grpc.Dial(addr,
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+			grpc.WithPerRPCCredentials(emulatorCreds{}),
+			grpc.WithDefaultCallOptions(
+				grpc.MaxCallRecvMsgSize(math.MaxInt32),
+				grpc.MaxCallSendMsgSize(math.MaxInt32),
+			),
+		)
 		if err != nil {
 			return nil, fmt.Errorf("firestore: dialing address from env var FIRESTORE_EMULATOR_HOST: %s", err)
 		}
@@ -100,6 +108,13 @@ func newClient(ctx context.Context, projectID string, createClient func(ctx cont
 		projectID, _ = detect.ProjectID(ctx, projectID, "", opts...)
 		if projectID == "" {
 			projectID = "dummy-emulator-firestore-project"
+		}
+	} else {
+		o = []option.ClientOption{
+			option.WithGRPCDialOption(grpc.WithDefaultCallOptions(
+				grpc.MaxCallRecvMsgSize(math.MaxInt32),
+				grpc.MaxCallSendMsgSize(math.MaxInt32),
+			)),
 		}
 	}
 	o = append(o, opts...)

--- a/firestore/integration_test.go
+++ b/firestore/integration_test.go
@@ -3677,9 +3677,7 @@ func TestIntegration_VerifyGRPCLimits(t *testing.T) {
 	// Create a large 5MB random payload (non-compressible) to verify transport limits
 	size := 5 * 1024 * 1024
 	largeData := make([]byte, size)
-	if _, err := rand.Read(largeData); err != nil {
-		t.Fatalf("Failed to generate random data: %v", err)
-	}
+	rand.Read(largeData)
 
 	docRef := c.Collection("large_docs").NewDoc()
 	t.Cleanup(func() {

--- a/firestore/integration_test.go
+++ b/firestore/integration_test.go
@@ -16,6 +16,7 @@ package firestore
 
 import (
 	"context"
+	"crypto/rand"
 	"errors"
 	"flag"
 	"fmt"
@@ -3664,5 +3665,45 @@ func TestIntegration_TransactionWithReadOptionsError(t *testing.T) {
 	}, ReadOnly)
 	if err != errInvalidReadTime {
 		t.Fatalf("got err %v, want %v", err, errInvalidReadTime)
+	}
+}
+
+func TestIntegration_VerifyGRPCLimits(t *testing.T) {
+	skipIfEdition(t, "16MB Documents", editionStandard)
+	t.Skip("Temporarily skipped. Not yet in production.")
+	ctx := context.Background()
+	c := integrationClient(t)
+
+	// Create a large 5MB random payload (non-compressible) to verify transport limits
+	size := 5 * 1024 * 1024
+	largeData := make([]byte, size)
+	if _, err := rand.Read(largeData); err != nil {
+		t.Fatalf("Failed to generate random data: %v", err)
+	}
+
+	docRef := c.Collection("large_docs").NewDoc()
+	t.Cleanup(func() {
+		deleteDocuments([]*DocumentRef{docRef})
+	})
+
+	// 1. Verify Send Limit
+	_, err := docRef.Set(ctx, map[string]interface{}{"payload": largeData})
+	if err != nil {
+		t.Fatalf("Failed to write large document (Send failed): %v", err)
+	}
+
+	// 2. Verify Receive Limit
+	snap, err := docRef.Get(ctx)
+	if err != nil {
+		t.Fatalf("Failed to read large document (Recv failed): %v", err)
+	}
+
+	if !snap.Exists() {
+		t.Fatal("Document does not exist after write")
+	}
+
+	gotData := snap.Data()["payload"].([]byte)
+	if len(gotData) != size {
+		t.Errorf("Got data size %d, want %d", len(gotData), size)
 	}
 }


### PR DESCRIPTION
Configures the underlying gRPC client to explicitly support sending and receiving messages up to `math.MaxInt32` bytes. This enables support for larger documents (up to 16MB) in the Go Firestore SDK.

## Current Limits (Without this PR)
*   **Receive Limit**: Already configured to `math.MaxInt32` in the auto-generated `apiv1` client.
*   **Send Limit**: Not explicitly configured in the SDK. While the current `grpc-go` library implementation defaults to unlimited (`math.MaxInt32`) for client-side sending, explicitly setting it to `math.MaxInt32` ensures robustness against future gRPC default changes and aligns with the expected behavior across other Firestore SDKs (which may have a 4MB default send limit).
 

## Changes
This PR explicitly configures both `MaxCallRecvMsgSize` and `MaxCallSendMsgSize` to `math.MaxInt32` in `client.go` to guarantee support for large payloads.

Also adds a regression test in `integration_test.go`:
*   **`TestIntegration_VerifyGRPCLimits`**: Verifies the client can send and receive a 5MB payload (exceeding the default 4MB gRPC limits) using non-compressible random bytes. It asserts that both the write (`Set`) and read (`Get`) operations succeed.


Fixes : b/515735339