### PR TITLE
chore: librarian release pull request: 20260604T195603Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -893,7 +893,7 @@ libraries:
       - internal/generated/snippets/contactcenterinsights/
     tag_format: '{id}/v{version}'
   - id: container
-    version: 1.52.0
+    version: 1.53.0
     last_generated_commit: ""
     apis:
       - path: google/container/v1
@@ -999,7 +999,7 @@ libraries:
       - internal/generated/snippets/datalabeling/
     tag_format: '{id}/v{version}'
   - id: datamanager
-    version: 1.1.0
+    version: 1.2.0
     last_generated_commit: ""
     apis:
       - path: google/ads/datamanager/v1
@@ -1027,7 +1027,7 @@ libraries:
       - internal/generated/snippets/dataplex/
     tag_format: '{id}/v{version}'
   - id: dataproc
-    version: 2.22.0
+    version: 2.23.0
     last_generated_commit: ""
     apis:
       - path: google/cloud/dataproc/v1
@@ -1168,7 +1168,7 @@ libraries:
       - internal/generated/snippets/discoveryengine/
     tag_format: '{id}/v{version}'
   - id: dlp
-    version: 1.34.0
+    version: 1.35.0
     last_generated_commit: ""
     apis:
       - path: google/privacy/dlp/v2
@@ -2241,7 +2241,7 @@ libraries:
       - internal/generated/snippets/recommendationengine/
     tag_format: '{id}/v{version}'
   - id: recommender
-    version: 1.18.0
+    version: 1.19.0
     last_generated_commit: ""
     apis:
       - path: google/cloud/recommender/v1
@@ -2354,7 +2354,7 @@ libraries:
       - internal/generated/snippets/run/
     tag_format: '{id}/v{version}'
   - id: saasplatform
-    version: 0.8.0
+    version: 0.9.0
     last_generated_commit: ""
     apis:
       - path: google/cloud/saasplatform/saasservicemgmt/v1beta1

--- a/container/CHANGES.md
+++ b/container/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+## [1.53.0](https://github.com/googleapis/google-cloud-go/releases/tag/container%2Fv1.53.0) (2026-06-04)
+
+### Features
+
+* update API sources and regenerate (#14701) ([a9b7921](https://github.com/googleapis/google-cloud-go/commit/a9b7921551e9c1535496731da53e880e9e364efa))
+
 ## [1.52.0](https://github.com/googleapis/google-cloud-go/releases/tag/container%2Fv1.52.0) (2026-05-14)
 
 ### Features

--- a/container/examples/apiv1/snippet_metadata.google.container.v1.json
+++ b/container/examples/apiv1/snippet_metadata.google.container.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/container/apiv1",
-    "version": "1.52.0"
+    "version": "1.53.0"
   },
   "snippets": [
     {

--- a/container/internal/version.go
+++ b/container/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "1.52.0"
+const Version = "1.53.0"

--- a/datamanager/CHANGES.md
+++ b/datamanager/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+## [1.2.0](https://github.com/googleapis/google-cloud-go/releases/tag/datamanager%2Fv1.2.0) (2026-06-04)
+
+### Features
+
+* update API sources and regenerate (#14701) ([a9b7921](https://github.com/googleapis/google-cloud-go/commit/a9b7921551e9c1535496731da53e880e9e364efa))
+
 ## [1.1.0](https://github.com/googleapis/google-cloud-go/releases/tag/datamanager%2Fv1.1.0) (2026-05-21)
 
 ### Features

--- a/datamanager/examples/apiv1/snippet_metadata.google.ads.datamanager.v1.json
+++ b/datamanager/examples/apiv1/snippet_metadata.google.ads.datamanager.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/datamanager/apiv1",
-    "version": "1.1.0"
+    "version": "1.2.0"
   },
   "snippets": [
     {

--- a/datamanager/internal/version.go
+++ b/datamanager/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "1.1.0"
+const Version = "1.2.0"

--- a/dataproc/CHANGES.md
+++ b/dataproc/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+## [2.23.0](https://github.com/googleapis/google-cloud-go/releases/tag/dataproc%2Fv2.23.0) (2026-06-04)
+
+### Features
+
+* update API sources and regenerate (#14701) ([a9b7921](https://github.com/googleapis/google-cloud-go/commit/a9b7921551e9c1535496731da53e880e9e364efa))
+
 ## [2.22.0](https://github.com/googleapis/google-cloud-go/releases/tag/dataproc%2Fv2.22.0) (2026-05-14)
 
 ### Features

--- a/dataproc/examples/apiv1/snippet_metadata.google.cloud.dataproc.v1.json
+++ b/dataproc/examples/apiv1/snippet_metadata.google.cloud.dataproc.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/dataproc/v2/apiv1",
-    "version": "2.22.0"
+    "version": "2.23.0"
   },
   "snippets": [
     {

--- a/dataproc/internal/version.go
+++ b/dataproc/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "2.22.0"
+const Version = "2.23.0"

--- a/dlp/CHANGES.md
+++ b/dlp/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+## [1.35.0](https://github.com/googleapis/google-cloud-go/releases/tag/dlp%2Fv1.35.0) (2026-06-04)
+
+### Features
+
+* update API sources and regenerate (#14701) ([a9b7921](https://github.com/googleapis/google-cloud-go/commit/a9b7921551e9c1535496731da53e880e9e364efa))
+
 ## [1.34.0](https://github.com/googleapis/google-cloud-go/releases/tag/dlp%2Fv1.34.0) (2026-05-07)
 
 ## [1.33.0](https://github.com/googleapis/google-cloud-go/releases/tag/dlp%2Fv1.33.0) (2026-04-30)

--- a/dlp/examples/apiv2/snippet_metadata.google.privacy.dlp.v2.json
+++ b/dlp/examples/apiv2/snippet_metadata.google.privacy.dlp.v2.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/dlp/apiv2",
-    "version": "1.34.0"
+    "version": "1.35.0"
   },
   "snippets": [
     {

--- a/dlp/internal/version.go
+++ b/dlp/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "1.34.0"
+const Version = "1.35.0"

--- a/internal/generated/snippets/container/apiv1/snippet_metadata.google.container.v1.json
+++ b/internal/generated/snippets/container/apiv1/snippet_metadata.google.container.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/container/apiv1",
-    "version": "1.52.0"
+    "version": "1.53.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/datamanager/apiv1/snippet_metadata.google.ads.datamanager.v1.json
+++ b/internal/generated/snippets/datamanager/apiv1/snippet_metadata.google.ads.datamanager.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/datamanager/apiv1",
-    "version": "1.1.0"
+    "version": "1.2.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/dataproc/apiv1/snippet_metadata.google.cloud.dataproc.v1.json
+++ b/internal/generated/snippets/dataproc/apiv1/snippet_metadata.google.cloud.dataproc.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/dataproc/v2/apiv1",
-    "version": "2.22.0"
+    "version": "2.23.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/dlp/apiv2/snippet_metadata.google.privacy.dlp.v2.json
+++ b/internal/generated/snippets/dlp/apiv2/snippet_metadata.google.privacy.dlp.v2.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/dlp/apiv2",
-    "version": "1.34.0"
+    "version": "1.35.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/recommender/apiv1/snippet_metadata.google.cloud.recommender.v1.json
+++ b/internal/generated/snippets/recommender/apiv1/snippet_metadata.google.cloud.recommender.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/recommender/apiv1",
-    "version": "1.18.0"
+    "version": "1.19.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/recommender/apiv1beta1/snippet_metadata.google.cloud.recommender.v1beta1.json
+++ b/internal/generated/snippets/recommender/apiv1beta1/snippet_metadata.google.cloud.recommender.v1beta1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/recommender/apiv1beta1",
-    "version": "1.18.0"
+    "version": "1.19.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/snippet_metadata.google.cloud.saasplatform.saasservicemgmt.v1beta1.json
+++ b/internal/generated/snippets/saasplatform/saasservicemgmt/apiv1beta1/snippet_metadata.google.cloud.saasplatform.saasservicemgmt.v1beta1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/saasplatform/saasservicemgmt/apiv1beta1",
-    "version": "0.8.0"
+    "version": "0.9.0"
   },
   "snippets": [
     {

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -544,7 +544,7 @@ libraries:
     apis:
       - path: google/cloud/contactcenterinsights/v1
   - name: container
-    version: 1.52.0
+    version: 1.53.0
     apis:
       - path: google/container/v1
   - name: containeranalysis
@@ -593,7 +593,7 @@ libraries:
     apis:
       - path: google/cloud/datalabeling/v1beta1
   - name: datamanager
-    version: 1.1.0
+    version: 1.2.0
     apis:
       - path: google/ads/datamanager/v1
         go:
@@ -603,7 +603,7 @@ libraries:
     apis:
       - path: google/cloud/dataplex/v1
   - name: dataproc
-    version: 2.22.0
+    version: 2.23.0
     apis:
       - path: google/cloud/dataproc/v1
         go:
@@ -664,7 +664,7 @@ libraries:
       - path: google/cloud/discoveryengine/v1beta
       - path: google/cloud/discoveryengine/v1alpha
   - name: dlp
-    version: 1.34.0
+    version: 1.35.0
     apis:
       - path: google/privacy/dlp/v2
         go:
@@ -1146,7 +1146,7 @@ libraries:
     apis:
       - path: google/cloud/recommendationengine/v1beta1
   - name: recommender
-    version: 1.18.0
+    version: 1.19.0
     apis:
       - path: google/cloud/recommender/v1
         go:
@@ -1201,7 +1201,7 @@ libraries:
     keep:
       - apiv2/locations_client.go
   - name: saasplatform
-    version: 0.8.0
+    version: 0.9.0
     apis:
       - path: google/cloud/saasplatform/saasservicemgmt/v1beta1
   - name: scheduler

--- a/recommender/CHANGES.md
+++ b/recommender/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+## [1.19.0](https://github.com/googleapis/google-cloud-go/releases/tag/recommender%2Fv1.19.0) (2026-06-04)
+
+### Features
+
+* update API sources and regenerate (#14701) ([a9b7921](https://github.com/googleapis/google-cloud-go/commit/a9b7921551e9c1535496731da53e880e9e364efa))
+
 ## [1.18.0](https://github.com/googleapis/google-cloud-go/releases/tag/recommender%2Fv1.18.0) (2026-05-07)
 
 ## [1.17.0](https://github.com/googleapis/google-cloud-go/releases/tag/recommender%2Fv1.17.0) (2026-04-30)

--- a/recommender/examples/apiv1/snippet_metadata.google.cloud.recommender.v1.json
+++ b/recommender/examples/apiv1/snippet_metadata.google.cloud.recommender.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/recommender/apiv1",
-    "version": "1.18.0"
+    "version": "1.19.0"
   },
   "snippets": [
     {

--- a/recommender/examples/apiv1beta1/snippet_metadata.google.cloud.recommender.v1beta1.json
+++ b/recommender/examples/apiv1beta1/snippet_metadata.google.cloud.recommender.v1beta1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/recommender/apiv1beta1",
-    "version": "1.18.0"
+    "version": "1.19.0"
   },
   "snippets": [
     {

--- a/recommender/internal/version.go
+++ b/recommender/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "1.18.0"
+const Version = "1.19.0"

--- a/saasplatform/CHANGES.md
+++ b/saasplatform/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+## [0.9.0](https://github.com/googleapis/google-cloud-go/releases/tag/saasplatform%2Fv0.9.0) (2026-06-04)
+
+### Features
+
+* update API sources and regenerate (#14701) ([a9b7921](https://github.com/googleapis/google-cloud-go/commit/a9b7921551e9c1535496731da53e880e9e364efa))
+
 ## [0.8.0](https://github.com/googleapis/google-cloud-go/releases/tag/saasplatform%2Fv0.8.0) (2026-05-28)
 
 ### Features

--- a/saasplatform/examples/saasservicemgmt/apiv1beta1/snippet_metadata.google.cloud.saasplatform.saasservicemgmt.v1beta1.json
+++ b/saasplatform/examples/saasservicemgmt/apiv1beta1/snippet_metadata.google.cloud.saasplatform.saasservicemgmt.v1beta1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/saasplatform/saasservicemgmt/apiv1beta1",
-    "version": "0.8.0"
+    "version": "0.9.0"
   },
   "snippets": [
     {

--- a/saasplatform/internal/version.go
+++ b/saasplatform/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "0.8.0"
+const Version = "0.9.0"


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.16.1-0.20260603212637-9762b43b5d69
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go@sha256:b7e38e80d677dc6b7266896bb99a33fa62348d3e39d7b8f2f6423e7dc4b35a60
<details><summary>container: v1.53.0</summary>

## [v1.53.0](https://github.com/googleapis/google-cloud-go/compare/container/v1.52.0...container/v1.53.0) (2026-06-04)

### Features

* update API sources and regenerate (#14701) ([a9b79215](https://github.com/googleapis/google-cloud-go/commit/a9b79215))

</details>


<details><summary>datamanager: v1.2.0</summary>

## [v1.2.0](https://github.com/googleapis/google-cloud-go/compare/datamanager/v1.1.0...datamanager/v1.2.0) (2026-06-04)

### Features

* update API sources and regenerate (#14701) ([a9b79215](https://github.com/googleapis/google-cloud-go/commit/a9b79215))

</details>


<details><summary>dataproc: v2.23.0</summary>

## [v2.23.0](https://github.com/googleapis/google-cloud-go/compare/dataproc/v2.22.0...dataproc/v2.23.0) (2026-06-04)

### Features

* update API sources and regenerate (#14701) ([a9b79215](https://github.com/googleapis/google-cloud-go/commit/a9b79215))

</details>


<details><summary>dlp: v1.35.0</summary>

## [v1.35.0](https://github.com/googleapis/google-cloud-go/compare/dlp/v1.34.0...dlp/v1.35.0) (2026-06-04)

### Features

* update API sources and regenerate (#14701) ([a9b79215](https://github.com/googleapis/google-cloud-go/commit/a9b79215))

</details>


<details><summary>recommender: v1.19.0</summary>

## [v1.19.0](https://github.com/googleapis/google-cloud-go/compare/recommender/v1.18.0...recommender/v1.19.0) (2026-06-04)

### Features

* update API sources and regenerate (#14701) ([a9b79215](https://github.com/googleapis/google-cloud-go/commit/a9b79215))

</details>


<details><summary>saasplatform: v0.9.0</summary>

## [v0.9.0](https://github.com/googleapis/google-cloud-go/compare/saasplatform/v0.8.0...saasplatform/v0.9.0) (2026-06-04)

### Features

* update API sources and regenerate (#14701) ([a9b79215](https://github.com/googleapis/google-cloud-go/commit/a9b79215))

</details>