### PR TITLE
fix(bigtable): make testproxy rowToProto family order deterministic

### DIFF
--- a/bigtable/internal/testproxy/proxy.go
+++ b/bigtable/internal/testproxy/proxy.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -44,13 +45,26 @@ var (
 
 // rowToProto converts a Bigtable Go client Row struct into a
 // Bigtable protobuf Row struct. It iterates over all of the column families
-// (keys) and ReadItem slices (values) in the client Row struct
+// (keys) and ReadItem slices (values) in the client Row struct.
+//
+// Families are emitted in sorted name order. bigtable.Row is
+// map[string][]ReadItem, so a plain range loop would surface families in
+// random order, and the conformance tests (which assert with
+// protocmp.Transform — repeated-field order is significant) would fail
+// non-deterministically on any row with more than one family.
 func rowToProto(btRow bigtable.Row) (*btpb.Row, error) {
 	pbRow := &btpb.Row{
 		Key: []byte(btRow.Key()),
 	}
 
-	for fam, ris := range btRow {
+	famNames := make([]string, 0, len(btRow))
+	for fam := range btRow {
+		famNames = append(famNames, fam)
+	}
+	sort.Strings(famNames)
+
+	for _, fam := range famNames {
+		ris := btRow[fam]
 		pbFam := &btpb.Family{
 			Name: fam,
 		}


### PR DESCRIPTION
## Summary

Fixes #12621 (which was previously closed via an unrelated cross-reference without a code change — the bug has been silently flaking conformance runs ever since).

`bigtable.Row` is `map[string][]ReadItem`. The previous loop in `rowToProto` (testproxy/proxy.go) iterated that map directly, so the `Families` slice on the emitted `btpb.Row` came out in whatever order Go's per-call map randomization produced that run. The conformance suite compares responses with `protocmp.Transform()`, which treats repeated-field **order** as significant, so any row with ≥2 families had roughly a 50/50 chance of producing a `families:[B, A]` vs `families:[A, B]` diff and failing.

Most recently observed on the unrelated [parallel-prime PR (#20010)](https://github.com/googleapis/google-cloud-go/actions/runs/27718129051/job/81996214954) — the failure is `TestReadRow_NoRetry_CommitInSeparateChunk`, which uses two families (`A` and `B`).

Sort family names before iterating so the emitted families match the real Bigtable server's lex order (which is what the conformance test fixtures expect). Within-family ordering was never an issue: `ReadItems` are slice-appended in chunk-receive order at `reader.go:180`, and the inner loop ranges over a slice.

## Test plan
- [x] `go build ./internal/testproxy/...`
- [x] `go vet ./internal/testproxy/...`
- [x] `goimports -l` clean
- [ ] CI conformance runs cleanly (can't deterministically prove a flake is gone, but rerun history on PRs that hit this test will tell)