### PR TITLE
feat(bigtable): add Session state enum

### DIFF
--- a/bigtable/internal/transport/session_state.go
+++ b/bigtable/internal/transport/session_state.go
@@ -1,0 +1,53 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+// State represents the lifecycle state of a Session. Sessions move strictly
+// forward through the values; once StateClosed is reached the session is
+// terminal.
+type State int
+
+const (
+	// StateNew indicates the session is newly created and not yet active.
+	StateNew State = iota
+	// StateStarting indicates the session is dialing and handshaking.
+	StateStarting
+	// StateActive indicates the session is active and ready for RPCs.
+	StateActive
+	// StateClosing indicates the session is draining and shutting down. It
+	// covers both the pre-CloseSession drain and the post-CloseSession wait
+	// for the server's EOF.
+	StateClosing
+	// StateClosed indicates the session is closed.
+	StateClosed
+)
+
+// String returns a human-readable name for the state.
+func (s State) String() string {
+	switch s {
+	case StateNew:
+		return "New"
+	case StateStarting:
+		return "Starting"
+	case StateActive:
+		return "Active"
+	case StateClosing:
+		return "Closing"
+	case StateClosed:
+		return "Closed"
+	default:
+		return "Unknown"
+	}
+}

--- a/bigtable/internal/transport/session_state.go
+++ b/bigtable/internal/transport/session_state.go
@@ -15,22 +15,27 @@
 package internal
 
 // State represents the lifecycle state of a Session. Sessions move strictly
-// forward through the values; once StateClosed is reached the session is
-// terminal.
+// forward through the values (monotonic by ordinal); once StateClosed is
+// reached the session is terminal. Modeled on the SessionState enum in the
+// Java Bigtable client (google-cloud-java).
 type State int
 
 const (
-	// StateNew indicates the session is newly created and not yet active.
+	// StateNew indicates the session is newly created and not yet started.
 	StateNew State = iota
-	// StateStarting indicates the session is dialing and handshaking.
+	// StateStarting indicates the session is dialing and handshaking
+	// (OpenSession in flight).
 	StateStarting
-	// StateActive indicates the session is active and ready for RPCs.
-	StateActive
-	// StateClosing indicates the session is draining and shutting down. It
-	// covers both the pre-CloseSession drain and the post-CloseSession wait
-	// for the server's EOF.
+	// StateReady indicates the session has received OpenSessionResponse and
+	// is ready to dispatch vRPCs.
+	StateReady
+	// StateClosing indicates a client-initiated close is in progress: the
+	// session is draining outstanding vRPCs before sending CloseSession.
 	StateClosing
-	// StateClosed indicates the session is closed.
+	// StateWaitServerClose indicates CloseSession has been sent and the
+	// session is waiting for the server's EOF (trailers) on the stream.
+	StateWaitServerClose
+	// StateClosed indicates the session is fully closed. Terminal.
 	StateClosed
 )
 
@@ -41,10 +46,12 @@ func (s State) String() string {
 		return "New"
 	case StateStarting:
 		return "Starting"
-	case StateActive:
-		return "Active"
+	case StateReady:
+		return "Ready"
 	case StateClosing:
 		return "Closing"
+	case StateWaitServerClose:
+		return "WaitServerClose"
 	case StateClosed:
 		return "Closed"
 	default:

--- a/bigtable/internal/transport/session_state_test.go
+++ b/bigtable/internal/transport/session_state_test.go
@@ -1,0 +1,58 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import "testing"
+
+func TestState_String(t *testing.T) {
+	cases := []struct {
+		state State
+		want  string
+	}{
+		{StateNew, "New"},
+		{StateStarting, "Starting"},
+		{StateActive, "Active"},
+		{StateClosing, "Closing"},
+		{StateClosed, "Closed"},
+		{State(99), "Unknown"},
+	}
+	for _, tc := range cases {
+		if got := tc.state.String(); got != tc.want {
+			t.Errorf("State(%d).String() = %q, want %q", int(tc.state), got, tc.want)
+		}
+	}
+}
+
+// TestState_OrdinalsPinned guards against accidental renumbering of the State
+// constants. Several downstream paths (logs, metrics labels) rely on the
+// numeric ordinals being stable across releases; bumping one shifts every
+// state above it.
+func TestState_OrdinalsPinned(t *testing.T) {
+	cases := []struct {
+		state State
+		want  int
+	}{
+		{StateNew, 0},
+		{StateStarting, 1},
+		{StateActive, 2},
+		{StateClosing, 3},
+		{StateClosed, 4},
+	}
+	for _, tc := range cases {
+		if got := int(tc.state); got != tc.want {
+			t.Errorf("int(%s) = %d, want %d", tc.state, got, tc.want)
+		}
+	}
+}

--- a/bigtable/internal/transport/session_state_test.go
+++ b/bigtable/internal/transport/session_state_test.go
@@ -23,8 +23,9 @@ func TestState_String(t *testing.T) {
 	}{
 		{StateNew, "New"},
 		{StateStarting, "Starting"},
-		{StateActive, "Active"},
+		{StateReady, "Ready"},
 		{StateClosing, "Closing"},
+		{StateWaitServerClose, "WaitServerClose"},
 		{StateClosed, "Closed"},
 		{State(99), "Unknown"},
 	}
@@ -38,7 +39,8 @@ func TestState_String(t *testing.T) {
 // TestState_OrdinalsPinned guards against accidental renumbering of the State
 // constants. Several downstream paths (logs, metrics labels) rely on the
 // numeric ordinals being stable across releases; bumping one shifts every
-// state above it.
+// state above it. Ordinals also match the Java SessionState.phase values so
+// telemetry compares across language clients.
 func TestState_OrdinalsPinned(t *testing.T) {
 	cases := []struct {
 		state State
@@ -46,9 +48,10 @@ func TestState_OrdinalsPinned(t *testing.T) {
 	}{
 		{StateNew, 0},
 		{StateStarting, 1},
-		{StateActive, 2},
+		{StateReady, 2},
 		{StateClosing, 3},
-		{StateClosed, 4},
+		{StateWaitServerClose, 4},
+		{StateClosed, 5},
 	}
 	for _, tc := range cases {
 		if got := int(tc.state); got != tc.want {


### PR DESCRIPTION
## Summary

First in a series of small PRs that together replace the all-at-once #19980. Introduces just the **State** enum used by the upcoming Session primitive, modeled on the [`SessionState` enum in the Java Bigtable client](https://github.com/googleapis/google-cloud-java/blob/main/java-bigtable/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/internal/session/Session.java) so vocabulary and ordinals line up across language clients:

- Six values: `StateNew`, `StateStarting`, `StateReady`, `StateClosing`, `StateWaitServerClose`, `StateClosed`
- `StateClosing` is the client-initiated drain (before `CloseSession` is sent); `StateWaitServerClose` is the post-`CloseSession` wait for the server's EOF
- A `String()` method for logs
- An ordinal-pin test so log scrapers / metric labels stay stable across releases and match the Java `phase` values

Sessions move strictly forward through these values; once `StateClosed` is reached the session is terminal.

## What's next (stacked on top)

- Session struct + hooks
- Session lifecycle (`Start` / `Send` / `Close`, read loop, heartbeat, frame handlers)
- `Invoke` path (vRPC encode → send → await response → `InvokeResult`)
- `SessionTracer` (OTel session-scoped metrics) lands last

## Test plan
- [x] `gofmt`, `goimports`, `go vet`, `staticcheck`, `revive` clean
- [x] `go test ./internal/transport/ -run TestState -count=1` passes (both `TestState_String` and `TestState_OrdinalsPinned`)
