### PR TITLE
test(bigtable): retry PingAndWarm in integration test

### DIFF
--- a/bigtable/integration_test.go
+++ b/bigtable/integration_test.go
@@ -229,11 +229,26 @@ func TestIntegration_Pinger(t *testing.T) {
 	if !testEnv.Config().UseProd {
 		t.Skip("emulator doesn't support PingAndWarm")
 	}
-	if err := client.PingAndWarm(ctx); err != nil {
+	err = internal.Retry(ctx, gax.Backoff{
+		Initial:    2 * time.Second,
+		Max:        30 * time.Second,
+		Multiplier: 2.0,
+	}, func() (bool, error) {
+		err := client.PingAndWarm(ctx)
+		if err != nil {
+			s, ok := status.FromError(err)
+			if ok && s.Code() == codes.FailedPrecondition {
+				return false, err // retry
+			}
+			return true, err // stop and return other errors
+		}
+		return true, nil // success
+	})
+	if err != nil {
 		t.Fatalf("pinger failed. got %v, want %v", err, nil)
 	}
-
 }
+
 
 func TestIntegration_UpdateFamilyValueType(t *testing.T) {
 	t.Parallel()

--- a/bigtable/integration_test.go
+++ b/bigtable/integration_test.go
@@ -249,7 +249,6 @@ func TestIntegration_Pinger(t *testing.T) {
 	}
 }
 
-
 func TestIntegration_UpdateFamilyValueType(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()


### PR DESCRIPTION
Add retry logic to TestIntegration_Pinger to handle transient FailedPrecondition errors.

During parallel integration testing, TestIntegration_Pinger can fail if another test is concurrently creating a table in the same instance, resulting in a FailedPrecondition error (Table currently being created). Wrapping the PingAndWarm call in a retry block with backoff mitigates this flake.

Fixes #14688