### PR TITLE
fix(auth): prevent panic on short ES256 idtoken signature

### DIFF
--- a/auth/credentials/idtoken/validate.go
+++ b/auth/credentials/idtoken/validate.go
@@ -237,6 +237,9 @@ func (v *Validator) validateES256(ctx context.Context, keyID string, hashedConte
 		X:     new(big.Int).SetBytes(dx),
 		Y:     new(big.Int).SetBytes(dy),
 	}
+	if len(sig) != 2*es256KeySize {
+		return fmt.Errorf("idtoken: ES256 signature must be %d bytes, got %d", 2*es256KeySize, len(sig))
+	}
 	r := big.NewInt(0).SetBytes(sig[:es256KeySize])
 	s := big.NewInt(0).SetBytes(sig[es256KeySize:])
 	if valid := ecdsa.Verify(pk, hashedContent, r, s); !valid {

--- a/auth/credentials/idtoken/validate_test.go
+++ b/auth/credentials/idtoken/validate_test.go
@@ -29,6 +29,7 @@ import (
 	"io"
 	"math/big"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -284,6 +285,54 @@ func TestValidateES256(t *testing.T) {
 				t.Fatalf("got %v, want %v", payload.Audience, testAudience)
 			}
 		})
+	}
+}
+
+// TestValidateES256ShortSignature ensures a malformed ES256 token whose
+// signature decodes to fewer than 2*es256KeySize bytes is rejected with an
+// error instead of panicking with "slice bounds out of range" when the
+// signature is split into its r and s components.
+func TestValidateES256ShortSignature(t *testing.T) {
+	idToken, pk := createES256JWT(t)
+	// Replace the signature segment with one that decodes to a single byte.
+	header, claims, _ := strings.Cut(idToken, ".")
+	claims, _, _ = strings.Cut(claims, ".")
+	shortSig := base64.RawURLEncoding.EncodeToString([]byte{0x00})
+	idToken = fmt.Sprintf("%s.%s.%s", header, claims, shortSig)
+
+	client := &http.Client{
+		Transport: RoundTripFn(func(req *http.Request) *http.Response {
+			cr := certResponse{
+				Keys: []jwk{
+					{
+						Kid: keyID,
+						X:   base64.RawURLEncoding.EncodeToString(pk.X.Bytes()),
+						Y:   base64.RawURLEncoding.EncodeToString(pk.Y.Bytes()),
+					},
+				},
+			}
+			b, err := json.Marshal(&cr)
+			if err != nil {
+				t.Fatalf("unable to marshal response: %v", err)
+			}
+			return &http.Response{
+				StatusCode: 200,
+				Body:       io.NopCloser(bytes.NewReader(b)),
+				Header:     make(http.Header),
+			}
+		}),
+	}
+	oldNow := now
+	defer func() { now = oldNow }()
+	now = beforeExp
+
+	v, err := NewValidator(&ValidatorOptions{Client: client})
+	if err != nil {
+		t.Fatalf("NewValidator(...) = %q, want nil", err)
+	}
+	// Must return an error, not panic.
+	if _, err := v.Validate(context.Background(), idToken, testAudience); err == nil {
+		t.Fatal("Validate(ctx, <short-sig token>, aud) = nil, want error")
 	}
 }
 


### PR DESCRIPTION
## Summary

`idtoken`'s `validateES256` splits the JWT signature into its `r` and `s`
components with `sig[:es256KeySize]` / `sig[es256KeySize:]` **without first
checking the signature length**:

https://github.com/googleapis/google-cloud-go/blob/main/auth/credentials/idtoken/validate.go#L240-L241

The signature is base64url-decoded from the token's third segment in
`parseToken`, so it is fully caller/attacker controlled. A token whose
signature segment decodes to fewer than 32 bytes makes `sig[:es256KeySize]`
panic with `slice bounds out of range` instead of returning a validation
error.

Because `idtoken.Validate` is commonly called on **externally supplied
tokens** (e.g. a backend verifying the `x-goog-iap-jwt-assertion` header),
an unauthenticated caller can trigger this panic. There is no `recover()` in
the package, so in a gRPC server without a recovery interceptor — or any
background goroutine — the panic crashes the process.

## Why this is a bug, not intended

The sibling ECDSA verifier in the same module already guards the identical
operation before slicing:

https://github.com/googleapis/google-cloud-go/blob/main/auth/internal/jwt/jwt.go#L197

`validateES256` simply omits that check.

## Fix

Add the same length guard (mirroring `jwt.go`) before splitting the
signature, returning an error for any signature that is not exactly
`2 * es256KeySize` (64) bytes.

## Test

`TestValidateES256ShortSignature` builds a valid ES256 token, replaces its
signature with one that decodes to a single byte, and asserts `Validate`
returns an error. Verified it **panics/fails without the fix and passes with
it**. `go vet` and the existing `TestValidateES256` suite remain green.

## Reproduction

```
header  = {"alg":"ES256","kid":"<real kid from public IAP JWKS>"}
payload = {"aud":"<expected aud>","exp":<future>}
sig     = base64url(<1 byte>)
```

Submitting `header.payload.sig` to a service calling `idtoken.Validate`
triggers the panic prior to this change.