### PR TITLE
revert: release pubsublite 2.0.0 (#19998)

### DIFF
--- a/.release-please-individual-manifest.json
+++ b/.release-please-individual-manifest.json
@@ -10,7 +10,7 @@
   "firestore": "1.22.0",
   "pubsub": "1.50.2",
   "pubsub/v2": "2.6.0",
-  "pubsublite": "2.0.0",
+  "pubsublite": "1.8.2",
   "spanner": "1.92.0",
   "storage": "1.62.2",
   "vertexai": "0.19.0"

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -1078,7 +1078,7 @@ libraries:
       - README.md
     skip_release: true
   - name: pubsublite
-    version: 2.0.0
+    version: 1.8.2
     apis:
       - path: google/cloud/pubsublite/v1
         go:

--- a/pubsublite/CHANGES.md
+++ b/pubsublite/CHANGES.md
@@ -1,27 +1,5 @@
 # Changes
 
-## [2.0.0](https://github.com/googleapis/google-cloud-go/compare/pubsublite/v1.8.2...pubsublite/v2.0.0) (2026-06-17)
-
-
-### ⚠ BREAKING CHANGES
-
-* **all:** The HAS operator on timestamp fields now only accepts the wildcard "*" for presence checks (e.g. "create_time:*"). Using timestamp values with HAS (e.g. "create_time:\"2022-...\"") is no longer supported.
-
-### Features
-
-* Enable open telemetry attrs ([#14426](https://github.com/googleapis/google-cloud-go/issues/14426)) ([74eab64](https://github.com/googleapis/google-cloud-go/commit/74eab64d1b4e22d8c79b0de4e5fc9a36bc4c6c19))
-* **pubsublite:** Add GMK Implementation changes ([#14466](https://github.com/googleapis/google-cloud-go/issues/14466)) ([50a5550](https://github.com/googleapis/google-cloud-go/commit/50a55504dcecf7ca307722260da9f832c84fe56c))
-
-
-### Bug Fixes
-
-* **pubsublite:** Reduce pscompat BufferedByteLimit ([#14234](https://github.com/googleapis/google-cloud-go/issues/14234)) ([e768524](https://github.com/googleapis/google-cloud-go/commit/e768524ba5e8617a0b06ca2e3e73c60ffbb2129e)), closes [#14237](https://github.com/googleapis/google-cloud-go/issues/14237)
-
-
-### Miscellaneous Chores
-
-* **all:** Update deps (main) ([#14180](https://github.com/googleapis/google-cloud-go/issues/14180)) ([14b9656](https://github.com/googleapis/google-cloud-go/commit/14b965686dde28d25ce4ad0ca0056c04f5bd235a))
-
 ## [1.8.2](https://github.com/googleapis/google-cloud-go/compare/pubsublite/v1.8.1...pubsublite/v1.8.2) (2024-06-05)
 
 
@@ -359,3 +337,5 @@ pubsublite/internal/wire implementation:
 
 This is the first tag to carve out pubsublite as its own module. See:
 https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository.
+
+

--- a/pubsublite/internal/version.go
+++ b/pubsublite/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "2.0.0"
+const Version = "1.8.2"


### PR DESCRIPTION
This reverts commit a7b2ac666304a6328768332d6fa817abf9aaa71f. This should not have been a major version bump. I stopped release-please before the release got out so all we have to do is reset these files.