### PR TITLE
bigtable: fix streamingLoad leak in BigtableChannelPool.NewStream

### DIFF
--- a/bigtable/bigtable.go
+++ b/bigtable/bigtable.go
@@ -80,6 +80,8 @@ type Client struct {
 	retryOption             gax.CallOption
 	executeQueryRetryOption gax.CallOption
 	enableDirectAccess      bool
+	featureFlagsMD          metadata.MD // Pre-computed feature flags metadata to be sent with each request.
+	dynamicScaleMonitor     *btransport.DynamicScaleMonitor
 }
 
 // ClientConfig has configurations for the client.
@@ -94,6 +96,9 @@ type ClientConfig struct {
 	//
 	// TODO: support user provided meter provider
 	MetricsProvider MetricsProvider
+
+	// If true, enable dynamic channel pool
+	EnableDynamicChannelPool bool
 }
 
 // MetricsProvider is a wrapper for built in metrics meter provider
@@ -174,13 +179,48 @@ func NewClientWithConfig(ctx context.Context, project, instance string, config C
 		executeQueryRetryOption = clientOnlyExecuteQueryRetryOption
 	}
 
+	// Create the feature flags metadata once
+	ffMD := createFeatureFlagsMD(metricsTracerFactory.enabled, disableRetryInfo, enableDirectAccess)
+
 	var connPool gtransport.ConnPool
 	var connPoolErr error
+	var dsm *btransport.DynamicScaleMonitor
 	enableBigtableConnPool := btopt.EnableBigtableConnectionPool()
 	if enableBigtableConnPool {
-		connPool, connPoolErr = btransport.NewBigtableChannelPool(defaultBigtableConnPoolSize, btopt.BigtableLoadBalancingStrategy(), func() (*grpc.ClientConn, error) {
-			return gtransport.Dial(ctx, o...)
-		})
+		fullInstanceName := fmt.Sprintf("projects/%s/instances/%s", project, instance)
+
+		btPool, err := btransport.NewBigtableChannelPool(ctx,
+			defaultBigtableConnPoolSize,
+			btopt.LeastInFlight,
+			func() (*btransport.BigtableConn, error) {
+				grpcConn, err := gtransport.Dial(ctx, o...)
+				if err != nil {
+					return nil, err
+				}
+				return btransport.NewBigtableConn(grpcConn), nil
+			},
+			// options
+			btransport.WithInstanceName(fullInstanceName),
+			btransport.WithAppProfile(config.AppProfile),
+			btransport.WithFeatureFlagsMetadata(ffMD),
+		)
+
+		if err != nil {
+			connPoolErr = err
+		} else {
+			connPool = btPool
+
+			// Validate dynamic config early if enabled
+			if config.EnableDynamicChannelPool {
+				if err := btransport.ValidateDynamicConfig(btopt.DefaultDynamicChannelPoolConfig(defaultBigtableConnPoolSize)); err != nil {
+					return nil, fmt.Errorf("invalid DynamicChannelPoolConfig: %w", err)
+				}
+
+				dsm = btransport.NewDynamicScaleMonitor(btopt.DefaultDynamicChannelPoolConfig(defaultBigtableConnPoolSize), btPool)
+				dsm.Start(ctx) // Start the monitor's background goroutine
+			}
+		}
+
 	} else {
 		// use to regular ConnPool
 		connPool, connPoolErr = gtransport.DialPool(ctx, o...)
@@ -201,11 +241,16 @@ func NewClientWithConfig(ctx context.Context, project, instance string, config C
 		retryOption:             retryOption,
 		executeQueryRetryOption: executeQueryRetryOption,
 		enableDirectAccess:      enableDirectAccess,
+		featureFlagsMD:          ffMD,
+		dynamicScaleMonitor:     dsm,
 	}, nil
 }
 
 // Close closes the Client.
 func (c *Client) Close() error {
+	if c.dynamicScaleMonitor != nil {
+		c.dynamicScaleMonitor.Stop()
+	}
 	if c.metricsTracerFactory != nil {
 		c.metricsTracerFactory.shutdown()
 	}
@@ -414,18 +459,18 @@ type Table struct {
 	materializedView string
 }
 
-// newFeatureFlags creates the feature flags `bigtable-features` header
-// to be sent on each request. This includes all features supported and
-// and enabled on the client
-func (c *Client) newFeatureFlags() metadata.MD {
+// createFeatureFlagsMD creates the metadata for the `bigtable-features` header.
+// This header is sent on each request and includes all features supported and
+// enabled on the client.
+func createFeatureFlagsMD(clientSideMetricsEnabled, disableRetryInfo, enableDirectAccess bool) metadata.MD {
 	ff := btpb.FeatureFlags{
 		RoutingCookie:            true,
 		ReverseScans:             true,
 		LastScannedRowResponses:  true,
-		ClientSideMetricsEnabled: c.metricsTracerFactory.enabled,
-		RetryInfo:                !c.disableRetryInfo,
-		TrafficDirectorEnabled:   c.enableDirectAccess,
-		DirectAccessRequested:    c.enableDirectAccess,
+		ClientSideMetricsEnabled: clientSideMetricsEnabled,
+		RetryInfo:                !disableRetryInfo,
+		TrafficDirectorEnabled:   enableDirectAccess,
+		DirectAccessRequested:    enableDirectAccess,
 	}
 
 	val := ""
@@ -445,7 +490,7 @@ func (c *Client) Open(table string) *Table {
 		md: metadata.Join(metadata.Pairs(
 			resourcePrefixHeader, c.fullTableName(table),
 			requestParamsHeader, c.reqParamsHeaderValTable(table),
-		), c.newFeatureFlags()),
+		), c.featureFlagsMD),
 	}
 }
 
@@ -457,7 +502,7 @@ func (c *Client) OpenTable(table string) TableAPI {
 		md: metadata.Join(metadata.Pairs(
 			resourcePrefixHeader, c.fullTableName(table),
 			requestParamsHeader, c.reqParamsHeaderValTable(table),
-		), c.newFeatureFlags()),
+		), c.featureFlagsMD),
 	}}
 }
 
@@ -469,7 +514,7 @@ func (c *Client) OpenAuthorizedView(table, authorizedView string) TableAPI {
 		md: metadata.Join(metadata.Pairs(
 			resourcePrefixHeader, c.fullAuthorizedViewName(table, authorizedView),
 			requestParamsHeader, c.reqParamsHeaderValTable(table),
-		), c.newFeatureFlags()),
+		), c.featureFlagsMD),
 		authorizedView: authorizedView,
 	}}
 }
@@ -481,7 +526,7 @@ func (c *Client) OpenMaterializedView(materializedView string) TableAPI {
 		md: metadata.Join(metadata.Pairs(
 			resourcePrefixHeader, c.fullMaterializedViewName(materializedView),
 			requestParamsHeader, c.reqParamsHeaderValTable(materializedView),
-		), c.newFeatureFlags()),
+		), c.featureFlagsMD),
 		materializedView: materializedView,
 	}}
 }
@@ -540,7 +585,7 @@ func (c *Client) PrepareStatement(ctx context.Context, query string, paramTypes 
 	md := metadata.Join(metadata.Pairs(
 		resourcePrefixHeader, c.fullInstanceName(),
 		requestParamsHeader, c.reqParamsHeaderValInstance(),
-	), c.newFeatureFlags())
+	), c.featureFlagsMD)
 
 	ctx = mergeOutgoingMetadata(ctx, md)
 	return c.prepareStatementWithMetadata(ctx, query, paramTypes, opts...)
@@ -724,7 +769,7 @@ func (bs *BoundStatement) Execute(ctx context.Context, f func(ResultRow) bool, o
 	md := metadata.Join(metadata.Pairs(
 		resourcePrefixHeader, bs.ps.c.fullInstanceName(),
 		requestParamsHeader, bs.ps.c.reqParamsHeaderValInstance(),
-	), bs.ps.c.newFeatureFlags())
+	), bs.ps.c.featureFlagsMD)
 	ctx = mergeOutgoingMetadata(ctx, md)
 
 	ctx = trace.StartSpan(ctx, "cloud.google.com/go/bigtable.ExecuteQuery")
@@ -955,7 +1000,7 @@ func (c *Client) PingAndWarm(ctx context.Context) (err error) {
 	md := metadata.Join(metadata.Pairs(
 		resourcePrefixHeader, c.fullInstanceName(),
 		requestParamsHeader, c.reqParamsHeaderValInstance(),
-	), c.newFeatureFlags())
+	), c.featureFlagsMD)
 
 	ctx = mergeOutgoingMetadata(ctx, md)
 	ctx = trace.StartSpan(ctx, "cloud.google.com/go/bigtable/PingAndWarm")

--- a/bigtable/bigtable.go
+++ b/bigtable/bigtable.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"hash/crc32"
 	"io"
+	"log"
 	"net/url"
 	"os"
 	"strconv"
@@ -188,10 +189,9 @@ func NewClientWithConfig(ctx context.Context, project, instance string, config C
 	enableBigtableConnPool := btopt.EnableBigtableConnectionPool()
 	if enableBigtableConnPool {
 		fullInstanceName := fmt.Sprintf("projects/%s/instances/%s", project, instance)
-
-		directAccessOptions := append(o, internaloption.EnableDirectPath(true), internaloption.EnableDirectPathXds())
-
 		directAccessDialOptions := func() (*btransport.BigtableConn, error) {
+			btopt.Debugf(log.Default(), "dialing with direct access option")
+			directAccessOptions := append(o, internaloption.EnableDirectPath(true), internaloption.EnableDirectPathXds())
 			grpcConn, err := gtransport.Dial(ctx, directAccessOptions...)
 			if err != nil {
 				return nil, err

--- a/bigtable/bigtable.go
+++ b/bigtable/bigtable.go
@@ -120,6 +120,7 @@ func NewClient(ctx context.Context, project, instance string, opts ...option.Cli
 
 // NewClientWithConfig creates a new client with the given config.
 func NewClientWithConfig(ctx context.Context, project, instance string, config ClientConfig, opts ...option.ClientOption) (*Client, error) {
+	clientStartTime := time.Now()
 	metricsProvider := config.MetricsProvider
 	if emulatorAddr := os.Getenv("BIGTABLE_EMULATOR_HOST"); emulatorAddr != "" {
 		// Do not emit metrics when emulator is being used
@@ -229,6 +230,14 @@ func NewClientWithConfig(ctx context.Context, project, instance string, config C
 		if err != nil {
 			connPoolErr = err
 		} else {
+
+			// Report client startup latency
+			if metricsTracerFactory.enabled {
+				btopt.Debugf(log.Default(), "recording client startup latency %v", time.Since(clientStartTime))
+				clientStartupTime := time.Since(clientStartTime)
+				metricsTracerFactory.reportClientStartupLatency(ctx, clientStartupTime, "cloudpath")
+			}
+
 			connPool = btPool
 
 			// Validate dynamic config early if enabled

--- a/bigtable/bigtable.go
+++ b/bigtable/bigtable.go
@@ -203,6 +203,8 @@ func NewClientWithConfig(ctx context.Context, project, instance string, config C
 			btransport.WithInstanceName(fullInstanceName),
 			btransport.WithAppProfile(config.AppProfile),
 			btransport.WithFeatureFlagsMetadata(ffMD),
+			btransport.WithMetricsReporterConfig(btopt.DefaultMetricsReporterConfig()),
+			btransport.WithMeterProvider(metricsTracerFactory.otelMeterProvider),
 		)
 
 		if err != nil {
@@ -212,7 +214,7 @@ func NewClientWithConfig(ctx context.Context, project, instance string, config C
 
 			// Validate dynamic config early if enabled
 			if config.EnableDynamicChannelPool {
-				if err := btransport.ValidateDynamicConfig(btopt.DefaultDynamicChannelPoolConfig(defaultBigtableConnPoolSize)); err != nil {
+				if err := btransport.ValidateDynamicConfig(btopt.DefaultDynamicChannelPoolConfig(defaultBigtableConnPoolSize), defaultBigtableConnPoolSize); err != nil {
 					return nil, fmt.Errorf("invalid DynamicChannelPoolConfig: %w", err)
 				}
 

--- a/bigtable/bigtable.go
+++ b/bigtable/bigtable.go
@@ -189,6 +189,23 @@ func NewClientWithConfig(ctx context.Context, project, instance string, config C
 	if enableBigtableConnPool {
 		fullInstanceName := fmt.Sprintf("projects/%s/instances/%s", project, instance)
 
+		directAccessOptions := append(o, internaloption.EnableDirectPath(true), internaloption.EnableDirectPathXds())
+
+		directAccessDialOptions := func() (*btransport.BigtableConn, error) {
+			grpcConn, err := gtransport.Dial(ctx, directAccessOptions...)
+			if err != nil {
+				return nil, err
+			}
+			return btransport.NewBigtableConn(grpcConn), nil
+		}
+
+		var eligibilityReporterOption btransport.BigtableChannelPoolOption
+		if metricsTracerFactory.enabled {
+			eligibilityReporterOption = btransport.WithDirectAccessEligibleReporter(metricsTracerFactory.reportDirectAccessEligibleMetric)
+		} else {
+			eligibilityReporterOption = func(p *btransport.BigtableChannelPool) {}
+		}
+
 		btPool, err := btransport.NewBigtableChannelPool(ctx,
 			defaultBigtableConnPoolSize,
 			btopt.LeastInFlight,
@@ -205,6 +222,8 @@ func NewClientWithConfig(ctx context.Context, project, instance string, config C
 			btransport.WithFeatureFlagsMetadata(ffMD),
 			btransport.WithMetricsReporterConfig(btopt.DefaultMetricsReporterConfig()),
 			btransport.WithMeterProvider(metricsTracerFactory.otelMeterProvider),
+			btransport.WithDirectAccessDialFunc(directAccessDialOptions),
+			eligibilityReporterOption,
 		)
 
 		if err != nil {

--- a/bigtable/integration_test.go
+++ b/bigtable/integration_test.go
@@ -247,36 +247,8 @@ func TestIntegration_Pinger(t *testing.T) {
 	if !testEnv.Config().UseProd {
 		t.Skip("emulator doesn't support PingAndWarm")
 	}
-	numGoroutines := 10
-	pingsPerGoroutine := 100
-	totalPings := numGoroutines * pingsPerGoroutine
-	errs := make(chan error, totalPings) // Buffer to avoid blocking goroutines
-
-	var wg sync.WaitGroup
-	wg.Add(numGoroutines)
-
-	for i := 0; i < numGoroutines; i++ {
-		go func(gNum int) {
-			defer wg.Done()
-			for j := 0; j < pingsPerGoroutine; j++ {
-				if err := client.PingAndWarm(ctx); err != nil {
-					errs <- fmt.Errorf("goroutine %d, ping %d: %w", gNum, j, err)
-					return // Stop this goroutine on first error
-				}
-				// Optional: Add a small delay if needed to avoid overwhelming, though unlikely for PingAndWarm
-				// time.Sleep(1 * time.Millisecond)
-			}
-		}(i)
-	}
-
-	wg.Wait()
-	close(errs)
-
-	for err := range errs {
-		if err != nil {
-			t.Errorf("Pinger failed: %v", err)
-			// Don't break, collect all errors
-		}
+	if err := client.PingAndWarm(ctx); err != nil {
+		t.Fatalf("pinger failed. got %v, want %v", err, nil)
 	}
 
 }

--- a/bigtable/integration_test.go
+++ b/bigtable/integration_test.go
@@ -247,8 +247,36 @@ func TestIntegration_Pinger(t *testing.T) {
 	if !testEnv.Config().UseProd {
 		t.Skip("emulator doesn't support PingAndWarm")
 	}
-	if err := client.PingAndWarm(ctx); err != nil {
-		t.Fatalf("pinger failed. got %v, want %v", err, nil)
+	numGoroutines := 10
+	pingsPerGoroutine := 100
+	totalPings := numGoroutines * pingsPerGoroutine
+	errs := make(chan error, totalPings) // Buffer to avoid blocking goroutines
+
+	var wg sync.WaitGroup
+	wg.Add(numGoroutines)
+
+	for i := 0; i < numGoroutines; i++ {
+		go func(gNum int) {
+			defer wg.Done()
+			for j := 0; j < pingsPerGoroutine; j++ {
+				if err := client.PingAndWarm(ctx); err != nil {
+					errs <- fmt.Errorf("goroutine %d, ping %d: %w", gNum, j, err)
+					return // Stop this goroutine on first error
+				}
+				// Optional: Add a small delay if needed to avoid overwhelming, though unlikely for PingAndWarm
+				// time.Sleep(1 * time.Millisecond)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		if err != nil {
+			t.Errorf("Pinger failed: %v", err)
+			// Don't break, collect all errors
+		}
 	}
 
 }

--- a/bigtable/internal/option/option.go
+++ b/bigtable/internal/option/option.go
@@ -232,8 +232,8 @@ type DynamicChannelPoolConfig struct {
 	Enabled              bool          // Whether dynamic scaling is enabled.
 	MinConns             int           // Minimum conns allowed
 	MaxConns             int           // Maximum conns allowed.
-	AvgLoadHighThreshold int32         // Average weighted load per connection to trigger scale-up.
-	AvgLoadLowThreshold  int32         // Average weighted load per connection to trigger scale-down.
+	AvgLoadHighThreshold float64       // Average weighted load per connection to trigger scale-up.
+	AvgLoadLowThreshold  float64       // Average weighted load per connection to trigger scale-down.
 	MinScalingInterval   time.Duration // Minimum time between scaling operations (both up and down).
 	CheckInterval        time.Duration // How often to check if scaling is needed.
 	MaxRemoveConns       int           // Maximum number of connections to remove at once.

--- a/bigtable/internal/option/option.go
+++ b/bigtable/internal/option/option.go
@@ -226,3 +226,29 @@ func Debugf(logger *log.Logger, format string, v ...interface{}) {
 		logf(logger, debugFormat, v...)
 	}
 }
+
+// DynamicChannelPoolConfig holds the parameters for dynamic channel pool scaling.
+type DynamicChannelPoolConfig struct {
+	Enabled              bool          // Whether dynamic scaling is enabled.
+	MinConns             int           // Minimum number of connections in the pool.
+	MaxConns             int           // Maximum number of connections in the pool.
+	AvgLoadHighThreshold int32         // Average weighted load per connection to trigger scale-up.
+	AvgLoadLowThreshold  int32         // Average weighted load per connection to trigger scale-down.
+	MinScalingInterval   time.Duration // Minimum time between scaling operations (both up and down).
+	CheckInterval        time.Duration // How often to check if scaling is needed.
+	MaxRemoveConns       int           // Maximum number of connections to remove at once.
+}
+
+// DefaultDynamicChannelPoolConfig is default settings for dynamic channel pool
+func DefaultDynamicChannelPoolConfig(initialConns int) DynamicChannelPoolConfig {
+	return DynamicChannelPoolConfig{
+		Enabled:              true, // Enabled by default
+		MinConns:             10,
+		MaxConns:             200,
+		AvgLoadHighThreshold: 50, // Example thresholds, these likely need tuning
+		AvgLoadLowThreshold:  10,
+		MinScalingInterval:   1 * time.Minute,
+		CheckInterval:        30 * time.Second,
+		MaxRemoveConns:       2, // Cap for removals
+	}
+}

--- a/bigtable/internal/option/option.go
+++ b/bigtable/internal/option/option.go
@@ -20,6 +20,7 @@ package option
 import (
 	"context"
 	"fmt"
+	"log"
 	"os"
 	"strconv"
 	"strings"
@@ -200,4 +201,28 @@ func EnableBigtableConnectionPool() bool {
 		return false
 	}
 	return enableBigtableConnPool
+}
+
+// Logf logs the given message to the given logger, or the standard logger if
+// the given logger is nil.
+func logf(logger *log.Logger, format string, v ...interface{}) {
+	if logger == nil {
+		log.Printf(format, v...)
+	} else {
+		logger.Printf(format, v...)
+	}
+}
+
+var debug = os.Getenv("CBT_ENABLE_DEBUG") == "true"
+
+// Debugf logs the given message *only if* the global Debug flag is true.
+// It reuses Logf to handle the nil logger logic and prepends "DEBUG: "
+// to the message.
+func Debugf(logger *log.Logger, format string, v ...interface{}) {
+	// Only log if the Debug flag is set
+	if debug {
+		// Prepend "DEBUG: " to the format string
+		debugFormat := "DEBUG: " + format
+		logf(logger, debugFormat, v...)
+	}
 }

--- a/bigtable/internal/option/option.go
+++ b/bigtable/internal/option/option.go
@@ -230,8 +230,8 @@ func Debugf(logger *log.Logger, format string, v ...interface{}) {
 // DynamicChannelPoolConfig holds the parameters for dynamic channel pool scaling.
 type DynamicChannelPoolConfig struct {
 	Enabled              bool          // Whether dynamic scaling is enabled.
-	MinConns             int           // Minimum number of connections in the pool.
-	MaxConns             int           // Maximum number of connections in the pool.
+	MinConns             int           // Minimum conns allowed
+	MaxConns             int           // Maximum conns allowed.
 	AvgLoadHighThreshold int32         // Average weighted load per connection to trigger scale-up.
 	AvgLoadLowThreshold  int32         // Average weighted load per connection to trigger scale-down.
 	MinScalingInterval   time.Duration // Minimum time between scaling operations (both up and down).
@@ -245,10 +245,10 @@ func DefaultDynamicChannelPoolConfig(initialConns int) DynamicChannelPoolConfig 
 		Enabled:              true, // Enabled by default
 		MinConns:             10,
 		MaxConns:             200,
-		AvgLoadHighThreshold: 50, // Example thresholds, these likely need tuning
-		AvgLoadLowThreshold:  10,
+		AvgLoadHighThreshold: 50,
+		AvgLoadLowThreshold:  5,
 		MinScalingInterval:   1 * time.Minute,
 		CheckInterval:        30 * time.Second,
-		MaxRemoveConns:       2, // Cap for removals
+		MaxRemoveConns:       2, // Only Cap for removals
 	}
 }

--- a/bigtable/internal/option/option.go
+++ b/bigtable/internal/option/option.go
@@ -252,3 +252,18 @@ func DefaultDynamicChannelPoolConfig(initialConns int) DynamicChannelPoolConfig 
 		MaxRemoveConns:       2, // Only Cap for removals
 	}
 }
+
+// MetricsReporterConfig for periodic reporting
+// MetricsReporterConfig holds the parameters for metrics reporting.
+type MetricsReporterConfig struct {
+	Enabled           bool
+	ReportingInterval time.Duration
+}
+
+// DefaultMetricsReporterConfig with defaults used.
+func DefaultMetricsReporterConfig() MetricsReporterConfig {
+	return MetricsReporterConfig{
+		Enabled:           true,
+		ReportingInterval: 1 * time.Minute,
+	}
+}

--- a/bigtable/internal/transport/connpool.go
+++ b/bigtable/internal/transport/connpool.go
@@ -47,9 +47,7 @@ var maxDrainingTimeout = 2 * time.Minute
 type BigtableChannelPoolOption func(*BigtableChannelPool)
 
 const (
-	primeRPCTimeout     = 10 * time.Second
-	unaryLoadFactor     = 1
-	streamingLoadFactor = 2
+	primeRPCTimeout = 10 * time.Second
 )
 
 var errNoConnections = fmt.Errorf("bigtable_connpool: no connections available in the pool")

--- a/bigtable/internal/transport/connpool.go
+++ b/bigtable/internal/transport/connpool.go
@@ -598,13 +598,9 @@ func (p *BigtableChannelPool) addConnections(n int) bool {
 
 	currentConns := p.getConns()
 	numCurrent := len(currentConns)
-	if numCurrent >= p.dynamicConfig.MaxConns {
-		return false
-	}
 
-	if numCurrent+n > p.dynamicConfig.MaxConns {
-		n = p.dynamicConfig.MaxConns - numCurrent
-	}
+	maxDelta := p.dynamicConfig.MaxConns - numCurrent
+	n = min(n, maxDelta)
 
 	if n <= 0 {
 		return false

--- a/bigtable/internal/transport/connpool.go
+++ b/bigtable/internal/transport/connpool.go
@@ -381,14 +381,14 @@ func (p *BigtableChannelPool) Invoke(ctx context.Context, method string, args in
 
 // Conn provides connbased on selectfunc()
 func (p *BigtableChannelPool) Conn() *grpc.ClientConn {
-	bigtableConn := p.GetBigtableConn()
+	bigtableConn := p.getBigtableConn()
 	if bigtableConn == nil {
 		return nil
 	}
 	return bigtableConn.ClientConn
 }
 
-func (p *BigtableChannelPool) GetBigtableConn() *BigtableConn {
+func (p *BigtableChannelPool) getBigtableConn() *BigtableConn {
 	entry, err := p.selectFunc()
 	if err != nil {
 		return nil

--- a/bigtable/internal/transport/connpool.go
+++ b/bigtable/internal/transport/connpool.go
@@ -71,6 +71,7 @@ func (bc *BigtableConn) Prime(ctx context.Context) (bool, error) {
 
 	}
 
+	// TODO : Plumb featureflag and instanceName header
 	client := btpb.NewBigtableClient(bc.ClientConn)
 	req := &btpb.PingAndWarmRequest{
 		Name:         bc.instanceName,

--- a/bigtable/internal/transport/connpool.go
+++ b/bigtable/internal/transport/connpool.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"log"
 	"math/rand"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -308,13 +309,7 @@ func (p *BigtableChannelPool) replaceConnection(oldEntry *connEntry) {
 	}
 
 	currentConns := p.getConns()
-	idx := -1
-	for i, entry := range currentConns {
-		if entry == oldEntry {
-			idx = i
-			break
-		}
-	}
+	idx := slices.Index(currentConns, oldEntry)
 
 	// If the connection isn't in the slice, it was already removed.
 	// The drain process should still be kicked off.

--- a/bigtable/internal/transport/connpool.go
+++ b/bigtable/internal/transport/connpool.go
@@ -45,7 +45,7 @@ import (
 // We cap the max draining timeout to 30mins as there might be a long running stream (such as full table scan).
 var maxDrainingTimeout = 30 * time.Minute
 
-// BigtableChannelPool options
+// BigtableChannelPoolOption options
 type BigtableChannelPoolOption func(*BigtableChannelPool)
 
 const (
@@ -197,6 +197,7 @@ type BigtableChannelPool struct {
 	monitors []Monitor
 }
 
+// WithDynamicChannelPool provides the configuration for dynamic channel scaling
 func WithDynamicChannelPool(config btopt.DynamicChannelPoolConfig) BigtableChannelPoolOption {
 	return func(p *BigtableChannelPool) {
 		p.dynamicConfig = config

--- a/bigtable/internal/transport/connpool.go
+++ b/bigtable/internal/transport/connpool.go
@@ -41,7 +41,8 @@ import (
 )
 
 // A safety net to prevent a connection from draining indefinitely if a stream hangs.
-var maxDrainingTimeout = 2 * time.Minute
+// We cap the max draining timeout to 30mins as there might be a long running stream (such as full table scan).
+var maxDrainingTimeout = 30 * time.Minute
 
 // BigtableChannelPool options
 type BigtableChannelPoolOption func(*BigtableChannelPool)
@@ -71,7 +72,8 @@ func (bc *BigtableConn) Prime(ctx context.Context) error {
 
 	}
 
-	// TODO : Plumb featureflag and instanceName header
+	// TODO: Plumb featureflag
+	// TODO: Plumb RLS headers
 	client := btpb.NewBigtableClient(bc.ClientConn)
 	req := &btpb.PingAndWarmRequest{
 		Name:         bc.instanceName,

--- a/bigtable/internal/transport/connpool.go
+++ b/bigtable/internal/transport/connpool.go
@@ -195,6 +195,8 @@ func (p *BigtableChannelPool) getConns() []*connEntry {
 }
 
 // NewBigtableChannelPool creates a pool of connPoolSize and takes the dial func()
+// NewBigtableChannelPool primes the new connection in a non-blocking goroutine to warm it up.
+// We keep it consistent with the current channelpool behavior which is lazily initialized.
 func NewBigtableChannelPool(ctx context.Context, connPoolSize int, strategy btopt.LoadBalancingStrategy, dial func() (*BigtableConn, error), logger *log.Logger, mp metric.MeterProvider, opts ...BigtableChannelPoolOption) (*BigtableChannelPool, error) {
 	if connPoolSize <= 0 {
 		return nil, fmt.Errorf("bigtable_connpool: connPoolSize must be positive")

--- a/bigtable/internal/transport/connpool.go
+++ b/bigtable/internal/transport/connpool.go
@@ -16,42 +16,185 @@ package internal
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io"
+	"log"
 	"math/rand"
 	"sync"
 	"sync/atomic"
+	"time"
 
+	btpb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
+	"go.opentelemetry.io/otel/metric"
 	gtransport "google.golang.org/api/transport/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/alts"
+	"google.golang.org/grpc/peer"
+
+	"google.golang.org/grpc/status"
 
 	btopt "cloud.google.com/go/bigtable/internal/option"
 
 	"google.golang.org/grpc"
 )
 
+// A safety net to prevent a connection from draining indefinitely if a stream hangs.
+var maxDrainingTimeout = 2 * time.Minute
+
+// BigtableChannelPool options
+type BigtableChannelPoolOption func(*BigtableChannelPool)
+
+const (
+	primeRPCTimeout     = 10 * time.Second
+	unaryLoadFactor     = 1
+	streamingLoadFactor = 2
+)
+
 var errNoConnections = fmt.Errorf("bigtable_connpool: no connections available in the pool")
 var _ gtransport.ConnPool = &BigtableChannelPool{}
 
-// BigtableChannelPool implements ConnPool and routes requests to the connection
-// pool according to load balancing strategy.
-//
-// To benefit from automatic load tracking, use the Invoke and NewStream methods
-// directly on the BigtableChannelPool instance.
-type BigtableChannelPool struct {
-	conns []*grpc.ClientConn
-	load  []int64 // Tracks active requests per connection
+// BigtableConn wraps grpc.ClientConn to add Bigtable specific methods.
+type BigtableConn struct {
+	*grpc.ClientConn
+	instanceName string // Needed for PingAndWarm
+	appProfile   string // Needed for PingAndWarm
+}
 
-	// Mutex is only used for selecting the least loaded connection.
-	// The load array itself is manipulated using atomic operations.
-	mu         sync.Mutex
-	dial       func() (*grpc.ClientConn, error)
-	strategy   btopt.LoadBalancingStrategy
-	rrIndex    uint64              // For round-robin selection
-	selectFunc func() (int, error) // Stored function for connection selection
+// Prime sends a PingAndWarm request to warm up the connection.
+func (bc *BigtableConn) Prime(ctx context.Context) (bool, error) {
+	if bc.instanceName == "" {
+		return false, status.Error(codes.FailedPrecondition, "bigtable: instanceName is required for conn:Prime operation")
+	}
+	if bc.appProfile == "" {
+		return false, status.Error(codes.FailedPrecondition, "bigtable: appProfile is required for conn:Prime operation")
+
+	}
+
+	client := btpb.NewBigtableClient(bc.ClientConn)
+	req := &btpb.PingAndWarmRequest{
+		Name:         bc.instanceName,
+		AppProfileId: bc.appProfile,
+	}
+
+	// Use a timeout for the prime operation
+	primeCtx, cancel := context.WithTimeout(ctx, primeRPCTimeout)
+	defer cancel()
+
+	var p peer.Peer
+	_, err := client.PingAndWarm(primeCtx, req, grpc.Peer(&p))
+	if err != nil {
+		return false, err
+	}
+
+	isALTS := false
+	if p.AuthInfo != nil {
+		if _, ok := p.AuthInfo.(alts.AuthInfo); ok {
+			isALTS = true
+		}
+	}
+	return isALTS, nil
+}
+
+func NewBigtableConn(conn *grpc.ClientConn, instanceName, appProfileId string) *BigtableConn {
+	return &BigtableConn{
+		ClientConn:   conn,
+		instanceName: instanceName,
+		appProfile:   appProfileId,
+	}
+}
+
+// connEntry represents a single connection in the pool.
+type connEntry struct {
+	conn          *BigtableConn
+	unaryLoad     atomic.Int32 // In-flight unary requests
+	streamingLoad atomic.Int32 // Active streams
+	altsUsed      atomic.Bool  // alts used, best effort only checked during Prime()
+	errorCount    int64        // Errors since the last metric report
+	drainingState atomic.Bool  // True if the connection is being gracefully drained.
 
 }
 
+// isALTSUsed reports whether the connection is using ALTS aka Direct Access.
+// best effort basis
+func (e *connEntry) isALTSUsed() bool {
+	return e.altsUsed.Load()
+}
+
+// isDraining atomically checks if the connection is in the draining state.
+func (e *connEntry) isDraining() bool {
+	return e.drainingState.Load()
+}
+
+// markAsDraining atomically sets the connection's state to draining.
+// It returns true if it successfully marked it, false if it was already marked.
+func (e *connEntry) markAsDraining() bool {
+	return e.drainingState.CompareAndSwap(false, true)
+}
+
+// waitForDrainAndClose waits for a connection's in-flight request count to drop to zero
+// before closing it. It runs in a separate goroutine.
+func (p *BigtableChannelPool) waitForDrainAndClose(entry *connEntry) {
+	// Create a context with a drain timeout
+	ctx, cancel := context.WithTimeout(p.poolCtx, maxDrainingTimeout)
+	defer cancel()
+
+	ticker := time.NewTicker(250 * time.Millisecond) // 250ms tick
+	defer ticker.Stop()
+
+	btopt.Debugf(p.logger, "bigtable_connpool: Connection is draining, waiting for load to become 0.")
+
+	for {
+		select {
+		case <-ticker.C:
+			if entry.calculateWeightedLoad() == 0 {
+				btopt.Debugf(p.logger, "bigtable_connpool: Draining connection is idle, closing now.")
+				entry.conn.Close()
+				return
+			}
+		case <-ctx.Done():
+			btopt.Debugf(p.logger, "bigtable_connpool: Draining connection timed out after %v with load %d. Force closing.", maxDrainingTimeout, entry.calculateWeightedLoad())
+			entry.conn.Close()
+			return
+		}
+	}
+}
+
+func (e *connEntry) calculateWeightedLoad() int32 {
+	unary := e.unaryLoad.Load()
+	streaming := e.streamingLoad.Load()
+	return (unaryLoadFactor * unary) + (streamingLoadFactor * streaming)
+}
+
+// BigtableChannelPool implements ConnPool and routes requests to the connection
+// pool according to load balancing strategy.
+type BigtableChannelPool struct {
+	conns atomic.Value // Stores []*connEntry
+
+	dial       func() (*BigtableConn, error)
+	strategy   btopt.LoadBalancingStrategy
+	rrIndex    uint64                     // For round-robin selection
+	selectFunc func() (*connEntry, error) // returns *connEntry
+
+	dialMu sync.Mutex // Serializes dial/replace/resize operations
+
+	poolCtx    context.Context    // Context for the pool's background tasks
+	poolCancel context.CancelFunc // Function to cancel the poolCtx
+
+	logger *log.Logger // logging events
+}
+
+// getConns safely loads the current slice of connections.
+func (p *BigtableChannelPool) getConns() []*connEntry {
+	val := p.conns.Load()
+	if val == nil {
+		return nil
+	}
+	return val.([]*connEntry)
+}
+
 // NewBigtableChannelPool creates a pool of connPoolSize and takes the dial func()
-func NewBigtableChannelPool(connPoolSize int, strategy btopt.LoadBalancingStrategy, dial func() (*grpc.ClientConn, error)) (*BigtableChannelPool, error) {
+func NewBigtableChannelPool(ctx context.Context, connPoolSize int, strategy btopt.LoadBalancingStrategy, dial func() (*BigtableConn, error), logger *log.Logger, mp metric.MeterProvider, opts ...BigtableChannelPoolOption) (*BigtableChannelPool, error) {
 	if connPoolSize <= 0 {
 		return nil, fmt.Errorf("bigtable_connpool: connPoolSize must be positive")
 	}
@@ -59,10 +202,19 @@ func NewBigtableChannelPool(connPoolSize int, strategy btopt.LoadBalancingStrate
 	if dial == nil {
 		return nil, fmt.Errorf("bigtable_connpool: dial function cannot be nil")
 	}
+	poolCtx, poolCancel := context.WithCancel(ctx)
+
 	pool := &BigtableChannelPool{
-		dial:     dial,
-		strategy: strategy,
-		rrIndex:  0,
+		dial:       dial,
+		strategy:   strategy,
+		rrIndex:    0,
+		poolCtx:    poolCtx,
+		poolCancel: poolCancel,
+		logger:     logger,
+	}
+
+	for _, opt := range opts {
+		opt(pool)
 	}
 
 	// Set the selection function based on the strategy
@@ -75,30 +227,62 @@ func NewBigtableChannelPool(connPoolSize int, strategy btopt.LoadBalancingStrate
 		pool.selectFunc = pool.selectRoundRobin
 	}
 
+	initialConns := make([]*connEntry, connPoolSize)
 	for i := 0; i < connPoolSize; i++ {
+		select {
+		case <-pool.poolCtx.Done():
+			// Manually close connections created so far in this loop
+			for j := 0; j < i; j++ {
+				initialConns[j].conn.Close()
+			}
+			pool.poolCancel() // Ensure context is cancelled
+			return nil, pool.poolCtx.Err()
+		default:
+		}
+
+		// TODO Dial the initial connections in parallel using goroutines and a sync.WaitGroup
 		conn, err := dial()
 		if err != nil {
-			defer pool.Close()
+			// Manually close connections created so far in this loop
+			for j := 0; j < i; j++ {
+				initialConns[j].conn.Close()
+			}
+			pool.poolCancel() // Ensure context is cancelled
 			return nil, err
 		}
-		pool.conns = append(pool.conns, conn)
-		pool.load = append(pool.load, 0)
-
+		entry := &connEntry{conn: conn}
+		initialConns[i] = entry // TODO prime the connection
+		// Prime the new connection in a non-blocking goroutine to warm it up.
+		// We pass the conn object as an argument to avoid closing over the loop variable.
+		go func(e *connEntry) {
+			primeCtx, cancel := context.WithTimeout(pool.poolCtx, primeRPCTimeout)
+			defer cancel()
+			isALTS, err := e.conn.Prime(primeCtx)
+			if err != nil {
+				btopt.Debugf(pool.logger, "bigtable_connpool: failed to prime initial connection: %v\n", err)
+			} else if isALTS {
+				e.altsUsed.Store(true)
+			}
+		}(entry)
 	}
+	pool.conns.Store(initialConns)
 	return pool, nil
-
 }
 
 // Num returns the number of connections in the pool.
 func (p *BigtableChannelPool) Num() int {
-	return len(p.conns)
+	return len(p.getConns())
 }
 
 // Close closes all connections in the pool.
 func (p *BigtableChannelPool) Close() error {
+	p.poolCancel() // Cancel the context for background tasks
+	conns := p.getConns()
 	var errs multiError
-	for _, conn := range p.conns {
-		if err := conn.Close(); err != nil {
+
+	p.conns.Store(([]*connEntry)(nil)) // Mark as closed
+	for _, entry := range conns {
+		if err := entry.conn.Close(); err != nil {
 			errs = append(errs, err)
 		}
 	}
@@ -108,123 +292,220 @@ func (p *BigtableChannelPool) Close() error {
 	return errs
 }
 
+// replaceConnection closes the connection for the oldEntry
+func (p *BigtableChannelPool) replaceConnection(oldEntry *connEntry) {
+	p.dialMu.Lock() // Serialize replacements
+	defer p.dialMu.Unlock()
+
+	// Mark the connection
+	// if it is marked,
+	// it means another routine (health eviction or dynamic scale down) took over it.
+	if !oldEntry.markAsDraining() {
+		return
+	}
+
+	currentConns := p.getConns()
+	idx := -1
+	for i, entry := range currentConns {
+		if entry == oldEntry {
+			idx = i
+			break
+		}
+	}
+
+	// If the connection isn't in the slice, it was already removed.
+	// The drain process should still be kicked off.
+	if idx == -1 {
+		btopt.Debugf(p.logger, "bigtable_connpool: Connection to replace was already removed. Draining it.")
+		// thread safe to call waitForDrainAndClose as conn.Close() can be called multiple times.
+		go p.waitForDrainAndClose(oldEntry)
+		return
+	}
+	// Simple eviction logic.
+	btopt.Debugf(p.logger, "bigtable_connpool: Evicting connection at index %d\n", idx)
+	select {
+	case <-p.poolCtx.Done():
+		btopt.Debugf(p.logger, "bigtable_connpool: Pool context done, skipping redial: %v\n", p.poolCtx.Err())
+		return
+	default:
+	}
+	newConn, err := p.dial()
+	if err != nil {
+		btopt.Debugf(p.logger, "bigtable_connpool: Failed to redial connection at index %d: %v\n", idx, err)
+		return
+	}
+
+	newEntry := &connEntry{
+		conn: newConn,
+	}
+
+	go func() {
+		primeCtx, cancel := context.WithTimeout(p.poolCtx, primeRPCTimeout)
+		defer cancel()
+		isALTS, err := newConn.Prime(primeCtx)
+		if err != nil {
+			btopt.Debugf(p.logger, "bigtable_connpool: failed to prime replacement connection at index %d: %v\n", idx, err)
+		} else if isALTS {
+			newEntry.altsUsed.Store(true)
+		}
+	}()
+
+	// Copy-on-write
+	newConns := make([]*connEntry, len(currentConns))
+	copy(newConns, currentConns)
+	newConns[idx] = newEntry
+	p.conns.Store(newConns)
+
+	btopt.Debugf(p.logger, "bigtable_connpool: Replacing connection at index %d\n", idx)
+
+	// Start the graceful shutdown process for the old connection
+	go p.waitForDrainAndClose(oldEntry)
+}
+
 // Invoke selects the least loaded connection and calls Invoke on it.
 // This method provides automatic load tracking.
+// Load is tracked as a unary call.
 func (p *BigtableChannelPool) Invoke(ctx context.Context, method string, args interface{}, reply interface{}, opts ...grpc.CallOption) error {
-	index, err := p.selectFunc()
+	entry, err := p.selectFunc()
 	if err != nil {
 		return err
 	}
-	conn := p.conns[index]
+	entry.unaryLoad.Add(1)
+	defer entry.unaryLoad.Add(-1)
 
-	atomic.AddInt64(&p.load[index], 1)
-	defer atomic.AddInt64(&p.load[index], -1)
+	err = entry.conn.Invoke(ctx, method, args, reply, opts...)
+	if err != nil {
+		atomic.AddInt64(&entry.errorCount, 1)
+	}
+	return err
 
-	return conn.Invoke(ctx, method, args, reply, opts...)
 }
 
 // Conn provides connbased on selectfunc()
 func (p *BigtableChannelPool) Conn() *grpc.ClientConn {
-	index, err := p.selectFunc()
-	if err != nil {
-		// no conn available
+	bigtableConn := p.GetBigtableConn()
+	if bigtableConn == nil {
 		return nil
 	}
-	return p.conns[index]
+	return bigtableConn.ClientConn
+}
+
+func (p *BigtableChannelPool) GetBigtableConn() *BigtableConn {
+	entry, err := p.selectFunc()
+	if err != nil {
+		return nil
+	}
+	return entry.conn
 }
 
 // NewStream selects the least loaded connection and calls NewStream on it.
 // This method provides automatic load tracking via a wrapped stream.
 func (p *BigtableChannelPool) NewStream(ctx context.Context, desc *grpc.StreamDesc, method string, opts ...grpc.CallOption) (grpc.ClientStream, error) {
-	index, err := p.selectFunc()
+	entry, err := p.selectFunc()
 	if err != nil {
 		return nil, err
 	}
-	conn := p.conns[index]
 
-	atomic.AddInt64(&p.load[index], 1)
-
-	stream, err := conn.NewStream(ctx, desc, method, opts...)
-
+	entry.streamingLoad.Add(1)
+	stream, err := entry.conn.NewStream(ctx, desc, method, opts...)
 	if err != nil {
-		atomic.AddInt64(&p.load[index], -1) // Decrement if stream creation failed
+		atomic.AddInt64(&entry.errorCount, 1)
+		entry.streamingLoad.Add(-1) // Decrement immediately on creation failure
 		return nil, err
 	}
 
-	// Wrap the stream to decrement load when the stream finishes.
 	return &refCountedStream{
 		ClientStream: stream,
-		pool:         p,
-		connIndex:    index,
+		entry:        entry, // Store the entry itself
 		once:         sync.Once{},
 	}, nil
 }
 
 // selectLeastLoadedRandomOfTwo() returns the index of the connection via random of two
-func (p *BigtableChannelPool) selectLeastLoadedRandomOfTwo() (int, error) {
-	numConns := p.Num()
+func (p *BigtableChannelPool) selectLeastLoadedRandomOfTwo() (*connEntry, error) {
+	conns := p.getConns()
+	numConns := len(conns)
 	if numConns == 0 {
-		return -1, errNoConnections
+		return nil, errNoConnections
 	}
 	if numConns == 1 {
-		return 0, nil
+		if conns[0].isDraining() {
+			return nil, errNoConnections
+		}
+		return conns[0], nil
 	}
 
-	// Pick two distinct random indices
-	idx1 := rand.Intn(numConns)
-	idx2 := rand.Intn(numConns)
-	// Simple way to ensure they are different for small numConns.
-	// For very large numConns, the chance of collision is low,
-	// but a loop is safer.
-	for idx2 == idx1 {
-		idx2 = rand.Intn(numConns)
-	}
+	// Retry numConns * 2 times in worst case.
+	for i := 0; i < numConns*2 && numConns > 1; i++ {
+		idx1 := rand.Intn(numConns)
+		idx2 := rand.Intn(numConns)
 
-	load1 := atomic.LoadInt64(&p.load[idx1])
-	load2 := atomic.LoadInt64(&p.load[idx2])
+		entry1 := conns[idx1]
+		entry2 := conns[idx2]
 
-	if load1 <= load2 {
-		return idx1, nil
+		if entry1.isDraining() || entry2.isDraining() {
+			continue // Find another pair
+		}
+
+		if idx1 == idx2 {
+			return entry1, nil // Both random choices were the same and it's not draining
+		}
+
+		load1 := entry1.calculateWeightedLoad()
+		load2 := entry2.calculateWeightedLoad()
+		if load1 <= load2 {
+			return entry1, nil
+		}
+		return entry2, nil
 	}
-	return idx2, nil
+	//  Fallback to finding any active connection if the random strategy fails.,
+	return p.selectLeastLoaded()
 }
 
-func (p *BigtableChannelPool) selectRoundRobin() (int, error) {
-	numConns := p.Num()
+func (p *BigtableChannelPool) selectRoundRobin() (*connEntry, error) {
+	conns := p.getConns()
+	numConns := len(conns)
 	if numConns == 0 {
-		return -1, errNoConnections
+		return nil, errNoConnections
 	}
-	if numConns == 1 {
-		return 0, nil
+	// Add a retry loop to handle draining connections.
+	// We iterate at most numConns times to prevent an infinite loop if all connections are draining.
+	for i := 0; i < numConns; i++ {
+		nextIndex := atomic.AddUint64(&p.rrIndex, 1) - 1
+		entry := conns[int(nextIndex%uint64(numConns))]
+		if !entry.isDraining() {
+			return entry, nil
+		}
 	}
 
-	// Atomically increment and get the next index
-	nextIndex := atomic.AddUint64(&p.rrIndex, 1) - 1
-	return int(nextIndex % uint64(numConns)), nil
+	return nil, errNoConnections // All connections we checked are draining
 }
 
 // selectLeastLoaded returns the index of the connection with the minimum load.
-func (p *BigtableChannelPool) selectLeastLoaded() (int, error) {
-	numConns := p.Num()
-
+func (p *BigtableChannelPool) selectLeastLoaded() (*connEntry, error) {
+	conns := p.getConns()
+	numConns := len(conns)
 	if numConns == 0 {
-		return -1, errNoConnections
+		return nil, errNoConnections
 	}
 
-	p.mu.Lock()
-	defer p.mu.Unlock()
+	minIndex := -1
+	minLoad := int32(1<<31 - 1) // maxInt32
 
-	minIndex := 0
-	minLoad := atomic.LoadInt64(&p.load[0])
-
-	for i := 1; i < p.Num(); i++ {
-		currentLoad := atomic.LoadInt64(&p.load[i])
+	for i, entry := range conns {
+		if entry.isDraining() {
+			continue
+		}
+		currentLoad := entry.calculateWeightedLoad()
 		if currentLoad < minLoad {
 			minLoad = currentLoad
 			minIndex = i
 		}
 	}
-	return minIndex, nil
+	if minIndex == -1 {
+		return nil, errNoConnections // All connections are draining
+	}
+	return conns[minIndex], nil
 }
 
 // refCountedStream wraps a grpc.ClientStream to decrement the load count when the stream is done.
@@ -236,15 +517,15 @@ func (p *BigtableChannelPool) selectLeastLoaded() (int, error) {
 // The grpc.OnFinish callback is executed only when the entire stream is fully closed and the final status is determined.
 type refCountedStream struct {
 	grpc.ClientStream
-	pool      *BigtableChannelPool
-	connIndex int
-	once      sync.Once
+	entry *connEntry // Reference to the connection entry
+	once  sync.Once
 }
 
 // SendMsg calls the embedded stream's SendMsg method.
 func (s *refCountedStream) SendMsg(m interface{}) error {
 	err := s.ClientStream.SendMsg(m)
 	if err != nil {
+		atomic.AddInt64(&s.entry.errorCount, 1)
 		s.decrementLoad()
 	}
 	return err
@@ -254,6 +535,10 @@ func (s *refCountedStream) SendMsg(m interface{}) error {
 func (s *refCountedStream) RecvMsg(m interface{}) error {
 	err := s.ClientStream.RecvMsg(m)
 	if err != nil { // io.EOF is also an error, indicating stream end.
+		// io.EOF is a normal stream termination, not an error to be counted.
+		if !errors.Is(err, io.EOF) {
+			atomic.AddInt64(&s.entry.errorCount, 1)
+		}
 		s.decrementLoad()
 	}
 	return err
@@ -262,7 +547,7 @@ func (s *refCountedStream) RecvMsg(m interface{}) error {
 // decrementLoad ensures the load count is decremented exactly once.
 func (s *refCountedStream) decrementLoad() {
 	s.once.Do(func() {
-		atomic.AddInt64(&s.pool.load[s.connIndex], -1)
+		s.entry.streamingLoad.Add(-1)
 	})
 }
 

--- a/bigtable/internal/transport/connpool.go
+++ b/bigtable/internal/transport/connpool.go
@@ -611,18 +611,29 @@ func (p *BigtableChannelPool) NewStream(ctx context.Context, desc *grpc.StreamDe
 	}
 
 	entry.streamingLoad.Add(1)
-	stream, err := entry.conn.NewStream(ctx, desc, method, opts...)
+
+	rcs := &refCountedStream{entry: entry}
+
+	// grpc.OnFinish fires exactly once when gRPC has fully finished with the
+	// stream (status received, context cancelled, transport closed, etc.). It
+	// guarantees the load counter is decremented even when the caller abandons
+	// the stream without observing a final SendMsg/RecvMsg error — without it
+	// any such stream leaks streamingLoad permanently, poisoning load-balancing
+	// and stalling draining connections until maxDrainingTimeout.
+	streamOpts := append(opts, grpc.OnFinish(func(error) {
+		rcs.decrementLoad()
+	}))
+
+	stream, err := entry.conn.NewStream(ctx, desc, method, streamOpts...)
 	if err != nil {
 		entry.errorCount.Add(1)
-		entry.streamingLoad.Add(-1) // Decrement immediately on creation failure
+		// gRPC does not invoke OnFinish when NewStream itself fails, so
+		// release the load here. decrementLoad is idempotent.
+		rcs.decrementLoad()
 		return nil, err
 	}
-
-	return &refCountedStream{
-		ClientStream: stream,
-		entry:        entry, // Store the entry itself
-		once:         sync.Once{},
-	}, nil
+	rcs.ClientStream = stream
+	return rcs, nil
 }
 
 // selectLeastLoadedRandomOfTwo() returns the index of the connection via random of two
@@ -712,13 +723,16 @@ func (p *BigtableChannelPool) selectLeastLoaded() (*connEntry, error) {
 	return conns[minIndex], nil
 }
 
-// refCountedStream wraps a grpc.ClientStream to decrement the load count when the stream is done.
-// refCountedStream in this BigtableConnectionPool is to hook into the stream's lifecycle
-// to decrement the load counter (s.pool.load[s.connIndex]) when the stream is no longer usable.
-// This is primarily detected by errors occurring during SendMsg or RecvMsg (including io.EOF on RecvMsg).
-
-// Another option would have been to use grpc.OnFinish for streams is about the timing of when the load should be considered "finished".
-// The grpc.OnFinish callback is executed only when the entire stream is fully closed and the final status is determined.
+// refCountedStream wraps a grpc.ClientStream to decrement the connection's
+// streamingLoad counter exactly once when the stream is done. Decrement is
+// driven by two complementary signals:
+//   - SendMsg/RecvMsg errors (including io.EOF), which lets the load balancer
+//     stop counting the stream as soon as the caller observes it is finished.
+//   - grpc.OnFinish, wired in NewStream, which fires when gRPC fully closes
+//     the stream and acts as the backstop for callers that abandon the stream
+//     without draining (e.g. context cancellation).
+//
+// sync.Once ensures the two signals can race without double-decrementing.
 type refCountedStream struct {
 	grpc.ClientStream
 	entry *connEntry // Reference to the connection entry

--- a/bigtable/internal/transport/connpool.go
+++ b/bigtable/internal/transport/connpool.go
@@ -19,7 +19,6 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"io"
 	"log"
 	"math/rand"
 	"net/url"
@@ -602,8 +601,15 @@ func (p *BigtableChannelPool) getBigtableConn() *BigtableConn {
 	return entry.conn
 }
 
-// NewStream selects the least loaded connection and calls NewStream on it.
-// This method provides automatic load tracking via a wrapped stream.
+// NewStream selects a connection by the configured load-balancing strategy
+// and opens a stream on it, tracking streamingLoad for the lifetime of the
+// stream and counting any terminal error against the connection.
+//
+// grpc.OnFinish fires exactly once for any stream that was successfully
+// created — on normal completion, context cancellation, transport teardown,
+// etc. That single hook is the source of truth for both load accounting and
+// per-stream error attribution, so there is no need to wrap the returned
+// ClientStream.
 func (p *BigtableChannelPool) NewStream(ctx context.Context, desc *grpc.StreamDesc, method string, opts ...grpc.CallOption) (grpc.ClientStream, error) {
 	entry, err := p.selectFunc()
 	if err != nil {
@@ -612,28 +618,21 @@ func (p *BigtableChannelPool) NewStream(ctx context.Context, desc *grpc.StreamDe
 
 	entry.streamingLoad.Add(1)
 
-	rcs := &refCountedStream{entry: entry}
-
-	// grpc.OnFinish fires exactly once when gRPC has fully finished with the
-	// stream (status received, context cancelled, transport closed, etc.). It
-	// guarantees the load counter is decremented even when the caller abandons
-	// the stream without observing a final SendMsg/RecvMsg error — without it
-	// any such stream leaks streamingLoad permanently, poisoning load-balancing
-	// and stalling draining connections until maxDrainingTimeout.
-	streamOpts := append(opts, grpc.OnFinish(func(error) {
-		rcs.decrementLoad()
+	streamOpts := append(opts, grpc.OnFinish(func(finishErr error) {
+		if finishErr != nil {
+			entry.errorCount.Add(1)
+		}
+		entry.streamingLoad.Add(-1)
 	}))
 
 	stream, err := entry.conn.NewStream(ctx, desc, method, streamOpts...)
 	if err != nil {
+		// gRPC does not invoke OnFinish when NewStream itself fails.
 		entry.errorCount.Add(1)
-		// gRPC does not invoke OnFinish when NewStream itself fails, so
-		// release the load here. decrementLoad is idempotent.
-		rcs.decrementLoad()
+		entry.streamingLoad.Add(-1)
 		return nil, err
 	}
-	rcs.ClientStream = stream
-	return rcs, nil
+	return stream, nil
 }
 
 // selectLeastLoadedRandomOfTwo() returns the index of the connection via random of two
@@ -721,52 +720,6 @@ func (p *BigtableChannelPool) selectLeastLoaded() (*connEntry, error) {
 		return nil, errNoConnections // All connections are draining
 	}
 	return conns[minIndex], nil
-}
-
-// refCountedStream wraps a grpc.ClientStream to decrement the connection's
-// streamingLoad counter exactly once when the stream is done. Decrement is
-// driven by two complementary signals:
-//   - SendMsg/RecvMsg errors (including io.EOF), which lets the load balancer
-//     stop counting the stream as soon as the caller observes it is finished.
-//   - grpc.OnFinish, wired in NewStream, which fires when gRPC fully closes
-//     the stream and acts as the backstop for callers that abandon the stream
-//     without draining (e.g. context cancellation).
-//
-// sync.Once ensures the two signals can race without double-decrementing.
-type refCountedStream struct {
-	grpc.ClientStream
-	entry *connEntry // Reference to the connection entry
-	once  sync.Once
-}
-
-// SendMsg calls the embedded stream's SendMsg method.
-func (s *refCountedStream) SendMsg(m interface{}) error {
-	err := s.ClientStream.SendMsg(m)
-	if err != nil {
-		s.entry.errorCount.Add(1)
-		s.decrementLoad()
-	}
-	return err
-}
-
-// RecvMsg calls the embedded stream's RecvMsg method and decrements load on error.
-func (s *refCountedStream) RecvMsg(m interface{}) error {
-	err := s.ClientStream.RecvMsg(m)
-	if err != nil { // io.EOF is also an error, indicating stream end.
-		// io.EOF is a normal stream termination, not an error to be counted.
-		if !errors.Is(err, io.EOF) {
-			s.entry.errorCount.Add(1)
-		}
-		s.decrementLoad()
-	}
-	return err
-}
-
-// decrementLoad ensures the load count is decremented exactly once.
-func (s *refCountedStream) decrementLoad() {
-	s.once.Do(func() {
-		s.entry.streamingLoad.Add(-1)
-	})
 }
 
 // addConnections returns true if the pool size changed.

--- a/bigtable/internal/transport/connpool.go
+++ b/bigtable/internal/transport/connpool.go
@@ -155,12 +155,11 @@ func (bc *BigtableConn) Prime(ctx context.Context, fullInstanceName, appProfileI
 	if err != nil {
 		return err
 	}
-
 	if p.AuthInfo != nil {
 		if _, ok := p.AuthInfo.(alts.AuthInfo); ok {
 			bc.isALTSConn.Store(true)
 		}
-		fmt.Println("Using Peer Address", p.Addr)
+		btopt.Debugf(log.Default(), "Using Peer Address %v", p.Addr.String())
 	}
 	return nil
 }

--- a/bigtable/internal/transport/connpool.go
+++ b/bigtable/internal/transport/connpool.go
@@ -376,6 +376,8 @@ func NewBigtableChannelPool(ctx context.Context, connPoolSize int, strategy btop
 
 	pool.conns.Store(&initialConns)
 
+	btopt.Debugf(pool.logger, "bigtable_connpool: using load balancing strategy: %s\n", strategy)
+
 	metricsReporter, err := NewMetricsReporter(pool.metricsConfig, pool.connPoolStatsSupplier, pool.logger, pool.meterProvider)
 	if err == nil {
 		// ignore
@@ -383,11 +385,13 @@ func NewBigtableChannelPool(ctx context.Context, connPoolSize int, strategy btop
 	} else {
 		btopt.Debugf(pool.logger, "bigtable_connpool: failed to create metrics reporter: %v\n", err)
 	}
+	pool.startMonitors()
 	return pool, nil
 }
 
 func (p *BigtableChannelPool) startMonitors() {
 	for _, m := range p.monitors {
+		btopt.Debugf(p.logger, "bigtable_connpool: Starting monitor %T\n", m)
 		m.Start(p.poolCtx)
 	}
 }

--- a/bigtable/internal/transport/connpool.go
+++ b/bigtable/internal/transport/connpool.go
@@ -413,6 +413,7 @@ func NewBigtableChannelPool(ctx context.Context, connPoolSize int, strategy btop
 }
 
 func (p *BigtableChannelPool) checkDirectAccessEligibility(ctx context.Context) {
+	// deferred recover for avoiding crash
 	defer func() {
 		if r := recover(); r != nil {
 			btopt.Debugf(p.logger, "bigtable_connpool: Recovered from panic in checkDirectAccessEligibility: %v", r)
@@ -430,6 +431,7 @@ func (p *BigtableChannelPool) checkDirectAccessEligibility(ctx context.Context) 
 	}
 	defer conn.Close()
 
+	// this is sad. send this feature flags.
 	customFeatures := btpb.FeatureFlags{
 		RoutingCookie:            true,
 		ReverseScans:             true,
@@ -451,6 +453,7 @@ func (p *BigtableChannelPool) checkDirectAccessEligibility(ctx context.Context) 
 	err = conn.Prime(ctx, p.instanceName, p.appProfile, ffMd)
 
 	if err != nil {
+		// invoke the callback
 		p.directAccessEligibleReporter(ctx, isEligible)
 		return
 	}

--- a/bigtable/internal/transport/connpool.go
+++ b/bigtable/internal/transport/connpool.go
@@ -16,6 +16,7 @@ package internal
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"io"
@@ -34,6 +35,7 @@ import (
 	"google.golang.org/grpc/credentials/alts"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/peer"
+	"google.golang.org/protobuf/proto"
 
 	btopt "cloud.google.com/go/bigtable/internal/option"
 
@@ -422,14 +424,31 @@ func (p *BigtableChannelPool) checkDirectAccessEligibility(ctx context.Context) 
 
 	isEligible := false
 	conn, err := p.directAccessDialFunc()
-	defer conn.Close()
-
 	if err != nil {
 		p.directAccessEligibleReporter(ctx, isEligible)
 		return
 	}
+	defer conn.Close()
 
-	err = conn.Prime(ctx, p.instanceName, p.appProfile, p.featureFlagsMD)
+	customFeatures := btpb.FeatureFlags{
+		RoutingCookie:            true,
+		ReverseScans:             true,
+		LastScannedRowResponses:  true,
+		ClientSideMetricsEnabled: true,
+		RetryInfo:                true,
+		TrafficDirectorEnabled:   true,
+		DirectAccessRequested:    true,
+	}
+
+	val := ""
+	b, err := proto.Marshal(&customFeatures)
+	if err == nil {
+		val = base64.URLEncoding.EncodeToString(b)
+	}
+
+	ffMd := metadata.Pairs("bigtable-features", val)
+
+	err = conn.Prime(ctx, p.instanceName, p.appProfile, ffMd)
 
 	if err != nil {
 		p.directAccessEligibleReporter(ctx, isEligible)

--- a/bigtable/internal/transport/connpool.go
+++ b/bigtable/internal/transport/connpool.go
@@ -49,6 +49,20 @@ const requestParamsHeader = "x-goog-request-params"
 // BigtableChannelPoolOption options for configurable
 type BigtableChannelPoolOption func(*BigtableChannelPool)
 
+// connPoolStatsSupplier callback  that returns a snapshot of connection pool statistics.
+type connPoolStatsSupplier func() []connPoolStats
+
+// connPoolStats holds a snapshot of statistics for a single connection.
+type connPoolStats struct {
+	OutstandingUnaryLoad     int32
+	OutstandingStreamingLoad int32
+	ErrorCount               int64
+	IsALTSUsed               bool
+	LBPolicy                 string
+}
+
+var _ Monitor = (*MetricsReporter)(nil)
+
 // WithAppProfile provides the appProfile
 func WithAppProfile(appProfile string) BigtableChannelPoolOption {
 	return func(p *BigtableChannelPool) {
@@ -132,6 +146,28 @@ func (bc *BigtableConn) Prime(ctx context.Context, fullInstanceName, appProfileI
 		}
 	}
 	return nil
+}
+
+// connPoolStatsSupplier returns a snapshot of the current connection pool statistics.
+func (p *BigtableChannelPool) connPoolStatsSupplier() []connPoolStats {
+	conns := p.getConns()
+	if len(conns) == 0 {
+		return nil
+	}
+
+	stats := make([]connPoolStats, len(conns))
+	lbPolicy := p.strategy.String()
+
+	for i, entry := range conns {
+		stats[i] = connPoolStats{
+			OutstandingUnaryLoad:     entry.unaryLoad.Load(),
+			OutstandingStreamingLoad: entry.streamingLoad.Load(),
+			ErrorCount:               entry.errorCount.Swap(0),
+			IsALTSUsed:               entry.isALTSUsed(),
+			LBPolicy:                 lbPolicy,
+		}
+	}
+	return stats
 }
 
 // NewBigtableConn creates a wrapped grpc Client Conn
@@ -242,6 +278,15 @@ type BigtableChannelPool struct {
 	instanceName   string
 	featureFlagsMD metadata.MD
 	meterProvider  metric.MeterProvider
+	// configs
+	metricsConfig btopt.MetricsReporterConfig
+
+	// background monitors
+	monitors []Monitor
+}
+
+func WithMetricsReporterConfig(config btopt.MetricsReporterConfig) BigtableChannelPoolOption {
+	return func(p *BigtableChannelPool) { p.metricsConfig = config }
 }
 
 // getConns safely loads the current slice of connections.
@@ -330,7 +375,21 @@ func NewBigtableChannelPool(ctx context.Context, connPoolSize int, strategy btop
 	}
 
 	pool.conns.Store(&initialConns)
+
+	metricsReporter, err := NewMetricsReporter(pool.metricsConfig, pool.connPoolStatsSupplier, pool.logger, pool.meterProvider)
+	if err == nil {
+		// ignore
+		pool.monitors = append(pool.monitors, metricsReporter)
+	} else {
+		btopt.Debugf(pool.logger, "bigtable_connpool: failed to create metrics reporter: %v\n", err)
+	}
 	return pool, nil
+}
+
+func (p *BigtableChannelPool) startMonitors() {
+	for _, m := range p.monitors {
+		m.Start(p.poolCtx)
+	}
 }
 
 // Num returns the number of connections in the pool.
@@ -341,6 +400,10 @@ func (p *BigtableChannelPool) Num() int {
 // Close closes all connections in the pool.
 func (p *BigtableChannelPool) Close() error {
 	p.poolCancel() // Cancel the context for background tasks
+	// Stop all monitors.
+	for _, m := range p.monitors {
+		m.Stop()
+	}
 	conns := p.getConns()
 	var errs multiError
 

--- a/bigtable/internal/transport/connpool.go
+++ b/bigtable/internal/transport/connpool.go
@@ -423,6 +423,7 @@ func (p *BigtableChannelPool) checkDirectAccessEligibility(ctx context.Context) 
 	btopt.Debugf(p.logger, "bigtable_connpool: Starting DirectPath eligibility check.")
 
 	isEligible := false
+	timeStart := time.Now()
 	conn, err := p.directAccessDialFunc()
 	if err != nil {
 		p.directAccessEligibleReporter(ctx, isEligible)
@@ -461,6 +462,8 @@ func (p *BigtableChannelPool) checkDirectAccessEligibility(ctx context.Context) 
 	} else {
 		btopt.Debugf(p.logger, "bigtable_connpool: DirectPath Prime succeeded but not via ALTS.")
 	}
+
+	btopt.Debugf(p.logger, "bigtable_connpool: DirectPath eligibility %v", time.Since(timeStart))
 
 	p.directAccessEligibleReporter(ctx, isEligible)
 

--- a/bigtable/internal/transport/connpool.go
+++ b/bigtable/internal/transport/connpool.go
@@ -98,6 +98,20 @@ func WithFeatureFlagsMetadata(featureFlagsMd metadata.MD) BigtableChannelPoolOpt
 	}
 }
 
+// WithDirectAccessDialFunc provides the dial function for DirectPath eligibility checking.
+func WithDirectAccessDialFunc(dial func() (*BigtableConn, error)) BigtableChannelPoolOption {
+	return func(p *BigtableChannelPool) {
+		p.directAccessDialFunc = dial
+	}
+}
+
+// WithDirectAccessEligibleReporter provides the callback to report DirectPath eligibility.
+func WithDirectAccessEligibleReporter(reporter func(context.Context, bool)) BigtableChannelPoolOption {
+	return func(p *BigtableChannelPool) {
+		p.directAccessEligibleReporter = reporter
+	}
+}
+
 const (
 	primeRPCTimeout = 10 * time.Second
 )
@@ -144,6 +158,7 @@ func (bc *BigtableConn) Prime(ctx context.Context, fullInstanceName, appProfileI
 		if _, ok := p.AuthInfo.(alts.AuthInfo); ok {
 			bc.isALTSConn.Store(true)
 		}
+		fmt.Println("Using Peer Address", p.Addr)
 	}
 	return nil
 }
@@ -283,6 +298,9 @@ type BigtableChannelPool struct {
 
 	// background monitors
 	monitors []Monitor
+
+	directAccessDialFunc         func() (*BigtableConn, error)
+	directAccessEligibleReporter func(context.Context, bool)
 }
 
 func WithMetricsReporterConfig(config btopt.MetricsReporterConfig) BigtableChannelPoolOption {
@@ -375,8 +393,12 @@ func NewBigtableChannelPool(ctx context.Context, connPoolSize int, strategy btop
 	}
 
 	pool.conns.Store(&initialConns)
+	btopt.Debugf(pool.logger, "bigtable_connpool: started pool with load balancing strategy: %s\n", strategy)
 
-	btopt.Debugf(pool.logger, "bigtable_connpool: using load balancing strategy: %s\n", strategy)
+	// Start DirectAccess eligibility check in background.
+	if pool.directAccessDialFunc != nil && pool.directAccessEligibleReporter != nil {
+		go pool.checkDirectAccessEligibility(pool.poolCtx)
+	}
 
 	metricsReporter, err := NewMetricsReporter(pool.metricsConfig, pool.connPoolStatsSupplier, pool.logger, pool.meterProvider)
 	if err == nil {
@@ -387,6 +409,42 @@ func NewBigtableChannelPool(ctx context.Context, connPoolSize int, strategy btop
 	}
 	pool.startMonitors()
 	return pool, nil
+}
+
+func (p *BigtableChannelPool) checkDirectAccessEligibility(ctx context.Context) {
+	defer func() {
+		if r := recover(); r != nil {
+			btopt.Debugf(p.logger, "bigtable_connpool: Recovered from panic in checkDirectAccessEligibility: %v", r)
+			p.directAccessEligibleReporter(ctx, false)
+		}
+	}()
+	btopt.Debugf(p.logger, "bigtable_connpool: Starting DirectPath eligibility check.")
+
+	isEligible := false
+	conn, err := p.directAccessDialFunc()
+	defer conn.Close()
+
+	if err != nil {
+		p.directAccessEligibleReporter(ctx, isEligible)
+		return
+	}
+
+	err = conn.Prime(ctx, p.instanceName, p.appProfile, p.featureFlagsMD)
+
+	if err != nil {
+		p.directAccessEligibleReporter(ctx, isEligible)
+		return
+	}
+
+	if conn.isALTSConn.Load() {
+		btopt.Debugf(p.logger, "bigtable_connpool: DirectPath Prime succeeded with ALTS.")
+		isEligible = true
+	} else {
+		btopt.Debugf(p.logger, "bigtable_connpool: DirectPath Prime succeeded but not via ALTS.")
+	}
+
+	p.directAccessEligibleReporter(ctx, isEligible)
+
 }
 
 func (p *BigtableChannelPool) startMonitors() {

--- a/bigtable/internal/transport/connpool_helper_test.go
+++ b/bigtable/internal/transport/connpool_helper_test.go
@@ -203,3 +203,14 @@ func setConnLoads(conns []*connEntry, unary, stream int32) {
 		entry.streamingLoad.Store(stream)
 	}
 }
+
+// findMonitor safely finds a monitor of a specific type from the pool's slice.
+func findMonitor[T Monitor](pool *BigtableChannelPool) (T, bool) {
+	for _, m := range pool.monitors {
+		if monitor, ok := m.(T); ok {
+			return monitor, true
+		}
+	}
+	var zero T
+	return zero, false
+}

--- a/bigtable/internal/transport/connpool_helper_test.go
+++ b/bigtable/internal/transport/connpool_helper_test.go
@@ -118,6 +118,24 @@ func (s *fakeService) StreamingCall(stream testpb.BenchmarkService_StreamingCall
 	}
 }
 
+func (f *fakeService) reset() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.callCount = 0
+	f.pingCount = 0
+	f.serverErr = nil
+	f.pingErr = nil
+	f.delay = 0
+	f.lastPingAndWarmMetadata = nil
+	if f.streamSema != nil {
+		select {
+		case <-f.streamSema: // Drain if not closed
+		default:
+		}
+	}
+	f.streamSema = nil
+}
+
 func (s *fakeService) PingAndWarm(ctx context.Context, req *btpb.PingAndWarmRequest) (*btpb.PingAndWarmResponse, error) {
 	s.mu.Lock()
 	s.pingCount++

--- a/bigtable/internal/transport/connpool_helper_test.go
+++ b/bigtable/internal/transport/connpool_helper_test.go
@@ -1,0 +1,205 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"context"
+	"io"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	btpb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
+	"google.golang.org/grpc/credentials/insecure"
+	testpb "google.golang.org/grpc/interop/grpc_testing"
+)
+
+// fakeService is a mock gRPC server that implements both BenchmarkService and BigtableServer.
+type fakeService struct {
+	testpb.UnimplementedBenchmarkServiceServer
+	btpb.UnimplementedBigtableServer
+	mu            sync.Mutex
+	pingCount     int
+	callCount     int
+	streamSema    chan struct{} // To control stream lifetime
+	delay         time.Duration // To simulate work
+	serverErr     error         // Error to return from server
+	pingErr       error         // Error to return from PingAndWarm
+	pingErrMu     sync.Mutex    // Protects pingErr
+	streamRecvErr error         // Error to return from stream.Recv()
+	streamSendErr error         // Error to return from stream.Send()
+}
+
+func (s *fakeService) setPingErr(err error) {
+	s.pingErrMu.Lock()
+	defer s.pingErrMu.Unlock()
+	s.pingErr = err
+}
+
+func (s *fakeService) setDelay(duration time.Duration) {
+	s.pingErrMu.Lock()
+	defer s.pingErrMu.Unlock()
+	s.delay = duration
+}
+
+func (s *fakeService) getDelay() time.Duration {
+	s.pingErrMu.Lock()
+	defer s.pingErrMu.Unlock()
+	return s.delay
+}
+
+func (s *fakeService) getPingErr() error {
+	s.pingErrMu.Lock()
+	defer s.pingErrMu.Unlock()
+	return s.pingErr
+}
+
+func (s *fakeService) UnaryCall(ctx context.Context, req *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
+	s.mu.Lock()
+	s.callCount++
+	s.mu.Unlock()
+	if s.delay > 0 {
+		time.Sleep(s.delay)
+	}
+	if s.serverErr != nil {
+		return nil, s.serverErr
+	}
+	return &testpb.SimpleResponse{Payload: req.GetPayload()}, nil
+}
+
+func (s *fakeService) StreamingCall(stream testpb.BenchmarkService_StreamingCallServer) error {
+	s.mu.Lock()
+	s.callCount++
+	s.mu.Unlock()
+
+	if s.serverErr != nil {
+		return s.serverErr
+	}
+
+	if s.streamSema != nil {
+		<-s.streamSema
+	}
+
+	for {
+		req, err := stream.Recv()
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		if s.streamRecvErr != nil {
+			return s.streamRecvErr
+		}
+
+		if err := stream.Send(&testpb.SimpleResponse{Payload: req.GetPayload()}); err != nil {
+			return err
+		}
+		if s.streamSendErr != nil {
+			return s.streamSendErr
+		}
+	}
+}
+
+func (s *fakeService) PingAndWarm(ctx context.Context, req *btpb.PingAndWarmRequest) (*btpb.PingAndWarmResponse, error) {
+	s.mu.Lock()
+	s.pingCount++
+	defer s.mu.Unlock()
+
+	delay := s.getDelay()
+
+	if delay > 0 {
+		select {
+		case <-time.After(delay):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if err := s.getPingErr(); err != nil {
+		return nil, err
+	}
+	return &btpb.PingAndWarmResponse{}, nil
+}
+
+func (s *fakeService) getCallCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.callCount
+}
+
+func (s *fakeService) getPingCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.pingCount
+}
+
+func (s *fakeService) setPingCount(count int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.pingCount = count
+}
+
+func setupTestServer(t testing.TB, service *fakeService) string {
+	t.Helper()
+	lis, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("Failed to listen: %v", err)
+	}
+	srv := grpc.NewServer()
+	testpb.RegisterBenchmarkServiceServer(srv, service)
+	btpb.RegisterBigtableServer(srv, service)
+	go func() {
+		srv.Serve(lis)
+	}()
+
+	t.Cleanup(func() {
+		srv.Stop()
+		lis.Close()
+	})
+
+	return lis.Addr().String()
+}
+
+func dialBigtableserver(addr string) (*BigtableConn, error) {
+	return dialBigtableserverWithInstanceNameAndAppProfile(addr, "test-instance", "test-profile")
+}
+
+func dialBigtableserverWithInstanceNameAndAppProfile(addr string, instanceName, appProfile string) (*BigtableConn, error) {
+	conn, err := grpc.Dial(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return nil, err
+	}
+	return NewBigtableConn(conn, instanceName, appProfile), nil
+}
+
+// isConnClosed checks if a grpc.ClientConn has been closed.
+func isConnClosed(conn *grpc.ClientConn) bool {
+	return conn.GetState() == connectivity.Shutdown
+}
+
+// setConnLoads is a test helper to set the load on all connections in a slice.
+func setConnLoads(conns []*connEntry, unary, stream int32) {
+	for _, entry := range conns {
+		entry.unaryLoad.Store(unary)
+		entry.streamingLoad.Store(stream)
+	}
+}

--- a/bigtable/internal/transport/connpool_helper_test.go
+++ b/bigtable/internal/transport/connpool_helper_test.go
@@ -203,14 +203,3 @@ func setConnLoads(conns []*connEntry, unary, stream int32) {
 		entry.streamingLoad.Store(stream)
 	}
 }
-
-// findMonitor safely finds a monitor of a specific type from the pool's slice.
-func findMonitor[T Monitor](pool *BigtableChannelPool) (T, bool) {
-	for _, m := range pool.monitors {
-		if monitor, ok := m.(T); ok {
-			return monitor, true
-		}
-	}
-	var zero T
-	return zero, false
-}

--- a/bigtable/internal/transport/connpool_helper_test.go
+++ b/bigtable/internal/transport/connpool_helper_test.go
@@ -188,7 +188,7 @@ func dialBigtableserverWithInstanceNameAndAppProfile(addr string, instanceName, 
 	if err != nil {
 		return nil, err
 	}
-	return NewBigtableConn(conn, instanceName, appProfile), nil
+	return newBigtableConn(conn, instanceName, appProfile), nil
 }
 
 // isConnClosed checks if a grpc.ClientConn has been closed.

--- a/bigtable/internal/transport/connpool_helper_test.go
+++ b/bigtable/internal/transport/connpool_helper_test.go
@@ -206,7 +206,6 @@ func setupTestServer(t testing.TB, service *fakeService) string {
 		srv.Stop()
 		lis.Close()
 	})
-
 	return lis.Addr().String()
 }
 

--- a/bigtable/internal/transport/connpool_test.go
+++ b/bigtable/internal/transport/connpool_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"net/url"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -1121,6 +1122,290 @@ func TestReplaceConnection(t *testing.T) {
 		// Connection should NOT be replaced as Prime() fails
 		if pool.getConns()[idxToReplace] != currentEntry {
 			t.Errorf("Connection entry changed despite Prime() failure")
+		}
+	})
+}
+
+func TestAddConnections(t *testing.T) {
+	ctx := context.Background()
+	fake := &fakeService{}
+	addr := setupTestServer(t, fake)
+
+	baseDialFunc := func() (*BigtableConn, error) { return dialBigtableserver(addr) }
+
+	tests := []struct {
+		name           string
+		initialSize    int
+		increaseDelta  int
+		maxConns       int
+		dialFunc       func() (*BigtableConn, error)
+		primeErr       error
+		cancelCtx      bool
+		wantChange     bool
+		wantFinalSize  int
+		wantDials      int32 // dial() for each conn
+		wantPrimes     int32 // Prime() for each conn
+		primeShouldErr bool
+	}{
+		{
+			name:          "AddBelowMaxConns",
+			initialSize:   1,
+			increaseDelta: 2,
+			maxConns:      5,
+			dialFunc:      baseDialFunc,
+			wantChange:    true,
+			wantFinalSize: 3,
+			wantDials:     2,
+			wantPrimes:    2,
+		},
+		{
+			name:          "AddUptoMaxConns",
+			initialSize:   3,
+			increaseDelta: 3,
+			maxConns:      5,
+			dialFunc:      baseDialFunc,
+			wantChange:    true,
+			wantFinalSize: 5,
+			wantDials:     2,
+			wantPrimes:    2,
+		},
+		{
+			name:          "NoChangeIfMaxConnsReached",
+			initialSize:   5,
+			increaseDelta: 1,
+			maxConns:      5,
+			dialFunc:      baseDialFunc,
+			wantChange:    false,
+			wantFinalSize: 5,
+			wantDials:     0,
+		},
+		{
+			name:          "PartialDialFailurePartialAdd",
+			initialSize:   1,
+			increaseDelta: 3, // we want 3 delta, 4 conns
+			maxConns:      5,
+			dialFunc: func() func() (*BigtableConn, error) {
+				var count int32
+				return func() (*BigtableConn, error) {
+					if atomic.AddInt32(&count, 1) > 1 {
+						return nil, errors.New("simulated dial fail")
+					}
+					return baseDialFunc()
+				}
+			}(),
+			wantChange:    true,
+			wantFinalSize: 2, // only add 1 conns, as all dial attempt except 1 fails.
+			wantDials:     3, // Attempts all 3
+			wantPrimes:    1,
+		},
+		{
+			name:          "PrimeFailureCausesNoIncrease",
+			initialSize:   1,
+			increaseDelta: 2,
+			maxConns:      5,
+			dialFunc:      baseDialFunc,
+			primeErr:      errors.New("simulated prime fail"),
+			wantChange:    false,
+			wantFinalSize: 1, // Same as initialSize as prime fails. No point in adding
+			wantDials:     2,
+			wantPrimes:    2,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fake.reset()
+			if tc.primeErr != nil {
+				fake.setPingErr(tc.primeErr)
+			}
+
+			innerCtx, cancel := context.WithCancel(ctx)
+			defer cancel()
+
+			pool, err := NewBigtableChannelPool(innerCtx, tc.initialSize, btopt.RoundRobin, baseDialFunc, poolOpts()...)
+			if err != nil {
+				t.Fatalf("Failed to create pool: %v", err)
+			}
+			defer pool.Close()
+
+			pool.dial = tc.dialFunc // Override dial func for test
+
+			if tc.cancelCtx {
+				go func() {
+					time.Sleep(5 * time.Millisecond) // Cancel shortly after addConnections starts
+					cancel()
+				}()
+			}
+
+			changed := pool.addConnections(tc.increaseDelta, tc.maxConns)
+
+			if changed != tc.wantChange {
+				t.Errorf("addConnections() got change %v, want %v", changed, tc.wantChange)
+			}
+
+			finalSize := pool.Num()
+			if tc.wantDials != -1 && finalSize != tc.wantFinalSize && !tc.cancelCtx {
+				t.Errorf("addConnections() final size got %d, want %d", finalSize, tc.wantFinalSize)
+			}
+
+			// Allow goroutines to settle
+			time.Sleep(50 * time.Millisecond)
+
+			// Checks on dial/prime counts are not perfectly reliable with cancellations
+			if !tc.cancelCtx {
+				if tc.wantDials != -1 {
+					// This check is tricky because dial attempts stop if one fails in the loop.
+					// We can't easily count dials without instrumenting the test dialFunc.
+				}
+				if tc.wantPrimes != -1 {
+					if int32(fake.getPingCount()) != tc.wantPrimes {
+						// t.Errorf("addConnections() prime attempts got %d, want %d", fake.getPingCount(), tc.wantPrimes)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestRemoveConnections(t *testing.T) {
+	ctx := context.Background()
+	fake := &fakeService{}
+	addr := setupTestServer(t, fake)
+
+	dialFunc := func() (*BigtableConn, error) {
+		time.Sleep(time.Millisecond * 2)
+		return dialBigtableserver(addr)
+	}
+
+	tests := []struct {
+		name           string
+		initialSize    int
+		decreaseDelta  int
+		minConns       int
+		maxRemoveConns int
+		wantChange     bool
+		wantFinalSize  int
+	}{
+		{
+			name:           "RemoveAboveMinConns",
+			initialSize:    5,
+			decreaseDelta:  2,
+			minConns:       1,
+			maxRemoveConns: 5,
+			wantChange:     true,
+			wantFinalSize:  3,
+		},
+		{
+			name:           "RemoveToMinConns",
+			initialSize:    3,
+			decreaseDelta:  3,
+			minConns:       1,
+			maxRemoveConns: 5,
+			wantChange:     true,
+			wantFinalSize:  1,
+		},
+		{
+			name:           "NoChange",
+			initialSize:    3,
+			decreaseDelta:  3,
+			minConns:       2,
+			maxRemoveConns: 5,
+			wantChange:     true,
+			wantFinalSize:  2,
+		},
+		{
+			name:           "CapToMaxRemoveConns",
+			initialSize:    10,
+			decreaseDelta:  8,
+			minConns:       1,
+			maxRemoveConns: 3,
+			wantChange:     true,
+			wantFinalSize:  7,
+		},
+		{
+			name:           "NoRemoveAtMinConns",
+			initialSize:    1,
+			decreaseDelta:  1,
+			minConns:       1,
+			maxRemoveConns: 5,
+			wantChange:     false,
+			wantFinalSize:  1,
+		},
+		{
+			name:           "DeltaZeroNoChnage",
+			initialSize:    5,
+			decreaseDelta:  0,
+			minConns:       1,
+			maxRemoveConns: 5,
+			wantChange:     false,
+			wantFinalSize:  5,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			pool, err := NewBigtableChannelPool(ctx, tc.initialSize, btopt.RoundRobin, dialFunc, poolOpts()...)
+			if err != nil {
+				t.Fatalf("Failed to create pool: %v", err)
+			}
+			defer pool.Close()
+			time.Sleep(time.Duration(tc.initialSize*10) * time.Millisecond)
+
+			changed := pool.removeConnections(tc.decreaseDelta, tc.minConns, tc.maxRemoveConns)
+
+			if changed != tc.wantChange {
+				t.Errorf("removeConnections() got change %v, want %v", changed, tc.wantChange)
+			}
+
+			finalConns := pool.getConns()
+			if len(finalConns) != tc.wantFinalSize {
+				t.Errorf("removeConnections() final size got %d, want %d", len(finalConns), tc.wantFinalSize)
+			}
+		})
+	}
+
+	t.Run("VerifyOldestIsRemoved", func(t *testing.T) {
+		poolSize := 5
+		pool, err := NewBigtableChannelPool(ctx, poolSize, btopt.RoundRobin, dialFunc, poolOpts()...)
+		if err != nil {
+			t.Fatalf("Failed to create pool: %v", err)
+		}
+		defer pool.Close()
+
+		initialConns := make([]*connEntry, poolSize)
+		copy(initialConns, pool.getConns())
+
+		sort.Slice(initialConns, func(i, j int) bool {
+			return initialConns[i].createdAt().Before(initialConns[j].createdAt())
+		})
+
+		numToRemove := 2
+		pool.removeConnections(numToRemove, 1, 5)
+
+		finalConns := pool.getConns()
+		if len(finalConns) != poolSize-numToRemove {
+			t.Fatalf("Final pool size %d, want %d", len(finalConns), poolSize-numToRemove)
+		}
+
+		finalConnsSet := make(map[*connEntry]bool)
+		for _, entry := range finalConns {
+			finalConnsSet[entry] = true
+		}
+
+		for i := 0; i < numToRemove; i++ {
+			oldestEntry := initialConns[i]
+			if finalConnsSet[oldestEntry] {
+				t.Errorf("Oldest connection at index %d was not removed", i)
+			}
+			if !oldestEntry.isDraining() {
+				t.Errorf("Oldest connection at index %d was not marked draining", i)
+			}
+		}
+		for i := numToRemove; i < poolSize; i++ {
+			newerEntry := initialConns[i]
+			if !finalConnsSet[newerEntry] {
+				t.Errorf("Newer connection at index %d was unexpectedly removed", i)
+			}
 		}
 	})
 }

--- a/bigtable/internal/transport/connpool_test.go
+++ b/bigtable/internal/transport/connpool_test.go
@@ -146,11 +146,11 @@ func TestBigtableConn_Prime(t *testing.T) {
 		}
 		defer conn.Close()
 		fake.setPingCount(0)
-		isALTS, err := conn.Prime(ctx)
+		err = conn.Prime(ctx)
 		if err != nil {
 			t.Errorf("Prime() failed: %v", err)
 		}
-		if isALTS {
+		if conn.isALTSConn.Load() {
 			t.Errorf("Prime() got isALTS true, want false")
 		}
 		if fake.getPingCount() != 1 {
@@ -201,7 +201,7 @@ func TestBigtableConn_Prime(t *testing.T) {
 			fake.setPingErr(tc.pingErr)
 			defer func() { fake.setPingErr(nil) }()
 
-			_, err = conn.Prime(ctx)
+			err = conn.Prime(ctx)
 			if err == nil {
 				t.Fatalf("Prime() succeeded, want error")
 			}
@@ -235,7 +235,7 @@ func TestBigtableConn_Prime(t *testing.T) {
 		primeCtx, cancel := context.WithTimeout(ctx, 100*time.Millisecond) // Shorter than primeRPCTimeout
 		defer cancel()
 
-		_, err = conn.Prime(primeCtx)
+		err = conn.Prime(primeCtx)
 		if err == nil {
 			t.Fatalf("Prime() succeeded, want timeout error")
 		}

--- a/bigtable/internal/transport/connpool_test.go
+++ b/bigtable/internal/transport/connpool_test.go
@@ -19,122 +19,51 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net"
+	"log"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
-	btopt "cloud.google.com/go/bigtable/internal/option"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
-
-	testgrpc "google.golang.org/grpc/interop/grpc_testing"
+	"google.golang.org/grpc/codes"
 	testpb "google.golang.org/grpc/interop/grpc_testing"
 	"google.golang.org/grpc/status"
+
+	btopt "cloud.google.com/go/bigtable/internal/option"
+	"google.golang.org/api/option"
+
+	gtransport "google.golang.org/api/transport/grpc"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
-type fakeService struct {
-	testgrpc.UnimplementedBenchmarkServiceServer
-	mu         sync.Mutex
-	callCount  int
-	streamSema chan struct{} // To control stream lifetime
-	delay      time.Duration // To simulate work
-	serverErr  error         // Error to return from server
-}
-
-func (s *fakeService) UnaryCall(ctx context.Context, req *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
-	s.mu.Lock()
-	s.callCount++
-	s.mu.Unlock()
-	if s.delay > 0 {
-		time.Sleep(s.delay)
-	}
-	if s.serverErr != nil {
-		return nil, s.serverErr
-	}
-	// Echo the payload
-	return &testpb.SimpleResponse{Payload: req.GetPayload()}, nil
-}
-
-func (s *fakeService) StreamingCall(stream testpb.BenchmarkService_StreamingCallServer) error {
-	s.mu.Lock()
-	s.callCount++
-	s.mu.Unlock()
-
-	if s.serverErr != nil {
-		return s.serverErr
-	}
-
-	if s.streamSema != nil {
-		<-s.streamSema // Wait until released
-	}
-
-	for {
-		req, err := stream.Recv()
-		if err == io.EOF {
-			return nil
-		}
-		if err != nil {
-			return err
-		}
-		if err := stream.Send(&testpb.SimpleResponse{Payload: req.GetPayload()}); err != nil {
-			return err
+func entryIndex(s []*connEntry, e *connEntry) int {
+	for i, item := range s {
+		if item == e {
+			return i
 		}
 	}
-}
-
-func (s *fakeService) getCallCount() int {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.callCount
-}
-
-func setupTestServer(t *testing.T, service *fakeService) string {
-	t.Helper()
-	lis, err := net.Listen("tcp", ":0")
-	if err != nil {
-		t.Fatalf("Failed to listen: %v", err)
-
-	}
-	srv := grpc.NewServer()
-	testgrpc.RegisterBenchmarkServiceServer(srv, service)
-	go func() {
-		if err := srv.Serve(lis); err != nil {
-			// t.Logf is used here as t.Fatalf cannot be called in a separate goroutine
-			t.Logf("gRPC server error: %v", err)
-		}
-	}()
-
-	t.Cleanup(func() {
-		srv.Stop()
-		lis.Close()
-	})
-
-	return lis.Addr().String()
+	return -1
 }
 
 func TestSelectRoundRobin(t *testing.T) {
-	pool := &BigtableChannelPool{}
+	pool := &BigtableChannelPool{rrIndex: 0}
 
 	// Test empty pool
-	idx, err := pool.selectRoundRobin()
-	if idx != -1 {
-		t.Errorf("selectRoundRobin on empty pool got index %d, want -1", idx)
+	entry, err := pool.selectRoundRobin()
+	if entry != nil {
+		t.Errorf("selectRoundRobin on empty pool got entry, want nil")
 	}
-	if err == nil {
-		t.Errorf("selectRoundRobin on empty pool got nil error, want non-nil")
-	}
-	if err != errNoConnections {
+	if !errors.Is(err, errNoConnections) {
 		t.Errorf("selectRoundRobin on empty pool got error %v, want %v", err, errNoConnections)
 	}
 
 	// Test single connection pool
-	pool.conns = make([]*grpc.ClientConn, 1)
-	pool.load = make([]int64, 1)
-	idx, err = pool.selectRoundRobin()
-	if idx != 0 {
-		t.Errorf("selectRoundRobin on single conn pool got index %d, want 0", idx)
+	pool.conns.Store([]*connEntry{{}})
+	entry, err = pool.selectRoundRobin()
+	if entry == nil {
+		t.Errorf("selectRoundRobin on single conn pool got nil entry")
 	}
 	if err != nil {
 		t.Errorf("selectRoundRobin on single conn pool got error %v, want nil", err)
@@ -142,139 +71,186 @@ func TestSelectRoundRobin(t *testing.T) {
 
 	// Test multiple connections
 	poolSize := 3
-	pool.conns = make([]*grpc.ClientConn, poolSize)
-	pool.load = make([]int64, poolSize)
+	conns := make([]*connEntry, poolSize)
+	for i := 0; i < poolSize; i++ {
+		conns[i] = &connEntry{}
+	}
+	pool.conns.Store(conns)
 	pool.rrIndex = 0
 
-	// Test wrapping around
 	for i := 0; i < poolSize*2; i++ {
 		expectedIdx := i % poolSize
-		idx, err = pool.selectRoundRobin()
-		if idx != expectedIdx {
-			t.Errorf("selectRoundRobin call %d got index %d, want %d", i+1, idx, expectedIdx)
-		}
+		entry, err = pool.selectRoundRobin()
 		if err != nil {
 			t.Errorf("selectRoundRobin call %d got error %v, want nil", i+1, err)
+			continue
+		}
+		if entry != conns[expectedIdx] {
+			t.Errorf("selectRoundRobin call %d got entry for index %d, want %d", i+1, entryIndex(conns, entry), expectedIdx)
 		}
 	}
 }
 
-func TestSelectLeastLoadedRandomOfTwo(t *testing.T) {
-	pool := &BigtableChannelPool{}
+func TestNewBigtableChannelPoolEdgeCases(t *testing.T) {
+	ctx := context.Background()
+	fake := &fakeService{}
+	addr := setupTestServer(t, fake)
+	dialFunc := func() (*BigtableConn, error) { return dialBigtableserver(addr) }
 
-	// Test empty pool
-	idx, err := pool.selectLeastLoadedRandomOfTwo()
-	if idx != -1 {
-		t.Errorf("selectLeastLoadedRandomOfTwo on empty pool got index %d, want -1", idx)
-	}
-	if err == nil {
-		t.Errorf("selectLeastLoadedRandomOfTwo on empty pool got nil error, want non-nil")
-	}
-	if err != errNoConnections {
-		t.Errorf("selectLeastLoadedRandomOfTwo on empty pool got error %v, want %v", err, errNoConnections)
-	}
-
-	// Test single connection pool
-	pool.conns = make([]*grpc.ClientConn, 1)
-	pool.load = make([]int64, 1)
-	idx, err = pool.selectLeastLoadedRandomOfTwo()
-	if idx != 0 {
-		t.Errorf("selectLeastLoadedRandomOfTwo on single conn pool got index %d, want 0", idx)
-	}
-	if err != nil {
-		t.Errorf("selectLeastLoadedRandomOfTwo on single conn pool got error %v, want nil", err)
+	tests := []struct {
+		name     string
+		size     int
+		dial     func() (*BigtableConn, error)
+		wantErr  bool
+		errMatch string
+	}{
+		{name: "ZeroSize", size: 0, dial: dialFunc, wantErr: true, errMatch: "must be positive"},
+		{name: "NegativeSize", size: -1, dial: dialFunc, wantErr: true, errMatch: "must be positive"},
+		{name: "NilDial", size: 1, dial: nil, wantErr: true, errMatch: "dial function cannot be nil"},
+		{name: "Valid", size: 1, dial: dialFunc, wantErr: false},
 	}
 
-	// Test multiple connections
-	pool.conns = make([]*grpc.ClientConn, 5)
-	pool.load = []int64{10, 2, 30, 4, 50} // Loads for indices 0, 1, 2, 3, 4
-
-	for i := 0; i < 100; i++ { // Run multiple times due to randomness
-		idx, err = pool.selectLeastLoadedRandomOfTwo()
-		if err != nil {
-			t.Fatalf("selectLeastLoadedRandomOfTwo got unexpected error: %v", err)
-		}
-		if idx < 0 || idx >= len(pool.conns) {
-			t.Fatalf("Selected index %d is out of bounds", idx)
-		}
-	}
-
-	// Test case where loads are distinct
-	pool.load = []int64{5, 1, 10}
-	pool.conns = make([]*grpc.ClientConn, 3)
-	for i := 0; i < 100; i++ {
-		idx, err = pool.selectLeastLoadedRandomOfTwo()
-		if err != nil {
-			t.Errorf("selectLeastLoadedRandomOfTwo got unexpected error: %v", err)
-			continue
-		}
-		if idx < 0 || idx >= 3 {
-			t.Errorf("selectLeastLoadedRandomOfTwo got index %d, want index in [0, 2]", idx)
-			continue
-		}
-	}
-
-	// Test with all equal loads
-	pool.load = []int64{5, 5, 5}
-	for i := 0; i < 100; i++ {
-		idx, err = pool.selectLeastLoadedRandomOfTwo()
-		if err != nil {
-			t.Errorf("selectLeastLoadedRandomOfTwo got unexpected error: %v", err)
-			continue
-		}
-		if idx < 0 || idx >= 3 {
-			t.Errorf("Index %d out of bounds", idx)
-		}
-	}
-}
-
-func TestNewLeastLoadedChannelPool(t *testing.T) {
-	t.Run("SuccessfulCreation", func(t *testing.T) {
-		poolSize := 5
-		fake := &fakeService{}
-		addr := setupTestServer(t, fake)
-
-		dialFunc := func() (*grpc.ClientConn, error) {
-			return grpc.Dial(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
-		}
-
-		pool, err := NewBigtableChannelPool(poolSize, btopt.LeastInFlight, dialFunc)
-		if err != nil {
-			t.Fatalf("NewBigtableChannelPool failed: %v", err)
-		}
-		defer pool.Close()
-
-		if pool.Num() != poolSize {
-			t.Errorf("Pool size got %d, want %d", pool.Num(), poolSize)
-		}
-		for i, conn := range pool.conns {
-			if conn == nil {
-				t.Errorf("conn at index %d is nil", i)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			pool, err := NewBigtableChannelPool(ctx, tc.size, btopt.RoundRobin, tc.dial, nil, nil)
+			if tc.wantErr {
+				if err == nil {
+					t.Errorf("NewBigtableChannelPool(%d) succeeded, want error containing %q", tc.size, tc.errMatch)
+				} else if !strings.Contains(err.Error(), tc.errMatch) {
+					t.Errorf("NewBigtableChannelPool(%d) got error %v, want error containing %q", tc.size, err, tc.errMatch)
+				}
+				if pool != nil {
+					pool.Close() // Cleanup if unexpectedly created
+				}
+			} else {
+				if err != nil {
+					t.Errorf("NewBigtableChannelPool(%d) failed: %v", tc.size, err)
+				}
+				if pool != nil {
+					pool.Close()
+				}
 			}
+		})
+	}
+}
+
+func TestBigtableConn_Prime(t *testing.T) {
+	ctx := context.Background()
+	fake := &fakeService{}
+	addr := setupTestServer(t, fake)
+
+	t.Run("SuccessfulPrime", func(t *testing.T) {
+		conn, err := dialBigtableserverWithInstanceNameAndAppProfile(addr, "my-instance", "my-profile")
+		if err != nil {
+			t.Fatalf("Failed to dial: %v", err)
+		}
+		defer conn.Close()
+		fake.setPingCount(0)
+		isALTS, err := conn.Prime(ctx)
+		if err != nil {
+			t.Errorf("Prime() failed: %v", err)
+		}
+		if isALTS {
+			t.Errorf("Prime() got isALTS true, want false")
+		}
+		if fake.getPingCount() != 1 {
+			t.Errorf("PingAndWarm call count got %d, want 1", fake.getPingCount())
 		}
 	})
 
-	t.Run("DialFailure", func(t *testing.T) {
-		poolSize := 3
-		dialCount := 0
-		dialFunc := func() (*grpc.ClientConn, error) {
-			dialCount++
-			if dialCount > 1 {
-				return nil, errors.New("simulated dial error")
-			}
-			fake := &fakeService{}
-			addr := setupTestServer(t, fake)
-			return grpc.Dial(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
-		}
+	testCases := []struct {
+		name         string
+		instanceName string
+		appProfile   string
+		pingErr      error
+		wantErrCode  codes.Code
+		wantErrMsg   string
+	}{
+		{
+			name:         "MissingInstanceName",
+			instanceName: "",
+			appProfile:   "my-profile",
+			wantErrCode:  codes.FailedPrecondition,
+			wantErrMsg:   "instanceName is required",
+		},
+		{
+			name:         "MissingAppProfile",
+			instanceName: "my-instance",
+			appProfile:   "",
+			wantErrCode:  codes.FailedPrecondition,
+			wantErrMsg:   "appProfile is required",
+		},
+		{
+			name:         "ServerPingError",
+			instanceName: "my-instance",
+			appProfile:   "my-profile",
+			pingErr:      status.Error(codes.Internal, "simulated ping error"),
+			wantErrCode:  codes.Internal,
+			wantErrMsg:   "simulated ping error",
+		},
+	}
 
-		_, err := NewBigtableChannelPool(poolSize, btopt.LeastInFlight, dialFunc)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			conn, err := dialBigtableserverWithInstanceNameAndAppProfile(addr, tc.instanceName, tc.appProfile)
+			if err != nil {
+				t.Fatalf("Failed to dial: %v", err)
+			}
+			defer conn.Close()
+
+			fake.setPingErr(tc.pingErr)
+			defer func() { fake.setPingErr(nil) }()
+
+			_, err = conn.Prime(ctx)
+			if err == nil {
+				t.Fatalf("Prime() succeeded, want error")
+			}
+
+			st, ok := status.FromError(err)
+			if !ok {
+				t.Fatalf("Prime() returned non-status error: %v", err)
+			}
+			if st.Code() != tc.wantErrCode {
+				t.Errorf("Prime() got error code %v, want %v", st.Code(), tc.wantErrCode)
+			}
+			if !strings.Contains(st.Message(), tc.wantErrMsg) {
+				t.Errorf("Prime() got error message %q, want message containing %q", st.Message(), tc.wantErrMsg)
+			}
+		})
+	}
+
+	t.Run("PrimeTimeout", func(t *testing.T) {
+		conn, err := dialBigtableserverWithInstanceNameAndAppProfile(addr, "my-instance", "my-profile")
+		if err != nil {
+			t.Fatalf("Failed to dial: %v", err)
+		}
+		defer conn.Close()
+
+		origDelay := fake.delay
+		fake.delay = 20 * time.Second // Longer than primeRPCTimeout
+		defer func() {
+			fake.setDelay(origDelay)
+		}()
+
+		primeCtx, cancel := context.WithTimeout(ctx, 100*time.Millisecond) // Shorter than primeRPCTimeout
+		defer cancel()
+
+		_, err = conn.Prime(primeCtx)
 		if err == nil {
-			t.Errorf("NewBigtableChannelPool should have failed due to dial error, but got no error")
+			t.Fatalf("Prime() succeeded, want timeout error")
+		}
+		st, ok := status.FromError(err)
+		if !ok {
+			t.Fatalf("Prime() returned non-status error: %v", err)
+		}
+		if st.Code() != codes.DeadlineExceeded {
+			t.Errorf("Prime() got error code %v, want %v", st.Code(), codes.DeadlineExceeded)
 		}
 	})
 }
 
 func TestPoolInvoke(t *testing.T) {
+	ctx := context.Background()
 	strategies := []btopt.LoadBalancingStrategy{
 		btopt.LeastInFlight,
 		btopt.RoundRobin,
@@ -286,11 +262,9 @@ func TestPoolInvoke(t *testing.T) {
 			poolSize := 3
 			fake := &fakeService{}
 			addr := setupTestServer(t, fake)
-			dialFunc := func() (*grpc.ClientConn, error) {
-				return grpc.Dial(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
-			}
+			dialFunc := func() (*BigtableConn, error) { return dialBigtableserver(addr) }
 
-			pool, err := NewBigtableChannelPool(poolSize, strategy, dialFunc)
+			pool, err := NewBigtableChannelPool(ctx, poolSize, strategy, dialFunc, nil, nil)
 			if err != nil {
 				t.Fatalf("Failed to create pool: %v", err)
 			}
@@ -308,16 +282,47 @@ func TestPoolInvoke(t *testing.T) {
 				t.Errorf("Server call count got %d, want 1", fake.getCallCount())
 			}
 
-			for i, load := range pool.load {
-				if load != 0 {
-					t.Errorf("Load at index %d is non-zero after Invoke: %d", i, load)
+			for _, entry := range pool.getConns() {
+				if entry.unaryLoad.Load() != 0 {
+					t.Errorf("Unary load is non-zero after Invoke: %d", entry.unaryLoad.Load())
+				}
+			}
+
+			// Test invoke with server error
+			fake.callCount = 0
+			fake.serverErr = status.Error(codes.Internal, "simulated invoke error")
+			err = pool.Invoke(context.Background(), "/grpc.testing.BenchmarkService/UnaryCall", req, res)
+			if err == nil {
+				t.Errorf("Invoke succeeded, want error")
+			} else {
+				st, ok := status.FromError(err)
+				if !ok || st.Code() != codes.Internal || !strings.Contains(st.Message(), "simulated invoke error") {
+					t.Errorf("Invoke got error %v, want Internal server error", err)
+				}
+			}
+			fake.serverErr = nil
+			if fake.getCallCount() != 1 {
+				t.Errorf("Server call count got %d, want 1 after error", fake.getCallCount())
+			}
+			for _, entry := range pool.getConns() {
+				if entry.unaryLoad.Load() != 0 {
+					t.Errorf("Unary load is non-zero after failed Invoke: %d", entry.unaryLoad.Load())
 				}
 			}
 		})
 	}
+	t.Run("EmptyPoolInvoke", func(t *testing.T) {
+		pool := &BigtableChannelPool{} // No connections
+		pool.selectFunc = pool.selectRoundRobin
+		err := pool.Invoke(ctx, "/grpc.testing.BenchmarkService/UnaryCall", &testpb.SimpleRequest{}, &testpb.SimpleResponse{})
+		if !errors.Is(err, errNoConnections) {
+			t.Errorf("Invoke on empty pool got error %v, want %v", err, errNoConnections)
+		}
+	})
 }
 
 func TestPoolNewStream(t *testing.T) {
+	ctx := context.Background()
 	strategies := []btopt.LoadBalancingStrategy{
 		btopt.LeastInFlight,
 		btopt.RoundRobin,
@@ -329,30 +334,29 @@ func TestPoolNewStream(t *testing.T) {
 			poolSize := 2
 			fake := &fakeService{}
 			addr := setupTestServer(t, fake)
-			dialFunc := func() (*grpc.ClientConn, error) {
-				return grpc.Dial(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
-			}
+			dialFunc := func() (*BigtableConn, error) { return dialBigtableserver(addr) }
 
-			pool, err := NewBigtableChannelPool(poolSize, strategy, dialFunc)
+			pool, err := NewBigtableChannelPool(ctx, poolSize, strategy, dialFunc, nil, nil)
 			if err != nil {
 				t.Fatalf("Failed to create pool: %v", err)
 			}
 			defer pool.Close()
 
-			ctx := context.Background()
-			stream, err := pool.NewStream(ctx, &grpc.StreamDesc{StreamName: "StreamingCall"}, "/grpc.testing.BenchmarkService/StreamingCall")
+			streamCtx := context.Background()
+			stream, err := pool.NewStream(streamCtx, &grpc.StreamDesc{StreamName: "StreamingCall"}, "/grpc.testing.BenchmarkService/StreamingCall")
 			if err != nil {
 				t.Fatalf("NewStream failed: %v", err)
 			}
 
-			loadSum := int64(0)
-			for _, l := range pool.load {
-				loadSum += l
+			loadSum := int32(0)
+			for _, entry := range pool.getConns() {
+				loadSum += entry.streamingLoad.Load()
 			}
 			if loadSum != 1 {
-				t.Errorf("Total load after NewStream got %d, want 1. Loads: %v", loadSum, pool.load)
+				t.Errorf("Total streaming load after NewStream got %d, want 1.", loadSum)
 			}
 
+			// ... stream interaction ...
 			req := &testpb.SimpleRequest{Payload: &testpb.Payload{Body: []byte("msg1")}}
 			if err := stream.SendMsg(req); err != nil {
 				t.Fatalf("SendMsg failed: %v", err)
@@ -361,98 +365,341 @@ func TestPoolNewStream(t *testing.T) {
 			if err := stream.RecvMsg(res); err != nil {
 				t.Fatalf("RecvMsg failed: %v", err)
 			}
-			if string(res.GetPayload().GetBody()) != "msg1" {
-				t.Errorf("RecvMsg got %q, want %q", string(res.GetPayload().GetBody()), "msg1")
-			}
-
-			if err := stream.CloseSend(); err != nil {
-				t.Fatalf("CloseSend failed: %v", err)
-			}
-
-			if err := stream.RecvMsg(res); err != io.EOF {
-				t.Errorf("Expected io.EOF after CloseSend, got %v", err)
-			}
-
-			time.Sleep(10 * time.Millisecond)
-			loadSum = int64(0)
-			for i, l := range pool.load {
-				if l < 0 {
-					t.Errorf("Load at index %d went negative: %d", i, l)
+			stream.CloseSend()
+			for {
+				if err := stream.RecvMsg(res); err != nil {
+					if err == io.EOF {
+						break
+					}
+					t.Fatalf("RecvMsg after close failed: %v", err)
 				}
-				loadSum += l
+			}
+
+			time.Sleep(20 * time.Millisecond) // Allow decrements to complete
+			loadSum = int32(0)
+			for _, entry := range pool.getConns() {
+				loadSum += entry.streamingLoad.Load()
 			}
 			if loadSum != 0 {
-				t.Errorf("Total load after stream completion got %d, want 0. Loads: %v", loadSum, pool.load)
+				t.Errorf("Total streaming load after stream completion got %d, want 0.", loadSum)
 			}
 		})
 	}
+
+	t.Run("EmptyPoolNewStream", func(t *testing.T) {
+		pool := &BigtableChannelPool{} // No connections
+		pool.selectFunc = pool.selectRoundRobin
+		_, err := pool.NewStream(ctx, &grpc.StreamDesc{StreamName: "StreamingCall"}, "/grpc.testing.BenchmarkService/StreamingCall")
+		if !errors.Is(err, errNoConnections) {
+			t.Errorf("NewStream on empty pool got error %v, want %v", err, errNoConnections)
+		}
+	})
+
+	t.Run("NewStreamServerError", func(t *testing.T) {
+		poolSize := 1
+		fake := &fakeService{}
+		addr := setupTestServer(t, fake)
+		dialFunc := func() (*BigtableConn, error) { return dialBigtableserver(addr) }
+		pool, err := NewBigtableChannelPool(ctx, poolSize, btopt.RoundRobin, dialFunc, nil, nil)
+		if err != nil {
+			t.Fatalf("Failed to create pool: %v", err)
+		}
+		defer pool.Close()
+
+		wantErr := status.Error(codes.Unavailable, "simulated stream creation error")
+		fake.serverErr = wantErr
+		defer func() { fake.serverErr = nil }()
+
+		stream, err := pool.NewStream(ctx, &grpc.StreamDesc{StreamName: "StreamingCall"}, "/grpc.testing.BenchmarkService/StreamingCall")
+		if err == nil { // NewStream in grpc-go doesn't return an error if the connection is up, the error is on first Recv/Send
+			// t.Fatalf("NewStream should have failed")
+		} else {
+			// This case should ideally not happen based on grpc behavior
+			if pool.getConns()[0].streamingLoad.Load() != 0 {
+				t.Errorf("Load is non-zero after NewStream failed: %d", pool.getConns()[0].streamingLoad.Load())
+			}
+			return
+		}
+
+		if pool.getConns()[0].streamingLoad.Load() != 1 {
+			t.Fatalf("Load is %d, want 1 after NewStream", pool.getConns()[0].streamingLoad.Load())
+		}
+
+		err = stream.RecvMsg(&testpb.SimpleResponse{})
+		if err == nil {
+			t.Errorf("RecvMsg succeeded, want server error")
+		} else {
+			st, ok := status.FromError(err)
+			if !ok || st.Code() != codes.Unavailable || !strings.Contains(st.Message(), "simulated stream creation error") {
+				t.Errorf("RecvMsg got error %v, want %v", err, wantErr)
+			}
+		}
+
+		time.Sleep(20 * time.Millisecond)
+
+		if pool.getConns()[0].streamingLoad.Load() != 0 {
+			t.Errorf("Load is %d, want 0 after stream error", pool.getConns()[0].streamingLoad.Load())
+		}
+	})
+}
+
+func TestNewBigtableChannelPool(t *testing.T) {
+	ctx := context.Background()
+	t.Run("SuccessfulCreation", func(t *testing.T) {
+		poolSize := 5
+		fake := &fakeService{}
+		addr := setupTestServer(t, fake)
+		dialFunc := func() (*BigtableConn, error) { return dialBigtableserver(addr) }
+
+		pool, err := NewBigtableChannelPool(ctx, poolSize, btopt.LeastInFlight, dialFunc, nil, nil)
+		if err != nil {
+			t.Fatalf("NewBigtableChannelPool failed: %v", err)
+		}
+		defer pool.Close()
+
+		if pool.Num() != poolSize {
+			t.Errorf("Pool size got %d, want %d", pool.Num(), poolSize)
+		}
+		// Wait for priming goroutines to likely complete
+		time.Sleep(100 * time.Millisecond)
+
+		if fake.getPingCount() < 1 {
+			t.Errorf("Connections were not primed, ping count is %d", fake.getPingCount())
+		}
+
+		conns := pool.getConns()
+		if len(conns) != poolSize {
+			t.Fatalf("getConns() length got %d, want %d", len(conns), poolSize)
+		}
+		// Wait for priming goroutines to likely complete
+		time.Sleep(100 * time.Millisecond)
+
+		for i, entry := range conns {
+			if entry == nil || entry.conn == nil {
+				t.Errorf("conn at index %d is nil", i)
+				continue
+			}
+			if entry.isALTSUsed() {
+				t.Errorf("conn at index %d isALTSUsed() got true, want false", i)
+			}
+		}
+	})
+
+	t.Run("DialFailure", func(t *testing.T) {
+		poolSize := 3
+		dialCount := 0
+		dialFunc := func() (*BigtableConn, error) {
+			dialCount++
+			if dialCount > 1 {
+				return nil, errors.New("simulated dial error")
+			}
+			fake := &fakeService{}
+			addr := setupTestServer(t, fake)
+			return dialBigtableserver(addr)
+		}
+
+		_, err := NewBigtableChannelPool(ctx, poolSize, btopt.LeastInFlight, dialFunc, nil, nil)
+		if err == nil {
+			t.Errorf("NewBigtableChannelPool should have failed due to dial error")
+		}
+	})
 }
 
 func TestSelectLeastLoaded(t *testing.T) {
 	pool := &BigtableChannelPool{}
+	pool.conns.Store(([]*connEntry)(nil)) // Ensure it's empty
 
-	// Test empty pool
-	idx, err := pool.selectLeastLoaded()
-	if idx != -1 {
-		t.Errorf("selectLeastLoaded on empty pool got index %d, want -1", idx)
-	}
-	if err == nil {
-		t.Errorf("selectLeastLoaded on empty pool got nil error, want non-nil")
-	}
-	if err != errNoConnections {
-		t.Errorf("selectLeastLoaded on empty pool got error %v, want %v", err, errNoConnections)
+	_, err := pool.selectLeastLoaded()
+	if !errors.Is(err, errNoConnections) {
+		t.Errorf("Empty pool: got err %v, want %v", err, errNoConnections)
 	}
 
-	// Test single connection pool
-	pool.conns = make([]*grpc.ClientConn, 1)
-	pool.load = make([]int64, 1)
-	idx, err = pool.selectLeastLoaded()
-	if idx != 0 {
-		t.Errorf("selectLeastLoaded on single conn pool got index %d, want 0", idx)
+	// streamingLoadFactor is 2, unaryLoadFactor is 1
+	testLoads := []struct{ unary, stream int32 }{
+		{3, 0}, // Load: 3
+		{1, 1}, // Load: 1*1 + 2*1 = 3
+		{0, 2}, // Load: 4
+		{5, 0}, // Load: 5
+		{1, 0}, // Load: 1 (Smallest)
 	}
+	conns := make([]*connEntry, len(testLoads))
+	expectedMinIndex := 4
+	for i, loads := range testLoads {
+		conns[i] = &connEntry{}
+		conns[i].unaryLoad.Store(loads.unary)
+		conns[i].streamingLoad.Store(loads.stream)
+	}
+	pool.conns.Store(conns)
+
+	entry, err := pool.selectLeastLoaded()
 	if err != nil {
-		t.Errorf("selectLeastLoaded on single conn pool got error %v, want nil", err)
+		t.Errorf("Multi conn: got error %v, want nil", err)
 	}
-
-	// Test multiple connections
-	pool.conns = make([]*grpc.ClientConn, 5)
-	pool.load = []int64{3, 1, 4, 1, 5}
-	idx, err = pool.selectLeastLoaded()
-	if idx != 1 {
-		t.Errorf("selectLeastLoadedIterative got index %d, want 1 for loads %v", idx, pool.load)
-	}
-	if err != nil {
-		t.Errorf("selectLeastLoadedIterative got error %v, want nil for loads %v", err, pool.load)
+	if entry != conns[expectedMinIndex] {
+		t.Errorf("Multi conn: selected entry with load %d, want entry with load 1 (index %d)", entry.calculateWeightedLoad(), expectedMinIndex)
 	}
 }
 
-func TestPoolClose(t *testing.T) {
-	poolSize := 2
-	fake := &fakeService{}
-	addr := setupTestServer(t, fake)
-	dialFunc := func() (*grpc.ClientConn, error) {
-		return grpc.Dial(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+func TestSelectLeastLoadedRandomOfTwo(t *testing.T) {
+	pool := &BigtableChannelPool{}
+
+	entry, err := pool.selectLeastLoadedRandomOfTwo()
+	if entry != nil || !errors.Is(err, errNoConnections) {
+		t.Errorf("Empty pool: got %v, %v, want nil, %v", entry, err, errNoConnections)
 	}
 
-	pool, err := NewBigtableChannelPool(poolSize, btopt.LeastInFlight, dialFunc)
+	conns := []*connEntry{{}}
+	pool.conns.Store(conns)
+	entry, err = pool.selectLeastLoadedRandomOfTwo()
+	if entry != conns[0] || err != nil {
+		t.Errorf("Single conn: got %v, %v, want %v, nil", entry, err, conns[0])
+	}
+
+	// streamingLoadFactor is 2, unaryLoadFactor is 1
+	testLoads := []struct{ unary, stream int32 }{
+		{10, 0}, // Load: 10
+		{0, 4},  // Load: 8
+		{20, 5}, // Load: 30
+		{2, 1},  // Load: 4
+		{0, 20}, // Load: 40
+	}
+	conns = make([]*connEntry, len(testLoads))
+	for i, loads := range testLoads {
+		conns[i] = &connEntry{}
+		conns[i].unaryLoad.Store(loads.unary)
+		conns[i].streamingLoad.Store(loads.stream)
+	}
+	pool.conns.Store(conns)
+	for i := 0; i < 100; i++ {
+		entry, err = pool.selectLeastLoadedRandomOfTwo()
+		if err != nil {
+			t.Fatalf("Multi conn: got unexpected error: %v", err)
+		}
+		if entry == nil {
+			t.Fatalf("Multi conn: got nil entry")
+		}
+		// We can't deterministically know which one was chosen, just that one was.
+	}
+}
+
+func TestCachingStreamDecrement(t *testing.T) {
+	ctx := context.Background()
+	poolSize := 1
+	fake := &fakeService{}
+	addr := setupTestServer(t, fake)
+	dialFunc := func() (*BigtableConn, error) {
+		conn, err := grpc.Dial(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+		if err != nil {
+			return nil, err
+		}
+		return NewBigtableConn(conn, "test-instance", "test-profile"), nil
+	}
+
+	pool, err := NewBigtableChannelPool(ctx, poolSize, btopt.LeastInFlight, dialFunc, nil, nil)
 	if err != nil {
 		t.Fatalf("Failed to create pool: %v", err)
 	}
+	defer pool.Close()
+	entry := pool.getConns()[0]
 
-	if err := pool.Close(); err != nil {
-		t.Errorf("Close failed: %v", err)
-	}
+	t.Run("DecrementOnRecvError", func(t *testing.T) {
+		fake.serverErr = errors.New("stream recv error")
+		defer func() { fake.serverErr = nil }()
+		entry.streamingLoad.Store(0)
+
+		stream, err := pool.NewStream(context.Background(), &grpc.StreamDesc{StreamName: "StreamingCall"}, "/grpc.testing.BenchmarkService/StreamingCall")
+		if err != nil {
+			t.Fatalf("NewStream failed: %v", err)
+		}
+		if entry.streamingLoad.Load() != 1 {
+			t.Errorf("Load is %d, want 1 after NewStream", entry.streamingLoad.Load())
+		}
+
+		stream.RecvMsg(&testpb.SimpleResponse{})
+		time.Sleep(20 * time.Millisecond)
+
+		if entry.streamingLoad.Load() != 0 {
+			t.Errorf("Load is %d, want 0 after RecvMsg error", entry.streamingLoad.Load())
+		}
+	})
+
+	t.Run("DecrementOnSendError", func(t *testing.T) {
+		entry.streamingLoad.Store(0)
+		fake.serverErr = nil
+
+		stream, err := pool.NewStream(context.Background(), &grpc.StreamDesc{StreamName: "StreamingCall", ServerStreams: true, ClientStreams: false}, "/grpc.testing.BenchmarkService/StreamingCall")
+		if err != nil {
+			t.Fatalf("NewStream failed: %v", err)
+		}
+		if entry.streamingLoad.Load() != 1 {
+			t.Errorf("Load is %d, want 1 after NewStream", entry.streamingLoad.Load())
+		}
+
+		if err := stream.CloseSend(); err != nil {
+			t.Fatalf("CloseSend failed: %v", err)
+		}
+		for {
+			if err := stream.RecvMsg(&testpb.SimpleResponse{}); err != nil {
+				if err == io.EOF {
+					break
+				}
+				t.Fatalf("RecvMsg failed unexpectedly: %v", err)
+			}
+		}
+
+		err = stream.SendMsg(&testpb.SimpleRequest{Payload: &testpb.Payload{Body: []byte("wont send")}})
+		if err == nil {
+			t.Errorf("SendMsg should have failed after stream is closed")
+		}
+
+		time.Sleep(20 * time.Millisecond)
+		if entry.streamingLoad.Load() != 0 {
+			t.Errorf("Load is %d, want 0 after SendMsg error", entry.streamingLoad.Load())
+		}
+	})
+
+	t.Run("NoDecrementOnSuccessfulSend", func(t *testing.T) {
+		entry.streamingLoad.Store(0)
+		fake.serverErr = nil
+		fake.streamSema = make(chan struct{})
+
+		stream, err := pool.NewStream(context.Background(), &grpc.StreamDesc{StreamName: "StreamingCall"}, "/grpc.testing.BenchmarkService/StreamingCall")
+		if err != nil {
+			t.Fatalf("NewStream failed: %v", err)
+		}
+		if entry.streamingLoad.Load() != 1 {
+			t.Errorf("Load is %d, want 1", entry.streamingLoad.Load())
+		}
+
+		if err := stream.SendMsg(&testpb.SimpleRequest{Payload: &testpb.Payload{Body: []byte("test")}}); err != nil {
+			t.Fatalf("SendMsg failed: %v", err)
+		}
+		if entry.streamingLoad.Load() != 1 {
+			t.Errorf("Load is %d, want 1 after successful SendMsg", entry.streamingLoad.Load())
+		}
+
+		close(fake.streamSema)
+		stream.CloseSend()
+		for {
+			if err := stream.RecvMsg(&testpb.SimpleResponse{}); err != nil {
+				break
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+		if entry.streamingLoad.Load() != 0 {
+			t.Errorf("Load is %d, want 0 after stream cleanup", entry.streamingLoad.Load())
+		}
+	})
 }
 
 func TestMultipleStreamsSingleConn(t *testing.T) {
-	poolSize := 1 // Force all streams to use the same connection
+	ctx := context.Background()
+	poolSize := 1
 	fake := &fakeService{}
 	addr := setupTestServer(t, fake)
-	dialFunc := func() (*grpc.ClientConn, error) {
-		return grpc.Dial(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
-	}
+	dialFunc := func() (*BigtableConn, error) { return dialBigtableserver(addr) }
 
-	pool, err := NewBigtableChannelPool(poolSize, btopt.LeastInFlight, dialFunc)
+	pool, err := NewBigtableChannelPool(ctx, poolSize, btopt.LeastInFlight, dialFunc, nil, nil)
 	if err != nil {
 		t.Fatalf("Failed to create pool: %v", err)
 	}
@@ -460,22 +707,21 @@ func TestMultipleStreamsSingleConn(t *testing.T) {
 
 	numStreams := 5
 	streams := make([]grpc.ClientStream, numStreams)
-	ctx := context.Background()
 
-	// Open streams and check load
+	connEntry := pool.getConns()[0]
+
 	for i := 0; i < numStreams; i++ {
 		stream, err := pool.NewStream(ctx, &grpc.StreamDesc{StreamName: "StreamingCall"}, "/grpc.testing.BenchmarkService/StreamingCall")
 		if err != nil {
 			t.Fatalf("NewStream %d failed: %v", i, err)
 		}
 		streams[i] = stream
-		expectedLoad := int64(i + 1)
-		if atomic.LoadInt64(&pool.load[0]) != expectedLoad {
-			t.Errorf("Load after opening stream %d is %d, want %d", i, atomic.LoadInt64(&pool.load[0]), expectedLoad)
+		expectedLoad := int32(i + 1)
+		if connEntry.streamingLoad.Load() != expectedLoad {
+			t.Errorf("Load after opening stream %d is %d, want %d", i, connEntry.streamingLoad.Load(), expectedLoad)
 		}
 	}
 
-	// Basic interaction with each stream
 	for i, stream := range streams {
 		msg := fmt.Sprintf("stream%d", i)
 		req := &testpb.SimpleRequest{Payload: &testpb.Payload{Body: []byte(msg)}}
@@ -495,12 +741,10 @@ func TestMultipleStreamsSingleConn(t *testing.T) {
 		t.Errorf("Server call count got %d, want %d", fake.getCallCount(), numStreams)
 	}
 
-	// Close streams and check load
 	for i, stream := range streams {
 		if err := stream.CloseSend(); err != nil {
 			t.Errorf("CloseSend on stream %d failed: %v", i, err)
 		}
-		// Drain the stream
 		for {
 			if err := stream.RecvMsg(&testpb.SimpleResponse{}); err != nil {
 				if err != io.EOF {
@@ -509,121 +753,450 @@ func TestMultipleStreamsSingleConn(t *testing.T) {
 				break
 			}
 		}
-		time.Sleep(10 * time.Millisecond) // Allow decrement to propagate
+		time.Sleep(20 * time.Millisecond)
 
-		expectedLoad := int64(numStreams - 1 - i)
-		if atomic.LoadInt64(&pool.load[0]) != expectedLoad {
-			t.Errorf("Load after closing stream %d is %d, want %d", i, atomic.LoadInt64(&pool.load[0]), expectedLoad)
+		expectedLoad := int32(numStreams - 1 - i)
+		currentLoad := connEntry.streamingLoad.Load()
+		if currentLoad != expectedLoad {
+			t.Errorf("Load after closing stream %d is %d, want %d", i, currentLoad, expectedLoad)
 		}
 	}
 
-	if atomic.LoadInt64(&pool.load[0]) != 0 {
-		t.Errorf("Final load is %d, want 0", atomic.LoadInt64(&pool.load[0]))
+	finalLoad := connEntry.streamingLoad.Load()
+	if finalLoad != 0 {
+		t.Errorf("Final load is %d, want 0", finalLoad)
 	}
 }
 
-func TestCachingStreamDecrement(t *testing.T) {
-	poolSize := 1
+func TestPoolClose(t *testing.T) {
+	ctx := context.Background()
+	poolSize := 2
 	fake := &fakeService{}
 	addr := setupTestServer(t, fake)
-	dialFunc := func() (*grpc.ClientConn, error) {
-		return grpc.Dial(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
-	}
-
-	pool, err := NewBigtableChannelPool(poolSize, btopt.LeastInFlight, dialFunc)
+	dialFunc := func() (*BigtableConn, error) { return dialBigtableserver(addr) }
+	pool, err := NewBigtableChannelPool(ctx, poolSize, btopt.LeastInFlight, dialFunc, log.Default(), nil)
 	if err != nil {
 		t.Fatalf("Failed to create pool: %v", err)
 	}
-	defer pool.Close()
 
-	t.Run("DecrementOnRecvError", func(t *testing.T) {
-		fake.serverErr = errors.New("stream recv error")
-		defer func() { fake.serverErr = nil }()
+	pool.Close()
 
-		ctx := context.Background()
-		stream, err := pool.NewStream(ctx, &grpc.StreamDesc{StreamName: "StreamingCall"}, "/grpc.testing.BenchmarkService/StreamingCall")
+	if pool.getConns() != nil {
+		t.Errorf("pool.getConns() got non-nil after Close, want nil")
+	}
+
+}
+
+func TestGracefulDraining(t *testing.T) {
+	ctx := context.Background()
+	fake := &fakeService{}
+	addr := setupTestServer(t, fake)
+	dialFunc := func() (*BigtableConn, error) { return dialBigtableserver(addr) }
+
+	t.Run("DrainingOnReplaceConnection", func(t *testing.T) {
+		pool, err := NewBigtableChannelPool(ctx, 1, btopt.RoundRobin, dialFunc, nil, nil)
 		if err != nil {
-			t.Fatalf("NewStream failed: %v", err)
+			t.Fatalf("Failed to create pool: %v", err)
 		}
-		if atomic.LoadInt64(&pool.load[0]) != 1 {
-			t.Errorf("Load is %d, want 1 after NewStream", atomic.LoadInt64(&pool.load[0]))
-		}
+		defer pool.Close()
 
-		err = stream.RecvMsg(&testpb.SimpleResponse{})
-		if err == nil {
-			t.Errorf("RecvMsg should have failed")
-		}
+		oldEntry := pool.getConns()[0]
 
-		time.Sleep(10 * time.Millisecond)
-		if atomic.LoadInt64(&pool.load[0]) != 0 {
-			t.Errorf("Load is %d, want 0 after RecvMsg error", atomic.LoadInt64(&pool.load[0]))
-		}
-	})
-
-	t.Run("DecrementOnSendError", func(t *testing.T) {
-		ctx := context.Background()
-		stream, err := pool.NewStream(ctx, &grpc.StreamDesc{StreamName: "StreamingCall"}, "/grpc.testing.BenchmarkService/StreamingCall")
-		if err != nil {
-			t.Fatalf("NewStream failed: %v", err)
-		}
-		if atomic.LoadInt64(&pool.load[0]) != 1 {
-			t.Errorf("Load is %d, want 1 after NewStream", atomic.LoadInt64(&pool.load[0]))
-		}
-
-		// Close the sending side of the stream.
-		if err := stream.CloseSend(); err != nil {
-			t.Fatalf("CloseSend failed: %v", err)
-		}
-
-		// Wait for the server to acknowledge the closure by receiving io.EOF.
-		for {
-			if err := stream.RecvMsg(&testpb.SimpleResponse{}); err != nil {
-				if err == io.EOF {
-					break // Normal stream end.
-				}
-				t.Fatalf("RecvMsg failed unexpectedly while draining: %v", err)
-			}
-		}
-
-		// Any subsequent SendMsg call must return an error.
-		err = stream.SendMsg(&testpb.SimpleRequest{Payload: &testpb.Payload{Body: []byte("wont send")}})
-		if err == nil {
-			t.Errorf("SendMsg should have failed after stream is closed (RecvMsg returned io.EOF)")
-		} else {
-			// Optionally check the error type. It's often related to a closed stream.
-			st, ok := status.FromError(err)
-			if ok {
-				t.Logf("SendMsg failed as expected with status: %v", st)
-			} else {
-				t.Logf("SendMsg failed as expected with error: %v", err)
-			}
-		}
-
-		// The decrement should have occurred when SendMsg returned an error.
-		time.Sleep(10 * time.Millisecond) // Give a moment for the decrement to be visible.
-		if atomic.LoadInt64(&pool.load[0]) != 0 {
-			t.Errorf("Load is %d, want 0 after SendMsg error on closed stream", atomic.LoadInt64(&pool.load[0]))
-		}
-	})
-
-	t.Run("NoDecrementOnSuccessfulSend", func(t *testing.T) {
+		// Create a long-lived stream to simulate in-flight traffic
 		fake.streamSema = make(chan struct{})
-		defer close(fake.streamSema)
-
-		ctx := context.Background()
-		stream, err := pool.NewStream(ctx, &grpc.StreamDesc{StreamName: "StreamingCall"}, "/grpc.testing.BenchmarkService/StreamingCall")
+		stream, err := pool.NewStream(ctx, &grpc.StreamDesc{ServerStreams: true}, "/grpc.testing.BenchmarkService/StreamingCall")
 		if err != nil {
 			t.Fatalf("NewStream failed: %v", err)
 		}
-		if atomic.LoadInt64(&pool.load[0]) != 1 {
-			t.Errorf("Load is %d, want 1", atomic.LoadInt64(&pool.load[0]))
+
+		if oldEntry.streamingLoad.Load() != 1 {
+			t.Fatalf("Streaming load should be 1, got %d", oldEntry.streamingLoad.Load())
 		}
 
-		if err := stream.SendMsg(&testpb.SimpleRequest{Payload: &testpb.Payload{Body: []byte("test")}}); err != nil {
-			t.Fatalf("SendMsg failed: %v", err)
+		// Trigger the replacement, which should start draining the old connection
+		pool.replaceConnection(oldEntry)
+
+		if !oldEntry.isDraining() {
+			t.Fatal("Old connection was not marked as draining")
 		}
-		if atomic.LoadInt64(&pool.load[0]) != 1 {
-			t.Errorf("Load is %d, want 1 after successful SendMsg", atomic.LoadInt64(&pool.load[0]))
+		if isConnClosed(oldEntry.conn.ClientConn) {
+			t.Fatal("Old connection was closed immediately instead of draining")
+		}
+
+		// Verify the new connection is in the pool and is not draining
+		newEntry := pool.getConns()[0]
+		if newEntry == oldEntry {
+			t.Fatal("Connection was not replaced in the pool")
+		}
+		if newEntry.isDraining() {
+			t.Fatal("New connection is incorrectly marked as draining")
+		}
+
+		// Verify new requests go to the new connection
+		selectedEntry, err := pool.selectFunc()
+		if err != nil {
+			t.Fatalf("Failed to select a connection: %v", err)
+		}
+		if selectedEntry != newEntry {
+			t.Fatalf("A new request was routed to the old draining connection")
+		}
+
+		// Finish the stream on the old connection
+		close(fake.streamSema) // Unblock server
+		stream.CloseSend()
+		for {
+			if err := stream.RecvMsg(&testpb.SimpleResponse{}); err == io.EOF {
+				break
+			}
+		}
+
+		// Wait for the waitForDrainAndClose goroutine to finish
+		time.Sleep(500 * time.Millisecond)
+
+		if oldEntry.streamingLoad.Load() != 0 {
+			t.Errorf("Old connection load is still %d after stream completion", oldEntry.streamingLoad.Load())
+		}
+		if !isConnClosed(oldEntry.conn.ClientConn) {
+			t.Error("Old connection was not closed after its load dropped to zero")
 		}
 	})
+
+	t.Run("SelectionSkipsDrainingConns", func(t *testing.T) {
+		pool, err := NewBigtableChannelPool(ctx, 3, btopt.RoundRobin, dialFunc, nil, nil)
+		if err != nil {
+			t.Fatalf("Failed to create pool: %v", err)
+		}
+		defer pool.Close()
+
+		conns := pool.getConns()
+		drainingEntry := conns[1]
+		drainingEntry.drainingState.Store(true) // Manually mark as draining
+
+		// Run selection many times and ensure the draining one is never picked
+		for i := 0; i < 20; i++ {
+			entry, err := pool.selectRoundRobin()
+			if err != nil {
+				t.Fatalf("Selection failed: %v", err)
+			}
+			if entry == drainingEntry {
+				t.Fatal("Selection logic picked a connection that is draining")
+			}
+		}
+
+		// Mark all as draining and expect an error
+		for _, entry := range conns {
+			entry.drainingState.Store(true)
+		}
+		_, err = pool.selectRoundRobin()
+		if !errors.Is(err, errNoConnections) {
+			t.Errorf("Expected errNoConnections when all connections are draining, got %v", err)
+		}
+	})
+
+	t.Run("DrainingTimeout", func(t *testing.T) {
+		// Temporarily shorten the timeout for this specific test
+		originalTimeout := maxDrainingTimeout
+		maxDrainingTimeout = 100 * time.Millisecond
+		defer func() { maxDrainingTimeout = originalTimeout }()
+
+		pool, err := NewBigtableChannelPool(ctx, 1, btopt.RoundRobin, dialFunc, nil, nil)
+		if err != nil {
+			t.Fatalf("Failed to create pool: %v", err)
+		}
+		defer pool.Close()
+
+		oldEntry := pool.getConns()[0]
+
+		// Create a stream that will never finish
+		fake.streamSema = make(chan struct{})
+		pool.NewStream(ctx, &grpc.StreamDesc{}, "/grpc.testing.BenchmarkService/StreamingCall")
+
+		// Trigger replacement
+		pool.replaceConnection(oldEntry)
+
+		if isConnClosed(oldEntry.conn.ClientConn) {
+			t.Fatal("Connection was closed immediately")
+		}
+
+		// Wait for the drain timeout to fire
+		time.Sleep(maxDrainingTimeout + 50*time.Millisecond)
+
+		if !isConnClosed(oldEntry.conn.ClientConn) {
+			t.Error("Connection was not force-closed after the draining timeout")
+		}
+		// In a real scenario, we'd log that the load was still > 0, e.g.,
+		if oldEntry.streamingLoad.Load() == 0 {
+			t.Error("Load was unexpectedly 0, timeout should not have been the reason for closing")
+		}
+	})
+}
+
+func TestReplaceConnection(t *testing.T) {
+	ctx := context.Background()
+	fake := &fakeService{}
+	addr := setupTestServer(t, fake)
+	idxToReplace := 0
+
+	var dialSucceed bool
+	var dialCount int32
+	var mu sync.Mutex // To protect dialSucceed
+
+	dialFunc := func() (*BigtableConn, error) {
+		atomic.AddInt32(&dialCount, 1)
+		mu.Lock()
+		ds := dialSucceed
+		mu.Unlock()
+		if !ds {
+			return nil, errors.New("simulated redial failure")
+		}
+		return dialBigtableserver(addr)
+	}
+
+	t.Run("SuccessfulReplace", func(t *testing.T) {
+		mu.Lock()
+		dialSucceed = true
+		mu.Unlock()
+		atomic.StoreInt32(&dialCount, 0)
+
+		pool, err := NewBigtableChannelPool(ctx, 2, btopt.RoundRobin, dialFunc, log.Default(), nil)
+		if err != nil {
+			t.Fatalf("Failed to create pool: %v", err)
+		}
+		defer pool.Close()
+
+		atomic.StoreInt32(&dialCount, 0) // Reset count for replaceConnection call
+
+		oldEntry := pool.getConns()[idxToReplace]
+		pool.replaceConnection(oldEntry)
+
+		if atomic.LoadInt32(&dialCount) != 1 {
+			t.Errorf("Dial function called %d times by replaceConnection, want 1", atomic.LoadInt32(&dialCount))
+		}
+		newEntry := pool.getConns()[idxToReplace]
+		if newEntry == oldEntry || newEntry.conn == oldEntry.conn {
+			t.Errorf("Connection not replaced")
+		}
+		if newEntry.unaryLoad.Load() != 0 || newEntry.streamingLoad.Load() != 0 {
+			t.Errorf("New entry load not zero")
+		}
+		time.Sleep(50 * time.Millisecond) // Wait for prime to finish
+		if newEntry.isALTSUsed() {
+			t.Errorf("New entry isALTSUsed() got true, want false")
+		}
+	})
+
+	t.Run("FailedRedial", func(t *testing.T) {
+		// Pool creation should succeed
+		mu.Lock()
+		dialSucceed = true
+		mu.Unlock()
+		atomic.StoreInt32(&dialCount, 0)
+
+		pool, err := NewBigtableChannelPool(ctx, 2, btopt.RoundRobin, dialFunc, log.Default(), nil)
+		if err != nil {
+			t.Fatalf("Failed to create pool: %v", err)
+		}
+		defer pool.Close()
+
+		// Make the *next* dial fail (the one in replaceConnection)
+		mu.Lock()
+		dialSucceed = false
+		mu.Unlock()
+		atomic.StoreInt32(&dialCount, 0) // Reset count for replaceConnection call
+
+		currentEntry := pool.getConns()[idxToReplace]
+		pool.replaceConnection(currentEntry)
+
+		if atomic.LoadInt32(&dialCount) != 1 {
+			t.Errorf("Dial function called %d times by replaceConnection, want 1", atomic.LoadInt32(&dialCount))
+		}
+		if pool.getConns()[idxToReplace] != currentEntry {
+			t.Errorf("Connection entry changed despite redial failure")
+		}
+	})
+
+	t.Run("PoolContextDone", func(t *testing.T) {
+		mu.Lock()
+		dialSucceed = true
+		mu.Unlock()
+		atomic.StoreInt32(&dialCount, 0)
+
+		poolCancelled, err := NewBigtableChannelPool(ctx, 2, btopt.RoundRobin, dialFunc, log.Default(), nil)
+		if err != nil {
+			t.Fatalf("Failed to create poolCancelled: %v", err)
+		}
+		// Intentionally not closing poolCancelled normally, just cancelling context
+
+		poolCancelled.poolCancel()       // Cancel the context
+		atomic.StoreInt32(&dialCount, 0) // Reset count for replaceConnection call
+
+		currentEntry := poolCancelled.getConns()[idxToReplace]
+		poolCancelled.replaceConnection(currentEntry)
+
+		if atomic.LoadInt32(&dialCount) != 0 {
+			t.Errorf("Dial function called %d times by replaceConnection, want 0 because context is done", atomic.LoadInt32(&dialCount))
+		}
+		if poolCancelled.getConns()[idxToReplace] != currentEntry {
+			t.Errorf("Connection entry changed despite context done")
+		}
+		poolCancelled.Close() // Still close to free resources
+	})
+}
+
+// --- Benchmarks ---
+
+func createBenchmarkFake() *fakeService {
+	return &fakeService{delay: 1 * time.Microsecond} // Simulate a tiny bit of work
+}
+
+func setupBenchmarkPool(b *testing.B, strategy btopt.LoadBalancingStrategy, poolSize int, serverAddr string) *BigtableChannelPool {
+	b.Helper()
+
+	dialFunc := func() (*BigtableConn, error) {
+		return dialBigtableserver(serverAddr)
+	}
+
+	ctx := context.Background()
+	pool, err := NewBigtableChannelPool(ctx, poolSize, strategy, dialFunc, nil, nil)
+	if err != nil {
+		b.Fatalf("Failed to create pool: %v", err)
+	}
+
+	b.Cleanup(func() {
+		pool.Close()
+	})
+	return pool
+}
+
+func BenchmarkPoolInvoke(b *testing.B) {
+	fake := createBenchmarkFake()
+	serverAddr := setupTestServer(b, fake) // Server lives for all sub-benchmarks of BenchmarkPoolInvoke
+
+	strategies := []btopt.LoadBalancingStrategy{
+		btopt.RoundRobin,
+		btopt.LeastInFlight,
+		btopt.PowerOfTwoLeastInFlight,
+	}
+	poolSizes := []int{1, 8, 64}
+
+	req := &testpb.SimpleRequest{Payload: &testpb.Payload{Body: []byte("benchmark")}}
+	ctx := context.Background()
+
+	for _, size := range poolSizes {
+		for _, strategy := range strategies {
+			b.Run(fmt.Sprintf("%s_PoolSize%d", strategy, size), func(b *testing.B) {
+				pool := setupBenchmarkPool(b, strategy, size, serverAddr)
+
+				b.ResetTimer()
+				b.RunParallel(func(pb *testing.PB) {
+					for pb.Next() {
+						res := &testpb.SimpleResponse{}
+
+						err := pool.Invoke(ctx, "/grpc.testing.BenchmarkService/UnaryCall", req, res)
+						if err != nil {
+							b.Fatalf("Invoke failed: %v", err) // Fail fast
+						}
+					}
+				})
+			})
+		}
+	}
+	// --- Standard gtransport.DialPool ---
+	for _, size := range poolSizes {
+		b.Run(fmt.Sprintf("StandardPool_Size%d", size), func(b *testing.B) {
+			stdPool, err := gtransport.DialPool(ctx,
+				option.WithEndpoint(serverAddr),
+				option.WithGRPCConnectionPool(size),
+				option.WithoutAuthentication(),
+				option.WithGRPCDialOption(grpc.WithTransportCredentials(insecure.NewCredentials())),
+			)
+			if err != nil {
+				b.Fatalf("gtransport.DialPool failed: %v", err)
+			}
+			b.Cleanup(func() { stdPool.Close() })
+
+			client := testpb.NewBenchmarkServiceClient(stdPool)
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					if _, err := client.UnaryCall(ctx, req); err != nil {
+						b.Fatalf("UnaryCall failed: %v", err)
+					}
+				}
+			})
+		})
+	}
+}
+
+func BenchmarkPoolNewStream(b *testing.B) {
+	fake := createBenchmarkFake()
+	serverAddr := setupTestServer(b, fake)
+
+	strategies := []btopt.LoadBalancingStrategy{
+		btopt.RoundRobin,
+		btopt.LeastInFlight,
+		btopt.PowerOfTwoLeastInFlight,
+	}
+	poolSizes := []int{1, 8, 64}
+	ctx := context.Background()
+
+	for _, size := range poolSizes {
+		for _, strategy := range strategies {
+			b.Run(fmt.Sprintf("%s_PoolSize%d", strategy, size), func(b *testing.B) {
+				pool := setupBenchmarkPool(b, strategy, size, serverAddr)
+
+				b.ResetTimer()
+				b.RunParallel(func(pb *testing.PB) {
+					for pb.Next() {
+						stream, err := pool.NewStream(ctx, &grpc.StreamDesc{StreamName: "StreamingCall"}, "/grpc.testing.BenchmarkService/StreamingCall")
+						if err != nil {
+							b.Fatalf("NewStream failed: %v", err)
+						}
+						req := &testpb.SimpleRequest{Payload: &testpb.Payload{Body: []byte("a")}}
+						if err := stream.SendMsg(req); err != nil {
+							st, ok := status.FromError(err)
+							if ok && st.Code() == codes.Unavailable {
+								b.Fatalf("SendMsg failed with Unavailable: %v", err)
+							}
+							b.Logf("SendMsg failed: %v", err)
+						}
+						stream.CloseSend()
+					}
+				})
+			})
+		}
+	}
+}
+
+func BenchmarkSelectionStrategies(b *testing.B) {
+	fake := createBenchmarkFake()
+	serverAddr := setupTestServer(b, fake)
+
+	poolSizes := []int{1, 8, 64, 256}
+
+	for _, size := range poolSizes {
+		b.Run(fmt.Sprintf("PoolSize%d", size), func(b *testing.B) {
+			poolRR := setupBenchmarkPool(b, btopt.RoundRobin, size, serverAddr)
+			poolLIF := setupBenchmarkPool(b, btopt.LeastInFlight, size, serverAddr)
+			poolP2 := setupBenchmarkPool(b, btopt.PowerOfTwoLeastInFlight, size, serverAddr)
+
+			b.Run("RoundRobin", func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					poolRR.selectRoundRobin()
+				}
+			})
+
+			b.Run("LeastInFlight", func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					poolLIF.selectLeastLoaded()
+				}
+			})
+
+			b.Run("PowerOfTwoLeastInFlight", func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					poolP2.selectLeastLoadedRandomOfTwo()
+				}
+			})
+		})
+	}
 }

--- a/bigtable/internal/transport/connpool_test.go
+++ b/bigtable/internal/transport/connpool_test.go
@@ -592,7 +592,7 @@ func TestCachingStreamDecrement(t *testing.T) {
 		if err != nil {
 			return nil, err
 		}
-		return NewBigtableConn(conn, "test-instance", "test-profile"), nil
+		return newBigtableConn(conn, "test-instance", "test-profile"), nil
 	}
 
 	pool, err := NewBigtableChannelPool(ctx, poolSize, btopt.LeastInFlight, dialFunc, nil, nil)

--- a/bigtable/internal/transport/connpool_test.go
+++ b/bigtable/internal/transport/connpool_test.go
@@ -759,8 +759,13 @@ func TestMultipleStreamsSingleConn(t *testing.T) {
 
 	connEntry := pool.getConns()[0]
 
+	// ClientStreams/ServerStreams both true so the stream stays open across
+	// the SendMsg/RecvMsg round-trip in the next loop; without them gRPC
+	// treats it as a unary call and fires OnFinish after the first response,
+	// which would decrement the load before the close-and-drain phase.
+	streamDesc := &grpc.StreamDesc{StreamName: "StreamingCall", ClientStreams: true, ServerStreams: true}
 	for i := 0; i < numStreams; i++ {
-		stream, err := pool.NewStream(ctx, &grpc.StreamDesc{StreamName: "StreamingCall"}, "/grpc.testing.BenchmarkService/StreamingCall")
+		stream, err := pool.NewStream(ctx, streamDesc, "/grpc.testing.BenchmarkService/StreamingCall")
 		if err != nil {
 			t.Fatalf("NewStream %d failed: %v", i, err)
 		}
@@ -976,10 +981,13 @@ func TestGracefulDraining(t *testing.T) {
 		if !isConnClosed(oldEntry.conn.ClientConn) {
 			t.Error("Connection was not force-closed after the draining timeout")
 		}
-		// In a real scenario, we'd log that the load was still > 0, e.g.,
-		if oldEntry.streamingLoad.Load() == 0 {
-			t.Error("Load was unexpectedly 0, timeout should not have been the reason for closing")
-		}
+		// Note: we used to assert streamingLoad > 0 here as a proxy for
+		// "the timeout — not natural drain — caused the close". That proxy
+		// no longer works: grpc.OnFinish fires when the transport is torn
+		// down by the force-close, which legitimately decrements the load.
+		// The isConnClosed check above is sufficient — the stream is stuck
+		// on streamSema so the only way the conn closes within the sleep
+		// window is the timeout.
 	})
 }
 

--- a/bigtable/internal/transport/connpool_test.go
+++ b/bigtable/internal/transport/connpool_test.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"net/url"
 	"reflect"
+	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -1628,4 +1629,100 @@ func BenchmarkSelectionStrategies(b *testing.B) {
 			})
 		})
 	}
+}
+
+// BenchmarkAbandonedStreamLoadLeak measures whether streamingLoad is reclaimed
+// when callers abandon a stream by cancelling its context without draining
+// SendMsg/RecvMsg to a final error.
+//
+// Before the grpc.OnFinish wiring in NewStream, every iteration leaked one
+// count on streamingLoad, so residual_load/op approaches 1.0 and the
+// connection's calculateConnLoad() grows linearly with b.N — which both
+// poisons load-balancing decisions and prevents waitForDrainAndClose from
+// ever observing a zero load. After the fix, OnFinish fires when gRPC fully
+// tears the stream down, so residual_load/op should sit near 0.
+//
+// Run:
+//
+//	go test -bench BenchmarkAbandonedStreamLoadLeak -benchmem -run=^$ \
+//	    ./internal/transport
+func BenchmarkAbandonedStreamLoadLeak(b *testing.B) {
+	ctx := context.Background()
+	fake := &fakeService{}
+	// Block server-side StreamingCall so the stream stays open until the
+	// client cancels — this is the abandoned-stream shape we care about.
+	fake.streamSema = make(chan struct{})
+	defer close(fake.streamSema)
+
+	addr := setupTestServer(b, fake)
+	dialFunc := func() (*BigtableConn, error) { return dialBigtableserver(addr) }
+
+	pool, err := NewBigtableChannelPool(ctx, 1, btopt.RoundRobin, dialFunc, poolOpts()...)
+	if err != nil {
+		b.Fatalf("Failed to create pool: %v", err)
+	}
+	defer pool.Close()
+
+	desc := &grpc.StreamDesc{
+		StreamName:    "StreamingCall",
+		ClientStreams: true,
+		ServerStreams: true,
+	}
+	const method = "/grpc.testing.BenchmarkService/StreamingCall"
+
+	// Force GC and sample resident heap so we can report a real heap delta
+	// (B/op from -benchmem counts bytes ALLOCATED, not bytes RESIDENT).
+	runtime.GC()
+	var before, after runtime.MemStats
+	runtime.ReadMemStats(&before)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		streamCtx, cancel := context.WithCancel(ctx)
+		if _, err := pool.NewStream(streamCtx, desc, method); err != nil {
+			cancel()
+			b.Fatalf("NewStream failed: %v", err)
+		}
+		// Abandon the stream — never call SendMsg/RecvMsg again. This is the
+		// real-world path that leaks load (caller hits ctx deadline, panics,
+		// or the stream value is dropped on the floor).
+		cancel()
+	}
+
+	b.StopTimer()
+
+	// OnFinish runs on a gRPC goroutine after the transport tears the stream
+	// down; poll briefly so we measure the steady-state residual rather than
+	// in-flight cleanup.
+	deadline := time.Now().Add(2 * time.Second)
+	var residual int32
+	for time.Now().Before(deadline) {
+		residual = 0
+		for _, entry := range pool.getConns() {
+			residual += entry.streamingLoad.Load()
+		}
+		if residual == 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// Sample heap after cleanup has settled. A second GC is needed because
+	// the first one runs concurrently with finalizers / unreachable-but-not-
+	// yet-collected gRPC stream state from the loop above.
+	runtime.GC()
+	runtime.GC()
+	runtime.ReadMemStats(&after)
+	heapDelta := int64(after.HeapAlloc) - int64(before.HeapAlloc)
+
+	// Report leaked load per operation. Without the fix this trends to 1.0;
+	// with the fix it should be ~0.
+	b.ReportMetric(float64(residual)/float64(b.N), "residual_load/op")
+	b.ReportMetric(float64(residual), "residual_load_total")
+	// Resident heap delta (post-GC). Captures memory pinned by leaked stream
+	// state — distinct from B/op, which is allocator throughput.
+	b.ReportMetric(float64(heapDelta)/float64(b.N), "heap_bytes/op")
+	b.ReportMetric(float64(heapDelta), "heap_bytes_total")
 }

--- a/bigtable/internal/transport/connpool_test.go
+++ b/bigtable/internal/transport/connpool_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"net/url"
+	"reflect"
 	"sort"
 	"strings"
 	"sync"
@@ -1388,6 +1389,87 @@ func TestRemoveConnections(t *testing.T) {
 			}
 		}
 	})
+}
+
+func TestConnPoolStatisticsVisitor(t *testing.T) {
+	ctx := context.Background()
+	poolSize := 3
+	fake := &fakeService{}
+	addr := setupTestServer(t, fake)
+	dialFunc := func() (*BigtableConn, error) { return dialBigtableserver(addr) }
+
+	pool, err := NewBigtableChannelPool(ctx, poolSize, btopt.RoundRobin, dialFunc, poolOpts()...)
+	if err != nil {
+		t.Fatalf("Failed to create pool: %v", err)
+	}
+	defer pool.Close()
+
+	// Wait for connections to be established
+	time.Sleep(100 * time.Millisecond)
+
+	conns := pool.getConns()
+	if len(conns) != poolSize {
+		t.Fatalf("Pool size mismatch: got %d, want %d", len(conns), poolSize)
+	}
+
+	testData := []struct {
+		unary     int32
+		streaming int32
+		errors    int64
+		isALTS    bool
+	}{
+		{unary: 5, streaming: 2, errors: 10, isALTS: false},
+		{unary: 0, streaming: 1, errors: 0, isALTS: true},
+		{unary: 3, streaming: 0, errors: 5, isALTS: false},
+	}
+
+	if len(testData) != poolSize {
+		t.Fatalf("Test data size: pool size mismatch: got %d, want %d", len(testData), poolSize)
+	}
+
+	for i, data := range testData {
+		if i < len(conns) {
+			conns[i].unaryLoad.Store(data.unary)
+			conns[i].streamingLoad.Store(data.streaming)
+			conns[i].errorCount.Store(data.errors)
+			conns[i].conn.isALTSConn.Store(data.isALTS)
+		}
+	}
+
+	// Get the snapshot
+	stats := pool.connPoolStatsSupplier()
+
+	if len(stats) != poolSize {
+		t.Errorf("Snapshot size mismatch: got %d, want %d", len(stats), poolSize)
+	}
+
+	expectedStats := make([]connPoolStats, poolSize)
+	for i, data := range testData {
+		expectedStats[i] = connPoolStats{
+			OutstandingUnaryLoad:     data.unary,
+			OutstandingStreamingLoad: data.streaming,
+			ErrorCount:               data.errors,
+			IsALTSUsed:               data.isALTS,
+			LBPolicy:                 btopt.RoundRobin.String(),
+		}
+	}
+
+	sort.Slice(stats, func(i, j int) bool { return stats[i].OutstandingUnaryLoad < stats[j].OutstandingUnaryLoad })
+	sort.Slice(expectedStats, func(i, j int) bool {
+		return expectedStats[i].OutstandingUnaryLoad < expectedStats[j].OutstandingUnaryLoad
+	})
+
+	if !reflect.DeepEqual(stats, expectedStats) {
+		t.Errorf("Snapshot data mismatch:\ngot:  %v\nwant: %v", stats, expectedStats)
+	}
+
+	// Verify error counts are reset
+	connsAfter := pool.getConns()
+	for i, entry := range connsAfter {
+		if entry.errorCount.Load() != 0 {
+			t.Errorf("entry[%d].errorCount was not reset: got %d, want 0", i, entry.errorCount.Load())
+		}
+	}
 }
 
 // --- Benchmarks ---

--- a/bigtable/internal/transport/dynamic_scale_monitor.go
+++ b/bigtable/internal/transport/dynamic_scale_monitor.go
@@ -97,7 +97,7 @@ func (dsm *DynamicScaleMonitor) evaluateAndScale() {
 
 	var totalWeightedLoad int32
 	for _, entry := range conns {
-		totalWeightedLoad += entry.calculateWeightedLoad()
+		totalWeightedLoad += entry.calculateConnLoad()
 	}
 	avgLoad := totalWeightedLoad / int32(numConns)
 

--- a/bigtable/internal/transport/dynamic_scale_monitor.go
+++ b/bigtable/internal/transport/dynamic_scale_monitor.go
@@ -1,0 +1,178 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"sync"
+	"time"
+
+	btopt "cloud.google.com/go/bigtable/internal/option"
+)
+
+// DynamicScaleMonitor manages dynamic scaling of the connection pool.
+type DynamicScaleMonitor struct {
+	config          btopt.DynamicChannelPoolConfig
+	pool            *BigtableChannelPool
+	lastScalingTime time.Time
+	mu              sync.Mutex
+	ticker          *time.Ticker
+	done            chan struct{}
+	stopOnce        sync.Once
+}
+
+// NewDynamicScaleMonitor creates a new DynamicScaleMonitor.
+func NewDynamicScaleMonitor(config btopt.DynamicChannelPoolConfig, pool *BigtableChannelPool) *DynamicScaleMonitor {
+	return &DynamicScaleMonitor{
+		config: config,
+		pool:   pool,
+		done:   make(chan struct{}),
+	}
+}
+
+// Start begins the periodic scaling check loop.
+func (dsm *DynamicScaleMonitor) Start(ctx context.Context) {
+	if !dsm.config.Enabled {
+		return
+	}
+	dsm.ticker = time.NewTicker(dsm.config.CheckInterval)
+	go func() {
+		defer dsm.ticker.Stop()
+		for {
+			select {
+			case <-dsm.ticker.C:
+				dsm.evaluateAndScale()
+			case <-dsm.done:
+				return
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+}
+
+// Stop terminates the scaling check loop.
+func (dsm *DynamicScaleMonitor) Stop() {
+	if !dsm.config.Enabled {
+		return
+	}
+	dsm.stopOnce.Do(func() {
+		close(dsm.done)
+	})
+}
+
+func (dsm *DynamicScaleMonitor) evaluateAndScale() {
+	dsm.mu.Lock()
+	defer dsm.mu.Unlock()
+
+	if time.Since(dsm.lastScalingTime) < dsm.config.MinScalingInterval {
+		return // Too soon since last scaling operation
+	}
+
+	conns := dsm.pool.getConns()
+	numConns := len(conns)
+	if numConns == 0 {
+		if dsm.config.MinConns > 0 {
+			btopt.Debugf(dsm.pool.logger, "bigtable_connpool: WARNING: Pool empty, attempting to scale up to MinConns\n")
+			if dsm.pool.addConnections(dsm.config.MinConns) {
+				dsm.lastScalingTime = time.Now()
+			}
+		}
+		return
+	}
+
+	var totalWeightedLoad int32
+	for _, entry := range conns {
+		totalWeightedLoad += entry.calculateWeightedLoad()
+	}
+	avgLoad := totalWeightedLoad / int32(numConns)
+
+	targetLoad := (dsm.config.AvgLoadLowThreshold + dsm.config.AvgLoadHighThreshold) / 2
+	if targetLoad == 0 {
+		targetLoad = 1
+	} // Avoid division by zero
+
+	if avgLoad >= dsm.config.AvgLoadHighThreshold && numConns < dsm.config.MaxConns {
+		// Scale Up
+		desiredConns := int(math.Ceil(float64(totalWeightedLoad) / float64(targetLoad)))
+		addCount := desiredConns - numConns
+		if addCount < 1 {
+			addCount = 1 // Add at least one
+		}
+		if numConns+addCount > dsm.config.MaxConns {
+			addCount = dsm.config.MaxConns - numConns
+		}
+
+		if addCount > 0 {
+			btopt.Debugf(dsm.pool.logger, "bigtable_connpool: Scaling up: AvgLoad=%d, CurrentSize=%d, Adding=%d\n", avgLoad, numConns, addCount)
+			if dsm.pool.addConnections(addCount) {
+				dsm.lastScalingTime = time.Now()
+			}
+		}
+	} else if avgLoad <= dsm.config.AvgLoadLowThreshold && numConns > dsm.config.MinConns {
+		// Scale Down
+		desiredConns := int(math.Ceil(float64(totalWeightedLoad) / float64(targetLoad)))
+		if desiredConns < dsm.config.MinConns {
+			desiredConns = dsm.config.MinConns
+		}
+		removeCount := numConns - desiredConns
+		if removeCount < 1 && numConns > dsm.config.MinConns {
+			removeCount = 1 // Try to remove at least one if needed.
+		}
+
+		if removeCount > dsm.config.MaxRemoveConns {
+			removeCount = dsm.config.MaxRemoveConns
+		}
+
+		if numConns-removeCount < dsm.config.MinConns {
+			removeCount = numConns - dsm.config.MinConns
+		}
+
+		if removeCount > 0 {
+			btopt.Debugf(dsm.pool.logger, "bigtable_connpool: Scaling down: AvgLoad=%d, CurrentSize=%d, Removing=%d\n", avgLoad, numConns, removeCount)
+			if dsm.pool.removeConnections(removeCount) {
+				dsm.lastScalingTime = time.Now()
+			}
+		}
+	}
+}
+
+// validateDynamicConfig is a helper to centralize validation logic.
+func validateDynamicConfig(config btopt.DynamicChannelPoolConfig, connPoolSize int) error {
+	if config.MinConns <= 0 {
+		return fmt.Errorf("bigtable_connpool: DynamicChannelPoolConfig.MinConns must be positive")
+	}
+	if config.MaxConns < config.MinConns {
+		return fmt.Errorf("bigtable_connpool: DynamicChannelPoolConfig.MaxConns (%d) was less than MinConns (%d)", config.MaxConns, config.MinConns)
+	}
+	if connPoolSize < config.MinConns || connPoolSize > config.MaxConns {
+		return fmt.Errorf("bigtable_connpool: initial connPoolSize (%d) must be between DynamicChannelPoolConfig.MinConns (%d) and MaxConns (%d)", connPoolSize, config.MinConns, config.MaxConns)
+	}
+	if config.AvgLoadLowThreshold >= config.AvgLoadHighThreshold {
+		return fmt.Errorf("bigtable_connpool: DynamicChannelPoolConfig.AvgLoadLowThreshold (%d) must be less than AvgLoadHighThreshold (%d)", config.AvgLoadLowThreshold, config.AvgLoadHighThreshold)
+	}
+	if config.CheckInterval <= 0 {
+		return fmt.Errorf("bigtable_connpool: DynamicChannelPoolConfig.CheckInterval must be positive")
+	}
+	if config.MinScalingInterval < 0 {
+		return fmt.Errorf("bigtable_connpool: DynamicChannelPoolConfig.MinScalingInterval cannot be negative")
+	}
+	if config.MaxRemoveConns <= 0 {
+		return fmt.Errorf("bigtable_connpool: DynamicChannelPoolConfig.MaxRemoveConns must be positive")
+	}
+	return nil
+}

--- a/bigtable/internal/transport/dynamic_scale_monitor.go
+++ b/bigtable/internal/transport/dynamic_scale_monitor.go
@@ -80,7 +80,7 @@ func (dsm *DynamicScaleMonitor) evaluateAndScale() {
 	defer dsm.mu.Unlock()
 
 	if time.Since(dsm.lastScalingTime) < dsm.config.MinScalingInterval {
-		return // should not happen
+		return // lastScalingTime is populated after removeConn or addConn succeeds
 	}
 
 	conns := dsm.pool.getConns()

--- a/bigtable/internal/transport/dynamic_scale_monitor.go
+++ b/bigtable/internal/transport/dynamic_scale_monitor.go
@@ -24,7 +24,7 @@ import (
 	btopt "cloud.google.com/go/bigtable/internal/option"
 )
 
-// DynamicScaleMonitor manages dynamic scaling of the connection pool.
+// DynamicScaleMonitor manages upscale and downscale of the connection pool.
 type DynamicScaleMonitor struct {
 	config          btopt.DynamicChannelPoolConfig
 	pool            *BigtableChannelPool
@@ -44,7 +44,7 @@ func NewDynamicScaleMonitor(config btopt.DynamicChannelPoolConfig, pool *Bigtabl
 	}
 }
 
-// Start begins the periodic scaling check loop.
+// Start logic
 func (dsm *DynamicScaleMonitor) Start(ctx context.Context) {
 	if !dsm.config.Enabled {
 		return
@@ -80,14 +80,16 @@ func (dsm *DynamicScaleMonitor) evaluateAndScale() {
 	defer dsm.mu.Unlock()
 
 	if time.Since(dsm.lastScalingTime) < dsm.config.MinScalingInterval {
-		return // Too soon since last scaling operation
+		return // should not happen
 	}
 
 	conns := dsm.pool.getConns()
 	numConns := len(conns)
 	if numConns == 0 {
 		if dsm.config.MinConns > 0 {
-			btopt.Debugf(dsm.pool.logger, "bigtable_connpool: WARNING: Pool empty, attempting to scale up to MinConns\n")
+			// likely a bug if numConns is zero as monitor runs after conn pool is setup
+			// or misuse of monitor (if monitor runs before channel pool is fully setup)
+			btopt.Debugf(dsm.pool.logger, "bigtable_connpool: BUG: Pool empty, attempting to scale up to MinConns\n")
 			if dsm.pool.addConnections(dsm.config.MinConns) {
 				dsm.lastScalingTime = time.Now()
 			}
@@ -95,11 +97,11 @@ func (dsm *DynamicScaleMonitor) evaluateAndScale() {
 		return
 	}
 
-	var totalWeightedLoad int32
+	var loadSum int32
 	for _, entry := range conns {
-		totalWeightedLoad += entry.calculateConnLoad()
+		loadSum += entry.calculateConnLoad()
 	}
-	avgLoad := totalWeightedLoad / int32(numConns)
+	avgLoad := loadSum / int32(numConns)
 
 	targetLoad := (dsm.config.AvgLoadLowThreshold + dsm.config.AvgLoadHighThreshold) / 2
 	if targetLoad == 0 {
@@ -108,24 +110,26 @@ func (dsm *DynamicScaleMonitor) evaluateAndScale() {
 
 	if avgLoad >= dsm.config.AvgLoadHighThreshold && numConns < dsm.config.MaxConns {
 		// Scale Up
-		desiredConns := int(math.Ceil(float64(totalWeightedLoad) / float64(targetLoad)))
+		desiredConns := int(math.Ceil(float64(loadSum) / float64(targetLoad)))
 		addCount := desiredConns - numConns
 		if addCount < 1 {
 			addCount = 1 // Add at least one
 		}
 		if numConns+addCount > dsm.config.MaxConns {
+			//capped
 			addCount = dsm.config.MaxConns - numConns
 		}
 
 		if addCount > 0 {
 			btopt.Debugf(dsm.pool.logger, "bigtable_connpool: Scaling up: AvgLoad=%d, CurrentSize=%d, Adding=%d\n", avgLoad, numConns, addCount)
+			// TODO: make this a separate goroutine
 			if dsm.pool.addConnections(addCount) {
 				dsm.lastScalingTime = time.Now()
 			}
 		}
 	} else if avgLoad <= dsm.config.AvgLoadLowThreshold && numConns > dsm.config.MinConns {
 		// Scale Down
-		desiredConns := int(math.Ceil(float64(totalWeightedLoad) / float64(targetLoad)))
+		desiredConns := int(math.Ceil(float64(loadSum) / float64(targetLoad)))
 		if desiredConns < dsm.config.MinConns {
 			desiredConns = dsm.config.MinConns
 		}
@@ -139,11 +143,13 @@ func (dsm *DynamicScaleMonitor) evaluateAndScale() {
 		}
 
 		if numConns-removeCount < dsm.config.MinConns {
+			// capped
 			removeCount = numConns - dsm.config.MinConns
 		}
 
 		if removeCount > 0 {
 			btopt.Debugf(dsm.pool.logger, "bigtable_connpool: Scaling down: AvgLoad=%d, CurrentSize=%d, Removing=%d\n", avgLoad, numConns, removeCount)
+			// TODO: make this a separate goroutine
 			if dsm.pool.removeConnections(removeCount) {
 				dsm.lastScalingTime = time.Now()
 			}

--- a/bigtable/internal/transport/dynamic_scale_monitor_test.go
+++ b/bigtable/internal/transport/dynamic_scale_monitor_test.go
@@ -1,0 +1,227 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"context"
+	"math"
+	"testing"
+	"time"
+
+	btopt "cloud.google.com/go/bigtable/internal/option"
+)
+
+func TestDynamicChannelScaling(t *testing.T) {
+	ctx := context.Background()
+	fake := &fakeService{}
+	addr := setupTestServer(t, fake)
+	dialFunc := func() (*BigtableConn, error) { return dialBigtableserver(addr) }
+
+	baseConfig := btopt.DynamicChannelPoolConfig{
+		Enabled:              true,
+		MinConns:             2,
+		MaxConns:             10,
+		AvgLoadHighThreshold: 10,               // Scale up if avg load >= 10
+		AvgLoadLowThreshold:  3,                // Scale down if avg load <= 3
+		MinScalingInterval:   0,                // Disable time throttling for most tests
+		CheckInterval:        10 * time.Second, // Not directly used by calling evaluateAndScale
+		MaxRemoveConns:       3,
+	}
+	targetLoadFactor := float64(baseConfig.AvgLoadLowThreshold+baseConfig.AvgLoadHighThreshold) / 2.0
+
+	tests := []struct {
+		name        string
+		initialSize int
+		configOpt   func(*btopt.DynamicChannelPoolConfig)
+		setLoad     func(conns []*connEntry)
+		wantSize    int
+	}{
+		{
+			name:        "ScaleUp",
+			initialSize: 3,
+			setLoad: func(conns []*connEntry) {
+				setConnLoads(conns, 12, 0) // Avg load 12 > 10
+			},
+			// Total load = 3 * 12 = 36. Desired = ceil(36 / 6.5) = 6
+			wantSize: 6,
+		},
+		{
+			name:        "ScaleUpCappedAtMax",
+			initialSize: 8,
+			setLoad: func(conns []*connEntry) {
+				setConnLoads(conns, 20, 0) // Avg load 20 > 10
+			},
+			// Total load = 8 * 20 = 160. Desired = ceil(160 / 6.5) = 25. Capped at MaxConns = 10
+			wantSize: 10,
+		},
+		{
+			name:        "ScaleDown",
+			initialSize: 9,
+			setLoad: func(conns []*connEntry) {
+				setConnLoads(conns, 1, 0) // Avg load 1 < 3
+			},
+			// Total load = 9 * 1 = 9. Desired = ceil(9 / 6.5) = 2.
+			wantSize: 6,
+		},
+		{
+			name:        "ScaleDownCappedAtMin",
+			initialSize: 3,
+			setLoad: func(conns []*connEntry) {
+				setConnLoads(conns, 1, 0) // Avg load 1 < 3
+			},
+			// Total load = 3 * 1 = 3. Desired = ceil(3 / 6.5) = 1. Capped at MinConns = 2
+			wantSize: 2,
+		},
+		{
+			name:        "ScaleDownLimitedByMaxRemove",
+			initialSize: 10,
+			configOpt: func(cfg *btopt.DynamicChannelPoolConfig) {
+				cfg.MaxRemoveConns = 2
+			},
+			setLoad: func(conns []*connEntry) {
+				setConnLoads(conns, 0, 0) // Avg load 0 < 3
+			},
+			// Total load = 0. Desired = 2 (MinConns). removeCount = 10 - 2 = 8. Limited by MaxRemoveConns = 2.
+			wantSize: 10 - 2,
+		},
+		{
+			name:        "NoScaleUp",
+			initialSize: 5,
+			setLoad: func(conns []*connEntry) {
+				setConnLoads(conns, 7, 0) // 3 < Avg load 7 < 10
+			},
+			wantSize: 5,
+		},
+		{
+			name:        "NoScaleDown",
+			initialSize: 5,
+			setLoad: func(conns []*connEntry) {
+				setConnLoads(conns, 5, 1) // Weighted load 5*1 + 1*2 = 7.  3 < 7 < 10
+			},
+			wantSize: 5,
+		},
+		{
+			name:        "ScaleUpAddAtLeastOne",
+			initialSize: 2,
+			setLoad: func(conns []*connEntry) {
+				setConnLoads(conns, 10, 0) // Avg load 10, right at threshold.
+			},
+			// Total load = 20. Desired = ceil(20 / 6.5) = 4. Add 2.
+			wantSize: 4,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			config := baseConfig
+			if tc.configOpt != nil {
+				tc.configOpt(&config)
+			}
+
+			pool, err := NewBigtableChannelPool(ctx, tc.initialSize, btopt.RoundRobin, dialFunc, nil, nil, WithDynamicChannelPool(config))
+			if err != nil {
+				t.Fatalf("Failed to create pool: %v", err)
+			}
+			defer pool.Close()
+
+			if tc.setLoad != nil {
+				tc.setLoad(pool.getConns())
+			}
+
+			// Capture the load for debugging
+			var totalLoad int32
+			conns := pool.getConns()
+			for _, entry := range conns {
+				totalLoad += entry.calculateWeightedLoad()
+			}
+			avgLoad := float64(totalLoad) / float64(len(conns))
+			desiredConns := int(math.Ceil(float64(totalLoad) / targetLoadFactor))
+			t.Logf("Initial size: %d, Avg load: %.2f, Total load: %d, Target desired conns: %d", tc.initialSize, avgLoad, totalLoad, desiredConns)
+
+			dynamicMonitor, ok := findMonitor[*DynamicScaleMonitor](pool)
+			if !ok {
+				t.Fatal("Could not find ChannelHealthMonitor in pool")
+			}
+			dynamicMonitor.evaluateAndScale()
+
+			if gotSize := pool.Num(); gotSize != tc.wantSize {
+				t.Errorf("evaluateAndScale() resulted in pool size %d, want %d", gotSize, tc.wantSize)
+			}
+		})
+	}
+
+	t.Run("MinScalingInterval", func(t *testing.T) {
+		config := baseConfig
+		config.MinScalingInterval = 5 * time.Minute
+		initialSize := 3
+
+		pool, err := NewBigtableChannelPool(ctx, initialSize, btopt.RoundRobin, dialFunc, nil, nil, WithDynamicChannelPool(config))
+		if err != nil {
+			t.Fatalf("Failed to create pool: %v", err)
+		}
+		defer pool.Close()
+
+		// Set load to trigger scale up
+		setConnLoads(pool.getConns(), 15, 0)
+
+		// 1. Simulate recent scaling
+		dynamicMonitor, ok := findMonitor[*DynamicScaleMonitor](pool)
+		if !ok {
+			t.Fatal("Could not find ChannelHealthMonitor in pool")
+		}
+		dynamicMonitor.mu.Lock()
+		dynamicMonitor.lastScalingTime = time.Now()
+		dynamicMonitor.mu.Unlock()
+
+		dynamicMonitor.evaluateAndScale()
+		if gotSize := pool.Num(); gotSize != initialSize {
+			t.Errorf("Pool size changed to %d, want %d (should be throttled)", gotSize, initialSize)
+		}
+
+		// 2. Allow scaling again by moving lastScalingTime to the past
+		dynamicMonitor.mu.Lock()
+		dynamicMonitor.lastScalingTime = time.Now().Add(-10 * time.Minute)
+		dynamicMonitor.mu.Unlock()
+
+		dynamicMonitor.evaluateAndScale()
+		if gotSize := pool.Num(); gotSize == initialSize {
+			t.Errorf("Pool size %d, want > %d (should have scaled up)", gotSize, initialSize)
+		} else {
+			t.Logf("Scaled up to %d connections", gotSize)
+		}
+	})
+
+	t.Run("EmptyPoolScaleUp", func(t *testing.T) {
+		config := baseConfig
+		// Pool creation requires size > 0. So, create and then manually empty it.
+		pool, err := NewBigtableChannelPool(ctx, config.MinConns, btopt.RoundRobin, dialFunc, nil, nil, WithDynamicChannelPool(config))
+		if err != nil {
+			t.Fatalf("Failed to create pool: %v", err)
+		}
+		defer pool.Close()
+
+		// Manually empty the pool to test the zero-connection code path
+		pool.conns.Store(([]*connEntry)(nil))
+
+		dynamicMonitor, ok := findMonitor[*DynamicScaleMonitor](pool)
+		if !ok {
+			t.Fatal("Could not find ChannelHealthMonitor in pool")
+		}
+		dynamicMonitor.evaluateAndScale()
+		if gotSize := pool.Num(); gotSize != config.MinConns {
+			t.Errorf("Pool size after empty scale-up is %d, want %d", gotSize, config.MinConns)
+		}
+	})
+}

--- a/bigtable/internal/transport/dynamic_scale_monitor_test.go
+++ b/bigtable/internal/transport/dynamic_scale_monitor_test.go
@@ -144,7 +144,7 @@ func TestDynamicChannelScaling(t *testing.T) {
 			var totalLoad int32
 			conns := pool.getConns()
 			for _, entry := range conns {
-				totalLoad += entry.calculateWeightedLoad()
+				totalLoad += entry.calculateConnLoad()
 			}
 			avgLoad := float64(totalLoad) / float64(len(conns))
 			desiredConns := int(math.Ceil(float64(totalLoad) / targetLoadFactor))

--- a/bigtable/internal/transport/dynamic_scale_monitor_test.go
+++ b/bigtable/internal/transport/dynamic_scale_monitor_test.go
@@ -185,23 +185,4 @@ func TestDynamicChannelScaling(t *testing.T) {
 			t.Logf("Scaled up to %d connections", gotSize)
 		}
 	})
-
-	t.Run("EmptyPoolScaleUp", func(t *testing.T) {
-		config := baseConfig
-		pool, err := NewBigtableChannelPool(ctx, config.MinConns, btopt.RoundRobin, dialFunc, poolOpts()...)
-		if err != nil {
-			t.Fatalf("Failed to create pool: %v", err)
-		}
-		defer pool.Close()
-
-		pool.conns.Store(&[]*connEntry{}) // Manually empty
-
-		dsm := NewDynamicScaleMonitor(config, pool)
-		dsm.evaluateAndScale()
-		time.Sleep(50 * time.Millisecond)
-
-		if gotSize := pool.Num(); gotSize != config.MinConns {
-			t.Errorf("Pool size after empty scale-up is %d, want %d", gotSize, config.MinConns)
-		}
-	})
 }

--- a/bigtable/internal/transport/metrics_reporter.go
+++ b/bigtable/internal/transport/metrics_reporter.go
@@ -1,0 +1,154 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sync"
+	"time"
+
+	btopt "cloud.google.com/go/bigtable/internal/option"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+const (
+	// outstandingRPCsMetricName is the name for the outstanding RPCs histogram.
+	outstandingRPCsMetricName = "connection_pool/outstanding_rpcs"
+	// perConnErrorCountMetricName is the name for the per-connection error count histogram.
+	perConnErrorCountMetricName = "per_connection_error_count"
+)
+
+// MetricsReporter periodically collects and reports metrics for the connection pool.
+type MetricsReporter struct {
+	config                btopt.MetricsReporterConfig
+	connPoolStatsSupplier connPoolStatsSupplier
+	logger                *log.Logger
+	ticker                *time.Ticker
+	done                  chan struct{}
+	stopOnce              sync.Once
+
+	// OpenTelemetry metric instruments
+	meterProvider                    metric.MeterProvider
+	outstandingRPCsHistogram         metric.Float64Histogram
+	perConnectionErrorCountHistogram metric.Float64Histogram
+}
+
+func NewMetricsReporter(config btopt.MetricsReporterConfig, connPoolStatsSupplier connPoolStatsSupplier, logger *log.Logger, mp metric.MeterProvider) (*MetricsReporter, error) {
+	mr := &MetricsReporter{
+		config:                config,
+		connPoolStatsSupplier: connPoolStatsSupplier,
+		logger:                logger,
+		done:                  make(chan struct{}),
+		meterProvider:         mp,
+	}
+
+	if !config.Enabled {
+		// Stats Disabled, return error during ctor
+		return nil, fmt.Errorf("bigtable_connpool: MetricsReporterConfig.Enabled is false")
+	}
+
+	if mp == nil {
+		// State: Stats Enabled but MeterProvider is nil, return error during ctor
+		return nil, fmt.Errorf("bigtable_connpool: MetricsReporterConfig.Enabled is true, but MeterProvider is nil")
+	}
+
+	// create meter
+	meter := mp.Meter("bigtable.googleapis.com/internal/client/")
+	var err error
+
+	// fail if meter cannot be created.
+	mr.outstandingRPCsHistogram, err = meter.Float64Histogram(outstandingRPCsMetricName, metric.WithDescription("Distribution of outstanding RPCs per connection."), metric.WithUnit("1"))
+	if err != nil {
+		return nil, fmt.Errorf("bigtable_connpool: failed to create %s histogram: %w", outstandingRPCsMetricName, err)
+	}
+
+	mr.perConnectionErrorCountHistogram, err = meter.Float64Histogram(perConnErrorCountMetricName, metric.WithDescription("Distribution of errors per connection per minute."), metric.WithUnit("1"))
+	if err != nil {
+		return nil, fmt.Errorf("bigtable_connpool: failed to create %s histogram: %w", perConnErrorCountMetricName, err)
+	}
+
+	return mr, nil
+}
+
+func (mr *MetricsReporter) Start(ctx context.Context) {
+	// config.Enabled should ensure that all relevant thing (meterProvider and meter should exists)
+	if !mr.config.Enabled {
+		return
+	}
+
+	// If config.Enabled is true, mr exists
+
+	mr.ticker = time.NewTicker(mr.config.ReportingInterval)
+	go func() {
+		defer mr.ticker.Stop()
+		for {
+			select {
+			case <-mr.ticker.C:
+				mr.snapshotAndRecordMetrics(ctx)
+			case <-mr.done:
+				return
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+}
+
+func (mr *MetricsReporter) Stop() {
+	mr.stopOnce.Do(func() {
+		if mr.config.Enabled {
+			close(mr.done)
+		}
+	})
+}
+
+// snapshotAndRecordMetrics collects and records metrics for the current state of the connection pool.
+func (mr *MetricsReporter) snapshotAndRecordMetrics(ctx context.Context) {
+	stats := mr.connPoolStatsSupplier()
+	if len(stats) == 0 {
+		return
+	}
+
+	for _, stat := range stats {
+		transportType := "cloudpath"
+		if stat.IsALTSUsed {
+			transportType = "directpath"
+		}
+
+		// Common attributes for this connection
+		baseAttrs := []attribute.KeyValue{
+			attribute.String("transport_type", transportType),
+			attribute.String("lb_policy", stat.LBPolicy),
+		}
+		baseAttrSet := attribute.NewSet(baseAttrs...)
+
+		if mr.outstandingRPCsHistogram != nil {
+			// Record distribution sample for unary load
+			unaryAttrs := attribute.NewSet(append(baseAttrs, attribute.Bool("streaming", false))...)
+			mr.outstandingRPCsHistogram.Record(ctx, float64(stat.OutstandingUnaryLoad), metric.WithAttributeSet(unaryAttrs))
+
+			// Record distribution sample for streaming load
+			streamingAttrs := attribute.NewSet(append(baseAttrs, attribute.Bool("streaming", true))...)
+			mr.outstandingRPCsHistogram.Record(ctx, float64(stat.OutstandingStreamingLoad), metric.WithAttributeSet(streamingAttrs))
+		}
+		// Record per-connection error count for the interval
+		if mr.perConnectionErrorCountHistogram != nil {
+			mr.perConnectionErrorCountHistogram.Record(ctx, float64(stat.ErrorCount), metric.WithAttributeSet(baseAttrSet))
+		}
+	}
+}

--- a/bigtable/internal/transport/metrics_reporter.go
+++ b/bigtable/internal/transport/metrics_reporter.go
@@ -48,6 +48,7 @@ type MetricsReporter struct {
 	perConnectionErrorCountHistogram metric.Float64Histogram
 }
 
+// NewMetricsReporter starts a monitor to export periodic metrics
 func NewMetricsReporter(config btopt.MetricsReporterConfig, connPoolStatsSupplier connPoolStatsSupplier, logger *log.Logger, mp metric.MeterProvider) (*MetricsReporter, error) {
 	mr := &MetricsReporter{
 		config:                config,
@@ -85,13 +86,12 @@ func NewMetricsReporter(config btopt.MetricsReporterConfig, connPoolStatsSupplie
 	return mr, nil
 }
 
+// Start starts the reporter.
 func (mr *MetricsReporter) Start(ctx context.Context) {
 	// config.Enabled should ensure that all relevant thing (meterProvider and meter should exists)
 	if !mr.config.Enabled {
 		return
 	}
-
-	// If config.Enabled is true, mr exists
 
 	mr.ticker = time.NewTicker(mr.config.ReportingInterval)
 	go func() {
@@ -109,6 +109,7 @@ func (mr *MetricsReporter) Start(ctx context.Context) {
 	}()
 }
 
+// Stop stops the reporter gracefully
 func (mr *MetricsReporter) Stop() {
 	mr.stopOnce.Do(func() {
 		if mr.config.Enabled {
@@ -120,11 +121,23 @@ func (mr *MetricsReporter) Stop() {
 // snapshotAndRecordMetrics collects and records metrics for the current state of the connection pool.
 func (mr *MetricsReporter) snapshotAndRecordMetrics(ctx context.Context) {
 	stats := mr.connPoolStatsSupplier()
+	for _, stat := range stats {
+		fmt.Println(stat.ErrorCount)
+		fmt.Println(stat.OutstandingStreamingLoad)
+		fmt.Println(stat.OutstandingUnaryLoad)
+		fmt.Println(stat.IsALTSUsed)
+		fmt.Println(stat.LBPolicy)
+	}
+
 	if len(stats) == 0 {
 		return
 	}
 
 	for _, stat := range stats {
+		// Record per-connection error count for the interval
+		if mr.perConnectionErrorCountHistogram != nil {
+			mr.perConnectionErrorCountHistogram.Record(ctx, float64(stat.ErrorCount))
+		}
 		transportType := "cloudpath"
 		if stat.IsALTSUsed {
 			transportType = "directpath"
@@ -135,7 +148,6 @@ func (mr *MetricsReporter) snapshotAndRecordMetrics(ctx context.Context) {
 			attribute.String("transport_type", transportType),
 			attribute.String("lb_policy", stat.LBPolicy),
 		}
-		baseAttrSet := attribute.NewSet(baseAttrs...)
 
 		if mr.outstandingRPCsHistogram != nil {
 			// Record distribution sample for unary load
@@ -146,9 +158,6 @@ func (mr *MetricsReporter) snapshotAndRecordMetrics(ctx context.Context) {
 			streamingAttrs := attribute.NewSet(append(baseAttrs, attribute.Bool("streaming", true))...)
 			mr.outstandingRPCsHistogram.Record(ctx, float64(stat.OutstandingStreamingLoad), metric.WithAttributeSet(streamingAttrs))
 		}
-		// Record per-connection error count for the interval
-		if mr.perConnectionErrorCountHistogram != nil {
-			mr.perConnectionErrorCountHistogram.Record(ctx, float64(stat.ErrorCount), metric.WithAttributeSet(baseAttrSet))
-		}
+
 	}
 }

--- a/bigtable/internal/transport/metrics_reporter.go
+++ b/bigtable/internal/transport/metrics_reporter.go
@@ -121,14 +121,6 @@ func (mr *MetricsReporter) Stop() {
 // snapshotAndRecordMetrics collects and records metrics for the current state of the connection pool.
 func (mr *MetricsReporter) snapshotAndRecordMetrics(ctx context.Context) {
 	stats := mr.connPoolStatsSupplier()
-	for _, stat := range stats {
-		fmt.Println(stat.ErrorCount)
-		fmt.Println(stat.OutstandingStreamingLoad)
-		fmt.Println(stat.OutstandingUnaryLoad)
-		fmt.Println(stat.IsALTSUsed)
-		fmt.Println(stat.LBPolicy)
-	}
-
 	if len(stats) == 0 {
 		return
 	}

--- a/bigtable/internal/transport/metrics_reporter_test.go
+++ b/bigtable/internal/transport/metrics_reporter_test.go
@@ -1,0 +1,207 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	btopt "cloud.google.com/go/bigtable/internal/option"
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	"google.golang.org/grpc"
+	testpb "google.golang.org/grpc/interop/grpc_testing"
+)
+
+func findMetric(rm metricdata.ResourceMetrics, name string) (metricdata.Metrics, bool) {
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			fmt.Print(m.Name)
+			if m.Name == name {
+				return m, true
+			}
+		}
+	}
+	return metricdata.Metrics{}, false
+}
+
+func TestMetricsExporting(t *testing.T) {
+	ctx := context.Background()
+	fake := &fakeService{}
+	addr := setupTestServer(t, fake)
+	dialFunc := func() (*BigtableConn, error) { return dialBigtableserver(addr) }
+
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+
+	poolSize := 2
+	strategy := btopt.RoundRobin
+	pool, err := NewBigtableChannelPool(ctx, poolSize, strategy, dialFunc, WithMeterProvider(provider), WithMetricsReporterConfig(btopt.DefaultMetricsReporterConfig()))
+	if err != nil {
+		t.Fatalf("Failed to create pool: %v", err)
+	}
+	defer pool.Close()
+
+	// Wait for initial priming to settle
+	time.Sleep(100 * time.Millisecond)
+
+	// Action 1: Successful Invoke on conn 0
+	req := &testpb.SimpleRequest{Payload: &testpb.Payload{Body: []byte("hello")}}
+	res := &testpb.SimpleResponse{}
+	if err := pool.Invoke(ctx, "/grpc.testing.BenchmarkService/UnaryCall", req, res); err != nil {
+		t.Errorf("Invoke failed: %v", err)
+	}
+
+	// Action 2: Failed Invoke on conn 1
+	fake.serverErr = errors.New("simulated error")
+	pool.Invoke(ctx, "/grpc.testing.BenchmarkService/UnaryCall", req, res) // Error expected
+	fake.serverErr = nil
+
+	// Action 3: Successful Stream on conn 0
+	stream, err := pool.NewStream(ctx, &grpc.StreamDesc{StreamName: "StreamingCall"}, "/grpc.testing.BenchmarkService/StreamingCall")
+	if err != nil {
+		t.Fatalf("NewStream failed: %v", err)
+	}
+	stream.SendMsg(req)
+	stream.RecvMsg(res)
+	stream.CloseSend()
+	for {
+		if err := stream.RecvMsg(res); err != nil {
+			break
+		}
+	}
+
+	// Action 4: Stream with SendMsg error on conn 1
+	fake.streamSendErr = errors.New("simulated send error")
+	stream2, err := pool.NewStream(ctx, &grpc.StreamDesc{StreamName: "StreamingCall"}, "/grpc.testing.BenchmarkService/StreamingCall")
+	if err != nil {
+		t.Fatalf("NewStream 2 failed: %v", err)
+	}
+	stream2.SendMsg(req) // Expect error, triggers load decrement and error count
+	stream2.CloseSend()
+	for {
+		if err := stream2.RecvMsg(res); err != nil {
+			break
+		}
+	}
+	fake.streamSendErr = nil
+
+	time.Sleep(20 * time.Millisecond) // Allow stream error handling to complete
+
+	// Find the MetricsReporter and force metrics collection
+	var metricsReporter *MetricsReporter
+	for _, monitor := range pool.monitors {
+		if mr, ok := monitor.(*MetricsReporter); ok {
+			metricsReporter = mr
+			break
+		}
+	}
+
+	// Force metrics collection
+	metricsReporter.snapshotAndRecordMetrics(ctx)
+
+	rm := metricdata.ResourceMetrics{}
+	if err := reader.Collect(ctx, &rm); err != nil {
+		t.Fatalf("Failed to collect metrics: %v", err)
+	}
+
+	// --- Check outstanding_rpcs ---
+	outstandingRPCs, ok := findMetric(rm, "connection_pool/outstanding_rpcs")
+	if !ok {
+		t.Fatalf("Metric connection_pool/outstanding_rpcs not found")
+	}
+
+	hist, ok := outstandingRPCs.Data.(metricdata.Histogram[float64])
+	if !ok {
+		t.Fatalf("Metric connection_pool/outstanding_rpcs is not a Histogram[float64]: %T", outstandingRPCs.Data)
+	}
+
+	// Expected: poolSize * 2 data points (unary and streaming for each connection)
+	if len(hist.DataPoints) != 2 {
+		t.Errorf("Outstanding RPCs histogram has %d data points, want %d", len(hist.DataPoints), poolSize*2)
+	}
+
+	var totalUnary, totalStreaming float64
+	for _, dp := range hist.DataPoints {
+		attrMap := make(map[string]attribute.Value)
+		for _, kv := range dp.Attributes.ToSlice() {
+			attrMap[string(kv.Key)] = kv.Value
+		}
+
+		if val, ok := attrMap["lb_policy"]; !ok || val.AsString() != strategy.String() {
+			t.Errorf("Missing or incorrect lb_policy attribute: want %v, got %v", strategy.String(), val)
+		}
+		if val, ok := attrMap["transport_type"]; !ok || val.AsString() != "cloudpath" {
+			t.Errorf("Missing or incorrect transport_type attribute: want 'cloudpath', got %v", val)
+		}
+
+		streamingVal, ok := attrMap["streaming"]
+		if !ok {
+			t.Errorf("Missing streaming attribute")
+			continue
+		}
+		if streamingVal.Type() != attribute.BOOL {
+			t.Errorf("streaming attribute is not a BOOL: got %v", streamingVal.Type())
+			continue
+		}
+		isStreaming := streamingVal.AsBool()
+
+		if isStreaming {
+			totalStreaming += dp.Sum
+		} else {
+			totalUnary += dp.Sum
+		}
+	}
+	if totalUnary != 0 {
+		t.Errorf("Total Unary load sum is %f, want 0", totalUnary)
+	}
+	if totalStreaming != 0 {
+		t.Errorf("Total Streaming load sum is %f, want 0", totalStreaming)
+	}
+
+	// --- Check per_connection_error_count ---
+	errorCount, ok := findMetric(rm, "per_connection_error_count")
+	if !ok {
+		t.Fatalf("Metric per_connection_error_count not found")
+	}
+	errorHist, ok := errorCount.Data.(metricdata.Histogram[float64])
+	if !ok {
+		t.Fatalf("Metric per_connection_error_count is not a Histogram[float64]: %T", errorCount.Data)
+	}
+
+	if len(errorHist.DataPoints) != 1 {
+		t.Errorf("Error Count histogram has %d data points, want %d", len(errorHist.DataPoints), poolSize)
+	}
+
+	var totalErrorSum float64
+	for _, dp := range errorHist.DataPoints {
+		totalErrorSum += dp.Sum
+	}
+	// Expected errors: 1 from Invoke, 1 from Stream SendMsg
+	if totalErrorSum != 2 {
+		t.Errorf("Total Error Count sum is %f, want 2", totalErrorSum)
+	}
+
+	// Check if error counts on entries are reset
+	for _, entry := range pool.getConns() {
+		if entry.errorCount.Load() != 0 {
+			t.Errorf("entry.errorCount is %d after metric collection, want 0", entry.errorCount.Load())
+		}
+	}
+}

--- a/bigtable/internal/transport/monitor.go
+++ b/bigtable/internal/transport/monitor.go
@@ -1,0 +1,26 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import "context"
+
+// Monitor defines the interface for background tasks like health checking,
+// dynamic scaling, and metrics reporting.
+type Monitor interface {
+	// Start begins the monitor's background processing loop.
+	Start(ctx context.Context)
+	// Stop gracefully terminates the monitor's background processing.
+	Stop()
+}

--- a/bigtable/metrics.go
+++ b/bigtable/metrics.go
@@ -334,7 +334,7 @@ func (tf *builtinMetricsTracerFactory) newAsyncRefreshErrHandler() func() {
 }
 
 // reportDirectAccessEligibleMetric sets the value of the DirectPath eligibility gauge.
-func (tf *builtinMetricsTracerFactory) reportDirectAccessEligibleMetric(ctx context.Context, isEligible bool) {
+func (tf *builtinMetricsTracerFactory) reportDirectAccessEligibleMetric(ctx context.Context, isEligible bool, ipPreference string) {
 	if tf.directAccessEligible == nil {
 		return
 	}
@@ -346,11 +346,10 @@ func (tf *builtinMetricsTracerFactory) reportDirectAccessEligibleMetric(ctx cont
 	tf.directAccessEligible.Record(ctx, val)
 }
 
-func (tf *builtinMetricsTracerFactory) reportClientStartupLatency(ctx context.Context, startTime time.Time, transportType string) {
+func (tf *builtinMetricsTracerFactory) reportClientStartupLatency(ctx context.Context, duration time.Duration, transportType string) {
 	if tf.clientStartupTime == nil {
 		return
 	}
-	duration := time.Since(startTime)
 	attrs := attribute.NewSet(attribute.String("transport_type", transportType))
 	tf.clientStartupTime.Record(ctx, float64(duration.Milliseconds()), metric.WithAttributeSet(attrs))
 }

--- a/bigtable/metrics.go
+++ b/bigtable/metrics.go
@@ -71,6 +71,10 @@ const (
 	metricNameDebugTags               = "debug_tags"
 	metricNameConnErrCount            = "connectivity_error_count"
 
+	// Client specific metric Names
+	metricNameClientStartupTime    = "startup_time"
+	metricNameDirectAccessEligible = "direct_access/compatible"
+
 	// Metric units
 	metricUnitMS    = "ms"
 	metricUnitCount = "1"
@@ -196,8 +200,7 @@ type builtinMetricsTracerFactory struct {
 	clientAttributes []attribute.KeyValue
 
 	// otelMeterProvider
-	otelMeterProvider metric.MeterProvider
-
+	otelMeterProvider       metric.MeterProvider
 	operationLatencies      metric.Float64Histogram
 	serverLatencies         metric.Float64Histogram
 	attemptLatencies        metric.Float64Histogram
@@ -207,6 +210,10 @@ type builtinMetricsTracerFactory struct {
 	retryCount              metric.Int64Counter
 	connErrCount            metric.Int64Counter
 	debugTags               metric.Int64Counter
+
+	// client specific metrics
+	clientStartupTime    metric.Float64Histogram
+	directAccessEligible metric.Int64Gauge
 }
 
 // Returns error only if metricsProvider is of unknown type. Rest all errors are swallowed
@@ -272,6 +279,13 @@ func newBuiltinMetricsTracerFactory(ctx context.Context, project, instance, appP
 		meterProvider.Shutdown(ctx)
 	}
 
+	if tracerFactory.otelMeterProvider != nil {
+		err := tracerFactory.createClientInstruments(tracerFactory.otelMeterProvider)
+		if err != nil {
+			return disabledMetricsTracerFactory, nil
+		}
+	}
+
 	// Create meter and instruments
 	meter := meterProvider.Meter(builtInMetricsMeterName, metric.WithInstrumentationVersion(internal.Version))
 	err = tracerFactory.createInstruments(meter)
@@ -279,6 +293,7 @@ func newBuiltinMetricsTracerFactory(ctx context.Context, project, instance, appP
 		// Swallow the error and disable metrics
 		return disabledMetricsTracerFactory, nil
 	}
+
 	// Swallow the error and disable metrics
 	return tracerFactory, nil
 }
@@ -316,6 +331,51 @@ func (tf *builtinMetricsTracerFactory) newAsyncRefreshErrHandler() func() {
 		tf.debugTags.Add(context.Background(), 1,
 			metric.WithAttributes(asyncRefreshMetricAttrs...))
 	}
+}
+
+// reportDirectAccessEligibleMetric sets the value of the DirectPath eligibility gauge.
+func (tf *builtinMetricsTracerFactory) reportDirectAccessEligibleMetric(ctx context.Context, isEligible bool) {
+	if tf.directAccessEligible == nil {
+		return
+	}
+	val := int64(0)
+	if isEligible {
+		val = 1
+	}
+	fmt.Println("Reporting DirectAccess eligible metric")
+	tf.directAccessEligible.Record(ctx, val)
+}
+
+func (tf *builtinMetricsTracerFactory) reportClientStartupLatency(ctx context.Context, startTime time.Time, transportType string) {
+	if tf.clientStartupTime == nil {
+		return
+	}
+	duration := time.Since(startTime)
+	attrs := attribute.NewSet(attribute.String("transport_type", transportType))
+	tf.clientStartupTime.Record(ctx, float64(duration.Milliseconds()), metric.WithAttributeSet(attrs))
+}
+
+func (tf *builtinMetricsTracerFactory) createClientInstruments(clientMeterProvider metric.MeterProvider) error {
+	meter := clientMeterProvider.Meter(builtInMetricsMeterName)
+	var err error
+
+	tf.clientStartupTime, err = meter.Float64Histogram(
+		metricNameClientStartupTime,
+		metric.WithDescription("Total time for completion of logic of NewClientWithConfig i"),
+		metric.WithUnit(metricUnitMS),
+		metric.WithExplicitBucketBoundaries(bucketBounds...),
+	)
+
+	if err != nil {
+		return err
+	}
+
+	tf.directAccessEligible, err = meter.Int64Gauge(
+		metricNameDirectAccessEligible,
+		metric.WithDescription("Reports 1 if the environment is eligible for DirectPath, 0 otherwise. Based on a  connection attempt at startup."),
+		metric.WithUnit("1"),
+	)
+	return err
 }
 
 func (tf *builtinMetricsTracerFactory) createInstruments(meter metric.Meter) error {

--- a/bigtable/metrics.go
+++ b/bigtable/metrics.go
@@ -20,12 +20,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"os"
 	"reflect"
 	"sync/atomic"
 	"time"
 
 	"cloud.google.com/go/bigtable/internal"
+	btopt "cloud.google.com/go/bigtable/internal/option"
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
@@ -188,6 +190,8 @@ type metricInfo struct {
 }
 
 type builtinMetricsTracerFactory struct {
+	exporter *monitoringExporter
+
 	enabled bool
 
 	clientOpts []option.ClientOption
@@ -247,7 +251,7 @@ func newBuiltinMetricsTracerFactory(ctx context.Context, project, instance, appP
 	}
 
 	// Create default meter provider
-	mpOptions, err := builtInMeterProviderOptions(project, opts...)
+	metricsExporter, mpOptions, err := builtInMeterProviderOptions(project, opts...)
 	if err != nil {
 		// Swallow the error and disable metrics
 		return disabledMetricsTracerFactory, nil
@@ -294,18 +298,20 @@ func newBuiltinMetricsTracerFactory(ctx context.Context, project, instance, appP
 		return disabledMetricsTracerFactory, nil
 	}
 
+	tracerFactory.exporter = metricsExporter
+
 	// Swallow the error and disable metrics
 	return tracerFactory, nil
 }
 
-func builtInMeterProviderOptions(project string, opts ...option.ClientOption) ([]sdkmetric.Option, error) {
+func builtInMeterProviderOptions(project string, opts ...option.ClientOption) (*monitoringExporter, []sdkmetric.Option, error) {
 	allOpts := createExporterOptions(opts...)
 	defaultExporter, err := newMonitoringExporter(context.Background(), project, allOpts...)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	return []sdkmetric.Option{sdkmetric.WithReader(
+	return defaultExporter, []sdkmetric.Option{sdkmetric.WithReader(
 		sdkmetric.NewPeriodicReader(
 			defaultExporter,
 			sdkmetric.WithInterval(defaultSamplePeriod),
@@ -335,14 +341,14 @@ func (tf *builtinMetricsTracerFactory) newAsyncRefreshErrHandler() func() {
 
 // reportDirectAccessEligibleMetric sets the value of the DirectPath eligibility gauge.
 func (tf *builtinMetricsTracerFactory) reportDirectAccessEligibleMetric(ctx context.Context, isEligible bool) {
-	if tf.directAccessEligible == nil {
+	if !tf.enabled || tf.exporter == nil {
 		return
 	}
 	val := int64(0)
 	if isEligible {
 		val = 1
 	}
-	fmt.Println("Reporting DirectAccess eligible metric")
+	btopt.Debugf(log.Default(), "Reporting DirectAccess eligible metric: %v", isEligible)
 	tf.directAccessEligible.Record(ctx, val)
 }
 

--- a/bigtable/metrics.go
+++ b/bigtable/metrics.go
@@ -334,7 +334,7 @@ func (tf *builtinMetricsTracerFactory) newAsyncRefreshErrHandler() func() {
 }
 
 // reportDirectAccessEligibleMetric sets the value of the DirectPath eligibility gauge.
-func (tf *builtinMetricsTracerFactory) reportDirectAccessEligibleMetric(ctx context.Context, isEligible bool, ipPreference string) {
+func (tf *builtinMetricsTracerFactory) reportDirectAccessEligibleMetric(ctx context.Context, isEligible bool) {
 	if tf.directAccessEligible == nil {
 		return
 	}

--- a/bigtable/metrics.go
+++ b/bigtable/metrics.go
@@ -195,6 +195,9 @@ type builtinMetricsTracerFactory struct {
 	// do not change across different function calls on client
 	clientAttributes []attribute.KeyValue
 
+	// otelMeterProvider
+	otelMeterProvider metric.MeterProvider
+
 	operationLatencies      metric.Float64Histogram
 	serverLatencies         metric.Float64Histogram
 	attemptLatencies        metric.Float64Histogram
@@ -260,6 +263,7 @@ func newBuiltinMetricsTracerFactory(ctx context.Context, project, instance, appP
 	// the error from newOtelMetricsContext is silently ignored since metrics are not critical to client creation.
 	if err == nil {
 		tracerFactory.clientOpts = otelContext.clientOpts
+		tracerFactory.otelMeterProvider = otelContext.otelMeterProvider
 	}
 	tracerFactory.shutdown = func() {
 		if otelContext != nil {

--- a/bigtable/otel_metrics.go
+++ b/bigtable/otel_metrics.go
@@ -59,7 +59,7 @@ type bigtableClientMonitoredResource struct {
 
 func (bmr *bigtableClientMonitoredResource) exporter() (metric.Exporter, error) {
 	exporter, err := mexporter.New(
-		mexporter.WithProjectID(bmr.clientProject),
+		mexporter.WithProjectID(bmr.project),
 		mexporter.WithMetricDescriptorTypeFormatter(metricFormatter),
 		mexporter.WithCreateServiceTimeSeries(),
 		mexporter.WithMonitoredResourceDescription(bigtableClientMonitoredResourceName, []string{"project_id", "instance", "app_profile", "client_project", "cloud_platform", "host_id", "host_name", "client_name", "uuid", "region"}),

--- a/bigtable/otel_metrics.go
+++ b/bigtable/otel_metrics.go
@@ -59,7 +59,7 @@ type bigtableClientMonitoredResource struct {
 
 func (bmr *bigtableClientMonitoredResource) exporter() (metric.Exporter, error) {
 	exporter, err := mexporter.New(
-		mexporter.WithProjectID(bmr.clientProject),
+		mexporter.WithProjectID(bmr.project),
 		mexporter.WithMetricDescriptorTypeFormatter(metricFormatter),
 		mexporter.WithCreateServiceTimeSeries(),
 		mexporter.WithMonitoredResourceDescription(bigtableClientMonitoredResourceName, []string{"project_id", "instance", "app_profile", "client_project", "cloud_platform", "host_id", "host_name", "client_name", "uuid", "region"}),
@@ -127,11 +127,11 @@ func newBigtableClientMonitoredResource(ctx context.Context, project, appProfile
 	return smr, nil
 }
 
-type metricsContext struct {
+type otelMetricsContext struct {
 	// client options passed to gRPC channels
 	clientOpts []option.ClientOption
 	// instance of metric reader used by gRPC client-side metrics
-	provider *metric.MeterProvider
+	otelMeterProvider *metric.MeterProvider
 	// clean func to call when closing gRPC client
 	close func()
 }
@@ -149,7 +149,7 @@ type metricsConfig struct {
 	resourceOpts    []resource.Option    // used by tests
 }
 
-func newOtelMetricsContext(ctx context.Context, cfg metricsConfig) (*metricsContext, error) {
+func newOtelMetricsContext(ctx context.Context, cfg metricsConfig) (*otelMetricsContext, error) {
 	var exporter metric.Exporter
 	meterOpts := []metric.Option{}
 	if cfg.customExporter == nil {
@@ -187,9 +187,9 @@ func newOtelMetricsContext(ctx context.Context, cfg metricsConfig) (*metricsCont
 		meterOpts = append(meterOpts, metric.WithReader(
 			metric.NewPeriodicReader(&exporterLogSuppressor{Exporter: exporter}, metric.WithInterval(interval))))
 	}
-	provider := metric.NewMeterProvider(meterOpts...)
+	otelMeterProvider := metric.NewMeterProvider(meterOpts...)
 	mo := opentelemetry.MetricsOptions{
-		MeterProvider: provider,
+		MeterProvider: otelMeterProvider,
 		Metrics: stats.NewMetricSet(
 			"grpc.client.attempt.duration",
 			"grpc.lb.rls.default_target_picks",
@@ -206,11 +206,11 @@ func newOtelMetricsContext(ctx context.Context, cfg metricsConfig) (*metricsCont
 		option.WithGRPCDialOption(
 			grpc.WithDefaultCallOptions(grpc.StaticMethodCallOption{})),
 	}
-	return &metricsContext{
-		clientOpts: opts,
-		provider:   provider,
+	return &otelMetricsContext{
+		clientOpts:        opts,
+		otelMeterProvider: otelMeterProvider,
 		close: func() {
-			provider.Shutdown(ctx)
+			otelMeterProvider.Shutdown(ctx)
 		},
 	}, nil
 }

--- a/bigtable/otel_metrics.go
+++ b/bigtable/otel_metrics.go
@@ -59,7 +59,7 @@ type bigtableClientMonitoredResource struct {
 
 func (bmr *bigtableClientMonitoredResource) exporter() (metric.Exporter, error) {
 	exporter, err := mexporter.New(
-		mexporter.WithProjectID(bmr.project),
+		mexporter.WithProjectID(bmr.clientProject),
 		mexporter.WithMetricDescriptorTypeFormatter(metricFormatter),
 		mexporter.WithCreateServiceTimeSeries(),
 		mexporter.WithMonitoredResourceDescription(bigtableClientMonitoredResourceName, []string{"project_id", "instance", "app_profile", "client_project", "cloud_platform", "host_id", "host_name", "client_name", "uuid", "region"}),


### PR DESCRIPTION
## Summary

- **Fix:** wire `grpc.OnFinish` in `BigtableChannelPool.NewStream` so `streamingLoad` is decremented for every stream, including the ones callers abandon (context cancellation, deadline, panic, dropped reference). Previously the only decrement path was an error observed inside `SendMsg`/`RecvMsg`, so any abandoned stream leaked one count permanently — which poisoned the least-loaded / power-of-two selectors and caused `waitForDrainAndClose` to never observe `calculateConnLoad() == 0`, stalling draining connections until the 30-minute `maxDrainingTimeout` force-close.
- **Simplify:** with `OnFinish` as the single source of truth for both load accounting and per-stream error attribution, the `refCountedStream` wrapper (`SendMsg`/`RecvMsg` shims + `sync.Once` decrement) becomes redundant. Removed — `−39` lines in `connpool.go`, one less struct allocation and method-dispatch hop per stream on the hot path.
- **Adds `BenchmarkAbandonedStreamLoadLeak`** that opens-and-abandons `b.N` streams and reports `residual_load/op` as a custom metric. Trends to `1.000` without the fix and `0` with — acts as a regression test visible in `-bench` output.

## Behavioral notes worth a reviewer's eye

- `errorCount` semantic narrows from "every `SendMsg`/`RecvMsg` error" to "one increment per stream that ended with error". This aligns with how unary `Invoke` already counts errors. No existing test asserts exact stream-error counts, but downstream metrics consumers expecting the old per-call semantic will see lower numbers.
- Two existing tests asserted behavior that only held under the wrapper's blind-spot — `TestMultipleStreamsSingleConn` (passed `StreamDesc{StreamName: ...}` which gRPC treats as unary; the auto-close was invisible to the wrapper but real) and `TestGracefulDraining/DrainingTimeout` (used `streamingLoad > 0` after force-close as a proxy for "timeout fired, not natural drain", which is no longer a valid proxy because `OnFinish` fires on transport teardown). Both fixed in this PR; details in the second commit message.
- Decrement timing shifts from synchronous-in-caller (`SendMsg`/`RecvMsg` return path) to a gRPC `OnFinish` goroutine a few microseconds later. The benchmark polls and tolerates this; no test caught a tight-window assertion.

## Test plan

- [x] `go test -race -count=1 ./bigtable/internal/transport/` — full transport package passes
- [x] `go test -bench=BenchmarkAbandonedStreamLoadLeak -benchtime=2000x -benchmem ./bigtable/internal/transport/` — `residual_load/op = 0` (vs `1.000` on unfixed baseline)
- [ ] Reviewer: confirm the `errorCount` semantic shift is acceptable for downstream metrics
- [ ] Reviewer: confirm the two test updates (`TestMultipleStreamsSingleConn`, `TestGracefulDraining/DrainingTimeout`) reflect intended contract, not regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)