### PR TITLE
chore: librarian release pull request: 20260602T195727Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1902,7 +1902,7 @@ libraries:
       - internal/generated/snippets/networkmanagement/
     tag_format: '{id}/v{version}'
   - id: networksecurity
-    version: 0.16.0
+    version: 0.17.0
     last_generated_commit: ""
     apis:
       - path: google/cloud/networksecurity/v1beta1

--- a/internal/generated/snippets/networksecurity/apiv1/snippet_metadata.google.cloud.networksecurity.v1.json
+++ b/internal/generated/snippets/networksecurity/apiv1/snippet_metadata.google.cloud.networksecurity.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/networksecurity/apiv1",
-    "version": "0.16.0"
+    "version": "0.17.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/networksecurity/apiv1beta1/snippet_metadata.google.cloud.networksecurity.v1beta1.json
+++ b/internal/generated/snippets/networksecurity/apiv1beta1/snippet_metadata.google.cloud.networksecurity.v1beta1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/networksecurity/apiv1beta1",
-    "version": "0.16.0"
+    "version": "0.17.0"
   },
   "snippets": [
     {

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -998,7 +998,7 @@ libraries:
     apis:
       - path: google/cloud/networkmanagement/v1
   - name: networksecurity
-    version: 0.16.0
+    version: 0.17.0
     apis:
       - path: google/cloud/networksecurity/v1
       - path: google/cloud/networksecurity/v1beta1

--- a/networksecurity/CHANGES.md
+++ b/networksecurity/CHANGES.md
@@ -1,5 +1,7 @@
 # Changes
 
+## [0.17.0](https://github.com/googleapis/google-cloud-go/releases/tag/networksecurity%2Fv0.17.0) (2026-06-02)
+
 ## [0.16.0](https://github.com/googleapis/google-cloud-go/releases/tag/networksecurity%2Fv0.16.0) (2026-05-07)
 
 ## [0.15.0](https://github.com/googleapis/google-cloud-go/releases/tag/networksecurity%2Fv0.15.0) (2026-04-30)

--- a/networksecurity/internal/version.go
+++ b/networksecurity/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "0.16.0"
+const Version = "0.17.0"


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.15.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go@sha256:b04b076f5eedbb5546bd6fc1404969dd3698c8b19c0f34ae815a84ae735a606a
<details><summary>networksecurity: v0.17.0</summary>

## [v0.17.0](https://github.com/googleapis/google-cloud-go/compare/networksecurity/v0.16.0...networksecurity/v0.17.0) (2026-06-02)

</details>

b/515492611
