### PR TITLE
chore: librarian release pull request: 20260611T211916Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -101,7 +101,7 @@ libraries:
       - internal/generated/snippets/aiplatform/
     tag_format: '{id}/v{version}'
   - id: alloydb
-    version: 1.26.0
+    version: 1.27.0
     last_generated_commit: ""
     apis:
       - path: google/cloud/alloydb/v1
@@ -400,12 +400,10 @@ libraries:
       - internal/generated/snippets/automl/
     tag_format: '{id}/v{version}'
   - id: backstory
-    version: 0.0.0
+    version: 0.1.0
+    last_generated_commit: ""
     apis:
       - path: backstory
-        go:
-          import_path: backstory/backstorypb
-          proto_only: true
     source_roots:
       - backstory
     preserve_regex: []
@@ -641,7 +639,7 @@ libraries:
       - internal/generated/snippets/certificatemanager/
     tag_format: '{id}/v{version}'
   - id: ces
-    version: 1.0.0
+    version: 1.1.0
     last_generated_commit: ""
     apis:
       - path: google/cloud/ces/v1beta
@@ -847,7 +845,7 @@ libraries:
     remove_regex: []
     tag_format: '{id}/v{version}'
   - id: confidentialcomputing
-    version: 1.16.0
+    version: 1.17.0
     last_generated_commit: ""
     apis:
       - path: google/cloud/confidentialcomputing/v1
@@ -1182,7 +1180,7 @@ libraries:
       - internal/generated/snippets/discoveryengine/
     tag_format: '{id}/v{version}'
   - id: dlp
-    version: 1.35.0
+    version: 1.36.0
     last_generated_commit: ""
     apis:
       - path: google/privacy/dlp/v2
@@ -1360,7 +1358,7 @@ libraries:
       - internal/generated/snippets/functions/
     tag_format: '{id}/v{version}'
   - id: geminidataanalytics
-    version: 1.2.0
+    version: 1.3.0
     last_generated_commit: ""
     apis:
       - path: google/cloud/geminidataanalytics/v1beta
@@ -1836,7 +1834,7 @@ libraries:
       - internal/generated/snippets/migrationcenter/
     tag_format: '{id}/v{version}'
   - id: modelarmor
-    version: 1.0.0
+    version: 1.1.0
     last_generated_commit: ""
     apis:
       - path: google/cloud/modelarmor/v1
@@ -1977,7 +1975,7 @@ libraries:
       - internal/generated/snippets/optimization/
     tag_format: '{id}/v{version}'
   - id: oracledatabase
-    version: 1.0.0
+    version: 1.1.0
     last_generated_commit: ""
     apis:
       - path: google/cloud/oracledatabase/v1
@@ -3072,7 +3070,7 @@ libraries:
       - internal/generated/snippets/workloadmanager/
     tag_format: '{id}/v{version}'
   - id: workstations
-    version: 1.6.0
+    version: 1.7.0
     last_generated_commit: ""
     apis:
       - path: google/cloud/workstations/v1beta

--- a/alloydb/CHANGES.md
+++ b/alloydb/CHANGES.md
@@ -3,6 +3,12 @@
 
 
 
+## [1.27.0](https://github.com/googleapis/google-cloud-go/releases/tag/alloydb%2Fv1.27.0) (2026-06-11)
+
+### Features
+
+* update API sources and regenerate (#19950) ([c7607be](https://github.com/googleapis/google-cloud-go/commit/c7607be52757b803df345670b5d0621c2bb9ba30))
+
 ## [1.26.0](https://github.com/googleapis/google-cloud-go/releases/tag/alloydb%2Fv1.26.0) (2026-05-07)
 
 ## [1.25.0](https://github.com/googleapis/google-cloud-go/releases/tag/alloydb%2Fv1.25.0) (2026-04-30)

--- a/alloydb/examples/apiv1/snippet_metadata.google.cloud.alloydb.v1.json
+++ b/alloydb/examples/apiv1/snippet_metadata.google.cloud.alloydb.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/alloydb/apiv1",
-    "version": "1.26.0"
+    "version": "1.27.0"
   },
   "snippets": [
     {

--- a/alloydb/examples/apiv1alpha/snippet_metadata.google.cloud.alloydb.v1alpha.json
+++ b/alloydb/examples/apiv1alpha/snippet_metadata.google.cloud.alloydb.v1alpha.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/alloydb/apiv1alpha",
-    "version": "1.26.0"
+    "version": "1.27.0"
   },
   "snippets": [
     {

--- a/alloydb/examples/apiv1beta/snippet_metadata.google.cloud.alloydb.v1beta.json
+++ b/alloydb/examples/apiv1beta/snippet_metadata.google.cloud.alloydb.v1beta.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/alloydb/apiv1beta",
-    "version": "1.26.0"
+    "version": "1.27.0"
   },
   "snippets": [
     {

--- a/alloydb/internal/version.go
+++ b/alloydb/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "1.26.0"
+const Version = "1.27.0"

--- a/backstory/CHANGES.md
+++ b/backstory/CHANGES.md
@@ -1,0 +1,6 @@
+## [0.1.0](https://github.com/googleapis/google-cloud-go/releases/tag/backstory%2Fv0.1.0) (2026-06-11)
+
+### Features
+
+* onboard a new library (#19952) ([1d2a264](https://github.com/googleapis/google-cloud-go/commit/1d2a2644bd5d53a8454a49de5a7b894561bb987b))
+

--- a/backstory/internal/version.go
+++ b/backstory/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "0.0.0"
+const Version = "0.1.0"

--- a/ces/CHANGES.md
+++ b/ces/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+## [1.1.0](https://github.com/googleapis/google-cloud-go/releases/tag/ces%2Fv1.1.0) (2026-06-11)
+
+### Features
+
+* update API sources and regenerate (#19950) ([c7607be](https://github.com/googleapis/google-cloud-go/commit/c7607be52757b803df345670b5d0621c2bb9ba30))
+
 ## [1.0.0](https://github.com/googleapis/google-cloud-go/releases/tag/ces%2Fv1.0.0) (2026-05-08)
 
 ## [0.9.0](https://github.com/googleapis/google-cloud-go/releases/tag/ces%2Fv0.9.0) (2026-05-07)

--- a/ces/examples/apiv1/snippet_metadata.google.cloud.ces.v1.json
+++ b/ces/examples/apiv1/snippet_metadata.google.cloud.ces.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/ces/apiv1",
-    "version": "1.0.0"
+    "version": "1.1.0"
   },
   "snippets": [
     {

--- a/ces/examples/apiv1beta/snippet_metadata.google.cloud.ces.v1beta.json
+++ b/ces/examples/apiv1beta/snippet_metadata.google.cloud.ces.v1beta.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/ces/apiv1beta",
-    "version": "1.0.0"
+    "version": "1.1.0"
   },
   "snippets": [
     {

--- a/ces/internal/version.go
+++ b/ces/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "1.0.0"
+const Version = "1.1.0"

--- a/confidentialcomputing/CHANGES.md
+++ b/confidentialcomputing/CHANGES.md
@@ -1,6 +1,12 @@
 # Changes
 
 
+## [1.17.0](https://github.com/googleapis/google-cloud-go/releases/tag/confidentialcomputing%2Fv1.17.0) (2026-06-11)
+
+### Features
+
+* update API sources and regenerate (#19950) ([c7607be](https://github.com/googleapis/google-cloud-go/commit/c7607be52757b803df345670b5d0621c2bb9ba30))
+
 ## [1.16.0](https://github.com/googleapis/google-cloud-go/releases/tag/confidentialcomputing%2Fv1.16.0) (2026-05-07)
 
 ## [1.15.0](https://github.com/googleapis/google-cloud-go/releases/tag/confidentialcomputing%2Fv1.15.0) (2026-04-30)

--- a/confidentialcomputing/examples/apiv1/snippet_metadata.google.cloud.confidentialcomputing.v1.json
+++ b/confidentialcomputing/examples/apiv1/snippet_metadata.google.cloud.confidentialcomputing.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/confidentialcomputing/apiv1",
-    "version": "1.16.0"
+    "version": "1.17.0"
   },
   "snippets": [
     {

--- a/confidentialcomputing/examples/apiv1alpha1/snippet_metadata.google.cloud.confidentialcomputing.v1alpha1.json
+++ b/confidentialcomputing/examples/apiv1alpha1/snippet_metadata.google.cloud.confidentialcomputing.v1alpha1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/confidentialcomputing/apiv1alpha1",
-    "version": "1.16.0"
+    "version": "1.17.0"
   },
   "snippets": [
     {

--- a/confidentialcomputing/internal/version.go
+++ b/confidentialcomputing/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "1.16.0"
+const Version = "1.17.0"

--- a/dlp/CHANGES.md
+++ b/dlp/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+## [1.36.0](https://github.com/googleapis/google-cloud-go/releases/tag/dlp%2Fv1.36.0) (2026-06-11)
+
+### Features
+
+* update API sources and regenerate (#19950) ([c7607be](https://github.com/googleapis/google-cloud-go/commit/c7607be52757b803df345670b5d0621c2bb9ba30))
+
 ## [1.35.0](https://github.com/googleapis/google-cloud-go/releases/tag/dlp%2Fv1.35.0) (2026-06-04)
 
 ### Features

--- a/dlp/examples/apiv2/snippet_metadata.google.privacy.dlp.v2.json
+++ b/dlp/examples/apiv2/snippet_metadata.google.privacy.dlp.v2.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/dlp/apiv2",
-    "version": "1.35.0"
+    "version": "1.36.0"
   },
   "snippets": [
     {

--- a/dlp/internal/version.go
+++ b/dlp/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "1.35.0"
+const Version = "1.36.0"

--- a/geminidataanalytics/CHANGES.md
+++ b/geminidataanalytics/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+## [1.3.0](https://github.com/googleapis/google-cloud-go/releases/tag/geminidataanalytics%2Fv1.3.0) (2026-06-11)
+
+### Features
+
+* update API sources and regenerate (#19950) ([c7607be](https://github.com/googleapis/google-cloud-go/commit/c7607be52757b803df345670b5d0621c2bb9ba30))
+
 ## [1.2.0](https://github.com/googleapis/google-cloud-go/releases/tag/geminidataanalytics%2Fv1.2.0) (2026-05-28)
 
 ### Features

--- a/geminidataanalytics/examples/apiv1/snippet_metadata.google.cloud.geminidataanalytics.v1.json
+++ b/geminidataanalytics/examples/apiv1/snippet_metadata.google.cloud.geminidataanalytics.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/geminidataanalytics/apiv1",
-    "version": "1.2.0"
+    "version": "1.3.0"
   },
   "snippets": [
     {

--- a/geminidataanalytics/examples/apiv1beta/snippet_metadata.google.cloud.geminidataanalytics.v1beta.json
+++ b/geminidataanalytics/examples/apiv1beta/snippet_metadata.google.cloud.geminidataanalytics.v1beta.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/geminidataanalytics/apiv1beta",
-    "version": "1.2.0"
+    "version": "1.3.0"
   },
   "snippets": [
     {

--- a/geminidataanalytics/internal/version.go
+++ b/geminidataanalytics/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "1.2.0"
+const Version = "1.3.0"

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -68,7 +68,7 @@ libraries:
       - path: google/cloud/aiplatform/v1beta1
     skip_generate: true
   - name: alloydb
-    version: 1.26.0
+    version: 1.27.0
     apis:
       - path: google/cloud/alloydb/v1
       - path: google/cloud/alloydb/connectors/v1
@@ -197,7 +197,7 @@ libraries:
       - path: google/cloud/automl/v1
       - path: google/cloud/automl/v1beta1
   - name: backstory
-    version: 0.0.0
+    version: 0.1.0
     apis:
       - path: backstory
         go:
@@ -424,7 +424,7 @@ libraries:
     apis:
       - path: google/cloud/certificatemanager/v1
   - name: ces
-    version: 1.0.0
+    version: 1.1.0
     apis:
       - path: google/cloud/ces/v1
       - path: google/cloud/ces/v1beta
@@ -534,7 +534,7 @@ libraries:
       - internal/version.go
     skip_release: true
   - name: confidentialcomputing
-    version: 1.16.0
+    version: 1.17.0
     apis:
       - path: google/cloud/confidentialcomputing/v1
       - path: google/cloud/confidentialcomputing/v1alpha1
@@ -672,7 +672,7 @@ libraries:
       - path: google/cloud/discoveryengine/v1beta
       - path: google/cloud/discoveryengine/v1alpha
   - name: dlp
-    version: 1.35.0
+    version: 1.36.0
     apis:
       - path: google/privacy/dlp/v2
         go:
@@ -759,7 +759,7 @@ libraries:
       - path: google/cloud/functions/v1
       - path: google/cloud/functions/v2beta
   - name: geminidataanalytics
-    version: 1.2.0
+    version: 1.3.0
     apis:
       - path: google/cloud/geminidataanalytics/v1
       - path: google/cloud/geminidataanalytics/v1beta
@@ -965,7 +965,7 @@ libraries:
     apis:
       - path: google/cloud/migrationcenter/v1
   - name: modelarmor
-    version: 1.0.0
+    version: 1.1.0
     apis:
       - path: google/cloud/modelarmor/v1
       - path: google/cloud/modelarmor/v1beta
@@ -1025,7 +1025,7 @@ libraries:
     apis:
       - path: google/cloud/optimization/v1
   - name: oracledatabase
-    version: 1.0.0
+    version: 1.1.0
     apis:
       - path: google/cloud/oracledatabase/v1
   - name: orchestration
@@ -1504,7 +1504,7 @@ libraries:
     apis:
       - path: google/cloud/workloadmanager/v1
   - name: workstations
-    version: 1.6.0
+    version: 1.7.0
     apis:
       - path: google/cloud/workstations/v1
       - path: google/cloud/workstations/v1beta

--- a/modelarmor/CHANGES.md
+++ b/modelarmor/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+## [1.1.0](https://github.com/googleapis/google-cloud-go/releases/tag/modelarmor%2Fv1.1.0) (2026-06-11)
+
+### Features
+
+* update API sources and regenerate (#19950) ([c7607be](https://github.com/googleapis/google-cloud-go/commit/c7607be52757b803df345670b5d0621c2bb9ba30))
+
 ## [1.0.0](https://github.com/googleapis/google-cloud-go/releases/tag/modelarmor%2Fv1.0.0) (2026-05-08)
 
 ## [0.11.0](https://github.com/googleapis/google-cloud-go/releases/tag/modelarmor%2Fv0.11.0) (2026-05-07)

--- a/modelarmor/examples/apiv1/snippet_metadata.google.cloud.modelarmor.v1.json
+++ b/modelarmor/examples/apiv1/snippet_metadata.google.cloud.modelarmor.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/modelarmor/apiv1",
-    "version": "1.0.0"
+    "version": "1.1.0"
   },
   "snippets": [
     {

--- a/modelarmor/examples/apiv1beta/snippet_metadata.google.cloud.modelarmor.v1beta.json
+++ b/modelarmor/examples/apiv1beta/snippet_metadata.google.cloud.modelarmor.v1beta.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/modelarmor/apiv1beta",
-    "version": "1.0.0"
+    "version": "1.1.0"
   },
   "snippets": [
     {

--- a/modelarmor/internal/version.go
+++ b/modelarmor/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "1.0.0"
+const Version = "1.1.0"

--- a/oracledatabase/CHANGES.md
+++ b/oracledatabase/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+## [1.1.0](https://github.com/googleapis/google-cloud-go/releases/tag/oracledatabase%2Fv1.1.0) (2026-06-11)
+
+### Features
+
+* update API sources and regenerate (#19950) ([c7607be](https://github.com/googleapis/google-cloud-go/commit/c7607be52757b803df345670b5d0621c2bb9ba30))
+
 ## [1.0.0](https://github.com/googleapis/google-cloud-go/releases/tag/oracledatabase%2Fv1.0.0) (2026-05-08)
 
 ## [0.11.0](https://github.com/googleapis/google-cloud-go/releases/tag/oracledatabase%2Fv0.11.0) (2026-05-07)

--- a/oracledatabase/examples/apiv1/snippet_metadata.google.cloud.oracledatabase.v1.json
+++ b/oracledatabase/examples/apiv1/snippet_metadata.google.cloud.oracledatabase.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/oracledatabase/apiv1",
-    "version": "1.0.0"
+    "version": "1.1.0"
   },
   "snippets": [
     {

--- a/oracledatabase/internal/version.go
+++ b/oracledatabase/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "1.0.0"
+const Version = "1.1.0"

--- a/workstations/CHANGES.md
+++ b/workstations/CHANGES.md
@@ -3,6 +3,12 @@
 
 
 
+## [1.7.0](https://github.com/googleapis/google-cloud-go/releases/tag/workstations%2Fv1.7.0) (2026-06-11)
+
+### Features
+
+* update API sources and regenerate (#19950) ([c7607be](https://github.com/googleapis/google-cloud-go/commit/c7607be52757b803df345670b5d0621c2bb9ba30))
+
 ## [1.6.0](https://github.com/googleapis/google-cloud-go/releases/tag/workstations%2Fv1.6.0) (2026-05-07)
 
 ### Features

--- a/workstations/examples/apiv1/snippet_metadata.google.cloud.workstations.v1.json
+++ b/workstations/examples/apiv1/snippet_metadata.google.cloud.workstations.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/workstations/apiv1",
-    "version": "1.6.0"
+    "version": "1.7.0"
   },
   "snippets": [
     {

--- a/workstations/examples/apiv1beta/snippet_metadata.google.cloud.workstations.v1beta.json
+++ b/workstations/examples/apiv1beta/snippet_metadata.google.cloud.workstations.v1beta.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/workstations/apiv1beta",
-    "version": "1.6.0"
+    "version": "1.7.0"
   },
   "snippets": [
     {

--- a/workstations/internal/version.go
+++ b/workstations/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "1.6.0"
+const Version = "1.7.0"


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.20.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go@sha256:b7e38e80d677dc6b7266896bb99a33fa62348d3e39d7b8f2f6423e7dc4b35a60
<details><summary>alloydb: v1.27.0</summary>

## [v1.27.0](https://github.com/googleapis/google-cloud-go/compare/alloydb/v1.26.0...alloydb/v1.27.0) (2026-06-11)

### Features

* update API sources and regenerate (#19950) ([c7607be5](https://github.com/googleapis/google-cloud-go/commit/c7607be5))

</details>


<details><summary>backstory: v0.1.0</summary>

## [v0.1.0](https://github.com/googleapis/google-cloud-go/compare/backstory/v0.0.0...backstory/v0.1.0) (2026-06-11)

### Features

* onboard a new library (#19952) ([1d2a2644](https://github.com/googleapis/google-cloud-go/commit/1d2a2644))

</details>


<details><summary>ces: v1.1.0</summary>

## [v1.1.0](https://github.com/googleapis/google-cloud-go/compare/ces/v1.0.0...ces/v1.1.0) (2026-06-11)

### Features

* update API sources and regenerate (#19950) ([c7607be5](https://github.com/googleapis/google-cloud-go/commit/c7607be5))

</details>


<details><summary>confidentialcomputing: v1.17.0</summary>

## [v1.17.0](https://github.com/googleapis/google-cloud-go/compare/confidentialcomputing/v1.16.0...confidentialcomputing/v1.17.0) (2026-06-11)

### Features

* update API sources and regenerate (#19950) ([c7607be5](https://github.com/googleapis/google-cloud-go/commit/c7607be5))

</details>


<details><summary>dlp: v1.36.0</summary>

## [v1.36.0](https://github.com/googleapis/google-cloud-go/compare/dlp/v1.35.0...dlp/v1.36.0) (2026-06-11)

### Features

* update API sources and regenerate (#19950) ([c7607be5](https://github.com/googleapis/google-cloud-go/commit/c7607be5))

</details>


<details><summary>geminidataanalytics: v1.3.0</summary>

## [v1.3.0](https://github.com/googleapis/google-cloud-go/compare/geminidataanalytics/v1.2.0...geminidataanalytics/v1.3.0) (2026-06-11)

### Features

* update API sources and regenerate (#19950) ([c7607be5](https://github.com/googleapis/google-cloud-go/commit/c7607be5))

</details>


<details><summary>modelarmor: v1.1.0</summary>

## [v1.1.0](https://github.com/googleapis/google-cloud-go/compare/modelarmor/v1.0.0...modelarmor/v1.1.0) (2026-06-11)

### Features

* update API sources and regenerate (#19950) ([c7607be5](https://github.com/googleapis/google-cloud-go/commit/c7607be5))

</details>


<details><summary>oracledatabase: v1.1.0</summary>

## [v1.1.0](https://github.com/googleapis/google-cloud-go/compare/oracledatabase/v1.0.0...oracledatabase/v1.1.0) (2026-06-11)

### Features

* update API sources and regenerate (#19950) ([c7607be5](https://github.com/googleapis/google-cloud-go/commit/c7607be5))

</details>


<details><summary>workstations: v1.7.0</summary>

## [v1.7.0](https://github.com/googleapis/google-cloud-go/compare/workstations/v1.6.0...workstations/v1.7.0) (2026-06-11)

### Features

* update API sources and regenerate (#19950) ([c7607be5](https://github.com/googleapis/google-cloud-go/commit/c7607be5))

</details>