### PR TITLE
fix(firestore): robust transaction rollback on cancellation

### DIFF
--- a/firestore/transaction.go
+++ b/firestore/transaction.go
@@ -278,7 +278,7 @@ func (c *Client) RunTransaction(ctx context.Context, f func(context.Context, *Tr
 func (t *Transaction) rollback() {
 	// Use a background context with a timeout to ensure rollback completes
 	// even if the transaction context (t.ctx) is cancelled.
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(t.ctx), 5*time.Second)
 	defer cancel()
 	ctx = withResourceHeader(ctx, t.c.path())
 	_ = t.c.c.Rollback(ctx, &pb.RollbackRequest{

--- a/firestore/transaction.go
+++ b/firestore/transaction.go
@@ -190,7 +190,9 @@ func (c *Client) RunTransaction(ctx context.Context, f func(context.Context, *Tr
 	// TODO(jba): use other than the standard backoff parameters?
 	// TODO(jba): get backoff time from gRPC trailer metadata? See
 	// extractRetryDelay in https://code.googlesource.com/gocloud/+/master/spanner/retry.go.
+	var errDuringCommit bool
 	for i := 0; i < t.maxAttempts; i++ {
+		errDuringCommit = false
 		t.ctx = trace.StartSpan(t.ctx, "cloud.google.com/go/firestore.Client.BeginTransaction")
 		var res *pb.BeginTransactionResponse
 		res, err = t.c.c.BeginTransaction(t.ctx, &pb.BeginTransactionRequest{
@@ -222,6 +224,7 @@ func (c *Client) RunTransaction(ctx context.Context, f func(context.Context, *Tr
 				Transaction: t.id,
 			})
 			trace.EndSpan(t.ctx, err)
+			errDuringCommit = err != nil
 
 			// on success, handle the commit response
 			if err == nil {
@@ -233,7 +236,9 @@ func (c *Client) RunTransaction(ctx context.Context, f func(context.Context, *Tr
 		}
 
 		// At this point, `err` is non-nil. It came from `f` or `Commit`.
-		t.rollback()
+		if !errDuringCommit {
+			t.rollback()
+		}
 
 		// If not a retryable error, or if read-only, return now.
 		// (We've already rolled back).
@@ -271,7 +276,12 @@ func (c *Client) RunTransaction(ctx context.Context, f func(context.Context, *Tr
 }
 
 func (t *Transaction) rollback() {
-	_ = t.c.c.Rollback(t.ctx, &pb.RollbackRequest{
+	// Use a background context with a timeout to ensure rollback completes
+	// even if the transaction context (t.ctx) is cancelled.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	ctx = withResourceHeader(ctx, t.c.path())
+	_ = t.c.c.Rollback(ctx, &pb.RollbackRequest{
 		Database:    t.c.path(),
 		Transaction: t.id,
 	})

--- a/firestore/transaction_test.go
+++ b/firestore/transaction_test.go
@@ -141,8 +141,6 @@ func TestRunTransaction(t *testing.T) {
 	srv.reset()
 	srv.addRPC(beginReq, beginRes)
 	srv.addRPC(commitReq, status.Errorf(codes.Aborted, ""))
-	rollbackReq := &pb.RollbackRequest{Database: db, Transaction: tid}
-	srv.addRPC(rollbackReq, &emptypb.Empty{})
 	tid2 := []byte{2} // Use a new transaction ID for the response to the retry BeginTransaction
 	beginReqRetry := &pb.BeginTransactionRequest{
 		Database: db,
@@ -266,7 +264,6 @@ func TestTransactionErrors(t *testing.T) {
 			},
 		})
 		srv.addRPC(commitReq, unknownErr)
-		srv.addRPC(rollbackReq, &emptypb.Empty{})
 
 		err := c.RunTransaction(ctx, get)
 		if status.Code(err) != codes.Unknown {
@@ -417,7 +414,6 @@ func TestTransactionErrors(t *testing.T) {
 		// Attempt 1 (Fails)
 		srv.addRPC(beginReq, beginRes)                          // 1. BeginTransaction (tid1)
 		srv.addRPC(commitReq, status.Errorf(codes.Aborted, "")) // 2. Commit (tid1) fails (Aborted)
-		srv.addRPC(rollbackReq, &emptypb.Empty{})               // 3. Rollback (tid1)
 
 		// Attempt 2 (Fails)
 		beginReqRetry := &pb.BeginTransactionRequest{
@@ -433,10 +429,6 @@ func TestTransactionErrors(t *testing.T) {
 
 		commitReq2 := &pb.CommitRequest{Database: db, Transaction: tid2} // New commit request with tid2
 		srv.addRPC(commitReq2, status.Errorf(codes.Aborted, ""))         // 5. Commit (tid2) fails (Aborted)
-
-		// Final Rollback on Aborted error when MaxAttempts is reached
-		rollbackReq2 := &pb.RollbackRequest{Database: db, Transaction: tid2}
-		srv.addRPC(rollbackReq2, &emptypb.Empty{}) // 6. Rollback (tid2)
 
 		err := c.RunTransaction(ctx, func(context.Context, *Transaction) error { return nil },
 			MaxAttempts(2))
@@ -477,6 +469,41 @@ func TestTransactionErrors(t *testing.T) {
 		}
 		if !srv.isEmpty() {
 			t.Errorf("Expected %+v requests but not received. srv.reqItems: %+v", len(srv.reqItems), srv.reqItems)
+		}
+	})
+
+	t.Run("Cancel context during f", func(t *testing.T) {
+		srv.reset()
+		srv.addRPC(beginReq, beginRes)
+		srv.addRPC(rollbackReq, &emptypb.Empty{})
+
+		ctx, cancel := context.WithCancel(context.Background())
+		err := c.RunTransaction(ctx, func(ctx context.Context, tx *Transaction) error {
+			cancel() // Cancel context inside f
+			return ctx.Err()
+		})
+		if err != context.Canceled {
+			t.Errorf("got %v, want Canceled", err)
+		}
+		if !srv.isEmpty() {
+			t.Errorf("Expected all RPCs to be met, but got remaining: %+v", srv.reqItems)
+		}
+	})
+
+	t.Run("Commit fails, no rollback", func(t *testing.T) {
+		srv.reset()
+		srv.addRPC(beginReq, beginRes)
+		srv.addRPC(commitReq, unknownErr)
+		// No rollbackReq expected here
+
+		err := c.RunTransaction(ctx, func(ctx context.Context, tx *Transaction) error {
+			return nil
+		})
+		if status.Code(err) != codes.Unknown {
+			t.Errorf("got %v, want Unknown", err)
+		}
+		if !srv.isEmpty() {
+			t.Errorf("Expected all RPCs to be met, but got remaining: %+v", srv.reqItems)
 		}
 	})
 }
@@ -553,9 +580,6 @@ func TestRunTransaction_Retries(t *testing.T) {
 		},
 		status.Errorf(codes.Aborted, "something failed! please retry me!"),
 	)
-
-	rollbackReq := &pb.RollbackRequest{Database: db, Transaction: tid}
-	srv.addRPC(rollbackReq, &emptypb.Empty{})
 
 	// Attempt 2: Begin (Retry)
 	srv.addRPC(


### PR DESCRIPTION
This PR fixes issues with transaction rollback behavior on context cancellation and commit failures.

1.  **Robust Rollback on Cancellation:** Previously, if a transaction was cancelled (e.g., via context cancellation during the user function), the `rollback()` call would use the cancelled transaction context. This caused the `Rollback` RPC to fail immediately on the client side without reaching the backend, leaving the transaction active on the backend until timeout. We now use a detached context (`context.Background()`) with a timeout for rollback calls to ensure they reach the backend.
2.  **Skip Rollback after Commit Attempt:** We now track if the error occurred during the `Commit` RPC and skip rollback if so. Attempting to rollback after a commit has failed is unnecessary and can cause errors, as the transaction is already finalized on the backend. This aligns with the Spanner Go client behavior.
3.  **Test Updates:** Added new tests to verify rollback on cancellation and no rollback on commit failure. Updated existing tests to remove expectations of rollback after commit failure.

Fixes: https://github.com/googleapis/google-cloud-go/issues/8740