### PR TITLE
chore(ci): fail generation check on untracked or modified files

### DIFF
--- a/.github/workflows/generation_check.yaml
+++ b/.github/workflows/generation_check.yaml
@@ -35,7 +35,11 @@ jobs:
         if: steps.changes.outputs.librarian == 'true' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
         run: |
           librarian generate --all
-          git diff --exit-code
+          if [ -n "$(git status --porcelain)" ]; then
+            git diff
+            git status
+            exit 1
+          fi
       - name: Create issue on diff
         if: failure() && github.event_name == 'push' && github.ref == 'refs/heads/main'
         env:

--- a/.github/workflows/generation_check.yaml
+++ b/.github/workflows/generation_check.yaml
@@ -37,7 +37,7 @@ jobs:
           librarian generate --all
           if [ -n "$(git status --porcelain)" ]; then
             git status
-            echo "Regeneration failed. Please un 'librarian generate --all' to update the generated files."
+            echo "Regeneration failed. Please run 'librarian generate --all' to update the generated files."
             exit 1
           fi
       - name: Create issue on diff

--- a/.github/workflows/generation_check.yaml
+++ b/.github/workflows/generation_check.yaml
@@ -36,8 +36,8 @@ jobs:
         run: |
           librarian generate --all
           if [ -n "$(git status --porcelain)" ]; then
-            git diff
             git status
+            echo "Regeneration failed. Please un 'librarian generate --all' to update the generated files."
             exit 1
           fi
       - name: Create issue on diff


### PR DESCRIPTION
Currently, the regeneration check workflow uses `git diff --exit-code` to verify if code regeneration produced any differences. However, `git diff` only checks tracked files. If the regeneration process creates new files (such as newly generated client files that were
previously excluded), they remain untracked and the check passes without reporting a failure.

Change the check to use `git status --porcelain` to detect any changes (including modifications, deletions, and untracked files).

Add instructions on how to resolve the failure.

Fixes https://github.com/googleapis/librarian/issues/6354