### PR TITLE
test(auth): reject authorized_user ADC credentials in idtoken loader

### DIFF
--- a/auth/credentials/idtoken/idtoken_test.go
+++ b/auth/credentials/idtoken/idtoken_test.go
@@ -370,3 +370,18 @@ func readTestFile(t *testing.T, filename string) []byte {
 	}
 	return b
 }
+
+func TestNewCredentials_UserCredentials_ADC_Unsupported(t *testing.T) {
+	t.Setenv(credsfile.GoogleAppCredsEnvVar, "../../internal/testdata/user.json")
+	opts := &Options{
+		Audience: "aud",
+	}
+	_, err := NewCredentials(opts)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	wantErrMsg := "idtoken: unsupported credentials type: authorized_user"
+	if !strings.Contains(err.Error(), wantErrMsg) {
+		t.Errorf("got error message %q, want error message containing %q", err.Error(), wantErrMsg)
+	}
+}


### PR DESCRIPTION
This library was missing test coverage for validating that `authorized_user` credential payloads are cleanly rejected when loaded via Application Default Credentials (ADC) by the `idtoken` loader.

Because an `authorized_user` relies on a one-time interactive OAuth 3-legged web flow, its refresh token can only mint access tokens for pre-consented scopes. It cannot programmatically generate an OpenID Connect (OIDC) ID token for an arbitrary new `audience` without forcing the user back to a browser consent screen.