### PR TITLE
chore: adapt component name for v2 libraries

### DIFF
--- a/release-please-individual-config.json
+++ b/release-please-individual-config.json
@@ -20,7 +20,7 @@
       ]
     },
     "bigquery/v2": {
-      "component": "bigquery/v2"
+      "component": "bigquery"
     },
     "bigtable": {
       "component": "bigtable"
@@ -41,7 +41,7 @@
       ]
     },
     "pubsub/v2": {
-      "component": "pubsub/v2"
+      "component": "pubsub"
     },
     "pubsublite": {
       "component": "pubsublite"


### PR DESCRIPTION
Because `include-component-in-tag` in tag was set that the v2 was in the component name release-please would search for a tag like `pubsub/v2/v2.6.0` which is incorrect. This caused more commits to show up than desired because it falls back to search last X commits in a path.

Related: #20002