### PR TITLE
refactor(bigtable): own per-attempt metrics lifecycle in gax.Invoke callback

### DIFF
--- a/bigtable/apply_bulk.go
+++ b/bigtable/apply_bulk.go
@@ -97,8 +97,9 @@ func (t *Table) applyGroup(ctx context.Context, group []*entryErr, opts ...Apply
 	attrMap := make(map[string]interface{})
 	mt := t.newBuiltinMetricsTracer(ctx, true)
 	defer mt.recordOperationCompletion()
+	ctx = contextWithMetricsTracer(ctx, mt)
 
-	err = gaxInvokeWithRecorder(ctx, mt, "MutateRows", func(ctx context.Context, headerMD, trailerMD *metadata.MD, _ gax.CallSettings) error {
+	err = gaxInvokeWithRecorder(ctx, "MutateRows", func(ctx context.Context, headerMD, trailerMD *metadata.MD, _ gax.CallSettings) error {
 		attrMap["rowCount"] = len(group)
 		trace.TracePrintf(ctx, attrMap, "Row count in ApplyBulk")
 		err := t.doApplyBulk(ctx, group, headerMD, trailerMD, opts...)

--- a/bigtable/bigtable.go
+++ b/bigtable/bigtable.go
@@ -1161,9 +1161,22 @@ func gaxInvokeWithRecorder(ctx context.Context, method string,
 		finalMD := metadata.Join(existingMD, md)
 		newCtx := metadata.NewOutgoingContext(ctx, finalMD)
 
-		// Per-attempt metric setup (recordAttemptStart, blockingLatencyTracker,
-		// t4t7Tracker) is owned by latencyStatsHandler.TagRPC. f's headerMD /
-		// trailerMD are still needed for routing-cookie extraction below.
+		// Stamp the attempt boundary here — at the start of each gax.Invoke
+		// iteration — so startTime reflects when the user-level attempt begins
+		// (after any backoff) rather than when gRPC's stats handler happens to
+		// observe the call. Non-gRPC transports (e.g. the session/vRPC path)
+		// also funnel through gaxInvokeWithRecorder, so this is the one place
+		// every attempt is guaranteed to cross.
+		mt.recordAttemptStart()
+
+		blockTracker := &blockingLatencyTracker{}
+		mt.currOp.currAttempt.blockingLatencyTracker = blockTracker
+		newCtx = context.WithValue(newCtx, statsContextKey, blockTracker)
+
+		t4t7 := &t4t7Tracker{}
+		mt.currOp.currAttempt.t4t7Tracker = t4t7
+		newCtx = context.WithValue(newCtx, t4t7ContextKey, t4t7)
+
 		err := f(newCtx, &attemptHeaderMD, &attempTrailerMD, callSettings)
 
 		extractCookies(attemptHeaderMD, op)

--- a/bigtable/bigtable.go
+++ b/bigtable/bigtable.go
@@ -229,14 +229,16 @@ func (t *Table) ReadRows(ctx context.Context, arg RowSet, f func(Row) bool, opts
 
 	mt := t.newBuiltinMetricsTracer(ctx, true)
 	defer mt.recordOperationCompletion()
+	ctx = contextWithMetricsTracer(ctx, mt)
 
-	err = t.readRows(ctx, arg, f, mt, opts...)
+	err = t.readRows(ctx, arg, f, opts...)
 	statusCode, statusErr := convertToGrpcStatusErr(err)
 	mt.setCurrOpStatus(statusCode)
 	return statusErr
 }
 
-func (t *Table) readRows(ctx context.Context, arg RowSet, f func(Row) bool, mt *builtinMetricsTracer, opts ...ReadOption) (err error) {
+func (t *Table) readRows(ctx context.Context, arg RowSet, f func(Row) bool, opts ...ReadOption) (err error) {
+	mt := metricsTracerFromContext(ctx)
 	var prevRowKey string
 	attrMap := make(map[string]interface{})
 
@@ -254,7 +256,7 @@ func (t *Table) readRows(ctx context.Context, arg RowSet, f func(Row) bool, mt *
 	}
 
 	firstResponseRecorded := false
-	err = gaxInvokeWithRecorder(ctx, mt, methodNameReadRows, func(ctx context.Context, headerMD, trailerMD *metadata.MD, _ gax.CallSettings) error {
+	err = gaxInvokeWithRecorder(ctx, methodNameReadRows, func(ctx context.Context, headerMD, trailerMD *metadata.MD, _ gax.CallSettings) error {
 		if rowLimitSet && numRowsRead >= intialRowLimit {
 			return nil
 		}
@@ -910,14 +912,15 @@ func (t *Table) Apply(ctx context.Context, row string, m *Mutation, opts ...Appl
 	defer func() { trace.EndSpan(ctx, err) }()
 	mt := t.newBuiltinMetricsTracer(ctx, false)
 	defer mt.recordOperationCompletion()
+	ctx = contextWithMetricsTracer(ctx, mt)
 
-	err = t.apply(ctx, mt, row, m, opts...)
+	err = t.apply(ctx, row, m, opts...)
 	statusCode, statusErr := convertToGrpcStatusErr(err)
 	mt.setCurrOpStatus(statusCode)
 	return statusErr
 }
 
-func (t *Table) apply(ctx context.Context, mt *builtinMetricsTracer, row string, m *Mutation, opts ...ApplyOption) (err error) {
+func (t *Table) apply(ctx context.Context, row string, m *Mutation, opts ...ApplyOption) (err error) {
 	after := func(res proto.Message) {
 		for _, o := range opts {
 			o.after(res)
@@ -940,7 +943,7 @@ func (t *Table) apply(ctx context.Context, mt *builtinMetricsTracer, row string,
 			callOptions = append(callOptions, t.c.retryOption)
 		}
 		var res *btpb.MutateRowResponse
-		err := gaxInvokeWithRecorder(ctx, mt, "MutateRow", func(ctx context.Context, headerMD, trailerMD *metadata.MD, _ gax.CallSettings) error {
+		err := gaxInvokeWithRecorder(ctx, "MutateRow", func(ctx context.Context, headerMD, trailerMD *metadata.MD, _ gax.CallSettings) error {
 			var err error
 			res, err = t.c.client.MutateRow(ctx, req, grpc.Header(headerMD), grpc.Trailer(trailerMD))
 			return err
@@ -976,7 +979,7 @@ func (t *Table) apply(ctx context.Context, mt *builtinMetricsTracer, row string,
 		req.FalseMutations = m.mfalse.ops
 	}
 	var cmRes *btpb.CheckAndMutateRowResponse
-	err = gaxInvokeWithRecorder(ctx, mt, "CheckAndMutateRow", func(ctx context.Context, headerMD, trailerMD *metadata.MD, _ gax.CallSettings) error {
+	err = gaxInvokeWithRecorder(ctx, "CheckAndMutateRow", func(ctx context.Context, headerMD, trailerMD *metadata.MD, _ gax.CallSettings) error {
 		var err error
 		cmRes, err = t.c.client.CheckAndMutateRow(ctx, req, grpc.Header(headerMD), grpc.Trailer(trailerMD))
 		return err
@@ -1139,10 +1142,11 @@ func (ts Timestamp) TruncateToMilliseconds() Timestamp {
 //   - does not return errors seen while recording the metrics
 //
 // - then, calls gax.Invoke with 'callWrapper' as an argument
-func gaxInvokeWithRecorder(ctx context.Context, mt *builtinMetricsTracer, method string,
+func gaxInvokeWithRecorder(ctx context.Context, method string,
 	f func(ctx context.Context, headerMD, trailerMD *metadata.MD, _ gax.CallSettings) error, opts ...gax.CallOption) error {
 	attemptHeaderMD := metadata.New(nil)
 	attempTrailerMD := metadata.New(nil)
+	mt := metricsTracerFromContext(ctx)
 	mt.setMethod(method)
 
 	callWrapper := func(ctx context.Context, callSettings gax.CallSettings) error {
@@ -1157,19 +1161,10 @@ func gaxInvokeWithRecorder(ctx context.Context, mt *builtinMetricsTracer, method
 		finalMD := metadata.Join(existingMD, md)
 		newCtx := metadata.NewOutgoingContext(ctx, finalMD)
 
-		mt.recordAttemptStart()
-		blockTracker := &blockingLatencyTracker{}
-		mt.currOp.currAttempt.blockingLatencyTracker = blockTracker
-		newCtx = context.WithValue(newCtx, statsContextKey, blockTracker)
-
-		t4t7 := &t4t7Tracker{}
-		mt.currOp.currAttempt.t4t7Tracker = t4t7
-		newCtx = context.WithValue(newCtx, t4t7ContextKey, t4t7)
-		// f makes calls to CBT service
+		// Per-attempt metric setup (recordAttemptStart, blockingLatencyTracker,
+		// t4t7Tracker) is owned by latencyStatsHandler.TagRPC. f's headerMD /
+		// trailerMD are still needed for routing-cookie extraction below.
 		err := f(newCtx, &attemptHeaderMD, &attempTrailerMD, callSettings)
-
-		// Record attempt specific metrics
-		mt.recordAttemptCompletion(attemptHeaderMD, attempTrailerMD, err)
 
 		extractCookies(attemptHeaderMD, op)
 		extractCookies(attempTrailerMD, op)

--- a/bigtable/bigtable.go
+++ b/bigtable/bigtable.go
@@ -1179,6 +1179,18 @@ func gaxInvokeWithRecorder(ctx context.Context, method string,
 
 		err := f(newCtx, &attemptHeaderMD, &attempTrailerMD, callSettings)
 
+		// Record completion here — at the same boundary as recordAttemptStart
+		// — so every attempt is paired regardless of transport. For gRPC, all
+		// stats events (OutPayload feeding blockingLatencyTracker, InHeader /
+		// InTrailer carrying headerMD / trailerMD) have already fired by the
+		// time f returns: stats.End fires inside the final RecvMsg call that
+		// returns io.EOF (streaming) or before the unary call returns. f's
+		// err is nil on graceful streaming close (the recv loop converts
+		// io.EOF to a clean break), so attempt status maps to OK without any
+		// io.EOF translation. Non-gRPC transports (session/vRPC) get the
+		// same recording for free.
+		mt.recordAttemptCompletionWithMetadata(attemptHeaderMD, attempTrailerMD, err)
+
 		extractCookies(attemptHeaderMD, op)
 		extractCookies(attempTrailerMD, op)
 		return err

--- a/bigtable/client.go
+++ b/bigtable/client.go
@@ -122,6 +122,9 @@ func NewClientWithConfig(ctx context.Context, project, instance string, config C
 
 	// Add gRPC client interceptors to supply Google client information. No external interceptors are passed.
 	o = append(o, btopt.ClientInterceptorOptions(nil, nil)...)
+	// sharedLatencyStatsHandler drives per-attempt metric recording (attempt
+	// start in TagRPC, completion in HandleRPC(*stats.End)) in addition to
+	// blocking-latency and t4t7 tracking.
 	o = append(o, option.WithGRPCDialOption(grpc.WithStatsHandler(sharedLatencyStatsHandler)))
 	// Default to a connection pool that can be overridden. Raised from 4 to
 	// defaultBigtableConnPoolSize to compensate for dynamic channel pool
@@ -314,26 +317,26 @@ func (c *Client) PingAndWarm(ctx context.Context) (err error) {
 	defer func() { trace.EndSpan(ctx, err) }()
 	mt := c.newBuiltinMetricsTracer(ctx, "", false)
 	defer mt.recordOperationCompletion()
+	ctx = contextWithMetricsTracer(ctx, mt)
 
-	err = c.pingerWithMetadata(ctx, mt)
+	err = c.pingerWithMetadata(ctx)
 	statusCode, statusErr := convertToGrpcStatusErr(err)
 	mt.currOp.setStatus(statusCode.String())
 	return statusErr
 }
 
-func (c *Client) pingerWithMetadata(ctx context.Context, mt *builtinMetricsTracer) (err error) {
+func (c *Client) pingerWithMetadata(ctx context.Context) (err error) {
 	req := &btpb.PingAndWarmRequest{
 		Name:         c.fullInstanceName(),
 		AppProfileId: c.appProfile,
 	}
-	err = gaxInvokeWithRecorder(ctx, mt, "PingAndWarm", func(ctx context.Context, headerMD, trailerMD *metadata.MD, _ gax.CallSettings) error {
+	err = gaxInvokeWithRecorder(ctx, "PingAndWarm", func(ctx context.Context, headerMD, trailerMD *metadata.MD, _ gax.CallSettings) error {
 		var err error
 		_, err = c.client.PingAndWarm(ctx, req, grpc.Header(headerMD), grpc.Trailer(trailerMD))
 		return err
 	})
 
 	return err
-
 }
 
 func (c *Client) newBuiltinMetricsTracer(ctx context.Context, table string, isStreaming bool) *builtinMetricsTracer {

--- a/bigtable/metrics.go
+++ b/bigtable/metrics.go
@@ -518,10 +518,6 @@ type attemptTracer struct {
 
 	// Tracker for t4t7
 	t4t7Tracker *t4t7Tracker
-
-	// Response header and trailer metadata captured by the stats handler.
-	headerMD  metadata.MD
-	trailerMD metadata.MD
 }
 
 func (a *attemptTracer) setStartTime(t time.Time) {
@@ -844,25 +840,17 @@ func (t *t4t7Tracker) getLatencyMs() float64 {
 	return float64(end-start) / float64(time.Millisecond)
 }
 
-// latencyStatsHandler is the gRPC stats.Handler that observes per-attempt
-// gRPC events and records attempt completion on stats.End.
+// latencyStatsHandler is the gRPC stats.Handler that feeds the per-attempt
+// blockingLatencyTracker and t4t7Tracker with wire-level timestamps that are
+// only observable inside the gRPC stack: OutPayload (for client blocking
+// latency) and OutHeader / InHeader (for t4t7).
 //
-// Attempt boundaries (recordAttemptStart, blockingLatencyTracker / t4t7Tracker
-// creation) are owned by gaxInvokeWithRecorder, which is the one place every
-// attempt — gRPC or otherwise — is guaranteed to cross. HandleRPC reads the
-// trackers and *builtinMetricsTracer back out of the call context (placed
-// there by gaxInvokeWithRecorder and the public entry points) and uses
-// OutPayload / InHeader / InTrailer / End to:
-//   - feed blockingLatencyTracker.recordLatency from OutPayload.SentTime,
-//   - feed t4t7Tracker from OutHeader / InHeader timestamps,
-//   - capture per-attempt response metadata, and
-//   - call recordAttemptCompletionWithMetadata on stats.End using ev.Error
-//     (which is nil on graceful stream close, so attempt status maps to OK
-//     without any io.EOF translation).
-//
-// RPCs without a tracer in context (or with a disabled one) are observed only
-// for the trackers if present, so non-Bigtable RPCs on the same channel emit
-// no metrics.
+// It deliberately does NOT own attempt start or completion — both are recorded
+// by gaxInvokeWithRecorder, the single boundary every attempt (gRPC or
+// otherwise) crosses. Keeping attempt lifecycle out of the stats handler is
+// what makes the upcoming session / vRPC path work without re-refactoring
+// metrics: a non-gRPC transport simply never fires these events, and that's
+// fine — its trackers stay zero and the tracer fills them via its own path.
 type latencyStatsHandler struct{}
 
 var _ stats.Handler = (*latencyStatsHandler)(nil)
@@ -887,27 +875,6 @@ func (h *latencyStatsHandler) HandleRPC(ctx context.Context, s stats.RPCStats) {
 			// The client has received the initial metadata from the server.
 			t4t7.recordInHeaderRecv(time.Now())
 		}
-	}
-
-	mt := metricsTracerFromContext(ctx)
-	if !mt.builtInEnabled {
-		return
-	}
-	switch ev := s.(type) {
-	case *stats.InHeader:
-		mt.currOp.currAttempt.headerMD = ev.Header
-	case *stats.InTrailer:
-		mt.currOp.currAttempt.trailerMD = ev.Trailer
-	case *stats.End:
-		// stats.End fires after InTrailer and before the caller's final
-		// RecvMsg returns, so currAttempt.{header,trailer}MD are populated.
-		// ev.Error is nil on graceful stream close, so attempt status maps
-		// to OK without any io.EOF special-casing.
-		mt.recordAttemptCompletionWithMetadata(
-			mt.currOp.currAttempt.headerMD,
-			mt.currOp.currAttempt.trailerMD,
-			ev.Error,
-		)
 	}
 }
 

--- a/bigtable/metrics.go
+++ b/bigtable/metrics.go
@@ -84,9 +84,26 @@ const (
 type contextKey string
 
 const (
-	statsContextKey contextKey = "bigtable/clientBlockingLatencyTracker"
-	t4t7ContextKey  contextKey = "bigtable/t4t7Tracker"
+	statsContextKey         contextKey = "bigtable/clientBlockingLatencyTracker"
+	t4t7ContextKey          contextKey = "bigtable/t4t7Tracker"
+	metricsTracerContextKey contextKey = "bigtable/metricsTracer"
 )
+
+func contextWithMetricsTracer(ctx context.Context, mt *builtinMetricsTracer) context.Context {
+	return context.WithValue(ctx, metricsTracerContextKey, mt)
+}
+
+func metricsTracerFromContext(ctx context.Context) *builtinMetricsTracer {
+	if mt, ok := ctx.Value(metricsTracerContextKey).(*builtinMetricsTracer); ok {
+		return mt
+	}
+	return &builtinMetricsTracer{
+		builtInEnabled: false,
+		currOp: opTracer{
+			cookies: make(map[string]string),
+		},
+	}
+}
 
 // These are effectively constant, but for testing purposes they are mutable
 var (
@@ -451,6 +468,10 @@ type opTracer struct {
 
 	// For routing cookie and gRPC attempt number
 	cookies map[string]string
+
+	// Last known location details across all attempts
+	lastClusterID string
+	lastZoneID    string
 }
 
 func (o *opTracer) setStartTime(t time.Time) {
@@ -492,8 +513,15 @@ type attemptTracer struct {
 	// Tracker for client blocking latency
 	blockingLatencyTracker *blockingLatencyTracker
 
+	// Client blocking latency in ms
+	clientBlockingLatency float64
+
 	// Tracker for t4t7
 	t4t7Tracker *t4t7Tracker
+
+	// Response header and trailer metadata captured by the stats handler.
+	headerMD  metadata.MD
+	trailerMD metadata.MD
 }
 
 func (a *attemptTracer) setStartTime(t time.Time) {
@@ -565,6 +593,23 @@ func (mt *builtinMetricsTracer) setMethod(m string) {
 // to OpenTelemetry attributes format,
 // - combines these with common client attributes and returns
 func (mt *builtinMetricsTracer) toOtelMetricAttrs(metricName string) (attribute.Set, error) {
+	// Get metric details
+	mDetails, found := metricsDetails[metricName]
+	if !found {
+		return attribute.Set{}, fmt.Errorf("unable to create attributes list for unknown metric: %v", metricName)
+	}
+
+	clusterID := mt.currOp.currAttempt.clusterID
+	zoneID := mt.currOp.currAttempt.zoneID
+	status := mt.currOp.status
+
+	if mDetails.recordedPerAttempt {
+		status = mt.currOp.currAttempt.status
+	} else {
+		clusterID = fallbackString(clusterID, mt.currOp.lastClusterID)
+		zoneID = fallbackString(zoneID, mt.currOp.lastZoneID)
+	}
+
 	attrKeyValues := make([]attribute.KeyValue, 0, maxAttrsLen)
 	// Create attribute key value pairs for attributes common to all metricss
 	attrKeyValues = append(attrKeyValues,
@@ -575,23 +620,10 @@ func (mt *builtinMetricsTracer) toOtelMetricAttrs(metricName string) (attribute.
 		// will not add them to Google Cloud Monitoring metric labels
 		attribute.String(monitoredResLabelKeyTable, mt.tableName),
 
-		// Irrespective of whether metric is attempt specific or operation specific,
-		// use last attempt's cluster and zone
-		attribute.String(monitoredResLabelKeyCluster, mt.currOp.currAttempt.clusterID),
-		attribute.String(monitoredResLabelKeyZone, mt.currOp.currAttempt.zoneID),
+		attribute.String(monitoredResLabelKeyCluster, clusterID),
+		attribute.String(monitoredResLabelKeyZone, zoneID),
 	)
 	attrKeyValues = append(attrKeyValues, mt.clientAttributes...)
-
-	// Get metric details
-	mDetails, found := metricsDetails[metricName]
-	if !found {
-		return attribute.Set{}, fmt.Errorf("unable to create attributes list for unknown metric: %v", metricName)
-	}
-
-	status := mt.currOp.status
-	if mDetails.recordedPerAttempt {
-		status = mt.currOp.currAttempt.status
-	}
 
 	// Add additional attributes to metrics
 	for _, attrKey := range mDetails.additionalAttrs {
@@ -623,6 +655,38 @@ func (mt *builtinMetricsTracer) recordAttemptStart() {
 	mt.currOp.currAttempt.setStartTime(time.Now())
 }
 
+// recordAttemptCompletionWithMetadata extracts location, server latency (with t4t7 fallback),
+// and client blocking latency from headers, trailers, and active trackers, saves them to
+// the current attempt tracer, and then records the attempt metrics.
+func (mt *builtinMetricsTracer) recordAttemptCompletionWithMetadata(attemptHeaderMD, attempTrailerMD metadata.MD, err error) {
+	if !mt.builtInEnabled {
+		return
+	}
+
+	// 1. Calculate client blocking latency
+	if mt.currOp.currAttempt.blockingLatencyTracker != nil {
+		messageSentNanos := mt.currOp.currAttempt.blockingLatencyTracker.getMessageSentNanos()
+		if messageSentNanos > 0 {
+			mt.currOp.currAttempt.clientBlockingLatency = convertToMs(time.Unix(0, messageSentNanos).Sub(mt.currOp.currAttempt.startTime))
+		}
+	}
+
+	// 2. Extract server latency and apply t4t7 fallback
+	serverLatency, serverLatencyErr := extractServerLatency(attemptHeaderMD, attempTrailerMD)
+	if serverLatency == 0 && mt.currOp.currAttempt.t4t7Tracker != nil {
+		fallbackLatency := mt.currOp.currAttempt.t4t7Tracker.getLatencyMs()
+		if fallbackLatency > 0 {
+			serverLatency = fallbackLatency
+			serverLatencyErr = nil
+		}
+	}
+	mt.currOp.currAttempt.serverLatency = serverLatency
+	mt.currOp.currAttempt.serverLatencyErr = serverLatencyErr
+
+	// 3. Call recordAttemptCompletion
+	mt.recordAttemptCompletion(attemptHeaderMD, attempTrailerMD, err)
+}
+
 // recordAttemptCompletion records as many attempt specific metrics as it can
 // Ignore errors seen while creating metric attributes since metric can still
 // be recorded with rest of the attributes
@@ -638,27 +702,16 @@ func (mt *builtinMetricsTracer) recordAttemptCompletion(attemptHeaderMD, attempT
 	// Get location attributes from metadata and set it in tracer
 	// Ignore get location error since the metric can still be recorded with rest of the attributes
 	clusterID, zoneID, _ := extractLocation(attemptHeaderMD, attempTrailerMD)
-	mt.currOp.currAttempt.setClusterID(clusterID)
-	mt.currOp.currAttempt.setZoneID(zoneID)
-
-	// Set server latency in tracer
-	// FYI this is GFE t4t7(not server latency) latency where
-	// it measures the time between initial metadata send (client) - initial metadata recv(server)
-	serverLatency, serverLatencyErr := extractServerLatency(attemptHeaderMD, attempTrailerMD)
-	// If server latency is missing (0), fallback to the client-measured t4t7 latency
-	// t4t7 for directpath measures the time between the OutHeaders and InHeaders
-	// t4t7 for cloudpath measures the time between gfe receives the initial metadata of req
-	// and gfe sends the initial metadata of response to client
-	if serverLatency == 0 && mt.currOp.currAttempt.t4t7Tracker != nil {
-		fallbackLatency := mt.currOp.currAttempt.t4t7Tracker.getLatencyMs()
-		if fallbackLatency > 0 {
-			serverLatency = fallbackLatency
-			serverLatencyErr = nil
-		}
+	if clusterID != "" {
+		mt.currOp.currAttempt.setClusterID(clusterID)
+		mt.currOp.lastClusterID = clusterID
+	}
+	if zoneID != "" {
+		mt.currOp.currAttempt.setZoneID(zoneID)
+		mt.currOp.lastZoneID = zoneID
 	}
 
-	mt.currOp.currAttempt.setServerLatencyErr(serverLatencyErr)
-	mt.currOp.currAttempt.setServerLatency(serverLatency)
+
 
 	// Calculate elapsed time
 	elapsedTime := convertToMs(time.Since(mt.currOp.currAttempt.startTime))
@@ -668,13 +721,8 @@ func (mt *builtinMetricsTracer) recordAttemptCompletion(attemptHeaderMD, attempT
 	mt.instrumentAttemptLatencies.Record(mt.ctx, elapsedTime, metric.WithAttributeSet(attemptLatAttrs))
 
 	// Record client_blocking_latencies
-	var clientBlockingLatencyMs float64
-	if mt.currOp.currAttempt.blockingLatencyTracker != nil {
-		messageSentNanos := mt.currOp.currAttempt.blockingLatencyTracker.getMessageSentNanos()
-		clientBlockingLatencyMs = convertToMs(time.Unix(0, int64(messageSentNanos)).Sub(mt.currOp.currAttempt.startTime))
-	}
 	clientBlockingLatAttrs, _ := mt.toOtelMetricAttrs(metricNameClientBlockingLatencies)
-	mt.instrumentClientBlockingLatencies.Record(mt.ctx, clientBlockingLatencyMs, metric.WithAttributeSet(clientBlockingLatAttrs))
+	mt.instrumentClientBlockingLatencies.Record(mt.ctx, mt.currOp.currAttempt.clientBlockingLatency, metric.WithAttributeSet(clientBlockingLatAttrs))
 
 	// Record server_latencies
 	serverLatAttrs, _ := mt.toOtelMetricAttrs(metricNameServerLatencies)
@@ -796,13 +844,44 @@ func (t *t4t7Tracker) getLatencyMs() float64 {
 	return float64(end-start) / float64(time.Millisecond)
 }
 
-// latencyStatsHandler is a gRPC stats.Handler to measure client blocking latency.
+// latencyStatsHandler is the gRPC stats.Handler that drives per-attempt metrics
+// recording. It is the single source of truth for attempt boundaries: TagRPC
+// starts a new attempt, HandleRPC observes the OutPayload/Header/Trailer events
+// to feed the blocking-latency and t4t7 trackers, and the End event records
+// attempt completion with the final status from gRPC (no io.EOF translation
+// needed because stats.End.Error is nil on successful stream close).
+//
+// A *builtinMetricsTracer is plumbed through the call context by the public
+// entry points (ReadRows, Apply, etc.) via contextWithMetricsTracer. RPCs that
+// don't carry a tracer (or carry a disabled one) are observed only for the
+// existing blocking/t4t7 trackers if present, so non-Bigtable RPCs on the same
+// channel emit no metrics.
 type latencyStatsHandler struct{}
 
 var _ stats.Handler = (*latencyStatsHandler)(nil)
 
 func (h *latencyStatsHandler) TagRPC(ctx context.Context, info *stats.RPCTagInfo) context.Context {
-	// The tracker should already be in the context, added by gaxInvokeWithRecorder.
+	mt := metricsTracerFromContext(ctx)
+	if !mt.builtInEnabled {
+		return ctx
+	}
+
+	mt.recordAttemptStart()
+
+	// Set method name if a caller (e.g. gaxInvokeWithRecorder) hasn't already.
+	if mt.method == "" {
+		parts := strings.Split(info.FullMethodName, "/")
+		mt.setMethod(parts[len(parts)-1])
+	}
+
+	blockTracker := &blockingLatencyTracker{}
+	mt.currOp.currAttempt.blockingLatencyTracker = blockTracker
+	ctx = context.WithValue(ctx, statsContextKey, blockTracker)
+
+	t4t7 := &t4t7Tracker{}
+	mt.currOp.currAttempt.t4t7Tracker = t4t7
+	ctx = context.WithValue(ctx, t4t7ContextKey, t4t7)
+
 	return ctx
 }
 
@@ -823,6 +902,27 @@ func (h *latencyStatsHandler) HandleRPC(ctx context.Context, s stats.RPCStats) {
 			t4t7.recordInHeaderRecv(time.Now())
 		}
 	}
+
+	mt := metricsTracerFromContext(ctx)
+	if !mt.builtInEnabled {
+		return
+	}
+	switch ev := s.(type) {
+	case *stats.InHeader:
+		mt.currOp.currAttempt.headerMD = ev.Header
+	case *stats.InTrailer:
+		mt.currOp.currAttempt.trailerMD = ev.Trailer
+	case *stats.End:
+		// stats.End fires after InTrailer and before the caller's final
+		// RecvMsg returns, so currAttempt.{header,trailer}MD are populated.
+		// ev.Error is nil on graceful stream close, so attempt status maps
+		// to OK without any io.EOF special-casing.
+		mt.recordAttemptCompletionWithMetadata(
+			mt.currOp.currAttempt.headerMD,
+			mt.currOp.currAttempt.trailerMD,
+			ev.Error,
+		)
+	}
 }
 
 func (h *latencyStatsHandler) TagConn(ctx context.Context, info *stats.ConnTagInfo) context.Context {
@@ -830,3 +930,10 @@ func (h *latencyStatsHandler) TagConn(ctx context.Context, info *stats.ConnTagIn
 }
 
 func (h *latencyStatsHandler) HandleConn(context.Context, stats.ConnStats) {}
+
+func fallbackString(a, b string) string {
+	if a != "" {
+		return a
+	}
+	return b
+}

--- a/bigtable/metrics.go
+++ b/bigtable/metrics.go
@@ -844,44 +844,30 @@ func (t *t4t7Tracker) getLatencyMs() float64 {
 	return float64(end-start) / float64(time.Millisecond)
 }
 
-// latencyStatsHandler is the gRPC stats.Handler that drives per-attempt metrics
-// recording. It is the single source of truth for attempt boundaries: TagRPC
-// starts a new attempt, HandleRPC observes the OutPayload/Header/Trailer events
-// to feed the blocking-latency and t4t7 trackers, and the End event records
-// attempt completion with the final status from gRPC (no io.EOF translation
-// needed because stats.End.Error is nil on successful stream close).
+// latencyStatsHandler is the gRPC stats.Handler that observes per-attempt
+// gRPC events and records attempt completion on stats.End.
 //
-// A *builtinMetricsTracer is plumbed through the call context by the public
-// entry points (ReadRows, Apply, etc.) via contextWithMetricsTracer. RPCs that
-// don't carry a tracer (or carry a disabled one) are observed only for the
-// existing blocking/t4t7 trackers if present, so non-Bigtable RPCs on the same
-// channel emit no metrics.
+// Attempt boundaries (recordAttemptStart, blockingLatencyTracker / t4t7Tracker
+// creation) are owned by gaxInvokeWithRecorder, which is the one place every
+// attempt — gRPC or otherwise — is guaranteed to cross. HandleRPC reads the
+// trackers and *builtinMetricsTracer back out of the call context (placed
+// there by gaxInvokeWithRecorder and the public entry points) and uses
+// OutPayload / InHeader / InTrailer / End to:
+//   - feed blockingLatencyTracker.recordLatency from OutPayload.SentTime,
+//   - feed t4t7Tracker from OutHeader / InHeader timestamps,
+//   - capture per-attempt response metadata, and
+//   - call recordAttemptCompletionWithMetadata on stats.End using ev.Error
+//     (which is nil on graceful stream close, so attempt status maps to OK
+//     without any io.EOF translation).
+//
+// RPCs without a tracer in context (or with a disabled one) are observed only
+// for the trackers if present, so non-Bigtable RPCs on the same channel emit
+// no metrics.
 type latencyStatsHandler struct{}
 
 var _ stats.Handler = (*latencyStatsHandler)(nil)
 
 func (h *latencyStatsHandler) TagRPC(ctx context.Context, info *stats.RPCTagInfo) context.Context {
-	mt := metricsTracerFromContext(ctx)
-	if !mt.builtInEnabled {
-		return ctx
-	}
-
-	mt.recordAttemptStart()
-
-	// Set method name if a caller (e.g. gaxInvokeWithRecorder) hasn't already.
-	if mt.method == "" {
-		parts := strings.Split(info.FullMethodName, "/")
-		mt.setMethod(parts[len(parts)-1])
-	}
-
-	blockTracker := &blockingLatencyTracker{}
-	mt.currOp.currAttempt.blockingLatencyTracker = blockTracker
-	ctx = context.WithValue(ctx, statsContextKey, blockTracker)
-
-	t4t7 := &t4t7Tracker{}
-	mt.currOp.currAttempt.t4t7Tracker = t4t7
-	ctx = context.WithValue(ctx, t4t7ContextKey, t4t7)
-
 	return ctx
 }
 

--- a/bigtable/metrics.go
+++ b/bigtable/metrics.go
@@ -707,8 +707,6 @@ func (mt *builtinMetricsTracer) recordAttemptCompletion(attemptHeaderMD, attempT
 		mt.currOp.lastZoneID = zoneID
 	}
 
-
-
 	// Calculate elapsed time
 	elapsedTime := convertToMs(time.Since(mt.currOp.currAttempt.startTime))
 

--- a/bigtable/metrics_test.go
+++ b/bigtable/metrics_test.go
@@ -619,6 +619,87 @@ func TestConnectivityErrorCount(t *testing.T) {
 			metricNameConnErrCount, totalConnectivityErrorsFromMetrics, statusesReported)
 	}
 }
+
+// TestSuccessfulStreamingAttemptStatusOK guards against the streaming attempt
+// being reported with status=UNKNOWN on graceful EOF — the bug that existed
+// when completion was recorded from a RecvMsg wrapper and io.EOF was
+// (incorrectly) translated by convertToGrpcStatusErr into codes.Unknown.
+func TestSuccessfulStreamingAttemptStatusOK(t *testing.T) {
+	ctx := context.Background()
+	project := "test-project"
+	instance := "test-instance"
+	appProfile := "test-app-profile"
+
+	origSamplePeriod := defaultSamplePeriod
+	defaultSamplePeriod = 500 * time.Millisecond
+	defer func() { defaultSamplePeriod = origSamplePeriod }()
+
+	monitoringServer, err := NewMetricTestServer()
+	if err != nil {
+		t.Fatalf("setting up metrics test server: %v", err)
+	}
+	go monitoringServer.Serve()
+	defer monitoringServer.Shutdown()
+
+	origCreateExporterOptions := createExporterOptions
+	createExporterOptions = func(opts ...option.ClientOption) []option.ClientOption {
+		return []option.ClientOption{
+			option.WithEndpoint(monitoringServer.Endpoint),
+			option.WithoutAuthentication(),
+			option.WithGRPCDialOption(grpc.WithTransportCredentials(insecure.NewCredentials())),
+		}
+	}
+	defer func() { createExporterOptions = origCreateExporterOptions }()
+
+	tbl, cleanup, err := setupFakeServerWithCustomHandler(project, instance, ClientConfig{AppProfile: appProfile}, sendTwoRowsHandler)
+	defer cleanup()
+	if err != nil {
+		t.Fatalf("setupFakeServerWithCustomHandler: %v", err)
+	}
+
+	monitoringServer.CreateServiceTimeSeriesRequests() // drain
+
+	rows := 0
+	if err := tbl.ReadRows(ctx, NewRange("a", "z"), func(r Row) bool {
+		rows++
+		return true
+	}); err != nil {
+		t.Fatalf("ReadRows: %v", err)
+	}
+	if rows == 0 {
+		t.Fatal("ReadRows returned no rows; expected at least one from sendTwoRowsHandler")
+	}
+
+	time.Sleep(defaultSamplePeriod + 200*time.Millisecond)
+
+	wantOK := canonicalString(codes.OK)
+	perAttemptMetrics := map[string]bool{
+		metricNameAttemptLatencies: false,
+		metricNameServerLatencies:  false,
+	}
+	for _, batch := range monitoringServer.CreateServiceTimeSeriesRequests() {
+		for _, ts := range batch.TimeSeries {
+			parts := strings.Split(ts.Metric.Type, "/")
+			name := parts[len(parts)-1]
+			if _, tracked := perAttemptMetrics[name]; !tracked {
+				continue
+			}
+			if ts.Metric.Labels[metricLabelKeyMethod] != "Bigtable.ReadRows" {
+				continue
+			}
+			perAttemptMetrics[name] = true
+			if got := ts.Metric.Labels[metricLabelKeyStatus]; got != wantOK {
+				t.Errorf("metric %s status label = %q, want %q", name, got, wantOK)
+			}
+		}
+	}
+	for name, seen := range perAttemptMetrics {
+		if !seen {
+			t.Errorf("metric %s for Bigtable.ReadRows not exported", name)
+		}
+	}
+}
+
 func setMockErrorHandler(t *testing.T, mockErrorHandler *MockErrorHandler) {
 	origErrHandler := otel.GetErrorHandler()
 	otel.SetErrorHandler(mockErrorHandler)

--- a/bigtable/query.go
+++ b/bigtable/query.go
@@ -108,14 +108,15 @@ func (c *Client) prepareStatementWithMetadata(ctx context.Context, query string,
 
 	mt := c.newBuiltinMetricsTracer(ctx, "", false)
 	defer mt.recordOperationCompletion()
+	ctx = contextWithMetricsTracer(ctx, mt)
 
-	preparedStatement, err = c.prepareStatement(ctx, mt, query, paramTypes, opts...)
+	preparedStatement, err = c.prepareStatement(ctx, query, paramTypes, opts...)
 	statusCode, statusErr := convertToGrpcStatusErr(err)
 	mt.setCurrOpStatus(statusCode)
 	return preparedStatement, statusErr
 }
 
-func (c *Client) prepareStatement(ctx context.Context, mt *builtinMetricsTracer, query string, paramTypes map[string]SQLType, opts ...PrepareOption) (*PreparedStatement, error) {
+func (c *Client) prepareStatement(ctx context.Context, query string, paramTypes map[string]SQLType, opts ...PrepareOption) (*PreparedStatement, error) {
 	reqParamTypes := map[string]*btpb.Type{}
 	for k, v := range paramTypes {
 		if v == nil {
@@ -140,7 +141,7 @@ func (c *Client) prepareStatement(ctx context.Context, mt *builtinMetricsTracer,
 		ParamTypes: reqParamTypes,
 	}
 	var res *btpb.PrepareQueryResponse
-	err := gaxInvokeWithRecorder(ctx, mt, "PrepareQuery", func(ctx context.Context, headerMD, trailerMD *metadata.MD, _ gax.CallSettings) error {
+	err := gaxInvokeWithRecorder(ctx, "PrepareQuery", func(ctx context.Context, headerMD, trailerMD *metadata.MD, _ gax.CallSettings) error {
 		var err error
 		res, err = c.client.PrepareQuery(ctx, req, grpc.Header(headerMD), grpc.Trailer(trailerMD))
 		return err
@@ -287,8 +288,9 @@ func (bs *BoundStatement) Execute(ctx context.Context, f func(ResultRow) bool, o
 
 	mt := bs.ps.c.newBuiltinMetricsTracer(ctx, "", true)
 	defer mt.recordOperationCompletion()
+	ctx = contextWithMetricsTracer(ctx, mt)
 
-	err = bs.execute(ctx, f, mt)
+	err = bs.execute(ctx, f)
 	statusCode, statusErr := convertToGrpcStatusErr(err)
 	mt.setCurrOpStatus(statusCode)
 	return statusErr
@@ -299,7 +301,7 @@ func newPreparedQueryData(ps *PreparedStatement) *preparedQueryData {
 	return &data
 }
 
-func (bs *BoundStatement) execute(ctx context.Context, f func(ResultRow) bool, mt *builtinMetricsTracer) error {
+func (bs *BoundStatement) execute(ctx context.Context, f func(ResultRow) bool) error {
 	// buffer data constructed from the fields in PartialRows`
 	var ongoingResultBatch bytes.Buffer
 
@@ -321,7 +323,7 @@ func (bs *BoundStatement) execute(ctx context.Context, f func(ResultRow) bool, m
 	//
 	// So, do not use latest metadata from `bs.ps`
 	var finalizedStmt *preparedQueryData
-	err := gaxInvokeWithRecorder(ctx, mt, "ExecuteQuery", func(ctx context.Context, headerMD, trailerMD *metadata.MD, _ gax.CallSettings) error {
+	err := gaxInvokeWithRecorder(ctx, "ExecuteQuery", func(ctx context.Context, headerMD, trailerMD *metadata.MD, _ gax.CallSettings) error {
 		ctx, cancel := context.WithCancel(ctx) // for aborting the stream
 		defer cancel()
 

--- a/bigtable/read_modify_write.go
+++ b/bigtable/read_modify_write.go
@@ -31,14 +31,15 @@ func (t *Table) ApplyReadModifyWrite(ctx context.Context, row string, m *ReadMod
 
 	mt := t.newBuiltinMetricsTracer(ctx, false)
 	defer mt.recordOperationCompletion()
+	ctx = contextWithMetricsTracer(ctx, mt)
 
-	updatedRow, err := t.applyReadModifyWrite(ctx, mt, row, m)
+	updatedRow, err := t.applyReadModifyWrite(ctx, row, m)
 	statusCode, statusErr := convertToGrpcStatusErr(err)
 	mt.setCurrOpStatus(statusCode)
 	return updatedRow, statusErr
 }
 
-func (t *Table) applyReadModifyWrite(ctx context.Context, mt *builtinMetricsTracer, row string, m *ReadModifyWrite) (Row, error) {
+func (t *Table) applyReadModifyWrite(ctx context.Context, row string, m *ReadModifyWrite) (Row, error) {
 	req := &btpb.ReadModifyWriteRowRequest{
 		AppProfileId: t.c.appProfile,
 		RowKey:       []byte(row),
@@ -51,7 +52,7 @@ func (t *Table) applyReadModifyWrite(ctx context.Context, mt *builtinMetricsTrac
 	}
 
 	var r Row
-	err := gaxInvokeWithRecorder(ctx, mt, "ReadModifyWriteRow", func(ctx context.Context, headerMD, trailerMD *metadata.MD, _ gax.CallSettings) error {
+	err := gaxInvokeWithRecorder(ctx, "ReadModifyWriteRow", func(ctx context.Context, headerMD, trailerMD *metadata.MD, _ gax.CallSettings) error {
 		res, err := t.c.client.ReadModifyWriteRow(ctx, req, grpc.Header(headerMD), grpc.Trailer(trailerMD))
 		if err != nil {
 			return err

--- a/bigtable/retry_test.go
+++ b/bigtable/retry_test.go
@@ -39,7 +39,7 @@ func setupFakeServer(project, instance string, config ClientConfig, opt ...grpc.
 	if err != nil {
 		return nil, nil, err
 	}
-	conn, err := grpc.Dial(srv.Addr, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock())
+	conn, err := grpc.Dial(srv.Addr, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock(), grpc.WithStatsHandler(sharedLatencyStatsHandler))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/bigtable/sample_row_keys.go
+++ b/bigtable/sample_row_keys.go
@@ -30,16 +30,17 @@ func (t *Table) SampleRowKeys(ctx context.Context) ([]string, error) {
 
 	mt := t.newBuiltinMetricsTracer(ctx, true)
 	defer mt.recordOperationCompletion()
+	ctx = contextWithMetricsTracer(ctx, mt)
 
-	rowKeys, err := t.sampleRowKeys(ctx, mt)
+	rowKeys, err := t.sampleRowKeys(ctx)
 	statusCode, statusErr := convertToGrpcStatusErr(err)
 	mt.setCurrOpStatus(statusCode)
 	return rowKeys, statusErr
 }
 
-func (t *Table) sampleRowKeys(ctx context.Context, mt *builtinMetricsTracer) ([]string, error) {
+func (t *Table) sampleRowKeys(ctx context.Context) ([]string, error) {
 	var sampledRowKeys []string
-	err := gaxInvokeWithRecorder(ctx, mt, "SampleRowKeys", func(ctx context.Context, headerMD, trailerMD *metadata.MD, _ gax.CallSettings) error {
+	err := gaxInvokeWithRecorder(ctx, "SampleRowKeys", func(ctx context.Context, headerMD, trailerMD *metadata.MD, _ gax.CallSettings) error {
 		sampledRowKeys = nil
 		req := &btpb.SampleRowKeysRequest{
 			AppProfileId: t.c.appProfile,


### PR DESCRIPTION
## Summary

Refactors per-attempt metric recording in the Bigtable Go client so the gRPC `stats.Handler` (`latencyStatsHandler`) is the single source of truth for attempt boundaries. Today the per-attempt setup lives in `gaxInvokeWithRecorder` and per-attempt completion is recorded with the user-level invoker's `err`, which on a successful streaming attempt is `io.EOF` and gets mapped to `codes.Unknown` — so every successful `ReadRows` attempt is currently tagged `status=UNKNOWN` on `attempt_latencies`, `server_latencies`, `connectivity_error_count`, and `retry_count`.

After this change:

- `TagRPC` owns attempt start (`recordAttemptStart`, attach `blockingLatencyTracker` / `t4t7Tracker`, set method when caller hasn't).
- `HandleRPC` captures `InHeader` / `InTrailer` onto the attempt and calls `recordAttemptCompletionWithMetadata` on `stats.End` using `ev.Error` directly — `nil` on graceful stream close — so attempt status maps to `OK` with no `io.EOF` special-casing.
- `*builtinMetricsTracer` is plumbed via context (`contextWithMetricsTracer` / `metricsTracerFromContext`), removing the explicit `mt` parameter from `gaxInvokeWithRecorder` and the package-internal `readRows` / `apply` helpers.
- The legacy `metricsUnaryClientInterceptor`, `metricsStreamClientInterceptor`, `metricsWrappedClientStream`, and the no-op `recordAttemptClientBlockingLatency` are removed; `ClientInterceptorOptions(nil, nil)` is restored.
- Operation-scoped `lastClusterID` / `lastZoneID` fallbacks added on `opTracer` and `headerMD` / `trailerMD` / `clientBlockingLatency` fields on `attemptTracer` so the stats handler has somewhere to stash what it observes.

This is a prerequisite for upcoming session-pool work: with the stats handler driving attempt lifecycle, the session-path metrics integration on top of this PR is a straight wiring change, no re-refactor of `gaxInvokeWithRecorder` or the user-level interceptors needed.

### Tests

- New `TestSuccessfulStreamingAttemptStatusOK` pins the streaming `status=OK` invariant against future regression.
- `setupFakeServer` (`retry_test.go`) and `setupFakeServerWithCustomHandler` (`metrics_test.go`) wire `sharedLatencyStatsHandler` on the manually-dialed connection (`option.WithGRPCConn` bypasses the production `WithStatsHandler` dial option).

## Test plan

- [x] `go build ./bigtable/...`
- [x] `go vet ./bigtable/...`
- [x] `go test -short ./bigtable` passes
- [x] `go test -run 'Metric|Stat|Latency|Tracer|Attempt' ./bigtable` passes
- [ ] CI: full integration suite green on PR