### PR TITLE
refactor(bigtable): return session response protos directly from vRPC descriptors

### DIFF
--- a/bigtable/internal/transport/descriptors.go
+++ b/bigtable/internal/transport/descriptors.go
@@ -110,19 +110,11 @@ type ReadRowArgs struct {
 	Filter *btpb.RowFilter
 }
 
-// ReadRowResult holds the result returned from a virtual RPC ReadRow call.
-type ReadRowResult struct {
-	Row *btpb.Row
-}
-
 // MutateRowArgs contains arguments required for a virtual RPC MutateRow call.
 type MutateRowArgs struct {
 	RowKey    string
 	Mutations []*btpb.Mutation
 }
-
-// MutateRowResult holds the result of a MutateRow virtual RPC.
-type MutateRowResult struct{}
 
 func encodeReadRow(args ReadRowArgs) *btpb.SessionReadRowRequest {
 	return &btpb.SessionReadRowRequest{
@@ -131,24 +123,11 @@ func encodeReadRow(args ReadRowArgs) *btpb.SessionReadRowRequest {
 	}
 }
 
-func decodeReadRow(resp *btpb.SessionReadRowResponse) ReadRowResult {
-	if resp == nil {
-		return ReadRowResult{}
-	}
-	return ReadRowResult{
-		Row: resp.Row,
-	}
-}
-
 func encodeMutateRow(args MutateRowArgs) *btpb.SessionMutateRowRequest {
 	return &btpb.SessionMutateRowRequest{
 		Key:       []byte(args.RowKey),
 		Mutations: args.Mutations,
 	}
-}
-
-func decodeMutateRow(resp *btpb.SessionMutateRowResponse) MutateRowResult {
-	return MutateRowResult{}
 }
 
 var (
@@ -162,7 +141,7 @@ var (
 			}
 		}),
 		DecodeFn: createTableDecoder(func(env *btpb.TableResponse) interface{} {
-			return decodeReadRow(env.GetReadRow())
+			return env.GetReadRow()
 		}),
 	}
 
@@ -176,7 +155,7 @@ var (
 			}
 		}),
 		DecodeFn: createTableDecoder(func(env *btpb.TableResponse) interface{} {
-			return decodeMutateRow(env.GetMutateRow())
+			return env.GetMutateRow()
 		}),
 	}
 
@@ -190,7 +169,7 @@ var (
 			}
 		}),
 		DecodeFn: createAuthViewDecoder(func(env *btpb.AuthorizedViewResponse) interface{} {
-			return decodeReadRow(env.GetReadRow())
+			return env.GetReadRow()
 		}),
 	}
 
@@ -204,7 +183,7 @@ var (
 			}
 		}),
 		DecodeFn: createAuthViewDecoder(func(env *btpb.AuthorizedViewResponse) interface{} {
-			return decodeMutateRow(env.GetMutateRow())
+			return env.GetMutateRow()
 		}),
 	}
 
@@ -218,7 +197,7 @@ var (
 			}
 		}),
 		DecodeFn: createMatViewDecoder(func(env *btpb.MaterializedViewResponse) interface{} {
-			return decodeReadRow(env.GetReadRow())
+			return env.GetReadRow()
 		}),
 	}
 )

--- a/bigtable/internal/transport/descriptors_test.go
+++ b/bigtable/internal/transport/descriptors_test.go
@@ -98,9 +98,9 @@ func TestTableDescriptors_ReadRow(t *testing.T) {
 		t.Fatalf("Failed to decode READ_ROW: %v", err)
 	}
 
-	result, ok := decoded.(ReadRowResult)
+	result, ok := decoded.(*btpb.SessionReadRowResponse)
 	if !ok {
-		t.Fatalf("Expected decoded result to be ReadRowResult, got %T", decoded)
+		t.Fatalf("Expected decoded result to be *btpb.SessionReadRowResponse, got %T", decoded)
 	}
 
 	if !bytes.Equal(result.Row.Key, []byte("row-key-1")) {
@@ -167,9 +167,9 @@ func TestTableDescriptors_MutateRow(t *testing.T) {
 		t.Fatalf("Failed to decode MUTATE_ROW: %v", err)
 	}
 
-	_, ok = decoded.(MutateRowResult)
+	_, ok = decoded.(*btpb.SessionMutateRowResponse)
 	if !ok {
-		t.Fatalf("Expected decoded result to be MutateRowResult, got %T", decoded)
+		t.Fatalf("Expected decoded result to be *btpb.SessionMutateRowResponse, got %T", decoded)
 	}
 }
 
@@ -222,9 +222,9 @@ func TestAuthorizedViewDescriptors_ReadRow(t *testing.T) {
 		t.Fatalf("Failed to decode READ_ROW_AUTH_VIEW: %v", err)
 	}
 
-	result, ok := decoded.(ReadRowResult)
+	result, ok := decoded.(*btpb.SessionReadRowResponse)
 	if !ok {
-		t.Fatalf("Expected decoded result to be ReadRowResult, got %T", decoded)
+		t.Fatalf("Expected decoded result to be *btpb.SessionReadRowResponse, got %T", decoded)
 	}
 
 	if !bytes.Equal(result.Row.Key, []byte("row-key-3")) {
@@ -276,9 +276,9 @@ func TestAuthorizedViewDescriptors_MutateRow(t *testing.T) {
 		t.Fatalf("Failed to decode MUTATE_ROW_AUTH_VIEW: %v", err)
 	}
 
-	_, ok = decoded.(MutateRowResult)
+	_, ok = decoded.(*btpb.SessionMutateRowResponse)
 	if !ok {
-		t.Fatalf("Expected decoded result to be MutateRowResult, got %T", decoded)
+		t.Fatalf("Expected decoded result to be *btpb.SessionMutateRowResponse, got %T", decoded)
 	}
 }
 
@@ -331,9 +331,9 @@ func TestMaterializedViewDescriptors_ReadRow(t *testing.T) {
 		t.Fatalf("Failed to decode READ_ROW_MAT_VIEW: %v", err)
 	}
 
-	result, ok := decoded.(ReadRowResult)
+	result, ok := decoded.(*btpb.SessionReadRowResponse)
 	if !ok {
-		t.Fatalf("Expected decoded result to be ReadRowResult, got %T", decoded)
+		t.Fatalf("Expected decoded result to be *btpb.SessionReadRowResponse, got %T", decoded)
 	}
 
 	if !bytes.Equal(result.Row.Key, []byte("row-key-5")) {


### PR DESCRIPTION
## Summary

The `ReadRowResult{Row}` / `MutateRowResult{}` wrappers in `bigtable/internal/transport/descriptors.go` are lossy intermediates between the wire and the caller:

- `ReadRowResult` exposes only `.Row`, dropping `SessionReadRowResponse.Stats`.
- `MutateRowResult` is empty — it discards the entire `SessionMutateRowResponse`.

Drop the wrappers and the `decodeReadRow` / `decodeMutateRow` helpers. Each descriptor's `Decode` now returns the typed envelope getter (`env.GetReadRow()` / `env.GetMutateRow()`) directly, so callers receive `*btpb.SessionReadRowResponse` / `*btpb.SessionMutateRowResponse` and can read `.Row` / `.Stats` themselves.

This gives the transport layer a clean `SessionReadRowRequest -> SessionReadRowResponse` contract that downstream consumers can plug into without going through a Go-level intermediate.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./internal/transport/...` clean
- [x] `go test ./internal/transport/...` passes (descriptor tests updated to assert the new proto return type)