### PR TITLE
fix(auth): authenticate generateIdToken requests with base credentials

### DIFF
--- a/auth/credentials/idtoken/file.go
+++ b/auth/credentials/idtoken/file.go
@@ -100,9 +100,11 @@ func credsFromDefault(creds *auth.Credentials, opts *Options) (*auth.Credentials
 			Audience:        opts.Audience,
 			TargetPrincipal: account,
 			IncludeEmail:    true,
-			Client:          opts.client(),
-			Credentials:     baseCreds, // Use the non-impersonated base credentials!
-			Logger:          internallog.New(opts.Logger),
+			// Do NOT default a nil Client here so that NewIDTokenCredentials
+			// builds a client authenticated with the base credentials!
+			Client:      opts.Client,
+			Credentials: baseCreds, // Use the non-impersonated base credentials!
+			Logger:      internallog.New(opts.Logger),
 		}
 		idTokenCreds, err := impersonate.NewIDTokenCredentials(&config)
 		if err != nil {

--- a/auth/credentials/idtoken/idtoken_test.go
+++ b/auth/credentials/idtoken/idtoken_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -285,6 +286,106 @@ func TestNewCredentials_ImpersonatedAndExternal(t *testing.T) {
 			}
 			if ud != internal.DefaultUniverseDomain {
 				t.Errorf("got %q, want %q", ud, internal.DefaultUniverseDomain)
+			}
+		})
+	}
+}
+
+// TestNewCredentials_ImpersonatedAndExternal_NoClient is a regression test for
+// https://github.com/googleapis/google-cloud-go/issues/19939. When the caller
+// does not provide a client, the generateIdToken request must be authenticated
+// with the base credentials instead of being sent through an unauthenticated
+// default client.
+func TestNewCredentials_ImpersonatedAndExternal_NoClient(t *testing.T) {
+	wantTok, _ := createRS256JWT(t)
+	var gotAuth string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/subject":
+			w.Write([]byte(`{"id_token": "subject-token"}`))
+		case r.URL.Path == "/sts":
+			w.Write([]byte(`{"access_token": "sts-token", "issued_token_type": "urn:ietf:params:oauth:token-type:access_token", "token_type": "Bearer", "expires_in": 3600}`))
+		case strings.Contains(r.URL.Path, "generateAccessToken"):
+			t.Errorf("unexpected call to generateAccessToken")
+		case strings.Contains(r.URL.Path, "generateIdToken"):
+			gotAuth = r.Header.Get("Authorization")
+			fmt.Fprintf(w, `{"token": %q}`, wantTok)
+		default:
+			t.Errorf("unexpected request to %q", r.URL.Path)
+		}
+	}))
+	defer ts.Close()
+
+	// Route all requests, including the generateIdToken call to the
+	// https://iamcredentials.googleapis.com endpoint, to the local test
+	// server. Both internal.DefaultClient and the authenticated client built
+	// by the impersonate package clone http.DefaultTransport, which preserves
+	// the dial overrides.
+	dial := func(ctx context.Context, network, addr string) (net.Conn, error) {
+		return net.Dial("tcp", ts.Listener.Addr().String())
+	}
+	origTransport := http.DefaultTransport
+	http.DefaultTransport = &http.Transport{
+		DialContext:    dial,
+		DialTLSContext: dial,
+	}
+	t.Cleanup(func() { http.DefaultTransport = origTransport })
+
+	externalAccountJSON := fmt.Sprintf(`{
+		"type": "external_account",
+		"audience": "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/pool/providers/provider",
+		"subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+		"service_account_impersonation_url": "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/sa@fake_project.iam.gserviceaccount.com:generateAccessToken",
+		"token_url": "%s/sts",
+		"credential_source": {
+			"url": "%s/subject",
+			"format": {
+				"type": "json",
+				"subject_token_field_name": "id_token"
+			}
+		}
+	}`, ts.URL, ts.URL)
+
+	tests := []struct {
+		name string
+		json []byte
+		// wantAuthPrefix is a prefix because the impersonated service account
+		// case authenticates with a self-signed JWT that is not stable across
+		// runs.
+		wantAuthPrefix string
+	}{
+		{
+			name:           "external account",
+			json:           []byte(externalAccountJSON),
+			wantAuthPrefix: "Bearer sts-token",
+		},
+		{
+			name:           "impersonated service account",
+			json:           readTestFile(t, "../../internal/testdata/imp.json"),
+			wantAuthPrefix: "Bearer ey",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotAuth = ""
+			creds, err := NewCredentials(&Options{
+				Audience:        "aud",
+				CredentialsJSON: tt.json,
+				Logger:          slog.New(slog.NewTextHandler(io.Discard, nil)),
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			tok, err := creds.Token(context.Background())
+			if err != nil {
+				t.Fatalf("creds.Token() = %v", err)
+			}
+			if tok.Value != wantTok {
+				t.Errorf("got %q, want %q", tok.Value, wantTok)
+			}
+			if !strings.HasPrefix(gotAuth, tt.wantAuthPrefix) {
+				t.Errorf("generateIdToken Authorization header = %q, want prefix %q", gotAuth, tt.wantAuthPrefix)
 			}
 		})
 	}

--- a/auth/credentials/idtoken/idtoken_test.go
+++ b/auth/credentials/idtoken/idtoken_test.go
@@ -323,7 +323,8 @@ func TestNewCredentials_ImpersonatedAndExternal_NoClient(t *testing.T) {
 	// by the impersonate package clone http.DefaultTransport, which preserves
 	// the dial overrides.
 	dial := func(ctx context.Context, network, addr string) (net.Conn, error) {
-		return net.Dial("tcp", ts.Listener.Addr().String())
+		var d net.Dialer
+		return d.DialContext(ctx, "tcp", ts.Listener.Addr().String())
 	}
 	origTransport := http.DefaultTransport
 	http.DefaultTransport = &http.Transport{


### PR DESCRIPTION
When the Application Default Credentials are an external_account or impersonated_service_account configuration, idtoken.NewCredentials sends the generateIdToken request without an Authorization header and the IAM Credentials API rejects it with 401 CREDENTIALS_MISSING.

credsFromDefault always passed a default unauthenticated client to impersonate.IDTokenOptions, and impersonate.NewIDTokenCredentials builds an authenticated client from the provided credentials only when the client is nil.
As a result, the non-impersonated base credentials introduced in #14474 never authenticated the generateIdToken request.

This change passes the user-provided client through as-is, so that impersonate.NewIDTokenCredentials builds a client authenticated with the base credentials when no client is provided.
The added regression test replaces http.DefaultTransport to route all requests to a local test server and asserts that the generateIdToken request carries an Authorization header derived from the base credentials.

Fixes #19939