### PR TITLE
test(auth): add TestCachedTokenProvider_TokenSyncRace

### DIFF
--- a/auth/auth_token_async_test.go
+++ b/auth/auth_token_async_test.go
@@ -122,3 +122,47 @@ func TestCachedTokenProvider_TokenAsyncRace(t *testing.T) {
 		})
 	}
 }
+
+func TestCachedTokenProvider_TokenSyncRace(t *testing.T) {
+	for _, disableAsync := range []bool{false, true} {
+		name := fmt.Sprintf("DisableAsyncRefresh-%t", disableAsync)
+		t.Run(name, func(t *testing.T) {
+			now := time.Now()
+			timeNow = func() time.Time { return now }
+			defer func() { timeNow = time.Now }()
+
+			tp := &controllableTokenProvider{}
+			ctp := NewCachedTokenProvider(tp, &CachedTokenProviderOptions{
+				DisableAsyncRefresh: disableAsync,
+			}).(*cachedTokenProvider)
+
+			// Keep the underlying provider blocked initially
+			blockChan := make(chan struct{})
+			tp.setBlockChan(blockChan)
+			tp.tok = &Token{Value: "refreshed", Expiry: now.Add(1 * time.Hour)}
+
+			var wg sync.WaitGroup
+			numGoroutines := 20
+			wg.Add(numGoroutines)
+			for i := 0; i < numGoroutines; i++ {
+				go func() {
+					defer wg.Done()
+					_, _ = ctp.Token(context.Background())
+				}()
+			}
+
+			// Give goroutines time to block on the mutex or the channel
+			time.Sleep(50 * time.Millisecond)
+
+			// Release the block on the underlying provider
+			close(blockChan)
+			wg.Wait()
+
+			// Verify the underlying provider was only called once
+			if got, want := tp.getCount(), 1; got != want {
+				t.Errorf("tp.count = %d; want %d. Synchronous thundering herd protection failed.", got, want)
+			}
+		})
+	}
+}
+

--- a/auth/auth_token_async_test.go
+++ b/auth/auth_token_async_test.go
@@ -165,4 +165,3 @@ func TestCachedTokenProvider_TokenSyncRace(t *testing.T) {
 		})
 	}
 }
-


### PR DESCRIPTION
This commit addresses a test coverage gap regarding Thundering Herd protection on synchronous token refreshes.

The problem: There was no explicit test coverage verifying that multiple concurrent goroutines blocking on an expired token refresh are properly synchronized. Without synchronization, a high-concurrency application could trigger a "thundering herd" of simultaneous redundant network requests to the token endpoint.

What other languages do: Robust implementations (like Swift, Rust, Node.js, and recent fixes to Python/Ruby) employ strict synchronization primitives (like Mutexes, Locks, or Promise consolidation). This guarantees that only exactly one network request is made, while all other concurrent callers await and share the new cached result. This test proves that Go's implementation correctly provides this lock synchronization.