### PR TITLE
chore(ci): run librariangen tests on pull requests

### DIFF
--- a/.github/workflows/librariangen.yml
+++ b/.github/workflows/librariangen.yml
@@ -1,0 +1,34 @@
+name: librariangen
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'internal/librariangen/**'
+      - '.github/workflows/librariangen.yml'
+  pull_request:
+    paths:
+      - 'internal/librariangen/**'
+      - '.github/workflows/librariangen.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.26.x'
+
+      - name: Run unit tests
+        run: |
+          cd internal/librariangen
+          go test -v ./...


### PR DESCRIPTION
Run the unit tests of the internal librariangen tool in a GitHub Actions workflow when files in the internal/librariangen directory change. This helps identify issues as part of normal pull requests without adding overhead to the Kokoro presubmit tests, which skip internal tools.

Fixes #12773
