### PR TITLE
feat(bigtable): add session core (Session struct, lifecycle, Invoke)

### DIFF
--- a/bigtable/internal/transport/session.go
+++ b/bigtable/internal/transport/session.go
@@ -1,0 +1,342 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"context"
+	"errors"
+	"log"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	spb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
+	btopt "cloud.google.com/go/bigtable/internal/option"
+	"golang.org/x/sync/semaphore"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+// multiPlexingLimit caps the number of vRPCs in flight on a single session
+// stream. The current protocol does not support multiplexing, so the value
+// must stay at 1; raising it requires a negotiated server-side change.
+const multiPlexingLimit = 1
+
+// Default heartbeat tunables. The interval is replaced once the server sends a
+// SessionParametersResponse; the initial deadline is generous enough to span
+// the first handshake.
+const (
+	defaultHeartbeatInterval = 10 * time.Second
+	initialHeartbeatGrace    = 30 * time.Minute
+)
+
+// Sentinel session-level error codes. They are wrapped in a gRPC Unavailable
+// status (so existing retry plumbing sees codes.Unavailable) while errors.Is
+// lets callers distinguish the underlying cause.
+var (
+	// ErrSessionNotActive is returned by Invoke when the session is not yet
+	// active or has begun shutting down.
+	ErrSessionNotActive = errors.New("bigtable: session not active")
+	// ErrUnavailableHeartBeatMissed indicates the session was torn down because
+	// the server stopped sending heartbeats within the negotiated window.
+	ErrUnavailableHeartBeatMissed = errors.New("bigtable: session unavailable: server heartbeat missed")
+	// ErrUnavailableGoAway indicates the server sent a GOAWAY and cancelled
+	// vRPCs that had not yet been admitted.
+	ErrUnavailableGoAway = errors.New("bigtable: session unavailable: server sent GOAWAY")
+	// ErrUnavailableSessionError indicates the server reported a fatal
+	// session-level error (an ErrorResponse with rpc_id == 0).
+	ErrUnavailableSessionError = errors.New("bigtable: session unavailable: server reported session error")
+)
+
+// State represents the lifecycle state of a Session. Sessions move strictly
+// forward through the values; once StateClosed is reached the session is
+// terminal.
+type State int
+
+const (
+	// StateNew indicates the session is newly created and not yet active.
+	StateNew State = iota
+	// StateStarting indicates the session is dialing and handshaking.
+	StateStarting
+	// StateActive indicates the session is active and ready for RPCs.
+	StateActive
+	// StateClosing indicates the session is draining and shutting down. It
+	// covers both the pre-CloseSession drain and the post-CloseSession wait
+	// for the server's EOF.
+	StateClosing
+	// StateClosed indicates the session is closed.
+	StateClosed
+)
+
+// String returns a human-readable name for the state.
+func (s State) String() string {
+	switch s {
+	case StateNew:
+		return "New"
+	case StateStarting:
+		return "Starting"
+	case StateActive:
+		return "Active"
+	case StateClosing:
+		return "Closing"
+	case StateClosed:
+		return "Closed"
+	default:
+		return "Unknown"
+	}
+}
+
+// Stream is the bidirectional gRPC stream a Session multiplexes over.
+type Stream interface {
+	Send(*spb.SessionRequest) error
+	Recv() (*spb.SessionResponse, error)
+	Header() (metadata.MD, error)
+}
+
+// SessionHooks contains optional callbacks invoked at points in a session's
+// lifecycle. Any field may be nil; the session calls only the non-nil hooks.
+// Hooks must not block; dispatch long work to a goroutine. This follows the
+// net/http/httptrace.ClientTrace pattern.
+type SessionHooks struct {
+	OnStart  func(ctx context.Context)
+	OnActive func(s *Session)
+	OnClose  func(s *Session, err error)
+}
+
+func (h SessionHooks) onStart(ctx context.Context) {
+	if h.OnStart != nil {
+		h.OnStart(ctx)
+	}
+}
+
+func (h SessionHooks) onActive(s *Session) {
+	if h.OnActive != nil {
+		h.OnActive(s)
+	}
+}
+
+func (h SessionHooks) onClose(s *Session, err error) {
+	if h.OnClose != nil {
+		h.OnClose(s, err)
+	}
+}
+
+// vrpcResult is the single value delivered to Invoke through resultChan.
+type vrpcResult struct {
+	resp        *spb.VirtualRpcResponse
+	clusterInfo *spb.ClusterInformation
+	err         error
+}
+
+// vrpcImpl tracks the state of an in-flight virtual RPC.
+type vrpcImpl struct {
+	id         int64
+	method     string
+	resultChan chan vrpcResult
+}
+
+// Session manages the lifecycle of a Bigtable Session and routes vRPCs over
+// its bidirectional Stream.
+type Session struct {
+	// nextRPCID is mutated exclusively via atomic ops; using atomic.Int64
+	// guarantees 8-byte alignment on 32-bit platforms without struct layout
+	// constraints.
+	nextRPCID atomic.Int64
+
+	mu     sync.Mutex
+	sendMu sync.Mutex
+
+	logger      *log.Logger
+	logName     string
+	stream      Stream
+	hooks       SessionHooks
+	sessionType SessionType
+	// TODO: add sessionTracer field for session-scoped OTel metrics
+	// (open/close/duration/uptime, per-operation latency). Lands in a
+	// follow-up PR; lifecycle and vRPC sites will then re-add the
+	// recordOpen/recordClose/recordOperation/setPeerInfo callbacks.
+	vrpcSem *semaphore.Weighted
+
+	state           State
+	lastStateChange time.Time
+	// closeOnce serializes hooks.OnClose so it fires exactly once even if
+	// multiple paths race to close the session.
+	closeOnce sync.Once
+
+	activeRPCs map[int64]*vrpcImpl
+
+	heartbeatInterval     time.Duration
+	nextHeartbeatDeadline time.Time
+
+	// quiescent is closed when no vRPCs remain in activeRPCs after the
+	// session enters StateClosing, or when ForceClose runs. Close() waits on
+	// it to drain in-flight RPCs without polling.
+	quiescent     chan struct{}
+	quiescentOnce sync.Once
+
+	peerInfo      *spb.PeerInfo
+	refreshConfig *spb.SessionRefreshConfig
+
+	hasOkRpcs    bool
+	hasErrorRpcs bool
+}
+
+// SessionOption configures a Session at construction time.
+type SessionOption func(*Session)
+
+// WithSessionLogger attaches a logger for diagnostic output. Without it, the
+// session logs nothing.
+func WithSessionLogger(logger *log.Logger) SessionOption {
+	return func(s *Session) { s.logger = logger }
+}
+
+// NewSession constructs a Session bound to the given stream. Pass a zero-value
+// SessionHooks if you don't need lifecycle callbacks.
+func NewSession(logName string, stream Stream, hooks SessionHooks, sessionType SessionType, opts ...SessionOption) *Session {
+	s := &Session{
+		state:                 StateNew,
+		lastStateChange:       time.Now(),
+		logName:               logName,
+		stream:                stream,
+		hooks:                 hooks,
+		activeRPCs:            make(map[int64]*vrpcImpl),
+		heartbeatInterval:     defaultHeartbeatInterval,
+		nextHeartbeatDeadline: time.Now().Add(initialHeartbeatGrace),
+		quiescent:             make(chan struct{}),
+		sessionType:           sessionType,
+		vrpcSem:               semaphore.NewWeighted(multiPlexingLimit),
+	}
+	for _, o := range opts {
+		o(s)
+	}
+	return s
+}
+
+// LogName returns the session's diagnostic identifier.
+func (s *Session) LogName() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.logName
+}
+
+// State returns the current state.
+func (s *Session) State() State {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.state
+}
+
+// PeerInfo returns the peer info, or nil if it has not been parsed yet.
+func (s *Session) PeerInfo() *spb.PeerInfo {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.peerInfo
+}
+
+// RefreshConfig returns the server-provided refresh configuration, or nil if
+// the server has not sent one.
+func (s *Session) RefreshConfig() *spb.SessionRefreshConfig {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.refreshConfig
+}
+
+// HasOkRpcs reports whether the session served at least one successful vRPC.
+func (s *Session) HasOkRpcs() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.hasOkRpcs
+}
+
+// HasErrorRpcs reports whether the session served at least one failed vRPC.
+func (s *Session) HasErrorRpcs() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.hasErrorRpcs
+}
+
+// debugf logs at debug level if a logger has been attached.
+func (s *Session) debugf(format string, args ...interface{}) {
+	if s.logger == nil {
+		return
+	}
+	btopt.Debugf(s.logger, "bigtable_session %s: "+format, append([]interface{}{s.logName}, args...)...)
+}
+
+// transitionTo sets the session state to `to` iff ok(currentState) returns
+// true. Returns the previous state and whether the transition was applied.
+// All callers using this helper share the same lock/timestamp/transition
+// pattern, so adding/removing transitions does not duplicate that bookkeeping.
+func (s *Session) transitionTo(to State, ok func(State) bool) (prev State, applied bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	prev = s.state
+	if !ok(prev) {
+		return prev, false
+	}
+	s.state = to
+	s.lastStateChange = time.Now()
+	return prev, true
+}
+
+// isState returns a predicate matching any of `allowed`.
+func isState(allowed ...State) func(State) bool {
+	return func(s State) bool {
+		for _, a := range allowed {
+			if s == a {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+// notState returns a predicate matching any state NOT in `forbidden`.
+func notState(forbidden ...State) func(State) bool {
+	return func(s State) bool {
+		for _, f := range forbidden {
+			if s == f {
+				return false
+			}
+		}
+		return true
+	}
+}
+
+// signalQuiescent closes the quiescent channel exactly once.
+func (s *Session) signalQuiescent() {
+	s.quiescentOnce.Do(func() { close(s.quiescent) })
+}
+
+// sessionErr couples a gRPC Unavailable status with a sentinel cause so that
+// both status.Code(err) and errors.Is(err, sentinel) work.
+type sessionErr struct {
+	st    *status.Status
+	cause error
+}
+
+func (e *sessionErr) Error() string              { return e.st.Err().Error() }
+func (e *sessionErr) Unwrap() error              { return e.cause }
+func (e *sessionErr) GRPCStatus() *status.Status { return e.st }
+
+// unavailable builds a sessionErr from a sentinel cause and human-readable
+// detail. The returned error carries codes.Unavailable.
+func unavailable(cause error, format string, args ...interface{}) error {
+	return &sessionErr{
+		st:    status.Newf(codes.Unavailable, format, args...),
+		cause: cause,
+	}
+}

--- a/bigtable/internal/transport/session_lifecycle.go
+++ b/bigtable/internal/transport/session_lifecycle.go
@@ -1,0 +1,394 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"time"
+
+	spb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
+	"google.golang.org/protobuf/proto"
+)
+
+const peerInfoHeaderKey = "bigtable-peer-info"
+
+// Start opens the session by sending OpenSessionRequest, then launches the
+// read and heartbeat loops. ctx governs the loops; cancelling it forces the
+// session closed. Unblocking the underlying Recv requires the caller to also
+// cancel the stream's context.
+func (s *Session) Start(ctx context.Context, req *spb.OpenSessionRequest) error {
+	if prev, ok := s.transitionTo(StateStarting, isState(StateNew)); !ok {
+		return fmt.Errorf("session already started or closed (state: %v)", prev)
+	}
+
+	openReq := &spb.SessionRequest{
+		Payload: &spb.SessionRequest_OpenSession{OpenSession: req},
+	}
+	if err := s.Send(openReq); err != nil {
+		s.ForceClose(&spb.CloseSessionRequest{
+			Reason:      spb.CloseSessionRequest_CLOSE_SESSION_REASON_ERROR,
+			Description: "failed to send open session request",
+		})
+		return fmt.Errorf("send open session request: %w", err)
+	}
+
+	go s.readLoop(ctx)
+	go s.heartBeatLoop(ctx)
+
+	s.hooks.onStart(ctx)
+	return nil
+}
+
+// ForceClose immediately transitions the session to StateClosed and cancels
+// every in-flight RPC. It is safe to call multiple times; only the first call
+// fires listener/tracer callbacks.
+func (s *Session) ForceClose(req *spb.CloseSessionRequest) {
+	if _, ok := s.transitionTo(StateClosed, notState(StateClosed)); !ok {
+		return
+	}
+
+	desc := "session force closed"
+	if req != nil && req.Description != "" {
+		desc = "session force closed: " + req.Description
+	}
+	s.cancelActiveRPCs(unavailable(closeReasonToCause(req), "%s", desc), nil)
+	s.signalQuiescent()
+	s.notifyClosed(nil)
+}
+
+// notifyClosed fires listener.OnClose exactly once over the lifetime of a
+// Session. TODO: also call tracer.recordClose once sessionTracer lands.
+func (s *Session) notifyClosed(streamErr error) {
+	s.closeOnce.Do(func() {
+		s.hooks.onClose(s, streamErr)
+	})
+}
+
+// Close requests a graceful shutdown: it transitions to StateClosing, waits
+// for in-flight RPCs to drain (or for ctx to fire), then sends
+// CloseSessionRequest. The server's EOF eventually drives handleClose, which
+// moves to StateClosed.
+func (s *Session) Close(ctx context.Context, req *spb.CloseSessionRequest) error {
+	if _, ok := s.transitionTo(StateClosing, isState(StateNew, StateStarting, StateActive)); !ok {
+		return nil
+	}
+
+	// Wait for active RPCs to drain. The quiescent channel is closed by the
+	// last RPC's cleanup defer when it sees state==Closing && empty, or by
+	// ForceClose if it races us.
+	s.mu.Lock()
+	empty := len(s.activeRPCs) == 0
+	s.mu.Unlock()
+	if empty {
+		s.signalQuiescent()
+	} else {
+		select {
+		case <-s.quiescent:
+		case <-ctx.Done():
+			s.ForceClose(nil)
+			return ctx.Err()
+		}
+	}
+
+	// If ForceClose raced us during the drain, our work is done.
+	if s.State() == StateClosed {
+		return nil
+	}
+
+	closeReq := &spb.SessionRequest{
+		Payload: &spb.SessionRequest_CloseSession{CloseSession: req},
+	}
+	if err := s.Send(closeReq); err != nil {
+		s.ForceClose(nil)
+		return fmt.Errorf("send close session request: %w", err)
+	}
+	return nil
+}
+
+// Send writes a SessionRequest under sendMu so concurrent producers don't
+// corrupt the underlying stream.
+func (s *Session) Send(req *spb.SessionRequest) error {
+	s.sendMu.Lock()
+	defer s.sendMu.Unlock()
+	return s.stream.Send(req)
+}
+
+// readLoop drives the inbound side of the stream until Recv returns an error.
+func (s *Session) readLoop(ctx context.Context) {
+	// Extract peer info from the header metadata asynchronously so we don't
+	// block reads on the header arriving.
+	go func() {
+		headerMD, err := s.stream.Header()
+		if err != nil {
+			s.debugf("stream Header() failed: %v", err)
+			return
+		}
+		s.peerInfoExtracter(headerMD.Get(peerInfoHeaderKey))
+	}()
+
+	// Supervisor: if ctx is cancelled, mark the session closed so callers
+	// observe state immediately. Unblocking Recv() requires the underlying
+	// stream's context to be cancelled by the caller.
+	readLoopDone := make(chan struct{})
+	go func() {
+		select {
+		case <-ctx.Done():
+			s.ForceClose(&spb.CloseSessionRequest{
+				Reason:      spb.CloseSessionRequest_CLOSE_SESSION_REASON_USER,
+				Description: "client context cancelled",
+			})
+		case <-readLoopDone:
+		}
+	}()
+	defer close(readLoopDone)
+
+	for {
+		resp, err := s.stream.Recv()
+		if err != nil {
+			s.handleClose(err)
+			return
+		}
+		s.handleSessionResponse(resp)
+	}
+}
+
+// handleSessionResponse dispatches every SessionResponse oneof variant.
+// Receiving any recognized frame resets the heartbeat watchdog; unknown
+// frames do NOT, so a misbehaving server cannot keep the watchdog satisfied
+// with junk payloads.
+func (s *Session) handleSessionResponse(resp *spb.SessionResponse) {
+	switch p := resp.GetPayload().(type) {
+	case *spb.SessionResponse_OpenSession:
+		s.handleOpenSession(p.OpenSession)
+	case *spb.SessionResponse_VirtualRpc:
+		s.handleVRPCResponse(p.VirtualRpc)
+	case *spb.SessionResponse_Error:
+		s.handleErrorResponse(p.Error)
+	case *spb.SessionResponse_SessionParameters:
+		s.handleSessionParameters(p.SessionParameters)
+	case *spb.SessionResponse_Heartbeat:
+		// Server emits Heartbeats during long-running VRPCs; the deadline
+		// reset below is what keeps the watchdog from firing on them.
+	case *spb.SessionResponse_GoAway:
+		s.handleGoAway(p.GoAway)
+	case *spb.SessionResponse_SessionRefreshConfig:
+		s.handleSessionRefreshConfig(p.SessionRefreshConfig)
+	default:
+		s.debugf("received SessionResponse with unknown payload type %T", p)
+		return
+	}
+	s.resetHeartbeatDeadline()
+}
+
+// handleOpenSession transitions Starting -> Active and signals listeners.
+func (s *Session) handleOpenSession(_ *spb.OpenSessionResponse) {
+	if _, ok := s.transitionTo(StateActive, isState(StateStarting)); !ok {
+		return
+	}
+	// TODO: tracer.recordOpen(ctx, nil) once sessionTracer lands.
+	s.hooks.onActive(s)
+}
+
+// handleErrorResponse splits per-RPC errors (rpc_id != 0) from session-level
+// errors (rpc_id == 0). Session-level errors force-close the session;
+// ForceClose then cancels all in-flight RPCs with ErrUnavailableSessionError.
+func (s *Session) handleErrorResponse(errResp *spb.ErrorResponse) {
+	if errResp.GetRpcId() != 0 {
+		s.handleVRPCErrorResponse(errResp)
+		return
+	}
+	desc := "server reported session-level error"
+	if errResp.Status != nil && errResp.Status.Message != "" {
+		desc = fmt.Sprintf("server session error: %s", errResp.Status.Message)
+	}
+	s.debugf("%s", desc)
+	s.ForceClose(&spb.CloseSessionRequest{
+		Reason:      spb.CloseSessionRequest_CLOSE_SESSION_REASON_ERROR,
+		Description: desc,
+	})
+}
+
+// handleSessionParameters updates the heartbeat interval negotiated by the
+// server and immediately recomputes the watchdog deadline against the new
+// interval.
+func (s *Session) handleSessionParameters(params *spb.SessionParametersResponse) {
+	if params.KeepAlive == nil {
+		return
+	}
+	interval := params.KeepAlive.AsDuration()
+	if interval <= 0 {
+		return
+	}
+	s.mu.Lock()
+	s.heartbeatInterval = interval
+	s.nextHeartbeatDeadline = time.Now().Add(3 * interval)
+	s.mu.Unlock()
+}
+
+// handleSessionRefreshConfig stores the server-provided refresh configuration
+// for later use by reconnection logic.
+func (s *Session) handleSessionRefreshConfig(cfg *spb.SessionRefreshConfig) {
+	s.mu.Lock()
+	s.refreshConfig = cfg
+	s.mu.Unlock()
+	s.debugf("stored SessionRefreshConfig (optimized_open=%t, metadata_entries=%d)",
+		cfg.GetOptimizedOpenRequest() != nil, len(cfg.GetMetadata()))
+}
+
+// handleGoAway transitions to StateClosing and cancels every RPC with an id
+// greater than the last admitted one. A late-arriving GOAWAY from an already
+// terminal session is ignored — we do not move backwards.
+func (s *Session) handleGoAway(goAway *spb.GoAwayResponse) {
+	s.transitionTo(StateClosing, notState(StateClosing, StateClosed))
+
+	lastAdmitted := goAway.GetLastRpcIdAdmitted()
+	s.debugf("received GOAWAY reason=%q description=%q last_rpc_id_admitted=%d",
+		goAway.GetReason(), goAway.GetDescription(), lastAdmitted)
+
+	err := unavailable(ErrUnavailableGoAway,
+		"vRPC not admitted before GOAWAY (last_admitted=%d)", lastAdmitted)
+	s.cancelActiveRPCs(err, func(id int64) bool { return id > lastAdmitted })
+}
+
+// handleClose is invoked when Recv returns an error. It transitions to
+// StateClosed and cancels every remaining in-flight RPC.
+func (s *Session) handleClose(err error) {
+	if _, ok := s.transitionTo(StateClosed, notState(StateClosed)); !ok {
+		return
+	}
+	s.cancelActiveRPCs(unavailable(err, "session closed: %v", err), nil)
+	s.signalQuiescent()
+	s.notifyClosed(err)
+}
+
+// resetHeartbeatDeadline pushes out the watchdog to (3 * heartbeatInterval)
+// from now. The 3x multiplier follows the protocol guidance of tolerating two
+// missed heartbeats.
+func (s *Session) resetHeartbeatDeadline() {
+	s.mu.Lock()
+	s.nextHeartbeatDeadline = time.Now().Add(3 * s.heartbeatInterval)
+	s.mu.Unlock()
+}
+
+// heartBeatLoop watches the session's heartbeat deadline using a single Timer
+// that re-arms itself when a frame extends the deadline. The watchdog is
+// only enforced while at least one VRPC is in flight: the server emits
+// Heartbeats during long-running VRPCs, so an idle session legitimately
+// receives no heartbeats and must not be torn down.
+func (s *Session) heartBeatLoop(ctx context.Context) {
+	s.mu.Lock()
+	deadline := s.nextHeartbeatDeadline
+	s.mu.Unlock()
+
+	timer := time.NewTimer(time.Until(deadline))
+	defer timer.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-timer.C:
+			s.mu.Lock()
+			if s.state == StateClosed {
+				s.mu.Unlock()
+				return
+			}
+			active := len(s.activeRPCs)
+			remaining := time.Until(s.nextHeartbeatDeadline)
+			interval := s.heartbeatInterval
+			s.mu.Unlock()
+
+			if active == 0 {
+				// Idle session: no heartbeats are expected. Re-check after
+				// one interval so a freshly-started VRPC is picked up.
+				timer.Reset(interval)
+				continue
+			}
+			if remaining > 0 {
+				// Deadline was pushed out while we were sleeping; re-arm.
+				timer.Reset(remaining)
+				continue
+			}
+			s.ForceClose(&spb.CloseSessionRequest{
+				Reason:      spb.CloseSessionRequest_CLOSE_SESSION_REASON_MISSED_HEARTBEAT,
+				Description: "client terminated session due to missed server heartbeats",
+			})
+			return
+		}
+	}
+}
+
+// peerInfoExtracter parses the base64-encoded peer info header and caches
+// the decoded PeerInfo on the session.
+func (s *Session) peerInfoExtracter(peerInfoData []string) {
+	if len(peerInfoData) == 0 {
+		return
+	}
+	encodings := []*base64.Encoding{
+		base64.RawURLEncoding,
+		base64.StdEncoding,
+		base64.RawStdEncoding,
+	}
+	var decoded []byte
+	var lastErr error
+	for _, enc := range encodings {
+		d, err := enc.DecodeString(peerInfoData[0])
+		if err == nil {
+			decoded = d
+			lastErr = nil
+			break
+		}
+		lastErr = err
+	}
+	if lastErr != nil {
+		s.debugf("decode base64 PeerInfo failed: %v", lastErr)
+		return
+	}
+	var peerInfo spb.PeerInfo
+	if err := proto.Unmarshal(decoded, &peerInfo); err != nil {
+		s.debugf("unmarshal PeerInfo proto failed: %v", err)
+		return
+	}
+	s.mu.Lock()
+	s.peerInfo = &peerInfo
+	s.mu.Unlock()
+	// TODO: capture s.logName under s.mu above and pass it to
+	// tracer.setPeerInfo(&peerInfo, logName) once sessionTracer lands.
+	s.debugf("parsed PeerInfo: transport_type=%s afe=%s",
+		peerInfo.GetTransportType(), peerInfo.GetApplicationFrontendSubzone())
+}
+
+// closeReasonToCause maps a CloseSessionRequest reason to a sentinel error,
+// or nil when the close is benign (user-initiated, downsize, unset). Callers
+// of unavailable(nil, …) get a codes.Unavailable error without a wrapped
+// sentinel, so errors.Is against the session sentinels returns false — which
+// is the correct signal for "this was an expected shutdown."
+func closeReasonToCause(req *spb.CloseSessionRequest) error {
+	if req == nil {
+		return nil
+	}
+	switch req.Reason {
+	case spb.CloseSessionRequest_CLOSE_SESSION_REASON_MISSED_HEARTBEAT:
+		return ErrUnavailableHeartBeatMissed
+	case spb.CloseSessionRequest_CLOSE_SESSION_REASON_GOAWAY:
+		return ErrUnavailableGoAway
+	case spb.CloseSessionRequest_CLOSE_SESSION_REASON_ERROR:
+		return ErrUnavailableSessionError
+	default:
+		return nil
+	}
+}

--- a/bigtable/internal/transport/session_test.go
+++ b/bigtable/internal/transport/session_test.go
@@ -1,0 +1,911 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	spb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
+	rpcstatus "google.golang.org/genproto/googleapis/rpc/status"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/durationpb"
+)
+
+// fakeStream implements Stream and exposes channels so tests can drive both
+// sides of the conversation.
+type fakeStream struct {
+	sentMu sync.Mutex
+	sent   []*spb.SessionRequest
+	recv   chan recvOp
+	hdr    metadata.MD
+	hdrErr error
+	sendFn func(*spb.SessionRequest) error
+}
+
+type recvOp struct {
+	resp *spb.SessionResponse
+	err  error
+}
+
+func newFakeStream() *fakeStream {
+	return &fakeStream{
+		recv: make(chan recvOp, 32),
+		hdr:  metadata.MD{},
+	}
+}
+
+func (f *fakeStream) Send(req *spb.SessionRequest) error {
+	if f.sendFn != nil {
+		if err := f.sendFn(req); err != nil {
+			return err
+		}
+	}
+	f.sentMu.Lock()
+	f.sent = append(f.sent, req)
+	f.sentMu.Unlock()
+	return nil
+}
+
+func (f *fakeStream) Recv() (*spb.SessionResponse, error) {
+	op, ok := <-f.recv
+	if !ok {
+		return nil, fmt.Errorf("stream closed")
+	}
+	return op.resp, op.err
+}
+
+func (f *fakeStream) Header() (metadata.MD, error) {
+	return f.hdr, f.hdrErr
+}
+
+func (f *fakeStream) snapshotSent() []*spb.SessionRequest {
+	f.sentMu.Lock()
+	defer f.sentMu.Unlock()
+	out := make([]*spb.SessionRequest, len(f.sent))
+	copy(out, f.sent)
+	return out
+}
+
+// hookCounts captures lifecycle callbacks via a SessionHooks value.
+type hookCounts struct {
+	mu          sync.Mutex
+	startCount  int
+	activeCount int
+	closeCount  int
+	closeErr    error
+}
+
+func (c *hookCounts) hooks() SessionHooks {
+	return SessionHooks{
+		OnStart: func(context.Context) {
+			c.mu.Lock()
+			defer c.mu.Unlock()
+			c.startCount++
+		},
+		OnActive: func(*Session) {
+			c.mu.Lock()
+			defer c.mu.Unlock()
+			c.activeCount++
+		},
+		OnClose: func(_ *Session, err error) {
+			c.mu.Lock()
+			defer c.mu.Unlock()
+			c.closeCount++
+			c.closeErr = err
+		},
+	}
+}
+
+func (c *hookCounts) counts() (start, active, closed int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.startCount, c.activeCount, c.closeCount
+}
+
+// fakeDesc is a minimal VRpcDescriptor for Invoke tests.
+type fakeDesc struct {
+	method string
+	enc    func(req interface{}) ([]byte, error)
+	dec    func(buf []byte) (interface{}, error)
+}
+
+func (f *fakeDesc) Method() string                              { return f.method }
+func (f *fakeDesc) Encode(req interface{}) ([]byte, error)      { return f.enc(req) }
+func (f *fakeDesc) Decode(buf []byte) (interface{}, error)      { return f.dec(buf) }
+
+func newTestSession(t *testing.T, stream Stream, hooks SessionHooks) *Session {
+	t.Helper()
+	return NewSession("test-session", stream, hooks, SessionTypeTable)
+}
+
+// waitFor polls cond every 5ms up to timeout, failing the test if cond never
+// becomes true.
+func waitFor(t *testing.T, timeout time.Duration, cond func() bool, msg string) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("timed out after %v waiting for: %s", timeout, msg)
+}
+
+// --- pure value tests --------------------------------------------------------
+
+func TestMultiPlexingLimit(t *testing.T) {
+	if multiPlexingLimit != 1 {
+		t.Errorf("multiPlexingLimit = %d, want 1 (multiplexing unsupported)", multiPlexingLimit)
+	}
+}
+
+func TestState_String(t *testing.T) {
+	tests := []struct {
+		s    State
+		want string
+	}{
+		{StateNew, "New"},
+		{StateStarting, "Starting"},
+		{StateActive, "Active"},
+		{StateClosing, "Closing"},
+		{StateClosed, "Closed"},
+		{State(99), "Unknown"},
+	}
+	for _, tt := range tests {
+		if got := tt.s.String(); got != tt.want {
+			t.Errorf("State(%d).String() = %q, want %q", int(tt.s), got, tt.want)
+		}
+	}
+}
+
+func TestNewSession_Defaults(t *testing.T) {
+	stream := newFakeStream()
+	s := NewSession("log", stream, SessionHooks{}, SessionTypeAuthorizedView)
+
+	if got := s.State(); got != StateNew {
+		t.Errorf("initial state = %v, want StateNew", got)
+	}
+	if got := s.LogName(); got != "log" {
+		t.Errorf("LogName = %q, want %q", got, "log")
+	}
+	if got := s.sessionType; got != SessionTypeAuthorizedView {
+		t.Errorf("sessionType = %v, want SessionTypeAuthorizedView", got)
+	}
+	if s.activeRPCs == nil {
+		t.Error("activeRPCs map not initialized")
+	}
+	if s.quiescent == nil {
+		t.Error("quiescent channel not initialized")
+	}
+	if s.heartbeatInterval != defaultHeartbeatInterval {
+		t.Errorf("heartbeatInterval = %v, want %v", s.heartbeatInterval, defaultHeartbeatInterval)
+	}
+	if s.vrpcSem == nil {
+		t.Error("vrpcSem not initialized")
+	}
+	if s.PeerInfo() != nil {
+		t.Error("PeerInfo should start nil")
+	}
+	if s.RefreshConfig() != nil {
+		t.Error("RefreshConfig should start nil")
+	}
+	if s.HasOkRpcs() || s.HasErrorRpcs() {
+		t.Error("HasOkRpcs/HasErrorRpcs should start false")
+	}
+}
+
+func TestCloseReasonToCause(t *testing.T) {
+	tests := []struct {
+		name string
+		req  *spb.CloseSessionRequest
+		want error
+	}{
+		{"nil request maps to nil", nil, nil},
+		{"unset reason → nil", &spb.CloseSessionRequest{Reason: spb.CloseSessionRequest_CLOSE_SESSION_REASON_UNSET}, nil},
+		{"user-initiated → nil", &spb.CloseSessionRequest{Reason: spb.CloseSessionRequest_CLOSE_SESSION_REASON_USER}, nil},
+		{"downsize → nil", &spb.CloseSessionRequest{Reason: spb.CloseSessionRequest_CLOSE_SESSION_REASON_DOWNSIZE}, nil},
+		{"missed heartbeat", &spb.CloseSessionRequest{Reason: spb.CloseSessionRequest_CLOSE_SESSION_REASON_MISSED_HEARTBEAT}, ErrUnavailableHeartBeatMissed},
+		{"goaway", &spb.CloseSessionRequest{Reason: spb.CloseSessionRequest_CLOSE_SESSION_REASON_GOAWAY}, ErrUnavailableGoAway},
+		{"error", &spb.CloseSessionRequest{Reason: spb.CloseSessionRequest_CLOSE_SESSION_REASON_ERROR}, ErrUnavailableSessionError},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := closeReasonToCause(tt.req); !errors.Is(got, tt.want) && got != tt.want {
+				t.Errorf("closeReasonToCause(%v) = %v, want %v", tt.req, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUnavailable_WrapsCauseAndStatus(t *testing.T) {
+	err := unavailable(ErrUnavailableHeartBeatMissed, "heartbeat dead for %s", "test")
+
+	if !errors.Is(err, ErrUnavailableHeartBeatMissed) {
+		t.Error("errors.Is should match ErrUnavailableHeartBeatMissed")
+	}
+	if errors.Is(err, ErrUnavailableGoAway) {
+		t.Error("errors.Is should not match unrelated sentinel")
+	}
+	if code := status.Code(err); code != codes.Unavailable {
+		t.Errorf("status.Code = %v, want Unavailable", code)
+	}
+	if msg := err.Error(); msg == "" {
+		t.Error("error string should be non-empty")
+	}
+
+	// nil cause should not crash and should still be Unavailable.
+	err = unavailable(nil, "no cause")
+	if code := status.Code(err); code != codes.Unavailable {
+		t.Errorf("nil-cause: status.Code = %v, want Unavailable", code)
+	}
+	if errors.Is(err, ErrUnavailableHeartBeatMissed) {
+		t.Error("nil-cause: errors.Is should not match any sentinel")
+	}
+}
+
+// --- handler-level tests (no Start/readLoop) ---------------------------------
+
+// makeActive constructs a session and forces it into StateActive without going
+// through the handshake.
+func makeActive(t *testing.T, hooks SessionHooks) (*Session, *fakeStream) {
+	t.Helper()
+	stream := newFakeStream()
+	s := newTestSession(t, stream, hooks)
+	s.mu.Lock()
+	s.state = StateActive
+	s.mu.Unlock()
+	return s, stream
+}
+
+func TestHandleOpenSession_TransitionsToActive(t *testing.T) {
+	stream := newFakeStream()
+	listener := &hookCounts{}
+	s := newTestSession(t, stream, listener.hooks())
+	s.mu.Lock()
+	s.state = StateStarting
+	s.mu.Unlock()
+
+	s.handleOpenSession(&spb.OpenSessionResponse{})
+
+	if got := s.State(); got != StateActive {
+		t.Errorf("state = %v, want StateActive", got)
+	}
+	if _, active, _ := listener.counts(); active != 1 {
+		t.Errorf("OnActive called %d times, want 1", active)
+	}
+
+	// Re-delivery (idempotent): no extra listener firings.
+	s.handleOpenSession(&spb.OpenSessionResponse{})
+	if _, active, _ := listener.counts(); active != 1 {
+		t.Errorf("OnActive called %d times after re-delivery, want 1", active)
+	}
+}
+
+func TestHandleVRPCResponse_RoutesByRpcID(t *testing.T) {
+	s, _ := makeActive(t, SessionHooks{})
+
+	rpc := &vrpcImpl{id: 7, method: "ReadRow", resultChan: make(chan vrpcResult, 1)}
+	s.mu.Lock()
+	s.activeRPCs[7] = rpc
+	s.mu.Unlock()
+
+	resp := &spb.VirtualRpcResponse{RpcId: 7, Payload: []byte("p")}
+	s.handleVRPCResponse(resp)
+
+	select {
+	case res := <-rpc.resultChan:
+		if res.resp != resp {
+			t.Errorf("got resp %p, want %p", res.resp, resp)
+		}
+	default:
+		t.Fatal("no result delivered")
+	}
+	if !s.HasOkRpcs() {
+		t.Error("HasOkRpcs should be true after successful response")
+	}
+	// Unknown rpc_id is dropped silently.
+	s.handleVRPCResponse(&spb.VirtualRpcResponse{RpcId: 999})
+}
+
+func TestHandleVRPCErrorResponse_RoutesByRpcID(t *testing.T) {
+	s, _ := makeActive(t, SessionHooks{})
+
+	rpc := &vrpcImpl{id: 3, method: "ReadRow", resultChan: make(chan vrpcResult, 1)}
+	s.mu.Lock()
+	s.activeRPCs[3] = rpc
+	s.mu.Unlock()
+
+	errResp := &spb.ErrorResponse{
+		RpcId:  3,
+		Status: &rpcstatus.Status{Code: int32(codes.FailedPrecondition), Message: "boom"},
+	}
+	s.handleVRPCErrorResponse(errResp)
+
+	select {
+	case res := <-rpc.resultChan:
+		if res.err == nil {
+			t.Fatal("expected error result")
+		}
+		if got := status.Code(res.err); got != codes.FailedPrecondition {
+			t.Errorf("status code = %v, want FailedPrecondition", got)
+		}
+	default:
+		t.Fatal("no result delivered")
+	}
+	if !s.HasErrorRpcs() {
+		t.Error("HasErrorRpcs should be true after error response")
+	}
+}
+
+func TestHandleErrorResponse_SessionFatalForcesClose(t *testing.T) {
+	listener := &hookCounts{}
+	s, _ := makeActive(t, listener.hooks())
+
+	// Pre-existing in-flight RPC; should be cancelled by ForceClose.
+	rpc := &vrpcImpl{id: 11, method: "ReadRow", resultChan: make(chan vrpcResult, 1)}
+	s.mu.Lock()
+	s.activeRPCs[11] = rpc
+	s.mu.Unlock()
+
+	s.handleErrorResponse(&spb.ErrorResponse{
+		RpcId:  0,
+		Status: &rpcstatus.Status{Code: int32(codes.Internal), Message: "fatal"},
+	})
+
+	if got := s.State(); got != StateClosed {
+		t.Errorf("state = %v, want StateClosed", got)
+	}
+	select {
+	case res := <-rpc.resultChan:
+		if !errors.Is(res.err, ErrUnavailableSessionError) {
+			t.Errorf("cancelled cause = %v, want ErrUnavailableSessionError", res.err)
+		}
+	default:
+		t.Fatal("in-flight RPC not cancelled by session-fatal error")
+	}
+	if _, _, closed := listener.counts(); closed != 1 {
+		t.Errorf("OnClose called %d times, want 1", closed)
+	}
+}
+
+func TestHandleGoAway_CancelsBeyondAdmitted(t *testing.T) {
+	s, _ := makeActive(t, SessionHooks{})
+
+	// rpc 1 and 2 admitted; 3 and 4 should be cancelled.
+	for _, id := range []int64{1, 2, 3, 4} {
+		s.mu.Lock()
+		s.activeRPCs[id] = &vrpcImpl{id: id, resultChan: make(chan vrpcResult, 1)}
+		s.mu.Unlock()
+	}
+
+	s.handleGoAway(&spb.GoAwayResponse{LastRpcIdAdmitted: 2, Reason: "test"})
+
+	if got := s.State(); got != StateClosing {
+		t.Errorf("state = %v, want StateClosing", got)
+	}
+	s.mu.Lock()
+	_, has1 := s.activeRPCs[1]
+	_, has2 := s.activeRPCs[2]
+	_, has3 := s.activeRPCs[3]
+	_, has4 := s.activeRPCs[4]
+	s.mu.Unlock()
+	if !has1 || !has2 {
+		t.Error("admitted RPCs (1, 2) should remain in activeRPCs")
+	}
+	if has3 || has4 {
+		t.Error("RPCs beyond admitted (3, 4) should have been removed")
+	}
+}
+
+func TestHandleSessionParameters_UpdatesIntervalAndDeadline(t *testing.T) {
+	s, _ := makeActive(t, SessionHooks{})
+	before := time.Now()
+
+	s.handleSessionParameters(&spb.SessionParametersResponse{
+		KeepAlive: durationpb.New(2 * time.Second),
+	})
+
+	s.mu.Lock()
+	gotInterval := s.heartbeatInterval
+	gotDeadline := s.nextHeartbeatDeadline
+	s.mu.Unlock()
+
+	if gotInterval != 2*time.Second {
+		t.Errorf("heartbeatInterval = %v, want 2s", gotInterval)
+	}
+	// Expect deadline ≈ now + 6s (3 * 2s).
+	wantMin := before.Add(5 * time.Second)
+	if gotDeadline.Before(wantMin) {
+		t.Errorf("nextHeartbeatDeadline = %v, want >= %v", gotDeadline, wantMin)
+	}
+
+	// Zero / nil keepalive should be ignored.
+	s.handleSessionParameters(&spb.SessionParametersResponse{})
+	s.handleSessionParameters(&spb.SessionParametersResponse{KeepAlive: durationpb.New(0)})
+
+	s.mu.Lock()
+	if s.heartbeatInterval != 2*time.Second {
+		t.Errorf("heartbeatInterval changed after no-op updates: %v", s.heartbeatInterval)
+	}
+	s.mu.Unlock()
+}
+
+func TestHandleSessionRefreshConfig_Stored(t *testing.T) {
+	s, _ := makeActive(t, SessionHooks{})
+
+	cfg := &spb.SessionRefreshConfig{
+		OptimizedOpenRequest: &spb.OpenSessionRequest{ProtocolVersion: 7},
+	}
+	s.handleSessionRefreshConfig(cfg)
+
+	got := s.RefreshConfig()
+	if got != cfg {
+		t.Errorf("RefreshConfig = %v, want %v", got, cfg)
+	}
+}
+
+func TestHandleSessionResponse_UnknownDoesNotResetDeadline(t *testing.T) {
+	s, _ := makeActive(t, SessionHooks{})
+	s.mu.Lock()
+	s.nextHeartbeatDeadline = time.Unix(0, 0) // way in the past
+	s.mu.Unlock()
+
+	// SessionResponse with no oneof set → unknown payload path.
+	s.handleSessionResponse(&spb.SessionResponse{})
+
+	s.mu.Lock()
+	got := s.nextHeartbeatDeadline
+	s.mu.Unlock()
+	if !got.Equal(time.Unix(0, 0)) {
+		t.Errorf("unknown payload reset deadline to %v; expected unchanged", got)
+	}
+
+	// A recognized variant must reset.
+	s.handleSessionResponse(&spb.SessionResponse{
+		Payload: &spb.SessionResponse_Heartbeat{Heartbeat: &spb.HeartbeatResponse{}},
+	})
+	s.mu.Lock()
+	got = s.nextHeartbeatDeadline
+	s.mu.Unlock()
+	if got.Equal(time.Unix(0, 0)) {
+		t.Error("recognized heartbeat did not reset deadline")
+	}
+}
+
+// --- Invoke tests -------------------------------------------------------
+
+func newRoundTripDesc() *fakeDesc {
+	return &fakeDesc{
+		method: "RoundTrip",
+		enc: func(req interface{}) ([]byte, error) {
+			return []byte(fmt.Sprintf("req:%v", req)), nil
+		},
+		dec: func(buf []byte) (interface{}, error) {
+			return string(buf), nil
+		},
+	}
+}
+
+func TestInvoke_RejectsWhenNotActive(t *testing.T) {
+	stream := newFakeStream()
+	s := newTestSession(t, stream, SessionHooks{}) // state = New
+	_, err := s.Invoke(context.Background(), newRoundTripDesc(), "hello")
+	if !errors.Is(err, ErrSessionNotActive) {
+		t.Errorf("err = %v, want ErrSessionNotActive in chain", err)
+	}
+	if code := status.Code(err); code != codes.Unavailable {
+		t.Errorf("status.Code = %v, want Unavailable", code)
+	}
+}
+
+func TestInvoke_HappyPath(t *testing.T) {
+	s, stream := makeActive(t, SessionHooks{})
+	desc := newRoundTripDesc()
+
+	done := make(chan struct{})
+	var res InvokeResult
+	var execErr error
+	go func() {
+		defer close(done)
+		res, execErr = s.Invoke(context.Background(), desc, "hello")
+	}()
+
+	// Wait for the request to be sent.
+	waitFor(t, time.Second, func() bool { return len(stream.snapshotSent()) > 0 }, "Send called")
+
+	sent := stream.snapshotSent()[0].GetVirtualRpc()
+	if sent == nil {
+		t.Fatal("sent frame is not a VirtualRpcRequest")
+	}
+	if string(sent.Payload) != "req:hello" {
+		t.Errorf("encoded payload = %q, want %q", sent.Payload, "req:hello")
+	}
+
+	// Deliver response.
+	s.handleVRPCResponse(&spb.VirtualRpcResponse{
+		RpcId:       sent.RpcId,
+		Payload:     []byte("world"),
+		ClusterInfo: &spb.ClusterInformation{ClusterId: "c1"},
+	})
+
+	<-done
+	if execErr != nil {
+		t.Fatalf("Invoke error: %v", execErr)
+	}
+	if got := res.Response.(string); got != "world" {
+		t.Errorf("resp = %q, want %q", got, "world")
+	}
+	if res.ClusterInfo == nil || res.ClusterInfo.ClusterId != "c1" {
+		t.Errorf("clusterInfo = %v, want ClusterId=c1", res.ClusterInfo)
+	}
+}
+
+func TestInvoke_ContextCancel(t *testing.T) {
+	s, _ := makeActive(t, SessionHooks{})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := s.Invoke(ctx, newRoundTripDesc(), "hello")
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("err = %v, want context.Canceled", err)
+	}
+}
+
+func TestInvoke_SendFailureCleansUpMap(t *testing.T) {
+	stream := newFakeStream()
+	stream.sendFn = func(req *spb.SessionRequest) error {
+		return fmt.Errorf("network down")
+	}
+	s := newTestSession(t, stream, SessionHooks{})
+	s.mu.Lock()
+	s.state = StateActive
+	s.mu.Unlock()
+
+	_, err := s.Invoke(context.Background(), newRoundTripDesc(), "hello")
+	if err == nil {
+		t.Fatal("expected error from failed Send")
+	}
+	s.mu.Lock()
+	leftOver := len(s.activeRPCs)
+	s.mu.Unlock()
+	if leftOver != 0 {
+		t.Errorf("activeRPCs = %d, want 0 (defer should clean up on Send failure)", leftOver)
+	}
+}
+
+// --- Close / ForceClose ------------------------------------------------------
+
+func TestForceClose_Idempotent(t *testing.T) {
+	listener := &hookCounts{}
+	s, _ := makeActive(t, listener.hooks())
+
+	s.ForceClose(nil)
+	s.ForceClose(nil)
+	s.ForceClose(&spb.CloseSessionRequest{Reason: spb.CloseSessionRequest_CLOSE_SESSION_REASON_ERROR})
+
+	if got := s.State(); got != StateClosed {
+		t.Errorf("state = %v, want StateClosed", got)
+	}
+	if _, _, closed := listener.counts(); closed != 1 {
+		t.Errorf("OnClose fired %d times, want 1", closed)
+	}
+}
+
+func TestForceClose_CancelsInflightWithReason(t *testing.T) {
+	s, _ := makeActive(t, SessionHooks{})
+	rpc := &vrpcImpl{id: 1, resultChan: make(chan vrpcResult, 1)}
+	s.mu.Lock()
+	s.activeRPCs[1] = rpc
+	s.mu.Unlock()
+
+	s.ForceClose(&spb.CloseSessionRequest{
+		Reason:      spb.CloseSessionRequest_CLOSE_SESSION_REASON_MISSED_HEARTBEAT,
+		Description: "no heartbeat",
+	})
+
+	select {
+	case res := <-rpc.resultChan:
+		if !errors.Is(res.err, ErrUnavailableHeartBeatMissed) {
+			t.Errorf("cancelled cause = %v, want ErrUnavailableHeartBeatMissed", res.err)
+		}
+	default:
+		t.Fatal("in-flight RPC not notified")
+	}
+}
+
+func TestClose_Graceful_NoInflightSendsCloseRequest(t *testing.T) {
+	stream := newFakeStream()
+	s := newTestSession(t, stream, SessionHooks{})
+	s.mu.Lock()
+	s.state = StateActive
+	s.mu.Unlock()
+
+	if err := s.Close(context.Background(), &spb.CloseSessionRequest{
+		Reason: spb.CloseSessionRequest_CLOSE_SESSION_REASON_USER,
+	}); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+	if got := s.State(); got != StateClosing {
+		t.Errorf("state = %v, want StateClosing", got)
+	}
+	sent := stream.snapshotSent()
+	if len(sent) != 1 || sent[0].GetCloseSession() == nil {
+		t.Errorf("expected one CloseSession frame, got %d sent frames", len(sent))
+	}
+}
+
+func TestClose_AlreadyClosingIsNoop(t *testing.T) {
+	stream := newFakeStream()
+	s := newTestSession(t, stream, SessionHooks{})
+	s.mu.Lock()
+	s.state = StateClosed
+	s.mu.Unlock()
+
+	if err := s.Close(context.Background(), nil); err != nil {
+		t.Errorf("Close on closed session = %v, want nil", err)
+	}
+	if got := s.State(); got != StateClosed {
+		t.Errorf("state changed to %v", got)
+	}
+	if len(stream.snapshotSent()) != 0 {
+		t.Error("Close on closed session should not send")
+	}
+}
+
+func TestClose_CtxCancelDuringDrainForceCloses(t *testing.T) {
+	s, _ := makeActive(t, SessionHooks{})
+	// Pin an in-flight RPC so the drain loop is forced to wait.
+	rpc := &vrpcImpl{id: 1, resultChan: make(chan vrpcResult, 1)}
+	s.mu.Lock()
+	s.activeRPCs[1] = rpc
+	s.mu.Unlock()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancelDone := make(chan struct{})
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+		close(cancelDone)
+	}()
+
+	err := s.Close(ctx, &spb.CloseSessionRequest{
+		Reason: spb.CloseSessionRequest_CLOSE_SESSION_REASON_USER,
+	})
+	<-cancelDone
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("Close err = %v, want context.Canceled", err)
+	}
+	if got := s.State(); got != StateClosed {
+		t.Errorf("state = %v, want StateClosed after ctx-cancel ForceClose", got)
+	}
+	// In-flight RPC should have been cancelled by ForceClose.
+	select {
+	case res := <-rpc.resultChan:
+		if res.err == nil {
+			t.Error("expected cancellation error on in-flight RPC")
+		}
+	default:
+		t.Error("in-flight RPC not cancelled")
+	}
+}
+
+// --- heartbeat ---------------------------------------------------------------
+
+func TestHeartBeatLoop_ForceClosesOnMissedHeartbeat(t *testing.T) {
+	s, _ := makeActive(t, SessionHooks{})
+	rpc := &vrpcImpl{id: 1, resultChan: make(chan vrpcResult, 1)}
+	s.mu.Lock()
+	s.activeRPCs[1] = rpc
+	s.nextHeartbeatDeadline = time.Now().Add(-time.Second) // already missed
+	s.mu.Unlock()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go s.heartBeatLoop(ctx)
+
+	waitFor(t, time.Second, func() bool { return s.State() == StateClosed }, "ForceClose from missed heartbeat")
+
+	select {
+	case res := <-rpc.resultChan:
+		if !errors.Is(res.err, ErrUnavailableHeartBeatMissed) {
+			t.Errorf("cancelled cause = %v, want ErrUnavailableHeartBeatMissed", res.err)
+		}
+		if code := status.Code(res.err); code != codes.Unavailable {
+			t.Errorf("status.Code = %v, want Unavailable (so existing retry plumbing applies)", code)
+		}
+	default:
+		t.Error("in-flight RPC not cancelled on heartbeat miss")
+	}
+}
+
+func TestHeartBeatLoop_HeartbeatsKeepInflightVRPCAlive(t *testing.T) {
+	// Positive case: while a VRPC is in flight and the server is sending
+	// Heartbeats, the watchdog must NOT fire. This proves the dispatch in
+	// handleSessionResponse correctly resets the deadline on every
+	// recognized frame.
+	s, _ := makeActive(t, SessionHooks{})
+	s.mu.Lock()
+	s.heartbeatInterval = 30 * time.Millisecond
+	s.nextHeartbeatDeadline = time.Now().Add(90 * time.Millisecond) // 3 * interval
+	s.activeRPCs[1] = &vrpcImpl{id: 1, resultChan: make(chan vrpcResult, 1)}
+	s.mu.Unlock()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go s.heartBeatLoop(ctx)
+
+	// Pump heartbeats for longer than 3*interval; without the deadline
+	// reset on each frame, the watchdog would have fired by now.
+	for i := 0; i < 8; i++ {
+		time.Sleep(25 * time.Millisecond)
+		s.handleSessionResponse(&spb.SessionResponse{
+			Payload: &spb.SessionResponse_Heartbeat{Heartbeat: &spb.HeartbeatResponse{}},
+		})
+	}
+
+	if got := s.State(); got != StateActive {
+		t.Errorf("session torn down despite arriving heartbeats; state = %v", got)
+	}
+}
+
+func TestHeartBeatLoop_IdleSessionIsNotTornDown(t *testing.T) {
+	// Server sends Heartbeats only during in-flight VRPCs. An idle session
+	// with an elapsed deadline must NOT be force-closed; the loop should
+	// keep checking until activity returns.
+	s, _ := makeActive(t, SessionHooks{})
+	s.mu.Lock()
+	s.heartbeatInterval = 20 * time.Millisecond // make idle re-check fast
+	s.nextHeartbeatDeadline = time.Now().Add(-time.Hour)
+	s.mu.Unlock()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go func() {
+		s.heartBeatLoop(ctx)
+		close(done)
+	}()
+
+	// Give the loop time to wake up several times on the idle interval.
+	time.Sleep(150 * time.Millisecond)
+	if s.State() == StateClosed {
+		t.Fatal("idle session was force-closed despite having no in-flight VRPCs")
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("heartBeatLoop did not exit on ctx cancel")
+	}
+}
+
+func TestHeartBeatLoop_ExitsOnCtxCancel(t *testing.T) {
+	s, _ := makeActive(t, SessionHooks{})
+	s.mu.Lock()
+	s.nextHeartbeatDeadline = time.Now().Add(time.Hour) // never expires
+	s.mu.Unlock()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		s.heartBeatLoop(ctx)
+		close(done)
+	}()
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("heartBeatLoop did not exit on ctx cancel")
+	}
+	if s.State() != StateActive {
+		t.Errorf("state = %v, want StateActive (no force-close on ctx exit)", s.State())
+	}
+}
+
+// --- peerInfoExtracter -------------------------------------------------------
+
+func TestPeerInfoExtracter_ParsesValidHeader(t *testing.T) {
+	s := newTestSession(t, newFakeStream(), SessionHooks{})
+
+	pi := &spb.PeerInfo{
+		ApplicationFrontendSubzone: "us-central1-a",
+		TransportType:              spb.PeerInfo_TRANSPORT_TYPE_DIRECT_ACCESS,
+	}
+	raw, err := proto.Marshal(pi)
+	if err != nil {
+		t.Fatalf("proto.Marshal: %v", err)
+	}
+	encoded := base64.RawURLEncoding.EncodeToString(raw)
+
+	s.peerInfoExtracter([]string{encoded})
+
+	got := s.PeerInfo()
+	if got == nil {
+		t.Fatal("PeerInfo nil after extraction")
+	}
+	if got.GetApplicationFrontendSubzone() != "us-central1-a" {
+		t.Errorf("AFE = %q, want us-central1-a", got.GetApplicationFrontendSubzone())
+	}
+	if got.GetTransportType() != spb.PeerInfo_TRANSPORT_TYPE_DIRECT_ACCESS {
+		t.Errorf("TransportType = %v, want DIRECT_ACCESS", got.GetTransportType())
+	}
+}
+
+func TestPeerInfoExtracter_EmptyAndBadInputs(t *testing.T) {
+	s := newTestSession(t, newFakeStream(), SessionHooks{})
+
+	s.peerInfoExtracter(nil)
+	s.peerInfoExtracter([]string{})
+	if s.PeerInfo() != nil {
+		t.Error("PeerInfo should remain nil for empty input")
+	}
+
+	s.peerInfoExtracter([]string{"!!!not-base64!!!"})
+	if s.PeerInfo() != nil {
+		t.Error("PeerInfo should remain nil for undecodable input")
+	}
+}
+
+// --- Start integration -------------------------------------------------------
+
+func TestStart_HandshakeAndClose(t *testing.T) {
+	stream := newFakeStream()
+	listener := &hookCounts{}
+	s := newTestSession(t, stream, listener.hooks())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := s.Start(ctx, &spb.OpenSessionRequest{ProtocolVersion: 1}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	waitFor(t, time.Second, func() bool { _, _, _ = listener.counts(); start, _, _ := listener.counts(); return start == 1 }, "OnStart")
+
+	// Initial Open frame sent.
+	if sent := stream.snapshotSent(); len(sent) != 1 || sent[0].GetOpenSession() == nil {
+		t.Fatalf("expected OpenSession frame as first send, got %d frames", len(sent))
+	}
+
+	// Deliver the OpenSession response, then EOF.
+	stream.recv <- recvOp{resp: &spb.SessionResponse{
+		Payload: &spb.SessionResponse_OpenSession{OpenSession: &spb.OpenSessionResponse{}},
+	}}
+	waitFor(t, time.Second, func() bool { return s.State() == StateActive }, "StateActive")
+	if _, active, _ := listener.counts(); active != 1 {
+		t.Errorf("OnActive fired %d times, want 1", active)
+	}
+
+	stream.recv <- recvOp{err: fmt.Errorf("server EOF")}
+	waitFor(t, time.Second, func() bool { return s.State() == StateClosed }, "StateClosed after EOF")
+	if _, _, closed := listener.counts(); closed != 1 {
+		t.Errorf("OnClose fired %d times, want 1", closed)
+	}
+}
+
+func TestStart_RejectsIfNotNew(t *testing.T) {
+	s, _ := makeActive(t, SessionHooks{})
+	if err := s.Start(context.Background(), &spb.OpenSessionRequest{}); err == nil {
+		t.Error("Start on active session should return error")
+	}
+}

--- a/bigtable/internal/transport/session_vrpc.go
+++ b/bigtable/internal/transport/session_vrpc.go
@@ -1,0 +1,242 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	spb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// InvokeResult carries the full set of outputs from a single Invoke call.
+//
+// Fields:
+//   - Response: decoded vRPC payload (typed per VRpcDescriptor.Decode); nil on error.
+//   - ClusterInfo: server-reported routing/cluster identity; may be set on
+//     both success and error paths if the server included it.
+//   - Stats: server-reported per-request statistics (notably BackendLatency);
+//     nil if the server did not populate Stats on the success frame.
+//   - SentAt: local monotonic timestamp captured immediately before the vRPC
+//     frame was handed to the bidi Send. Used downstream to derive
+//     client-side blocking latency (sentAt - attemptStart).
+//
+// ErrorResponse.RetryInfo from the server is plumbed via the returned error
+// using gRPC status details — callers can extract it with
+// status.FromError(err).Details() and type-asserting to *errdetails.RetryInfo
+// (this is exactly how RetryingVRpc already consumes it).
+type InvokeResult struct {
+	Response    interface{}
+	ClusterInfo *spb.ClusterInformation
+	Stats       *spb.SessionRequestStats
+	SentAt      time.Time
+}
+
+// Invoke executes a single virtual RPC on this session and returns every
+// observable output of the roundtrip — decoded response, cluster info,
+// server-reported Stats, and the local SentAt timestamp — so callers can
+// populate metrics (client_blocking_latency, server_backend_latency) and
+// respect server-supplied retry hints without losing data on the way out of
+// the transport.
+//
+// Calls are serialized by vrpcSem; concurrent callers queue behind the
+// in-flight RPC until the semaphore is released.
+func (s *Session) Invoke(ctx context.Context, desc VRpcDescriptor, req interface{}) (result InvokeResult, err error) {
+	if err := s.vrpcSem.Acquire(ctx, multiPlexingLimit); err != nil {
+		return InvokeResult{}, err
+	}
+	defer s.vrpcSem.Release(multiPlexingLimit)
+
+	startTime := time.Now()
+	// TODO: defer tracer.recordOperation(ctx, startTime, desc.Method(), err)
+	// once sessionTracer lands.
+
+	s.mu.Lock()
+	if s.state != StateActive {
+		st := s.state
+		s.mu.Unlock()
+		return InvokeResult{}, unavailable(ErrSessionNotActive, "session is not active (state: %v)", st)
+	}
+	s.mu.Unlock()
+
+	reqBytes, err := desc.Encode(req)
+	if err != nil {
+		return InvokeResult{}, fmt.Errorf("encode vRPC request: %w", err)
+	}
+
+	rpcID := s.nextRPCID.Add(1)
+	rpc := &vrpcImpl{
+		id:         rpcID,
+		method:     desc.Method(),
+		resultChan: make(chan vrpcResult, 1),
+	}
+
+	s.mu.Lock()
+	s.activeRPCs[rpcID] = rpc
+	s.mu.Unlock()
+	defer func() {
+		s.mu.Lock()
+		delete(s.activeRPCs, rpcID)
+		drained := s.state == StateClosing && len(s.activeRPCs) == 0
+		s.mu.Unlock()
+		if drained {
+			s.signalQuiescent()
+		}
+	}()
+
+	// Reset the heartbeat deadline whenever we send an outbound frame: the
+	// server's keepalive clock is implicitly reset by our activity.
+	s.resetHeartbeatDeadline()
+
+	attempt := int64(VRpcAttempt(ctx))
+	if attempt == 0 {
+		// Calls bypassing the retry interceptor have no attempt set in the
+		// context; treat them as the first attempt.
+		attempt = 1
+	}
+	virtRpc := &spb.VirtualRpcRequest{
+		RpcId:   rpcID,
+		Payload: reqBytes,
+		Metadata: &spb.VirtualRpcRequest_Metadata{
+			AttemptNumber: attempt,
+			AttemptStart:  timestamppb.New(startTime),
+		},
+	}
+	if dl, ok := ctx.Deadline(); ok {
+		if remaining := time.Until(dl); remaining > 0 {
+			virtRpc.Deadline = durationpb.New(remaining)
+		}
+	}
+	sessionReq := &spb.SessionRequest{
+		Payload: &spb.SessionRequest_VirtualRpc{
+			VirtualRpc: virtRpc,
+		},
+	}
+	// Capture SentAt immediately before the frame is handed to Send so
+	// downstream metrics can compute client-side blocking latency as
+	// (SentAt - attemptStart) without double-counting encode/setup overhead.
+	sentAt := time.Now()
+	result.SentAt = sentAt
+	if err := s.Send(sessionReq); err != nil {
+		return result, fmt.Errorf("send vRPC request: %w", err)
+	}
+
+	select {
+	case <-ctx.Done():
+		return result, ctx.Err()
+	case res := <-rpc.resultChan:
+		result.ClusterInfo = res.clusterInfo
+		if res.err != nil {
+			return result, res.err
+		}
+		if res.resp.RpcId != rpcID {
+			return result, fmt.Errorf("internal: response RpcId %d does not match request RpcId %d", res.resp.RpcId, rpcID)
+		}
+		respMsg, decodeErr := desc.Decode(res.resp.Payload)
+		if decodeErr != nil {
+			return result, fmt.Errorf("decode vRPC response: %w", decodeErr)
+		}
+		result.Response = respMsg
+		result.Stats = res.resp.Stats
+		return result, nil
+	}
+}
+
+// handleVRPCResponse delivers a server VirtualRpcResponse to the waiting
+// Invoke caller, if any.
+func (s *Session) handleVRPCResponse(resp *spb.VirtualRpcResponse) {
+	s.mu.Lock()
+	rpc, ok := s.activeRPCs[resp.RpcId]
+	if ok {
+		s.hasOkRpcs = true
+	}
+	s.mu.Unlock()
+
+	if !ok {
+		s.debugf("dropping VirtualRpcResponse for unknown rpc_id=%d", resp.RpcId)
+		return
+	}
+	s.deliver(rpc, vrpcResult{resp: resp, clusterInfo: resp.ClusterInfo})
+}
+
+// handleVRPCErrorResponse routes per-vRPC errors to the waiting caller.
+// Session-level errors (rpc_id == 0) are handled in handleSessionResponse.
+func (s *Session) handleVRPCErrorResponse(errResp *spb.ErrorResponse) {
+	s.mu.Lock()
+	rpc, ok := s.activeRPCs[errResp.RpcId]
+	if ok {
+		s.hasErrorRpcs = true
+	}
+	s.mu.Unlock()
+
+	if !ok {
+		s.debugf("dropping ErrorResponse for unknown rpc_id=%d", errResp.RpcId)
+		return
+	}
+
+	var goErr error
+	if errResp.Status != nil {
+		st := status.FromProto(errResp.Status)
+		// If the server attached RetryInfo to the ErrorResponse envelope,
+		// pack it into the status details so downstream consumers
+		// (notably RetryingVRpc) can recover it via status.FromError(err).
+		// .Details() — the same path they already use for inline retry
+		// hints. WithDetails returns a fresh *Status on success; on the
+		// rare failure (e.g. anypb marshal) we fall back to the bare
+		// status so the error path still propagates the server's code.
+		if errResp.RetryInfo != nil {
+			if withDetails, derr := st.WithDetails(errResp.RetryInfo); derr == nil {
+				st = withDetails
+			}
+		}
+		goErr = st.Err()
+	} else {
+		goErr = fmt.Errorf("unknown vRPC error (rpc_id=%d)", errResp.RpcId)
+	}
+	s.deliver(rpc, vrpcResult{err: goErr, clusterInfo: errResp.ClusterInfo})
+}
+
+// deliver writes a result onto the RPC's buffered (cap 1) channel. The
+// non-blocking send protects against duplicate server frames for the same
+// rpc_id; the first wins, subsequent ones are dropped.
+func (s *Session) deliver(rpc *vrpcImpl, res vrpcResult) {
+	select {
+	case rpc.resultChan <- res:
+	default:
+		s.debugf("duplicate result for rpc_id=%d (%s) dropped", rpc.id, rpc.method)
+	}
+}
+
+// cancelActiveRPCs removes and notifies every in-flight RPC matching filter
+// (or all, if filter is nil) with the given error.
+func (s *Session) cancelActiveRPCs(err error, filter func(rpcID int64) bool) {
+	s.mu.Lock()
+	cancelled := make([]*vrpcImpl, 0, len(s.activeRPCs))
+	for id, rpc := range s.activeRPCs {
+		if filter == nil || filter(id) {
+			cancelled = append(cancelled, rpc)
+			delete(s.activeRPCs, id)
+		}
+	}
+	s.mu.Unlock()
+
+	for _, rpc := range cancelled {
+		s.deliver(rpc, vrpcResult{err: err})
+	}
+}

--- a/bigtable/internal/transport/session_vrpc_test.go
+++ b/bigtable/internal/transport/session_vrpc_test.go
@@ -1,0 +1,323 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	spb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	rpcstatus "google.golang.org/genproto/googleapis/rpc/status"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/durationpb"
+)
+
+// runVRpcCapture drives an Invoke call to completion with a stub
+// VirtualRpcResponse, then returns the *VirtualRpcRequest that was sent on the
+// wire. All inspection of the deadline / metadata plumbing is done against
+// this snapshot.
+func runVRpcCapture(t *testing.T, ctx context.Context) *spb.VirtualRpcRequest {
+	t.Helper()
+	s, stream := makeActive(t, SessionHooks{})
+	desc := newRoundTripDesc()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, _ = s.Invoke(ctx, desc, "hello")
+	}()
+
+	waitFor(t, time.Second, func() bool { return len(stream.snapshotSent()) > 0 }, "Send called")
+	sent := stream.snapshotSent()[0].GetVirtualRpc()
+	if sent == nil {
+		t.Fatal("sent frame was not a VirtualRpcRequest")
+	}
+
+	// Deliver a benign success so Invoke returns and the goroutine exits.
+	s.handleVRPCResponse(&spb.VirtualRpcResponse{
+		RpcId:   sent.RpcId,
+		Payload: []byte("ok"),
+	})
+	<-done
+	return sent
+}
+
+func TestInvoke_DeadlineCarriedInRequest(t *testing.T) {
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(500*time.Millisecond))
+	defer cancel()
+
+	sent := runVRpcCapture(t, ctx)
+	if sent.Deadline == nil {
+		t.Fatal("VirtualRpc.Deadline = nil, want non-nil when ctx carries a deadline")
+	}
+	d := sent.Deadline.AsDuration()
+	if d <= 0 || d > 500*time.Millisecond {
+		t.Errorf("VirtualRpc.Deadline = %v, want in (0, 500ms]", d)
+	}
+	// A negative or absurdly small value would imply we lost most of the
+	// budget to test setup; sanity-bound it.
+	if d < time.Microsecond {
+		t.Errorf("VirtualRpc.Deadline = %v, suspiciously small", d)
+	}
+}
+
+func TestInvoke_NoDeadlineWhenCtxHasNone(t *testing.T) {
+	sent := runVRpcCapture(t, context.Background())
+	if sent.Deadline != nil {
+		t.Errorf("VirtualRpc.Deadline = %v, want nil when ctx has no deadline", sent.Deadline.AsDuration())
+	}
+}
+
+func TestInvoke_AttemptNumberFromCtx(t *testing.T) {
+	// WithAttempt is a no-op unless WithVRpcMetadata has seeded the context
+	// with a vrpcMetadata struct first — that's how the retrying interceptor
+	// uses it in production (the retry loop seeds attempt=1 on entry, then
+	// updates via WithAttempt on each retry).
+	ctx := WithVRpcMetadata(context.Background(), "ReadRow", 1)
+	ctx = WithAttempt(ctx, 7)
+	sent := runVRpcCapture(t, ctx)
+	if sent.Metadata == nil {
+		t.Fatal("VirtualRpc.Metadata = nil")
+	}
+	if got := sent.Metadata.AttemptNumber; got != 7 {
+		t.Errorf("AttemptNumber = %d, want 7", got)
+	}
+}
+
+func TestInvoke_AttemptNumberDefault(t *testing.T) {
+	sent := runVRpcCapture(t, context.Background())
+	if sent.Metadata == nil {
+		t.Fatal("VirtualRpc.Metadata = nil")
+	}
+	if got := sent.Metadata.AttemptNumber; got != 1 {
+		t.Errorf("AttemptNumber = %d, want 1 (calls without WithAttempt should default to first attempt)", got)
+	}
+}
+
+func TestInvoke_AttemptStartIsRecent(t *testing.T) {
+	before := time.Now()
+	sent := runVRpcCapture(t, context.Background())
+	after := time.Now()
+
+	if sent.Metadata == nil || sent.Metadata.AttemptStart == nil {
+		t.Fatal("VirtualRpc.Metadata.AttemptStart = nil")
+	}
+	got := sent.Metadata.AttemptStart.AsTime()
+	// Allow a small slop so wall-clock skew between captures doesn't flake.
+	const slop = 2 * time.Second
+	if got.Before(before.Add(-slop)) || got.After(after.Add(slop)) {
+		t.Errorf("AttemptStart = %v, want within [%v, %v] (slop %v)", got, before, after, slop)
+	}
+}
+
+// --- Invoke: Stats, SentAt, RetryInfo plumbing ------------------------
+
+// runInvoke drives an Invoke call to completion by waiting for the
+// outbound frame, calling deliver(sent) to produce the server response, and
+// returning the populated InvokeResult + err. It mirrors runVRpcCapture but
+// returns the full InvokeResult so tests can assert on Stats / SentAt /
+// ClusterInfo without the back-compat triple stripping them.
+func runInvoke(t *testing.T, ctx context.Context, deliver func(s *Session, sent *spb.VirtualRpcRequest)) (InvokeResult, error) {
+	t.Helper()
+	s, stream := makeActive(t, SessionHooks{})
+	desc := newRoundTripDesc()
+
+	type outcome struct {
+		res InvokeResult
+		err error
+	}
+	resCh := make(chan outcome, 1)
+	go func() {
+		r, err := s.Invoke(ctx, desc, "hello")
+		resCh <- outcome{res: r, err: err}
+	}()
+
+	waitFor(t, time.Second, func() bool { return len(stream.snapshotSent()) > 0 }, "Send called")
+	sent := stream.snapshotSent()[0].GetVirtualRpc()
+	if sent == nil {
+		t.Fatal("sent frame was not a VirtualRpcRequest")
+	}
+	deliver(s, sent)
+	select {
+	case out := <-resCh:
+		return out.res, out.err
+	case <-time.After(time.Second):
+		t.Fatal("Invoke did not return after delivering response")
+		return InvokeResult{}, nil
+	}
+}
+
+func TestInvoke_StatsExtractedFromResponse(t *testing.T) {
+	const wantBackend = 123 * time.Millisecond
+
+	before := time.Now()
+	res, err := runInvoke(t, context.Background(), func(s *Session, sent *spb.VirtualRpcRequest) {
+		s.handleVRPCResponse(&spb.VirtualRpcResponse{
+			RpcId:   sent.RpcId,
+			Payload: []byte("ok"),
+			Stats: &spb.SessionRequestStats{
+				BackendLatency: durationpb.New(wantBackend),
+			},
+		})
+	})
+	if err != nil {
+		t.Fatalf("Invoke: unexpected err %v", err)
+	}
+	if res.Stats == nil {
+		t.Fatal("InvokeResult.Stats = nil, want non-nil (server-supplied Stats must be propagated)")
+	}
+	if got := res.Stats.GetBackendLatency().AsDuration(); got != wantBackend {
+		t.Errorf("InvokeResult.Stats.BackendLatency = %v, want %v", got, wantBackend)
+	}
+	// Sanity bookend on SentAt.
+	if res.SentAt.Before(before) {
+		t.Errorf("SentAt %v < before %v", res.SentAt, before)
+	}
+}
+
+func TestInvoke_StatsNilWhenServerOmits(t *testing.T) {
+	res, err := runInvoke(t, context.Background(), func(s *Session, sent *spb.VirtualRpcRequest) {
+		s.handleVRPCResponse(&spb.VirtualRpcResponse{
+			RpcId:   sent.RpcId,
+			Payload: []byte("ok"),
+			// Stats intentionally nil.
+		})
+	})
+	if err != nil {
+		t.Fatalf("Invoke: unexpected err %v", err)
+	}
+	if res.Stats != nil {
+		t.Errorf("InvokeResult.Stats = %v, want nil when server omits Stats", res.Stats)
+	}
+}
+
+func TestInvoke_SentAtIsNonZero(t *testing.T) {
+	before := time.Now()
+	res, err := runInvoke(t, context.Background(), func(s *Session, sent *spb.VirtualRpcRequest) {
+		s.handleVRPCResponse(&spb.VirtualRpcResponse{
+			RpcId:   sent.RpcId,
+			Payload: []byte("ok"),
+		})
+	})
+	after := time.Now()
+	if err != nil {
+		t.Fatalf("Invoke: unexpected err %v", err)
+	}
+	if res.SentAt.IsZero() {
+		t.Fatal("SentAt is zero after a successful send; want non-zero")
+	}
+	// SentAt must land in the [before, after] window (with a small slop to
+	// tolerate clock skew between samples).
+	const slop = 2 * time.Second
+	if res.SentAt.Before(before.Add(-slop)) || res.SentAt.After(after.Add(slop)) {
+		t.Errorf("SentAt = %v, want within [%v, %v]", res.SentAt, before, after)
+	}
+}
+
+func TestInvoke_SentAtIsSetEvenOnSendFailure(t *testing.T) {
+	// session_vrpc.go captures SentAt *before* calling Send. That is the
+	// contract callers rely on for client-blocking-latency math — we record
+	// when we attempted to hand the frame off, not whether the handoff
+	// succeeded. This test pins that contract: a Send-failure must still
+	// return a non-zero SentAt.
+	stream := newFakeStream()
+	stream.sendFn = func(req *spb.SessionRequest) error {
+		return fmt.Errorf("network down")
+	}
+	s := newTestSession(t, stream, SessionHooks{})
+	s.mu.Lock()
+	s.state = StateActive
+	s.mu.Unlock()
+
+	before := time.Now()
+	res, err := s.Invoke(context.Background(), newRoundTripDesc(), "hello")
+	after := time.Now()
+	if err == nil {
+		t.Fatal("Invoke: expected error from failing Send, got nil")
+	}
+	if res.SentAt.IsZero() {
+		t.Errorf("SentAt is zero after Send failure; want non-zero (session_vrpc.go captures SentAt before calling Send)")
+	}
+	const slop = 2 * time.Second
+	if res.SentAt.Before(before.Add(-slop)) || res.SentAt.After(after.Add(slop)) {
+		t.Errorf("SentAt = %v on Send-failure path; want within [%v, %v]", res.SentAt, before, after)
+	}
+}
+
+func TestInvoke_ClusterInfoOnErrorPath(t *testing.T) {
+	res, err := runInvoke(t, context.Background(), func(s *Session, sent *spb.VirtualRpcRequest) {
+		s.handleVRPCErrorResponse(&spb.ErrorResponse{
+			RpcId:       sent.RpcId,
+			Status:      &rpcstatus.Status{Code: int32(codes.FailedPrecondition), Message: "boom"},
+			ClusterInfo: &spb.ClusterInformation{ClusterId: "c1", ZoneId: "z1"},
+		})
+	})
+	if err == nil {
+		t.Fatal("Invoke returned nil err on ErrorResponse path; want non-nil")
+	}
+	if res.ClusterInfo == nil {
+		t.Fatal("InvokeResult.ClusterInfo = nil on error path; want it preserved from ErrorResponse.ClusterInfo")
+	}
+	if got := res.ClusterInfo.ClusterId; got != "c1" {
+		t.Errorf("ClusterInfo.ClusterId = %q, want %q", got, "c1")
+	}
+	if got := res.ClusterInfo.ZoneId; got != "z1" {
+		t.Errorf("ClusterInfo.ZoneId = %q, want %q", got, "z1")
+	}
+}
+
+func TestInvoke_RetryInfoPackedIntoStatus(t *testing.T) {
+	// Marquee test for the RetryInfo plumbing in handleVRPCErrorResponse:
+	// the server-supplied RetryInfo on ErrorResponse must be packed into the
+	// status details so downstream consumers can recover it via
+	// status.FromError(err).Details(). RetryingVRpc reads it from there.
+	const wantDelay = 250 * time.Millisecond
+
+	_, err := runInvoke(t, context.Background(), func(s *Session, sent *spb.VirtualRpcRequest) {
+		s.handleVRPCErrorResponse(&spb.ErrorResponse{
+			RpcId:     sent.RpcId,
+			Status:    &rpcstatus.Status{Code: int32(codes.Unavailable), Message: "boom"},
+			RetryInfo: &errdetails.RetryInfo{RetryDelay: durationpb.New(wantDelay)},
+		})
+	})
+	if err == nil {
+		t.Fatal("Invoke returned nil err on ErrorResponse path; want non-nil")
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("status.FromError(%v) returned ok=false; want a gRPC status error", err)
+	}
+	if st.Code() != codes.Unavailable {
+		t.Errorf("status.Code = %v, want Unavailable", st.Code())
+	}
+	var found *errdetails.RetryInfo
+	for _, d := range st.Details() {
+		if ri, ok := d.(*errdetails.RetryInfo); ok {
+			found = ri
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("RetryInfo not found in status.Details (%d details total); the handleVRPCErrorResponse plumbing failed to attach it", len(st.Details()))
+	}
+	if got := found.GetRetryDelay().AsDuration(); got != wantDelay {
+		t.Errorf("RetryInfo.RetryDelay = %v, want %v", got, wantDelay)
+	}
+}
+

--- a/bigtable/internal/transport/vrpc.go
+++ b/bigtable/internal/transport/vrpc.go
@@ -1,0 +1,75 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"context"
+)
+
+type contextKey struct{}
+
+type vrpcMetadata struct {
+	method  string
+	attempt int
+}
+
+// WithVRpcMetadata returns a new context with virtual RPC metadata set.
+func WithVRpcMetadata(ctx context.Context, method string, attempt int) context.Context {
+	return context.WithValue(ctx, contextKey{}, &vrpcMetadata{
+		method:  method,
+		attempt: attempt,
+	})
+}
+
+// WithAttempt returns a new context with the virtual RPC attempt updated.
+func WithAttempt(ctx context.Context, attempt int) context.Context {
+	if md, ok := ctx.Value(contextKey{}).(*vrpcMetadata); ok {
+		return context.WithValue(ctx, contextKey{}, &vrpcMetadata{
+			method:  md.method,
+			attempt: attempt,
+		})
+	}
+	return ctx
+}
+
+// VRpcMethod extracts the virtual RPC method name from the context.
+func VRpcMethod(ctx context.Context) string {
+	if md, ok := ctx.Value(contextKey{}).(*vrpcMetadata); ok {
+		return md.method
+	}
+	return ""
+}
+
+// VRpcAttempt extracts the virtual RPC attempt number (1-indexed) from the context.
+func VRpcAttempt(ctx context.Context) int {
+	if md, ok := ctx.Value(contextKey{}).(*vrpcMetadata); ok {
+		return md.attempt
+	}
+	return 0
+}
+
+// Handler represents the core execution function of a virtual RPC downstream invocation.
+type Handler func(ctx context.Context, req interface{}) (interface{}, error)
+
+// Interceptor represents a decorator middleware that intercepts a virtual RPC downstream invocation.
+type Interceptor func(ctx context.Context, req interface{}, handler Handler) (interface{}, error)
+
+// VRpcListener receives notifications of vRPC attempt lifecycles.
+type VRpcListener interface {
+	// OnAttemptStart is called before a new attempt is executed.
+	OnAttemptStart(ctx context.Context)
+	// OnAttemptComplete is called after an attempt completes (with success or error).
+	OnAttemptComplete(ctx context.Context, err error)
+}


### PR DESCRIPTION
## Summary

Introduces the **Session** primitive used by the upcoming session-pool transport: a per-stream state machine that owns the bidirectional `SessionRequest`/`SessionResponse` conversation with the server, plus the `Invoke` path for sending vRPCs over an active session.

This PR is the first in a sequence and is self-contained — it adds new files under `bigtable/internal/transport/` and does not touch any existing code paths.

### What's in the box

- **`session.go`** — `Session` struct, `State` enum (`New` / `Starting` / `Active` / `Closing` / `Closed`), sentinel errors (`ErrSessionNotActive`, `ErrUnavailableGoAway`, `ErrUnavailableHeartBeatMissed`, `ErrUnavailableSessionError`), hook surface (`SessionHooks`), `transitionTo` helper.
- **`session_lifecycle.go`** — `Start` / `Send` / `Close` / `ForceClose`, the read loop, the heartbeat loop, and per-frame handlers (`OpenSession`, `Heartbeat`, `GoAway`, `SessionParameters`, `SessionRefreshConfig`, `ErrorResponse`).
- **`session_vrpc.go`** — `Invoke` path. Per-RPC: encode → `Send` → await response, returning `InvokeResult{Response, ClusterInfo, Stats, SentAt}`. `RetryInfo` from server `ErrorResponse` is plumbed into the returned error via gRPC status details so `RetryingVRpc` can honor server-supplied backoff.
- **`vrpc.go`** — vRPC context helpers (`WithVRpcMetadata`, `WithAttempt`, `VRpcAttempt`) used by the retry interceptor and the `Invoke` path to propagate method name and attempt number across retries.
- **`session_test.go` / `session_vrpc_test.go`** — state-machine, send/recv, drain, heartbeat, `Stats` / `SentAt` / `RetryInfo` plumbing, deadline carry, attempt-number-from-ctx.

### Deferred to a follow-up

`sessionTracer` (OTel session-scoped metrics — open / close / duration / uptime / per-operation latency) is intentionally **not** included here. The four call sites that will plug it back in are marked with explicit `TODO` comments:

- `session.go` — `tracer *sessionTracer` field on `Session`
- `session_lifecycle.go` — `notifyClosed` (recordClose), `handleOpenSession` (recordOpen), peer-info extracter (setPeerInfo)
- `session_vrpc.go` — `Invoke` (recordOperation)

## Test plan
- [x] `go build ./...` in `bigtable/`
- [x] `go vet ./internal/transport/...`
- [x] `go test ./internal/transport/... -count=1` (passes; 3.75s)
- [ ] Session-pool / SessionTable wiring lands in subsequent PRs