### PR TITLE
chore: librarian release pull request: 20260603T093646Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -2681,7 +2681,7 @@ libraries:
       - internal/generated/snippets/speech/
     tag_format: '{id}/v{version}'
   - id: storage
-    version: 1.62.2
+    version: 1.62.3
     last_generated_commit: ""
     apis:
       - path: google/storage/control/v2

--- a/internal/generated/snippets/storage/control/apiv2/snippet_metadata.google.storage.control.v2.json
+++ b/internal/generated/snippets/storage/control/apiv2/snippet_metadata.google.storage.control.v2.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/storage/control/apiv2",
-    "version": "1.62.2"
+    "version": "1.62.3"
   },
   "snippets": [
     {

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -2327,7 +2327,7 @@ libraries:
             - F_open_telemetry_attributes
             - F_proto_cloneof
   - name: storage
-    version: 1.62.2
+    version: 1.62.3
     apis:
       - path: google/storage/v2
         go:

--- a/storage/CHANGES.md
+++ b/storage/CHANGES.md
@@ -42,6 +42,18 @@
 
 * Update `EnableParallelUpload` documentation in `writer.go` (#14328) ([22d0749](http://github.com/googleapis/google-cloud-go/commit/22d0749f8fdbeaa34f2a836b63510bd0c3def990))
 
+## [1.61.5](https://github.com/googleapis/google-cloud-go/releases/tag/storage%2Fv1.61.5) (2026-06-01)
+
+### Bug Fixes
+
+* fix race condition during retries in gRPC writer (#14649) ([e87213b](https://github.com/googleapis/google-cloud-go/commit/e87213b78affff3aafb6ee0ecd542d65719e5c5c))
+
+## [1.61.4](https://github.com/googleapis/google-cloud-go/releases/tag/storage%2Fv1.61.4) (2026-05-21)
+
+### Bug Fixes
+
+* add server closed idle connection to retriable errors (#14594) ([37580e7](https://github.com/googleapis/google-cloud-go/commit/37580e7eb530bbcf54951425947060c51cb0b30a))
+
 ## [1.61.3](https://github.com/googleapis/google-cloud-go/releases/tag/storage%2Fv1.61.3) (2026-03-13)
 
 ### Documentation

--- a/storage/CHANGES.md
+++ b/storage/CHANGES.md
@@ -1,6 +1,13 @@
 # Changes
 
 
+## [1.62.3](https://github.com/googleapis/google-cloud-go/releases/tag/storage%2Fv1.62.3) (2026-06-03)
+
+### Bug Fixes
+
+* add server closed idle connection to retriable errors (#14594) ([20b37d6](https://github.com/googleapis/google-cloud-go/commit/20b37d65d56d4b5e7b8d43b1f6b2ddefcd8944be))
+* fix race condition during retries in gRPC writer (#14649) ([04b6c63](https://github.com/googleapis/google-cloud-go/commit/04b6c635c09de1772fcefd8a7fd5e4ffdd370b79))
+
 ## [1.62.2](https://github.com/googleapis/google-cloud-go/releases/tag/storage%2Fv1.62.2) (2026-05-18)
 
 ### Features

--- a/storage/internal/version.go
+++ b/storage/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "1.62.2"
+const Version = "1.62.3"


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.16.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go@sha256:b04b076f5eedbb5546bd6fc1404969dd3698c8b19c0f34ae815a84ae735a606a
<details><summary>storage: v1.62.3</summary>

## [v1.62.3](https://github.com/googleapis/google-cloud-go/compare/storage/v1.62.2...storage/v1.62.3) (2026-06-03)

### Bug Fixes

* fix race condition during retries in gRPC writer (#14649) ([04b6c635](https://github.com/googleapis/google-cloud-go/commit/04b6c635))

* add server closed idle connection to retriable errors (#14594) ([20b37d65](https://github.com/googleapis/google-cloud-go/commit/20b37d65))

</details>