### PR TITLE
chore: update librarian version

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 language: go
-version: v0.15.0
+version: v0.16.1-0.20260603141118-7278ace00162
 repo: googleapis/google-cloud-go
 sources:
   googleapis:

--- a/maps/README.md
+++ b/maps/README.md
@@ -32,7 +32,7 @@ or there is not yet a stable backend available.
 
 ## Google Cloud Samples
 
-To browse ready to use code samples check [Google Cloud Samples](https://cloud.google.com/docs/samples?l=go).
+To browse ready to use code samples check [Google Cloud Samples](https://developers.google.com/maps/documentation/places/web-service/client-library-examples#go).
 
 ## Go Version Support
 


### PR DESCRIPTION
Upgrade Librarian version to v0.16.1-0.20260603141118-7278ace00162 and generated code using it.