### PR TITLE
chore(internal/kokoro): skip examples directories in continuous tests

### DIFF
--- a/internal/kokoro/continuous.sh
+++ b/internal/kokoro/continuous.sh
@@ -113,7 +113,7 @@ runDirectoryTests() {
     # bigquery/benchmarks: build constraints exclude all Go files
     return
   fi
-  if [[ $PWD == *"/examples/"* && $PWD != *"/internal/examples/"* ]]; then
+  if [[ "$PWD/" == *"/examples/"* && "$PWD/" != *"/internal/examples/"* ]]; then
     # examples: build constraints exclude all Go files
     return
   fi

--- a/internal/kokoro/continuous.sh
+++ b/internal/kokoro/continuous.sh
@@ -113,6 +113,10 @@ runDirectoryTests() {
     # bigquery/benchmarks: build constraints exclude all Go files
     return
   fi
+  if [[ $PWD == *"/examples/"* && $PWD != *"/internal/examples/"* ]]; then
+    # examples: build constraints exclude all Go files
+    return
+  fi
   if { [[ $PWD == *"/internal/"* ]] ||
     [[ $PWD == *"/third_party/"* ]]; } &&
     [[ $KOKORO_JOB_NAME == *"earliest"* ]]; then


### PR DESCRIPTION
The continuous integration script runs tests in directories containing Go files. However, the generated examples in directories matching /examples/ (such as accesscontextmanager/examples/apiv1/Client/CommitServicePerimeters) contain only example code with the examples build tag. Running tests in these directories without the examples tag causes go test to fail because all files are excluded by build constraints.

To prevent these failures, skip running tests in directories that contain /examples/ in their path, unless they are inside /internal/examples/.

5206 tests failed: 

https://github.com/googleapis/google-cloud-go/issues?q=is%3Aissue%20%22examples%22%20%22TestMain%20failed%22%20created%3A2026-06-05%20label%3A%22flakybot%3A%20issue%22%20label%3A%22type%3A%20bug%22

https://github.com/googleapis/google-cloud-go/issues?q=is%3Aissue%20%22examples%22%20%22TestMain%20failed%22%20created%3A2026-06-04%20label%3A%22flakybot%3A%20issue%22%20label%3A%22type%3A%20bug%22

Snippets were recently moved in https://github.com/googleapis/google-cloud-go/pull/14705