### PR TITLE
fix(bigtable): raise default connection-recycler MaxAge to 7 days

### DIFF
--- a/bigtable/internal/option/option.go
+++ b/bigtable/internal/option/option.go
@@ -291,11 +291,17 @@ type ConnectionRecycleConfig struct {
 }
 
 // DefaultConnectionRecycleConfig returns the default configuration:
-// MaxAge: 45 minutes, Jitter: 5 minutes, RunFrequency: 1 minute, Enabled: true.
+// MaxAge: 7 days, MaxJitter: 12 hours, RunFrequency: 1 hour.
+//
+// MaxAge was raised from 45 minutes to 7 days to limit the recycle rate while
+// the upstream gRPC-Go xDS client memory leak is being addressed; the prior
+// default churned DirectPath-xDS connections frequently enough to expose that
+// leak as steady heap growth
+// (see https://github.com/googleapis/google-cloud-go/issues/14582).
 func DefaultConnectionRecycleConfig() ConnectionRecycleConfig {
 	return ConnectionRecycleConfig{
-		MaxAge:       45 * time.Minute,
-		MaxJitter:    5 * time.Minute,
-		RunFrequency: 1 * time.Minute,
+		MaxAge:       7 * 24 * time.Hour,
+		MaxJitter:    12 * time.Hour,
+		RunFrequency: 1 * time.Hour,
 	}
 }


### PR DESCRIPTION
## Summary

Raises `DefaultConnectionRecycleConfig` from `MaxAge: 45m / MaxJitter: 5m / RunFrequency: 1m` to `MaxAge: 7d / MaxJitter: 12h / RunFrequency: 1h`. Mitigates the memory growth reported in #14582 by cutting recycle-driven connection churn by roughly two orders of magnitude.

