### PR TITLE
chore: cleanup librarian config for stale proto.CloneOf feature

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -34,7 +34,6 @@ default:
     toolchain: go1.25.8
     default_enabled_generator_features:
       - F_open_telemetry_attributes
-      - F_proto_cloneof
 libraries:
   - name: accessapproval
     version: 1.13.0
@@ -156,21 +155,18 @@ libraries:
           enabled_generator_features:
             - F_mtls_hard_bound_tokens
             - F_open_telemetry_attributes
-            - F_proto_cloneof
           no_metadata: true
       - path: google/cloud/asset/v1p5beta1
         go:
           enabled_generator_features:
             - F_mtls_hard_bound_tokens
             - F_open_telemetry_attributes
-            - F_proto_cloneof
           no_metadata: true
       - path: google/cloud/asset/v1p2beta1
         go:
           enabled_generator_features:
             - F_mtls_hard_bound_tokens
             - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: assuredworkloads
     version: 1.18.0
     apis:
@@ -240,133 +236,114 @@ libraries:
           enabled_generator_features:
             - F_dynamic_resource_heuristics
             - F_open_telemetry_attributes
-            - F_proto_cloneof
           no_snippets: true
       - path: google/cloud/bigquery/datapolicies/v2
         go:
           enabled_generator_features:
             - F_dynamic_resource_heuristics
             - F_open_telemetry_attributes
-            - F_proto_cloneof
           no_snippets: true
       - path: google/cloud/bigquery/datatransfer/v1
         go:
           enabled_generator_features:
             - F_dynamic_resource_heuristics
             - F_open_telemetry_attributes
-            - F_proto_cloneof
           no_snippets: true
       - path: google/cloud/bigquery/biglake/v1
         go:
           enabled_generator_features:
             - F_dynamic_resource_heuristics
             - F_open_telemetry_attributes
-            - F_proto_cloneof
           no_snippets: true
       - path: google/cloud/bigquery/storage/v1
         go:
           enabled_generator_features:
             - F_dynamic_resource_heuristics
             - F_open_telemetry_attributes
-            - F_proto_cloneof
           no_snippets: true
       - path: google/cloud/bigquery/connection/v1
         go:
           enabled_generator_features:
             - F_dynamic_resource_heuristics
             - F_open_telemetry_attributes
-            - F_proto_cloneof
           no_snippets: true
       - path: google/cloud/bigquery/reservation/v1
         go:
           enabled_generator_features:
             - F_dynamic_resource_heuristics
             - F_open_telemetry_attributes
-            - F_proto_cloneof
           no_snippets: true
       - path: google/cloud/bigquery/analyticshub/v1
         go:
           enabled_generator_features:
             - F_dynamic_resource_heuristics
             - F_open_telemetry_attributes
-            - F_proto_cloneof
           no_snippets: true
       - path: google/cloud/bigquery/datapolicies/v1
         go:
           enabled_generator_features:
             - F_dynamic_resource_heuristics
             - F_open_telemetry_attributes
-            - F_proto_cloneof
           no_snippets: true
       - path: google/cloud/bigquery/datapolicies/v2beta1
         go:
           enabled_generator_features:
             - F_dynamic_resource_heuristics
             - F_open_telemetry_attributes
-            - F_proto_cloneof
           no_snippets: true
       - path: google/cloud/bigquery/migration/v2alpha
         go:
           enabled_generator_features:
             - F_dynamic_resource_heuristics
             - F_open_telemetry_attributes
-            - F_proto_cloneof
           no_snippets: true
       - path: google/cloud/bigquery/storage/v1beta2
         go:
           enabled_generator_features:
             - F_dynamic_resource_heuristics
             - F_open_telemetry_attributes
-            - F_proto_cloneof
           no_snippets: true
       - path: google/cloud/bigquery/datapolicies/v1beta1
         go:
           enabled_generator_features:
             - F_dynamic_resource_heuristics
             - F_open_telemetry_attributes
-            - F_proto_cloneof
           no_snippets: true
       - path: google/cloud/bigquery/dataexchange/v1beta1
         go:
           enabled_generator_features:
             - F_dynamic_resource_heuristics
             - F_open_telemetry_attributes
-            - F_proto_cloneof
           no_snippets: true
       - path: google/cloud/bigquery/connection/v1beta1
         go:
           enabled_generator_features:
             - F_dynamic_resource_heuristics
             - F_open_telemetry_attributes
-            - F_proto_cloneof
           no_snippets: true
       - path: google/cloud/bigquery/storage/v1beta1
         go:
           enabled_generator_features:
             - F_dynamic_resource_heuristics
             - F_open_telemetry_attributes
-            - F_proto_cloneof
           no_snippets: true
       - path: google/cloud/bigquery/storage/v1beta
         go:
           enabled_generator_features:
             - F_dynamic_resource_heuristics
             - F_open_telemetry_attributes
-            - F_proto_cloneof
           no_snippets: true
       - path: google/cloud/bigquery/biglake/v1alpha1
         go:
           enabled_generator_features:
             - F_dynamic_resource_heuristics
             - F_open_telemetry_attributes
-            - F_proto_cloneof
           no_snippets: true
       - path: google/cloud/bigquery/storage/v1alpha
         go:
           enabled_generator_features:
             - F_dynamic_resource_heuristics
             - F_open_telemetry_attributes
-            - F_proto_cloneof
           no_snippets: true
     keep:
       - README.md
@@ -382,7 +359,6 @@ libraries:
             - F_dynamic_resource_heuristics
             - F_open_telemetry_attributes
             - F_wrapper_types_for_page_size
-            - F_proto_cloneof
           import_path: bigquery/v2/apiv2
           no_snippets: true
     keep:
@@ -486,7 +462,6 @@ libraries:
           enabled_generator_features:
             - F_mtls_hard_bound_tokens
             - F_open_telemetry_attributes
-            - F_proto_cloneof
           import_path: cloudtasks/apiv2
       - path: google/cloud/tasks/v2beta3
         go:
@@ -494,7 +469,6 @@ libraries:
           enabled_generator_features:
             - F_mtls_hard_bound_tokens
             - F_open_telemetry_attributes
-            - F_proto_cloneof
           import_path: cloudtasks/apiv2beta3
       - path: google/cloud/tasks/v2beta2
         go:
@@ -502,7 +476,6 @@ libraries:
           enabled_generator_features:
             - F_mtls_hard_bound_tokens
             - F_open_telemetry_attributes
-            - F_proto_cloneof
           import_path: cloudtasks/apiv2beta2
   - name: commerce
     version: 1.7.0
@@ -517,14 +490,12 @@ libraries:
           enabled_generator_features:
             - F_dynamic_resource_heuristics
             - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/compute/v1beta
         go:
           diregapic: true
           enabled_generator_features:
             - F_dynamic_resource_heuristics
             - F_open_telemetry_attributes
-            - F_proto_cloneof
     go:
       nested_module: metadata
   - name: compute/metadata
@@ -586,7 +557,6 @@ libraries:
           enabled_generator_features:
             - F_mtls_hard_bound_tokens
             - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: dataform
     version: 1.0.0
     apis:
@@ -630,14 +600,12 @@ libraries:
           enabled_generator_features:
             - F_mtls_hard_bound_tokens
             - F_open_telemetry_attributes
-            - F_proto_cloneof
           proto_only: true
       - path: google/datastore/admin/v1
         go:
           enabled_generator_features:
             - F_mtls_hard_bound_tokens
             - F_open_telemetry_attributes
-            - F_proto_cloneof
     skip_release: true
   - name: datastream
     version: 1.20.0
@@ -704,7 +672,6 @@ libraries:
           enabled_generator_features:
             - F_mtls_hard_bound_tokens
             - F_open_telemetry_attributes
-            - F_proto_cloneof
           import_path: errorreporting/apiv1beta1
   - name: essentialcontacts
     version: 1.12.0
@@ -714,7 +681,6 @@ libraries:
           enabled_generator_features:
             - F_mtls_hard_bound_tokens
             - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: eventarc
     version: 1.23.0
     apis:
@@ -737,7 +703,6 @@ libraries:
             - F_mtls_hard_bound_tokens
             - F_open_telemetry_attributes
             - F_ordered_routing_headers
-            - F_proto_cloneof
           no_snippets: true
       - path: google/firestore/admin/v1
         go:
@@ -746,7 +711,6 @@ libraries:
             - F_mtls_hard_bound_tokens
             - F_open_telemetry_attributes
             - F_ordered_routing_headers
-            - F_proto_cloneof
           import_path: firestore/apiv1/admin
           no_snippets: true
     keep:
@@ -806,32 +770,27 @@ libraries:
           enabled_generator_features:
             - F_mtls_hard_bound_tokens
             - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/iam/v2
         go:
           enabled_generator_features:
             - F_mtls_hard_bound_tokens
             - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/iam/v1
         go:
           enabled_generator_features:
             - F_mtls_hard_bound_tokens
             - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/iam/credentials/v1
         go:
           enabled_generator_features:
             - F_mtls_hard_bound_tokens
             - F_open_telemetry_attributes
-            - F_proto_cloneof
           no_metadata: true
       - path: google/iam/v3beta
         go:
           enabled_generator_features:
             - F_mtls_hard_bound_tokens
             - F_open_telemetry_attributes
-            - F_proto_cloneof
     go:
       nested_module: admin
   - name: iap
@@ -858,13 +817,11 @@ libraries:
           enabled_generator_features:
             - F_mtls_hard_bound_tokens
             - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/kms/inventory/v1
         go:
           enabled_generator_features:
             - F_mtls_hard_bound_tokens
             - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: language
     version: 1.18.0
     apis:
@@ -891,7 +848,6 @@ libraries:
           enabled_generator_features:
             - F_mtls_hard_bound_tokens
             - F_open_telemetry_attributes
-            - F_proto_cloneof
     go:
       nested_module: logadmin
   - name: longrunning
@@ -977,20 +933,17 @@ libraries:
           enabled_generator_features:
             - F_mtls_hard_bound_tokens
             - F_open_telemetry_attributes
-            - F_proto_cloneof
           import_path: monitoring/apiv3/v2
       - path: google/monitoring/dashboard/v1
         go:
           enabled_generator_features:
             - F_mtls_hard_bound_tokens
             - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/monitoring/metricsscope/v1
         go:
           enabled_generator_features:
             - F_mtls_hard_bound_tokens
             - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: netapp
     version: 1.17.0
     apis:
@@ -1040,13 +993,11 @@ libraries:
           enabled_generator_features:
             - F_mtls_hard_bound_tokens
             - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/orgpolicy/v1
         go:
           enabled_generator_features:
             - F_mtls_hard_bound_tokens
             - F_open_telemetry_attributes
-            - F_proto_cloneof
           proto_only: true
   - name: osconfig
     version: 1.21.0
@@ -1120,7 +1071,6 @@ libraries:
           enabled_generator_features:
             - F_mtls_hard_bound_tokens
             - F_open_telemetry_attributes
-            - F_proto_cloneof
           import_path: pubsub/v2/apiv1
           no_metadata: true
           no_snippets: true
@@ -1161,13 +1111,11 @@ libraries:
           enabled_generator_features:
             - F_mtls_hard_bound_tokens
             - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/recommender/v1beta1
         go:
           enabled_generator_features:
             - F_mtls_hard_bound_tokens
             - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: redis
     version: 1.23.0
     apis:
@@ -1182,13 +1130,11 @@ libraries:
           enabled_generator_features:
             - F_mtls_hard_bound_tokens
             - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/resourcemanager/v2
         go:
           enabled_generator_features:
             - F_mtls_hard_bound_tokens
             - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: retail
     version: 1.31.0
     apis:
@@ -1225,13 +1171,11 @@ libraries:
           enabled_generator_features:
             - F_mtls_hard_bound_tokens
             - F_open_telemetry_attributes
-            - F_proto_cloneof
       - path: google/cloud/secretmanager/v1beta2
         go:
           enabled_generator_features:
             - F_mtls_hard_bound_tokens
             - F_open_telemetry_attributes
-            - F_proto_cloneof
   - name: securesourcemanager
     version: 1.9.0
     apis:
@@ -1413,7 +1357,6 @@ libraries:
           enabled_generator_features:
             - F_mtls_hard_bound_tokens
             - F_open_telemetry_attributes
-            - F_proto_cloneof
           import_path: trace/apiv2
       - path: google/devtools/cloudtrace/v1
         go:
@@ -1421,7 +1364,6 @@ libraries:
           enabled_generator_features:
             - F_mtls_hard_bound_tokens
             - F_open_telemetry_attributes
-            - F_proto_cloneof
           import_path: trace/apiv1
           no_metadata: true
   - name: translate


### PR DESCRIPTION
As of gapic-generator-go version v0.61.0 the proto cloneof feature is effectively no-op.  This PR cleans up existing references to enable the feature from librarian.yaml

related: internal b/505084464