### PR TITLE
fix(auth): reject malformed ES256 signatures in idtoken Validate

### DIFF
--- a/auth/credentials/idtoken/validate.go
+++ b/auth/credentials/idtoken/validate.go
@@ -237,6 +237,9 @@ func (v *Validator) validateES256(ctx context.Context, keyID string, hashedConte
 		X:     new(big.Int).SetBytes(dx),
 		Y:     new(big.Int).SetBytes(dy),
 	}
+	if len(sig) != 2*es256KeySize {
+		return fmt.Errorf("idtoken: ES256 signature should be %d bytes, got %d", 2*es256KeySize, len(sig))
+	}
 	r := big.NewInt(0).SetBytes(sig[:es256KeySize])
 	s := big.NewInt(0).SetBytes(sig[es256KeySize:])
 	if valid := ecdsa.Verify(pk, hashedContent, r, s); !valid {

--- a/auth/credentials/idtoken/validate_test.go
+++ b/auth/credentials/idtoken/validate_test.go
@@ -287,6 +287,54 @@ func TestValidateES256(t *testing.T) {
 	}
 }
 
+func TestValidateES256MalformedSignature(t *testing.T) {
+	header, claims := commonToken(t, "ES256")
+	// A real key so findMatchingKey and decode(X)/decode(Y) succeed and the
+	// token reaches signature verification.
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("unable to generate key: %v", err)
+	}
+
+	for _, tt := range []struct {
+		name   string
+		sigLen int
+	}{
+		{name: "short signature", sigLen: 3},
+		{name: "empty signature", sigLen: 0},
+		{name: "long signature", sigLen: 100},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			sig := base64.RawURLEncoding.EncodeToString(make([]byte, tt.sigLen))
+			idToken := fmt.Sprintf("%s.%s.%s", header, claims, sig)
+
+			client := &http.Client{Transport: RoundTripFn(func(req *http.Request) *http.Response {
+				cr := certResponse{Keys: []jwk{{
+					Kid: keyID,
+					X:   base64.RawURLEncoding.EncodeToString(priv.X.Bytes()),
+					Y:   base64.RawURLEncoding.EncodeToString(priv.Y.Bytes()),
+				}}}
+				b, err := json.Marshal(&cr)
+				if err != nil {
+					t.Fatalf("unable to marshal response: %v", err)
+				}
+				return &http.Response{StatusCode: 200, Body: io.NopCloser(bytes.NewReader(b)), Header: make(http.Header)}
+			})}
+			oldNow := now
+			defer func() { now = oldNow }()
+			now = beforeExp
+
+			v, err := NewValidator(&ValidatorOptions{Client: client, ES256CertsURL: "http://example.com"})
+			if err != nil {
+				t.Fatalf("NewValidator(...) = %q, want nil", err)
+			}
+			if _, err := v.Validate(context.Background(), idToken, testAudience); err == nil {
+				t.Fatal("Validate(...) = nil, want error for malformed ES256 signature")
+			}
+		})
+	}
+}
+
 func TestParsePayload(t *testing.T) {
 	idToken, _ := createRS256JWT(t)
 	tests := []struct {

--- a/auth/credentials/idtoken/validate_test.go
+++ b/auth/credentials/idtoken/validate_test.go
@@ -29,6 +29,7 @@ import (
 	"io"
 	"math/big"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -330,6 +331,8 @@ func TestValidateES256MalformedSignature(t *testing.T) {
 			}
 			if _, err := v.Validate(context.Background(), idToken, testAudience); err == nil {
 				t.Fatal("Validate(...) = nil, want error for malformed ES256 signature")
+			} else if !strings.Contains(err.Error(), "ES256 signature should be") {
+				t.Fatalf("Validate(...) = %v, want error about ES256 signature length", err)
 			}
 		})
 	}


### PR DESCRIPTION
Spotted this reading through the idtoken verifier. The ES256 branch trusts the decoded signature to be at least 32 bytes and slices it straight into r and s, but those bytes come from the untrusted token so the length is whatever the caller sends. A token with a valid kid, alg of ES256 and a signature segment that base64url-decodes to under 32 bytes runs validateES256 off the end of the slice and panics with `slice bounds out of range [:32]` before any signature check runs.

1. validateES256 splits the signature at a fixed 32-byte offset (sig[:es256KeySize] and sig[es256KeySize:]) with no length check, so a short signature on an attacker-supplied token panics rather than being rejected.
2. VerifyJWS in auth/internal/jwt already guards this, rejecting any ECDSA signature that is not 64 bytes before splitting; validateES256 was the one verification path missing it.

Added the same guard so a wrong-length signature is treated as a malformed token, matching the behaviour of VerifyJWS. Since Validate is the entry point callers use on inbound tokens, the bad input reaches this path with no authentication in between, so the risk if left is a remotely triggerable panic in the verifier. Included a regression test driving Validate with short, empty and oversized signatures.