### PR TITLE
test(bigtable): drop shared setupIntegration cost from Pinger test

### DIFF
--- a/bigtable/integration_test.go
+++ b/bigtable/integration_test.go
@@ -228,6 +228,7 @@ func TestIntegration_Pinger(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewIntegrationEnv: %v", err)
 	}
+	t.Cleanup(func() { testEnv.Close() })
 	if !testEnv.Config().UseProd {
 		t.Skip("emulator doesn't support PingAndWarm")
 	}

--- a/bigtable/integration_test.go
+++ b/bigtable/integration_test.go
@@ -221,31 +221,23 @@ func cleanup(c IntegrationTestConfig) error {
 func TestIntegration_Pinger(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	testEnv, client, _, _, _, cleanup, err := setupIntegration(ctx, t)
+	// PingAndWarm is instance-scoped, so skip the shared setupIntegration cost
+	// (table create + 10 column families + readiness poll) and only build the
+	// data client we actually need.
+	testEnv, err := NewIntegrationEnv()
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("NewIntegrationEnv: %v", err)
 	}
-	t.Cleanup(func() { cleanup() })
 	if !testEnv.Config().UseProd {
 		t.Skip("emulator doesn't support PingAndWarm")
 	}
-	err = internal.Retry(ctx, gax.Backoff{
-		Initial:    2 * time.Second,
-		Max:        30 * time.Second,
-		Multiplier: 2.0,
-	}, func() (bool, error) {
-		err := client.PingAndWarm(ctx)
-		if err != nil {
-			s, ok := status.FromError(err)
-			if ok && s.Code() == codes.FailedPrecondition {
-				return false, err // retry
-			}
-			return true, err // stop and return other errors
-		}
-		return true, nil // success
-	})
+	client, err := testEnv.NewClient()
 	if err != nil {
-		t.Fatalf("pinger failed. got %v, want %v", err, nil)
+		t.Fatalf("NewClient: %v", err)
+	}
+	t.Cleanup(func() { client.Close() })
+	if err := client.PingAndWarm(ctx); err != nil {
+		t.Fatalf("PingAndWarm: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

`TestIntegration_Pinger` only exercises `PingAndWarm`, which is instance-scoped and needs no table. The shared `setupIntegration` helper, however, always creates a fresh table, ten column families, and polls for table readiness — work that dominates the test's runtime.

Build only the data client we actually need. The retry wrapper around `PingAndWarm` went away with the table dependency it was guarding (the `FailedPrecondition` it was retrying came from "Table currently being created", which no longer applies).

## Measured

Against an existing prod instance (`autonomous-mote-782` / `sushanb-prober`):

| | Before | After |
|---|---|---|
| `TestIntegration_Pinger` | 260.83 s | **2.00 s** |

## Test plan

- [x] `go test -run='TestIntegration_Pinger.*' -v -it.use-prod -it.project=… -it.cluster=… -it.instance=…` passes
- [x] `go vet ./...` clean