### PR TITLE
refactor(bigtable): decouple metrics tracer and support client-side metrics for session and classic transport

### DIFF
--- a/bigtable/apply_bulk.go
+++ b/bigtable/apply_bulk.go
@@ -97,8 +97,9 @@ func (t *Table) applyGroup(ctx context.Context, group []*entryErr, opts ...Apply
 	attrMap := make(map[string]interface{})
 	mt := t.newBuiltinMetricsTracer(ctx, true)
 	defer mt.recordOperationCompletion()
+	ctx = contextWithMetricsTracer(ctx, mt)
 
-	err = gaxInvokeWithRecorder(ctx, mt, "MutateRows", func(ctx context.Context, headerMD, trailerMD *metadata.MD, _ gax.CallSettings) error {
+	err = gaxInvokeWithRecorder(ctx, "MutateRows", func(ctx context.Context, headerMD, trailerMD *metadata.MD, _ gax.CallSettings) error {
 		attrMap["rowCount"] = len(group)
 		trace.TracePrintf(ctx, attrMap, "Row count in ApplyBulk")
 		err := t.doApplyBulk(ctx, group, headerMD, trailerMD, opts...)

--- a/bigtable/bigtable.go
+++ b/bigtable/bigtable.go
@@ -197,6 +197,8 @@ func createFeatureFlagsMD(clientSideMetricsEnabled, disableRetryInfo, enableDire
 		RetryInfo:                !disableRetryInfo,
 		TrafficDirectorEnabled:   enableDirectAccess,
 		DirectAccessRequested:    enableDirectAccess,
+		SessionsCompatible:       true,
+		PeerInfo:                 true,
 	}
 
 	val := ""

--- a/bigtable/bigtable.go
+++ b/bigtable/bigtable.go
@@ -226,14 +226,16 @@ func (t *Table) ReadRows(ctx context.Context, arg RowSet, f func(Row) bool, opts
 
 	mt := t.newBuiltinMetricsTracer(ctx, true)
 	defer mt.recordOperationCompletion()
+	ctx = contextWithMetricsTracer(ctx, mt)
 
-	err = t.readRows(ctx, arg, f, mt, opts...)
+	err = t.readRows(ctx, arg, f, opts...)
 	statusCode, statusErr := convertToGrpcStatusErr(err)
 	mt.setCurrOpStatus(statusCode)
 	return statusErr
 }
 
-func (t *Table) readRows(ctx context.Context, arg RowSet, f func(Row) bool, mt *builtinMetricsTracer, opts ...ReadOption) (err error) {
+func (t *Table) readRows(ctx context.Context, arg RowSet, f func(Row) bool, opts ...ReadOption) (err error) {
+	mt := metricsTracerFromContext(ctx)
 	var prevRowKey string
 	attrMap := make(map[string]interface{})
 
@@ -251,7 +253,7 @@ func (t *Table) readRows(ctx context.Context, arg RowSet, f func(Row) bool, mt *
 	}
 
 	firstResponseRecorded := false
-	err = gaxInvokeWithRecorder(ctx, mt, methodNameReadRows, func(ctx context.Context, headerMD, trailerMD *metadata.MD, _ gax.CallSettings) error {
+	err = gaxInvokeWithRecorder(ctx, methodNameReadRows, func(ctx context.Context, headerMD, trailerMD *metadata.MD, _ gax.CallSettings) error {
 		if rowLimitSet && numRowsRead >= intialRowLimit {
 			return nil
 		}
@@ -907,14 +909,15 @@ func (t *Table) Apply(ctx context.Context, row string, m *Mutation, opts ...Appl
 	defer func() { trace.EndSpan(ctx, err) }()
 	mt := t.newBuiltinMetricsTracer(ctx, false)
 	defer mt.recordOperationCompletion()
+	ctx = contextWithMetricsTracer(ctx, mt)
 
-	err = t.apply(ctx, mt, row, m, opts...)
+	err = t.apply(ctx, row, m, opts...)
 	statusCode, statusErr := convertToGrpcStatusErr(err)
 	mt.setCurrOpStatus(statusCode)
 	return statusErr
 }
 
-func (t *Table) apply(ctx context.Context, mt *builtinMetricsTracer, row string, m *Mutation, opts ...ApplyOption) (err error) {
+func (t *Table) apply(ctx context.Context, row string, m *Mutation, opts ...ApplyOption) (err error) {
 	after := func(res proto.Message) {
 		for _, o := range opts {
 			o.after(res)
@@ -937,7 +940,7 @@ func (t *Table) apply(ctx context.Context, mt *builtinMetricsTracer, row string,
 			callOptions = append(callOptions, t.c.retryOption)
 		}
 		var res *btpb.MutateRowResponse
-		err := gaxInvokeWithRecorder(ctx, mt, "MutateRow", func(ctx context.Context, headerMD, trailerMD *metadata.MD, _ gax.CallSettings) error {
+		err := gaxInvokeWithRecorder(ctx, "MutateRow", func(ctx context.Context, headerMD, trailerMD *metadata.MD, _ gax.CallSettings) error {
 			var err error
 			res, err = t.c.client.MutateRow(ctx, req, grpc.Header(headerMD), grpc.Trailer(trailerMD))
 			return err
@@ -973,7 +976,7 @@ func (t *Table) apply(ctx context.Context, mt *builtinMetricsTracer, row string,
 		req.FalseMutations = m.mfalse.ops
 	}
 	var cmRes *btpb.CheckAndMutateRowResponse
-	err = gaxInvokeWithRecorder(ctx, mt, "CheckAndMutateRow", func(ctx context.Context, headerMD, trailerMD *metadata.MD, _ gax.CallSettings) error {
+	err = gaxInvokeWithRecorder(ctx, "CheckAndMutateRow", func(ctx context.Context, headerMD, trailerMD *metadata.MD, _ gax.CallSettings) error {
 		var err error
 		cmRes, err = t.c.client.CheckAndMutateRow(ctx, req, grpc.Header(headerMD), grpc.Trailer(trailerMD))
 		return err
@@ -1136,8 +1139,9 @@ func (ts Timestamp) TruncateToMilliseconds() Timestamp {
 //   - does not return errors seen while recording the metrics
 //
 // - then, calls gax.Invoke with 'callWrapper' as an argument
-func gaxInvokeWithRecorder(ctx context.Context, mt *builtinMetricsTracer, method string,
+func gaxInvokeWithRecorder(ctx context.Context, method string,
 	f func(ctx context.Context, headerMD, trailerMD *metadata.MD, _ gax.CallSettings) error, opts ...gax.CallOption) error {
+	mt := metricsTracerFromContext(ctx)
 	attemptHeaderMD := metadata.New(nil)
 	attempTrailerMD := metadata.New(nil)
 	mt.setMethod(method)

--- a/bigtable/bigtable_test.go
+++ b/bigtable/bigtable_test.go
@@ -2387,9 +2387,12 @@ func newUnaryClientInterceptor(prepReqCount *int, respPtrs *[]prepareQueryResp, 
 	return func(ctx context.Context, method string, req, reply interface{},
 		cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
 		err := invoker(ctx, method, req, reply, cc, opts...)
-		defer func() { *prepReqCount++ }()
 		_, isPrepReq := req.(*btpb.PrepareQueryRequest)
-		if !isPrepReq || (err != nil && !strings.Contains(err.Error(), emulatorUnsupported)) {
+		if !isPrepReq {
+			return err
+		}
+		defer func() { *prepReqCount++ }()
+		if err != nil && !strings.Contains(err.Error(), emulatorUnsupported) {
 			return err
 		}
 

--- a/bigtable/bttest/inmem.go
+++ b/bigtable/bttest/inmem.go
@@ -1501,6 +1501,22 @@ func (s *server) ExecuteQuery(*btpb.ExecuteQueryRequest, btpb.Bigtable_ExecuteQu
 	return status.Errorf(codes.Unimplemented, "the emulator does not currently support ExecuteQuery")
 }
 
+func (s *server) GetClientConfiguration(ctx context.Context, req *btpb.GetClientConfigurationRequest) (*btpb.ClientConfiguration, error) {
+	return nil, status.Errorf(codes.Unimplemented, "the emulator does not currently support GetClientConfiguration")
+}
+
+func (s *server) OpenTable(stream btpb.Bigtable_OpenTableServer) error {
+	return status.Errorf(codes.Unimplemented, "the emulator does not currently support OpenTable")
+}
+
+func (s *server) OpenAuthorizedView(stream btpb.Bigtable_OpenAuthorizedViewServer) error {
+	return status.Errorf(codes.Unimplemented, "the emulator does not currently support OpenAuthorizedView")
+}
+
+func (s *server) OpenMaterializedView(stream btpb.Bigtable_OpenMaterializedViewServer) error {
+	return status.Errorf(codes.Unimplemented, "the emulator does not currently support OpenMaterializedView")
+}
+
 // needGC is invoked whenever the server needs gcloop running.
 func (s *server) needGC() {
 	s.mu.Lock()

--- a/bigtable/channel_pool_factory.go
+++ b/bigtable/channel_pool_factory.go
@@ -1,0 +1,154 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bigtable
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"google.golang.org/api/option"
+	"google.golang.org/api/option/internaloption"
+	gtransport "google.golang.org/api/transport/grpc"
+	"google.golang.org/grpc/metadata"
+
+	btransport "cloud.google.com/go/bigtable/internal/transport"
+	btopt "cloud.google.com/go/bigtable/internal/option"
+)
+
+// managedChannelPool encapsulates a connection pool along with its lifecycle monitors.
+type managedChannelPool struct {
+	pool         gtransport.ConnPool
+	dsm          *btransport.DynamicScaleMonitor
+	connRecycler *btransport.ConnectionRecycler
+}
+
+// Close stops all associated monitors/recyclers and closes the underlying pool.
+func (m managedChannelPool) Close() error {
+	if m.dsm != nil {
+		m.dsm.Stop()
+	}
+	if m.connRecycler != nil {
+		m.connRecycler.Stop()
+	}
+	if m.pool != nil {
+		return m.pool.Close()
+	}
+	return nil
+}
+
+// createAndStartManagedChannelPool initializes and starts the lifecycle monitors for a classic or session connection pool.
+func createAndStartManagedChannelPool(
+	ctx context.Context,
+	project, instance string,
+	config ClientConfig,
+	metricsTracerFactory *builtinMetricsTracerFactory,
+	o []option.ClientOption,
+	directPathOptions []option.ClientOption,
+	directAccessMD metadata.MD,
+	clientCreationTimestamp time.Time,
+	enableBigtableConnPool bool,
+) (managedChannelPool, error) {
+	var m managedChannelPool
+	if !enableBigtableConnPool {
+		var err error
+		m.pool, err = gtransport.DialPool(ctx, o...)
+		return m, err
+	}
+
+	pool, err := createBigtableChannelPool(ctx, project, instance, config, metricsTracerFactory, o, directPathOptions, directAccessMD, clientCreationTimestamp)
+	if err != nil {
+		return m, err
+	}
+	m.pool = pool
+
+	// Validate dynamic config early if enabled
+	if !config.DisableDynamicChannelPool {
+		if err := btransport.ValidateDynamicConfig(btopt.DefaultDynamicChannelPoolConfig(), defaultBigtableConnPoolSize); err != nil {
+			pool.Close()
+			return m, fmt.Errorf("invalid DynamicChannelPoolConfig: %w", err)
+		}
+
+		m.dsm = btransport.NewDynamicScaleMonitor(btopt.DefaultDynamicChannelPoolConfig(), pool)
+		m.dsm.Start(ctx)
+	}
+
+	// connection recycler
+	if !config.DisableConnectionRecycler {
+		m.connRecycler = btransport.NewConnectionRecycler(btopt.DefaultConnectionRecycleConfig(), pool)
+		m.connRecycler.Start(ctx)
+	}
+
+	return m, nil
+}
+
+// createBigtableChannelPool is a helper function to initialize a separate BigtableChannelPool instance.
+func createBigtableChannelPool(
+	ctx context.Context,
+	project, instance string,
+	config ClientConfig,
+	metricsTracerFactory *builtinMetricsTracerFactory,
+	o []option.ClientOption,
+	directPathOptions []option.ClientOption,
+	directAccessMD metadata.MD,
+	clientCreationTimestamp time.Time,
+) (*btransport.BigtableChannelPool, error) {
+	fmt.Printf(">>> createBigtableChannelPool called for project=%s, instance=%s <<<\n", project, instance)
+	uResolver, err := internaloption.NewUnsafeResolver(o...)
+	var connPoolSize int
+	if err != nil {
+		connPoolSize = defaultBigtableConnPoolSize
+	} else {
+		connPoolSize = uResolver.ResolvedGRPCConnPoolSize()
+		if connPoolSize == 0 {
+			connPoolSize = defaultBigtableConnPoolSize
+		}
+	}
+
+	fullInstanceName := fmt.Sprintf("projects/%s/instances/%s", project, instance)
+
+	directAccessDialerOptions := make([]option.ClientOption, len(o))
+	copy(directAccessDialerOptions, o)
+	directAccessDialerOptions = append(directAccessDialerOptions, directPathOptions...)
+	directAccessDialerOptions = append(directAccessDialerOptions, internaloption.AllowHardBoundTokens("ALTS"))
+
+	directAccessDialer := func() (*btransport.BigtableConn, error) {
+		grpcConn, err := gtransport.Dial(ctx, directAccessDialerOptions...)
+		if err != nil {
+			return nil, err
+		}
+		return btransport.NewBigtableConn(grpcConn), nil
+	}
+
+	return btransport.NewBigtableChannelPool(ctx,
+		connPoolSize,
+		btopt.BigtableLoadBalancingStrategy(),
+		func() (*btransport.BigtableConn, error) {
+			grpcConn, err := gtransport.Dial(ctx, o...)
+			if err != nil {
+				return nil, err
+			}
+			return btransport.NewBigtableConn(grpcConn), nil
+		},
+		clientCreationTimestamp,
+		btransport.WithInstanceName(fullInstanceName),
+		btransport.WithAppProfile(config.AppProfile),
+		btransport.WithFeatureFlagsMetadata(directAccessMD),
+		btransport.WithMetricsReporterConfig(btopt.DefaultMetricsReporterConfig()),
+		btransport.WithMeterProvider(metricsTracerFactory.otelMeterProvider),
+		btransport.WithDirectAccessFeatureFlagsMetadata(directAccessMD),
+		btransport.WithDirectAccessDialer(directAccessDialer),
+	)
+}

--- a/bigtable/client.go
+++ b/bigtable/client.go
@@ -50,6 +50,7 @@ type Client struct {
 	featureFlagsMD          metadata.MD // Pre-computed feature flags metadata to be sent with each request.
 	dynamicScaleMonitor     *btransport.DynamicScaleMonitor
 	connsRecycler           *btransport.ConnectionRecycler
+	configManager           *btransport.ClientConfigurationManager
 }
 
 // ClientConfig has configurations for the client.
@@ -259,9 +260,11 @@ func NewClientWithConfig(ctx context.Context, project, instance string, config C
 		return nil, connPoolErr
 	}
 
-	return &Client{
+	btClient := btpb.NewBigtableClient(connPool)
+
+	c := &Client{
 		connPool:                connPool,
-		client:                  btpb.NewBigtableClient(connPool),
+		client:                  btClient,
 		project:                 project,
 		instance:                instance,
 		appProfile:              config.AppProfile,
@@ -272,11 +275,25 @@ func NewClientWithConfig(ctx context.Context, project, instance string, config C
 		featureFlagsMD:          directAccessMD,
 		dynamicScaleMonitor:     dsm,
 		connsRecycler:           connRecycler,
-	}, nil
+	}
+
+	configMD := metadata.Join(metadata.Pairs(
+		resourcePrefixHeader, c.fullInstanceName(),
+		requestParamsHeader, c.reqParamsHeaderValInstance(),
+	), c.featureFlagsMD)
+
+	configManager := btransport.NewClientConfigurationManager(btClient, c.fullInstanceName(), config.AppProfile, configMD)
+	configManager.Start(ctx)
+	c.configManager = configManager
+
+	return c, nil
 }
 
 // Close closes the Client.
 func (c *Client) Close() error {
+	if c.configManager != nil {
+		c.configManager.Close()
+	}
 	if c.dynamicScaleMonitor != nil {
 		c.dynamicScaleMonitor.Stop()
 	}

--- a/bigtable/client.go
+++ b/bigtable/client.go
@@ -20,7 +20,6 @@ import (
 	"net/url"
 	"os"
 	"reflect"
-	"strconv"
 	"time"
 
 	btpb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
@@ -30,7 +29,6 @@ import (
 	gax "github.com/googleapis/gax-go/v2"
 	"google.golang.org/api/option"
 	"google.golang.org/api/option/internaloption"
-	gtransport "google.golang.org/api/transport/grpc"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 )
@@ -39,18 +37,22 @@ import (
 //
 // A Client is safe to use concurrently, except for its Close method.
 type Client struct {
-	connPool                gtransport.ConnPool
-	client                  btpb.BigtableClient
-	project, instance       string
-	appProfile              string
-	metricsTracerFactory    *builtinMetricsTracerFactory
-	disableRetryInfo        bool
-	retryOption             gax.CallOption
-	executeQueryRetryOption gax.CallOption
-	featureFlagsMD          metadata.MD // Pre-computed feature flags metadata to be sent with each request.
-	dynamicScaleMonitor     *btransport.DynamicScaleMonitor
-	connsRecycler           *btransport.ConnectionRecycler
-	configManager           *btransport.ClientConfigurationManager
+	classicPool                managedChannelPool
+	client                     btpb.BigtableClient
+	sessionClient              btpb.BigtableClient
+	project, instance          string
+	appProfile                 string
+	metricsTracerFactory       *builtinMetricsTracerFactory
+	disableRetryInfo           bool
+	retryOption                gax.CallOption
+	executeQueryRetryOption    gax.CallOption
+	featureFlagsMD             metadata.MD // Pre-computed feature flags metadata to be sent with each request.
+	configManager              *btransport.ClientConfigurationManager
+	sessionMgr                 *SessionManager
+	diverter                   *btransport.Diverter
+	config                     ClientConfig
+	backgroundCtx              context.Context
+	backgroundCancel           context.CancelFunc
 }
 
 // ClientConfig has configurations for the client.
@@ -73,6 +75,17 @@ type ClientConfig struct {
 	// DisableConnectionRecycler disables the automatic preemptive refresh of connection.
 	// Preemptive connection is default to true
 	DisableConnectionRecycler bool
+
+	DisableDirectAccess bool
+
+	// EnableSessionPool enables the dedicated session pool infrastructure for vRPC operations.
+	EnableSessionPool bool
+
+	// SessionPoolMin configures the minimum number of sessions in the pool.
+	SessionPoolMin int
+
+	// SessionPoolMax configures the maximum number of sessions in the pool.
+	SessionPoolMax int
 }
 
 // MetricsProvider is a wrapper for built in metrics meter provider
@@ -158,11 +171,6 @@ func NewClientWithConfig(ctx context.Context, project, instance string, config C
 	// and we evaluate the directAccess option after that.
 	directAccessMD := createFeatureFlagsMD(metricsTracerFactory.enabled, disableRetryInfo, true)
 
-	var connPool gtransport.ConnPool
-	var connPoolErr error
-	var dsm *btransport.DynamicScaleMonitor
-	var connRecycler *btransport.ConnectionRecycler
-
 	enableBigtableConnPool := btopt.EnableBigtableConnectionPool()
 	grpcConnOptType := reflect.TypeOf(option.WithGRPCConn(nil))
 	for _, opt := range opts {
@@ -171,100 +179,30 @@ func NewClientWithConfig(ctx context.Context, project, instance string, config C
 			break
 		}
 	}
-	var connPoolSize int
-	if enableBigtableConnPool {
-		uResolver, err := internaloption.NewUnsafeResolver(o...)
-		if err != nil {
-			// just fallback
-			connPoolSize = defaultBigtableConnPoolSize
-		}
-
-		connPoolSize = uResolver.ResolvedGRPCConnPoolSize()
-		// Fallback to 10 if it resolves to 0
-		if connPoolSize == 0 {
-			connPoolSize = defaultBigtableConnPoolSize
-		}
-
-		fullInstanceName := fmt.Sprintf("projects/%s/instances/%s", project, instance)
-
-		directAccessDialerOptions := make([]option.ClientOption, len(o))
-		copy(directAccessDialerOptions, o)
-		directAccessDialerOptions = append(directAccessDialerOptions, directPathOptions...)
-		// enable hard bound tokens by default
-		directAccessDialerOptions = append(directAccessDialerOptions, internaloption.AllowHardBoundTokens("ALTS"))
-
-		directAccessDialer := func() (*btransport.BigtableConn, error) {
-			grpcConn, err := gtransport.Dial(ctx, directAccessDialerOptions...)
-			if err != nil {
-				return nil, err
-			}
-			return btransport.NewBigtableConn(grpcConn), nil
-		}
-
-		btPool, err := btransport.NewBigtableChannelPool(ctx,
-			connPoolSize,
-			btopt.BigtableLoadBalancingStrategy(),
-			func() (*btransport.BigtableConn, error) {
-				grpcConn, err := gtransport.Dial(ctx, o...)
-				if err != nil {
-					return nil, err
-				}
-				return btransport.NewBigtableConn(grpcConn), nil
-			},
-			clientCreationTimestamp,
-			// options
-			btransport.WithInstanceName(fullInstanceName),
-			btransport.WithAppProfile(config.AppProfile),
-			btransport.WithFeatureFlagsMetadata(directAccessMD),
-			btransport.WithMetricsReporterConfig(btopt.DefaultMetricsReporterConfig()),
-			btransport.WithMeterProvider(metricsTracerFactory.otelMeterProvider),
-			btransport.WithDirectAccessFeatureFlagsMetadata(directAccessMD),
-			btransport.WithDirectAccessDialer(directAccessDialer),
-		)
-
-		if err != nil {
-			connPoolErr = err
-		} else {
-			connPool = btPool
-
-			// Validate dynamic config early if enabled
-			if !config.DisableDynamicChannelPool {
-				if err := btransport.ValidateDynamicConfig(btopt.DefaultDynamicChannelPoolConfig(), defaultBigtableConnPoolSize); err != nil {
-					return nil, fmt.Errorf("invalid DynamicChannelPoolConfig: %w", err)
-				}
-
-				dsm = btransport.NewDynamicScaleMonitor(btopt.DefaultDynamicChannelPoolConfig(), btPool)
-				dsm.Start(ctx) // Start the monitor's background goroutine
-			}
-			// connection recyler.
-			if !config.DisableConnectionRecycler {
-				connRecycler = btransport.NewConnectionRecycler(btopt.DefaultConnectionRecycleConfig(), btPool)
-				connRecycler.Start(ctx) // Start the monitor's background goroutine
-			}
-
-		}
-
-	} else {
-		enableDirectAccess, _ := strconv.ParseBool(os.Getenv("CBT_ENABLE_DIRECTPATH"))
-		if enableDirectAccess {
-			o = append(o, directPathOptions...)
-			if disableBoundToken, _ := strconv.ParseBool(os.Getenv("CBT_DISABLE_DIRECTPATH_BOUND_TOKEN")); !disableBoundToken {
-				o = append(o, internaloption.AllowHardBoundTokens("ALTS"))
-			}
-		}
-		// use to regular ConnPool
-		connPool, connPoolErr = gtransport.DialPool(ctx, o...)
+	var classicManaged managedChannelPool
+	var classicErr error
+	classicManaged, classicErr = createAndStartManagedChannelPool(ctx, project, instance, config, metricsTracerFactory, o, directPathOptions, directAccessMD, clientCreationTimestamp, enableBigtableConnPool)
+	if classicErr != nil {
+		return nil, classicErr
 	}
+	btClient := btpb.NewBigtableClient(classicManaged.pool)
 
-	if connPoolErr != nil {
-		return nil, connPoolErr
+	var sessionManaged managedChannelPool
+	var sessionClient btpb.BigtableClient
+	if config.EnableSessionPool {
+		var sessionErr error
+		sessionManaged, sessionErr = createAndStartManagedChannelPool(ctx, project, instance, config, metricsTracerFactory, o, directPathOptions, directAccessMD, clientCreationTimestamp, enableBigtableConnPool)
+		if sessionErr != nil {
+			classicManaged.Close()
+			return nil, fmt.Errorf("failed to create dedicated session pool: %w", sessionErr)
+		}
+		sessionClient = btpb.NewBigtableClient(sessionManaged.pool)
 	}
-
-	btClient := btpb.NewBigtableClient(connPool)
 
 	c := &Client{
-		connPool:                connPool,
+		classicPool:             classicManaged,
 		client:                  btClient,
+		sessionClient:           sessionClient,
 		project:                 project,
 		instance:                instance,
 		appProfile:              config.AppProfile,
@@ -273,9 +211,10 @@ func NewClientWithConfig(ctx context.Context, project, instance string, config C
 		retryOption:             retryOption,
 		executeQueryRetryOption: executeQueryRetryOption,
 		featureFlagsMD:          directAccessMD,
-		dynamicScaleMonitor:     dsm,
-		connsRecycler:           connRecycler,
+		config:                  config,
+		diverter:                btransport.NewDiverter(1.0),
 	}
+	c.backgroundCtx, c.backgroundCancel = context.WithCancel(context.Background())
 
 	configMD := metadata.Join(metadata.Pairs(
 		resourcePrefixHeader, c.fullInstanceName(),
@@ -286,24 +225,46 @@ func NewClientWithConfig(ctx context.Context, project, instance string, config C
 	configManager.Start(ctx)
 	c.configManager = configManager
 
+	c.sessionMgr = NewSessionManager(
+		config.EnableSessionPool,
+		metricsTracerFactory.enabled,
+		disableRetryInfo,
+		directAccessMD,
+		c.diverter,
+		configManager,
+		c.backgroundCtx,
+		config.SessionPoolMin,
+		config.SessionPoolMax,
+		metricsTracerFactory.otelMeterProvider,
+		sessionManaged,
+	)
+
 	return c, nil
 }
 
 // Close closes the Client.
 func (c *Client) Close() error {
+	fmt.Printf("Closing the client for project %s and instance %s\n", c.project, c.instance)
+	if c.backgroundCancel != nil {
+		c.backgroundCancel()
+	}
 	if c.configManager != nil {
 		c.configManager.Close()
-	}
-	if c.dynamicScaleMonitor != nil {
-		c.dynamicScaleMonitor.Stop()
 	}
 	if c.metricsTracerFactory != nil {
 		c.metricsTracerFactory.shutdown()
 	}
-	if c.connsRecycler != nil {
-		c.connsRecycler.Stop()
+
+	var sessionErr error
+	if c.sessionMgr != nil {
+		sessionErr = c.sessionMgr.Close()
 	}
-	return c.connPool.Close()
+
+	classicErr := c.classicPool.Close()
+	if sessionErr != nil {
+		return sessionErr
+	}
+	return classicErr
 }
 
 func (c *Client) fullInstanceName() string {
@@ -330,54 +291,7 @@ func (c *Client) reqParamsHeaderValInstance() string {
 	return fmt.Sprintf("name=%s&app_profile_id=%s", url.QueryEscape(c.fullInstanceName()), url.QueryEscape(c.appProfile))
 }
 
-// Open opens a table.
-func (c *Client) Open(table string) *Table {
-	return &Table{
-		c:     c,
-		table: table,
-		md: metadata.Join(metadata.Pairs(
-			resourcePrefixHeader, c.fullTableName(table),
-			requestParamsHeader, c.reqParamsHeaderValTable(table),
-		), c.featureFlagsMD),
-	}
-}
 
-// OpenTable opens a table.
-func (c *Client) OpenTable(table string) TableAPI {
-	return &tableImpl{Table{
-		c:     c,
-		table: table,
-		md: metadata.Join(metadata.Pairs(
-			resourcePrefixHeader, c.fullTableName(table),
-			requestParamsHeader, c.reqParamsHeaderValTable(table),
-		), c.featureFlagsMD),
-	}}
-}
-
-// OpenAuthorizedView opens an authorized view.
-func (c *Client) OpenAuthorizedView(table, authorizedView string) TableAPI {
-	return &tableImpl{Table{
-		c:     c,
-		table: table,
-		md: metadata.Join(metadata.Pairs(
-			resourcePrefixHeader, c.fullAuthorizedViewName(table, authorizedView),
-			requestParamsHeader, c.reqParamsHeaderValTable(table),
-		), c.featureFlagsMD),
-		authorizedView: authorizedView,
-	}}
-}
-
-// OpenMaterializedView opens a materialized view.
-func (c *Client) OpenMaterializedView(materializedView string) TableAPI {
-	return &tableImpl{Table{
-		c: c,
-		md: metadata.Join(metadata.Pairs(
-			resourcePrefixHeader, c.fullMaterializedViewName(materializedView),
-			requestParamsHeader, c.reqParamsHeaderValTable(materializedView),
-		), c.featureFlagsMD),
-		materializedView: materializedView,
-	}}
-}
 
 // PingAndWarm pings the server and warms up the connection.
 func (c *Client) PingAndWarm(ctx context.Context) (err error) {
@@ -417,3 +331,4 @@ func (c *Client) newBuiltinMetricsTracer(ctx context.Context, table string, isSt
 	mt := c.metricsTracerFactory.createBuiltinMetricsTracer(ctx, table, isStreaming)
 	return &mt
 }
+

--- a/bigtable/client.go
+++ b/bigtable/client.go
@@ -305,19 +305,20 @@ func (c *Client) PingAndWarm(ctx context.Context) (err error) {
 	defer func() { trace.EndSpan(ctx, err) }()
 	mt := c.newBuiltinMetricsTracer(ctx, "", false)
 	defer mt.recordOperationCompletion()
+	ctx = contextWithMetricsTracer(ctx, mt)
 
-	err = c.pingerWithMetadata(ctx, mt)
+	err = c.pingerWithMetadata(ctx)
 	statusCode, statusErr := convertToGrpcStatusErr(err)
 	mt.currOp.setStatus(statusCode.String())
 	return statusErr
 }
 
-func (c *Client) pingerWithMetadata(ctx context.Context, mt *builtinMetricsTracer) (err error) {
+func (c *Client) pingerWithMetadata(ctx context.Context) (err error) {
 	req := &btpb.PingAndWarmRequest{
 		Name:         c.fullInstanceName(),
 		AppProfileId: c.appProfile,
 	}
-	err = gaxInvokeWithRecorder(ctx, mt, "PingAndWarm", func(ctx context.Context, headerMD, trailerMD *metadata.MD, _ gax.CallSettings) error {
+	err = gaxInvokeWithRecorder(ctx, "PingAndWarm", func(ctx context.Context, headerMD, trailerMD *metadata.MD, _ gax.CallSettings) error {
 		var err error
 		_, err = c.client.PingAndWarm(ctx, req, grpc.Header(headerMD), grpc.Trailer(trailerMD))
 		return err

--- a/bigtable/client.go
+++ b/bigtable/client.go
@@ -282,7 +282,7 @@ func NewClientWithConfig(ctx context.Context, project, instance string, config C
 		requestParamsHeader, c.reqParamsHeaderValInstance(),
 	), c.featureFlagsMD)
 
-	configManager := btransport.NewClientConfigurationManager(btClient, c.fullInstanceName(), config.AppProfile, configMD)
+	configManager := btransport.NewClientConfigurationManager(btClient, c.fullInstanceName(), config.AppProfile, configMD, nil)
 	configManager.Start(ctx)
 	c.configManager = configManager
 

--- a/bigtable/correctness_test.go
+++ b/bigtable/correctness_test.go
@@ -1,0 +1,205 @@
+package bigtable
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"testing"
+
+	btpb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
+	"google.golang.org/api/option"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+)
+
+// localMockServer implements btpb.BigtableServer for testing.
+type localMockServer struct {
+	btpb.UnimplementedBigtableServer
+}
+
+func (s *localMockServer) GetClientConfiguration(ctx context.Context, req *btpb.GetClientConfigurationRequest) (*btpb.ClientConfiguration, error) {
+	return &btpb.ClientConfiguration{
+		SessionConfiguration: &btpb.SessionClientConfiguration{
+			SessionLoad: 1.0, // Enable sessions fully
+		},
+	}, nil
+}
+
+func (s *localMockServer) OpenTable(stream btpb.Bigtable_OpenTableServer) error {
+	req, err := stream.Recv()
+	if err != nil {
+		return err
+	}
+	if req.GetOpenSession() == nil {
+		return fmt.Errorf("expected OpenSession request")
+	}
+
+	resp := &btpb.SessionResponse{
+		Payload: &btpb.SessionResponse_OpenSession{
+			OpenSession: &btpb.OpenSessionResponse{},
+		},
+	}
+	if err := stream.Send(resp); err != nil {
+		return err
+	}
+
+	for {
+		req, err := stream.Recv()
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		vrpcReq := req.GetVirtualRpc()
+		if vrpcReq != nil {
+			tableResp := &btpb.TableResponse{
+				Payload: &btpb.TableResponse_ReadRow{
+					ReadRow: &btpb.SessionReadRowResponse{
+						Row: &btpb.Row{
+							Key: []byte("row1"),
+							Families: []*btpb.Family{
+								{
+									Name: "fam1",
+									Columns: []*btpb.Column{
+										{
+											Qualifier: []byte("col1"),
+											Cells: []*btpb.Cell{
+												{
+													Value: []byte("val1"),
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			payloadBytes, err := proto.Marshal(tableResp)
+			if err != nil {
+				return err
+			}
+			resp := &btpb.SessionResponse{
+				Payload: &btpb.SessionResponse_VirtualRpc{
+					VirtualRpc: &btpb.VirtualRpcResponse{
+						RpcId:   1,
+						Payload: payloadBytes,
+					},
+				},
+			}
+			if err := stream.Send(resp); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+// ReadRows implements the classic path for comparison.
+func (s *localMockServer) ReadRows(req *btpb.ReadRowsRequest, stream btpb.Bigtable_ReadRowsServer) error {
+	resp := &btpb.ReadRowsResponse{
+		Chunks: []*btpb.ReadRowsResponse_CellChunk{
+			{
+				RowKey:     []byte("row1"),
+				FamilyName: &wrapperspb.StringValue{Value: "fam1"},
+				Qualifier:  &wrapperspb.BytesValue{Value: []byte("col1")},
+				Value:      []byte("val1"),
+				RowStatus:  &btpb.ReadRowsResponse_CellChunk_CommitRow{CommitRow: true},
+			},
+		},
+	}
+	return stream.Send(resp)
+}
+
+func (s *localMockServer) PingAndWarm(ctx context.Context, req *btpb.PingAndWarmRequest) (*btpb.PingAndWarmResponse, error) {
+	return &btpb.PingAndWarmResponse{}, nil
+}
+
+func TestSessionReadRowCorrectness(t *testing.T) {
+	ctx := context.Background()
+
+	// Setup local mock server
+	lis, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("Failed to listen: %v", err)
+	}
+	srv := grpc.NewServer()
+	mock := &localMockServer{}
+	btpb.RegisterBigtableServer(srv, mock)
+	go func() {
+		srv.Serve(lis)
+	}()
+	defer srv.Stop()
+	defer lis.Close()
+
+	addr := lis.Addr().String()
+
+	// Client 1: Classic (forced via env)
+	os.Setenv("CBT_DISABLE_SESSIONS", "true")
+	defer os.Unsetenv("CBT_DISABLE_SESSIONS")
+
+	clientClassic, err := NewClient(ctx, "test-project", "test-instance", option.WithEndpoint(addr), option.WithGRPCDialOption(grpc.WithTransportCredentials(insecure.NewCredentials())), option.WithoutAuthentication())
+	if err != nil {
+		t.Fatalf("Failed to create classic client: %v", err)
+	}
+	defer clientClassic.Close()
+
+	// Client 2: Session (default, should be enabled by mock config)
+	os.Unsetenv("CBT_DISABLE_SESSIONS") // Ensure it's not disabled
+	clientSession, err := NewClient(ctx, "test-project", "test-instance", option.WithEndpoint(addr), option.WithGRPCDialOption(grpc.WithTransportCredentials(insecure.NewCredentials())), option.WithoutAuthentication())
+	if err != nil {
+		t.Fatalf("Failed to create session client: %v", err)
+	}
+	defer clientSession.Close()
+
+	// Call ReadRow on both
+	tableClassic := clientClassic.Open("test-table")
+	rowClassic, err := tableClassic.ReadRow(ctx, "row1")
+	if err != nil {
+		t.Fatalf("Classic ReadRow failed: %v", err)
+	}
+
+	tableSession := clientSession.Open("test-table")
+	rowSession, err := tableSession.ReadRow(ctx, "row1")
+	if err != nil {
+		t.Fatalf("Session ReadRow failed: %v", err)
+	}
+
+	// Compare results
+	if rowClassic == nil || rowSession == nil {
+		t.Fatalf("One of the rows is nil: classic=%v, session=%v", rowClassic, rowSession)
+	}
+
+	if len(rowClassic) != len(rowSession) {
+		t.Errorf("Row length mismatch: classic=%d, session=%d", len(rowClassic), len(rowSession))
+	}
+
+	// Deep comparison of families and cells
+	for fam, itemsClassic := range rowClassic {
+		itemsSession, ok := rowSession[fam]
+		if !ok {
+			t.Errorf("Family %s missing in session row", fam)
+			continue
+		}
+		if len(itemsClassic) != len(itemsSession) {
+			t.Errorf("Family %s length mismatch: classic=%d, session=%d", fam, len(itemsClassic), len(itemsSession))
+			continue
+		}
+		for i := range itemsClassic {
+			if itemsClassic[i].Row != itemsSession[i].Row {
+				t.Errorf("Item %d Row mismatch: classic=%s, session=%s", i, itemsClassic[i].Row, itemsSession[i].Row)
+			}
+			if itemsClassic[i].Column != itemsSession[i].Column {
+				t.Errorf("Item %d Column mismatch: classic=%s, session=%s", i, itemsClassic[i].Column, itemsSession[i].Column)
+			}
+			if string(itemsClassic[i].Value) != string(itemsSession[i].Value) {
+				t.Errorf("Item %d Value mismatch: classic=%s, session=%s", i, string(itemsClassic[i].Value), string(itemsSession[i].Value))
+			}
+		}
+	}
+}

--- a/bigtable/internal/mockserver/inmem.go
+++ b/bigtable/internal/mockserver/inmem.go
@@ -54,6 +54,8 @@ type Server struct {
 	PingAndWarmFn func(context.Context, *btpb.PingAndWarmRequest) (*btpb.PingAndWarmResponse, error)
 	// ReadModifyWriteRowFn mocks ReadModifyWriteRow.
 	ReadModifyWriteRowFn func(context.Context, *btpb.ReadModifyWriteRowRequest) (*btpb.ReadModifyWriteRowResponse, error)
+	// GetClientConfigurationFn mocks GetClientConfiguration.
+	GetClientConfigurationFn func(context.Context, *btpb.GetClientConfigurationRequest) (*btpb.ClientConfiguration, error)
 }
 
 // NewServer creates a new Server.
@@ -138,6 +140,14 @@ func (s *Server) PingAndWarm(ctx context.Context, srv *btpb.PingAndWarmRequest) 
 func (s *Server) ReadModifyWriteRow(ctx context.Context, srv *btpb.ReadModifyWriteRowRequest) (*btpb.ReadModifyWriteRowResponse, error) {
 	if s.ReadModifyWriteRowFn != nil {
 		return s.ReadModifyWriteRowFn(ctx, srv)
+	}
+	return nil, status.Error(codes.Unimplemented, "unimplemented")
+}
+
+// GetClientConfiguration implements GetClientConfiguration of the BigtableServer interface.
+func (s *Server) GetClientConfiguration(ctx context.Context, req *btpb.GetClientConfigurationRequest) (*btpb.ClientConfiguration, error) {
+	if s.GetClientConfigurationFn != nil {
+		return s.GetClientConfigurationFn(ctx, req)
 	}
 	return nil, status.Error(codes.Unimplemented, "unimplemented")
 }

--- a/bigtable/internal/transport/chain.go
+++ b/bigtable/internal/transport/chain.go
@@ -14,15 +14,19 @@
 
 package internal
 
+import (
+	"context"
+)
+
 // ChainInterceptors chains multiple interceptors into a single virtual RPC execution Handler.
 // The first interceptor in the list is executed first, wrapping the subsequent ones.
 func ChainInterceptors(interceptors ...Interceptor) Interceptor {
-	return func(ctx CallContext, req interface{}, invoker Handler) (interface{}, error) {
+	return func(ctx context.Context, req interface{}, invoker Handler) (interface{}, error) {
 		chain := invoker
 		for i := len(interceptors) - 1; i >= 0; i-- {
 			currentIdx := i
 			nextHandler := chain
-			chain = func(c CallContext, r interface{}) (interface{}, error) {
+			chain = func(c context.Context, r interface{}) (interface{}, error) {
 				return interceptors[currentIdx](c, r, nextHandler)
 			}
 		}

--- a/bigtable/internal/transport/chain.go
+++ b/bigtable/internal/transport/chain.go
@@ -1,0 +1,31 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+// ChainInterceptors chains multiple interceptors into a single virtual RPC execution Handler.
+// The first interceptor in the list is executed first, wrapping the subsequent ones.
+func ChainInterceptors(interceptors ...Interceptor) Interceptor {
+	return func(ctx CallContext, req interface{}, invoker Handler) (interface{}, error) {
+		chain := invoker
+		for i := len(interceptors) - 1; i >= 0; i-- {
+			currentIdx := i
+			nextHandler := chain
+			chain = func(c CallContext, r interface{}) (interface{}, error) {
+				return interceptors[currentIdx](c, r, nextHandler)
+			}
+		}
+		return chain(ctx, req)
+	}
+}

--- a/bigtable/internal/transport/client_configuration_manager.go
+++ b/bigtable/internal/transport/client_configuration_manager.go
@@ -16,11 +16,13 @@ package internal
 
 import (
 	"context"
+	"log"
 	"math/rand"
 	"sync"
 	"time"
 
 	bigtablepb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
+	btopt "cloud.google.com/go/bigtable/internal/option"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 )
@@ -97,6 +99,7 @@ type ClientConfigurationManager struct {
 	appProfileId  string
 	metadata      metadata.MD
 	defaultConfig clientConfig
+	logger        *log.Logger
 
 	mu            sync.RWMutex
 	currentConfig clientConfig
@@ -145,6 +148,7 @@ func NewClientConfigurationManager(
 	instanceName string,
 	appProfileId string,
 	md metadata.MD,
+	logger *log.Logger,
 ) *ClientConfigurationManager {
 	done := make(chan struct{})
 
@@ -158,11 +162,13 @@ func NewClientConfigurationManager(
 		currentConfig: defaultClientConfig,
 		validUntil:    time.Now().Add(time.Hour * 24 * 365 * 100), //  default far in future
 		listeners:     make(map[int]configListener),
+		logger:        logger,
 	}
 }
 
 // Start begins the polling process.
 func (m *ClientConfigurationManager) Start(ctx context.Context) {
+	btopt.Debugf(m.logger, "bigtable: starting client configuration manager for instance %q, app profile %q", m.instanceName, m.appProfileId)
 	// We need a context for the initial poll.
 	go func() {
 		pollCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
@@ -176,6 +182,7 @@ func (m *ClientConfigurationManager) Start(ctx context.Context) {
 
 // Close stops the polling process.
 func (m *ClientConfigurationManager) Close() {
+	btopt.Debugf(m.logger, "bigtable: closing client configuration manager")
 	close(m.done)
 }
 
@@ -200,6 +207,7 @@ func (m *ClientConfigurationManager) addListener(listener configListener) func()
 	seq := m.configSeq
 	m.mu.Unlock()
 
+	btopt.Debugf(m.logger, "bigtable: adding configuration listener (id: %d)", id)
 	listener(cfg, seq)
 
 	return func() {
@@ -248,6 +256,7 @@ func (m *ClientConfigurationManager) pollingLoop(parentCtx context.Context) {
 // poll queries the GetClientConfiguration API and triggers registered listeners with the new configuration.
 // If the poll fails and the previous configuration's validity has expired, it falls back to the default config.
 func (m *ClientConfigurationManager) poll(ctx context.Context) {
+	btopt.Debugf(m.logger, "bigtable: polling client configuration...")
 	req := &bigtablepb.GetClientConfigurationRequest{
 		InstanceName: m.instanceName,
 		AppProfileId: m.appProfileId,
@@ -262,13 +271,17 @@ func (m *ClientConfigurationManager) poll(ctx context.Context) {
 	maxRetries := m.currentConfig.Polling.MaxRpcRetryCount
 	m.mu.RUnlock()
 
-	// Retry with randomized exponential backoff using seconds (preventing fast tight loops)
+	// Retry with randomized exponential backoff using seconds
 	for i := 0; i <= maxRetries; i++ {
 		var header, trailer metadata.MD
+		rpcStart := time.Now()
 		resp, err = m.client.GetClientConfiguration(ctx, req, grpc.Header(&header), grpc.Trailer(&trailer))
+		rpcDuration := time.Since(rpcStart)
 		if err == nil {
+			btopt.Debugf(m.logger, "bigtable: GetClientConfiguration RPC attempt %d completed successfully in %v", i, rpcDuration)
 			break
 		}
+		btopt.Debugf(m.logger, "bigtable: GetClientConfiguration RPC attempt %d failed in %v: %v", i, rpcDuration, err)
 		if i < maxRetries {
 			delay := time.Duration(rand.Intn(1<<i)) * time.Second
 			select {
@@ -280,12 +293,14 @@ func (m *ClientConfigurationManager) poll(ctx context.Context) {
 	}
 
 	if err != nil {
+		btopt.Debugf(m.logger, "bigtable: failed to poll client configuration: %v", err)
 		m.mu.Lock()
 		var listeners []configListener
 		var cfgToNotify clientConfig
 		var seq int64
 		// Fall back to default configuration if validity window has expired
 		if time.Now().After(m.validUntil) {
+			btopt.Debugf(m.logger, "bigtable: client configuration validity window expired, falling back to default config")
 			m.currentConfig = m.defaultConfig
 			m.configSeq++
 			seq = m.configSeq
@@ -306,6 +321,7 @@ func (m *ClientConfigurationManager) poll(ctx context.Context) {
 	}
 
 	parsedResp := parseConfig(resp, m.defaultConfig)
+	btopt.Debugf(m.logger, "bigtable: successfully polled new client configuration. validityDuration: %v", parsedResp.Polling.ValidityDuration)
 
 	m.mu.Lock()
 	m.currentConfig = parsedResp

--- a/bigtable/internal/transport/client_configuration_manager.go
+++ b/bigtable/internal/transport/client_configuration_manager.go
@@ -1,0 +1,438 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"context"
+	"math/rand"
+	"sync"
+	"time"
+
+	bigtablepb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+const MinPollingInterval = 1 * time.Minute
+
+// clientConfig holds configuration for the client.
+type clientConfig struct {
+	Polling          pollingConfig
+	Session          sessionConfig
+	HasSessionConfig bool
+}
+
+// Clone returns a deep copy of the clientConfig.
+func (c clientConfig) Clone() clientConfig {
+	// return by value so it copies but future proofing
+	return c
+}
+
+type pollingConfig struct {
+	PollingInterval  time.Duration
+	ValidityDuration time.Duration
+	MaxRpcRetryCount int
+}
+
+type sessionConfig struct {
+	SessionLoad float64
+	ChannelPool channelPoolConfig
+	SessionPool sessionPoolConfig
+}
+
+type channelPoolConfig struct {
+	MinServerCount             int
+	MaxServerCount             int
+	PerServerSessionCount      int
+	DirectAccessCheckInterval  time.Duration
+	DirectAccessErrorThreshold float32
+}
+
+type sessionPoolConfig struct {
+	Headroom                           float32
+	MinSessionCount                    int
+	MaxSessionCount                    int
+	NewSessionCreationBudget           int
+	NewSessionCreationPenalty          time.Duration
+	ConsecutiveSessionFailureThreshold int
+	NewSessionQueueLength              int
+	LoadBalancing                      loadBalancingOptions
+}
+
+type loadBalancingStrategy int
+
+const (
+	StrategyLeastInFlight loadBalancingStrategy = iota
+	StrategyRandom
+	StrategyPeakEwma
+)
+
+type loadBalancingOptions struct {
+	Strategy         loadBalancingStrategy
+	RandomSubsetSize int
+}
+
+// configListener is a callback function for configuration changes.
+type configListener func(newConfig clientConfig, seq int64)
+
+// ClientConfigurationManager manages the dynamic client configuration for Bigtable.
+// It periodically polls for client configuration updates via GetClientConfiguration RPCs.
+type ClientConfigurationManager struct {
+	// done is closed when the manager is closed to signal the background polling goroutine to exit.
+	done          chan struct{}
+	client        bigtablepb.BigtableClient
+	instanceName  string
+	appProfileId  string
+	metadata      metadata.MD
+	defaultConfig clientConfig
+
+	mu            sync.RWMutex
+	currentConfig clientConfig
+	// configSeq is a monotonically increasing sequence number incremented every time the configuration changes.
+	configSeq      int64
+	validUntil     time.Time
+	listeners      map[int]configListener
+	nextListenerID int
+}
+
+var defaultClientConfig = clientConfig{
+	Polling: pollingConfig{
+		PollingInterval:  300 * time.Second,
+		ValidityDuration: 100 * 365 * 24 * time.Hour, // Safe representation of 10,000 years.
+		MaxRpcRetryCount: 5,
+	},
+	Session: sessionConfig{
+		SessionLoad: 0,
+		ChannelPool: channelPoolConfig{
+			MinServerCount:             2,
+			MaxServerCount:             25,
+			PerServerSessionCount:      10,
+			DirectAccessCheckInterval:  60 * time.Second,
+			DirectAccessErrorThreshold: 0.8,
+		},
+		SessionPool: sessionPoolConfig{
+			Headroom:                           0.5,
+			MinSessionCount:                    5,
+			MaxSessionCount:                    400,
+			NewSessionCreationBudget:           50,
+			NewSessionCreationPenalty:          60 * time.Second,
+			ConsecutiveSessionFailureThreshold: 10,
+			NewSessionQueueLength:              10,
+			LoadBalancing: loadBalancingOptions{
+				Strategy:         StrategyLeastInFlight,
+				RandomSubsetSize: 0,
+			},
+		},
+	},
+	HasSessionConfig: true,
+}
+
+// NewClientConfigurationManager creates a new ClientConfigurationManager.
+func NewClientConfigurationManager(
+	client bigtablepb.BigtableClient,
+	instanceName string,
+	appProfileId string,
+	md metadata.MD,
+) *ClientConfigurationManager {
+	done := make(chan struct{})
+
+	return &ClientConfigurationManager{
+		done:          done,
+		client:        client,
+		instanceName:  instanceName,
+		appProfileId:  appProfileId,
+		metadata:      md,
+		defaultConfig: defaultClientConfig,
+		currentConfig: defaultClientConfig,
+		validUntil:    time.Now().Add(time.Hour * 24 * 365 * 100), //  default far in future
+		listeners:     make(map[int]configListener),
+	}
+}
+
+// Start begins the polling process.
+func (m *ClientConfigurationManager) Start(ctx context.Context) {
+	// We need a context for the initial poll.
+	go func() {
+		pollCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+		m.poll(pollCtx)
+	}()
+
+	// Start background polling
+	go m.pollingLoop(ctx)
+}
+
+// Close stops the polling process.
+func (m *ClientConfigurationManager) Close() {
+	close(m.done)
+}
+
+// getConfig returns the current configuration.
+func (m *ClientConfigurationManager) getConfig() clientConfig {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.currentConfig.Clone()
+}
+
+// addListener adds a listener for configuration changes.
+func (m *ClientConfigurationManager) addListener(listener configListener) func() {
+	m.mu.Lock()
+	id := m.nextListenerID
+	m.nextListenerID++
+	if m.listeners == nil {
+		m.listeners = make(map[int]configListener)
+	}
+	m.listeners[id] = listener
+
+	cfg := m.currentConfig.Clone()
+	seq := m.configSeq
+	m.mu.Unlock()
+
+	listener(cfg, seq)
+
+	return func() {
+		m.mu.Lock()
+		delete(m.listeners, id)
+		m.mu.Unlock()
+	}
+}
+
+// pollingLoop continuously polls the Bigtable control plane at the configured interval.
+// It enforces a minimum interval (MinPollingInterval) to protect the control plane from DDoSes.
+func (m *ClientConfigurationManager) pollingLoop(parentCtx context.Context) {
+	ctx, cancel := context.WithCancel(parentCtx)
+	defer cancel()
+
+	go func() {
+		select {
+		case <-m.done:
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+
+	for {
+		m.mu.RLock()
+		cfg := m.currentConfig
+		m.mu.RUnlock()
+
+		interval := cfg.Polling.PollingInterval
+		if interval < MinPollingInterval {
+			interval = MinPollingInterval
+		}
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(interval):
+			// Poll with a 5-second timeout per RPC attempt
+			pollCtx, pollCancel := context.WithTimeout(ctx, 5*time.Second)
+			m.poll(pollCtx)
+			pollCancel()
+		}
+	}
+}
+
+// poll queries the GetClientConfiguration API and triggers registered listeners with the new configuration.
+// If the poll fails and the previous configuration's validity has expired, it falls back to the default config.
+func (m *ClientConfigurationManager) poll(ctx context.Context) {
+	req := &bigtablepb.GetClientConfigurationRequest{
+		InstanceName: m.instanceName,
+		AppProfileId: m.appProfileId,
+	}
+
+	ctx = metadata.NewOutgoingContext(ctx, m.metadata)
+
+	var resp *bigtablepb.ClientConfiguration
+	var err error
+
+	m.mu.RLock()
+	maxRetries := m.currentConfig.Polling.MaxRpcRetryCount
+	m.mu.RUnlock()
+
+	// Retry with randomized exponential backoff using seconds (preventing fast tight loops)
+	for i := 0; i <= maxRetries; i++ {
+		var header, trailer metadata.MD
+		resp, err = m.client.GetClientConfiguration(ctx, req, grpc.Header(&header), grpc.Trailer(&trailer))
+		if err == nil {
+			break
+		}
+		if i < maxRetries {
+			delay := time.Duration(rand.Intn(1<<i)) * time.Second
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(delay):
+			}
+		}
+	}
+
+	if err != nil {
+		m.mu.Lock()
+		var listeners []configListener
+		var cfgToNotify clientConfig
+		var seq int64
+		// Fall back to default configuration if validity window has expired
+		if time.Now().After(m.validUntil) {
+			m.currentConfig = m.defaultConfig
+			m.configSeq++
+			seq = m.configSeq
+			listeners = make([]configListener, 0, len(m.listeners))
+			for _, l := range m.listeners {
+				listeners = append(listeners, l)
+			}
+			cfgToNotify = m.currentConfig
+		}
+		m.mu.Unlock()
+
+		if listeners != nil {
+			for _, l := range listeners {
+				l(cfgToNotify.Clone(), seq)
+			}
+		}
+		return
+	}
+
+	parsedResp := parseConfig(resp, m.defaultConfig)
+
+	m.mu.Lock()
+	m.currentConfig = parsedResp
+	m.configSeq++
+	seq := m.configSeq
+	m.validUntil = time.Now().Add(parsedResp.Polling.ValidityDuration)
+
+	listeners := make([]configListener, 0, len(m.listeners))
+	for _, l := range m.listeners {
+		listeners = append(listeners, l)
+	}
+	cfgToNotify := m.currentConfig
+	m.mu.Unlock()
+
+	for _, l := range listeners {
+		l(cfgToNotify.Clone(), seq)
+	}
+}
+
+// parseConfig converts the protobuf ClientConfiguration message into the internal clientConfig structure,
+// validating bounds such as MinPollingInterval and capping validity duration to prevent integer overflows.
+func parseConfig(protoCfg *bigtablepb.ClientConfiguration, defaultCfg clientConfig) clientConfig {
+	res := defaultCfg
+
+	if protoCfg == nil {
+		return res
+	}
+
+	if p := protoCfg.GetPollingConfiguration(); p != nil {
+		res.Polling = parsePollingConfig(p, res.Polling)
+	}
+
+	if protoCfg.SessionConfiguration != nil {
+		s := protoCfg.SessionConfiguration
+		res.Session = parseSessionConfig(s, res.Session)
+		res.HasSessionConfig = s.SessionLoad > 0
+	} else {
+		res.HasSessionConfig = false
+	}
+
+	return res
+}
+
+func parsePollingConfig(p *bigtablepb.ClientConfiguration_PollingConfiguration, defaultCfg pollingConfig) pollingConfig {
+	res := defaultCfg
+	if p == nil {
+		return res
+	}
+	if p.PollingInterval != nil {
+		res.PollingInterval = p.PollingInterval.AsDuration()
+	}
+	if res.PollingInterval < MinPollingInterval {
+		res.PollingInterval = MinPollingInterval
+	}
+	if p.ValidityDuration != nil {
+		res.ValidityDuration = p.ValidityDuration.AsDuration()
+		if res.ValidityDuration > 100*365*24*time.Hour {
+			res.ValidityDuration = 100 * 365 * 24 * time.Hour
+		}
+	}
+	res.MaxRpcRetryCount = int(p.MaxRpcRetryCount)
+	return res
+}
+
+func parseSessionConfig(s *bigtablepb.SessionClientConfiguration, defaultCfg sessionConfig) sessionConfig {
+	res := defaultCfg
+	if s == nil {
+		return res
+	}
+	res.SessionLoad = float64(s.SessionLoad)
+	if s.ChannelConfiguration != nil {
+		res.ChannelPool = parseChannelPoolConfig(s.ChannelConfiguration, res.ChannelPool)
+	}
+	if s.SessionPoolConfiguration != nil {
+		res.SessionPool = parseSessionPoolConfig(s.SessionPoolConfiguration, res.SessionPool)
+	}
+	return res
+}
+
+func parseChannelPoolConfig(cc *bigtablepb.SessionClientConfiguration_ChannelPoolConfiguration, defaultCfg channelPoolConfig) channelPoolConfig {
+	res := defaultCfg
+	if cc == nil {
+		return res
+	}
+	res.MinServerCount = int(cc.MinServerCount)
+	res.MaxServerCount = int(cc.MaxServerCount)
+	res.PerServerSessionCount = int(cc.PerServerSessionCount)
+	if fallback := cc.GetDirectAccessWithFallback(); fallback != nil {
+		if fallback.CheckInterval != nil {
+			res.DirectAccessCheckInterval = fallback.CheckInterval.AsDuration()
+		}
+		res.DirectAccessErrorThreshold = fallback.ErrorRateThreshold
+	}
+	return res
+}
+
+func parseSessionPoolConfig(sp *bigtablepb.SessionClientConfiguration_SessionPoolConfiguration, defaultCfg sessionPoolConfig) sessionPoolConfig {
+	res := defaultCfg
+	if sp == nil {
+		return res
+	}
+	res.Headroom = sp.Headroom
+	res.MinSessionCount = int(sp.MinSessionCount)
+	res.MaxSessionCount = int(sp.MaxSessionCount)
+	res.NewSessionCreationBudget = int(sp.NewSessionCreationBudget)
+	if sp.NewSessionCreationPenalty != nil {
+		res.NewSessionCreationPenalty = sp.NewSessionCreationPenalty.AsDuration()
+	}
+	res.ConsecutiveSessionFailureThreshold = int(sp.ConsecutiveSessionFailureThreshold)
+	res.NewSessionQueueLength = int(sp.NewSessionQueueLength)
+
+	if sp.LoadBalancingOptions != nil {
+		lbo := sp.LoadBalancingOptions
+		switch opt := lbo.LoadBalancingStrategy.(type) {
+		case *bigtablepb.LoadBalancingOptions_Random_:
+			res.LoadBalancing.Strategy = StrategyRandom
+		case *bigtablepb.LoadBalancingOptions_LeastInFlight_:
+			res.LoadBalancing.Strategy = StrategyLeastInFlight
+			if opt.LeastInFlight != nil {
+				res.LoadBalancing.RandomSubsetSize = int(opt.LeastInFlight.RandomSubsetSize)
+			}
+		case *bigtablepb.LoadBalancingOptions_PeakEwma_:
+			res.LoadBalancing.Strategy = StrategyPeakEwma
+			if opt.PeakEwma != nil {
+				res.LoadBalancing.RandomSubsetSize = int(opt.PeakEwma.RandomSubsetSize)
+			}
+		}
+	}
+	return res
+}

--- a/bigtable/internal/transport/client_configuration_manager.go
+++ b/bigtable/internal/transport/client_configuration_manager.go
@@ -217,6 +217,17 @@ func (m *ClientConfigurationManager) addListener(listener configListener) func()
 	}
 }
 
+// AddSessionPoolListener registers a callback that receives raw SessionPoolConfiguration updates.
+func (m *ClientConfigurationManager) AddSessionPoolListener(listener func(*bigtablepb.SessionClientConfiguration_SessionPoolConfiguration)) func() {
+	return m.addListener(func(cfg clientConfig, seq int64) {
+		spCfg := &bigtablepb.SessionClientConfiguration_SessionPoolConfiguration{
+			MinSessionCount: int32(cfg.Session.SessionPool.MinSessionCount),
+			MaxSessionCount: int32(cfg.Session.SessionPool.MaxSessionCount),
+		}
+		listener(spCfg)
+	})
+}
+
 // pollingLoop continuously polls the Bigtable control plane at the configured interval.
 // It enforces a minimum interval (MinPollingInterval) to protect the control plane from DDoSes.
 func (m *ClientConfigurationManager) pollingLoop(parentCtx context.Context) {

--- a/bigtable/internal/transport/client_configuration_manager_test.go
+++ b/bigtable/internal/transport/client_configuration_manager_test.go
@@ -41,7 +41,7 @@ func (m *mockBigtableClient) GetClientConfiguration(ctx context.Context, req *bi
 
 func TestNewClientConfigurationManager(t *testing.T) {
 	client := &mockBigtableClient{}
-	manager := NewClientConfigurationManager(client, "instance", "profile", nil)
+	manager := NewClientConfigurationManager(client, "instance", "profile", nil, nil)
 
 	if manager == nil {
 		t.Fatal("Expected manager to be non-nil")
@@ -67,7 +67,7 @@ func TestManagerPoll_Success(t *testing.T) {
 		return expectedCfg, nil
 	}
 
-	manager := NewClientConfigurationManager(client, "instance", "profile", nil)
+	manager := NewClientConfigurationManager(client, "instance", "profile", nil, nil)
 	manager.poll(context.Background())
 
 	cfg := manager.getConfig()
@@ -78,7 +78,7 @@ func TestManagerPoll_Success(t *testing.T) {
 
 func TestManagerPoll_FailureKeepsOldConfig(t *testing.T) {
 	client := &mockBigtableClient{}
-	manager := NewClientConfigurationManager(client, "instance", "profile", nil)
+	manager := NewClientConfigurationManager(client, "instance", "profile", nil, nil)
 
 	// Set a valid until time in the future
 	manager.validUntil = time.Now().Add(time.Hour)
@@ -97,7 +97,7 @@ func TestManagerPoll_FailureKeepsOldConfig(t *testing.T) {
 
 func TestManagerPoll_FailureFallbackToDefault(t *testing.T) {
 	client := &mockBigtableClient{}
-	manager := NewClientConfigurationManager(client, "instance", "profile", nil)
+	manager := NewClientConfigurationManager(client, "instance", "profile", nil, nil)
 
 	// Set a valid until time in the past
 	manager.validUntil = time.Now().Add(-time.Hour)
@@ -119,7 +119,7 @@ func TestManagerPoll_FailureFallbackToDefault(t *testing.T) {
 
 func TestManagerNotifyListeners(t *testing.T) {
 	client := &mockBigtableClient{}
-	manager := NewClientConfigurationManager(client, "instance", "profile", nil)
+	manager := NewClientConfigurationManager(client, "instance", "profile", nil, nil)
 
 	var wg sync.WaitGroup
 	wg.Add(2) // Expect two notifications: immediate, and after poll
@@ -174,7 +174,7 @@ func TestManagerNotifyListeners(t *testing.T) {
 
 func TestGetConfig_ReturnsCopy(t *testing.T) {
 	client := &mockBigtableClient{}
-	manager := NewClientConfigurationManager(client, "instance", "profile", nil)
+	manager := NewClientConfigurationManager(client, "instance", "profile", nil, nil)
 
 	cfg1 := manager.getConfig()
 	cfg1.Polling.MaxRpcRetryCount = 999
@@ -187,7 +187,7 @@ func TestGetConfig_ReturnsCopy(t *testing.T) {
 
 func TestManagerNotifyListeners_Race(t *testing.T) {
 	client := &mockBigtableClient{}
-	manager := NewClientConfigurationManager(client, "instance", "profile", nil)
+	manager := NewClientConfigurationManager(client, "instance", "profile", nil, nil)
 
 	// Initial config is default (seq 0)
 

--- a/bigtable/internal/transport/client_configuration_manager_test.go
+++ b/bigtable/internal/transport/client_configuration_manager_test.go
@@ -1,0 +1,300 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	bigtablepb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/durationpb"
+)
+
+type mockBigtableClient struct {
+	bigtablepb.BigtableClient
+	getConfigFunc func(ctx context.Context, req *bigtablepb.GetClientConfigurationRequest) (*bigtablepb.ClientConfiguration, error)
+}
+
+func (m *mockBigtableClient) GetClientConfiguration(ctx context.Context, req *bigtablepb.GetClientConfigurationRequest, opts ...grpc.CallOption) (*bigtablepb.ClientConfiguration, error) {
+	if m.getConfigFunc != nil {
+		return m.getConfigFunc(ctx, req)
+	}
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func TestNewClientConfigurationManager(t *testing.T) {
+	client := &mockBigtableClient{}
+	manager := NewClientConfigurationManager(client, "instance", "profile", nil)
+
+	if manager == nil {
+		t.Fatal("Expected manager to be non-nil")
+	}
+
+	cfg := manager.getConfig()
+	if cfg.Polling.MaxRpcRetryCount != 5 {
+		t.Errorf("Expected MaxRpcRetryCount to be 5, got %d", cfg.Polling.MaxRpcRetryCount)
+	}
+}
+
+func TestManagerPoll_Success(t *testing.T) {
+	client := &mockBigtableClient{}
+	expectedCfg := &bigtablepb.ClientConfiguration{
+		Polling: &bigtablepb.ClientConfiguration_PollingConfiguration_{
+			PollingConfiguration: &bigtablepb.ClientConfiguration_PollingConfiguration{
+				PollingInterval: durationpb.New(600 * time.Second),
+			},
+		},
+	}
+
+	client.getConfigFunc = func(ctx context.Context, req *bigtablepb.GetClientConfigurationRequest) (*bigtablepb.ClientConfiguration, error) {
+		return expectedCfg, nil
+	}
+
+	manager := NewClientConfigurationManager(client, "instance", "profile", nil)
+	manager.poll(context.Background())
+
+	cfg := manager.getConfig()
+	if cfg.Polling.PollingInterval != 600*time.Second {
+		t.Errorf("Expected polling interval to be 600s, got %v", cfg.Polling.PollingInterval)
+	}
+}
+
+func TestManagerPoll_FailureKeepsOldConfig(t *testing.T) {
+	client := &mockBigtableClient{}
+	manager := NewClientConfigurationManager(client, "instance", "profile", nil)
+
+	// Set a valid until time in the future
+	manager.validUntil = time.Now().Add(time.Hour)
+
+	client.getConfigFunc = func(ctx context.Context, req *bigtablepb.GetClientConfigurationRequest) (*bigtablepb.ClientConfiguration, error) {
+		return nil, status.Error(codes.Unavailable, "service unavailable")
+	}
+
+	manager.poll(context.Background())
+
+	cfg := manager.getConfig()
+	if cfg != manager.defaultConfig {
+		t.Error("Expected config to be equivalent to default config on failure before expiration")
+	}
+}
+
+func TestManagerPoll_FailureFallbackToDefault(t *testing.T) {
+	client := &mockBigtableClient{}
+	manager := NewClientConfigurationManager(client, "instance", "profile", nil)
+
+	// Set a valid until time in the past
+	manager.validUntil = time.Now().Add(-time.Hour)
+
+	// Change current config to something non-default
+	manager.currentConfig = clientConfig{}
+
+	client.getConfigFunc = func(ctx context.Context, req *bigtablepb.GetClientConfigurationRequest) (*bigtablepb.ClientConfiguration, error) {
+		return nil, status.Error(codes.Unavailable, "service unavailable")
+	}
+
+	manager.poll(context.Background())
+
+	cfg := manager.getConfig()
+	if cfg != manager.defaultConfig {
+		t.Error("Expected config to fallback to default config on failure after expiration")
+	}
+}
+
+func TestManagerNotifyListeners(t *testing.T) {
+	client := &mockBigtableClient{}
+	manager := NewClientConfigurationManager(client, "instance", "profile", nil)
+
+	var wg sync.WaitGroup
+	wg.Add(2) // Expect two notifications: immediate, and after poll
+	var receivedConfigs []clientConfig
+	var receivedSeqs []int64
+
+	manager.addListener(func(cfg clientConfig, seq int64) {
+		receivedConfigs = append(receivedConfigs, cfg)
+		receivedSeqs = append(receivedSeqs, seq)
+		wg.Done()
+	})
+
+	expectedCfg := &bigtablepb.ClientConfiguration{
+		Polling: &bigtablepb.ClientConfiguration_PollingConfiguration_{
+			PollingConfiguration: &bigtablepb.ClientConfiguration_PollingConfiguration{
+				PollingInterval: durationpb.New(600 * time.Second),
+			},
+		},
+	}
+
+	client.getConfigFunc = func(ctx context.Context, req *bigtablepb.GetClientConfigurationRequest) (*bigtablepb.ClientConfiguration, error) {
+		return expectedCfg, nil
+	}
+
+	manager.poll(context.Background())
+	wg.Wait()
+
+	if len(receivedConfigs) != 2 {
+		t.Fatalf("Expected 2 notifications, got %d", len(receivedConfigs))
+	}
+
+	// First config should be equivalent to default config
+	if receivedConfigs[0] != manager.defaultConfig {
+		t.Error("Expected first notification to have default config")
+	}
+
+	// Second config should have the updated polling interval
+	if receivedConfigs[1].Polling.PollingInterval != 600*time.Second {
+		t.Errorf("Expected second notification to have polling interval 600s, got %v", receivedConfigs[1].Polling.PollingInterval)
+	}
+
+	if len(receivedSeqs) != 2 {
+		t.Fatalf("Expected 2 sequences, got %d", len(receivedSeqs))
+	}
+	if receivedSeqs[0] != 0 {
+		t.Errorf("Expected first sequence to be 0, got %d", receivedSeqs[0])
+	}
+	if receivedSeqs[1] != 1 {
+		t.Errorf("Expected second sequence to be 1, got %d", receivedSeqs[1])
+	}
+}
+
+func TestGetConfig_ReturnsCopy(t *testing.T) {
+	client := &mockBigtableClient{}
+	manager := NewClientConfigurationManager(client, "instance", "profile", nil)
+
+	cfg1 := manager.getConfig()
+	cfg1.Polling.MaxRpcRetryCount = 999
+
+	cfg2 := manager.getConfig()
+	if cfg2.Polling.MaxRpcRetryCount == 999 {
+		t.Error("Expected modifications to returned config to not affect manager state")
+	}
+}
+
+func TestManagerNotifyListeners_Race(t *testing.T) {
+	client := &mockBigtableClient{}
+	manager := NewClientConfigurationManager(client, "instance", "profile", nil)
+
+	// Initial config is default (seq 0)
+
+	config1 := &bigtablepb.ClientConfiguration{
+		SessionConfiguration: &bigtablepb.SessionClientConfiguration{
+			SessionLoad: 1.0,
+			SessionPoolConfiguration: &bigtablepb.SessionClientConfiguration_SessionPoolConfiguration{
+				MinSessionCount: 10, // Distinct value
+			},
+		},
+	}
+	config2 := &bigtablepb.ClientConfiguration{
+		SessionConfiguration: &bigtablepb.SessionClientConfiguration{
+			SessionLoad: 1.0,
+			SessionPoolConfiguration: &bigtablepb.SessionClientConfiguration_SessionPoolConfiguration{
+				MinSessionCount: 20, // Distinct value
+			},
+		},
+	}
+
+	// We will use a mock client that returns config1 then config2
+	var configIndex int
+	var configMu sync.Mutex
+	client.getConfigFunc = func(ctx context.Context, req *bigtablepb.GetClientConfigurationRequest) (*bigtablepb.ClientConfiguration, error) {
+		configMu.Lock()
+		defer configMu.Unlock()
+		if configIndex == 0 {
+			configIndex++
+			return config1, nil
+		}
+		return config2, nil
+	}
+
+	// 1. First poll to get config1 (seq becomes 1)
+	manager.poll(context.Background())
+	// Now manager.currentConfig is config1, configSeq is 1
+
+	var listenerMu sync.Mutex
+	var lastSeq int64
+	var activeConfig clientConfig
+	var activeConfigSet bool
+
+	// Channels to control the race
+	blockImmediate := make(chan struct{})
+	immediateCalled := make(chan struct{})
+	newerCompleted := make(chan struct{})
+
+	// This listener mimics SessionPoolImpl
+	listener := func(cfg clientConfig, seq int64) {
+		listenerMu.Lock()
+		isImmediate := seq == 1 && cfg.Session.SessionPool.MinSessionCount == 10
+		listenerMu.Unlock()
+
+		if isImmediate {
+			close(immediateCalled)
+			<-blockImmediate // Block the immediate notification
+		}
+
+		listenerMu.Lock()
+		defer listenerMu.Unlock()
+
+		// Sequence check
+		if seq <= lastSeq {
+			return
+		}
+		lastSeq = seq
+		activeConfig = cfg
+		activeConfigSet = true
+
+		if seq == 2 {
+			close(newerCompleted)
+		}
+	}
+
+	// Start AddListener in a goroutine.
+	// It will immediately call listener(config1, 1) which will block.
+	go func() {
+		manager.addListener(listener)
+	}()
+
+	// Wait until immediate notification is called and blocked
+	<-immediateCalled
+
+	// Now trigger second poll.
+	// This will update config to config2 (seq 2).
+	// It will notify listeners (including our registered listener) with (config2, 2).
+	// This call to listener should NOT block because seq != 1.
+	manager.poll(context.Background())
+
+	// Wait for the newer notification to complete
+	<-newerCompleted
+
+	// Now unblock the immediate notification (config1, 1)
+	close(blockImmediate)
+
+	// Give some time for immediate notification to finish (it should be discarded)
+	time.Sleep(50 * time.Millisecond)
+
+	listenerMu.Lock()
+	defer listenerMu.Unlock()
+
+	// Assert that activeConfig is config2 (seq 2) and NOT config1 (seq 1)
+	if !activeConfigSet {
+		t.Fatal("Expected activeConfig to be non-nil")
+	}
+	minSessions := activeConfig.Session.SessionPool.MinSessionCount
+	if minSessions != 20 {
+		t.Errorf("Expected activeConfig to have MinSessionCount 20 (config2), got %d", minSessions)
+	}
+}

--- a/bigtable/internal/transport/connpool.go
+++ b/bigtable/internal/transport/connpool.go
@@ -789,6 +789,11 @@ func (p *BigtableChannelPool) NewStream(ctx context.Context, desc *grpc.StreamDe
 	}, nil
 }
 
+// MeterProvider returns the meter provider for creating instruments.
+func (p *BigtableChannelPool) MeterProvider() metric.MeterProvider {
+	return p.meterProvider
+}
+
 // selectLeastLoadedRandomOfTwo() returns the index of the connection via random of two
 func (p *BigtableChannelPool) selectLeastLoadedRandomOfTwo() (*connEntry, error) {
 	conns := p.getConns()

--- a/bigtable/internal/transport/descriptors.go
+++ b/bigtable/internal/transport/descriptors.go
@@ -1,0 +1,237 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	btpb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
+	spb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
+	"google.golang.org/protobuf/proto"
+)
+
+// VRpcDescriptor defines the interface for virtual RPC encoding and decoding.
+type VRpcDescriptor interface {
+	Method() string
+	Encode(req interface{}) ([]byte, error)
+	Decode(buf []byte) (interface{}, error)
+}
+
+// VRpcDescriptorImpl implements VRpcDescriptor using custom encoder/decoder closures.
+type VRpcDescriptorImpl struct {
+	MethodName string
+	EncodeFn   func(req interface{}) ([]byte, error)
+	DecodeFn   func(buf []byte) (interface{}, error)
+}
+
+// Method returns the virtual RPC method identifier name.
+func (d *VRpcDescriptorImpl) Method() string {
+	return d.MethodName
+}
+
+// Encode serializes standard Bigtable request payload into virtual RPC bytes.
+func (d *VRpcDescriptorImpl) Encode(req interface{}) ([]byte, error) {
+	return d.EncodeFn(req)
+}
+
+// Decode de-serializes virtual RPC bytes back into standard Bigtable response message.
+func (d *VRpcDescriptorImpl) Decode(buf []byte) (interface{}, error) {
+	return d.DecodeFn(buf)
+}
+
+/// region vRPC family encoder/decoder factories
+
+func createTableEncoder(subEncoder func(req interface{}, envelope *spb.TableRequest)) func(interface{}) ([]byte, error) {
+	return func(req interface{}) ([]byte, error) {
+		envelope := &spb.TableRequest{}
+		subEncoder(req, envelope)
+		return proto.Marshal(envelope)
+	}
+}
+
+func createTableDecoder(subDecoder func(envelope *spb.TableResponse) interface{}) func([]byte) (interface{}, error) {
+	return func(buf []byte) (interface{}, error) {
+		envelope := &spb.TableResponse{}
+		if err := proto.Unmarshal(buf, envelope); err != nil {
+			return nil, err
+		}
+		return subDecoder(envelope), nil
+	}
+}
+
+func createAuthViewEncoder(subEncoder func(req interface{}, envelope *spb.AuthorizedViewRequest)) func(interface{}) ([]byte, error) {
+	return func(req interface{}) ([]byte, error) {
+		envelope := &spb.AuthorizedViewRequest{}
+		subEncoder(req, envelope)
+		return proto.Marshal(envelope)
+	}
+}
+
+func createAuthViewDecoder(subDecoder func(envelope *spb.AuthorizedViewResponse) interface{}) func([]byte) (interface{}, error) {
+	return func(buf []byte) (interface{}, error) {
+		envelope := &spb.AuthorizedViewResponse{}
+		if err := proto.Unmarshal(buf, envelope); err != nil {
+			return nil, err
+		}
+		return subDecoder(envelope), nil
+	}
+}
+
+func createMatViewEncoder(subEncoder func(req interface{}, envelope *spb.MaterializedViewRequest)) func(interface{}) ([]byte, error) {
+	return func(req interface{}) ([]byte, error) {
+		envelope := &spb.MaterializedViewRequest{}
+		subEncoder(req, envelope)
+		return proto.Marshal(envelope)
+	}
+}
+
+func createMatViewDecoder(subDecoder func(envelope *spb.MaterializedViewResponse) interface{}) func([]byte) (interface{}, error) {
+	return func(buf []byte) (interface{}, error) {
+		envelope := &spb.MaterializedViewResponse{}
+		if err := proto.Unmarshal(buf, envelope); err != nil {
+			return nil, err
+		}
+		return subDecoder(envelope), nil
+	}
+}
+
+type ReadRowArgs struct {
+	RowKey string
+	Filter *btpb.RowFilter
+}
+
+type ReadRowResult struct {
+	Row *btpb.Row
+}
+
+type MutateRowArgs struct {
+	RowKey    string
+	Mutations []*btpb.Mutation
+}
+
+// MutateRowResult holds the result of a MutateRow virtual RPC.
+type MutateRowResult struct{}
+
+func encodeReadRow(args ReadRowArgs) *spb.SessionReadRowRequest {
+	return &spb.SessionReadRowRequest{
+		Key:    []byte(args.RowKey),
+		Filter: args.Filter,
+	}
+}
+
+func decodeReadRow(payload []byte) (ReadRowResult, error) {
+	var resp spb.SessionReadRowResponse
+	if err := proto.Unmarshal(payload, &resp); err != nil {
+		return ReadRowResult{}, err
+	}
+	return ReadRowResult{
+		Row: resp.Row,
+	}, nil
+}
+
+func encodeMutateRow(args MutateRowArgs) *spb.SessionMutateRowRequest {
+	return &spb.SessionMutateRowRequest{
+		Key:       []byte(args.RowKey),
+		Mutations: args.Mutations,
+	}
+}
+
+func decodeMutateRow(payload []byte) (MutateRowResult, error) {
+	var resp spb.SessionMutateRowResponse
+	if err := proto.Unmarshal(payload, &resp); err != nil {
+		return MutateRowResult{}, err
+	}
+	return MutateRowResult{}, nil
+}
+
+var (
+	// READ_ROW executes Point Reads on standard tables.
+	READ_ROW = &VRpcDescriptorImpl{
+		MethodName: "ReadRow",
+		EncodeFn: createTableEncoder(func(req interface{}, env *spb.TableRequest) {
+			args := req.(ReadRowArgs)
+			env.Payload = &spb.TableRequest_ReadRow{
+				ReadRow: encodeReadRow(args),
+			}
+		}),
+		DecodeFn: createTableDecoder(func(env *spb.TableResponse) interface{} {
+			payload, _ := proto.Marshal(env.GetReadRow())
+			res, _ := decodeReadRow(payload)
+			return res
+		}),
+	}
+
+	// MUTATE_ROW executes Point Mutations on standard tables.
+	MUTATE_ROW = &VRpcDescriptorImpl{
+		MethodName: "MutateRow",
+		EncodeFn: createTableEncoder(func(req interface{}, env *spb.TableRequest) {
+			args := req.(MutateRowArgs)
+			env.Payload = &spb.TableRequest_MutateRow{
+				MutateRow: encodeMutateRow(args),
+			}
+		}),
+		DecodeFn: createTableDecoder(func(env *spb.TableResponse) interface{} {
+			payload, _ := proto.Marshal(env.GetMutateRow())
+			res, _ := decodeMutateRow(payload)
+			return res
+		}),
+	}
+
+	// READ_ROW_AUTH_VIEW executes Point Reads on Authorized Views.
+	READ_ROW_AUTH_VIEW = &VRpcDescriptorImpl{
+		MethodName: "ReadRow",
+		EncodeFn: createAuthViewEncoder(func(req interface{}, env *spb.AuthorizedViewRequest) {
+			args := req.(ReadRowArgs)
+			env.Payload = &spb.AuthorizedViewRequest_ReadRow{
+				ReadRow: encodeReadRow(args),
+			}
+		}),
+		DecodeFn: createAuthViewDecoder(func(env *spb.AuthorizedViewResponse) interface{} {
+			payload, _ := proto.Marshal(env.GetReadRow())
+			res, _ := decodeReadRow(payload)
+			return res
+		}),
+	}
+
+	// MUTATE_ROW_AUTH_VIEW executes Point Mutations on Authorized Views.
+	MUTATE_ROW_AUTH_VIEW = &VRpcDescriptorImpl{
+		MethodName: "MutateRow",
+		EncodeFn: createAuthViewEncoder(func(req interface{}, env *spb.AuthorizedViewRequest) {
+			args := req.(MutateRowArgs)
+			env.Payload = &spb.AuthorizedViewRequest_MutateRow{
+				MutateRow: encodeMutateRow(args),
+			}
+		}),
+		DecodeFn: createAuthViewDecoder(func(env *spb.AuthorizedViewResponse) interface{} {
+			payload, _ := proto.Marshal(env.GetMutateRow())
+			res, _ := decodeMutateRow(payload)
+			return res
+		}),
+	}
+
+	// READ_ROW_MAT_VIEW executes Point Reads on Materialized Views.
+	READ_ROW_MAT_VIEW = &VRpcDescriptorImpl{
+		MethodName: "ReadRow",
+		EncodeFn: createMatViewEncoder(func(req interface{}, env *spb.MaterializedViewRequest) {
+			args := req.(ReadRowArgs)
+			env.Payload = &spb.MaterializedViewRequest_ReadRow{
+				ReadRow: encodeReadRow(args),
+			}
+		}),
+		DecodeFn: createMatViewDecoder(func(env *spb.MaterializedViewResponse) interface{} {
+			payload, _ := proto.Marshal(env.GetReadRow())
+			res, _ := decodeReadRow(payload)
+			return res
+		}),
+	}
+)

--- a/bigtable/internal/transport/diverter.go
+++ b/bigtable/internal/transport/diverter.go
@@ -1,0 +1,50 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"math"
+	"math/rand/v2"
+	"sync/atomic"
+)
+
+// Diverter decides whether to use the session-based protocol or classic protocol.
+type Diverter struct {
+	sessionLoadBits atomic.Uint64
+}
+
+// NewDiverter creates a new Diverter with the given session load ratio (0.0 to 1.0).
+func NewDiverter(sessionLoad float64) *Diverter {
+	d := &Diverter{}
+	d.sessionLoadBits.Store(math.Float64bits(sessionLoad))
+	return d
+}
+
+// SetSessionLoad updates the session load ratio.
+func (d *Diverter) SetSessionLoad(load float64) {
+	d.sessionLoadBits.Store(math.Float64bits(load))
+}
+
+// UseSession returns true if the next call should use the session protocol.
+func (d *Diverter) UseSession() bool {
+	load := math.Float64frombits(d.sessionLoadBits.Load())
+	if load <= 0 {
+		return false
+	}
+	if load >= 1 {
+		return true
+	}
+	return rand.Float64() <= load
+}

--- a/bigtable/internal/transport/diverter_test.go
+++ b/bigtable/internal/transport/diverter_test.go
@@ -1,0 +1,114 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestDiverterZeroAndOne(t *testing.T) {
+	tests := []struct {
+		name         string
+		sessionLoad  float64
+		expectedRes  bool
+	}{
+		{
+			name:        "Load is zero",
+			sessionLoad: 0.0,
+			expectedRes: false,
+		},
+		{
+			name:        "Load is negative",
+			sessionLoad: -0.5,
+			expectedRes: false,
+		},
+		{
+			name:        "Load is one",
+			sessionLoad: 1.0,
+			expectedRes: true,
+		},
+		{
+			name:        "Load is greater than one",
+			sessionLoad: 1.5,
+			expectedRes: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			d := NewDiverter(tc.sessionLoad)
+			for i := 0; i < 1000; i++ {
+				if got := d.UseSession(); got != tc.expectedRes {
+					t.Errorf("UseSession() = %v, want %v for load %f", got, tc.expectedRes, tc.sessionLoad)
+				}
+			}
+		})
+	}
+}
+
+func TestDiverterSetSessionLoad(t *testing.T) {
+	d := NewDiverter(0.0)
+	if got := d.UseSession(); got != false {
+		t.Errorf("Expected initial UseSession() to be false, got %v", got)
+	}
+
+	d.SetSessionLoad(1.0)
+	if got := d.UseSession(); got != true {
+		t.Errorf("Expected UseSession() to be true after SetSessionLoad(1.0), got %v", got)
+	}
+}
+
+func TestDiverterProbabilistic(t *testing.T) {
+	load := 0.4
+	d := NewDiverter(load)
+	iterations := 10000
+	trueCount := 0
+
+	for i := 0; i < iterations; i++ {
+		if d.UseSession() {
+			trueCount++
+		}
+	}
+
+	expected := int(float64(iterations) * load)
+	tolerance := 300 // Allow a variance range of +/- 3% of total iterations
+
+	if trueCount < expected-tolerance || trueCount > expected+tolerance {
+		t.Errorf("Expected approximately %d true results (with tolerance %d), got %d", expected, tolerance, trueCount)
+	}
+}
+
+func TestDiverterConcurrentAccess(t *testing.T) {
+	d := NewDiverter(0.5)
+	var wg sync.WaitGroup
+	numWorkers := 20
+	iterations := 1000
+
+	for i := 0; i < numWorkers; i++ {
+		wg.Add(1)
+		go func(workerID int) {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				if j%10 == 0 {
+					d.SetSessionLoad(float64(workerID) / float64(numWorkers))
+				}
+				_ = d.UseSession()
+			}
+		}(i)
+	}
+
+	wg.Wait()
+}

--- a/bigtable/internal/transport/diverter_test.go
+++ b/bigtable/internal/transport/diverter_test.go
@@ -21,9 +21,9 @@ import (
 
 func TestDiverterZeroAndOne(t *testing.T) {
 	tests := []struct {
-		name         string
-		sessionLoad  float64
-		expectedRes  bool
+		name        string
+		sessionLoad float64
+		expectedRes bool
 	}{
 		{
 			name:        "Load is zero",

--- a/bigtable/internal/transport/peak_emwa.go
+++ b/bigtable/internal/transport/peak_emwa.go
@@ -1,0 +1,61 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"math"
+	"sync"
+	"time"
+)
+
+// PeakEwma implements a thread-safe moving average latency continuous time-decay cost calculator.
+type PeakEwma struct {
+	mu         sync.Mutex
+	tau        time.Duration
+	value      float64
+	lastUpdate time.Time
+}
+
+// NewPeakEwma creates a new PeakEwma calculator with the given decay time constant.
+func NewPeakEwma(tau time.Duration) *PeakEwma {
+	return &PeakEwma{
+		tau:   tau,
+	}
+}
+
+// Update updates the EWMA with a new latency sample.
+func (e *PeakEwma) Update(latency time.Duration) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	now := time.Now()
+	if e.lastUpdate.IsZero() {
+		e.value = float64(latency)
+		e.lastUpdate = now
+		return
+	}
+	dt := now.Sub(e.lastUpdate)
+	e.lastUpdate = now
+	// Continuous time-decay weight: e^(-dt/tau)
+	weight := math.Exp(-float64(dt) / float64(e.tau))
+	// EWMA = EWMA * weight + latency * (1 - weight)
+	e.value = e.value*weight + float64(latency)*(1-weight)
+}
+
+// Value returns the current EWMA value.
+func (e *PeakEwma) Value() float64 {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.value
+}

--- a/bigtable/internal/transport/picker.go
+++ b/bigtable/internal/transport/picker.go
@@ -1,0 +1,196 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"context"
+	"math/rand"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	spb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
+)
+
+// RoundRobinPicker picks sessions in a round-robin sequence.
+type RoundRobinPicker struct {
+	mu       sync.Mutex
+	sessions []*SessionHandle
+	next     uint32
+}
+
+// NewRoundRobinPicker creates a new RoundRobinPicker.
+func NewRoundRobinPicker(sessions []*SessionHandle) *RoundRobinPicker {
+	return &RoundRobinPicker{
+		sessions: sessions,
+	}
+}
+
+// PickSession selects the next session sequentially.
+func (p *RoundRobinPicker) PickSession() *SessionHandle {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if len(p.sessions) == 0 {
+		return nil
+	}
+	sh := p.sessions[p.next%uint32(len(p.sessions))]
+	p.next++
+	return sh
+}
+
+// PeakEwmaPicker picks sessions based on outstanding request count and EWMA latency.
+type PeakEwmaPicker struct {
+	mu               sync.Mutex
+	sessions         []*SessionHandle
+	randomSubsetSize int
+	rng              *rand.Rand
+}
+
+// NewPeakEwmaPicker creates a new PeakEwmaPicker.
+func NewPeakEwmaPicker(sessions []*SessionHandle, randomSubsetSize int) *PeakEwmaPicker {
+	if randomSubsetSize <= 0 {
+		randomSubsetSize = 2 // Default to 2-choice randomized selection
+	}
+	return &PeakEwmaPicker{
+		sessions:         sessions,
+		randomSubsetSize: randomSubsetSize,
+		rng:              rand.New(rand.NewSource(time.Now().UnixNano())),
+	}
+}
+
+// PickSession selects a session using the Peak EWMA least-cost algorithm.
+func (p *PeakEwmaPicker) PickSession() *SessionHandle {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if len(p.sessions) == 0 {
+		return nil
+	}
+
+	// If the subset size is larger than the number of sessions, scan all sessions
+	subsetSize := p.randomSubsetSize
+	if subsetSize >= len(p.sessions) {
+		return p.pickMinCost(p.sessions)
+	}
+
+	// Randomized K-choice selection
+	choices := make([]*SessionHandle, subsetSize)
+	for i := 0; i < subsetSize; i++ {
+		idx := p.rng.Intn(len(p.sessions))
+		choices[i] = p.sessions[idx]
+	}
+
+	return p.pickMinCost(choices)
+}
+
+func (p *PeakEwmaPicker) pickMinCost(choices []*SessionHandle) *SessionHandle {
+	var minSH *SessionHandle
+	minCost := -1.0
+
+	for _, sh := range choices {
+		cost := p.getSessionCost(sh)
+		if minCost < 0 || cost < minCost {
+			minCost = cost
+			minSH = sh
+		}
+	}
+	return minSH
+}
+
+func (p *PeakEwmaPicker) getSessionCost(sh *SessionHandle) float64 {
+	outstanding := atomic.LoadInt64(&sh.outstanding)
+	val := 1.0
+	if sh.ewma != nil {
+		ewmaVal := sh.ewma.Value()
+		if ewmaVal > 0 {
+			val = ewmaVal
+		}
+	}
+	return float64(outstanding+1) * val
+}
+
+// SessionHandle wraps a Session.
+type SessionHandle struct {
+	session      *Session
+	outstanding  int64
+	ewma         *PeakEwma
+	lastActivity int64 // UnixNano timestamp of the last completed call
+}
+
+// NewSessionHandle creates a new SessionHandle wrapping a Session.
+func NewSessionHandle(session *Session) *SessionHandle {
+	return &SessionHandle{
+		session: session,
+		ewma:    NewPeakEwma(10 * time.Second),
+	}
+}
+
+// IncOutstanding increments outstanding calls.
+func (h *SessionHandle) IncOutstanding() {
+	atomic.AddInt64(&h.outstanding, 1)
+}
+
+// DecOutstanding decrements outstanding calls and updates EWMA latency + lastActivity timestamp.
+func (h *SessionHandle) DecOutstanding(latency time.Duration) {
+	atomic.AddInt64(&h.outstanding, -1)
+	if h.ewma != nil && latency > 0 {
+		h.ewma.Update(latency)
+	}
+	atomic.StoreInt64(&h.lastActivity, time.Now().UnixNano())
+}
+
+// GetLastActivity returns the time of the last activity.
+func (h *SessionHandle) GetLastActivity() time.Time {
+	nano := atomic.LoadInt64(&h.lastActivity)
+	if nano == 0 {
+		return time.Time{}
+	}
+	return time.Unix(0, nano)
+}
+
+// ExecuteVRpc delegates the virtual RPC execution to the underlying session.
+func (h *SessionHandle) ExecuteVRpc(ctx context.Context, desc VRpcDescriptor, req interface{}) (interface{}, *spb.ClusterInformation, error) {
+	return h.session.ExecuteVRpc(ctx, desc, req)
+}
+
+// Picker defines the interface for picking a session from a pool.
+type Picker interface {
+	PickSession() *SessionHandle
+}
+
+// RandomPicker picks a session randomly from a list of sessions.
+type RandomPicker struct {
+	mu       sync.Mutex
+	sessions []*SessionHandle
+	rng      *rand.Rand
+}
+
+// NewRandomPicker creates a new RandomPicker.
+func NewRandomPicker(sessions []*SessionHandle) *RandomPicker {
+	return &RandomPicker{
+		sessions: sessions,
+		rng:      rand.New(rand.NewSource(time.Now().UnixNano())),
+	}
+}
+
+// PickSession selects a session randomly.
+func (p *RandomPicker) PickSession() *SessionHandle {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if len(p.sessions) == 0 {
+		return nil
+	}
+	idx := p.rng.Intn(len(p.sessions))
+	return p.sessions[idx]
+}

--- a/bigtable/internal/transport/pool_sizer.go
+++ b/bigtable/internal/transport/pool_sizer.go
@@ -1,0 +1,104 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"math"
+	"sync"
+
+	spb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
+)
+
+// PoolStats defines the snapshot statistics of a session pool.
+type PoolStats struct {
+	ReadyCount    int
+	StartingCount int
+	InUseCount    int
+	PendingCount  int
+}
+
+// StatsFetcher is a function type that retrieves the current PoolStats.
+type StatsFetcher func() *PoolStats
+
+// PoolSizer calculates the optimal session pool size based on workload metrics.
+type PoolSizer struct {
+	mu          sync.Mutex
+	fetcher     StatsFetcher
+	minSessions int
+	maxSessions int
+	headroomPct float64 // Headroom percentage cushion (e.g., 0.10 for 10%)
+}
+
+// NewPoolSizer creates a new PoolSizer.
+func NewPoolSizer(fetcher StatsFetcher, minSessions, maxSessions int, headroomPct float64) *PoolSizer {
+	if headroomPct <= 0 {
+		headroomPct = 0.10 // Default to 10% headroom
+	}
+	return &PoolSizer{
+		fetcher:     fetcher,
+		minSessions: minSessions,
+		maxSessions: maxSessions,
+		headroomPct: headroomPct,
+	}
+}
+
+// UpdateConfig dynamically adjusts the sizer capacity bounds and headroom cushions at runtime.
+func (s *PoolSizer) UpdateConfig(config *spb.SessionClientConfiguration_SessionPoolConfiguration) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.minSessions = int(config.MinSessionCount)
+	s.maxSessions = int(config.MaxSessionCount)
+	s.headroomPct = float64(config.Headroom)
+}
+
+// GetScaleDelta evaluates the current statistics and calculates the required scaling delta
+// to maintain the desired headroom cushion and satisfy pending calls.
+func (s *PoolSizer) GetScaleDelta() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	stats := s.fetcher()
+	if stats == nil {
+		return 0
+	}
+
+	// Formula: sessionsInUse = InUseCount + ceil(PendingCount / 10.0)
+	effectivePending := int(math.Ceil(float64(stats.PendingCount) / 10.0))
+	sessionsInUse := stats.InUseCount + effectivePending
+
+	// Formula: desiredCapacity = clamp(sessionsInUse + ceil(sessionsInUse * headroomPct), minSessions, maxSessions)
+	unboundedIdle := int(math.Ceil(float64(sessionsInUse) * s.headroomPct))
+	desiredCapacity := sessionsInUse + unboundedIdle
+
+	if desiredCapacity < s.minSessions {
+		desiredCapacity = s.minSessions
+	}
+	if desiredCapacity > s.maxSessions {
+		desiredCapacity = s.maxSessions
+	}
+
+	eventualCapacity := stats.ReadyCount + stats.StartingCount
+
+	if desiredCapacity > eventualCapacity {
+		return desiredCapacity - eventualCapacity
+	}
+
+	if desiredCapacity < stats.ReadyCount {
+		return desiredCapacity - stats.ReadyCount
+	}
+
+	return 0
+}

--- a/bigtable/internal/transport/retrying.go
+++ b/bigtable/internal/transport/retrying.go
@@ -110,6 +110,7 @@ func RetryingVRpc(opts RetryingOptions) Interceptor {
 				return nil, err
 			}
 
+
 			if !hasServerDelay {
 				delay = backoff
 				nextBackoff := float64(backoff) * opts.BackoffMultiplier
@@ -130,6 +131,7 @@ func RetryingVRpc(opts RetryingOptions) Interceptor {
 		return nil, lastErr
 	}
 }
+
 
 func isRetryableCode(code codes.Code) bool {
 	switch code {

--- a/bigtable/internal/transport/retrying.go
+++ b/bigtable/internal/transport/retrying.go
@@ -1,0 +1,169 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"sync/atomic"
+	"time"
+
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// RetryingOptions configures the retry behavior of RetryingVRpc.
+type RetryingOptions struct {
+	MaxAttempts       int32 // Atomic race cap for max attempts.
+	InitialBackoff    time.Duration
+	MaxBackoff        time.Duration
+	BackoffMultiplier float64
+	Listener          VRpcListener
+}
+
+// RetryingVRpc returns an Interceptor that retries failed virtual RPCs with
+// exponential delay backoffs and optional custom server RetryInfo parsing.
+func RetryingVRpc(opts RetryingOptions) Interceptor {
+	if opts.MaxAttempts <= 0 {
+		opts.MaxAttempts = 3
+	}
+	if opts.InitialBackoff <= 0 {
+		opts.InitialBackoff = 20 * time.Millisecond
+	}
+	if opts.MaxBackoff <= 0 {
+		opts.MaxBackoff = 32 * time.Second
+	}
+	if opts.BackoffMultiplier <= 0 {
+		opts.BackoffMultiplier = 1.3
+	}
+
+	return func(ctx CallContext, req interface{}, next Handler) (interface{}, error) {
+		var attempt int32
+		backoff := opts.InitialBackoff
+
+		var shieldedListener *closedListenerShield
+		if opts.Listener != nil {
+			shieldedListener = &closedListenerShield{listener: opts.Listener}
+			defer shieldedListener.Close()
+		}
+
+		var lastErr error
+
+		for {
+			currentAttempt := atomic.AddInt32(&attempt, 1)
+			if currentAttempt > atomic.LoadInt32(&opts.MaxAttempts) {
+				break
+			}
+
+			attemptCtx := &callContext{
+				Context: ctx,
+				method:  ctx.Method(),
+				attempt: int(currentAttempt),
+			}
+
+			if shieldedListener != nil {
+				shieldedListener.OnAttemptStart(attemptCtx)
+			}
+
+			res, err := next(attemptCtx, req)
+
+			if shieldedListener != nil {
+				shieldedListener.OnAttemptComplete(attemptCtx, err)
+			}
+
+			if err == nil {
+				return res, nil
+			}
+
+			lastErr = err
+
+			if ctx.Err() != nil {
+				return nil, ctx.Err()
+			}
+
+			var delay time.Duration
+			hasServerDelay := false
+
+			if s, ok := status.FromError(err); ok {
+				if !isRetryableCode(s.Code()) {
+					return nil, err
+				}
+
+				for _, detail := range s.Details() {
+					if retryInfo, ok := detail.(*errdetails.RetryInfo); ok {
+						if retryInfo.GetRetryDelay().IsValid() {
+							delay = retryInfo.GetRetryDelay().AsDuration()
+							hasServerDelay = true
+							break
+						}
+					}
+				}
+			} else {
+				return nil, err
+			}
+
+			if !hasServerDelay {
+				delay = backoff
+				nextBackoff := float64(backoff) * opts.BackoffMultiplier
+				if nextBackoff > float64(opts.MaxBackoff) {
+					backoff = opts.MaxBackoff
+				} else {
+					backoff = time.Duration(nextBackoff)
+				}
+			}
+
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(delay):
+			}
+		}
+
+		return nil, lastErr
+	}
+}
+
+func isRetryableCode(code codes.Code) bool {
+	switch code {
+	case codes.Aborted, codes.DeadlineExceeded, codes.Internal, codes.ResourceExhausted, codes.Unavailable:
+		return true
+	default:
+		return false
+	}
+}
+
+type closedListenerShield struct {
+	listener VRpcListener
+	closed   int32
+}
+
+func (s *closedListenerShield) Close() {
+	atomic.StoreInt32(&s.closed, 1)
+}
+
+func (s *closedListenerShield) isClosed() bool {
+	return atomic.LoadInt32(&s.closed) == 1
+}
+
+func (s *closedListenerShield) OnAttemptStart(ctx CallContext) {
+	if !s.isClosed() && s.listener != nil {
+		s.listener.OnAttemptStart(ctx)
+	}
+}
+
+func (s *closedListenerShield) OnAttemptComplete(ctx CallContext, err error) {
+	if !s.isClosed() && s.listener != nil {
+		s.listener.OnAttemptComplete(ctx, err)
+	}
+}

--- a/bigtable/internal/transport/retrying.go
+++ b/bigtable/internal/transport/retrying.go
@@ -15,6 +15,7 @@
 package internal
 
 import (
+	"context"
 	"sync/atomic"
 	"time"
 
@@ -48,7 +49,7 @@ func RetryingVRpc(opts RetryingOptions) Interceptor {
 		opts.BackoffMultiplier = 1.3
 	}
 
-	return func(ctx CallContext, req interface{}, next Handler) (interface{}, error) {
+	return func(ctx context.Context, req interface{}, next Handler) (interface{}, error) {
 		var attempt int32
 		backoff := opts.InitialBackoff
 
@@ -66,11 +67,7 @@ func RetryingVRpc(opts RetryingOptions) Interceptor {
 				break
 			}
 
-			attemptCtx := &callContext{
-				Context: ctx,
-				method:  ctx.Method(),
-				attempt: int(currentAttempt),
-			}
+			attemptCtx := WithAttempt(ctx, int(currentAttempt))
 
 			if shieldedListener != nil {
 				shieldedListener.OnAttemptStart(attemptCtx)
@@ -156,13 +153,13 @@ func (s *closedListenerShield) isClosed() bool {
 	return atomic.LoadInt32(&s.closed) == 1
 }
 
-func (s *closedListenerShield) OnAttemptStart(ctx CallContext) {
+func (s *closedListenerShield) OnAttemptStart(ctx context.Context) {
 	if !s.isClosed() && s.listener != nil {
 		s.listener.OnAttemptStart(ctx)
 	}
 }
 
-func (s *closedListenerShield) OnAttemptComplete(ctx CallContext, err error) {
+func (s *closedListenerShield) OnAttemptComplete(ctx context.Context, err error) {
 	if !s.isClosed() && s.listener != nil {
 		s.listener.OnAttemptComplete(ctx, err)
 	}

--- a/bigtable/internal/transport/session.go
+++ b/bigtable/internal/transport/session.go
@@ -1,0 +1,171 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	spb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
+	"google.golang.org/grpc/metadata"
+)
+
+// State represents the state of a Session.
+type State int
+
+const (
+	// StateNew indicates the session is newly created and not yet active.
+	StateNew State = iota
+	// StateStarting indicates the session is dialing and handshaking.
+	StateStarting
+	// StateActive indicates the session is active and ready for RPCs.
+	StateActive
+	// StateClosing indicates the session is in the process of closing.
+	StateClosing
+	// StateWaitServerClose indicates the session has requested close and is waiting for server EOF.
+	StateWaitServerClose
+	// StateClosed indicates the session is closed.
+	StateClosed
+)
+
+func (s State) String() string {
+	switch s {
+	case StateNew:
+		return "New"
+	case StateStarting:
+		return "Starting"
+	case StateActive:
+		return "Active"
+	case StateClosing:
+		return "Closing"
+	case StateWaitServerClose:
+		return "WaitServerClose"
+	case StateClosed:
+		return "Closed"
+	default:
+		return "Unknown"
+	}
+}
+
+// Stream represents a bidirectional stream for Session requests and responses.
+type Stream interface {
+	Send(*spb.SessionRequest) error
+	Recv() (*spb.SessionResponse, error)
+	Header() (metadata.MD, error)
+}
+
+// Listener receives notifications of Session lifecycle events.
+type Listener interface {
+	OnStart(ctx context.Context)
+	OnActive(s *Session)
+	OnClose(s *Session, err error)
+}
+
+type vrpcResult struct {
+	resp        *spb.VirtualRpcResponse
+	clusterInfo *spb.ClusterInformation
+	err         error
+}
+
+// VRPCImpl represents an active virtual RPC.
+type VRPCImpl struct {
+	id         int64
+	method     string
+	resultChan chan vrpcResult
+}
+
+// Session manages the lifecycle of a Bigtable Session.
+type Session struct {
+	mu                    sync.Mutex
+	sendMu                sync.Mutex
+	vrpcMu                sync.Mutex // Serializes vRPC execution to ensure only one runs at a time per session.
+	state                 State
+	lastStateChange       time.Time
+	logName               string
+	stream                Stream
+	listener              Listener
+	activeRPCs            map[int64]*VRPCImpl
+	nextRPCID             int64
+	heartbeatInterval     time.Duration
+	nextHeartbeatDeadline time.Time
+	peerInfo              *spb.PeerInfo
+	hasOkRpcs             bool
+	hasErrorRpcs          bool
+
+	handshakeDone chan struct{}
+	handshakeErr  error
+	tracer        *sessionTracer
+	sessionType   SessionType
+}
+
+// NewSession creates a new Session constructor.
+func NewSession(logName string, stream Stream, listener Listener, sessionType SessionType) *Session {
+	return &Session{
+		state:                 StateNew,
+		lastStateChange:       time.Now(),
+		logName:               logName,
+		stream:                stream,
+		listener:              listener,
+		activeRPCs:            make(map[int64]*VRPCImpl),
+		heartbeatInterval:     10 * time.Second,
+		nextHeartbeatDeadline: time.Now().Add(30 * time.Minute),
+		handshakeDone:         make(chan struct{}),
+		tracer:                newSessionTracer(sessionType),
+		sessionType:           sessionType,
+	}
+}
+
+// LogName returns the session log identifier.
+func (s *Session) LogName() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.logName
+}
+
+// State returns the current operational State of the Session.
+func (s *Session) State() State {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.state
+}
+
+// StateString returns the current session state string.
+func (s *Session) StateString() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.state.String()
+}
+
+// PeerInfo returns the  peer information of the session connection.
+func (s *Session) PeerInfo() *spb.PeerInfo {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.peerInfo
+}
+
+// HasOkRpcs returns true if the session processed successful RPCs.
+func (s *Session) HasOkRpcs() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.hasOkRpcs
+}
+
+// HasErrorRpcs returns true if the session processed failed RPCs.
+func (s *Session) HasErrorRpcs() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.hasErrorRpcs
+}

--- a/bigtable/internal/transport/session.go
+++ b/bigtable/internal/transport/session.go
@@ -20,8 +20,11 @@ import (
 	"time"
 
 	spb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
+	"golang.org/x/sync/semaphore"
 	"google.golang.org/grpc/metadata"
 )
+
+const sessionConcurrencyLimit = 1 // Limit of 1 indicates no multiplexing.
 
 // State represents the state of a Session.
 type State int
@@ -91,7 +94,7 @@ type VRPCImpl struct {
 type Session struct {
 	mu                    sync.Mutex
 	sendMu                sync.Mutex
-	vrpcMu                sync.Mutex // Serializes vRPC execution to ensure only one runs at a time per session.
+	vrpcSem               *semaphore.Weighted // Serializes vRPC execution to ensure only one runs at a time per session.
 	state                 State
 	lastStateChange       time.Time
 	logName               string
@@ -125,6 +128,7 @@ func NewSession(logName string, stream Stream, listener Listener, sessionType Se
 		handshakeDone:         make(chan struct{}),
 		tracer:                newSessionTracer(sessionType),
 		sessionType:           sessionType,
+		vrpcSem:               semaphore.NewWeighted(sessionConcurrencyLimit),
 	}
 }
 

--- a/bigtable/internal/transport/session_creation_budget.go
+++ b/bigtable/internal/transport/session_creation_budget.go
@@ -1,0 +1,64 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"context"
+	"time"
+)
+
+// SessionThrottler manages the pacing and rate-limiting for creating new sessions.
+type SessionThrottler interface {
+	// Acquire blocks until a session creation token is available or ctx is done.
+	Acquire(ctx context.Context) error
+	// Release returns a token back to the throttler, registering a penalty duration hold-off on failure.
+	Release(success bool)
+}
+
+// AdaptiveSessionThrottler implements a concurrency governor with adaptive failure penalties using a channel semaphore.
+type AdaptiveSessionThrottler struct {
+	sem             chan struct{}
+	penaltyDuration time.Duration
+}
+
+// NewAdaptiveSessionThrottler creates a new SessionThrottler implemented by AdaptiveSessionThrottler.
+func NewAdaptiveSessionThrottler(maxConcurrent int, penaltyDuration time.Duration) SessionThrottler {
+	return &AdaptiveSessionThrottler{
+		sem:             make(chan struct{}, maxConcurrent),
+		penaltyDuration: penaltyDuration,
+	}
+}
+
+// Acquire blocks context-safely until a session creation token is available or ctx is done.
+func (b *AdaptiveSessionThrottler) Acquire(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case b.sem <- struct{}{}:
+		return nil
+	}
+}
+
+// Release releases a token back to the throttler, registering a penalty duration hold-off on failure.
+func (b *AdaptiveSessionThrottler) Release(success bool) {
+	if success {
+		<-b.sem
+	} else {
+		// Hold the token for b.penaltyDuration before releasing it to protect the backend AFE
+		time.AfterFunc(b.penaltyDuration, func() {
+			<-b.sem
+		})
+	}
+}

--- a/bigtable/internal/transport/session_descriptors.go
+++ b/bigtable/internal/transport/session_descriptors.go
@@ -1,0 +1,115 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"fmt"
+
+	spb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
+	"google.golang.org/protobuf/proto"
+)
+
+// SessionType represents the protocol target session type.
+type SessionType int
+
+const (
+	// SessionTypeTable indicates standard table session type.
+	SessionTypeTable SessionType = iota
+	// SessionTypeAuthorizedView indicates authorized view session type.
+	SessionTypeAuthorizedView
+	// SessionTypeMaterializedView indicates materialized view session type.
+	SessionTypeMaterializedView
+)
+
+func (t SessionType) String() string {
+	switch t {
+	case SessionTypeTable:
+		return "table"
+	case SessionTypeAuthorizedView:
+		return "authorized_view"
+	case SessionTypeMaterializedView:
+		return "materialized_view"
+	default:
+		return "unknown"
+	}
+}
+
+// SessionDescriptor models a dynamic envelope handshake parameters compiler.
+type SessionDescriptor struct {
+	Type       SessionType
+	MethodName string
+	HeaderKeys []string
+	LogNameFn  func(req proto.Message) string
+	MetadataFn func(req proto.Message) map[string]string // Dynamically populates handshake metadata headers E2E!
+}
+
+var (
+	// TABLE_SESSION manages standard table scoped connection streams.
+	TABLE_SESSION = &SessionDescriptor{
+		Type:       SessionTypeTable,
+		MethodName: "OpenTable",
+		HeaderKeys: []string{"table_name", "app_profile_id", "permission"},
+		LogNameFn: func(req proto.Message) string {
+			r := req.(*spb.OpenTableRequest)
+			return fmt.Sprintf("TableSession(table=%s, app_profile=%s, perm=%s)", r.TableName, r.AppProfileId, r.Permission.String())
+		},
+		MetadataFn: func(req proto.Message) map[string]string {
+			r := req.(*spb.OpenTableRequest)
+			return map[string]string{
+				"open_session.payload.table_name":     r.TableName,
+				"open_session.payload.app_profile_id": r.AppProfileId,
+				"open_session.payload.permission":     r.Permission.String(),
+			}
+		},
+	}
+
+	// AUTHORIZED_VIEW_SESSION manages authorized view scoped connection streams.
+	AUTHORIZED_VIEW_SESSION = &SessionDescriptor{
+		Type:       SessionTypeAuthorizedView,
+		MethodName: "OpenAuthorizedView",
+		HeaderKeys: []string{"authorized_view_name", "app_profile_id", "permission"},
+		LogNameFn: func(req proto.Message) string {
+			r := req.(*spb.OpenAuthorizedViewRequest)
+			return fmt.Sprintf("AuthorizedViewSession(view=%s, app_profile=%s, perm=%s)", r.AuthorizedViewName, r.AppProfileId, r.Permission.String())
+		},
+		MetadataFn: func(req proto.Message) map[string]string {
+			r := req.(*spb.OpenAuthorizedViewRequest)
+			return map[string]string{
+				"open_session.payload.authorized_view_name": r.AuthorizedViewName,
+				"open_session.payload.app_profile_id":       r.AppProfileId,
+				"open_session.payload.permission":           r.Permission.String(),
+			}
+		},
+	}
+
+	// MATERIALIZED_VIEW_SESSION manages materialized view scoped connection streams (Read-Only).
+	MATERIALIZED_VIEW_SESSION = &SessionDescriptor{
+		Type:       SessionTypeMaterializedView,
+		MethodName: "OpenMaterializedView",
+		HeaderKeys: []string{"materialized_view_name", "app_profile_id", "permission"},
+		LogNameFn: func(req proto.Message) string {
+			r := req.(*spb.OpenMaterializedViewRequest)
+			return fmt.Sprintf("MaterializedViewSession(view=%s, app_profile=%s, perm=%s)", r.MaterializedViewName, r.AppProfileId, r.Permission.String())
+		},
+		MetadataFn: func(req proto.Message) map[string]string {
+			r := req.(*spb.OpenMaterializedViewRequest)
+			return map[string]string{
+				"open_session.payload.materialized_view_name": r.MaterializedViewName,
+				"open_session.payload.app_profile_id":         r.AppProfileId,
+				"open_session.payload.permission":             r.Permission.String(),
+			}
+		},
+	}
+)

--- a/bigtable/internal/transport/session_descriptors_test.go
+++ b/bigtable/internal/transport/session_descriptors_test.go
@@ -1,0 +1,189 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"testing"
+
+	spb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
+)
+
+func TestSessionType_String(t *testing.T) {
+	tests := []struct {
+		t    SessionType
+		want string
+	}{
+		{SessionTypeTable, "table"},
+		{SessionTypeAuthorizedView, "authorized_view"},
+		{SessionTypeMaterializedView, "materialized_view"},
+		{SessionType(99), "unknown"},
+	}
+
+	for _, tt := range tests {
+		if got := tt.t.String(); got != tt.want {
+			t.Errorf("SessionType(%d).String() = %q, want %q", int(tt.t), got, tt.want)
+		}
+	}
+}
+
+func TestTableSessionDescriptor(t *testing.T) {
+	desc := TABLE_SESSION
+
+	if desc.Type != SessionTypeTable {
+		t.Errorf("Expected type %v, got %v", SessionTypeTable, desc.Type)
+	}
+	if desc.MethodName != "OpenTable" {
+		t.Errorf("Expected MethodName 'OpenTable', got %q", desc.MethodName)
+	}
+
+	expectedHeaders := []string{"table_name", "app_profile_id", "permission"}
+	if len(desc.HeaderKeys) != len(expectedHeaders) {
+		t.Fatalf("Expected HeaderKeys length %d, got %d", len(expectedHeaders), len(desc.HeaderKeys))
+	}
+	for i, h := range expectedHeaders {
+		if desc.HeaderKeys[i] != h {
+			t.Errorf("At index %d: expected header key %q, got %q", i, h, desc.HeaderKeys[i])
+		}
+	}
+
+	req := &spb.OpenTableRequest{
+		TableName:    "projects/p/instances/i/tables/t",
+		AppProfileId: "app-profile-1",
+		Permission:   spb.OpenTableRequest_PERMISSION_READ_WRITE,
+	}
+
+	// Test LogNameFn
+	logName := desc.LogNameFn(req)
+	expectedLogName := "TableSession(table=projects/p/instances/i/tables/t, app_profile=app-profile-1, perm=PERMISSION_READ_WRITE)"
+	if logName != expectedLogName {
+		t.Errorf("Expected log name %q, got %q", expectedLogName, logName)
+	}
+
+	// Test MetadataFn
+	meta := desc.MetadataFn(req)
+	expectedMeta := map[string]string{
+		"open_session.payload.table_name":     "projects/p/instances/i/tables/t",
+		"open_session.payload.app_profile_id": "app-profile-1",
+		"open_session.payload.permission":     "PERMISSION_READ_WRITE",
+	}
+	if len(meta) != len(expectedMeta) {
+		t.Fatalf("Expected metadata length %d, got %d", len(expectedMeta), len(meta))
+	}
+	for k, v := range expectedMeta {
+		if meta[k] != v {
+			t.Errorf("Metadata key %q: expected value %q, got %q", k, v, meta[k])
+		}
+	}
+}
+
+func TestAuthorizedViewSessionDescriptor(t *testing.T) {
+	desc := AUTHORIZED_VIEW_SESSION
+
+	if desc.Type != SessionTypeAuthorizedView {
+		t.Errorf("Expected type %v, got %v", SessionTypeAuthorizedView, desc.Type)
+	}
+	if desc.MethodName != "OpenAuthorizedView" {
+		t.Errorf("Expected MethodName 'OpenAuthorizedView', got %q", desc.MethodName)
+	}
+
+	expectedHeaders := []string{"authorized_view_name", "app_profile_id", "permission"}
+	if len(desc.HeaderKeys) != len(expectedHeaders) {
+		t.Fatalf("Expected HeaderKeys length %d, got %d", len(expectedHeaders), len(desc.HeaderKeys))
+	}
+	for i, h := range expectedHeaders {
+		if desc.HeaderKeys[i] != h {
+			t.Errorf("At index %d: expected header key %q, got %q", i, h, desc.HeaderKeys[i])
+		}
+	}
+
+	req := &spb.OpenAuthorizedViewRequest{
+		AuthorizedViewName: "projects/p/instances/i/tables/t/authorizedViews/v",
+		AppProfileId:       "app-profile-2",
+		Permission:         spb.OpenAuthorizedViewRequest_PERMISSION_READ,
+	}
+
+	// Test LogNameFn
+	logName := desc.LogNameFn(req)
+	expectedLogName := "AuthorizedViewSession(view=projects/p/instances/i/tables/t/authorizedViews/v, app_profile=app-profile-2, perm=PERMISSION_READ)"
+	if logName != expectedLogName {
+		t.Errorf("Expected log name %q, got %q", expectedLogName, logName)
+	}
+
+	// Test MetadataFn
+	meta := desc.MetadataFn(req)
+	expectedMeta := map[string]string{
+		"open_session.payload.authorized_view_name": "projects/p/instances/i/tables/t/authorizedViews/v",
+		"open_session.payload.app_profile_id":       "app-profile-2",
+		"open_session.payload.permission":           "PERMISSION_READ",
+	}
+	if len(meta) != len(expectedMeta) {
+		t.Fatalf("Expected metadata length %d, got %d", len(expectedMeta), len(meta))
+	}
+	for k, v := range expectedMeta {
+		if meta[k] != v {
+			t.Errorf("Metadata key %q: expected value %q, got %q", k, v, meta[k])
+		}
+	}
+}
+
+func TestMaterializedViewSessionDescriptor(t *testing.T) {
+	desc := MATERIALIZED_VIEW_SESSION
+
+	if desc.Type != SessionTypeMaterializedView {
+		t.Errorf("Expected type %v, got %v", SessionTypeMaterializedView, desc.Type)
+	}
+	if desc.MethodName != "OpenMaterializedView" {
+		t.Errorf("Expected MethodName 'OpenMaterializedView', got %q", desc.MethodName)
+	}
+
+	expectedHeaders := []string{"materialized_view_name", "app_profile_id", "permission"}
+	if len(desc.HeaderKeys) != len(expectedHeaders) {
+		t.Fatalf("Expected HeaderKeys length %d, got %d", len(expectedHeaders), len(desc.HeaderKeys))
+	}
+	for i, h := range expectedHeaders {
+		if desc.HeaderKeys[i] != h {
+			t.Errorf("At index %d: expected header key %q, got %q", i, h, desc.HeaderKeys[i])
+		}
+	}
+
+	req := &spb.OpenMaterializedViewRequest{
+		MaterializedViewName: "projects/p/instances/i/materializedViews/mv",
+		AppProfileId:         "app-profile-3",
+		Permission:           spb.OpenMaterializedViewRequest_PERMISSION_READ,
+	}
+
+	// Test LogNameFn
+	logName := desc.LogNameFn(req)
+	expectedLogName := "MaterializedViewSession(view=projects/p/instances/i/materializedViews/mv, app_profile=app-profile-3, perm=PERMISSION_READ)"
+	if logName != expectedLogName {
+		t.Errorf("Expected log name %q, got %q", expectedLogName, logName)
+	}
+
+	// Test MetadataFn
+	meta := desc.MetadataFn(req)
+	expectedMeta := map[string]string{
+		"open_session.payload.materialized_view_name": "projects/p/instances/i/materializedViews/mv",
+		"open_session.payload.app_profile_id":         "app-profile-3",
+		"open_session.payload.permission":             "PERMISSION_READ",
+	}
+	if len(meta) != len(expectedMeta) {
+		t.Fatalf("Expected metadata length %d, got %d", len(expectedMeta), len(meta))
+	}
+	for k, v := range expectedMeta {
+		if meta[k] != v {
+			t.Errorf("Metadata key %q: expected value %q, got %q", k, v, meta[k])
+		}
+	}
+}

--- a/bigtable/internal/transport/session_pool.go
+++ b/bigtable/internal/transport/session_pool.go
@@ -1,0 +1,452 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	spb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
+	"google.golang.org/grpc/metadata"
+)
+
+// SessionPoolImpl implements a thread-safe session pool.
+type SessionPoolImpl struct {
+	mu                 sync.Mutex
+	sizer              *PoolSizer
+	picker             Picker
+	budget             SessionThrottler
+	sessions           []*SessionHandle
+	startingSessions   map[*Session]bool
+	closed             bool
+	scalingInProgress  bool
+	minSessions        int
+	maxSessions        int
+	streamFactory      func(ctx context.Context) (Stream, error)
+	openSessionRequest *spb.OpenSessionRequest // Target specific stream handshake template
+	metadata           metadata.MD             // Pre-computed call metadata headers
+	nextSessionID      uint64                  // Monotonically increasing counter for unique session naming
+	sessionType        SessionType
+	poolName           string
+}
+
+// NewSessionPoolImpl creates a new SessionPoolImpl.
+func NewSessionPoolImpl(poolName string, min, max int, streamFactory func(ctx context.Context) (Stream, error), openSessionRequest *spb.OpenSessionRequest, md metadata.MD, sessionType SessionType) *SessionPoolImpl {
+	pool := &SessionPoolImpl{
+		poolName:           poolName,
+		minSessions:        min,
+		maxSessions:        max,
+		streamFactory:      streamFactory,
+		openSessionRequest: openSessionRequest,
+		metadata:           md,
+		startingSessions:   make(map[*Session]bool),
+		sessionType:        sessionType,
+	}
+
+	fetcher := func() *PoolStats {
+		return pool.Stats()
+	}
+	pool.sizer = NewPoolSizer(fetcher, min, max, 0.10)
+	pool.picker = NewRandomPicker(pool.sessions)
+	pool.budget = NewAdaptiveSessionThrottler(10, 10*time.Second)
+
+	return pool
+}
+
+// CheckoutSession retrieves a session from the pool for routing requests.
+func (p *SessionPoolImpl) CheckoutSession(ctx context.Context) (*SessionHandle, error) {
+	// Triggers scaling immediately if we might be short of sessions
+	p.mu.Lock()
+	if !p.closed && len(p.sessions) == 0 {
+		fmt.Printf(">>> POOL %s: all sessions busy, trying to create new session <<<\n", p.poolName)
+		go p.PerformScaling(ctx)
+	}
+	p.mu.Unlock()
+
+	ticker := time.NewTicker(15 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		p.mu.Lock()
+		if p.closed {
+			p.mu.Unlock()
+			return nil, errors.New("session pool is closed")
+		}
+
+		sh := p.picker.PickSession()
+		if sh != nil {
+			if sh.session.State() == StateActive {
+				sh.IncOutstanding()
+				p.mu.Unlock()
+				return sh, nil
+			}
+			// Session is not active anymore. Remove it immediately from pool sessions
+			idx := -1
+			for i, sHandle := range p.sessions {
+				if sHandle == sh {
+					idx = i
+					break
+				}
+			}
+			if idx != -1 {
+				p.sessions = append(p.sessions[:idx], p.sessions[idx+1:]...)
+				p.picker = NewRandomPicker(p.sessions)
+			}
+			// Trigger scale up immediately to replace the dead session
+			go p.PerformScaling(ctx)
+		}
+
+		p.mu.Unlock()
+
+		select {
+		case <-ctx.Done():
+			return nil, fmt.Errorf("no active sessions available: %w", ctx.Err())
+		case <-ticker.C:
+		}
+	}
+}
+
+// Stats returns the current operational statistics of the session pool.
+func (p *SessionPoolImpl) Stats() *PoolStats {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	ready := 0
+	inUse := 0
+	totalOutstanding := 0
+	for _, sh := range p.sessions {
+		if sh.session.State() == StateActive {
+			ready++
+		}
+		outstanding := atomic.LoadInt64(&sh.outstanding)
+		if outstanding > 0 {
+			inUse++
+			totalOutstanding += int(outstanding)
+		}
+	}
+
+	return &PoolStats{
+		ReadyCount:    ready,
+		InUseCount:    inUse,
+		StartingCount: len(p.startingSessions),
+		PendingCount:  totalOutstanding,
+	}
+}
+
+// Close gracefully closes all active sessions in the pool.
+func (p *SessionPoolImpl) Close() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.closed {
+		return nil
+	}
+	p.closed = true
+
+	for _, sh := range p.sessions {
+		if sh.session != nil {
+			go sh.session.Close(&spb.CloseSessionRequest{
+				Reason:      spb.CloseSessionRequest_CLOSE_SESSION_REASON_USER,
+				Description: "graceful pool teardown",
+			})
+		}
+	}
+	p.sessions = nil
+	return nil
+}
+
+// OnStart is a no-op callback for session start.
+func (p *SessionPoolImpl) OnStart(ctx context.Context) {}
+
+// OnActive is triggered when a background session finishes its open session req and becomes active.
+// The session is wrapped inside a SessionHandle and registered into the ready sessions list!
+func (p *SessionPoolImpl) OnActive(s *Session) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	delete(p.startingSessions, s)
+
+	if p.closed {
+		s.ForceClose(&spb.CloseSessionRequest{
+			Reason:      spb.CloseSessionRequest_CLOSE_SESSION_REASON_ERROR,
+			Description: "pool closed before session became active",
+		})
+		return
+	}
+
+	// Ensure we do not duplicate register the same session!
+	for _, sh := range p.sessions {
+		if sh.session == s {
+			return
+		}
+	}
+
+	sh := NewSessionHandle(s)
+	p.sessions = append(p.sessions, sh)
+
+	// Re-initialize picker with updated sessions list
+	p.picker = NewRandomPicker(p.sessions)
+}
+
+// OnClose removes the closed session from the active sessions list and updates the picker.
+func (p *SessionPoolImpl) OnClose(s *Session, err error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if _, starting := p.startingSessions[s]; starting {
+		delete(p.startingSessions, s)
+		return
+	}
+
+	idx := -1
+	for i, sh := range p.sessions {
+		if sh.session == s {
+			idx = i
+			break
+		}
+	}
+
+	if idx != -1 {
+		// Remove session handle from slice
+		p.sessions = append(p.sessions[:idx], p.sessions[idx+1:]...)
+		// Re-initialize picker with updated active sessions
+		p.picker = NewRandomPicker(p.sessions)
+		// Trigger scale up evaluation asynchronously immediately!
+		go p.PerformScaling(context.Background())
+	}
+}
+
+// UpdateConfig dynamically adjusts the pool size constraints and budget governor limits at runtime.
+func (p *SessionPoolImpl) UpdateConfig(config *spb.SessionClientConfiguration_SessionPoolConfiguration) {
+	p.mu.Lock()
+	p.minSessions = int(config.MinSessionCount)
+	p.maxSessions = int(config.MaxSessionCount)
+	fmt.Printf(">>> SessionPool %p UpdateConfig: minSessions=%d, maxSessions=%d <<<\n", p, p.minSessions, p.maxSessions)
+
+	if config.LoadBalancingOptions != nil {
+		lbo := config.LoadBalancingOptions
+		switch opt := lbo.LoadBalancingStrategy.(type) {
+		case *spb.LoadBalancingOptions_Random_:
+			p.picker = NewRandomPicker(p.sessions)
+		case *spb.LoadBalancingOptions_LeastInFlight_:
+			p.picker = NewRoundRobinPicker(p.sessions)
+		case *spb.LoadBalancingOptions_PeakEwma_:
+			subsetSize := 2
+			if opt.PeakEwma != nil {
+				subsetSize = int(opt.PeakEwma.RandomSubsetSize)
+			}
+			p.picker = NewPeakEwmaPicker(p.sessions, subsetSize)
+		}
+	}
+	p.mu.Unlock()
+
+	// Dynamically update sizer thresholds E2E!
+	p.sizer.UpdateConfig(config)
+}
+
+// StartHeartbeat begins the background scaling watchdog evaluation loop.
+func (p *SessionPoolImpl) StartHeartbeat(ctx context.Context, interval time.Duration) {
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				p.PerformScaling(ctx)
+			}
+		}
+	}()
+}
+
+func (p *SessionPoolImpl) PerformScaling(ctx context.Context) {
+	p.mu.Lock()
+	if p.closed || p.scalingInProgress {
+		p.mu.Unlock()
+		return
+	}
+	p.scalingInProgress = true
+	p.mu.Unlock()
+
+	defer func() {
+		p.mu.Lock()
+		p.scalingInProgress = false
+		p.mu.Unlock()
+	}()
+
+	stats := p.Stats()
+	fmt.Printf(">>> POOL %s STATS: Ready=%d, Starting=%d, InUse=%d, PendingOutstanding=%d <<<\n",
+		p.poolName, stats.ReadyCount, stats.StartingCount, stats.InUseCount, stats.PendingCount)
+
+	delta := p.sizer.GetScaleDelta()
+	if delta == 0 {
+		return
+	}
+
+	p.mu.Lock()
+	currentSessions := len(p.sessions)
+	startingSessions := len(p.startingSessions)
+	p.mu.Unlock()
+
+	fmt.Printf(">>> POOL %s PerformScaling starting evaluation: delta=%d, current_sessions=%d, starting_sessions=%d <<<\n", p.poolName, delta, currentSessions, startingSessions)
+
+	if delta > 0 {
+		// Scale up: provision new sessions asynchronously and wait for completion to release the gate
+		var wg sync.WaitGroup
+		for i := 0; i < delta; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				if err := p.createSession(ctx); err != nil {
+					fmt.Printf(">>> POOL %s PerformScaling createSession failed: %v <<<\n", p.poolName, err)
+				} else {
+					fmt.Printf(">>> POOL %s PerformScaling successfully provisioned a new session <<<\n", p.poolName)
+				}
+			}()
+		}
+		wg.Wait()
+	} else {
+		// Scale down: prune idle sessions gracefully
+		fmt.Printf(">>> POOL %s PerformScaling pruning %d idle sessions <<<\n", p.poolName, -delta)
+		p.pruneSessions(-delta)
+	}
+}
+
+func (p *SessionPoolImpl) createSession(ctx context.Context) error {
+	// Strip client deadline to prevent gRPC Bidi stream from having a user-set timeout
+	dialCtx := noDeadlineContext{Context: ctx}
+
+	// Acquire a token from the concurrency governor budget before dialing!
+	if err := p.budget.Acquire(dialCtx); err != nil {
+		return fmt.Errorf("failed to acquire session creation budget: %w", err)
+	}
+
+	success := false
+	defer func() {
+		p.budget.Release(success) // Release budget registering success/failure penalty token!
+	}()
+
+	// Inject the pre-computed target metadata headers context-safely E2E!
+	dialCtxOut := metadata.NewOutgoingContext(dialCtx, p.metadata)
+	stream, err := p.streamFactory(dialCtxOut)
+	if err != nil {
+		return err
+	}
+
+	// Determine session name and check limits briefly under lock
+	p.mu.Lock()
+	if p.closed {
+		p.mu.Unlock()
+		return fmt.Errorf("session pool is closed")
+	}
+	if len(p.sessions) >= p.maxSessions {
+		p.mu.Unlock()
+		return fmt.Errorf("session pool limit reached")
+	}
+	id := atomic.AddUint64(&p.nextSessionID, 1)
+	role := "session"
+	if strings.HasSuffix(p.poolName, ":read") {
+		role = "read"
+	} else if strings.HasSuffix(p.poolName, ":write") {
+		role = "write"
+	}
+	sessionName := fmt.Sprintf("session-%s-%d", role, id)
+	p.mu.Unlock()
+
+	// Create and start new session wrapper passing pool pointer as the lifecycle listener!
+	s := NewSession(sessionName, stream, p, p.sessionType)
+
+	p.mu.Lock()
+	p.startingSessions[s] = true
+	p.mu.Unlock()
+
+	if err := s.Start(dialCtx, p.openSessionRequest, nil); err != nil {
+		p.mu.Lock()
+		delete(p.startingSessions, s)
+		p.mu.Unlock()
+		fmt.Printf(">>> POOL %p createSession Start failed for %s: %v <<<\n", p, sessionName, err)
+		return fmt.Errorf("failed to start session: %w", err)
+	}
+
+	success = true
+	return nil
+}
+
+func (p *SessionPoolImpl) pruneSessions(count int) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.closed {
+		return
+	}
+
+	pruned := 0
+	var active []*SessionHandle
+	for _, sh := range p.sessions {
+		if pruned < count && atomic.LoadInt64(&sh.outstanding) == 0 {
+			// Prune this session by triggering full graceful close asynchronously
+			if sh.session != nil {
+				go sh.session.Close(&spb.CloseSessionRequest{
+					Reason:      spb.CloseSessionRequest_CLOSE_SESSION_REASON_DOWNSIZE,
+					Description: "prune session downsize",
+				})
+			}
+			pruned++
+		} else {
+			active = append(active, sh)
+		}
+	}
+
+	p.sessions = active
+	p.picker = NewRandomPicker(p.sessions)
+}
+
+type noDeadlineContext struct {
+	context.Context
+}
+
+func (noDeadlineContext) Deadline() (deadline time.Time, ok bool) {
+	return time.Time{}, false
+}
+
+func (noDeadlineContext) Done() <-chan struct{} {
+	return nil
+}
+
+func (noDeadlineContext) Err() error {
+	return nil
+}
+
+// ExecuteVRpc checks out a session, executes a virtual RPC request, and manages session outstanding counts.
+func (p *SessionPoolImpl) ExecuteVRpc(ctx context.Context, desc VRpcDescriptor, req interface{}) (resp interface{}, clInfo *spb.ClusterInformation, err error) {
+	sh, err := p.CheckoutSession(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	start := time.Now()
+	defer func() {
+		duration := time.Since(start)
+		sh.DecOutstanding(duration)
+	}()
+
+	return sh.session.ExecuteVRpc(ctx, desc, req)
+}

--- a/bigtable/internal/transport/session_synctest_test.go
+++ b/bigtable/internal/transport/session_synctest_test.go
@@ -1,0 +1,532 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build synctest
+
+package internal
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	spb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/durationpb"
+)
+
+func TestSession_MissedHeartbeat(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		stream := newMockSessionStream()
+		defer close(stream.recvChan)
+		listener := &mockSessionListener{}
+		session := NewSession("test-session", stream, listener, SessionTypeTable)
+
+		// Pre-activate the session
+		session.state = StateActive
+		close(session.handshakeDone)
+
+		// Register an active VRPC
+		resChan := make(chan vrpcResult, 1)
+		session.mu.Lock()
+		session.activeRPCs[42] = &VRPCImpl{
+			id:         42,
+			method:     "TestMethod",
+			resultChan: resChan,
+		}
+		// Configure watchdog to trigger immediately: set interval small, and next deadline to past
+		session.heartbeatInterval = 10 * time.Millisecond
+		session.nextHeartbeatDeadline = time.Now().Add(-1 * time.Second)
+		session.mu.Unlock()
+
+		// Start the heartbeat loop
+		go session.heartBeatLoop(ctx)
+
+		// Wait for the active RPC to be aborted due to missed heartbeat
+		var res vrpcResult
+		select {
+		case res = <-resChan:
+		case <-time.After(2 * time.Second):
+			t.Fatal("Timed out waiting for vRPC to be aborted by missed heartbeat")
+		}
+
+		if res.err == nil {
+			t.Fatal("Expected vRPC to fail, got success")
+		}
+
+		st, ok := status.FromError(res.err)
+		if !ok || st.Code() != codes.Unavailable {
+			t.Errorf("Expected Unavailable status error, got: %v", res.err)
+		}
+
+		session.mu.Lock()
+		state := session.state
+		session.mu.Unlock()
+
+		if state != StateClosed {
+			t.Errorf("Expected session state to transition to StateClosed, got %v", state)
+		}
+
+		listener.mu.Lock()
+		if !listener.closed {
+			t.Error("Expected OnClose to be called on listener")
+		}
+		listener.mu.Unlock()
+	})
+}
+
+type testMockPicker struct {
+	sh1 *SessionHandle
+	sh2 *SessionHandle
+	cnt int
+}
+
+func (p *testMockPicker) PickSession() *SessionHandle {
+	if p.cnt == 0 {
+		p.cnt++
+		return p.sh1
+	}
+	return p.sh2
+}
+
+func TestSessionPool_RetryingVRpc_ChannelFailover(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		// 1. Setup mock streams and sessions
+		stream1 := newMockSessionStream()
+		defer close(stream1.recvChan)
+		session1 := NewSession("test-session-1", stream1, nil, SessionTypeTable)
+		session1.state = StateActive
+		close(session1.handshakeDone)
+		go session1.readLoop(ctx)
+
+		stream2 := newMockSessionStream()
+		defer close(stream2.recvChan)
+		session2 := NewSession("test-session-2", stream2, nil, SessionTypeTable)
+		session2.state = StateActive
+		close(session2.handshakeDone)
+		go session2.readLoop(ctx)
+
+		sh1 := NewSessionHandle(session1)
+		sh2 := NewSessionHandle(session2)
+
+		// 2. Construct a SessionPoolImpl pre-populated with both sessions
+		pool := &SessionPoolImpl{
+			poolName: "test-pool",
+			sessions: []*SessionHandle{sh1, sh2},
+		}
+		pool.picker = &testMockPicker{sh1: sh1, sh2: sh2}
+
+		// 3. Define the baseHandler that calls pool.ExecuteVRpc
+		desc := &mockVRpcDescriptor{method: "TestMethod"}
+		baseHandler := func(attemptCtx context.Context, request interface{}) (interface{}, error) {
+			resp, _, err := pool.ExecuteVRpc(attemptCtx, desc, request)
+			return resp, err
+		}
+
+		// 4. Wrap baseHandler with RetryingVRpc interceptor
+		retryInterceptor := RetryingVRpc(RetryingOptions{
+			MaxAttempts:    3,
+			InitialBackoff: 1 * time.Millisecond,
+		})
+
+		// 5. Execute the vRPC in a separate goroutine so we can control/fail the first session
+		var respVal interface{}
+		var errVal error
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			respVal, errVal = retryInterceptor(ctx, "request_payload", baseHandler)
+		}()
+
+		// Wait a brief moment to ensure session1 is selected and request is sent
+		time.Sleep(50 * time.Millisecond)
+
+		stream1.mu.Lock()
+		if len(stream1.sent) == 0 {
+			stream1.mu.Unlock()
+			t.Fatal("Expected request to be sent on stream1")
+		}
+		sentReq1 := stream1.sent[0]
+		stream1.mu.Unlock()
+
+		vrpcReq1 := sentReq1.GetVirtualRpc()
+		if vrpcReq1 == nil {
+			t.Fatal("Expected SessionRequest to contain VirtualRpc payload")
+		}
+
+		// Simulate missed heartbeat / ForceClose on session1
+		session1.ForceClose(&spb.CloseSessionRequest{
+			Reason:      spb.CloseSessionRequest_CLOSE_SESSION_REASON_MISSED_HEARTBEAT,
+			Description: "session client terminated due to missed server heartbeats keepalive",
+		})
+
+		// Wait for retry and check that the request is sent to session2 / stream2
+		time.Sleep(50 * time.Millisecond)
+
+		stream2.mu.Lock()
+		if len(stream2.sent) == 0 {
+			stream2.mu.Unlock()
+			t.Fatal("Expected request to be sent on stream2 after session1 failover")
+		}
+		sentReq2 := stream2.sent[0]
+		stream2.mu.Unlock()
+
+		vrpcReq2 := sentReq2.GetVirtualRpc()
+		if vrpcReq2 == nil {
+			t.Fatal("Expected SessionRequest on stream2 to contain VirtualRpc payload")
+		}
+
+		// Inject successful mock response on stream2 matching its rpcID
+		stream2.recvChan <- &spb.SessionResponse{
+			Payload: &spb.SessionResponse_VirtualRpc{
+				VirtualRpc: &spb.VirtualRpcResponse{
+					RpcId:   vrpcReq2.RpcId,
+					Payload: []byte("response_payload_from_session2"),
+				},
+			},
+		}
+
+		wg.Wait()
+
+		if errVal != nil {
+			t.Fatalf("Expected successful vRPC execution after failover, got error: %v", errVal)
+		}
+
+		if respVal.(string) != "response_payload_from_session2" {
+			t.Errorf("Expected response payload %q, got %q", "response_payload_from_session2", respVal.(string))
+		}
+	})
+}
+
+type testSuccessivePicker struct {
+	shs []*SessionHandle
+	cnt int
+}
+
+func (p *testSuccessivePicker) PickSession() *SessionHandle {
+	if p.cnt >= len(p.shs) {
+		return nil
+	}
+	res := p.shs[p.cnt]
+	p.cnt++
+	return res
+}
+
+func TestSessionPool_RetryingVRpc_SuccessiveFailover(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		// 1. Setup 3 mock streams and sessions
+		stream1 := newMockSessionStream()
+		defer close(stream1.recvChan)
+		session1 := NewSession("test-session-1", stream1, nil, SessionTypeTable)
+		session1.state = StateActive
+		close(session1.handshakeDone)
+		go session1.readLoop(ctx)
+
+		stream2 := newMockSessionStream()
+		defer close(stream2.recvChan)
+		session2 := NewSession("test-session-2", stream2, nil, SessionTypeTable)
+		session2.state = StateActive
+		close(session2.handshakeDone)
+		go session2.readLoop(ctx)
+
+		stream3 := newMockSessionStream()
+		defer close(stream3.recvChan)
+		session3 := NewSession("test-session-3", stream3, nil, SessionTypeTable)
+		session3.state = StateActive
+		close(session3.handshakeDone)
+		go session3.readLoop(ctx)
+
+		sh1 := NewSessionHandle(session1)
+		sh2 := NewSessionHandle(session2)
+		sh3 := NewSessionHandle(session3)
+
+		// 2. Construct pool
+		pool := &SessionPoolImpl{
+			poolName: "test-pool",
+			sessions: []*SessionHandle{sh1, sh2, sh3},
+		}
+		pool.picker = &testSuccessivePicker{shs: []*SessionHandle{sh1, sh2, sh3}}
+
+		desc := &mockVRpcDescriptor{method: "TestMethod"}
+		baseHandler := func(attemptCtx context.Context, request interface{}) (interface{}, error) {
+			resp, _, err := pool.ExecuteVRpc(attemptCtx, desc, request)
+			return resp, err
+		}
+
+		retryInterceptor := RetryingVRpc(RetryingOptions{
+			MaxAttempts:    4,
+			InitialBackoff: 1 * time.Millisecond,
+		})
+
+		var respVal interface{}
+		var errVal error
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			respVal, errVal = retryInterceptor(ctx, "request_payload", baseHandler)
+		}()
+
+		// Fail session1
+		time.Sleep(50 * time.Millisecond)
+		session1.ForceClose(&spb.CloseSessionRequest{
+			Reason:      spb.CloseSessionRequest_CLOSE_SESSION_REASON_MISSED_HEARTBEAT,
+			Description: "session client terminated due to missed server heartbeats keepalive",
+		})
+
+		// Fail session2
+		time.Sleep(50 * time.Millisecond)
+		session2.ForceClose(&spb.CloseSessionRequest{
+			Reason:      spb.CloseSessionRequest_CLOSE_SESSION_REASON_MISSED_HEARTBEAT,
+			Description: "session client terminated due to missed server heartbeats keepalive",
+		})
+
+		// Succeed session3
+		time.Sleep(50 * time.Millisecond)
+		stream3.mu.Lock()
+		if len(stream3.sent) == 0 {
+			stream3.mu.Unlock()
+			t.Fatal("Expected request to be sent on stream3 after multiple failovers")
+		}
+		sentReq3 := stream3.sent[0]
+		stream3.mu.Unlock()
+
+		vrpcReq3 := sentReq3.GetVirtualRpc()
+		if vrpcReq3 == nil {
+			t.Fatal("Expected SessionRequest on stream3 to contain VirtualRpc payload")
+		}
+
+		stream3.recvChan <- &spb.SessionResponse{
+			Payload: &spb.SessionResponse_VirtualRpc{
+				VirtualRpc: &spb.VirtualRpcResponse{
+					RpcId:   vrpcReq3.RpcId,
+					Payload: []byte("success_on_session3"),
+				},
+			},
+		}
+
+		wg.Wait()
+
+		if errVal != nil {
+			t.Fatalf("Expected successful execution on third attempt, got error: %v", errVal)
+		}
+		if respVal.(string) != "success_on_session3" {
+			t.Errorf("Expected 'success_on_session3', got %q", respVal.(string))
+		}
+	})
+}
+
+func TestSessionPool_RetryingVRpc_MaxAttemptsExceeded(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		stream1 := newMockSessionStream()
+		defer close(stream1.recvChan)
+		session1 := NewSession("test-session-1", stream1, nil, SessionTypeTable)
+		session1.state = StateActive
+		close(session1.handshakeDone)
+		go session1.readLoop(ctx)
+
+		stream2 := newMockSessionStream()
+		defer close(stream2.recvChan)
+		session2 := NewSession("test-session-2", stream2, nil, SessionTypeTable)
+		session2.state = StateActive
+		close(session2.handshakeDone)
+		go session2.readLoop(ctx)
+
+		sh1 := NewSessionHandle(session1)
+		sh2 := NewSessionHandle(session2)
+
+		pool := &SessionPoolImpl{
+			poolName: "test-pool",
+			sessions: []*SessionHandle{sh1, sh2},
+		}
+		pool.picker = &testSuccessivePicker{shs: []*SessionHandle{sh1, sh2}}
+
+		desc := &mockVRpcDescriptor{method: "TestMethod"}
+		baseHandler := func(attemptCtx context.Context, request interface{}) (interface{}, error) {
+			resp, _, err := pool.ExecuteVRpc(attemptCtx, desc, request)
+			return resp, err
+		}
+
+		// MaxAttempts = 2
+		retryInterceptor := RetryingVRpc(RetryingOptions{
+			MaxAttempts:    2,
+			InitialBackoff: 1 * time.Millisecond,
+		})
+
+		var respVal interface{}
+		var errVal error
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			respVal, errVal = retryInterceptor(ctx, "request_payload", baseHandler)
+		}()
+
+		// Fail session1
+		time.Sleep(50 * time.Millisecond)
+		session1.ForceClose(&spb.CloseSessionRequest{
+			Reason:      spb.CloseSessionRequest_CLOSE_SESSION_REASON_MISSED_HEARTBEAT,
+			Description: "session client terminated due to missed server heartbeats keepalive",
+		})
+
+		// Fail session2
+		time.Sleep(50 * time.Millisecond)
+		session2.ForceClose(&spb.CloseSessionRequest{
+			Reason:      spb.CloseSessionRequest_CLOSE_SESSION_REASON_MISSED_HEARTBEAT,
+			Description: "session client terminated due to missed server heartbeats keepalive",
+		})
+
+		wg.Wait()
+
+		if errVal == nil {
+			t.Fatal("Expected error due to max attempts exceeded, got success")
+		}
+		st, ok := status.FromError(errVal)
+		if !ok || st.Code() != codes.Unavailable {
+			t.Errorf("Expected Unavailable status, got %v", errVal)
+		}
+		_ = respVal
+	})
+}
+
+func TestSessionPool_RetryingVRpc_ContextCancelled(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+
+		stream1 := newMockSessionStream()
+		defer close(stream1.recvChan)
+		session1 := NewSession("test-session-1", stream1, nil, SessionTypeTable)
+		session1.state = StateActive
+		close(session1.handshakeDone)
+		go session1.readLoop(ctx)
+
+		stream2 := newMockSessionStream()
+		defer close(stream2.recvChan)
+		session2 := NewSession("test-session-2", stream2, nil, SessionTypeTable)
+		session2.state = StateActive
+		close(session2.handshakeDone)
+		go session2.readLoop(ctx)
+
+		sh1 := NewSessionHandle(session1)
+		sh2 := NewSessionHandle(session2)
+
+		pool := &SessionPoolImpl{
+			poolName: "test-pool",
+			sessions: []*SessionHandle{sh1, sh2},
+		}
+		pool.picker = &testSuccessivePicker{shs: []*SessionHandle{sh1, sh2}}
+
+		desc := &mockVRpcDescriptor{method: "TestMethod"}
+		baseHandler := func(attemptCtx context.Context, request interface{}) (interface{}, error) {
+			resp, _, err := pool.ExecuteVRpc(attemptCtx, desc, request)
+			return resp, err
+		}
+
+		retryInterceptor := RetryingVRpc(RetryingOptions{
+			MaxAttempts:    3,
+			InitialBackoff: 100 * time.Millisecond,
+		})
+
+		var respVal interface{}
+		var errVal error
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			respVal, errVal = retryInterceptor(ctx, "request_payload", baseHandler)
+		}()
+
+		// Fail session1
+		time.Sleep(50 * time.Millisecond)
+		session1.ForceClose(&spb.CloseSessionRequest{
+			Reason:      spb.CloseSessionRequest_CLOSE_SESSION_REASON_MISSED_HEARTBEAT,
+			Description: "session client terminated due to missed server heartbeats keepalive",
+		})
+
+		// Cancel the parent context while it is backoff waiting
+		cancel()
+
+		wg.Wait()
+
+		if errVal == nil {
+			t.Fatal("Expected error due to context cancellation, got success")
+		}
+		if errVal != context.Canceled {
+			t.Errorf("Expected context.Canceled error, got %v", errVal)
+		}
+		_ = respVal
+	})
+}
+
+func TestSession_SessionParametersUpdatesHeartbeatInterval(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		stream := newMockSessionStream()
+		defer close(stream.recvChan)
+		session := NewSession("test-session", stream, nil, SessionTypeTable)
+
+		// Pre-activate the session
+		session.state = StateActive
+		close(session.handshakeDone)
+		go session.readLoop(ctx)
+
+		// Verify default heartbeat interval
+		session.mu.Lock()
+		defaultInterval := session.heartbeatInterval
+		session.mu.Unlock()
+		if defaultInterval != 10 * time.Second {
+			t.Errorf("Expected default heartbeatInterval to be 10s, got %v", defaultInterval)
+		}
+
+		// Inject SessionParametersResponse containing KeepAlive = 5s
+		stream.recvChan <- &spb.SessionResponse{
+			Payload: &spb.SessionResponse_SessionParameters{
+				SessionParameters: &spb.SessionParametersResponse{
+					KeepAlive: durationpb.New(5 * time.Second),
+				},
+			},
+		}
+
+		// Wait for readLoop to process response
+		time.Sleep(50 * time.Millisecond)
+
+		session.mu.Lock()
+		updatedInterval := session.heartbeatInterval
+		session.mu.Unlock()
+
+		if updatedInterval != 5 * time.Second {
+			t.Errorf("Expected updated heartbeatInterval to be 5s, got %v", updatedInterval)
+		}
+	})
+}
+
+

--- a/bigtable/internal/transport/session_test.go
+++ b/bigtable/internal/transport/session_test.go
@@ -1,0 +1,350 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	spb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+type mockSessionStream struct {
+	mu        sync.Mutex
+	sent      []*spb.SessionRequest
+	recvChan  chan *spb.SessionResponse
+	recvErr   error
+	headerMD  metadata.MD
+	headerErr error
+}
+
+func newMockSessionStream() *mockSessionStream {
+	return &mockSessionStream{
+		recvChan: make(chan *spb.SessionResponse, 100),
+		headerMD: metadata.New(nil),
+	}
+}
+
+func (m *mockSessionStream) Send(req *spb.SessionRequest) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.sent = append(m.sent, req)
+	return nil
+}
+
+func (m *mockSessionStream) Recv() (*spb.SessionResponse, error) {
+	if m.recvErr != nil {
+		return nil, m.recvErr
+	}
+	select {
+	case resp, ok := <-m.recvChan:
+		if !ok {
+			return nil, errors.New("stream closed")
+		}
+		return resp, nil
+	}
+}
+
+func (m *mockSessionStream) Header() (metadata.MD, error) {
+	return m.headerMD, m.headerErr
+}
+
+type mockSessionListener struct {
+	mu       sync.Mutex
+	started  bool
+	active   bool
+	closed   bool
+	closeErr error
+}
+
+func (m *mockSessionListener) OnStart(ctx context.Context) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.started = true
+}
+
+func (m *mockSessionListener) OnActive(s *Session) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.active = true
+}
+
+func (m *mockSessionListener) OnClose(s *Session, err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.closed = true
+	m.closeErr = err
+}
+
+type mockVRpcDescriptor struct {
+	method string
+}
+
+func (d *mockVRpcDescriptor) Method() string { return d.method }
+func (d *mockVRpcDescriptor) Encode(req interface{}) ([]byte, error) {
+	return []byte(req.(string)), nil
+}
+func (d *mockVRpcDescriptor) Decode(buf []byte) (interface{}, error) {
+	return string(buf), nil
+}
+
+func TestSession_Lifecycle(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	stream := newMockSessionStream()
+	listener := &mockSessionListener{}
+	session := NewSession("test-session", stream, listener, SessionTypeTable)
+
+	if session.State() != StateNew {
+		t.Errorf("Expected state to be StateNew, got %v", session.State())
+	}
+
+	// Start the session
+	req := &spb.OpenSessionRequest{}
+	err := session.Start(ctx, req, nil)
+	if err != nil {
+		t.Fatalf("Failed to start session: %v", err)
+	}
+
+	// Check initial state transition and listener
+	if session.State() != StateStarting {
+		t.Errorf("Expected state to be StateStarting, got %v", session.State())
+	}
+
+	listener.mu.Lock()
+	if !listener.started {
+		t.Error("Expected OnStart to be called on listener")
+	}
+	listener.mu.Unlock()
+
+	// Complete handshake by writing OpenSessionResponse
+	stream.recvChan <- &spb.SessionResponse{
+		Payload: &spb.SessionResponse_OpenSession{
+			OpenSession: &spb.OpenSessionResponse{},
+		},
+	}
+
+	// Wait for handshake completion
+	select {
+	case <-session.handshakeDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Timed out waiting for handshake completion")
+	}
+
+	if session.State() != StateActive {
+		t.Errorf("Expected state to be StateActive, got %v", session.State())
+	}
+
+	// Wait briefly for the asynchronous OnActive listener hook to run
+	time.Sleep(20 * time.Millisecond)
+
+	listener.mu.Lock()
+	if !listener.active {
+		t.Error("Expected OnActive to be called on listener")
+	}
+	listener.mu.Unlock()
+
+	// Force close session
+	session.ForceClose(&spb.CloseSessionRequest{Description: "test close"})
+
+	if session.State() != StateClosed {
+		t.Errorf("Expected state to be StateClosed, got %v", session.State())
+	}
+
+	listener.mu.Lock()
+	if !listener.closed {
+		t.Error("Expected OnClose to be called on listener")
+	}
+	listener.mu.Unlock()
+}
+
+func TestSession_ExecuteVRpc_Success(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	stream := newMockSessionStream()
+	session := NewSession("test-session", stream, nil, SessionTypeTable)
+
+	// Pre-activate the session for direct testing of ExecuteVRpc
+	session.state = StateActive
+	close(session.handshakeDone)
+
+	// Start background readLoop
+	go session.readLoop(ctx)
+
+	// Start executing vRPC in a separate goroutine so we can inject the response
+	var respVal interface{}
+	var errVal error
+	desc := &mockVRpcDescriptor{method: "TestMethod"}
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		respVal, _, errVal = session.ExecuteVRpc(ctx, desc, "request_payload")
+	}()
+
+	// Wait a brief moment to ensure request is sent to mockStream
+	time.Sleep(50 * time.Millisecond)
+
+	stream.mu.Lock()
+	if len(stream.sent) == 0 {
+		stream.mu.Unlock()
+		t.Fatal("Expected request to be sent on stream")
+	}
+	sentReq := stream.sent[0]
+	stream.mu.Unlock()
+
+	vrpcReq := sentReq.GetVirtualRpc()
+	if vrpcReq == nil {
+		t.Fatal("Expected SessionRequest to contain VirtualRpc payload")
+	}
+
+	if string(vrpcReq.Payload) != "request_payload" {
+		t.Errorf("Expected payload %q, got %q", "request_payload", string(vrpcReq.Payload))
+	}
+
+	// Inject successful mock response matching the rpcID
+	stream.recvChan <- &spb.SessionResponse{
+		Payload: &spb.SessionResponse_VirtualRpc{
+			VirtualRpc: &spb.VirtualRpcResponse{
+				RpcId:   vrpcReq.RpcId,
+				Payload: []byte("response_payload"),
+			},
+		},
+	}
+
+	wg.Wait()
+
+	if errVal != nil {
+		t.Fatalf("Expected successful vRPC execution, got error: %v", errVal)
+	}
+
+	if respVal.(string) != "response_payload" {
+		t.Errorf("Expected response payload %q, got %q", "response_payload", respVal.(string))
+	}
+}
+
+func TestSession_ExecuteVRpc_ClosedSession(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	stream := newMockSessionStream()
+	session := NewSession("test-session", stream, nil, SessionTypeTable)
+
+	// Ensure state is closed
+	session.state = StateClosed
+
+	desc := &mockVRpcDescriptor{method: "TestMethod"}
+	_, _, err := session.ExecuteVRpc(ctx, desc, "request")
+	if err == nil {
+		t.Fatal("Expected error executing vRPC on closed session, got success")
+	}
+
+	st, ok := status.FromError(err)
+	if !ok || st.Code() != codes.Unavailable {
+		t.Errorf("Expected Unavailable status error, got %v", err)
+	}
+}
+
+func TestSession_GoAway(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	stream := newMockSessionStream()
+	session := NewSession("test-session", stream, nil, SessionTypeTable)
+
+	// Pre-activate the session
+	session.state = StateActive
+	close(session.handshakeDone)
+
+	// Start background readLoop
+	go session.readLoop(ctx)
+
+	resChan10 := make(chan vrpcResult, 1)
+	resChan11 := make(chan vrpcResult, 1)
+
+	session.mu.Lock()
+	session.activeRPCs[10] = &VRPCImpl{
+		id:         10,
+		method:     "TestMethod",
+		resultChan: resChan10,
+	}
+	session.activeRPCs[11] = &VRPCImpl{
+		id:         11,
+		method:     "TestMethod",
+		resultChan: resChan11,
+	}
+	session.mu.Unlock()
+
+	// Inject GoAway with last_rpc_id_admitted equal to 10.
+	// This means 10 was admitted (should not be aborted),
+	// and 11 was NOT admitted (should be aborted immediately).
+	stream.recvChan <- &spb.SessionResponse{
+		Payload: &spb.SessionResponse_GoAway{
+			GoAway: &spb.GoAwayResponse{
+				LastRpcIdAdmitted: 10,
+			},
+		},
+	}
+
+	// Provide 10 response payload on the stream to let it succeed
+	stream.recvChan <- &spb.SessionResponse{
+		Payload: &spb.SessionResponse_VirtualRpc{
+			VirtualRpc: &spb.VirtualRpcResponse{
+				RpcId:   10,
+				Payload: []byte("resp10"),
+			},
+		},
+	}
+
+	// Verify 10 (admitted) succeeded
+	var res10 vrpcResult
+	select {
+	case res10 = <-resChan10:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Timed out waiting for vRPC 10 response")
+	}
+
+	if res10.err != nil {
+		t.Errorf("Expected vRPC 10 (admitted) to succeed, got error: %v", res10.err)
+	}
+	if string(res10.resp.Payload) != "resp10" {
+		t.Errorf("Expected vRPC 10 response payload 'resp10', got: %s", string(res10.resp.Payload))
+	}
+
+	// Verify 11 (unadmitted) failed with codes.Unavailable
+	var res11 vrpcResult
+	select {
+	case res11 = <-resChan11:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Timed out waiting for vRPC 11 response")
+	}
+
+	if res11.err == nil {
+		t.Fatal("Expected vRPC 11 (unadmitted) to fail, but got success")
+	}
+
+	st, ok := status.FromError(res11.err)
+	if !ok || st.Code() != codes.Unavailable {
+		t.Errorf("Expected Unavailable status error for unadmitted vRPC, got: %v", res11.err)
+	}
+}

--- a/bigtable/internal/transport/session_test.go
+++ b/bigtable/internal/transport/session_test.go
@@ -348,3 +348,5 @@ func TestSession_GoAway(t *testing.T) {
 		t.Errorf("Expected Unavailable status error for unadmitted vRPC, got: %v", res11.err)
 	}
 }
+
+

--- a/bigtable/internal/transport/session_tracer.go
+++ b/bigtable/internal/transport/session_tracer.go
@@ -1,0 +1,199 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	spb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"google.golang.org/grpc/status"
+)
+
+var (
+	// Metrics registered under bigtable.googleapis.com/internal/client/
+	// The formatter in otel_metrics.go will append this prefix and replace . with /
+	// So "session.durations" -> "bigtable.googleapis.com/internal/client/session/durations"
+
+	sessionDurations     metric.Float64Histogram
+	sessionOpenLatencies metric.Float64Histogram
+	sessionUptime        metric.Float64Histogram
+)
+
+// InitializeMetrics registers the session metrics.
+func InitializeMetrics(meterProvider metric.MeterProvider) error {
+	if meterProvider == nil {
+		return nil // No-op if not provider available
+	}
+	meter := meterProvider.Meter("cloud.google.com/go/bigtable/internal/client")
+
+	var err error
+	sessionDurations, err = meter.Float64Histogram("session.durations",
+		metric.WithDescription("Duration of operations within a session"),
+		metric.WithUnit("ms"))
+	if err != nil {
+		return fmt.Errorf("failed to create session.durations histogram: %w", err)
+	}
+
+	sessionOpenLatencies, err = meter.Float64Histogram("session.open_latencies",
+		metric.WithDescription("Latency to open a session"),
+		metric.WithUnit("ms"))
+	if err != nil {
+		return fmt.Errorf("failed to create session.open_latencies histogram: %w", err)
+	}
+
+	sessionUptime, err = meter.Float64Histogram("session.uptime",
+		metric.WithDescription("Total lifetime of a session"),
+		metric.WithUnit("ms"))
+	if err != nil {
+		return fmt.Errorf("failed to create session.uptime histogram: %w", err)
+	}
+
+	return nil
+}
+
+// sessionTracer tracks and records metrics for a specific Session lifecycle and operations.
+type sessionTracer struct {
+	mu          sync.Mutex
+	startTime   time.Time
+	openedAt    time.Time
+	peerInfo    *spb.PeerInfo
+	sessionName string
+	sessionType SessionType
+}
+
+// newSessionTracer initializes a new sessionTracer starting the open timer.
+func newSessionTracer(sessionType SessionType) *sessionTracer {
+	return &sessionTracer{
+		startTime:   time.Now(),
+		sessionType: sessionType,
+	}
+}
+
+func (t *sessionTracer) setPeerInfo(peerInfo *spb.PeerInfo, sessionName string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.peerInfo = peerInfo
+	t.sessionName = sessionName
+}
+
+// recordOpen records the latency to open the session and starts the uptime timer.
+func (t *sessionTracer) recordOpen(ctx context.Context, err error) {
+	t.mu.Lock()
+	t.openedAt = time.Now()
+	pi := t.peerInfo
+	name := t.sessionName
+	t.mu.Unlock()
+
+	if sessionOpenLatencies == nil {
+		return
+	}
+
+	var transportType string
+	var afeLocation string
+	if pi != nil {
+		transportType = pi.GetTransportType().String()
+		afeLocation = pi.GetApplicationFrontendSubzone()
+	}
+	if transportType == "" {
+		transportType = "unknown"
+	}
+
+	statusStr := "OK"
+	if err != nil {
+		statusStr = status.Code(err).String()
+	}
+
+	sessionOpenLatencies.Record(ctx, time.Since(t.startTime).Seconds()*1000.0, metric.WithAttributes(
+		attribute.String("transport_type", transportType),
+		attribute.String("status", statusStr),
+		attribute.String("session_type", t.sessionType.String()),
+		attribute.String("afe_location", afeLocation),
+		attribute.String("session_name", name),
+	))
+}
+
+// recordClose records the total lifetime/uptime of the session when it closes.
+func (t *sessionTracer) recordClose(ctx context.Context) {
+	t.mu.Lock()
+	openedAt := t.openedAt
+	pi := t.peerInfo
+	name := t.sessionName
+	t.mu.Unlock()
+
+	if openedAt.IsZero() || sessionUptime == nil {
+		return
+	}
+
+	var transportType string
+	var afeLocation string
+	if pi != nil {
+		transportType = pi.GetTransportType().String()
+		afeLocation = pi.GetApplicationFrontendSubzone()
+	}
+	if transportType == "" {
+		transportType = "unknown"
+	}
+
+	sessionUptime.Record(ctx, time.Since(openedAt).Seconds()*1000.0, metric.WithAttributes(
+		attribute.String("transport_type", transportType),
+		attribute.String("session_type", t.sessionType.String()),
+		attribute.Bool("ready", true),
+		attribute.String("afe_location", afeLocation),
+		attribute.String("session_name", name),
+	))
+}
+
+// recordOperation records the execution duration of a virtual RPC within the session.
+func (t *sessionTracer) recordOperation(ctx context.Context, opStartTime time.Time, method string, err error) {
+	if sessionDurations == nil {
+		return
+	}
+
+	t.mu.Lock()
+	pi := t.peerInfo
+	name := t.sessionName
+	t.mu.Unlock()
+
+	var transportType string
+	var afeLocation string
+	if pi != nil {
+		transportType = pi.GetTransportType().String()
+		afeLocation = pi.GetApplicationFrontendSubzone()
+	}
+	if transportType == "" {
+		transportType = "unknown"
+	}
+
+	statusStr := "OK"
+	if err != nil {
+		statusStr = status.Code(err).String()
+	}
+
+	sessionDurations.Record(ctx, time.Since(opStartTime).Seconds()*1000.0, metric.WithAttributes(
+		attribute.String("transport_type", transportType),
+		attribute.String("status", statusStr),
+		attribute.String("vrpcs", method),
+		attribute.String("session_type", t.sessionType.String()),
+		attribute.String("closing_reason", ""),
+		attribute.Bool("ready", true),
+		attribute.String("afe_location", afeLocation),
+		attribute.String("session_name", name),
+	))
+}

--- a/bigtable/internal/transport/session_transport.go
+++ b/bigtable/internal/transport/session_transport.go
@@ -267,6 +267,11 @@ func (s *Session) handleSessionResponse(resp *spb.SessionResponse) {
 		return
 	}
 
+	if hb := resp.GetHeartbeat(); hb != nil {
+		s.resetHeartbeatDeadline()
+		return
+	}
+
 	s.resetHeartbeatDeadline() // Reset deadline on any successfully received server frame!
 }
 
@@ -292,7 +297,7 @@ func (s *Session) heartBeatLoop(ctx context.Context) {
 			}
 
 			// Missed heartbeats read watchdog check!
-			if len(s.activeRPCs) > 0 && time.Now().After(s.nextHeartbeatDeadline) {
+			if time.Now().After(s.nextHeartbeatDeadline) {
 				s.mu.Unlock()
 				s.ForceClose(&spb.CloseSessionRequest{
 					Reason:      spb.CloseSessionRequest_CLOSE_SESSION_REASON_MISSED_HEARTBEAT,

--- a/bigtable/internal/transport/session_transport.go
+++ b/bigtable/internal/transport/session_transport.go
@@ -1,0 +1,355 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"time"
+
+	spb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+)
+
+// Start starts the session by sending the OpenSessionRequest and beginning the read loop.
+func (s *Session) Start(ctx context.Context, req *spb.OpenSessionRequest, md metadata.MD) error {
+	s.mu.Lock()
+	if s.state != StateNew {
+		s.mu.Unlock()
+		return fmt.Errorf("session already started or closed")
+	}
+	s.state = StateStarting
+	s.lastStateChange = time.Now()
+	s.mu.Unlock()
+
+	openReq := &spb.SessionRequest{
+		Payload: &spb.SessionRequest_OpenSession{
+			OpenSession: req,
+		},
+	}
+
+	if err := s.Send(openReq); err != nil {
+		s.ForceClose(&spb.CloseSessionRequest{
+			Reason:      spb.CloseSessionRequest_CLOSE_SESSION_REASON_ERROR,
+			Description: "failed to send open session request",
+		})
+		return fmt.Errorf("failed to send open session request: %w", err)
+	}
+
+	go s.readLoop(ctx)
+	go s.heartBeatLoop(ctx)
+
+	if s.listener != nil {
+		s.listener.OnStart(ctx)
+	}
+
+	return nil
+}
+
+// cancelActiveRPCs extracts active RPCs matching the filter (or all if filter is nil),
+// deletes them from the map, and notifies them of failure.
+func (s *Session) cancelActiveRPCs(err error, filter func(rpcID int64) bool) {
+	s.mu.Lock()
+	var active []*VRPCImpl
+	for id, rpc := range s.activeRPCs {
+		if filter == nil || filter(id) {
+			active = append(active, rpc)
+			delete(s.activeRPCs, id)
+		}
+	}
+	s.mu.Unlock()
+
+	for _, rpc := range active {
+		select {
+		case rpc.resultChan <- vrpcResult{err: err}:
+		default:
+		}
+	}
+}
+
+// ForceClose immediately closes the session, transitioning it to StateClosed.
+func (s *Session) ForceClose(req *spb.CloseSessionRequest) {
+	s.mu.Lock()
+	if s.state == StateClosed {
+		s.mu.Unlock()
+		return
+	}
+	s.state = StateClosed
+	s.lastStateChange = time.Now()
+	s.mu.Unlock()
+
+	s.tracer.recordClose(context.Background())
+
+	desc := "session force closed"
+	if req != nil && req.Description != "" {
+		desc = fmt.Sprintf("session force closed: %s", req.Description)
+	}
+	s.cancelActiveRPCs(status.Errorf(codes.Unavailable, "%s", desc), nil)
+
+	if s.listener != nil {
+		s.listener.OnClose(s, nil)
+	}
+}
+
+// Close initiates a graceful shutdown of the session, draining active RPCs,
+// sending CloseSessionRequest, and transitioning to StateWaitServerClose.
+func (s *Session) Close(req *spb.CloseSessionRequest) error {
+	s.mu.Lock()
+	if s.state == StateClosed || s.state == StateClosing || s.state == StateWaitServerClose {
+		s.mu.Unlock()
+		return nil
+	}
+	s.state = StateClosing
+	s.lastStateChange = time.Now()
+	s.mu.Unlock()
+
+	// Wait for active RPCs to drain safely
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		s.mu.Lock()
+		activeCount := len(s.activeRPCs)
+		s.mu.Unlock()
+
+		if activeCount == 0 {
+			break
+		}
+
+		select {
+		case <-ticker.C:
+		}
+	}
+
+	s.mu.Lock()
+	s.state = StateWaitServerClose
+	s.lastStateChange = time.Now()
+	s.mu.Unlock()
+
+	closeReq := &spb.SessionRequest{
+		Payload: &spb.SessionRequest_CloseSession{
+			CloseSession: req,
+		},
+	}
+
+	if err := s.Send(closeReq); err != nil {
+		s.ForceClose(req)
+		return fmt.Errorf("failed to send close session request: %w", err)
+	}
+
+	return nil
+}
+
+func (s *Session) readLoop(ctx context.Context) {
+	// 1. Parse peer information from stream header metadata asynchronously (non-blocking)!
+	go func() {
+		headerMD, err := s.stream.Header()
+		if err != nil {
+			fmt.Printf(">>> SESSION %s Header() returned error: %v <<<\n", s.logName, err)
+			return
+		}
+		s.peerInfoExtracter(headerMD.Get("bigtable-peer-info"))
+	}()
+
+	// Supervisor goroutine leak shield:
+	// If the context is cancelled, we force close the session to unblock Recv().
+	readLoopDone := make(chan struct{})
+	go func() {
+		select {
+		case <-ctx.Done():
+			s.ForceClose(&spb.CloseSessionRequest{
+				Reason:      spb.CloseSessionRequest_CLOSE_SESSION_REASON_USER,
+				Description: "client context cancelled, closing stream",
+			})
+		case <-readLoopDone:
+		}
+	}()
+	defer close(readLoopDone)
+
+	for {
+		resp, err := s.stream.Recv()
+		if err != nil {
+			s.handleClose(err)
+			return
+		}
+		s.handleSessionResponse(resp)
+	}
+}
+
+func (s *Session) handleClose(err error) {
+	s.mu.Lock()
+	if s.state == StateClosed {
+		s.mu.Unlock()
+		return
+	}
+	isStarting := s.state == StateStarting || s.state == StateNew
+	s.state = StateClosed
+	s.lastStateChange = time.Now()
+	if isStarting {
+		s.handshakeErr = err
+		select {
+		case <-s.handshakeDone:
+		default:
+			close(s.handshakeDone)
+		}
+	}
+	s.mu.Unlock()
+
+	s.tracer.recordClose(context.Background())
+
+	s.cancelActiveRPCs(status.Errorf(codes.Unavailable, "session closed handle close: %v", err), nil)
+
+	if s.listener != nil {
+		s.listener.OnClose(s, err)
+	}
+}
+
+func (s *Session) handleSessionResponse(resp *spb.SessionResponse) {
+	if openResp := resp.GetOpenSession(); openResp != nil {
+		s.mu.Lock()
+		isStarting := s.state == StateStarting
+		if isStarting {
+			s.state = StateActive
+			s.lastStateChange = time.Now()
+			close(s.handshakeDone)
+		}
+		s.mu.Unlock()
+		if isStarting {
+			s.tracer.recordOpen(context.Background(), nil)
+		}
+		if isStarting && s.listener != nil {
+			s.listener.OnActive(s)
+		}
+		return
+	}
+
+	if vrpc := resp.GetVirtualRpc(); vrpc != nil {
+		s.handleVRPCResponse(vrpc)
+		return
+	}
+
+	if errResp := resp.GetError(); errResp != nil {
+		s.handleVRPCErrorResponse(errResp)
+		return
+	}
+
+	if goAway := resp.GetGoAway(); goAway != nil {
+		s.handleGoAway(goAway)
+		return
+	}
+
+	if params := resp.GetSessionParameters(); params != nil {
+		s.mu.Lock()
+		if params.KeepAlive != nil {
+			interval := time.Duration(params.KeepAlive.Seconds)*time.Second + time.Duration(params.KeepAlive.Nanos)*time.Nanosecond
+			if interval > 0 {
+				s.heartbeatInterval = interval
+			}
+		}
+		s.mu.Unlock()
+		s.resetHeartbeatDeadline()
+		return
+	}
+
+	s.resetHeartbeatDeadline() // Reset deadline on any successfully received server frame!
+}
+
+func (s *Session) resetHeartbeatDeadline() {
+	s.mu.Lock()
+	s.nextHeartbeatDeadline = time.Now().Add(3 * s.heartbeatInterval)
+	s.mu.Unlock()
+}
+
+func (s *Session) heartBeatLoop(ctx context.Context) {
+	ticker := time.NewTicker(50 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.mu.Lock()
+			if s.state == StateClosed {
+				s.mu.Unlock()
+				return
+			}
+
+			// Missed heartbeats read watchdog check!
+			if len(s.activeRPCs) > 0 && time.Now().After(s.nextHeartbeatDeadline) {
+				s.mu.Unlock()
+				s.ForceClose(&spb.CloseSessionRequest{
+					Reason:      spb.CloseSessionRequest_CLOSE_SESSION_REASON_MISSED_HEARTBEAT,
+					Description: "session client terminated due to missed server heartbeats keepalive",
+				})
+				return
+			}
+			s.mu.Unlock()
+		}
+	}
+}
+
+// Send sends a SessionRequest thread-safely using sendMu to prevent concurrent stream corruption.
+func (s *Session) Send(req *spb.SessionRequest) error {
+	s.sendMu.Lock()
+	defer s.sendMu.Unlock()
+	return s.stream.Send(req)
+}
+
+func (s *Session) peerInfoExtracter(peerInfoData []string) {
+	if len(peerInfoData) == 0 {
+		return
+	}
+	decoded, err := base64.RawURLEncoding.DecodeString(peerInfoData[0])
+	if err != nil {
+		decoded, err = base64.StdEncoding.DecodeString(peerInfoData[0])
+		if err != nil {
+			decoded, err = base64.RawStdEncoding.DecodeString(peerInfoData[0])
+		}
+	}
+	if err != nil {
+		fmt.Printf(">>> SESSION %s failed to decode base64 PeerInfo: %v <<<\n", s.logName, err)
+		return
+	}
+	var peerInfo spb.PeerInfo
+	if err := proto.Unmarshal(decoded, &peerInfo); err != nil {
+		fmt.Printf(">>> SESSION %s failed to unmarshal PeerInfo proto: %v <<<\n", s.logName, err)
+		return
+	}
+	s.mu.Lock()
+	s.peerInfo = &peerInfo
+	s.mu.Unlock()
+	s.tracer.setPeerInfo(&peerInfo, s.logName)
+	fmt.Printf(">>> SESSION %s parsed PeerInfo: %+v <<<\n", s.logName, &peerInfo)
+}
+
+func (s *Session) handleGoAway(goAway *spb.GoAwayResponse) {
+	s.mu.Lock()
+	s.state = StateClosing
+	s.lastStateChange = time.Now()
+	s.mu.Unlock()
+
+	lastAdmitted := goAway.GetLastRpcIdAdmitted()
+	fmt.Printf(">>> SESSION %s received GOAWAY: last_rpc_id_admitted=%d <<<\n", s.logName, lastAdmitted)
+
+	err := status.Errorf(codes.Unavailable, "vRPC not admitted by server before GOAWAY")
+	s.cancelActiveRPCs(err, func(id int64) bool {
+		return id > lastAdmitted
+	})
+}

--- a/bigtable/internal/transport/session_vrpc.go
+++ b/bigtable/internal/transport/session_vrpc.go
@@ -1,0 +1,150 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"time"
+
+	spb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// ExecuteVRpc executes a virtual RPC sequentially and synchronously, multiplexing over the stream.
+func (s *Session) ExecuteVRpc(ctx context.Context, desc VRpcDescriptor, req interface{}) (resp interface{}, clusterInfo *spb.ClusterInformation, err error) {
+	s.vrpcMu.Lock()
+	defer s.vrpcMu.Unlock()
+
+	startTime := time.Now()
+	defer func() {
+		s.tracer.recordOperation(ctx, startTime, desc.Method(), err)
+	}()
+
+	s.mu.Lock()
+	if s.state != StateActive {
+		s.mu.Unlock()
+		return nil, nil, status.Errorf(codes.Unavailable, "session is not active (state: %v)", s.state)
+	}
+	s.mu.Unlock()
+
+	reqBytes, err := desc.Encode(req)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to encode request: %w", err)
+	}
+
+	rpcID := atomic.AddInt64(&s.nextRPCID, 1)
+
+	resultChan := make(chan vrpcResult, 1)
+	rpcImpl := &VRPCImpl{
+		id:         rpcID,
+		method:     desc.Method(),
+		resultChan: resultChan,
+	}
+
+	s.mu.Lock()
+	s.activeRPCs[rpcID] = rpcImpl
+	s.mu.Unlock()
+
+	defer func() {
+		s.mu.Lock()
+		delete(s.activeRPCs, rpcID)
+		s.mu.Unlock()
+	}()
+
+	vrpcReq := &spb.VirtualRpcRequest{
+		RpcId:   rpcID,
+		Payload: reqBytes,
+	}
+
+	sessionReq := &spb.SessionRequest{
+		Payload: &spb.SessionRequest_VirtualRpc{
+			VirtualRpc: vrpcReq,
+		},
+	}
+
+	s.resetHeartbeatDeadline() // Reset deadline when sending active request!
+
+	if err := s.Send(sessionReq); err != nil {
+		return nil, nil, fmt.Errorf("failed to send vRPC request: %w", err)
+	}
+
+	select {
+	case <-ctx.Done():
+		return nil, nil, ctx.Err()
+	case res := <-resultChan:
+		if res.err != nil {
+			return nil, res.clusterInfo, res.err
+		}
+		if res.resp.RpcId != rpcID {
+			return nil, nil, fmt.Errorf("internal error: response RpcId %d does not match request RpcId %d", res.resp.RpcId, rpcID)
+		}
+		respMsg, err := desc.Decode(res.resp.Payload)
+		if err != nil {
+			return nil, res.clusterInfo, fmt.Errorf("failed to decode response: %w", err)
+		}
+		// if res.clusterInfo != nil {
+		// 	fmt.Printf(">>> ExecuteVRpc response served by Cluster: Id=%s, Zone=%s <<<\n", res.clusterInfo.ClusterId, res.clusterInfo.ZoneId)
+		// }
+		// fmt.Printf(">>> ExecuteVRpc response decoded: Type=%T <<<\n", respMsg)
+		return respMsg, res.clusterInfo, nil
+	}
+}
+
+func (s *Session) handleVRPCResponse(resp *spb.VirtualRpcResponse) {
+	// fmt.Printf(">>> Session handleVRPCResponse: RpcId=%d, PayloadLength=%d <<<\n", resp.RpcId, len(resp.Payload))
+	s.mu.Lock()
+	rpc, ok := s.activeRPCs[resp.RpcId]
+	if ok {
+		s.hasOkRpcs = true
+	}
+	s.mu.Unlock()
+
+	if !ok {
+		return
+	}
+
+	select {
+	case rpc.resultChan <- vrpcResult{resp: resp, clusterInfo: resp.ClusterInfo}:
+	default:
+	}
+}
+
+func (s *Session) handleVRPCErrorResponse(errResp *spb.ErrorResponse) {
+	s.mu.Lock()
+	rpc, ok := s.activeRPCs[errResp.RpcId]
+	if ok {
+		s.hasErrorRpcs = true
+	}
+	s.mu.Unlock()
+
+	if !ok {
+		return
+	}
+
+	var goErr error
+	if errResp.Status != nil {
+		goErr = status.FromProto(errResp.Status).Err()
+	} else {
+		goErr = fmt.Errorf("unknown vRPC error")
+	}
+
+	select {
+	case rpc.resultChan <- vrpcResult{err: goErr, clusterInfo: errResp.ClusterInfo}:
+	default:
+	}
+}

--- a/bigtable/internal/transport/session_vrpc.go
+++ b/bigtable/internal/transport/session_vrpc.go
@@ -27,8 +27,10 @@ import (
 
 // ExecuteVRpc executes a virtual RPC sequentially and synchronously, multiplexing over the stream.
 func (s *Session) ExecuteVRpc(ctx context.Context, desc VRpcDescriptor, req interface{}) (resp interface{}, clusterInfo *spb.ClusterInformation, err error) {
-	s.vrpcMu.Lock()
-	defer s.vrpcMu.Unlock()
+	if err := s.vrpcSem.Acquire(ctx, sessionConcurrencyLimit); err != nil {
+		return nil, nil, err
+	}
+	defer s.vrpcSem.Release(sessionConcurrencyLimit)
 
 	startTime := time.Now()
 	defer func() {

--- a/bigtable/internal/transport/vrpc.go
+++ b/bigtable/internal/transport/vrpc.go
@@ -1,0 +1,60 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"context"
+)
+
+// CallContext represents the execution context of a virtual RPC invocation.
+type CallContext interface {
+	context.Context
+	// Method returns the name of the virtual RPC method.
+	Method() string
+	// Attempt returns the current attempt number (1-indexed).
+	Attempt() int
+}
+
+// Handler represents the core execution function of a virtual RPC downstream invocation.
+type Handler func(ctx CallContext, req interface{}) (interface{}, error)
+
+// Interceptor represents a decorator middleware that intercepts a virtual RPC downstream invocation.
+type Interceptor func(ctx CallContext, req interface{}, handler Handler) (interface{}, error)
+
+// VRpcListener receives notifications of vRPC attempt lifecycles.
+type VRpcListener interface {
+	// OnAttemptStart is called before a new attempt is executed.
+	OnAttemptStart(ctx CallContext)
+	// OnAttemptComplete is called after an attempt completes (with success or error).
+	OnAttemptComplete(ctx CallContext, err error)
+}
+
+type callContext struct {
+	context.Context
+	method  string
+	attempt int
+}
+
+func (c *callContext) Method() string { return c.method }
+func (c *callContext) Attempt() int   { return c.attempt }
+
+// NewCallContext creates a new CallContext with initial attempt set to 1.
+func NewCallContext(ctx context.Context, method string) CallContext {
+	return &callContext{
+		Context: ctx,
+		method:  method,
+		attempt: 1,
+	}
+}

--- a/bigtable/internal/transport/vrpc.go
+++ b/bigtable/internal/transport/vrpc.go
@@ -18,43 +18,58 @@ import (
 	"context"
 )
 
-// CallContext represents the execution context of a virtual RPC invocation.
-type CallContext interface {
-	context.Context
-	// Method returns the name of the virtual RPC method.
-	Method() string
-	// Attempt returns the current attempt number (1-indexed).
-	Attempt() int
-}
+type contextKey struct{}
 
-// Handler represents the core execution function of a virtual RPC downstream invocation.
-type Handler func(ctx CallContext, req interface{}) (interface{}, error)
-
-// Interceptor represents a decorator middleware that intercepts a virtual RPC downstream invocation.
-type Interceptor func(ctx CallContext, req interface{}, handler Handler) (interface{}, error)
-
-// VRpcListener receives notifications of vRPC attempt lifecycles.
-type VRpcListener interface {
-	// OnAttemptStart is called before a new attempt is executed.
-	OnAttemptStart(ctx CallContext)
-	// OnAttemptComplete is called after an attempt completes (with success or error).
-	OnAttemptComplete(ctx CallContext, err error)
-}
-
-type callContext struct {
-	context.Context
+type vrpcMetadata struct {
 	method  string
 	attempt int
 }
 
-func (c *callContext) Method() string { return c.method }
-func (c *callContext) Attempt() int   { return c.attempt }
-
-// NewCallContext creates a new CallContext with initial attempt set to 1.
-func NewCallContext(ctx context.Context, method string) CallContext {
-	return &callContext{
-		Context: ctx,
+// WithVRpcMetadata returns a new context with virtual RPC metadata set.
+func WithVRpcMetadata(ctx context.Context, method string, attempt int) context.Context {
+	return context.WithValue(ctx, contextKey{}, &vrpcMetadata{
 		method:  method,
-		attempt: 1,
+		attempt: attempt,
+	})
+}
+
+// WithAttempt returns a new context with the virtual RPC attempt updated.
+func WithAttempt(ctx context.Context, attempt int) context.Context {
+	if md, ok := ctx.Value(contextKey{}).(*vrpcMetadata); ok {
+		return context.WithValue(ctx, contextKey{}, &vrpcMetadata{
+			method:  md.method,
+			attempt: attempt,
+		})
 	}
+	return ctx
+}
+
+// VRpcMethod extracts the virtual RPC method name from the context.
+func VRpcMethod(ctx context.Context) string {
+	if md, ok := ctx.Value(contextKey{}).(*vrpcMetadata); ok {
+		return md.method
+	}
+	return ""
+}
+
+// VRpcAttempt extracts the virtual RPC attempt number (1-indexed) from the context.
+func VRpcAttempt(ctx context.Context) int {
+	if md, ok := ctx.Value(contextKey{}).(*vrpcMetadata); ok {
+		return md.attempt
+	}
+	return 0
+}
+
+// Handler represents the core execution function of a virtual RPC downstream invocation.
+type Handler func(ctx context.Context, req interface{}) (interface{}, error)
+
+// Interceptor represents a decorator middleware that intercepts a virtual RPC downstream invocation.
+type Interceptor func(ctx context.Context, req interface{}, handler Handler) (interface{}, error)
+
+// VRpcListener receives notifications of vRPC attempt lifecycles.
+type VRpcListener interface {
+	// OnAttemptStart is called before a new attempt is executed.
+	OnAttemptStart(ctx context.Context)
+	// OnAttemptComplete is called after an attempt completes (with success or error).
+	OnAttemptComplete(ctx context.Context, err error)
 }

--- a/bigtable/internal/transport/vrpc_test.go
+++ b/bigtable/internal/transport/vrpc_test.go
@@ -1,0 +1,286 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/durationpb"
+)
+
+type mockListener struct {
+	mu              sync.Mutex
+	starts          []int
+	completes       []int
+	completeErrors  []error
+}
+
+func (m *mockListener) OnAttemptStart(ctx context.Context) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.starts = append(m.starts, VRpcAttempt(ctx))
+}
+
+func (m *mockListener) OnAttemptComplete(ctx context.Context, err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.completes = append(m.completes, VRpcAttempt(ctx))
+	m.completeErrors = append(m.completeErrors, err)
+}
+
+func TestChainedInterceptors_Success(t *testing.T) {
+	var order []string
+
+	int1 := func(ctx context.Context, req interface{}, next Handler) (interface{}, error) {
+		order = append(order, "int1_start")
+		res, err := next(ctx, req)
+		order = append(order, "int1_end")
+		return res, err
+	}
+
+	int2 := func(ctx context.Context, req interface{}, next Handler) (interface{}, error) {
+		order = append(order, "int2_start")
+		res, err := next(ctx, req)
+		order = append(order, "int2_end")
+		return res, err
+	}
+
+	baseHandler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		order = append(order, "base")
+		return "response", nil
+	}
+
+	chained := ChainInterceptors(int1, int2)
+	ctx := WithVRpcMetadata(context.Background(), "TestMethod", 1)
+
+	resp, err := chained(ctx, "request", baseHandler)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	if resp.(string) != "response" {
+		t.Errorf("Expected response to be 'response', got %v", resp)
+	}
+
+	expectedOrder := []string{"int1_start", "int2_start", "base", "int2_end", "int1_end"}
+	if len(order) != len(expectedOrder) {
+		t.Fatalf("Expected order length %d, got %d", len(expectedOrder), len(order))
+	}
+	for i, v := range expectedOrder {
+		if order[i] != v {
+			t.Errorf("At index %d: expected %q, got %q", i, v, order[i])
+		}
+	}
+}
+
+func TestRetryingVRpc_SuccessOnRetry(t *testing.T) {
+	var attempts int
+	baseHandler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		attempts++
+		attemptInCtx := VRpcAttempt(ctx)
+		if attemptInCtx != attempts {
+			t.Errorf("Expected attempt %d in context, got %d", attempts, attemptInCtx)
+		}
+
+		if attempts < 3 {
+			return nil, status.Error(codes.Unavailable, "service temporarily unavailable")
+		}
+		return "success_resp", nil
+	}
+
+	listener := &mockListener{}
+	retryInterceptor := RetryingVRpc(RetryingOptions{
+		MaxAttempts:    5,
+		InitialBackoff: 1 * time.Millisecond,
+		Listener:       listener,
+	})
+
+	ctx := WithVRpcMetadata(context.Background(), "TestMethod", 1)
+	resp, err := retryInterceptor(ctx, "request", baseHandler)
+	if err != nil {
+		t.Fatalf("Expected success, got error: %v", err)
+	}
+
+	if resp.(string) != "success_resp" {
+		t.Errorf("Expected response 'success_resp', got %q", resp)
+	}
+
+	if attempts != 3 {
+		t.Errorf("Expected 3 attempts, got %d", attempts)
+	}
+
+	listener.mu.Lock()
+	defer listener.mu.Unlock()
+
+	expectedStarts := []int{1, 2, 3}
+	if len(listener.starts) != len(expectedStarts) {
+		t.Errorf("Expected %d starts, got %d", len(expectedStarts), len(listener.starts))
+	}
+	for i, v := range expectedStarts {
+		if listener.starts[i] != v {
+			t.Errorf("Expected start attempt at index %d to be %d, got %d", i, v, listener.starts[i])
+		}
+	}
+
+	expectedCompletes := []int{1, 2, 3}
+	if len(listener.completes) != len(expectedCompletes) {
+		t.Errorf("Expected %d completes, got %d", len(expectedCompletes), len(listener.completes))
+	}
+}
+
+func TestRetryingVRpc_NonRetryableError(t *testing.T) {
+	var attempts int
+	baseHandler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		attempts++
+		return nil, status.Error(codes.InvalidArgument, "invalid parameter value")
+	}
+
+	retryInterceptor := RetryingVRpc(RetryingOptions{
+		MaxAttempts:    5,
+		InitialBackoff: 1 * time.Millisecond,
+	})
+
+	ctx := WithVRpcMetadata(context.Background(), "TestMethod", 1)
+	_, err := retryInterceptor(ctx, "request", baseHandler)
+	if err == nil {
+		t.Fatal("Expected error, got nil")
+	}
+
+	st, ok := status.FromError(err)
+	if !ok || st.Code() != codes.InvalidArgument {
+		t.Errorf("Expected InvalidArgument status error, got %v", err)
+	}
+
+	if attempts != 1 {
+		t.Errorf("Expected non-retryable error to abort immediately (1 attempt), got %d attempts", attempts)
+	}
+}
+
+func TestRetryingVRpc_HonorServerRetryDelay(t *testing.T) {
+	var attempts int
+	baseHandler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		attempts++
+		if attempts == 1 {
+			// Return transient error with server-directed retry delay of 10ms
+			st := status.New(codes.Unavailable, "overloaded")
+			stWithDetails, err := st.WithDetails(&errdetails.RetryInfo{
+				RetryDelay: durationpb.New(10 * time.Millisecond),
+			})
+			if err != nil {
+				return nil, err
+			}
+			return nil, stWithDetails.Err()
+		}
+		return "ok", nil
+	}
+
+	retryInterceptor := RetryingVRpc(RetryingOptions{
+		MaxAttempts:    3,
+		InitialBackoff: 200 * time.Millisecond, // Default initial backoff is large, but server details should override it
+	})
+
+	startTime := time.Now()
+	ctx := WithVRpcMetadata(context.Background(), "TestMethod", 1)
+	resp, err := retryInterceptor(ctx, "request", baseHandler)
+	duration := time.Since(startTime)
+
+	if err != nil {
+		t.Fatalf("Expected successful response, got %v", err)
+	}
+
+	if resp.(string) != "ok" {
+		t.Errorf("Expected response 'ok', got %v", resp)
+	}
+
+	if duration >= 100*time.Millisecond {
+		t.Errorf("Expected retry delay to be small (10ms) honoring server RetryInfo, but took %v (might have used 200ms client backoff)", duration)
+	}
+}
+
+func TestVRpc_ContextMetadataRetention(t *testing.T) {
+	ctx := WithVRpcMetadata(context.Background(), "QueryMethod", 42)
+
+	if VRpcMethod(ctx) != "QueryMethod" {
+		t.Errorf("Expected method 'QueryMethod', got %q", VRpcMethod(ctx))
+	}
+	if VRpcAttempt(ctx) != 42 {
+		t.Errorf("Expected attempt 42, got %d", VRpcAttempt(ctx))
+	}
+
+	// Wrapping with context.WithValue (e.g. standard tracing span setter)
+	type extraKey struct{}
+	wrappedCtx := context.WithValue(ctx, extraKey{}, "extraValue")
+
+	// Ensure metadata is completely preserved when using standard context operations
+	if VRpcMethod(wrappedCtx) != "QueryMethod" {
+		t.Errorf("Expected method 'QueryMethod' to be preserved after WithValue wrapping, got %q", VRpcMethod(wrappedCtx))
+	}
+	if VRpcAttempt(wrappedCtx) != 42 {
+		t.Errorf("Expected attempt 42 to be preserved after WithValue wrapping, got %d", VRpcAttempt(wrappedCtx))
+	}
+}
+
+func TestRetryingVRpc_MaxAttemptsExceeded(t *testing.T) {
+	var attempts int
+	baseHandler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		attempts++
+		return nil, status.Error(codes.Unavailable, "temporary failure")
+	}
+
+	retryInterceptor := RetryingVRpc(RetryingOptions{
+		MaxAttempts:    3,
+		InitialBackoff: 1 * time.Millisecond,
+	})
+
+	ctx := WithVRpcMetadata(context.Background(), "TestMethod", 1)
+	_, err := retryInterceptor(ctx, "request", baseHandler)
+	if err == nil {
+		t.Fatal("Expected failure after maximum attempts, got success")
+	}
+
+	if attempts != 3 {
+		t.Errorf("Expected exactly 3 attempts before giving up, got %d", attempts)
+	}
+}
+
+func TestRetryingVRpc_NonGrpcError(t *testing.T) {
+	var attempts int
+	baseHandler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		attempts++
+		return nil, errors.New("some custom raw go error")
+	}
+
+	retryInterceptor := RetryingVRpc(RetryingOptions{
+		MaxAttempts:    3,
+		InitialBackoff: 1 * time.Millisecond,
+	})
+
+	ctx := WithVRpcMetadata(context.Background(), "TestMethod", 1)
+	_, err := retryInterceptor(ctx, "request", baseHandler)
+	if err == nil {
+		t.Fatal("Expected error, got nil")
+	}
+
+	if attempts != 1 {
+		t.Errorf("Expected non-gRPC raw errors to be treated as non-retryable and fail immediately (1 attempt), got %d attempts", attempts)
+	}
+}

--- a/bigtable/metrics.go
+++ b/bigtable/metrics.go
@@ -84,9 +84,26 @@ const (
 type contextKey string
 
 const (
-	statsContextKey contextKey = "bigtable/clientBlockingLatencyTracker"
-	t4t7ContextKey  contextKey = "bigtable/t4t7Tracker"
+	statsContextKey         contextKey = "bigtable/clientBlockingLatencyTracker"
+	t4t7ContextKey          contextKey = "bigtable/t4t7Tracker"
+	metricsTracerContextKey contextKey = "bigtable/metricsTracer"
 )
+
+func contextWithMetricsTracer(ctx context.Context, mt *builtinMetricsTracer) context.Context {
+	return context.WithValue(ctx, metricsTracerContextKey, mt)
+}
+
+func metricsTracerFromContext(ctx context.Context) *builtinMetricsTracer {
+	if mt, ok := ctx.Value(metricsTracerContextKey).(*builtinMetricsTracer); ok {
+		return mt
+	}
+	return &builtinMetricsTracer{
+		builtInEnabled: false,
+		currOp: opTracer{
+			cookies: make(map[string]string),
+		},
+	}
+}
 
 // These are effectively constant, but for testing purposes they are mutable
 var (
@@ -519,6 +536,9 @@ type attemptTracer struct {
 	// Tracker for client blocking latency
 	blockingLatencyTracker *blockingLatencyTracker
 
+	// Client blocking latency in ms
+	clientBlockingLatency float64
+
 	// Tracker for t4t7
 	t4t7Tracker *t4t7Tracker
 }
@@ -666,8 +686,12 @@ func (mt *builtinMetricsTracer) recordAttemptCompletion(attemptHeaderMD, attempT
 	// Get location attributes from metadata and set it in tracer
 	// Ignore get location error since the metric can still be recorded with rest of the attributes
 	clusterID, zoneID, _ := extractLocation(attemptHeaderMD, attempTrailerMD)
-	mt.currOp.currAttempt.setClusterID(clusterID)
-	mt.currOp.currAttempt.setZoneID(zoneID)
+	if mt.currOp.currAttempt.clusterID == "" || mt.currOp.currAttempt.clusterID == defaultCluster {
+		mt.currOp.currAttempt.setClusterID(clusterID)
+	}
+	if mt.currOp.currAttempt.zoneID == "" || mt.currOp.currAttempt.zoneID == defaultZone {
+		mt.currOp.currAttempt.setZoneID(zoneID)
+	}
 
 	// Set server latency in tracer
 	// FYI this is GFE t4t7(not server latency) latency where
@@ -700,6 +724,8 @@ func (mt *builtinMetricsTracer) recordAttemptCompletion(attemptHeaderMD, attempT
 	if mt.currOp.currAttempt.blockingLatencyTracker != nil {
 		messageSentNanos := mt.currOp.currAttempt.blockingLatencyTracker.getMessageSentNanos()
 		clientBlockingLatencyMs = convertToMs(time.Unix(0, int64(messageSentNanos)).Sub(mt.currOp.currAttempt.startTime))
+	} else {
+		clientBlockingLatencyMs = mt.currOp.currAttempt.clientBlockingLatency
 	}
 	clientBlockingLatAttrs, _ := mt.toOtelMetricAttrs(metricNameClientBlockingLatencies)
 	mt.instrumentClientBlockingLatencies.Record(mt.ctx, clientBlockingLatencyMs, metric.WithAttributeSet(clientBlockingLatAttrs))
@@ -780,6 +806,16 @@ func (mt *builtinMetricsTracer) incrementAppBlockingLatency(latency float64) {
 	}
 
 	mt.currOp.incrementAppBlockingLatency(latency)
+}
+
+func (mt *builtinMetricsTracer) recordClientBlockingLatency() {
+	if !mt.builtInEnabled {
+		return
+	}
+	startTime := mt.currOp.currAttempt.startTime
+	if !startTime.IsZero() {
+		mt.currOp.currAttempt.clientBlockingLatency = convertToMs(time.Since(startTime))
+	}
 }
 
 // blockingLatencyTracker is used to calculate the time between stream creation and the first message send.

--- a/bigtable/open.go
+++ b/bigtable/open.go
@@ -1,0 +1,165 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bigtable
+
+import (
+	"context"
+	"fmt"
+
+	"google.golang.org/grpc/metadata"
+
+	btpb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
+	btransport "cloud.google.com/go/bigtable/internal/transport"
+)
+
+// Open opens a table.
+func (c *Client) Open(table string) *Table {
+	return &Table{
+		c:     c,
+		table: table,
+		md: metadata.Join(metadata.Pairs(
+			resourcePrefixHeader, c.fullTableName(table),
+			requestParamsHeader, c.reqParamsHeaderValTable(table),
+		), c.featureFlagsMD),
+	}
+}
+
+// OpenTable opens a table.
+func (c *Client) OpenTable(table string) TableAPI {
+	classic := c.Open(table)
+	readStreamFactory := func(ctx context.Context) (btransport.Stream, error) {
+		if c.sessionClient != nil {
+			return c.sessionClient.OpenTable(ctx)
+		}
+		return c.client.OpenTable(ctx)
+	}
+	writeStreamFactory := func(ctx context.Context) (btransport.Stream, error) {
+		if c.sessionClient != nil {
+			return c.sessionClient.OpenTable(ctx)
+		}
+		return c.client.OpenTable(ctx)
+	}
+
+	readTableReq := &btpb.OpenTableRequest{
+		TableName:    c.fullTableName(table),
+		AppProfileId: c.appProfile,
+		Permission:   btpb.OpenTableRequest_PERMISSION_READ,
+	}
+	writeTableReq := &btpb.OpenTableRequest{
+		TableName:    c.fullTableName(table),
+		AppProfileId: c.appProfile,
+		Permission:   btpb.OpenTableRequest_PERMISSION_WRITE,
+	}
+
+	return c.sessionMgr.GetOrCreateSessionTable(
+		c.fullTableName(table),
+		classic,
+		btransport.TABLE_SESSION,
+		readStreamFactory,
+		writeStreamFactory,
+		readTableReq,
+		writeTableReq,
+		btransport.READ_ROW,
+		btransport.MUTATE_ROW,
+		fmt.Sprintf("table:%s", table),
+	)
+}
+
+// OpenAuthorizedView opens an authorized view.
+func (c *Client) OpenAuthorizedView(table, authorizedView string) TableAPI {
+	classic := &Table{
+		c:     c,
+		table: table,
+		md: metadata.Join(metadata.Pairs(
+			resourcePrefixHeader, c.fullAuthorizedViewName(table, authorizedView),
+			requestParamsHeader, c.reqParamsHeaderValTable(table),
+		), c.featureFlagsMD),
+		authorizedView: authorizedView,
+	}
+
+	readStreamFactory := func(ctx context.Context) (btransport.Stream, error) {
+		if c.sessionClient != nil {
+			return c.sessionClient.OpenAuthorizedView(ctx)
+		}
+		return c.client.OpenAuthorizedView(ctx)
+	}
+	writeStreamFactory := func(ctx context.Context) (btransport.Stream, error) {
+		if c.sessionClient != nil {
+			return c.sessionClient.OpenAuthorizedView(ctx)
+		}
+		return c.client.OpenAuthorizedView(ctx)
+	}
+
+	readTableReq := &btpb.OpenAuthorizedViewRequest{
+		AuthorizedViewName: c.fullAuthorizedViewName(table, authorizedView),
+		AppProfileId:       c.appProfile,
+		Permission:         btpb.OpenAuthorizedViewRequest_PERMISSION_READ,
+	}
+	writeTableReq := &btpb.OpenAuthorizedViewRequest{
+		AuthorizedViewName: c.fullAuthorizedViewName(table, authorizedView),
+		AppProfileId:       c.appProfile,
+		Permission:         btpb.OpenAuthorizedViewRequest_PERMISSION_WRITE,
+	}
+
+	return c.sessionMgr.GetOrCreateSessionTable(
+		c.fullAuthorizedViewName(table, authorizedView),
+		classic,
+		btransport.AUTHORIZED_VIEW_SESSION,
+		readStreamFactory,
+		writeStreamFactory,
+		readTableReq,
+		writeTableReq,
+		btransport.READ_ROW_AUTH_VIEW,
+		btransport.MUTATE_ROW_AUTH_VIEW,
+		fmt.Sprintf("auth_view:%s:%s", table, authorizedView),
+	)
+}
+
+// OpenMaterializedView opens a materialized view.
+func (c *Client) OpenMaterializedView(materializedView string) TableAPI {
+	classic := &Table{
+		c: c,
+		md: metadata.Join(metadata.Pairs(
+			resourcePrefixHeader, c.fullMaterializedViewName(materializedView),
+			requestParamsHeader, c.reqParamsHeaderValTable(materializedView),
+		), c.featureFlagsMD),
+		materializedView: materializedView,
+	}
+
+	readStreamFactory := func(ctx context.Context) (btransport.Stream, error) {
+		if c.sessionClient != nil {
+			return c.sessionClient.OpenMaterializedView(ctx)
+		}
+		return c.client.OpenMaterializedView(ctx)
+	}
+
+	readTableReq := &btpb.OpenMaterializedViewRequest{
+		MaterializedViewName: c.fullMaterializedViewName(materializedView),
+		AppProfileId:         c.appProfile,
+	}
+
+	return c.sessionMgr.GetOrCreateSessionTable(
+		c.fullMaterializedViewName(materializedView),
+		classic,
+		btransport.MATERIALIZED_VIEW_SESSION,
+		readStreamFactory,
+		nil,
+		readTableReq,
+		nil,
+		btransport.READ_ROW_MAT_VIEW,
+		nil,
+		fmt.Sprintf("mat_view:%s", materializedView),
+	)
+}

--- a/bigtable/query.go
+++ b/bigtable/query.go
@@ -108,14 +108,15 @@ func (c *Client) prepareStatementWithMetadata(ctx context.Context, query string,
 
 	mt := c.newBuiltinMetricsTracer(ctx, "", false)
 	defer mt.recordOperationCompletion()
+	ctx = contextWithMetricsTracer(ctx, mt)
 
-	preparedStatement, err = c.prepareStatement(ctx, mt, query, paramTypes, opts...)
+	preparedStatement, err = c.prepareStatement(ctx, query, paramTypes, opts...)
 	statusCode, statusErr := convertToGrpcStatusErr(err)
 	mt.setCurrOpStatus(statusCode)
 	return preparedStatement, statusErr
 }
 
-func (c *Client) prepareStatement(ctx context.Context, mt *builtinMetricsTracer, query string, paramTypes map[string]SQLType, opts ...PrepareOption) (*PreparedStatement, error) {
+func (c *Client) prepareStatement(ctx context.Context, query string, paramTypes map[string]SQLType, opts ...PrepareOption) (*PreparedStatement, error) {
 	reqParamTypes := map[string]*btpb.Type{}
 	for k, v := range paramTypes {
 		if v == nil {
@@ -140,7 +141,7 @@ func (c *Client) prepareStatement(ctx context.Context, mt *builtinMetricsTracer,
 		ParamTypes: reqParamTypes,
 	}
 	var res *btpb.PrepareQueryResponse
-	err := gaxInvokeWithRecorder(ctx, mt, "PrepareQuery", func(ctx context.Context, headerMD, trailerMD *metadata.MD, _ gax.CallSettings) error {
+	err := gaxInvokeWithRecorder(ctx, "PrepareQuery", func(ctx context.Context, headerMD, trailerMD *metadata.MD, _ gax.CallSettings) error {
 		var err error
 		res, err = c.client.PrepareQuery(ctx, req, grpc.Header(headerMD), grpc.Trailer(trailerMD))
 		return err
@@ -287,8 +288,9 @@ func (bs *BoundStatement) Execute(ctx context.Context, f func(ResultRow) bool, o
 
 	mt := bs.ps.c.newBuiltinMetricsTracer(ctx, "", true)
 	defer mt.recordOperationCompletion()
+	ctx = contextWithMetricsTracer(ctx, mt)
 
-	err = bs.execute(ctx, f, mt)
+	err = bs.execute(ctx, f)
 	statusCode, statusErr := convertToGrpcStatusErr(err)
 	mt.setCurrOpStatus(statusCode)
 	return statusErr
@@ -299,7 +301,7 @@ func newPreparedQueryData(ps *PreparedStatement) *preparedQueryData {
 	return &data
 }
 
-func (bs *BoundStatement) execute(ctx context.Context, f func(ResultRow) bool, mt *builtinMetricsTracer) error {
+func (bs *BoundStatement) execute(ctx context.Context, f func(ResultRow) bool) error {
 	// buffer data constructed from the fields in PartialRows`
 	var ongoingResultBatch bytes.Buffer
 
@@ -321,7 +323,7 @@ func (bs *BoundStatement) execute(ctx context.Context, f func(ResultRow) bool, m
 	//
 	// So, do not use latest metadata from `bs.ps`
 	var finalizedStmt *preparedQueryData
-	err := gaxInvokeWithRecorder(ctx, mt, "ExecuteQuery", func(ctx context.Context, headerMD, trailerMD *metadata.MD, _ gax.CallSettings) error {
+	err := gaxInvokeWithRecorder(ctx, "ExecuteQuery", func(ctx context.Context, headerMD, trailerMD *metadata.MD, _ gax.CallSettings) error {
 		ctx, cancel := context.WithCancel(ctx) // for aborting the stream
 		defer cancel()
 

--- a/bigtable/read_modify_write.go
+++ b/bigtable/read_modify_write.go
@@ -31,14 +31,15 @@ func (t *Table) ApplyReadModifyWrite(ctx context.Context, row string, m *ReadMod
 
 	mt := t.newBuiltinMetricsTracer(ctx, false)
 	defer mt.recordOperationCompletion()
+	ctx = contextWithMetricsTracer(ctx, mt)
 
-	updatedRow, err := t.applyReadModifyWrite(ctx, mt, row, m)
+	updatedRow, err := t.applyReadModifyWrite(ctx, row, m)
 	statusCode, statusErr := convertToGrpcStatusErr(err)
 	mt.setCurrOpStatus(statusCode)
 	return updatedRow, statusErr
 }
 
-func (t *Table) applyReadModifyWrite(ctx context.Context, mt *builtinMetricsTracer, row string, m *ReadModifyWrite) (Row, error) {
+func (t *Table) applyReadModifyWrite(ctx context.Context, row string, m *ReadModifyWrite) (Row, error) {
 	req := &btpb.ReadModifyWriteRowRequest{
 		AppProfileId: t.c.appProfile,
 		RowKey:       []byte(row),
@@ -51,7 +52,7 @@ func (t *Table) applyReadModifyWrite(ctx context.Context, mt *builtinMetricsTrac
 	}
 
 	var r Row
-	err := gaxInvokeWithRecorder(ctx, mt, "ReadModifyWriteRow", func(ctx context.Context, headerMD, trailerMD *metadata.MD, _ gax.CallSettings) error {
+	err := gaxInvokeWithRecorder(ctx, "ReadModifyWriteRow", func(ctx context.Context, headerMD, trailerMD *metadata.MD, _ gax.CallSettings) error {
 		res, err := t.c.client.ReadModifyWriteRow(ctx, req, grpc.Header(headerMD), grpc.Trailer(trailerMD))
 		if err != nil {
 			return err

--- a/bigtable/read_session_test.go
+++ b/bigtable/read_session_test.go
@@ -1,0 +1,288 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bigtable
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"google.golang.org/api/option"
+)
+
+func TestReadSessionSandbox(t *testing.T) {
+	// This test connects to the sandbox endpoint and performs a ReadRow via session-based transport.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	project := "autonomous-mote-782"
+	instance := "test-sushanb"
+	table := "sushanb"
+	endpoint := "test-bigtable.sandbox.googleapis.com:443"
+
+	cfg := ClientConfig{
+		EnableSessionPool: true,
+	}
+
+	// Create client configured to use sessions & the sandbox endpoint
+	client, err := NewClientWithConfig(ctx, project, instance, cfg, option.WithEndpoint(endpoint))
+	if err != nil {
+		t.Fatalf("failed to create bigtable client: %v", err)
+	}
+	defer client.Close()
+
+	tbl := client.OpenTable(table)
+	rowKey := "myrow-0"
+
+	t.Logf("Waiting for session pool to warm up...")
+	time.Sleep(3 * time.Second)
+
+	t.Logf("Reading row %q from table %q via session pool before write...", rowKey, table)
+	row, err := tbl.ReadRow(ctx, rowKey)
+	if err != nil {
+		t.Fatalf("ReadRow before write failed: %v", err)
+	}
+	if row != nil {
+		t.Logf("Successfully read row %q before write:", rowKey)
+		for fam, items := range row {
+			for _, item := range items {
+				t.Logf("  Family: %s, Column: %s, Value: %s", fam, item.Column, string(item.Value))
+			}
+		}
+	}
+
+	t.Logf("Applying mutation write via session pool to row %q...", rowKey)
+	mut := NewMutation()
+	mut.Set("cf12", "colq1", ServerTime, []byte("val-applied-vrpc"))
+	if err := tbl.Apply(ctx, rowKey, mut); err != nil {
+		t.Fatalf("Apply mutation failed: %v", err)
+	}
+	t.Logf("Successfully applied mutation write.")
+
+	t.Logf("Reading row %q from table %q via session pool after write...", rowKey, table)
+	rowAfter, err := tbl.ReadRow(ctx, rowKey)
+	if err != nil {
+		t.Fatalf("ReadRow after write failed: %v", err)
+	}
+	if rowAfter == nil {
+		t.Fatalf("Row %q not found after write", rowKey)
+	}
+
+	t.Logf("Successfully read row %q after write:", rowKey)
+	for fam, items := range rowAfter {
+		for _, item := range items {
+			t.Logf("  Family: %s, Column: %s, Value: %s", fam, item.Column, string(item.Value))
+		}
+	}
+}
+
+func TestHighQpsSessionSandbox(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 11*time.Minute)
+	defer cancel()
+
+	project := "autonomous-mote-782"
+	instance := "test-sushanb"
+	table := "sushanb"
+	endpoint := "test-bigtable.sandbox.googleapis.com:443"
+
+	cfg := ClientConfig{
+		EnableSessionPool: true,
+		SessionPoolMin:    3,
+		SessionPoolMax:    5,
+	}
+
+	client, err := NewClientWithConfig(ctx, project, instance, cfg, option.WithEndpoint(endpoint))
+	if err != nil {
+		t.Fatalf("failed to create bigtable client: %v", err)
+	}
+	defer client.Close()
+
+	tbl := client.OpenTable(table)
+
+	t.Logf("Waiting for session pool to warm up before high QPS test...")
+	time.Sleep(3 * time.Second)
+
+	concurrency := 10
+	testDuration := 10 * time.Minute
+	endTime := time.Now().Add(testDuration)
+
+	var successWrites int64
+	var successReads int64
+	var failedWrites int64
+	var failedReads int64
+
+	var wg sync.WaitGroup
+	t.Logf("Starting 10-minute high QPS sandbox test with %d concurrent workers...", concurrency)
+
+	for i := 0; i < concurrency; i++ {
+		wg.Add(1)
+		go func(workerID int) {
+			defer wg.Done()
+			counter := 0
+			for time.Now().Before(endTime) {
+				counter++
+				rowKey := fmt.Sprintf("sandbox-%d-%d", workerID, counter)
+				mut := NewMutation()
+				mut.Set("cf12", "colq1", ServerTime, []byte(fmt.Sprintf("val-worker-%d-%d", workerID, counter)))
+
+				// Perform write
+				if err := tbl.Apply(ctx, rowKey, mut); err != nil {
+					atomic.AddInt64(&failedWrites, 1)
+					fmt.Printf(">>> ERROR [worker-%d]: write failed: %v <<<\n", workerID, err)
+				} else {
+					atomic.AddInt64(&successWrites, 1)
+				}
+
+				// Perform read
+				_, err := tbl.ReadRow(ctx, rowKey)
+				if err != nil {
+					atomic.AddInt64(&failedReads, 1)
+					fmt.Printf(">>> ERROR [worker-%d]: read failed: %v <<<\n", workerID, err)
+				} else {
+					atomic.AddInt64(&successReads, 1)
+				}
+
+				time.Sleep(50 * time.Millisecond)
+			}
+		}(i)
+	}
+
+	// Background stats logger
+	doneChan := make(chan struct{})
+	go func() {
+		ticker := time.NewTicker(30 * time.Second)
+		defer ticker.Stop()
+		start := time.Now()
+
+		for {
+			select {
+			case <-doneChan:
+				return
+			case <-ticker.C:
+				sw := atomic.LoadInt64(&successWrites)
+				sr := atomic.LoadInt64(&successReads)
+				fw := atomic.LoadInt64(&failedWrites)
+				fr := atomic.LoadInt64(&failedReads)
+				elapsed := time.Since(start)
+				qps := float64(sw+sr) / elapsed.Seconds()
+				fmt.Printf(">>> STATS [%.1fs elapsed]: Success (W:%d, R:%d), Failed (W:%d, R:%d), QPS: %.2f <<<\n", elapsed.Seconds(), sw, sr, fw, fr, qps)
+			}
+		}
+	}()
+
+	wg.Wait()
+	close(doneChan)
+
+	finalSW := atomic.LoadInt64(&successWrites)
+	finalSR := atomic.LoadInt64(&successReads)
+	finalFW := atomic.LoadInt64(&failedWrites)
+	finalFR := atomic.LoadInt64(&failedReads)
+	t.Logf("10-minute high QPS test completed! Successful Writes: %d, Successful Reads: %d, Failed Writes: %d, Failed Reads: %d", finalSW, finalSR, finalFW, finalFR)
+	if finalFW > 0 || finalFR > 0 {
+		t.Errorf("Test had failed operations!")
+	}
+}
+
+func TestSequentialReads(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	project := "autonomous-mote-782"
+	instance := "test-sushanb"
+	table := "sushanb"
+	endpoint := "test-bigtable.sandbox.googleapis.com:443"
+
+	cfg := ClientConfig{
+		EnableSessionPool: true,
+	}
+
+	client, err := NewClientWithConfig(ctx, project, instance, cfg, option.WithEndpoint(endpoint))
+	if err != nil {
+		t.Fatalf("failed to nn bigtable client: %v", err)
+	}
+	defer client.Close()
+
+	tbl := client.OpenTable(table)
+	rowKey := "myrow-0"
+
+	t.Logf("Waiting for session pool to warm up...")
+	time.Sleep(3 * time.Second)
+
+	for i := 0; i < 10; i++ {
+		t.Logf("Sequential Read %d/10 for row %q...", i+1, rowKey)
+		t.Logf("Sleeping for 1s...")
+		time.Sleep(1 * time.Second)
+		row, err := tbl.ReadRow(ctx, rowKey)
+		if err != nil {
+			t.Fatalf("Read %d failed: %v", i+1, err)
+		}
+		if row != nil {
+			t.Logf("Read %d successfully. Columns read: %d", i+1, len(row["cf12"]))
+		} else {
+			t.Logf("Read %d: row %q not found", i+1, rowKey)
+		}
+	}
+}
+
+func TestDequentialReadsParallel(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	project := "autonomous-mote-782"
+	instance := "test-sushanb"
+	table := "sushanb"
+	endpoint := "test-bigtable.sandbox.googleapis.com:443"
+
+	cfg := ClientConfig{
+		EnableSessionPool: true,
+	}
+
+	client, err := NewClientWithConfig(ctx, project, instance, cfg, option.WithEndpoint(endpoint))
+	if err != nil {
+		t.Fatalf("failed to create bigtable client: %v", err)
+	}
+	defer client.Close()
+
+	tbl := client.OpenTable(table)
+
+	t.Logf("Waiting for session pool to warm up...")
+	time.Sleep(3 * time.Second)
+
+	var wg sync.WaitGroup
+	for seed := 0; seed < 10; seed++ {
+		wg.Add(1)
+		go func(s int) {
+			defer wg.Done()
+			rowKey := fmt.Sprintf("myrow-%d", s)
+			for i := 0; i < 10; i++ {
+				t.Logf("Seed %d - Sequential Read %d/10 for row %q...", s, i+1, rowKey)
+				row, err := tbl.ReadRow(ctx, rowKey)
+				if err != nil {
+					t.Errorf("Seed %d - Read %d failed: %v", s, i+1, err)
+					return
+				}
+				if row != nil {
+					t.Logf("Seed %d - Read %d successfully. Columns read: %d", s, i+1, len(row["cf12"]))
+				} else {
+					t.Logf("Seed %d - Read %d: row %q not found", s, i+1, rowKey)
+				}
+			}
+		}(seed)
+	}
+	wg.Wait()
+}

--- a/bigtable/read_session_test.go
+++ b/bigtable/read_session_test.go
@@ -208,7 +208,7 @@ func TestSequentialReads(t *testing.T) {
 	endpoint := "test-bigtable.sandbox.googleapis.com:443"
 
 	cfg := ClientConfig{
-		EnableSessionPool: true,
+		EnableSessionPool: false,
 	}
 
 	client, err := NewClientWithConfig(ctx, project, instance, cfg, option.WithEndpoint(endpoint))
@@ -223,7 +223,7 @@ func TestSequentialReads(t *testing.T) {
 	t.Logf("Waiting for session pool to warm up...")
 	time.Sleep(3 * time.Second)
 
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 100; i++ {
 		t.Logf("Sequential Read %d/10 for row %q...", i+1, rowKey)
 		t.Logf("Sleeping for 1s...")
 		time.Sleep(1 * time.Second)

--- a/bigtable/sample_row_keys.go
+++ b/bigtable/sample_row_keys.go
@@ -30,16 +30,17 @@ func (t *Table) SampleRowKeys(ctx context.Context) ([]string, error) {
 
 	mt := t.newBuiltinMetricsTracer(ctx, true)
 	defer mt.recordOperationCompletion()
+	ctx = contextWithMetricsTracer(ctx, mt)
 
-	rowKeys, err := t.sampleRowKeys(ctx, mt)
+	rowKeys, err := t.sampleRowKeys(ctx)
 	statusCode, statusErr := convertToGrpcStatusErr(err)
 	mt.setCurrOpStatus(statusCode)
 	return rowKeys, statusErr
 }
 
-func (t *Table) sampleRowKeys(ctx context.Context, mt *builtinMetricsTracer) ([]string, error) {
+func (t *Table) sampleRowKeys(ctx context.Context) ([]string, error) {
 	var sampledRowKeys []string
-	err := gaxInvokeWithRecorder(ctx, mt, "SampleRowKeys", func(ctx context.Context, headerMD, trailerMD *metadata.MD, _ gax.CallSettings) error {
+	err := gaxInvokeWithRecorder(ctx, "SampleRowKeys", func(ctx context.Context, headerMD, trailerMD *metadata.MD, _ gax.CallSettings) error {
 		sampledRowKeys = nil
 		req := &btpb.SampleRowKeysRequest{
 			AppProfileId: t.c.appProfile,

--- a/bigtable/session_manager.go
+++ b/bigtable/session_manager.go
@@ -1,0 +1,207 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bigtable
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	btpb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
+	btransport "cloud.google.com/go/bigtable/internal/transport"
+	"go.opentelemetry.io/otel/metric"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/proto"
+)
+
+// SessionManager manages dynamic table-specific session pools for vRPC operations.
+type SessionManager struct {
+	mu                sync.Mutex
+	enableSessionPool bool
+	metricsEnabled    bool
+	disableRetryInfo  bool
+	featureFlagsMD    metadata.MD
+	diverter          *btransport.Diverter
+	configManager     *btransport.ClientConfigurationManager
+	backgroundCtx     context.Context
+	sessionPools      map[string]*btransport.SessionPoolImpl
+	minSessions       int
+	maxSessions       int
+	channelPool       managedChannelPool
+}
+
+// NewSessionManager creates a new SessionManager.
+func NewSessionManager(
+	enableSessionPool bool,
+	metricsEnabled bool,
+	disableRetryInfo bool,
+	featureFlagsMD metadata.MD,
+	diverter *btransport.Diverter,
+	configManager *btransport.ClientConfigurationManager,
+	backgroundCtx context.Context,
+	minSessions int,
+	maxSessions int,
+	meterProvider metric.MeterProvider,
+	channelPool managedChannelPool,
+) *SessionManager {
+	if metricsEnabled && meterProvider != nil {
+		_ = btransport.InitializeMetrics(meterProvider)
+	}
+	return &SessionManager{
+		enableSessionPool: enableSessionPool,
+		metricsEnabled:    metricsEnabled,
+		disableRetryInfo:  disableRetryInfo,
+		featureFlagsMD:    featureFlagsMD,
+		diverter:          diverter,
+		configManager:     configManager,
+		backgroundCtx:     backgroundCtx,
+		sessionPools:      make(map[string]*btransport.SessionPoolImpl),
+		minSessions:       minSessions,
+		maxSessions:       maxSessions,
+		channelPool:       channelPool,
+	}
+}
+
+// Close closes all session pools managed by the SessionManager.
+func (m *SessionManager) Close() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, pool := range m.sessionPools {
+		pool.Close()
+	}
+	var err error
+	if m.channelPool.pool != nil {
+		err = m.channelPool.Close()
+	}
+	return err
+}
+
+// GetOrCreateSessionTable initializes or retrieves session-based transport pools for a table/view.
+func (m *SessionManager) GetOrCreateSessionTable(
+	resourceName string,
+	classic *Table,
+	sessionDesc *btransport.SessionDescriptor,
+	readStreamFactory func(ctx context.Context) (btransport.Stream, error),
+	writeStreamFactory func(ctx context.Context) (btransport.Stream, error),
+	readPayload proto.Message,
+	writePayload proto.Message,
+	readVRpcDesc btransport.VRpcDescriptor,
+	writeVRpcDesc btransport.VRpcDescriptor,
+	keyPrefix string,
+) TableAPI {
+	if !m.enableSessionPool {
+		return &tableImpl{*classic}
+	}
+
+	flags := &btpb.FeatureFlags{
+		RoutingCookie:            true,
+		ReverseScans:             true,
+		LastScannedRowResponses:  true,
+		ClientSideMetricsEnabled: m.metricsEnabled,
+		RetryInfo:                !m.disableRetryInfo,
+		TrafficDirectorEnabled:   true,
+		DirectAccessRequested:    true,
+		SessionsCompatible:       true,
+		PeerInfo:                 true,
+	}
+
+	readKey := fmt.Sprintf("%s:read", keyPrefix)
+	readPool := m.createPoolForPayload(resourceName, sessionDesc, readStreamFactory, readPayload, flags, readKey)
+
+	writeKey := fmt.Sprintf("%s:write", keyPrefix)
+	writePool := m.createPoolForPayload(resourceName, sessionDesc, writeStreamFactory, writePayload, flags, writeKey)
+
+	if readPool != nil && m.diverter != nil {
+		sessionTable := NewSessionTable(classic.table, classic, readPool, writePool, readVRpcDesc, writeVRpcDesc)
+		return NewTableShim(&tableImpl{*classic}, sessionTable, m.diverter)
+	}
+
+	return &tableImpl{*classic}
+}
+
+func (m *SessionManager) createPoolForPayload(
+	resourceName string,
+	sessionDesc *btransport.SessionDescriptor,
+	streamFactory func(ctx context.Context) (btransport.Stream, error),
+	payload proto.Message,
+	flags *btpb.FeatureFlags,
+	key string,
+) *btransport.SessionPoolImpl {
+	if payload == nil {
+		return nil
+	}
+
+	payloadBytes, _ := proto.Marshal(payload)
+	handshake := &btpb.OpenSessionRequest{
+		ProtocolVersion: 1,
+		Payload:         payloadBytes,
+		Flags:           flags,
+	}
+
+	var sessionMetadata []string
+	for k, v := range sessionDesc.MetadataFn(payload) {
+		sessionMetadata = append(sessionMetadata, fmt.Sprintf("%s=%s", k, url.QueryEscape(v)))
+	}
+	paramsVal := strings.Join(sessionMetadata, "&")
+
+	md := metadata.Join(metadata.Pairs(
+		resourcePrefixHeader, resourceName,
+		requestParamsHeader, paramsVal,
+	), m.featureFlagsMD)
+
+	min := 10
+	if m.minSessions > 0 {
+		min = m.minSessions
+	}
+	max := 100
+	if m.maxSessions > 0 {
+		max = m.maxSessions
+	}
+	return m.GetOrCreateSessionPool(key, min, max, streamFactory, handshake, md, sessionDesc.Type)
+}
+
+// GetOrCreateSessionPool gets or creates a session pool for a specific key.
+func (m *SessionManager) GetOrCreateSessionPool(
+	key string,
+	min, max int,
+	streamFactory func(ctx context.Context) (btransport.Stream, error),
+	openSessionRequest *btpb.OpenSessionRequest,
+	md metadata.MD,
+	sessionType btransport.SessionType,
+) *btransport.SessionPoolImpl {
+	fmt.Printf(">>> getOrCreateSessionPool: key=%s, min=%d, max=%d <<<\n", key, min, max)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	pool, ok := m.sessionPools[key]
+	if !ok {
+		pool = btransport.NewSessionPoolImpl(key, min, max, streamFactory, openSessionRequest, md, sessionType)
+		m.sessionPools[key] = pool
+
+		if m.configManager != nil {
+			m.configManager.AddSessionPoolListener(func(config *btpb.SessionClientConfiguration_SessionPoolConfiguration) {
+				pool.UpdateConfig(config)
+			})
+		}
+
+		// Start background heartbeat scaling pacemaker loop for this dedicated pool!
+		pool.StartHeartbeat(m.backgroundCtx, 1*time.Second)
+		pool.PerformScaling(m.backgroundCtx)
+	}
+	return pool
+}

--- a/bigtable/session_table.go
+++ b/bigtable/session_table.go
@@ -26,7 +26,7 @@ import (
 // SessionTable implements TableAPI by routing calls via virtual RPCs through dedicated session pools.
 type SessionTable struct {
 	tableName     string
-	classic       TableAPI
+	classic       *Table
 	readPool      *btransport.SessionPoolImpl
 	writePool     *btransport.SessionPoolImpl
 	readVRpcDesc  btransport.VRpcDescriptor
@@ -36,7 +36,7 @@ type SessionTable struct {
 // NewSessionTable creates a new SessionTable instance.
 func NewSessionTable(
 	tableName string,
-	classic TableAPI,
+	classic *Table,
 	readPool *btransport.SessionPoolImpl,
 	writePool *btransport.SessionPoolImpl,
 	readVRpcDesc btransport.VRpcDescriptor,
@@ -52,11 +52,35 @@ func NewSessionTable(
 	}
 }
 
+type sessionMetricsListener struct{}
+
+func (l sessionMetricsListener) OnAttemptStart(ctx context.Context) {
+	if mt := metricsTracerFromContext(ctx); mt != nil {
+		mt.recordAttemptStart()
+	}
+}
+
+func (l sessionMetricsListener) OnAttemptComplete(ctx context.Context, err error) {
+	if mt := metricsTracerFromContext(ctx); mt != nil {
+		mt.recordAttemptCompletion(nil, nil, err)
+	}
+}
+
 // ReadRow reads a single row via vRPC.
-func (t *SessionTable) ReadRow(ctx context.Context, row string, opts ...ReadOption) (Row, error) {
+func (t *SessionTable) ReadRow(ctx context.Context, row string, opts ...ReadOption) (rowVal Row, err error) {
 	if t.readPool == nil {
 		return t.classic.ReadRow(ctx, row, opts...)
 	}
+
+	mt := t.classic.newBuiltinMetricsTracer(ctx, false)
+	defer mt.recordOperationCompletion()
+	mt.setMethod("ReadRows")
+	ctx = contextWithMetricsTracer(ctx, mt)
+
+	defer func() {
+		statusCode, _ := convertToGrpcStatusErr(err)
+		mt.setCurrOpStatus(statusCode)
+	}()
 
 	req := &btpb.ReadRowsRequest{
 		TableName: t.tableName,
@@ -76,6 +100,7 @@ func (t *SessionTable) ReadRow(ctx context.Context, row string, opts ...ReadOpti
 		InitialBackoff:    10 * time.Millisecond,
 		MaxBackoff:        100 * time.Millisecond,
 		BackoffMultiplier: 1.5,
+		Listener:          sessionMetricsListener{},
 	})
 
 	args := btransport.ReadRowArgs{
@@ -84,12 +109,19 @@ func (t *SessionTable) ReadRow(ctx context.Context, row string, opts ...ReadOpti
 	}
 
 	baseHandler := func(attemptCtx context.Context, request interface{}) (interface{}, error) {
+		if mt := metricsTracerFromContext(attemptCtx); mt != nil {
+			mt.recordClientBlockingLatency()
+		}
 		resp, clusterInfo, err := t.readPool.ExecuteVRpc(attemptCtx, t.readVRpcDesc, request)
 		if err != nil {
 			return nil, err
 		}
 		if clusterInfo != nil {
 			fmt.Printf(">>> SessionTable ReadRow attempt served by Cluster: Id=%s, Zone=%s <<<\n", clusterInfo.ClusterId, clusterInfo.ZoneId)
+			if mt := metricsTracerFromContext(attemptCtx); mt != nil {
+				mt.currOp.currAttempt.setClusterID(clusterInfo.ClusterId)
+				mt.currOp.currAttempt.setZoneID(clusterInfo.ZoneId)
+			}
 		}
 		return resp, nil
 	}
@@ -109,10 +141,20 @@ func (t *SessionTable) ReadRow(ctx context.Context, row string, opts ...ReadOpti
 }
 
 // Apply applies a single mutation via vRPC.
-func (t *SessionTable) Apply(ctx context.Context, row string, m *Mutation, opts ...ApplyOption) error {
+func (t *SessionTable) Apply(ctx context.Context, row string, m *Mutation, opts ...ApplyOption) (err error) {
 	if t.writePool == nil || m.isConditional {
 		return t.classic.Apply(ctx, row, m, opts...)
 	}
+
+	mt := t.classic.newBuiltinMetricsTracer(ctx, false)
+	defer mt.recordOperationCompletion()
+	mt.setMethod("MutateRow")
+	ctx = contextWithMetricsTracer(ctx, mt)
+
+	defer func() {
+		statusCode, _ := convertToGrpcStatusErr(err)
+		mt.setCurrOpStatus(statusCode)
+	}()
 
 	fmt.Printf(">>> SessionTable Apply: row=%s via writePool=%p <<<\n", row, t.writePool)
 
@@ -121,6 +163,7 @@ func (t *SessionTable) Apply(ctx context.Context, row string, m *Mutation, opts 
 		InitialBackoff:    10 * time.Millisecond,
 		MaxBackoff:        100 * time.Millisecond,
 		BackoffMultiplier: 1.5,
+		Listener:          sessionMetricsListener{},
 	})
 
 	args := btransport.MutateRowArgs{
@@ -129,18 +172,25 @@ func (t *SessionTable) Apply(ctx context.Context, row string, m *Mutation, opts 
 	}
 
 	baseHandler := func(attemptCtx context.Context, request interface{}) (interface{}, error) {
+		if mt := metricsTracerFromContext(attemptCtx); mt != nil {
+			mt.recordClientBlockingLatency()
+		}
 		resp, clusterInfo, err := t.writePool.ExecuteVRpc(attemptCtx, t.writeVRpcDesc, request)
 		if err != nil {
 			return nil, err
 		}
 		if clusterInfo != nil {
 			fmt.Printf(">>> SessionTable Apply attempt served by Cluster: Id=%s, Zone=%s <<<\n", clusterInfo.ClusterId, clusterInfo.ZoneId)
+			if mt := metricsTracerFromContext(attemptCtx); mt != nil {
+				mt.currOp.currAttempt.setClusterID(clusterInfo.ClusterId)
+				mt.currOp.currAttempt.setZoneID(clusterInfo.ZoneId)
+			}
 		}
 		return resp, nil
 	}
 
 	chained := btransport.ChainInterceptors(retryInterceptor)
-	_, err := chained(ctx, args, baseHandler)
+	_, err = chained(ctx, args, baseHandler)
 	if err != nil {
 		return fmt.Errorf("failed to execute MutateRow vRPC: %w", err)
 	}

--- a/bigtable/session_table.go
+++ b/bigtable/session_table.go
@@ -1,0 +1,197 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bigtable
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	btpb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
+	btransport "cloud.google.com/go/bigtable/internal/transport"
+)
+
+// SessionTable implements TableAPI by routing calls via virtual RPCs through dedicated session pools.
+type SessionTable struct {
+	tableName     string
+	classic       TableAPI
+	readPool      *btransport.SessionPoolImpl
+	writePool     *btransport.SessionPoolImpl
+	readVRpcDesc  btransport.VRpcDescriptor
+	writeVRpcDesc btransport.VRpcDescriptor
+}
+
+// NewSessionTable creates a new SessionTable instance.
+func NewSessionTable(
+	tableName string,
+	classic TableAPI,
+	readPool *btransport.SessionPoolImpl,
+	writePool *btransport.SessionPoolImpl,
+	readVRpcDesc btransport.VRpcDescriptor,
+	writeVRpcDesc btransport.VRpcDescriptor,
+) *SessionTable {
+	return &SessionTable{
+		tableName:     tableName,
+		classic:       classic,
+		readPool:      readPool,
+		writePool:     writePool,
+		readVRpcDesc:  readVRpcDesc,
+		writeVRpcDesc: writeVRpcDesc,
+	}
+}
+
+// ReadRow reads a single row via vRPC.
+func (t *SessionTable) ReadRow(ctx context.Context, row string, opts ...ReadOption) (Row, error) {
+	if t.readPool == nil {
+		return t.classic.ReadRow(ctx, row, opts...)
+	}
+
+	req := &btpb.ReadRowsRequest{
+		TableName: t.tableName,
+		Rows: &btpb.RowSet{
+			RowKeys: [][]byte{[]byte(row)},
+		},
+	}
+	settings := makeReadSettings(req, 0)
+	for _, opt := range opts {
+		opt.set(&settings)
+	}
+
+	fmt.Printf(">>> SessionTable ReadRow: row=%s via readPool=%p <<<\n", row, t.readPool)
+
+	retryInterceptor := btransport.RetryingVRpc(btransport.RetryingOptions{
+		MaxAttempts:       10, // Up to 10 attempts (initial attempt + 9 retries)
+		InitialBackoff:    10 * time.Millisecond,
+		MaxBackoff:        100 * time.Millisecond,
+		BackoffMultiplier: 1.5,
+	})
+
+	args := btransport.ReadRowArgs{
+		RowKey: row,
+		Filter: req.Filter,
+	}
+
+	baseHandler := func(attemptCtx context.Context, request interface{}) (interface{}, error) {
+		resp, clusterInfo, err := t.readPool.ExecuteVRpc(attemptCtx, t.readVRpcDesc, request)
+		if err != nil {
+			return nil, err
+		}
+		if clusterInfo != nil {
+			fmt.Printf(">>> SessionTable ReadRow attempt served by Cluster: Id=%s, Zone=%s <<<\n", clusterInfo.ClusterId, clusterInfo.ZoneId)
+		}
+		return resp, nil
+	}
+
+	chained := btransport.ChainInterceptors(retryInterceptor)
+	res, err := chained(ctx, args, baseHandler)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute ReadRow vRPC: %w", err)
+	}
+
+	readResult, ok := res.(btransport.ReadRowResult)
+	if !ok {
+		return nil, fmt.Errorf("unexpected response type from vRPC: %T", res)
+	}
+
+	return protoRowToRow(readResult.Row), nil
+}
+
+// Apply applies a single mutation via vRPC.
+func (t *SessionTable) Apply(ctx context.Context, row string, m *Mutation, opts ...ApplyOption) error {
+	if t.writePool == nil || m.isConditional {
+		return t.classic.Apply(ctx, row, m, opts...)
+	}
+
+	fmt.Printf(">>> SessionTable Apply: row=%s via writePool=%p <<<\n", row, t.writePool)
+
+	retryInterceptor := btransport.RetryingVRpc(btransport.RetryingOptions{
+		MaxAttempts:       10, // Up to 10 attempts
+		InitialBackoff:    10 * time.Millisecond,
+		MaxBackoff:        100 * time.Millisecond,
+		BackoffMultiplier: 1.5,
+	})
+
+	args := btransport.MutateRowArgs{
+		RowKey:    row,
+		Mutations: m.ops,
+	}
+
+	baseHandler := func(attemptCtx context.Context, request interface{}) (interface{}, error) {
+		resp, clusterInfo, err := t.writePool.ExecuteVRpc(attemptCtx, t.writeVRpcDesc, request)
+		if err != nil {
+			return nil, err
+		}
+		if clusterInfo != nil {
+			fmt.Printf(">>> SessionTable Apply attempt served by Cluster: Id=%s, Zone=%s <<<\n", clusterInfo.ClusterId, clusterInfo.ZoneId)
+		}
+		return resp, nil
+	}
+
+	chained := btransport.ChainInterceptors(retryInterceptor)
+	_, err := chained(ctx, args, baseHandler)
+	if err != nil {
+		return fmt.Errorf("failed to execute MutateRow vRPC: %w", err)
+	}
+
+	return nil
+}
+
+// ReadRows delegates to classic TableAPI.
+func (t *SessionTable) ReadRows(ctx context.Context, arg RowSet, f func(Row) bool, opts ...ReadOption) error {
+	return t.classic.ReadRows(ctx, arg, f, opts...)
+}
+
+// SampleRowKeys delegates to classic TableAPI.
+func (t *SessionTable) SampleRowKeys(ctx context.Context) ([]string, error) {
+	return t.classic.SampleRowKeys(ctx)
+}
+
+// ApplyBulk delegates to classic TableAPI.
+func (t *SessionTable) ApplyBulk(ctx context.Context, rowKeys []string, muts []*Mutation, opts ...ApplyOption) ([]error, error) {
+	return t.classic.ApplyBulk(ctx, rowKeys, muts, opts...)
+}
+
+// ApplyReadModifyWrite delegates to classic TableAPI.
+func (t *SessionTable) ApplyReadModifyWrite(ctx context.Context, row string, m *ReadModifyWrite) (Row, error) {
+	return t.classic.ApplyReadModifyWrite(ctx, row, m)
+}
+
+func protoRowToRow(pr *btpb.Row) Row {
+	if pr == nil {
+		return nil
+	}
+	rowMap := make(Row)
+	rowKey := string(pr.Key)
+	for _, fam := range pr.Families {
+		familyName := fam.Name
+		for _, col := range fam.Columns {
+			columnName := familyName + ":" + string(col.Qualifier)
+			var items []ReadItem
+			for _, cell := range col.Cells {
+				items = append(items, ReadItem{
+					Row:       rowKey,
+					Column:    columnName,
+					Timestamp: Timestamp(cell.TimestampMicros),
+					Value:     cell.Value,
+					Labels:    cell.Labels,
+				})
+			}
+			if len(items) > 0 {
+				rowMap[familyName] = append(rowMap[familyName], items...)
+			}
+		}
+	}
+	return rowMap
+}

--- a/bigtable/table_shim.go
+++ b/bigtable/table_shim.go
@@ -1,3 +1,17 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package bigtable
 
 import (

--- a/bigtable/table_shim.go
+++ b/bigtable/table_shim.go
@@ -39,15 +39,7 @@ func NewTableShim(classic, session TableAPI, diverter *internal.Diverter) TableA
 // ReadRow implements TableAPI.
 func (t *TableShim) ReadRow(ctx context.Context, row string, opts ...ReadOption) (Row, error) {
 	if t.diverter.UseSession() {
-		rowRes, err := t.session.ReadRow(ctx, row, opts...)
-		if err != nil {
-			// Do not fall back to classic if the session call failed because the context was cancelled or timed out.
-			if ctx.Err() != nil {
-				return nil, err
-			}
-			return t.classic.ReadRow(ctx, row, opts...)
-		}
-		return rowRes, nil
+		return t.session.ReadRow(ctx, row, opts...)
 	}
 	return t.classic.ReadRow(ctx, row, opts...)
 }
@@ -55,15 +47,7 @@ func (t *TableShim) ReadRow(ctx context.Context, row string, opts ...ReadOption)
 // Apply implements TableAPI.
 func (t *TableShim) Apply(ctx context.Context, row string, m *Mutation, opts ...ApplyOption) error {
 	if t.diverter.UseSession() {
-		err := t.session.Apply(ctx, row, m, opts...)
-		if err != nil {
-			// Do not fall back to classic if the session call failed because the context was cancelled or timed out.
-			if ctx.Err() != nil {
-				return err
-			}
-			return t.classic.Apply(ctx, row, m, opts...)
-		}
-		return nil
+		return t.session.Apply(ctx, row, m, opts...)
 	}
 	return t.classic.Apply(ctx, row, m, opts...)
 }

--- a/bigtable/table_shim.go
+++ b/bigtable/table_shim.go
@@ -1,0 +1,75 @@
+package bigtable
+
+import (
+	"context"
+
+	internal "cloud.google.com/go/bigtable/internal/transport"
+)
+
+// TableShim wraps a classic and a session-based TableAPI and diverts traffic between them.
+type TableShim struct {
+	classic  TableAPI
+	session  TableAPI
+	diverter *internal.Diverter
+}
+
+// NewTableShim creates a new TableShim.
+func NewTableShim(classic, session TableAPI, diverter *internal.Diverter) TableAPI {
+	return &TableShim{
+		classic:  classic,
+		session:  session,
+		diverter: diverter,
+	}
+}
+
+// ReadRow implements TableAPI.
+func (t *TableShim) ReadRow(ctx context.Context, row string, opts ...ReadOption) (Row, error) {
+	if t.diverter.UseSession() {
+		rowRes, err := t.session.ReadRow(ctx, row, opts...)
+		if err != nil {
+			// Do not fall back to classic if the session call failed because the context was cancelled or timed out.
+			if ctx.Err() != nil {
+				return nil, err
+			}
+			return t.classic.ReadRow(ctx, row, opts...)
+		}
+		return rowRes, nil
+	}
+	return t.classic.ReadRow(ctx, row, opts...)
+}
+
+// Apply implements TableAPI.
+func (t *TableShim) Apply(ctx context.Context, row string, m *Mutation, opts ...ApplyOption) error {
+	if t.diverter.UseSession() {
+		err := t.session.Apply(ctx, row, m, opts...)
+		if err != nil {
+			// Do not fall back to classic if the session call failed because the context was cancelled or timed out.
+			if ctx.Err() != nil {
+				return err
+			}
+			return t.classic.Apply(ctx, row, m, opts...)
+		}
+		return nil
+	}
+	return t.classic.Apply(ctx, row, m, opts...)
+}
+
+// ReadRows implements TableAPI. It delegates to classic as session support is not yet implemented.
+func (t *TableShim) ReadRows(ctx context.Context, arg RowSet, f func(Row) bool, opts ...ReadOption) error {
+	return t.classic.ReadRows(ctx, arg, f, opts...)
+}
+
+// SampleRowKeys implements TableAPI. It delegates to classic.
+func (t *TableShim) SampleRowKeys(ctx context.Context) ([]string, error) {
+	return t.classic.SampleRowKeys(ctx)
+}
+
+// ApplyBulk implements TableAPI. It delegates to classic.
+func (t *TableShim) ApplyBulk(ctx context.Context, rowKeys []string, muts []*Mutation, opts ...ApplyOption) ([]error, error) {
+	return t.classic.ApplyBulk(ctx, rowKeys, muts, opts...)
+}
+
+// ApplyReadModifyWrite implements TableAPI. It delegates to classic.
+func (t *TableShim) ApplyReadModifyWrite(ctx context.Context, row string, m *ReadModifyWrite) (Row, error) {
+	return t.classic.ApplyReadModifyWrite(ctx, row, m)
+}

--- a/bigtable/table_shim_test.go
+++ b/bigtable/table_shim_test.go
@@ -147,7 +147,7 @@ func TestTableShim_ReadRow(t *testing.T) {
 		}
 	})
 
-	t.Run("Session fails and falls back to classic when context is NOT cancelled", func(t *testing.T) {
+	t.Run("Session fails and returns error directly without falling back to classic", func(t *testing.T) {
 		classicCalled := false
 		sessionCalled := false
 
@@ -167,50 +167,12 @@ func TestTableShim_ReadRow(t *testing.T) {
 		diverter := internal.NewDiverter(1.0)
 		shim := NewTableShim(classic, session, diverter)
 
-		res, err := shim.ReadRow(context.Background(), "row1")
-		if err != nil {
-			t.Errorf("Unexpected error: %v", err)
-		}
-		if res.Key() != "row1" {
-			t.Errorf("Expected row key row1, got %s", res.Key())
-		}
-		if !classicCalled {
-			t.Error("Expected classic to be called on fallback")
-		}
-		if !sessionCalled {
-			t.Error("Expected session to be called first")
-		}
-	})
-
-	t.Run("Session fails and does NOT fall back when context IS cancelled", func(t *testing.T) {
-		classicCalled := false
-		sessionCalled := false
-
-		classic := &mockTableAPI{
-			readRowFunc: func(ctx context.Context, row string, opts ...ReadOption) (Row, error) {
-				classicCalled = true
-				return dummyRow, nil
-			},
-		}
-		session := &mockTableAPI{
-			readRowFunc: func(ctx context.Context, row string, opts ...ReadOption) (Row, error) {
-				sessionCalled = true
-				return nil, dummyErr
-			},
-		}
-
-		diverter := internal.NewDiverter(1.0)
-		shim := NewTableShim(classic, session, diverter)
-
-		ctx, cancel := context.WithCancel(context.Background())
-		cancel() // Cancel the context immediately
-
-		_, err := shim.ReadRow(ctx, "row1")
+		_, err := shim.ReadRow(context.Background(), "row1")
 		if err != dummyErr {
 			t.Errorf("Expected session error %v, got %v", dummyErr, err)
 		}
 		if classicCalled {
-			t.Error("Expected classic NOT to be called when context is cancelled")
+			t.Error("Expected classic NOT to be called")
 		}
 		if !sessionCalled {
 			t.Error("Expected session to be called")
@@ -285,7 +247,7 @@ func TestTableShim_Apply(t *testing.T) {
 		}
 	})
 
-	t.Run("Session fails and falls back to classic when context is NOT cancelled", func(t *testing.T) {
+	t.Run("Session fails and returns error directly without falling back to classic", func(t *testing.T) {
 		classicCalled := false
 		sessionCalled := false
 
@@ -306,46 +268,11 @@ func TestTableShim_Apply(t *testing.T) {
 		shim := NewTableShim(classic, session, diverter)
 
 		err := shim.Apply(context.Background(), "row1", NewMutation())
-		if err != nil {
-			t.Errorf("Unexpected error: %v", err)
-		}
-		if !classicCalled {
-			t.Error("Expected classic to be called on fallback")
-		}
-		if !sessionCalled {
-			t.Error("Expected session to be called first")
-		}
-	})
-
-	t.Run("Session fails and does NOT fall back when context IS cancelled", func(t *testing.T) {
-		classicCalled := false
-		sessionCalled := false
-
-		classic := &mockTableAPI{
-			applyFunc: func(ctx context.Context, row string, m *Mutation, opts ...ApplyOption) error {
-				classicCalled = true
-				return nil
-			},
-		}
-		session := &mockTableAPI{
-			applyFunc: func(ctx context.Context, row string, m *Mutation, opts ...ApplyOption) error {
-				sessionCalled = true
-				return dummyErr
-			},
-		}
-
-		diverter := internal.NewDiverter(1.0)
-		shim := NewTableShim(classic, session, diverter)
-
-		ctx, cancel := context.WithCancel(context.Background())
-		cancel() // Cancel the context immediately
-
-		err := shim.Apply(ctx, "row1", NewMutation())
 		if err != dummyErr {
 			t.Errorf("Expected session error %v, got %v", dummyErr, err)
 		}
 		if classicCalled {
-			t.Error("Expected classic NOT to be called when context is cancelled")
+			t.Error("Expected classic NOT to be called")
 		}
 		if !sessionCalled {
 			t.Error("Expected session to be called")

--- a/bigtable/table_shim_test.go
+++ b/bigtable/table_shim_test.go
@@ -1,0 +1,430 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bigtable
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	internal "cloud.google.com/go/bigtable/internal/transport"
+)
+
+type mockTableAPI struct {
+	readRowFunc              func(ctx context.Context, row string, opts ...ReadOption) (Row, error)
+	applyFunc                func(ctx context.Context, row string, m *Mutation, opts ...ApplyOption) error
+	readRowsFunc             func(ctx context.Context, arg RowSet, f func(Row) bool, opts ...ReadOption) error
+	sampleRowKeysFunc        func(ctx context.Context) ([]string, error)
+	applyBulkFunc            func(ctx context.Context, rowKeys []string, muts []*Mutation, opts ...ApplyOption) ([]error, error)
+	applyReadModifyWriteFunc func(ctx context.Context, row string, m *ReadModifyWrite) (Row, error)
+}
+
+func (m *mockTableAPI) ReadRows(ctx context.Context, arg RowSet, f func(Row) bool, opts ...ReadOption) error {
+	if m.readRowsFunc != nil {
+		return m.readRowsFunc(ctx, arg, f, opts...)
+	}
+	return nil
+}
+
+func (m *mockTableAPI) ReadRow(ctx context.Context, row string, opts ...ReadOption) (Row, error) {
+	if m.readRowFunc != nil {
+		return m.readRowFunc(ctx, row, opts...)
+	}
+	return nil, nil
+}
+
+func (m *mockTableAPI) SampleRowKeys(ctx context.Context) ([]string, error) {
+	if m.sampleRowKeysFunc != nil {
+		return m.sampleRowKeysFunc(ctx)
+	}
+	return nil, nil
+}
+
+func (m *mockTableAPI) Apply(ctx context.Context, row string, mutation *Mutation, opts ...ApplyOption) error {
+	if m.applyFunc != nil {
+		return m.applyFunc(ctx, row, mutation, opts...)
+	}
+	return nil
+}
+
+func (m *mockTableAPI) ApplyBulk(ctx context.Context, rowKeys []string, muts []*Mutation, opts ...ApplyOption) ([]error, error) {
+	if m.applyBulkFunc != nil {
+		return m.applyBulkFunc(ctx, rowKeys, muts, opts...)
+	}
+	return nil, nil
+}
+
+func (m *mockTableAPI) ApplyReadModifyWrite(ctx context.Context, row string, rmw *ReadModifyWrite) (Row, error) {
+	if m.applyReadModifyWriteFunc != nil {
+		return m.applyReadModifyWriteFunc(ctx, row, rmw)
+	}
+	return nil, nil
+}
+
+func TestTableShim_ReadRow(t *testing.T) {
+	dummyRow := Row{"fam": []ReadItem{{Row: "row1"}}}
+	dummyErr := errors.New("dummy error")
+
+	t.Run("Classic only when UseSession is false", func(t *testing.T) {
+		classicCalled := false
+		sessionCalled := false
+
+		classic := &mockTableAPI{
+			readRowFunc: func(ctx context.Context, row string, opts ...ReadOption) (Row, error) {
+				classicCalled = true
+				return dummyRow, nil
+			},
+		}
+		session := &mockTableAPI{
+			readRowFunc: func(ctx context.Context, row string, opts ...ReadOption) (Row, error) {
+				sessionCalled = true
+				return nil, dummyErr
+			},
+		}
+
+		diverter := internal.NewDiverter(0.0) // 0% load
+		shim := NewTableShim(classic, session, diverter)
+
+		res, err := shim.ReadRow(context.Background(), "row1")
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+		if res.Key() != "row1" {
+			t.Errorf("Expected row key row1, got %s", res.Key())
+		}
+		if !classicCalled {
+			t.Error("Expected classic to be called")
+		}
+		if sessionCalled {
+			t.Error("Expected session NOT to be called")
+		}
+	})
+
+	t.Run("Session only when UseSession is true and succeeds", func(t *testing.T) {
+		classicCalled := false
+		sessionCalled := false
+
+		classic := &mockTableAPI{
+			readRowFunc: func(ctx context.Context, row string, opts ...ReadOption) (Row, error) {
+				classicCalled = true
+				return nil, dummyErr
+			},
+		}
+		session := &mockTableAPI{
+			readRowFunc: func(ctx context.Context, row string, opts ...ReadOption) (Row, error) {
+				sessionCalled = true
+				return dummyRow, nil
+			},
+		}
+
+		diverter := internal.NewDiverter(1.0) // 100% load
+		shim := NewTableShim(classic, session, diverter)
+
+		res, err := shim.ReadRow(context.Background(), "row1")
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+		if res.Key() != "row1" {
+			t.Errorf("Expected row key row1, got %s", res.Key())
+		}
+		if classicCalled {
+			t.Error("Expected classic NOT to be called")
+		}
+		if !sessionCalled {
+			t.Error("Expected session to be called")
+		}
+	})
+
+	t.Run("Session fails and falls back to classic when context is NOT cancelled", func(t *testing.T) {
+		classicCalled := false
+		sessionCalled := false
+
+		classic := &mockTableAPI{
+			readRowFunc: func(ctx context.Context, row string, opts ...ReadOption) (Row, error) {
+				classicCalled = true
+				return dummyRow, nil
+			},
+		}
+		session := &mockTableAPI{
+			readRowFunc: func(ctx context.Context, row string, opts ...ReadOption) (Row, error) {
+				sessionCalled = true
+				return nil, dummyErr
+			},
+		}
+
+		diverter := internal.NewDiverter(1.0)
+		shim := NewTableShim(classic, session, diverter)
+
+		res, err := shim.ReadRow(context.Background(), "row1")
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+		if res.Key() != "row1" {
+			t.Errorf("Expected row key row1, got %s", res.Key())
+		}
+		if !classicCalled {
+			t.Error("Expected classic to be called on fallback")
+		}
+		if !sessionCalled {
+			t.Error("Expected session to be called first")
+		}
+	})
+
+	t.Run("Session fails and does NOT fall back when context IS cancelled", func(t *testing.T) {
+		classicCalled := false
+		sessionCalled := false
+
+		classic := &mockTableAPI{
+			readRowFunc: func(ctx context.Context, row string, opts ...ReadOption) (Row, error) {
+				classicCalled = true
+				return dummyRow, nil
+			},
+		}
+		session := &mockTableAPI{
+			readRowFunc: func(ctx context.Context, row string, opts ...ReadOption) (Row, error) {
+				sessionCalled = true
+				return nil, dummyErr
+			},
+		}
+
+		diverter := internal.NewDiverter(1.0)
+		shim := NewTableShim(classic, session, diverter)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // Cancel the context immediately
+
+		_, err := shim.ReadRow(ctx, "row1")
+		if err != dummyErr {
+			t.Errorf("Expected session error %v, got %v", dummyErr, err)
+		}
+		if classicCalled {
+			t.Error("Expected classic NOT to be called when context is cancelled")
+		}
+		if !sessionCalled {
+			t.Error("Expected session to be called")
+		}
+	})
+}
+
+func TestTableShim_Apply(t *testing.T) {
+	dummyErr := errors.New("dummy error")
+
+	t.Run("Classic only when UseSession is false", func(t *testing.T) {
+		classicCalled := false
+		sessionCalled := false
+
+		classic := &mockTableAPI{
+			applyFunc: func(ctx context.Context, row string, m *Mutation, opts ...ApplyOption) error {
+				classicCalled = true
+				return nil
+			},
+		}
+		session := &mockTableAPI{
+			applyFunc: func(ctx context.Context, row string, m *Mutation, opts ...ApplyOption) error {
+				sessionCalled = true
+				return dummyErr
+			},
+		}
+
+		diverter := internal.NewDiverter(0.0)
+		shim := NewTableShim(classic, session, diverter)
+
+		err := shim.Apply(context.Background(), "row1", NewMutation())
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+		if !classicCalled {
+			t.Error("Expected classic to be called")
+		}
+		if sessionCalled {
+			t.Error("Expected session NOT to be called")
+		}
+	})
+
+	t.Run("Session only when UseSession is true and succeeds", func(t *testing.T) {
+		classicCalled := false
+		sessionCalled := false
+
+		classic := &mockTableAPI{
+			applyFunc: func(ctx context.Context, row string, m *Mutation, opts ...ApplyOption) error {
+				classicCalled = true
+				return dummyErr
+			},
+		}
+		session := &mockTableAPI{
+			applyFunc: func(ctx context.Context, row string, m *Mutation, opts ...ApplyOption) error {
+				sessionCalled = true
+				return nil
+			},
+		}
+
+		diverter := internal.NewDiverter(1.0)
+		shim := NewTableShim(classic, session, diverter)
+
+		err := shim.Apply(context.Background(), "row1", NewMutation())
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+		if classicCalled {
+			t.Error("Expected classic NOT to be called")
+		}
+		if !sessionCalled {
+			t.Error("Expected session to be called")
+		}
+	})
+
+	t.Run("Session fails and falls back to classic when context is NOT cancelled", func(t *testing.T) {
+		classicCalled := false
+		sessionCalled := false
+
+		classic := &mockTableAPI{
+			applyFunc: func(ctx context.Context, row string, m *Mutation, opts ...ApplyOption) error {
+				classicCalled = true
+				return nil
+			},
+		}
+		session := &mockTableAPI{
+			applyFunc: func(ctx context.Context, row string, m *Mutation, opts ...ApplyOption) error {
+				sessionCalled = true
+				return dummyErr
+			},
+		}
+
+		diverter := internal.NewDiverter(1.0)
+		shim := NewTableShim(classic, session, diverter)
+
+		err := shim.Apply(context.Background(), "row1", NewMutation())
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+		if !classicCalled {
+			t.Error("Expected classic to be called on fallback")
+		}
+		if !sessionCalled {
+			t.Error("Expected session to be called first")
+		}
+	})
+
+	t.Run("Session fails and does NOT fall back when context IS cancelled", func(t *testing.T) {
+		classicCalled := false
+		sessionCalled := false
+
+		classic := &mockTableAPI{
+			applyFunc: func(ctx context.Context, row string, m *Mutation, opts ...ApplyOption) error {
+				classicCalled = true
+				return nil
+			},
+		}
+		session := &mockTableAPI{
+			applyFunc: func(ctx context.Context, row string, m *Mutation, opts ...ApplyOption) error {
+				sessionCalled = true
+				return dummyErr
+			},
+		}
+
+		diverter := internal.NewDiverter(1.0)
+		shim := NewTableShim(classic, session, diverter)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // Cancel the context immediately
+
+		err := shim.Apply(ctx, "row1", NewMutation())
+		if err != dummyErr {
+			t.Errorf("Expected session error %v, got %v", dummyErr, err)
+		}
+		if classicCalled {
+			t.Error("Expected classic NOT to be called when context is cancelled")
+		}
+		if !sessionCalled {
+			t.Error("Expected session to be called")
+		}
+	})
+}
+
+func TestTableShim_DelegatedMethods(t *testing.T) {
+	classicCalled := false
+	sessionCalled := false
+
+	classic := &mockTableAPI{
+		readRowsFunc: func(ctx context.Context, arg RowSet, f func(Row) bool, opts ...ReadOption) error {
+			classicCalled = true
+			return nil
+		},
+		sampleRowKeysFunc: func(ctx context.Context) ([]string, error) {
+			classicCalled = true
+			return nil, nil
+		},
+		applyBulkFunc: func(ctx context.Context, rowKeys []string, muts []*Mutation, opts ...ApplyOption) ([]error, error) {
+			classicCalled = true
+			return nil, nil
+		},
+		applyReadModifyWriteFunc: func(ctx context.Context, row string, m *ReadModifyWrite) (Row, error) {
+			classicCalled = true
+			return nil, nil
+		},
+	}
+	session := &mockTableAPI{
+		readRowsFunc: func(ctx context.Context, arg RowSet, f func(Row) bool, opts ...ReadOption) error {
+			sessionCalled = true
+			return nil
+		},
+		sampleRowKeysFunc: func(ctx context.Context) ([]string, error) {
+			sessionCalled = true
+			return nil, nil
+		},
+		applyBulkFunc: func(ctx context.Context, rowKeys []string, muts []*Mutation, opts ...ApplyOption) ([]error, error) {
+			sessionCalled = true
+			return nil, nil
+		},
+		applyReadModifyWriteFunc: func(ctx context.Context, row string, m *ReadModifyWrite) (Row, error) {
+			sessionCalled = true
+			return nil, nil
+		},
+	}
+
+	diverter := internal.NewDiverter(1.0) // Even with 100% session load, these delegate to classic
+	shim := NewTableShim(classic, session, diverter)
+
+	// ReadRows
+	classicCalled = false
+	_ = shim.ReadRows(context.Background(), RowRange{}, func(r Row) bool { return true })
+	if !classicCalled || sessionCalled {
+		t.Errorf("ReadRows: expected classic called: %v, session called: %v", classicCalled, sessionCalled)
+	}
+
+	// SampleRowKeys
+	classicCalled = false
+	sessionCalled = false
+	_, _ = shim.SampleRowKeys(context.Background())
+	if !classicCalled || sessionCalled {
+		t.Errorf("SampleRowKeys: expected classic called: %v, session called: %v", classicCalled, sessionCalled)
+	}
+
+	// ApplyBulk
+	classicCalled = false
+	sessionCalled = false
+	_, _ = shim.ApplyBulk(context.Background(), nil, nil)
+	if !classicCalled || sessionCalled {
+		t.Errorf("ApplyBulk: expected classic called: %v, session called: %v", classicCalled, sessionCalled)
+	}
+
+	// ApplyReadModifyWrite
+	classicCalled = false
+	sessionCalled = false
+	_, _ = shim.ApplyReadModifyWrite(context.Background(), "row1", nil)
+	if !classicCalled || sessionCalled {
+		t.Errorf("ApplyReadModifyWrite: expected classic called: %v, session called: %v", classicCalled, sessionCalled)
+	}
+}


### PR DESCRIPTION
Decouples metrics tracer from direct method signatures using context propagation and adds client-side attempt metric support for virtual RPCs.