### PR TITLE
feat(storage): support deleteSourceObjects option in object compose

### DIFF
--- a/storage/client.go
+++ b/storage/client.go
@@ -357,11 +357,12 @@ type moveObjectParams struct {
 }
 
 type composeObjectRequest struct {
-	dstBucket     string
-	dstObject     destinationObject
-	srcs          []sourceObject
-	predefinedACL string
-	sendCRC32C    bool
+	dstBucket           string
+	dstObject           destinationObject
+	srcs                []sourceObject
+	predefinedACL       string
+	sendCRC32C          bool
+	deleteSourceObjects bool
 }
 
 type sourceObject struct {

--- a/storage/copy.go
+++ b/storage/copy.go
@@ -172,6 +172,10 @@ type Composer struct {
 	// the checksum, the compose will be rejected.
 	SendCRC32C bool
 
+	// DeleteSourceObjects specifies whether to delete the source objects after a
+	// successful composition.
+	DeleteSourceObjects bool
+
 	dst  *ObjectHandle
 	srcs []*ObjectHandle
 }
@@ -204,9 +208,10 @@ func (c *Composer) Run(ctx context.Context) (attrs *ObjectAttrs, err error) {
 	}
 
 	req := &composeObjectRequest{
-		dstBucket:     c.dst.bucket,
-		predefinedACL: c.PredefinedACL,
-		sendCRC32C:    c.SendCRC32C,
+		dstBucket:           c.dst.bucket,
+		predefinedACL:       c.PredefinedACL,
+		sendCRC32C:          c.SendCRC32C,
+		deleteSourceObjects: c.DeleteSourceObjects,
 	}
 	req.dstObject = destinationObject{
 		name:          c.dst.object,

--- a/storage/grpc_client.go
+++ b/storage/grpc_client.go
@@ -1055,6 +1055,9 @@ func (c *grpcStorageClient) ComposeObject(ctx context.Context, req *composeObjec
 		Destination:   dstObjPb,
 		SourceObjects: srcs,
 	}
+	if req.deleteSourceObjects {
+		rawReq.DeleteSourceObjects = proto.Bool(true)
+	}
 	if err := applyCondsProto("ComposeObject destination", defaultGen, req.dstObject.conds, rawReq); err != nil {
 		return nil, err
 	}

--- a/storage/http_client.go
+++ b/storage/http_client.go
@@ -767,7 +767,9 @@ func (c *httpStorageClient) UpdateObjectACL(ctx context.Context, bucket, object 
 
 func (c *httpStorageClient) ComposeObject(ctx context.Context, req *composeObjectRequest, opts ...storageOption) (*ObjectAttrs, error) {
 	s := callSettings(c.settings, opts...)
-	rawReq := &raw.ComposeRequest{}
+	rawReq := &raw.ComposeRequest{
+		DeleteSourceObjects: req.deleteSourceObjects,
+	}
 	// Compose requires a non-empty Destination, so we always set it,
 	// even if the caller-provided ObjectAttrs is the zero value.
 	rawReq.Destination = req.dstObject.attrs.toRawObject(req.dstBucket)

--- a/storage/integration_test.go
+++ b/storage/integration_test.go
@@ -2948,6 +2948,102 @@ func TestIntegration_ObjectCompose(t *testing.T) {
 	})
 }
 
+func TestIntegration_ObjectCompose_DeleteSourceObjects(t *testing.T) {
+	multiTransportTest(skipZonalBucket(context.Background(), "ZB does not support compose"), t, func(t *testing.T, ctx context.Context, bucket string, _ string, client *Client) {
+		b := client.Bucket(bucket)
+
+		testCases := []struct {
+			desc                string
+			deleteSourceObjects bool
+			wantSourcesDeleted  bool
+		}{
+			{
+				desc:                "delete source objects after compose",
+				deleteSourceObjects: true,
+				wantSourcesDeleted:  true,
+			},
+			{
+				desc:                "do not delete source objects after compose",
+				deleteSourceObjects: false,
+				wantSourcesDeleted:  false,
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.desc, func(t *testing.T) {
+				src1 := b.Object("delSrc1" + uidSpaceObjects.New())
+				src2 := b.Object("delSrc2" + uidSpaceObjects.New())
+
+				c1 := randomContents()
+				c2 := randomContents()
+				if err := writeObject(ctx, src1, "text/plain", c1); err != nil {
+					t.Fatalf("Write for %v failed with %v", src1, err)
+				}
+				if err := writeObject(ctx, src2, "text/plain", c2); err != nil {
+					t.Fatalf("Write for %v failed with %v", src2, err)
+				}
+				if !tc.wantSourcesDeleted {
+					defer src1.Delete(ctx)
+					defer src2.Delete(ctx)
+				}
+
+				compDst := b.Object("composedDel" + uidSpaceObjects.New())
+				c := compDst.ComposerFrom(src1, src2)
+				c.DeleteSourceObjects = tc.deleteSourceObjects
+				attrs, err := c.Run(ctx)
+				if err != nil {
+					t.Fatalf("ComposeFrom error: %v", err)
+				}
+				defer compDst.Delete(ctx)
+
+				if attrs.ComponentCount != 2 {
+					t.Errorf("ComponentCount = %v, want 2", attrs.ComponentCount)
+				}
+
+				// Verify source objects existence
+				_, err1 := src1.Attrs(ctx)
+				if tc.wantSourcesDeleted {
+					if err1 == nil {
+						t.Errorf("src1 still exists, expected it to be deleted")
+						src1.Delete(ctx)
+					}
+				} else {
+					if err1 != nil {
+						t.Errorf("src1 does not exist, expected it to exist: %v", err1)
+					}
+				}
+
+				_, err2 := src2.Attrs(ctx)
+				if tc.wantSourcesDeleted {
+					if err2 == nil {
+						t.Errorf("src2 still exists, expected it to be deleted")
+						src2.Delete(ctx)
+					}
+				} else {
+					if err2 != nil {
+						t.Errorf("src2 does not exist, expected it to exist: %v", err2)
+					}
+				}
+
+				// Verify contents of destination object.
+				r, err := compDst.NewReader(ctx)
+				if err != nil {
+					t.Fatalf("new reader on composed target: %v", err)
+				}
+				defer r.Close()
+				slurp, err := io.ReadAll(r)
+				if err != nil {
+					t.Fatalf("reading composed target: %v", err)
+				}
+				wantContents := append(c1, c2...)
+				if !bytes.Equal(slurp, wantContents) {
+					t.Errorf("Composed object contents mismatch:\ngot  %q\nwant %q", slurp, wantContents)
+				}
+			})
+		}
+	})
+}
+
 func TestIntegration_Copy(t *testing.T) {
 	ctx := skipExtraReadAPIs(context.Background(), "no reads in test")
 	multiTransportTest(ctx, t, func(t *testing.T, ctx context.Context, bucket string, prefix string, client *Client) {

--- a/storage/integration_test.go
+++ b/storage/integration_test.go
@@ -3009,23 +3009,23 @@ func TestIntegration_ObjectCompose_DeleteSourceObjects(t *testing.T) {
 				// Verify source objects existence
 				_, err1 := src1.Attrs(ctx)
 				if tc.wantSourcesDeleted {
-					if err1 == nil {
-						t.Errorf("src1 still exists, expected it to be deleted")
+					if !errors.Is(err1, ErrObjectNotExist) {
+						t.Errorf("src1 still exists, expected it to be deleted. Err: %v", err1)
 					}
 				} else {
 					if err1 != nil {
-						t.Errorf("src1 does not exist, expected it to exist: %v", err1)
+						t.Errorf("Error: src1.Attrs(): %v", err1)
 					}
 				}
 
 				_, err2 := src2.Attrs(ctx)
 				if tc.wantSourcesDeleted {
-					if err2 == nil {
-						t.Errorf("src2 still exists, expected it to be deleted")
+					if !errors.Is(err2, ErrObjectNotExist) {
+						t.Errorf("src2 still exists, expected it to be deleted. Err: %v", err2)
 					}
 				} else {
 					if err2 != nil {
-						t.Errorf("src2 does not exist, expected it to exist: %v", err2)
+						t.Errorf("Error: src2.Attrs(): %v", err2)
 					}
 				}
 

--- a/storage/integration_test.go
+++ b/storage/integration_test.go
@@ -2972,20 +2972,26 @@ func TestIntegration_ObjectCompose_DeleteSourceObjects(t *testing.T) {
 		for _, tc := range testCases {
 			t.Run(tc.desc, func(t *testing.T) {
 				src1 := b.Object("delSrc1" + uidSpaceObjects.New())
-				src2 := b.Object("delSrc2" + uidSpaceObjects.New())
-
 				c1 := randomContents()
-				c2 := randomContents()
 				if err := writeObject(ctx, src1, "text/plain", c1); err != nil {
 					t.Fatalf("Write for %v failed with %v", src1, err)
 				}
+				defer func() {
+					cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
+					defer cancel()
+					src1.Delete(cleanupCtx)
+				}()
+
+				src2 := b.Object("delSrc2" + uidSpaceObjects.New())
+				c2 := randomContents()
 				if err := writeObject(ctx, src2, "text/plain", c2); err != nil {
 					t.Fatalf("Write for %v failed with %v", src2, err)
 				}
-				if !tc.wantSourcesDeleted {
-					defer src1.Delete(ctx)
-					defer src2.Delete(ctx)
-				}
+				defer func() {
+					cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
+					defer cancel()
+					src2.Delete(cleanupCtx)
+				}()
 
 				compDst := b.Object("composedDel" + uidSpaceObjects.New())
 				c := compDst.ComposerFrom(src1, src2)
@@ -3005,7 +3011,6 @@ func TestIntegration_ObjectCompose_DeleteSourceObjects(t *testing.T) {
 				if tc.wantSourcesDeleted {
 					if err1 == nil {
 						t.Errorf("src1 still exists, expected it to be deleted")
-						src1.Delete(ctx)
 					}
 				} else {
 					if err1 != nil {
@@ -3017,7 +3022,6 @@ func TestIntegration_ObjectCompose_DeleteSourceObjects(t *testing.T) {
 				if tc.wantSourcesDeleted {
 					if err2 == nil {
 						t.Errorf("src2 still exists, expected it to be deleted")
-						src2.Delete(ctx)
 					}
 				} else {
 					if err2 != nil {

--- a/storage/pcu.go
+++ b/storage/pcu.go
@@ -47,6 +47,8 @@ const (
 //
 // **Note:** This feature is currently experimental and its API surface may change
 // in future releases. It is not yet recommended for production use.
+//
+// TODO(b/521239530): Add option to delete source parts after compose operation and remove cleanup logic.
 type ParallelUploadConfig struct {
 
 	// PartSize is the size of each part to be uploaded in parallel.

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -1695,14 +1695,15 @@ func TestObjectCompose(t *testing.T) {
 	}
 
 	testCases := []struct {
-		desc       string
-		dst        *ObjectHandle
-		srcs       []*ObjectHandle
-		attrs      *ObjectAttrs
-		sendCRC32C bool
-		wantReq    raw.ComposeRequest
-		wantURL    string
-		wantErr    bool
+		desc                string
+		dst                 *ObjectHandle
+		srcs                []*ObjectHandle
+		attrs               *ObjectAttrs
+		sendCRC32C          bool
+		deleteSourceObjects bool
+		wantReq             raw.ComposeRequest
+		wantURL             string
+		wantErr             bool
 	}{
 		{
 			desc: "basic case",
@@ -1792,6 +1793,24 @@ func TestObjectCompose(t *testing.T) {
 			},
 		},
 		{
+			desc: "with delete source objects",
+			dst:  c.Bucket("foo").Object("bar"),
+			srcs: []*ObjectHandle{
+				c.Bucket("foo").Object("baz"),
+				c.Bucket("foo").Object("quux"),
+			},
+			deleteSourceObjects: true,
+			wantURL:             "/storage/v1/b/foo/o/bar/compose?alt=json&prettyPrint=false",
+			wantReq: raw.ComposeRequest{
+				Destination:         &raw.Object{Bucket: "foo"},
+				DeleteSourceObjects: true,
+				SourceObjects: []*raw.ComposeRequestSourceObjects{
+					{Name: "baz"},
+					{Name: "quux"},
+				},
+			},
+		},
+		{
 			desc:    "no sources",
 			dst:     c.Bucket("foo").Object("bar"),
 			wantErr: true,
@@ -1852,6 +1871,7 @@ func TestObjectCompose(t *testing.T) {
 			composer.ObjectAttrs = *tt.attrs
 		}
 		composer.SendCRC32C = tt.sendCRC32C
+		composer.DeleteSourceObjects = tt.deleteSourceObjects
 		_, err := composer.Run(ctx)
 		if gotErr := err != nil; gotErr != tt.wantErr {
 			t.Errorf("%s: got error %v; want err %t", tt.desc, err, tt.wantErr)


### PR DESCRIPTION
Add DeleteSourceObjects field to Composer to support deleting source objects automatically after a successful compose operation.