### PR TITLE
chore: librarian release pull request: 20260615T093125Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -2647,7 +2647,7 @@ libraries:
       - internal/generated/snippets/shopping/
     tag_format: '{id}/v{version}'
   - id: spanner
-    version: 1.91.0
+    version: 1.92.0
     last_generated_commit: ""
     apis:
       - path: google/spanner/adapter/v1

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -1324,7 +1324,7 @@ libraries:
           import_path: shopping/type
           proto_only: true
   - name: spanner
-    version: 1.91.0
+    version: 1.92.0
     apis:
       - path: google/spanner/v1
         go:

--- a/spanner/CHANGES.md
+++ b/spanner/CHANGES.md
@@ -1,5 +1,21 @@
 # Changes
 
+## [1.92.0](https://github.com/googleapis/google-cloud-go/releases/tag/spanner%2Fv1.92.0) (2026-06-15)
+
+### Features
+
+* Enable EEF for cloud spanner when direct access is enabled (#14414) ([d7c4e0f](https://github.com/googleapis/google-cloud-go/commit/d7c4e0fd226cb0b8899e59e6aced4a2111fa5aed))
+* add OpenTelemetry metrics for dynamic channel pool (#14613) ([b54b4f0](https://github.com/googleapis/google-cloud-go/commit/b54b4f022fbda8910349ce26127c364bc16f9d2c))
+* add dynamic channel pool (#14611) ([51a53ce](https://github.com/googleapis/google-cloud-go/commit/51a53ceeb599e0d72ae8e77cd9c971bc1082cf58))
+* add option for auto-tagging transactions (#14646) ([be0afd9](https://github.com/googleapis/google-cloud-go/commit/be0afd99fc050f734ef36f7644f03d8db94b7d90))
+* update API sources and regenerate (#14537) ([07fe29b](https://github.com/googleapis/google-cloud-go/commit/07fe29ba4c5069d27d4149d8fa5f8814eb8789d7))
+
+### Bug Fixes
+
+* Support UUID as a base data type (#14117) ([f8b9a93](https://github.com/googleapis/google-cloud-go/commit/f8b9a93aefedc167db7c7a28140d47ef2f1e3a82))
+* handle unused variables (#13088) ([b295156](https://github.com/googleapis/google-cloud-go/commit/b2951564ca759c51300fdb5957b696f411c5b662))
+* propagate previous transaction ID on inline-begin retries (#19955) ([827f70e](https://github.com/googleapis/google-cloud-go/commit/827f70e66172ef66599c8ab7f38a8c1b901231a1))
+
 ## [1.91.0](https://github.com/googleapis/google-cloud-go/releases/tag/spanner%2Fv1.91.0) (2026-04-22)
 
 ## [1.90.0](https://github.com/googleapis/google-cloud-go/releases/tag/spanner%2Fv1.90.0) (2026-04-14)

--- a/spanner/internal/version.go
+++ b/spanner/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "1.91.0"
+const Version = "1.92.0"


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.20.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go@sha256:b7e38e80d677dc6b7266896bb99a33fa62348d3e39d7b8f2f6423e7dc4b35a60
<details><summary>spanner: v1.92.0</summary>

## [v1.92.0](https://github.com/googleapis/google-cloud-go/compare/spanner/v1.91.0...spanner/v1.92.0) (2026-06-15)

### Features

* update API sources and regenerate (#14537) ([07fe29ba](https://github.com/googleapis/google-cloud-go/commit/07fe29ba))

* add dynamic channel pool (#14611) ([51a53cee](https://github.com/googleapis/google-cloud-go/commit/51a53cee))

* add OpenTelemetry metrics for dynamic channel pool (#14613) ([b54b4f02](https://github.com/googleapis/google-cloud-go/commit/b54b4f02))

* add option for auto-tagging transactions (#14646) ([be0afd99](https://github.com/googleapis/google-cloud-go/commit/be0afd99))

* Enable EEF for cloud spanner when direct access is enabled (#14414) ([d7c4e0fd](https://github.com/googleapis/google-cloud-go/commit/d7c4e0fd))

### Bug Fixes

* propagate previous transaction ID on inline-begin retries (#19955) ([827f70e6](https://github.com/googleapis/google-cloud-go/commit/827f70e6))

* handle unused variables (#13088) ([b2951564](https://github.com/googleapis/google-cloud-go/commit/b2951564))

* Support UUID as a base data type (#14117) ([f8b9a93a](https://github.com/googleapis/google-cloud-go/commit/f8b9a93a))

</details>