### PR TITLE
chore: update librarian to v0.21.0

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 language: go
-version: v0.20.0
+version: v0.21.0
 repo: googleapis/google-cloud-go
 sources:
   googleapis:


### PR DESCRIPTION
Update librarian version and run re-generate. Re-generate did not introduce code change.
Produced with these commands:
```
go run github.com/googleapis/librarian/cmd/librarian@latest update version

# Get the updated version
V=$(go run github.com/googleapis/librarian/cmd/librarian@latest config get version)

# Regenerate everything to pick up librarian / sdk.yaml changes.
go run github.com/googleapis/librarian/cmd/librarian@${V} install
go run github.com/googleapis/librarian/cmd/librarian@${V} generate --all
```