### PR TITLE
chore(ci): use git status for diff summary in post-submit issues

### DIFF
--- a/.github/workflows/generation_check.yaml
+++ b/.github/workflows/generation_check.yaml
@@ -48,7 +48,7 @@ jobs:
           if [ -n "$(git status --porcelain)" ]; then
             TITLE="Regeneration check found diff"
             RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-            DIFF_STAT=$(git diff --stat)
+            DIFF_STAT=$(git status --porcelain)
             BODY="The post-submit [regeneration check]($RUN_URL) found a diff.
 
             Diff summary:


### PR DESCRIPTION
Since the regeneration check now captures both modified and untracked files using `git status --porcelain`, using `git diff --stat` for the issue description is no longer sufficient (as it misses untracked files).

Update the post-submit issue creation step to use `git status --porcelain` for the `DIFF_STAT` variable so that the generated issue description properly lists all modified and untracked files.

Fixes https://github.com/googleapis/librarian/issues/6360