### PR TITLE
chore(all): add workflow to run go mod tidy on Renovate PRs 

### DIFF
--- a/.github/workflows/renovate_tidy.yml
+++ b/.github/workflows/renovate_tidy.yml
@@ -25,7 +25,6 @@ jobs:
           go-version: '1.26.x'
       - name: Run go mod tidy across all modules
         run: |
-          go mod tidy
           for i in $(find . -name go.mod -not -path '*/vendor/*'); do
             pushd $(dirname "$i")
             go mod tidy
@@ -36,7 +35,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           if ! git diff --quiet; then
-            git add $(find . \( -name "go.mod" -o -name "go.sum" \) -not -path '*/vendor/*')
+            git add -u '**/go.mod' '**/go.sum'
             git commit -m "chore: run go mod tidy after Renovate dependency update"
             git push
           fi

--- a/.github/workflows/renovate_tidy.yml
+++ b/.github/workflows/renovate_tidy.yml
@@ -1,0 +1,42 @@
+---
+name: renovate-tidy
+
+on:
+  pull_request:
+    branches:
+      - main
+      - preview
+
+permissions:
+  contents: write
+
+jobs:
+  tidy:
+    if: github.actor == 'renovate[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/setup-go@v6
+        with:
+          go-version: '1.26.x'
+      - name: Run go mod tidy across all modules
+        run: |
+          go mod tidy
+          for i in $(find . -name go.mod -not -path '*/vendor/*'); do
+            pushd $(dirname "$i")
+            go mod tidy
+            popd
+          done
+      - name: Commit and push changes if any
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          if ! git diff --quiet; then
+            git add $(find . \( -name "go.mod" -o -name "go.sum" \) -not -path '*/vendor/*')
+            git commit -m "chore: run go mod tidy after Renovate dependency update"
+            git push
+          fi


### PR DESCRIPTION
 Fixes #19926                                                                                                             
                                                                                                                           
  Renovate-created PRs consistently fail CI because `spanner/benchmarks/go.mod`                                            
  becomes untidy after Renovate updates dependencies in `spanner/go.mod`.                                                  
                                                                                                                           
  `spanner/benchmarks/go.mod` uses a local replace directive pointing to `../spanner`.                                     
  When Renovate bumps a dependency in `spanner/go.mod` and runs `go mod tidy` via                                          
  `postUpdateOptions`, it does not cascade into `spanner/benchmarks/` — leaving its                                        
  indirect dependencies stale. `vet.sh` then detects the diff and fails CI.                                                
                                                                                                                           
  This adds a workflow that triggers only on Renovate PRs and runs the same                                                
  `go mod tidy` loop as `vet.sh` across all modules, then auto-commits any fixes                                           
  back to the PR branch.    