### PR TITLE
chore: librarian release pull request: 20260601T064138Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -5899,7 +5899,7 @@ libraries:
       - internal/generated/snippets/speech/
     tag_format: '{id}/v{version}'
   - id: storage
-    version: 1.61.4
+    version: 1.61.5
     last_generated_commit: 9eea40c74d97622bb0aa406dd313409a376cc73b
     apis:
       - path: google/storage/control/v2

--- a/internal/generated/snippets/storage/control/apiv2/snippet_metadata.google.storage.control.v2.json
+++ b/internal/generated/snippets/storage/control/apiv2/snippet_metadata.google.storage.control.v2.json
@@ -1,7 +1,7 @@
 {
   "clientLibrary": {
     "name": "cloud.google.com/go/storage/control/apiv2",
-    "version": "1.61.4",
+    "version": "1.61.5",
     "language": "GO",
     "apis": [
       {

--- a/storage/CHANGES.md
+++ b/storage/CHANGES.md
@@ -1,6 +1,12 @@
 # Changes
 
 
+## [1.61.5](https://github.com/googleapis/google-cloud-go/releases/tag/storage%2Fv1.61.5) (2026-06-01)
+
+### Bug Fixes
+
+* fix race condition during retries in gRPC writer (#14649) ([e87213b](https://github.com/googleapis/google-cloud-go/commit/e87213b78affff3aafb6ee0ecd542d65719e5c5c))
+
 ## [1.61.4](https://github.com/googleapis/google-cloud-go/releases/tag/storage%2Fv1.61.4) (2026-05-21)
 
 ### Bug Fixes

--- a/storage/internal/version.go
+++ b/storage/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "1.61.4"
+const Version = "1.61.5"


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.15.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go@sha256:19bb93e8f1f916c61b597db2bad65dc432f79baaabb210499d7d0e4ad1dffe29
<details><summary>storage: v1.61.5</summary>

## [v1.61.5](https://github.com/googleapis/google-cloud-go/compare/storage/v1.61.4...storage/v1.61.5) (2026-06-01)

### Bug Fixes

* fix race condition during retries in gRPC writer (#14649) ([e87213b7](https://github.com/googleapis/google-cloud-go/commit/e87213b7))

</details>