### PR TITLE
chore: librarian release pull request: 20260610T205713Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -548,7 +548,7 @@ libraries:
       - internal/generated/snippets/bigquery/v2
     tag_format: bigquery/v{version}
   - id: bigtable
-    version: 1.48.0
+    version: 1.49.0
     last_generated_commit: ""
     apis:
       - path: google/bigtable/admin/v2

--- a/bigtable/CHANGES.md
+++ b/bigtable/CHANGES.md
@@ -1,5 +1,21 @@
 # Changes
 
+## [1.49.0](https://github.com/googleapis/google-cloud-go/releases/tag/bigtable%2Fv1.49.0) (2026-06-10)
+
+### Features
+
+* add opensession descriptors for bigtable (#14647) ([8968f4f](https://github.com/googleapis/google-cloud-go/commit/8968f4fd7ca68297dcc42861878f90a5b339539d))
+* add traffic diverter and table shim  for bigtable (#14633) ([2f3c918](https://github.com/googleapis/google-cloud-go/commit/2f3c91847f882cef939496b92d5c4311583b4f5e))
+* add virtual RPC descriptors  (#14648) ([5eedda1](https://github.com/googleapis/google-cloud-go/commit/5eedda184cf228e72098a4d8c4a992b625ca9558))
+* enable new auth library and remove async refresh (#19943) ([0d3697b](https://github.com/googleapis/google-cloud-go/commit/0d3697b2f31a47b530cd7ba37323a4321d19091b))
+* update API sources and regenerate (#14701) ([a9b7921](https://github.com/googleapis/google-cloud-go/commit/a9b7921551e9c1535496731da53e880e9e364efa))
+
+### Bug Fixes
+
+* disable dynamic channel pool by default and raise default pool size to 10 (#19945) ([5ddf8d4](https://github.com/googleapis/google-cloud-go/commit/5ddf8d469ce0570aedaf925a9a377ddf51873a43))
+* raise default connection-recycler MaxAge to 7 days (#19940) ([a7959ef](https://github.com/googleapis/google-cloud-go/commit/a7959efcc0e145ac6bf0e271695a30284aa8b493))
+* retry unexpected EOF errors (#13157) ([2b4ac42](https://github.com/googleapis/google-cloud-go/commit/2b4ac429c5328ed230ead5e937cd11f7024b73bf))
+
 ## [1.48.0](https://github.com/googleapis/google-cloud-go/releases/tag/bigtable%2Fv1.48.0) (2026-05-26)
 
 ### Features

--- a/bigtable/internal/version.go
+++ b/bigtable/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "1.48.0"
+const Version = "1.49.0"

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -381,7 +381,7 @@ libraries:
       - README.md
     skip_release: true
   - name: bigtable
-    version: 1.48.0
+    version: 1.49.0
     apis:
       - path: google/bigtable/v2
         go:


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.20.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go@sha256:b7e38e80d677dc6b7266896bb99a33fa62348d3e39d7b8f2f6423e7dc4b35a60
<details><summary>bigtable: v1.49.0</summary>

## [v1.49.0](https://github.com/googleapis/google-cloud-go/compare/bigtable/v1.48.0...bigtable/v1.49.0) (2026-06-10)

### Features

* enable new auth library and remove async refresh (#19943) ([0d3697b2](https://github.com/googleapis/google-cloud-go/commit/0d3697b2))

* add traffic diverter and table shim  for bigtable (#14633) ([2f3c9184](https://github.com/googleapis/google-cloud-go/commit/2f3c9184))

* add virtual RPC descriptors  (#14648) ([5eedda18](https://github.com/googleapis/google-cloud-go/commit/5eedda18))

* add opensession descriptors for bigtable (#14647) ([8968f4fd](https://github.com/googleapis/google-cloud-go/commit/8968f4fd))

* update API sources and regenerate (#14701) ([a9b79215](https://github.com/googleapis/google-cloud-go/commit/a9b79215))

### Bug Fixes

* retry unexpected EOF errors (#13157) ([2b4ac429](https://github.com/googleapis/google-cloud-go/commit/2b4ac429))

* disable dynamic channel pool by default and raise default pool size to 10 (#19945) ([5ddf8d46](https://github.com/googleapis/google-cloud-go/commit/5ddf8d46))

* raise default connection-recycler MaxAge to 7 days (#19940) ([a7959efc](https://github.com/googleapis/google-cloud-go/commit/a7959efc))

</details>