### PR TITLE
Revert "feat(bigtable): generate gapic layer for admin client (#14386)"

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -390,9 +390,9 @@ libraries:
           proto_only: true
       - path: google/bigtable/admin/v2
         go:
-          enabled_generator_features:
-            - F_selective_gapic_generation
+          no_metadata: true
           no_snippets: true
+          proto_only: true
     keep:
       - README.md
     skip_release: true


### PR DESCRIPTION
This reverts commit f647088517d75f38ea4f030ca67c0d082ff9b0be.