### PR TITLE
fix(spanner): propagate previous transaction ID on inline-begin retries

### DIFF
--- a/spanner/transaction.go
+++ b/spanner/transaction.go
@@ -1604,7 +1604,8 @@ func (t *ReadWriteTransaction) acquire(ctx context.Context) (*sessionHandle, *sp
 					Begin: &sppb.TransactionOptions{
 						Mode: &sppb.TransactionOptions_ReadWrite_{
 							ReadWrite: &sppb.TransactionOptions_ReadWrite{
-								ReadLockMode: t.txOpts.ReadLockMode,
+								ReadLockMode:                            t.txOpts.ReadLockMode,
+								MultiplexedSessionPreviousTransactionId: t.previousTx,
 							},
 						},
 						ExcludeTxnFromChangeStreams: t.txOpts.ExcludeTxnFromChangeStreams,

--- a/spanner/transaction_test.go
+++ b/spanner/transaction_test.go
@@ -571,6 +571,94 @@ func TestClient_ReadWriteTransaction_PreviousTransactionID(t *testing.T) {
 	}
 }
 
+func TestClient_ReadWriteTransaction_InlineBeginRetryCarriesPreviousTransactionID(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name string
+		f    func(ctx context.Context, tx *ReadWriteTransaction) error
+	}{
+		{
+			name: "Update",
+			f: func(ctx context.Context, tx *ReadWriteTransaction) error {
+				_, err := tx.Update(ctx, NewStatement(UpdateBarSetFoo))
+				return err
+			},
+		},
+		{
+			name: "BatchUpdate",
+			f: func(ctx context.Context, tx *ReadWriteTransaction) error {
+				_, err := tx.BatchUpdate(ctx, []Statement{NewStatement(UpdateBarSetFoo)})
+				return err
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			server, client, teardown := setupMockedTestServerWithConfig(t, ClientConfig{
+				DisableNativeMetrics: true,
+			})
+			defer teardown()
+
+			// Abort the commit of the first attempt to force a retry of the
+			// transaction. The inline begin of the retry attempt must include
+			// the ID of the aborted transaction, so that the retry inherits
+			// its wound-wait lock priority.
+			server.TestSpanner.PutExecutionTime(MethodCommitTransaction,
+				SimulatedExecutionTime{
+					Errors: []error{status.Error(codes.Aborted, "Transaction aborted")},
+				})
+
+			attempts := 0
+			_, err := client.ReadWriteTransaction(ctx, func(ctx context.Context, tx *ReadWriteTransaction) error {
+				attempts++
+				return test.f(ctx, tx)
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if g, w := attempts, 2; g != w {
+				t.Fatalf("attempts mismatch\ngot: %d\nwant: %d", g, w)
+			}
+
+			requests := drainRequestsFromServer(server.TestSpanner)
+			var abortedTxID []byte
+			var beginOpts []*sppb.TransactionOptions_ReadWrite
+			for _, req := range requests {
+				var selector *sppb.TransactionSelector
+				switch r := req.(type) {
+				case *sppb.ExecuteSqlRequest:
+					selector = r.Transaction
+				case *sppb.ExecuteBatchDmlRequest:
+					selector = r.Transaction
+				case *sppb.CommitRequest:
+					if abortedTxID == nil {
+						abortedTxID = r.GetTransactionId()
+					}
+					continue
+				default:
+					continue
+				}
+				if begin, ok := selector.GetSelector().(*sppb.TransactionSelector_Begin); ok {
+					beginOpts = append(beginOpts, begin.Begin.GetReadWrite())
+				}
+			}
+			if g, w := len(beginOpts), 2; g != w {
+				t.Fatalf("inline-begin request count mismatch\ngot: %d\nwant: %d", g, w)
+			}
+			if got := beginOpts[0].GetMultiplexedSessionPreviousTransactionId(); len(got) != 0 {
+				t.Errorf("first attempt should not include a previous transaction ID, got %v", got)
+			}
+			if len(abortedTxID) == 0 {
+				t.Fatal("no transaction ID found in the first CommitRequest")
+			}
+			if g, w := beginOpts[1].GetMultiplexedSessionPreviousTransactionId(), abortedTxID; !bytes.Equal(g, w) {
+				t.Errorf("previous transaction ID mismatch on retry\ngot: %v\nwant: %v", g, w)
+			}
+		})
+	}
+}
+
 func TestMutationOnlyCaseAborted(t *testing.T) {
 	if !isMultiplexEnabled {
 		t.Skip("Skipping multiplex session tests when regular sessions enabled")


### PR DESCRIPTION
## Description

Set `MultiplexedSessionPreviousTransactionId` in the transaction selector built in `ReadWriteTransaction.acquire()`, consistent with `getTransactionSelector()` and explicit `BeginTransaction`, which already set it.

## Why
Multiplexed sessions do not inherit the wound-wait lock priority of the aborted transaction from the session,
so every retry started with a fresh lock priority and kept losing lock conflicts.
Tthis caused starvation and increased lock wait times and tail latencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## easy load test

<details><summary>Details (Click me)</summary>

use this script.
https://gist.github.com/nktks/e1b354ac28bbc691527b9158ff448f1a
**First two are this branch, last two are main branch.**
```
+ git rev-parse --short HEAD
c4d335002e
+ go run main.go -db $SPANNER_DATABASE
2026/06/11 11:20:51 seeded 10000 rows
2026/06/11 11:20:51 warmup 5s, then measuring for 1m0s

measured duration : 60.0s
committed txns    : 3845
failed txns       : 0
abort retries     : 7585 (1.97 retries/tx)
throughput        : 64.1 tx/s
latency mean      : 505.2 ms
latency p50       : 222.4 ms
latency p95       : 1773.4 ms
latency p99       : 2619.7 ms
latency max       : 3413.1 ms
2026/06/11 11:21:57 cleaned up all rows
+ sleep 60
+ go run main.go -db $SPANNER_DATABASE
2026/06/11 11:23:00 seeded 10000 rows
2026/06/11 11:23:00 warmup 5s, then measuring for 1m0s

measured duration : 60.0s
committed txns    : 3898
failed txns       : 0
abort retries     : 7659 (1.96 retries/tx)
throughput        : 65.0 tx/s
latency mean      : 493.0 ms
latency p50       : 257.1 ms
latency p95       : 1547.5 ms
latency p99       : 2187.3 ms
latency max       : 4015.6 ms
2026/06/11 11:24:06 cleaned up all rows
+ sleep 60
+ git checkout main
Switched to branch 'main'
Your branch is up to date with 'origin/main'.
+ go run main.go -db $SPANNER_DATABASE
2026/06/11 11:25:12 seeded 10000 rows
2026/06/11 11:25:12 warmup 5s, then measuring for 1m0s

measured duration : 60.0s
committed txns    : 3374
failed txns       : 0
abort retries     : 5833 (1.73 retries/tx)
throughput        : 56.2 tx/s
latency mean      : 565.3 ms
latency p50       : 151.0 ms
latency p95       : 2154.8 ms
latency p99       : 6289.1 ms
latency max       : 21532.6 ms
2026/06/11 11:26:19 cleaned up all rows
+ sleep 60
+ go run main.go -db $SPANNER_DATABASE
2026/06/11 11:27:23 seeded 10000 rows
2026/06/11 11:27:23 warmup 5s, then measuring for 1m0s

measured duration : 60.0s
committed txns    : 3333
failed txns       : 0
abort retries     : 5827 (1.75 retries/tx)
throughput        : 55.5 tx/s
latency mean      : 572.4 ms
latency p50       : 174.3 ms
latency p95       : 2271.1 ms
latency p99       : 5169.9 ms
latency max       : 14900.8 ms
2026/06/11 11:28:31 cleaned up all rows
```

### Cloud Monitoring metrics
(Sorry my console is japanease...)
<img width="1220" height="454" alt="image" src="https://github.com/user-attachments/assets/0235aabd-bf3a-43e6-93c4-403912ce80f3" />
<img width="1211" height="470" alt="image" src="https://github.com/user-attachments/assets/830226bf-7e5e-4023-96fc-9d8f4630993a" />
<img width="612" height="451" alt="image" src="https://github.com/user-attachments/assets/c65c08fd-c4b4-4d11-b3bf-beab038e36cc" />


</details>