### PR TITLE
feat(bigtable): generate gapic layer for admin client

### DIFF
--- a/.librarian/generator-input/repo-config.yaml
+++ b/.librarian/generator-input/repo-config.yaml
@@ -17,7 +17,9 @@ modules:
       - path: google/bigtable/v2
         disable_gapic: true
       - path: google/bigtable/admin/v2
-        disable_gapic: true
+        client_directory: admin/apiv2
+        enabled_generator_features:
+        - F_selective_gapic_generation
 
   - name: cloudbuild
     apis:

--- a/internal/gapicgen/cmd/genbot/Dockerfile
+++ b/internal/gapicgen/cmd/genbot/Dockerfile
@@ -28,11 +28,11 @@ RUN go version
 
 # Install Go tools.
 RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.36.11 && \
-    go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.6.2 && \
+    go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.3.0 && \
     go install golang.org/x/lint/golint@latest && \
-    go install golang.org/x/tools/cmd/goimports@latest && \
+    go install golang.org/x/tools/cmd/goimports@v0.44.0 && \
     go install honnef.co/go/tools/cmd/staticcheck@latest && \
-    go install github.com/googleapis/gapic-generator-go/cmd/protoc-gen-go_gapic@v0.38.0
+    go install github.com/googleapis/gapic-generator-go/cmd/protoc-gen-go_gapic@v0.61.0
 ENV PATH="${PATH}:/root/go/bin"
 
 # Source: http://debuggable.com/posts/disable-strict-host-checking-for-git-clone:49896ff3-0ac0-4263-9703-1eae4834cda3

--- a/internal/librariangen/README.md
+++ b/internal/librariangen/README.md
@@ -232,12 +232,12 @@ This method runs the generator directly as a Go binary, without any Docker conta
 
 To build and test `librariangen` locally, you must have the following tools installed and available in your `PATH`:
 
-*   **Go Toolchain:** (Version `1.23.0` is used in the container)
+*   **Go Toolchain:** (Version `1.25.8` is used; version `1.24.0` is used in the container)
 *   **`protoc`:** (Version `25.7` is used in the container)
-*   **`protoc-gen-go`:** `go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.35.2`
+*   **`protoc-gen-go`:** `go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.36.11`
 *   **`protoc-gen-go-grpc`:** `go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.3.0`
-*   **`protoc-gen-go_gapic`:** `go install github.com/googleapis/gapic-generator-go/cmd/protoc-gen-go_gapic@v0.53.1`
-*   **`goimports`:** `go install golang.org/x/tools/cmd/goimports@latest`
+*   **`protoc-gen-go_gapic`:** `go install github.com/googleapis/gapic-generator-go/cmd/protoc-gen-go_gapic@v0.61.0`
+*   **`goimports`:** `go install golang.org/x/tools/cmd/goimports@v0.44.0`
 *   **`staticcheck`:** `go install honnef.co/go/tools/cmd/staticcheck@2023.1.6`
 
 ### Running tests


### PR DESCRIPTION
Configure repo-config.yaml to enable GAPIC generation for the Cloud Bigtable admin v2 API using the selective generation feature.

Update the genbot Dockerfile to use specific versions of the generator tools: protoc-gen-go-grpc at v1.3.0, goimports at v0.44.0, and protoc-gen-go_gapic at v0.61.0. Also update the librariangen README to document the correct version requirements.