### PR TITLE
fix(bigtable): serialize Close against pool writers in BigtableChannelPool

### DIFF
--- a/bigtable/internal/transport/connpool.go
+++ b/bigtable/internal/transport/connpool.go
@@ -664,6 +664,15 @@ func (p *BigtableChannelPool) Num() int {
 // Close closes all connections in the pool.
 func (p *BigtableChannelPool) Close() error {
 	p.poolCancel() // Cancel the context for background tasks
+	// Serialize against pool writers (addConnections, removeConnections,
+	// replaceConnection) so an in-flight writer cannot store freshly-dialed
+	// entries into p.conns after we have already snapshotted and closed
+	// what we thought was the full set. Without this lock, a writer that
+	// finishes after Close's snapshot but before returning would leak any
+	// connections it created — they would sit in p.conns with no Close to
+	// shut them down.
+	p.dialMu.Lock()
+	defer p.dialMu.Unlock()
 	// Stop all monitors.
 	for _, m := range p.monitors {
 		m.Stop()

--- a/bigtable/internal/transport/connpool_test.go
+++ b/bigtable/internal/transport/connpool_test.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"net/url"
 	"reflect"
+	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -2085,5 +2086,80 @@ func BenchmarkSelectionStrategies(b *testing.B) {
 				}
 			})
 		})
+	}
+}
+
+// TestCloseRaceWithAddConnections is a -race stress test for concurrent
+// Close + addConnections. It exercises the code path the fix protects:
+// without the dialMu serialization in Close, the addConnections writer
+// could store newly-dialed entries into p.conns *after* Close had
+// snapshotted and closed the old set, leaking those connections.
+//
+// The race is hard to trigger naturally because factory.newEntry honors
+// poolCtx — a Close that wins the race usually cancels poolCtx before
+// addConnections' workers finish priming, and the workers then return
+// errors instead of producing entries. A deterministic demonstration would
+// need a custom factory that bypasses ctx; this test mainly guards against
+// data races (caught by -race) and any future regression in the contract.
+func TestCloseRaceWithAddConnections(t *testing.T) {
+	const trials = 50
+
+	for trial := 0; trial < trials; trial++ {
+		var (
+			dialedMu sync.Mutex
+			dialed   []*BigtableConn
+		)
+
+		fake := &fakeService{}
+		addr := setupTestServer(t, fake)
+		countingDial := func() (*BigtableConn, error) {
+			c, err := dialBigtableserver(addr)
+			if err != nil {
+				return nil, err
+			}
+			dialedMu.Lock()
+			dialed = append(dialed, c)
+			dialedMu.Unlock()
+			return c, nil
+		}
+
+		pool, err := NewBigtableChannelPool(context.Background(), 1, btopt.RoundRobin, countingDial, time.Now(), poolOpts()...)
+		if err != nil {
+			t.Fatalf("trial %d: NewBigtableChannelPool failed: %v", trial, err)
+		}
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			// Try to grow the pool by several connections while Close races us.
+			pool.addConnections(5, 16)
+		}()
+
+		// Yield so the goroutine has a chance to acquire dialMu and start
+		// dialing before Close arrives — this is the window the bug lives in.
+		runtime.Gosched()
+		if err := pool.Close(); err != nil {
+			t.Errorf("trial %d: Close returned error: %v", trial, err)
+		}
+		wg.Wait()
+
+		// Any conn dialed by countingDial must end up Shutdown — either
+		// because it was in p.conns when Close ran, or because addConnections
+		// (running under dialMu serialized after Close) saw poolCtx done and
+		// declined to add it (in which case factory.newEntry would not have
+		// produced a conn at all, so it wouldn't be in `dialed`).
+		dialedMu.Lock()
+		leaked := 0
+		for _, c := range dialed {
+			if !isConnClosed(c.ClientConn) {
+				leaked++
+			}
+		}
+		total := len(dialed)
+		dialedMu.Unlock()
+		if leaked > 0 {
+			t.Errorf("trial %d: %d/%d connections leaked (still alive after Close)", trial, leaked, total)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

`BigtableChannelPool.Close` cancels `poolCtx` and then iterates `p.conns` to shut each connection down, but it does so **without holding `dialMu`**. The pool's writers — `addConnections`, `removeConnections`, `replaceConnection` — all take `dialMu` while they dial and then mutate `p.conns`. So this interleaving is possible:

1. `addConnections` takes `dialMu`, starts dialing.
2. `Close` cancels `poolCtx`, snapshots `p.conns`, closes everything it sees, returns.
3. `addConnections` finishes priming, stores the freshly-dialed entries into `p.conns`, releases `dialMu`.

Those entries now sit in `p.conns` with nothing left to call `Close` on them — leaked.

The fix is to acquire `dialMu` in `Close` after cancelling `poolCtx`. Any writer either:
- finishes before `Close` takes the snapshot (its entries are closed), or
- sees the cancelled `poolCtx` in `factory.newEntry` and declines to produce a conn at all.

## Test plan

- [x] `go vet ./internal/transport/` clean
- [ ] `go test -race -run TestCloseRaceWithAddConnections -count=20 ./internal/transport/`
- [ ] Full package test suite: `go test -race ./internal/transport/`

### Note on the included test

`TestCloseRaceWithAddConnections` is primarily a `-race` guard. The leak itself is hard to trigger deterministically because `factory.newEntry` honors `poolCtx`, so the workers usually error out once `Close` cancels the context. A deterministic reproduction would need a factory that bypasses ctx; the test as written documents the contract and guards against future regressions / data races.