### PR TITLE
fix(bigtable): disable dynamic channel pool by default and raise default pool size to 10

### DIFF
--- a/bigtable/client.go
+++ b/bigtable/client.go
@@ -124,9 +124,12 @@ func NewClientWithConfig(ctx context.Context, project, instance string, config C
 	// Add gRPC client interceptors to supply Google client information. No external interceptors are passed.
 	o = append(o, btopt.ClientInterceptorOptions(nil, nil)...)
 	o = append(o, option.WithGRPCDialOption(grpc.WithStatsHandler(sharedLatencyStatsHandler)))
-	// Default to a small connection pool that can be overridden.
+	// Default to a connection pool that can be overridden. Raised from 4 to 10
+	// to align with defaultBigtableConnPoolSize and to compensate for dynamic
+	// channel pool scaling being disabled by default
+	// (see https://github.com/googleapis/google-cloud-go/issues/14582).
 	o = append(o,
-		option.WithGRPCConnectionPool(4),
+		option.WithGRPCConnectionPool(10),
 		// Set the max size to correspond to server-side limits.
 		option.WithGRPCDialOption(grpc.WithDefaultCallOptions(grpc.MaxCallSendMsgSize(1<<28), grpc.MaxCallRecvMsgSize(1<<28))),
 	)

--- a/bigtable/client.go
+++ b/bigtable/client.go
@@ -124,12 +124,12 @@ func NewClientWithConfig(ctx context.Context, project, instance string, config C
 	// Add gRPC client interceptors to supply Google client information. No external interceptors are passed.
 	o = append(o, btopt.ClientInterceptorOptions(nil, nil)...)
 	o = append(o, option.WithGRPCDialOption(grpc.WithStatsHandler(sharedLatencyStatsHandler)))
-	// Default to a connection pool that can be overridden. Raised from 4 to 10
-	// to align with defaultBigtableConnPoolSize and to compensate for dynamic
-	// channel pool scaling being disabled by default
+	// Default to a connection pool that can be overridden. Raised from 4 to
+	// defaultBigtableConnPoolSize to compensate for dynamic channel pool
+	// scaling being disabled by default
 	// (see https://github.com/googleapis/google-cloud-go/issues/14582).
 	o = append(o,
-		option.WithGRPCConnectionPool(10),
+		option.WithGRPCConnectionPool(defaultBigtableConnPoolSize),
 		// Set the max size to correspond to server-side limits.
 		option.WithGRPCDialOption(grpc.WithDefaultCallOptions(grpc.MaxCallSendMsgSize(1<<28), grpc.MaxCallRecvMsgSize(1<<28))),
 	)

--- a/bigtable/internal/option/option.go
+++ b/bigtable/internal/option/option.go
@@ -249,10 +249,17 @@ type DynamicChannelPoolConfig struct {
 	// E.g., 30 means a maximum increase of 30%.
 }
 
-// DefaultDynamicChannelPoolConfig is default settings for dynamic channel pool
+// DefaultDynamicChannelPoolConfig is default settings for dynamic channel pool.
+//
+// Enabled is false by default while the upstream gRPC-Go xDS client memory leak
+// is being addressed; scale events churn DirectPath-xDS connections often
+// enough to expose that leak as steady heap growth
+// (see https://github.com/googleapis/google-cloud-go/issues/14582). Callers
+// that want dynamic scaling can construct a DynamicChannelPoolConfig with
+// Enabled: true.
 func DefaultDynamicChannelPoolConfig() DynamicChannelPoolConfig {
 	return DynamicChannelPoolConfig{
-		Enabled:                          true, // Enabled by default
+		Enabled:                          false,
 		MinConns:                         10,
 		MaxConns:                         200,
 		AvgLoadHighThreshold:             50,


### PR DESCRIPTION
## Summary
- Disable dynamic channel pool scaling by default (`DefaultDynamicChannelPoolConfig().Enabled` flipped from `true` to `false`).
- Raise the default gRPC connection pool size from 4 to 10 to align with `defaultBigtableConnPoolSize` and compensate for the loss of dynamic scale-up.

## Why
Mitigates steady heap growth caused by the upstream gRPC-Go xDS client memory leak in DirectPath-xDS connections. Scale events churn connections often enough to expose that leak, and the prior pool default of 4 amplified the problem under load. See https://github.com/googleapis/google-cloud-go/issues/14582.

Pairs with the connection-recycler `MaxAge` bump (7d) in a sibling PR — both reduce DirectPath-xDS connection churn while the upstream fix lands.

## Compatibility
- `ClientConfig.DisableDynamicChannelPool` keeps its existing semantics; users who already opt out are unaffected.
- Callers who want dynamic scaling can construct a `DynamicChannelPoolConfig` with `Enabled: true`.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./internal/transport/... ./internal/option/... ./` (targeted: TestDynamic/TestValidate/TestConnPool/TestNewClient) — pass
- [ ] CI green