### PR TITLE
feat(bigtable): modularize channel priming behind a ChannelPrimer interface

### DIFF
--- a/bigtable/internal/transport/channel_pool_factory.go
+++ b/bigtable/internal/transport/channel_pool_factory.go
@@ -184,7 +184,7 @@ func CreateBigtableChannelPool(
 			}
 			return NewBigtableConn(grpcConn), nil
 		}
-		checker := newPingAndWarmDirectAccessChecker(
+		checker := newDirectAccessChecker(
 			directAccessDialer,
 			primer,
 			otelMeterProvider,

--- a/bigtable/internal/transport/channel_pool_factory.go
+++ b/bigtable/internal/transport/channel_pool_factory.go
@@ -184,7 +184,7 @@ func CreateBigtableChannelPool(
 			}
 			return NewBigtableConn(grpcConn), nil
 		}
-		checker := newDirectAccessChecker(
+		checker := newPingAndWarmDirectAccessChecker(
 			directAccessDialer,
 			primer,
 			otelMeterProvider,

--- a/bigtable/internal/transport/channel_pool_factory.go
+++ b/bigtable/internal/transport/channel_pool_factory.go
@@ -153,15 +153,17 @@ func CreateBigtableChannelPool(
 
 	fullInstanceName := fmt.Sprintf("projects/%s/instances/%s", project, instance)
 
-	// directAccessMD is the feature-flag metadata used for priming on both
-	// the direct-access and standard-path connection factories — the pool
-	// holds it via WithFeatureFlagsMetadata and applies it to every Prime().
+	// Build a single PingAndWarm primer and share it with both the pool's
+	// connection factory (via WithChannelPrimer) and the direct-access
+	// compatibility checker. Keeping the (instanceName, appProfile,
+	// featureFlagsMD) tuple in one place avoids the three-arg drift between
+	// the two consumers.
+	primer := newPingAndWarmChannelPrimer(fullInstanceName, config.AppProfile, directAccessMD)
+
 	poolOpts := []BigtableChannelPoolOption{
-		WithInstanceName(fullInstanceName),
-		WithAppProfile(config.AppProfile),
 		WithMetricsReporterConfig(btopt.DefaultMetricsReporterConfig()),
 		WithMeterProvider(otelMeterProvider),
-		WithFeatureFlagsMetadata(directAccessMD),
+		WithChannelPrimer(primer),
 	}
 
 	// Pluggable Direct Access strategy: the classic channel pool factory uses
@@ -184,9 +186,7 @@ func CreateBigtableChannelPool(
 		}
 		checker := newPingAndWarmDirectAccessChecker(
 			directAccessDialer,
-			fullInstanceName,
-			config.AppProfile,
-			directAccessMD,
+			primer,
 			otelMeterProvider,
 			nil, // logger plumbed by callers once available
 		)

--- a/bigtable/internal/transport/channel_primer.go
+++ b/bigtable/internal/transport/channel_primer.go
@@ -1,0 +1,63 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"context"
+
+	"google.golang.org/grpc/metadata"
+)
+
+// ChannelPrimer warms a freshly-dialed Bigtable channel before it is put
+// into rotation. The pool's connection factory consults the registered
+// primer after every successful dial; a nil ChannelPrimer means the pool
+// skips priming entirely and hands the raw connection straight to the
+// pool.
+//
+// Implementations differ in HOW the channel is warmed:
+//   - pingAndWarmChannelPrimer issues a PingAndWarm against the configured
+//     instance / app profile with the supplied feature-flag metadata
+//     (today's only behavior, used by the classic channel pool factory).
+type ChannelPrimer interface {
+	// Prime warms conn so the next request served by it does not pay the
+	// first-RPC connection-setup cost. The factory wraps Prime in a retry
+	// loop, so transient errors should propagate as-is.
+	Prime(ctx context.Context, conn *BigtableConn) error
+}
+
+// pingAndWarmChannelPrimer primes a channel by issuing a PingAndWarm RPC
+// against the configured instance + app profile, carrying the supplied
+// feature-flag metadata. Stateless aside from the configured identifiers,
+// so a single primer instance is shared across all dials in a pool.
+type pingAndWarmChannelPrimer struct {
+	instanceName   string
+	appProfile     string
+	featureFlagsMD metadata.MD
+}
+
+// newPingAndWarmChannelPrimer constructs the today-default channel primer.
+func newPingAndWarmChannelPrimer(instanceName, appProfile string, featureFlagsMD metadata.MD) *pingAndWarmChannelPrimer {
+	return &pingAndWarmChannelPrimer{
+		instanceName:   instanceName,
+		appProfile:     appProfile,
+		featureFlagsMD: featureFlagsMD,
+	}
+}
+
+// Prime delegates to BigtableConn.Prime, which sends PingAndWarm and
+// records the ALTS / IP-protocol observations on conn as a side effect.
+func (p *pingAndWarmChannelPrimer) Prime(ctx context.Context, conn *BigtableConn) error {
+	return conn.Prime(ctx, p.instanceName, p.appProfile, p.featureFlagsMD)
+}

--- a/bigtable/internal/transport/channel_primer_test.go
+++ b/bigtable/internal/transport/channel_primer_test.go
@@ -1,0 +1,78 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/grpc/metadata"
+)
+
+// TestPingAndWarmChannelPrimer_Prime verifies the primer delegates to
+// BigtableConn.Prime carrying the configured instance name, app profile,
+// and feature-flag metadata — i.e. that the primer is a thin wrapper that
+// keeps the (instance, profile, flags) tuple in one place.
+func TestPingAndWarmChannelPrimer_Prime(t *testing.T) {
+	fake := &fakeService{}
+	addr := setupTestServer(t, fake)
+	conn, err := dialBigtableserver(addr)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	t.Cleanup(func() { conn.Close() })
+
+	flagsMD := metadata.Pairs("bigtable-features", "primer-test")
+	primer := newPingAndWarmChannelPrimer(testInstanceName, testAppProfile, flagsMD)
+
+	if err := primer.Prime(context.Background(), conn); err != nil {
+		t.Fatalf("Prime returned error: %v", err)
+	}
+
+	if got := fake.getPingCount(); got != 1 {
+		t.Errorf("PingAndWarm call count = %d, want 1", got)
+	}
+
+	gotMD := fake.getPrimeMetadata()
+	if got := gotMD.Get("bigtable-features"); len(got) != 1 || got[0] != "primer-test" {
+		t.Errorf("feature-flag metadata on PingAndWarm = %v, want [primer-test]", got)
+	}
+	if got := gotMD.Get("x-goog-request-params"); len(got) != 1 {
+		t.Errorf("x-goog-request-params on PingAndWarm = %v, want one entry derived from instance/profile", got)
+	}
+}
+
+// TestConnectionFactory_NilPrimerSkipsPriming verifies the contract that a
+// nil ChannelPrimer turns priming off: newEntry dials the channel and
+// returns it without issuing PingAndWarm.
+func TestConnectionFactory_NilPrimerSkipsPriming(t *testing.T) {
+	fake := &fakeService{}
+	addr := setupTestServer(t, fake)
+
+	factory := &connectionFactory{
+		dial:   func() (*BigtableConn, error) { return dialBigtableserver(addr) },
+		primer: nil,
+	}
+
+	entry, err := factory.newEntry(context.Background())
+	if err != nil {
+		t.Fatalf("newEntry returned error: %v", err)
+	}
+	t.Cleanup(func() { entry.conn.Close() })
+
+	if got := fake.getPingCount(); got != 0 {
+		t.Errorf("PingAndWarm call count with nil primer = %d, want 0", got)
+	}
+}

--- a/bigtable/internal/transport/connpool.go
+++ b/bigtable/internal/transport/connpool.go
@@ -101,13 +101,6 @@ type connPoolStats struct {
 
 var _ Monitor = (*MetricsReporter)(nil)
 
-// WithAppProfile provides the appProfile
-func WithAppProfile(appProfile string) BigtableChannelPoolOption {
-	return func(p *BigtableChannelPool) {
-		p.appProfile = appProfile
-	}
-}
-
 // WithMeterProvider provides the meter provider for writing metrics
 func WithMeterProvider(mp metric.MeterProvider) BigtableChannelPoolOption {
 	return func(p *BigtableChannelPool) {
@@ -129,24 +122,22 @@ func WithDirectAccessChecker(checker DirectAccessChecker) BigtableChannelPoolOpt
 	}
 }
 
+// WithChannelPrimer plugs in the strategy used to warm freshly-dialed
+// channels before they enter rotation. Optional: when no primer is supplied,
+// the pool's connection factory dials the channel and returns it without
+// issuing any prime RPC. The classic channel pool factory wires up a
+// PingAndWarm-based primer; alternative pool factories can swap in a
+// different strategy (e.g. session-based) or pass nothing at all.
+func WithChannelPrimer(primer ChannelPrimer) BigtableChannelPoolOption {
+	return func(p *BigtableChannelPool) {
+		p.channelPrimer = primer
+	}
+}
+
 // WithLogger provides the logger for logging events
 func WithLogger(logger *log.Logger) BigtableChannelPoolOption {
 	return func(p *BigtableChannelPool) {
 		p.logger = logger
-	}
-}
-
-// WithInstanceName provides the full instance Name
-func WithInstanceName(instanceName string) BigtableChannelPoolOption {
-	return func(p *BigtableChannelPool) {
-		p.instanceName = instanceName
-	}
-}
-
-// WithFeatureFlagsMetadata provides the feature flags metadata
-func WithFeatureFlagsMetadata(featureFlagsMd metadata.MD) BigtableChannelPoolOption {
-	return func(p *BigtableChannelPool) {
-		p.featureFlagsMD = featureFlagsMd
 	}
 }
 
@@ -372,10 +363,7 @@ type BigtableChannelPool struct {
 	poolCtx    context.Context    // Context for the pool's background tasks
 	poolCancel context.CancelFunc // Function to cancel the poolCtx
 
-	logger         *log.Logger // logging events
-	appProfile     string
-	instanceName   string
-	featureFlagsMD metadata.MD
+	logger *log.Logger // logging events
 
 	factory *connectionFactory // Use the factory for connection creation
 
@@ -390,6 +378,13 @@ type BigtableChannelPool struct {
 	// Direct Access off pass the disabled stub so the
 	// direct_access/compatible metric still surfaces the off state.
 	directAccessChecker DirectAccessChecker
+
+	// channelPrimer is the pluggable strategy used to warm freshly-dialed
+	// channels. Optional: when nil, the connection factory skips priming
+	// entirely and hands the raw connection straight to the pool. The
+	// classic channel pool factory wires up a PingAndWarm-based primer; the
+	// future session-pool factory may skip it.
+	channelPrimer ChannelPrimer
 
 	// background monitors
 	monitors []Monitor
@@ -441,9 +436,9 @@ func NewBigtableChannelPool(ctx context.Context, connPoolSize int, strategy btop
 
 	// Default to the standard dialer. The Direct Access checker may swap the
 	// dialer for the direct-access equivalent after a successful compatibility
-	// probe. Feature-flag metadata always comes from pool.featureFlagsMD (set
-	// via WithFeatureFlagsMetadata) — both the direct-access and standard-path
-	// connection factories read it from the same place.
+	// probe. The ChannelPrimer (if any) is the single source of priming
+	// behavior — both the direct-access and standard-path factories run
+	// fresh connections through it before they enter rotation.
 	factoryDial := dial
 
 	var firstConn *BigtableConn
@@ -463,11 +458,9 @@ func NewBigtableChannelPool(ctx context.Context, connPoolSize int, strategy btop
 
 	// Initialize the connectionFactory
 	pool.factory = &connectionFactory{
-		dial:           factoryDial,
-		instanceName:   pool.instanceName,
-		appProfile:     pool.appProfile,
-		featureFlagsMD: pool.featureFlagsMD,
-		logger:         pool.logger,
+		dial:   factoryDial,
+		primer: pool.channelPrimer,
+		logger: pool.logger,
 	}
 
 	// Set the selection function based on the strategy
@@ -980,18 +973,18 @@ func (p *BigtableChannelPool) removeConnections(decreaseDelta, minConns, maxRemo
 
 }
 
-// connectionFactory is responsible for creating and priming new Bigtable connections.
-// TODO remove these members from BigtableConnPool struct
+// connectionFactory is responsible for creating and (optionally) priming
+// new Bigtable connections. When primer is nil the factory dials and
+// returns the connection without warming it.
 type connectionFactory struct {
-	dial           func() (*BigtableConn, error)
-	instanceName   string
-	appProfile     string
-	featureFlagsMD metadata.MD
-	logger         *log.Logger
+	dial   func() (*BigtableConn, error)
+	primer ChannelPrimer
+	logger *log.Logger
 }
 
-// newEntry creates a new connection, primes it, and returns it as a connEntry.
-// Blocks until the connection is successfully primed, or returns an error.
+// newEntry creates a new connection, primes it (if a primer is configured),
+// and returns it as a connEntry. Blocks until the connection is ready, or
+// returns an error.
 func (cf *connectionFactory) newEntry(ctx context.Context) (*connEntry, error) {
 	conn, err := cf.dial()
 	if err != nil {
@@ -1006,8 +999,13 @@ func (cf *connectionFactory) newEntry(ctx context.Context) (*connEntry, error) {
 	return &connEntry{conn: conn}, nil
 }
 
-// primeWithRetry attempts to prime the connection, retrying with exponential backoff.
+// primeWithRetry runs the configured ChannelPrimer with exponential backoff.
+// Returns nil immediately when no primer is configured, so the pool can be
+// used without priming.
 func (cf *connectionFactory) primeWithRetry(ctx context.Context, conn *BigtableConn) error {
+	if cf.primer == nil {
+		return nil
+	}
 	backoffPolicy := gax.Backoff{
 		Initial:    100 * time.Millisecond,
 		Max:        2 * time.Second,
@@ -1022,7 +1020,7 @@ func (cf *connectionFactory) primeWithRetry(ctx context.Context, conn *BigtableC
 			return fmt.Errorf("bigtable_connpool:  error before prime attempt %d: %w", attempt, err)
 		}
 
-		lastErr = conn.Prime(ctx, cf.instanceName, cf.appProfile, cf.featureFlagsMD)
+		lastErr = cf.primer.Prime(ctx, conn)
 		if lastErr == nil {
 			return nil
 		}

--- a/bigtable/internal/transport/connpool_test.go
+++ b/bigtable/internal/transport/connpool_test.go
@@ -49,8 +49,7 @@ const (
 // Helper function to provide default options for pool creation
 func poolOpts() []BigtableChannelPoolOption {
 	return []BigtableChannelPoolOption{
-		WithInstanceName(testInstanceName),
-		WithAppProfile(testAppProfile),
+		WithChannelPrimer(newPingAndWarmChannelPrimer(testInstanceName, testAppProfile, nil)),
 		WithDirectAccessChecker(newDisabledDirectAccessChecker(nil, nil)),
 	}
 }
@@ -156,7 +155,7 @@ func TestNewBigtableChannelPoolEdgeCases(t *testing.T) {
 		{
 			name: "NilDirectAccessChecker",
 			size: 1, dial: dialFunc,
-			opts:     []BigtableChannelPoolOption{WithInstanceName(testInstanceName), WithAppProfile(testAppProfile)},
+			opts:     []BigtableChannelPoolOption{WithChannelPrimer(newPingAndWarmChannelPrimer(testInstanceName, testAppProfile, nil))},
 			wantErr:  true,
 			errMatch: "DirectAccessChecker is required",
 		},
@@ -255,10 +254,8 @@ func TestConnectionFactory(t *testing.T) {
 			fake.setDelay(tt.primeDelay)
 
 			factory := &connectionFactory{
-				dial:           tt.dialFunc,
-				instanceName:   testInstanceName,
-				appProfile:     testAppProfile,
-				featureFlagsMD: metadata.MD{},
+				dial:   tt.dialFunc,
+				primer: newPingAndWarmChannelPrimer(testInstanceName, testAppProfile, metadata.MD{}),
 			}
 
 			ctx := context.Background()
@@ -1738,7 +1735,7 @@ func TestDirectAccessLogic(t *testing.T) {
 
 		poolSize := 3
 		fake.setPingCount(0)
-		opts := append(poolOpts(), WithDirectAccessChecker(newPingAndWarmDirectAccessChecker(daDial, testInstanceName, testAppProfile, nil, nil, nil)))
+		opts := append(poolOpts(), WithDirectAccessChecker(newPingAndWarmDirectAccessChecker(daDial, newPingAndWarmChannelPrimer(testInstanceName, testAppProfile, nil), nil, nil)))
 		pool, err := NewBigtableChannelPool(ctx, poolSize, btopt.RoundRobin, baseDialFunc, time.Now(), opts...)
 
 		if err != nil {
@@ -1781,7 +1778,7 @@ func TestDirectAccessLogic(t *testing.T) {
 		}
 
 		poolSize := 2
-		opts := append(poolOpts(), WithDirectAccessChecker(newPingAndWarmDirectAccessChecker(daDial, testInstanceName, testAppProfile, nil, nil, nil)))
+		opts := append(poolOpts(), WithDirectAccessChecker(newPingAndWarmDirectAccessChecker(daDial, newPingAndWarmChannelPrimer(testInstanceName, testAppProfile, nil), nil, nil)))
 		pool, err := NewBigtableChannelPool(ctx, poolSize, btopt.RoundRobin, baseDialFunc, time.Now(), opts...)
 		if err != nil {
 			t.Fatalf("Failed to create pool: %v", err)
@@ -1806,7 +1803,7 @@ func TestDirectAccessLogic(t *testing.T) {
 		}
 
 		poolSize := 1
-		opts := append(poolOpts(), WithDirectAccessChecker(newPingAndWarmDirectAccessChecker(daDial, testInstanceName, testAppProfile, nil, nil, nil)))
+		opts := append(poolOpts(), WithDirectAccessChecker(newPingAndWarmDirectAccessChecker(daDial, newPingAndWarmChannelPrimer(testInstanceName, testAppProfile, nil), nil, nil)))
 		pool, err := NewBigtableChannelPool(ctx, poolSize, btopt.RoundRobin, baseDialFunc, time.Now(), opts...)
 		if err != nil {
 			t.Fatalf("Failed to create pool: %v", err)
@@ -1832,7 +1829,7 @@ func TestDirectAccessLogic(t *testing.T) {
 			daConn = c
 			return c, nil
 		}
-		opts := append(poolOpts(), WithDirectAccessChecker(newPingAndWarmDirectAccessChecker(daDial, testInstanceName, testAppProfile, nil, nil, nil)))
+		opts := append(poolOpts(), WithDirectAccessChecker(newPingAndWarmDirectAccessChecker(daDial, newPingAndWarmChannelPrimer(testInstanceName, testAppProfile, nil), nil, nil)))
 		poolSize := 1
 		pool, err := NewBigtableChannelPool(ctx, poolSize, btopt.RoundRobin, baseDialFunc, time.Now(), opts...)
 		if err != nil {
@@ -1897,7 +1894,7 @@ func TestDirectAccessLogic(t *testing.T) {
 		}
 
 		poolSize := 1
-		opts := append(poolOpts(), WithDirectAccessChecker(newPingAndWarmDirectAccessChecker(daDial, testInstanceName, testAppProfile, nil, nil, nil)))
+		opts := append(poolOpts(), WithDirectAccessChecker(newPingAndWarmDirectAccessChecker(daDial, newPingAndWarmChannelPrimer(testInstanceName, testAppProfile, nil), nil, nil)))
 		pool, err := NewBigtableChannelPool(ctx, poolSize, btopt.RoundRobin, baseDialFunc, time.Now(), opts...)
 		if err != nil {
 			t.Fatalf("Failed to create pool: %v", err)

--- a/bigtable/internal/transport/connpool_test.go
+++ b/bigtable/internal/transport/connpool_test.go
@@ -1735,7 +1735,7 @@ func TestDirectAccessLogic(t *testing.T) {
 
 		poolSize := 3
 		fake.setPingCount(0)
-		opts := append(poolOpts(), WithDirectAccessChecker(newPingAndWarmDirectAccessChecker(daDial, newPingAndWarmChannelPrimer(testInstanceName, testAppProfile, nil), nil, nil)))
+		opts := append(poolOpts(), WithDirectAccessChecker(newDirectAccessChecker(daDial, newPingAndWarmChannelPrimer(testInstanceName, testAppProfile, nil), nil, nil)))
 		pool, err := NewBigtableChannelPool(ctx, poolSize, btopt.RoundRobin, baseDialFunc, time.Now(), opts...)
 
 		if err != nil {
@@ -1778,7 +1778,7 @@ func TestDirectAccessLogic(t *testing.T) {
 		}
 
 		poolSize := 2
-		opts := append(poolOpts(), WithDirectAccessChecker(newPingAndWarmDirectAccessChecker(daDial, newPingAndWarmChannelPrimer(testInstanceName, testAppProfile, nil), nil, nil)))
+		opts := append(poolOpts(), WithDirectAccessChecker(newDirectAccessChecker(daDial, newPingAndWarmChannelPrimer(testInstanceName, testAppProfile, nil), nil, nil)))
 		pool, err := NewBigtableChannelPool(ctx, poolSize, btopt.RoundRobin, baseDialFunc, time.Now(), opts...)
 		if err != nil {
 			t.Fatalf("Failed to create pool: %v", err)
@@ -1803,7 +1803,7 @@ func TestDirectAccessLogic(t *testing.T) {
 		}
 
 		poolSize := 1
-		opts := append(poolOpts(), WithDirectAccessChecker(newPingAndWarmDirectAccessChecker(daDial, newPingAndWarmChannelPrimer(testInstanceName, testAppProfile, nil), nil, nil)))
+		opts := append(poolOpts(), WithDirectAccessChecker(newDirectAccessChecker(daDial, newPingAndWarmChannelPrimer(testInstanceName, testAppProfile, nil), nil, nil)))
 		pool, err := NewBigtableChannelPool(ctx, poolSize, btopt.RoundRobin, baseDialFunc, time.Now(), opts...)
 		if err != nil {
 			t.Fatalf("Failed to create pool: %v", err)
@@ -1829,7 +1829,7 @@ func TestDirectAccessLogic(t *testing.T) {
 			daConn = c
 			return c, nil
 		}
-		opts := append(poolOpts(), WithDirectAccessChecker(newPingAndWarmDirectAccessChecker(daDial, newPingAndWarmChannelPrimer(testInstanceName, testAppProfile, nil), nil, nil)))
+		opts := append(poolOpts(), WithDirectAccessChecker(newDirectAccessChecker(daDial, newPingAndWarmChannelPrimer(testInstanceName, testAppProfile, nil), nil, nil)))
 		poolSize := 1
 		pool, err := NewBigtableChannelPool(ctx, poolSize, btopt.RoundRobin, baseDialFunc, time.Now(), opts...)
 		if err != nil {
@@ -1894,7 +1894,7 @@ func TestDirectAccessLogic(t *testing.T) {
 		}
 
 		poolSize := 1
-		opts := append(poolOpts(), WithDirectAccessChecker(newPingAndWarmDirectAccessChecker(daDial, newPingAndWarmChannelPrimer(testInstanceName, testAppProfile, nil), nil, nil)))
+		opts := append(poolOpts(), WithDirectAccessChecker(newDirectAccessChecker(daDial, newPingAndWarmChannelPrimer(testInstanceName, testAppProfile, nil), nil, nil)))
 		pool, err := NewBigtableChannelPool(ctx, poolSize, btopt.RoundRobin, baseDialFunc, time.Now(), opts...)
 		if err != nil {
 			t.Fatalf("Failed to create pool: %v", err)

--- a/bigtable/internal/transport/connpool_test.go
+++ b/bigtable/internal/transport/connpool_test.go
@@ -1735,7 +1735,7 @@ func TestDirectAccessLogic(t *testing.T) {
 
 		poolSize := 3
 		fake.setPingCount(0)
-		opts := append(poolOpts(), WithDirectAccessChecker(newDirectAccessChecker(daDial, newPingAndWarmChannelPrimer(testInstanceName, testAppProfile, nil), nil, nil)))
+		opts := append(poolOpts(), WithDirectAccessChecker(newPingAndWarmDirectAccessChecker(daDial, newPingAndWarmChannelPrimer(testInstanceName, testAppProfile, nil), nil, nil)))
 		pool, err := NewBigtableChannelPool(ctx, poolSize, btopt.RoundRobin, baseDialFunc, time.Now(), opts...)
 
 		if err != nil {
@@ -1778,7 +1778,7 @@ func TestDirectAccessLogic(t *testing.T) {
 		}
 
 		poolSize := 2
-		opts := append(poolOpts(), WithDirectAccessChecker(newDirectAccessChecker(daDial, newPingAndWarmChannelPrimer(testInstanceName, testAppProfile, nil), nil, nil)))
+		opts := append(poolOpts(), WithDirectAccessChecker(newPingAndWarmDirectAccessChecker(daDial, newPingAndWarmChannelPrimer(testInstanceName, testAppProfile, nil), nil, nil)))
 		pool, err := NewBigtableChannelPool(ctx, poolSize, btopt.RoundRobin, baseDialFunc, time.Now(), opts...)
 		if err != nil {
 			t.Fatalf("Failed to create pool: %v", err)
@@ -1803,7 +1803,7 @@ func TestDirectAccessLogic(t *testing.T) {
 		}
 
 		poolSize := 1
-		opts := append(poolOpts(), WithDirectAccessChecker(newDirectAccessChecker(daDial, newPingAndWarmChannelPrimer(testInstanceName, testAppProfile, nil), nil, nil)))
+		opts := append(poolOpts(), WithDirectAccessChecker(newPingAndWarmDirectAccessChecker(daDial, newPingAndWarmChannelPrimer(testInstanceName, testAppProfile, nil), nil, nil)))
 		pool, err := NewBigtableChannelPool(ctx, poolSize, btopt.RoundRobin, baseDialFunc, time.Now(), opts...)
 		if err != nil {
 			t.Fatalf("Failed to create pool: %v", err)
@@ -1829,7 +1829,7 @@ func TestDirectAccessLogic(t *testing.T) {
 			daConn = c
 			return c, nil
 		}
-		opts := append(poolOpts(), WithDirectAccessChecker(newDirectAccessChecker(daDial, newPingAndWarmChannelPrimer(testInstanceName, testAppProfile, nil), nil, nil)))
+		opts := append(poolOpts(), WithDirectAccessChecker(newPingAndWarmDirectAccessChecker(daDial, newPingAndWarmChannelPrimer(testInstanceName, testAppProfile, nil), nil, nil)))
 		poolSize := 1
 		pool, err := NewBigtableChannelPool(ctx, poolSize, btopt.RoundRobin, baseDialFunc, time.Now(), opts...)
 		if err != nil {
@@ -1894,7 +1894,7 @@ func TestDirectAccessLogic(t *testing.T) {
 		}
 
 		poolSize := 1
-		opts := append(poolOpts(), WithDirectAccessChecker(newDirectAccessChecker(daDial, newPingAndWarmChannelPrimer(testInstanceName, testAppProfile, nil), nil, nil)))
+		opts := append(poolOpts(), WithDirectAccessChecker(newPingAndWarmDirectAccessChecker(daDial, newPingAndWarmChannelPrimer(testInstanceName, testAppProfile, nil), nil, nil)))
 		pool, err := NewBigtableChannelPool(ctx, poolSize, btopt.RoundRobin, baseDialFunc, time.Now(), opts...)
 		if err != nil {
 			t.Fatalf("Failed to create pool: %v", err)

--- a/bigtable/internal/transport/direct_access_checker.go
+++ b/bigtable/internal/transport/direct_access_checker.go
@@ -29,7 +29,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/alts"
 	"google.golang.org/grpc/credentials/oauth"
-	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
 	"cloud.google.com/go/bigtable/internal/directaccess"
@@ -89,29 +88,32 @@ func newDirectAccessEligibleGauge(meterProvider metric.MeterProvider, logger *lo
 // dialing once and issuing PingAndWarm + ALTS inspection. On failure it
 // kicks off an asynchronous investigation that records a more specific
 // failure reason on the direct_access/compatible metric.
+//
+// The checker reuses the same *pingAndWarmChannelPrimer that the pool's
+// connection factory uses, so the exact PingAndWarm invocation (instance
+// name, app profile, feature-flag metadata) stays in one place — both the
+// compatibility probe and any single-endpoint investigation go through it.
 type pingAndWarmDirectAccessChecker struct {
 	dialer          func() (*BigtableConn, error)
-	instanceName    string
-	appProfile      string
-	featureFlagsMD  metadata.MD
+	primer          *pingAndWarmChannelPrimer
 	daEligibleGauge metric.Int64Gauge
 	logger          *log.Logger
 }
 
 // newPingAndWarmDirectAccessChecker constructs the today-default checker.
-// A nil meterProvider produces a checker that silently skips metric reporting.
+// A nil meterProvider produces a checker that silently skips metric
+// reporting. The primer must be non-nil; the channel pool factory
+// constructs a single *pingAndWarmChannelPrimer and shares it with both the
+// pool (via WithChannelPrimer) and this checker.
 func newPingAndWarmDirectAccessChecker(
 	dialer func() (*BigtableConn, error),
-	instanceName, appProfile string,
-	featureFlagsMD metadata.MD,
+	primer *pingAndWarmChannelPrimer,
 	meterProvider metric.MeterProvider,
 	logger *log.Logger,
 ) *pingAndWarmDirectAccessChecker {
 	return &pingAndWarmDirectAccessChecker{
 		dialer:          dialer,
-		instanceName:    instanceName,
-		appProfile:      appProfile,
-		featureFlagsMD:  featureFlagsMD,
+		primer:          primer,
 		daEligibleGauge: newDirectAccessEligibleGauge(meterProvider, logger),
 		logger:          logger,
 	}
@@ -134,7 +136,7 @@ func (c *pingAndWarmDirectAccessChecker) CheckCompatibility(ctx context.Context)
 		return nil, false
 	}
 
-	err = conn.Prime(ctx, c.instanceName, c.appProfile, c.featureFlagsMD)
+	err = c.primer.Prime(ctx, conn)
 	if err != nil {
 		// PermissionDenied is expected on probes that are otherwise healthy
 		// (the bootstrap credentials may lack PingAndWarm), so fall through
@@ -328,7 +330,7 @@ func (c *pingAndWarmDirectAccessChecker) probeSingleEndpoint(ctx context.Context
 	defer cancel()
 
 	btopt.Debugf(c.logger, "bigtable_direct_access: investigation: Executing Prime() on %s...", targetEndpoint)
-	if err := btc.Prime(primeCtx, c.instanceName, c.appProfile, c.featureFlagsMD); err != nil {
+	if err := c.primer.Prime(primeCtx, btc); err != nil {
 		return fmt.Errorf("Prime() failed: %w", err)
 	}
 

--- a/bigtable/internal/transport/direct_access_checker.go
+++ b/bigtable/internal/transport/direct_access_checker.go
@@ -89,13 +89,13 @@ func newDirectAccessEligibleGauge(meterProvider metric.MeterProvider, logger *lo
 // kicks off an asynchronous investigation that records a more specific
 // failure reason on the direct_access/compatible metric.
 //
-// The checker reuses the same *pingAndWarmChannelPrimer that the pool's
-// connection factory uses, so the exact PingAndWarm invocation (instance
-// name, app profile, feature-flag metadata) stays in one place — both the
+// The checker reuses the same ChannelPrimer that the pool's connection
+// factory uses, so the exact PingAndWarm invocation (instance name, app
+// profile, feature-flag metadata) stays in one place — both the
 // compatibility probe and any single-endpoint investigation go through it.
 type pingAndWarmDirectAccessChecker struct {
 	dialer          func() (*BigtableConn, error)
-	primer          *pingAndWarmChannelPrimer
+	primer          ChannelPrimer
 	daEligibleGauge metric.Int64Gauge
 	logger          *log.Logger
 }
@@ -103,11 +103,11 @@ type pingAndWarmDirectAccessChecker struct {
 // newPingAndWarmDirectAccessChecker constructs the today-default checker.
 // A nil meterProvider produces a checker that silently skips metric
 // reporting. The primer must be non-nil; the channel pool factory
-// constructs a single *pingAndWarmChannelPrimer and shares it with both the
-// pool (via WithChannelPrimer) and this checker.
+// constructs a single ChannelPrimer and shares it with both the pool (via
+// WithChannelPrimer) and this checker.
 func newPingAndWarmDirectAccessChecker(
 	dialer func() (*BigtableConn, error),
-	primer *pingAndWarmChannelPrimer,
+	primer ChannelPrimer,
 	meterProvider metric.MeterProvider,
 	logger *log.Logger,
 ) *pingAndWarmDirectAccessChecker {

--- a/bigtable/internal/transport/direct_access_checker.go
+++ b/bigtable/internal/transport/direct_access_checker.go
@@ -45,8 +45,9 @@ const xdsCdsURITemplate = "xdstp://traffic-director-c2p.xds.googleapis.com/envoy
 // for direct-access connections once compatibility is confirmed.
 //
 // Implementations differ in HOW compatibility is determined:
-//   - pingAndWarmDirectAccessChecker probes via a PingAndWarm call at startup
-//     (today's only behavior, used by the classic channel pool factory).
+//   - directAccessChecker probes via the configured ChannelPrimer at startup
+//     (today's only behavior, used by the classic channel pool factory; with
+//     pingAndWarmChannelPrimer wired in, the probe is a PingAndWarm call).
 //   - A future GetClientConfiguration-based checker (for session-based pools)
 //     will derive compatibility from a server-driven configuration response
 //     surfaced by ClientConfigurationManager.
@@ -84,34 +85,34 @@ func newDirectAccessEligibleGauge(meterProvider metric.MeterProvider, logger *lo
 	return gauge
 }
 
-// pingAndWarmDirectAccessChecker probes Direct Access compatibility by
-// dialing once and issuing PingAndWarm + ALTS inspection. On failure it
+// directAccessChecker probes Direct Access compatibility by dialing once and
+// running the configured ChannelPrimer + an ALTS inspection. On failure it
 // kicks off an asynchronous investigation that records a more specific
 // failure reason on the direct_access/compatible metric.
 //
 // The checker reuses the same ChannelPrimer that the pool's connection
-// factory uses, so the exact PingAndWarm invocation (instance name, app
-// profile, feature-flag metadata) stays in one place — both the
-// compatibility probe and any single-endpoint investigation go through it.
-type pingAndWarmDirectAccessChecker struct {
+// factory uses, so the exact priming invocation stays in one place — both
+// the compatibility probe and any single-endpoint investigation go through
+// it.
+type directAccessChecker struct {
 	dialer          func() (*BigtableConn, error)
 	primer          ChannelPrimer
 	daEligibleGauge metric.Int64Gauge
 	logger          *log.Logger
 }
 
-// newPingAndWarmDirectAccessChecker constructs the today-default checker.
-// A nil meterProvider produces a checker that silently skips metric
-// reporting. The primer must be non-nil; the channel pool factory
-// constructs a single ChannelPrimer and shares it with both the pool (via
-// WithChannelPrimer) and this checker.
-func newPingAndWarmDirectAccessChecker(
+// newDirectAccessChecker constructs the today-default checker. A nil
+// meterProvider produces a checker that silently skips metric reporting.
+// The primer must be non-nil; the channel pool factory constructs a single
+// ChannelPrimer and shares it with both the pool (via WithChannelPrimer)
+// and this checker.
+func newDirectAccessChecker(
 	dialer func() (*BigtableConn, error),
 	primer ChannelPrimer,
 	meterProvider metric.MeterProvider,
 	logger *log.Logger,
-) *pingAndWarmDirectAccessChecker {
-	return &pingAndWarmDirectAccessChecker{
+) *directAccessChecker {
+	return &directAccessChecker{
 		dialer:          dialer,
 		primer:          primer,
 		daEligibleGauge: newDirectAccessEligibleGauge(meterProvider, logger),
@@ -120,7 +121,7 @@ func newPingAndWarmDirectAccessChecker(
 }
 
 // Dialer returns the configured direct-access dialer.
-func (c *pingAndWarmDirectAccessChecker) Dialer() func() (*BigtableConn, error) {
+func (c *directAccessChecker) Dialer() func() (*BigtableConn, error) {
 	return c.dialer
 }
 
@@ -129,7 +130,7 @@ func (c *pingAndWarmDirectAccessChecker) Dialer() func() (*BigtableConn, error) 
 // returned so the pool can adopt it as its first connection (saving one
 // redial). On incompatible: any probe connection is closed and an async
 // investigation begins to report a specific failure reason.
-func (c *pingAndWarmDirectAccessChecker) CheckCompatibility(ctx context.Context) (*BigtableConn, bool) {
+func (c *directAccessChecker) CheckCompatibility(ctx context.Context) (*BigtableConn, bool) {
 	conn, err := c.dialer()
 	if err != nil {
 		btopt.Debugf(c.logger, "bigtable_direct_access: dial failed: %v", err)
@@ -161,7 +162,7 @@ func (c *pingAndWarmDirectAccessChecker) CheckCompatibility(ctx context.Context)
 }
 
 // reportSuccess records a direct_access/compatible=1 reading.
-func (c *pingAndWarmDirectAccessChecker) reportSuccess(ctx context.Context, ipPreference string) {
+func (c *directAccessChecker) reportSuccess(ctx context.Context, ipPreference string) {
 	if c.daEligibleGauge == nil {
 		return
 	}
@@ -173,7 +174,7 @@ func (c *pingAndWarmDirectAccessChecker) reportSuccess(ctx context.Context, ipPr
 
 // reportFailure records a direct_access/compatible=0 reading with the given
 // reason tag (e.g. "manually_disabled", "metadata_unreachable").
-func (c *pingAndWarmDirectAccessChecker) reportFailure(reason string) {
+func (c *directAccessChecker) reportFailure(reason string) {
 	if c.daEligibleGauge == nil {
 		return
 	}
@@ -187,7 +188,7 @@ func (c *pingAndWarmDirectAccessChecker) reportFailure(reason string) {
 // to determine why Direct Access was not usable, and reports the specific
 // reason to the metric. It walks the GCE-environment preconditions in order
 // of cheapness — short-circuits as soon as a failing precondition is found.
-func (c *pingAndWarmDirectAccessChecker) investigateFailure(originalErr error) {
+func (c *directAccessChecker) investigateFailure(originalErr error) {
 	if err := directaccess.IsRunningOnGCP(); err != nil {
 		btopt.Debugf(c.logger, "bigtable_direct_access: investigation: %v. Original error: %v", err, originalErr)
 		c.reportFailure("not_in_gcp")
@@ -296,7 +297,7 @@ func (c *pingAndWarmDirectAccessChecker) investigateFailure(originalErr error) {
 // probeSingleEndpoint attempts an ALTS-authenticated Prime() request directly
 // against a specific xDS endpoint, isolating whether the failure was at the
 // load-balancer level vs the endpoint itself.
-func (c *pingAndWarmDirectAccessChecker) probeSingleEndpoint(ctx context.Context, targetEndpoint string) error {
+func (c *directAccessChecker) probeSingleEndpoint(ctx context.Context, targetEndpoint string) error {
 	btopt.Debugf(c.logger, "bigtable_direct_access: investigation: Creating ALTS channel to %s...", targetEndpoint)
 
 	altsCreds := alts.NewClientCreds(alts.DefaultClientOptions())

--- a/bigtable/internal/transport/direct_access_checker.go
+++ b/bigtable/internal/transport/direct_access_checker.go
@@ -45,9 +45,8 @@ const xdsCdsURITemplate = "xdstp://traffic-director-c2p.xds.googleapis.com/envoy
 // for direct-access connections once compatibility is confirmed.
 //
 // Implementations differ in HOW compatibility is determined:
-//   - directAccessChecker probes via the configured ChannelPrimer at startup
-//     (today's only behavior, used by the classic channel pool factory; with
-//     pingAndWarmChannelPrimer wired in, the probe is a PingAndWarm call).
+//   - pingAndWarmDirectAccessChecker probes via a PingAndWarm call at startup
+//     (today's only behavior, used by the classic channel pool factory).
 //   - A future GetClientConfiguration-based checker (for session-based pools)
 //     will derive compatibility from a server-driven configuration response
 //     surfaced by ClientConfigurationManager.
@@ -85,34 +84,34 @@ func newDirectAccessEligibleGauge(meterProvider metric.MeterProvider, logger *lo
 	return gauge
 }
 
-// directAccessChecker probes Direct Access compatibility by dialing once and
-// running the configured ChannelPrimer + an ALTS inspection. On failure it
+// pingAndWarmDirectAccessChecker probes Direct Access compatibility by
+// dialing once and issuing PingAndWarm + ALTS inspection. On failure it
 // kicks off an asynchronous investigation that records a more specific
 // failure reason on the direct_access/compatible metric.
 //
 // The checker reuses the same ChannelPrimer that the pool's connection
-// factory uses, so the exact priming invocation stays in one place — both
-// the compatibility probe and any single-endpoint investigation go through
-// it.
-type directAccessChecker struct {
+// factory uses, so the exact PingAndWarm invocation (instance name, app
+// profile, feature-flag metadata) stays in one place — both the
+// compatibility probe and any single-endpoint investigation go through it.
+type pingAndWarmDirectAccessChecker struct {
 	dialer          func() (*BigtableConn, error)
 	primer          ChannelPrimer
 	daEligibleGauge metric.Int64Gauge
 	logger          *log.Logger
 }
 
-// newDirectAccessChecker constructs the today-default checker. A nil
-// meterProvider produces a checker that silently skips metric reporting.
-// The primer must be non-nil; the channel pool factory constructs a single
-// ChannelPrimer and shares it with both the pool (via WithChannelPrimer)
-// and this checker.
-func newDirectAccessChecker(
+// newPingAndWarmDirectAccessChecker constructs the today-default checker.
+// A nil meterProvider produces a checker that silently skips metric
+// reporting. The primer must be non-nil; the channel pool factory
+// constructs a single ChannelPrimer and shares it with both the pool (via
+// WithChannelPrimer) and this checker.
+func newPingAndWarmDirectAccessChecker(
 	dialer func() (*BigtableConn, error),
 	primer ChannelPrimer,
 	meterProvider metric.MeterProvider,
 	logger *log.Logger,
-) *directAccessChecker {
-	return &directAccessChecker{
+) *pingAndWarmDirectAccessChecker {
+	return &pingAndWarmDirectAccessChecker{
 		dialer:          dialer,
 		primer:          primer,
 		daEligibleGauge: newDirectAccessEligibleGauge(meterProvider, logger),
@@ -121,7 +120,7 @@ func newDirectAccessChecker(
 }
 
 // Dialer returns the configured direct-access dialer.
-func (c *directAccessChecker) Dialer() func() (*BigtableConn, error) {
+func (c *pingAndWarmDirectAccessChecker) Dialer() func() (*BigtableConn, error) {
 	return c.dialer
 }
 
@@ -130,7 +129,7 @@ func (c *directAccessChecker) Dialer() func() (*BigtableConn, error) {
 // returned so the pool can adopt it as its first connection (saving one
 // redial). On incompatible: any probe connection is closed and an async
 // investigation begins to report a specific failure reason.
-func (c *directAccessChecker) CheckCompatibility(ctx context.Context) (*BigtableConn, bool) {
+func (c *pingAndWarmDirectAccessChecker) CheckCompatibility(ctx context.Context) (*BigtableConn, bool) {
 	conn, err := c.dialer()
 	if err != nil {
 		btopt.Debugf(c.logger, "bigtable_direct_access: dial failed: %v", err)
@@ -162,7 +161,7 @@ func (c *directAccessChecker) CheckCompatibility(ctx context.Context) (*Bigtable
 }
 
 // reportSuccess records a direct_access/compatible=1 reading.
-func (c *directAccessChecker) reportSuccess(ctx context.Context, ipPreference string) {
+func (c *pingAndWarmDirectAccessChecker) reportSuccess(ctx context.Context, ipPreference string) {
 	if c.daEligibleGauge == nil {
 		return
 	}
@@ -174,7 +173,7 @@ func (c *directAccessChecker) reportSuccess(ctx context.Context, ipPreference st
 
 // reportFailure records a direct_access/compatible=0 reading with the given
 // reason tag (e.g. "manually_disabled", "metadata_unreachable").
-func (c *directAccessChecker) reportFailure(reason string) {
+func (c *pingAndWarmDirectAccessChecker) reportFailure(reason string) {
 	if c.daEligibleGauge == nil {
 		return
 	}
@@ -188,7 +187,7 @@ func (c *directAccessChecker) reportFailure(reason string) {
 // to determine why Direct Access was not usable, and reports the specific
 // reason to the metric. It walks the GCE-environment preconditions in order
 // of cheapness — short-circuits as soon as a failing precondition is found.
-func (c *directAccessChecker) investigateFailure(originalErr error) {
+func (c *pingAndWarmDirectAccessChecker) investigateFailure(originalErr error) {
 	if err := directaccess.IsRunningOnGCP(); err != nil {
 		btopt.Debugf(c.logger, "bigtable_direct_access: investigation: %v. Original error: %v", err, originalErr)
 		c.reportFailure("not_in_gcp")
@@ -297,7 +296,7 @@ func (c *directAccessChecker) investigateFailure(originalErr error) {
 // probeSingleEndpoint attempts an ALTS-authenticated Prime() request directly
 // against a specific xDS endpoint, isolating whether the failure was at the
 // load-balancer level vs the endpoint itself.
-func (c *directAccessChecker) probeSingleEndpoint(ctx context.Context, targetEndpoint string) error {
+func (c *pingAndWarmDirectAccessChecker) probeSingleEndpoint(ctx context.Context, targetEndpoint string) error {
 	btopt.Debugf(c.logger, "bigtable_direct_access: investigation: Creating ALTS channel to %s...", targetEndpoint)
 
 	altsCreds := alts.NewClientCreds(alts.DefaultClientOptions())


### PR DESCRIPTION
## Summary

Mirrors the pluggable shape that PR #19987 established for the Direct Access compatibility check. Channel priming had been hard-wired into the pool via three loose options (`WithInstanceName` / `WithAppProfile` / `WithFeatureFlagsMetadata`) that the `connectionFactory` had to stitch back together on every dial.

- New `ChannelPrimer` interface (`channel_primer.go`): `Prime(ctx, *BigtableConn) error`. The pluggable extension point that future pool factories (session-based, custom) can swap in.
- `pingAndWarmChannelPrimer` is today's only implementation; it owns the `(instance, appProfile, featureFlagsMD)` tuple and delegates to `BigtableConn.Prime` — the existing `PingAndWarm` RPC stays untouched.
- New `WithChannelPrimer` pool option replaces `WithInstanceName` / `WithAppProfile` / `WithFeatureFlagsMetadata`.
- `connectionFactory` now carries a `ChannelPrimer` instead of three individual fields. **When the primer is nil, `primeWithRetry` returns immediately** — the pool dials the channel and puts it straight into rotation, no `PingAndWarm` sent. The classic channel pool factory still wires the `pingAndWarmChannelPrimer`, so user-facing default behavior is unchanged.
- `pingAndWarmDirectAccessChecker` reuses the same primer rather than duplicating `conn.Prime(ctx, instance, profile, flags)` in two places. The factory now constructs **one** primer and shares it with both the pool (via `WithChannelPrimer`) and the checker, eliminating the three-arg drift that existed across the two consumers.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `golint` clean on touched files
- [x] `go test ./internal/transport/...` passes (existing tests migrated; new `channel_primer_test.go` covers (a) `pingAndWarmChannelPrimer.Prime` issues `PingAndWarm` carrying the configured feature-flag metadata, and (b) `connectionFactory` skips priming entirely when the primer is nil)