### PR TITLE
feat(firestore): add limit, offset, and languageCode options

### DIFF
--- a/firestore/pipeline.go
+++ b/firestore/pipeline.go
@@ -1056,6 +1056,40 @@ func WithSearchRetrievalDepth(depth int64) SearchOption {
 	})
 }
 
+// WithSearchLimit specifies the maximum number of documents to return from the search stage.
+// The limit is applied after documents are scored and sorted.
+//
+// Experimental: Update, Delete and Search stages in pipeline queries are in public preview
+// and are subject to potential breaking changes in future versions,
+// regardless of any other documented package stability guarantees.
+func WithSearchLimit(limit int64) SearchOption {
+	return newFuncSearchOption(func(so map[string]any) {
+		so["limit"] = limit
+	})
+}
+
+// WithSearchOffset specifies the number of documents to skip from the beginning of the search result set.
+//
+// Experimental: Update, Delete and Search stages in pipeline queries are in public preview
+// and are subject to potential breaking changes in future versions,
+// regardless of any other documented package stability guarantees.
+func WithSearchOffset(offset int64) SearchOption {
+	return newFuncSearchOption(func(so map[string]any) {
+		so["offset"] = offset
+	})
+}
+
+// WithSearchLanguageCode specifies the BCP-47 language code of text in the search query, such as "en" or "sr".
+//
+// Experimental: Update, Delete and Search stages in pipeline queries are in public preview
+// and are subject to potential breaking changes in future versions,
+// regardless of any other documented package stability guarantees.
+func WithSearchLanguageCode(languageCode string) SearchOption {
+	return newFuncSearchOption(func(so map[string]any) {
+		so["language_code"] = languageCode
+	})
+}
+
 // Search adds a search stage to the Pipeline.
 // This must be the first stage of the pipeline.
 // A limited set of expressions are supported in the search stage.

--- a/firestore/pipeline_search_integration_test.go
+++ b/firestore/pipeline_search_integration_test.go
@@ -207,4 +207,35 @@ func TestIntegration_PipelineSearch(t *testing.T) {
 		snapshot := pipeline.Execute(ctx)
 		assertResultIds(t, snapshot, "solTacos", "lotusBlossomThai", "mileHighCatch")
 	})
+
+	t.Run("limit", func(t *testing.T) {
+		pipeline := client.Pipeline().Collection(collectionName).Search(
+			WithSearchQuery(DocumentMatches("tacos")),
+			WithSearchSort(Score().Descending()),
+			WithSearchLimit(1),
+		)
+		snapshot := pipeline.Execute(ctx)
+		assertResultIds(t, snapshot, "eastsideTacos")
+	})
+
+	t.Run("offset", func(t *testing.T) {
+		pipeline := client.Pipeline().Collection(collectionName).Search(
+			WithSearchQuery(DocumentMatches("tacos")),
+			WithSearchSort(Score().Descending()),
+			WithSearchOffset(1),
+			WithSearchLimit(10), // offset cannot be used without limit
+		)
+		snapshot := pipeline.Execute(ctx)
+		assertResultIds(t, snapshot, "solTacos")
+	})
+
+	t.Run("languageCode", func(t *testing.T) {
+		pipeline := client.Pipeline().Collection(collectionName).Search(
+			WithSearchQuery(DocumentMatches("tacos")),
+			WithSearchSort(Score().Descending()),
+			WithSearchLanguageCode("en"),
+		)
+		snapshot := pipeline.Execute(ctx)
+		assertResultIds(t, snapshot, "eastsideTacos", "solTacos")
+	})
 }

--- a/firestore/pipeline_stage.go
+++ b/firestore/pipeline_stage.go
@@ -687,6 +687,33 @@ func (s *searchStage) toProto() (*pb.Pipeline_Stage, error) {
 				return nil, fmt.Errorf("firestore: invalid type for Search retrieval_depth: %T", v)
 			}
 
+		case "limit":
+			switch limit := v.(type) {
+			case int64:
+				optionsPb[k] = &pb.Value{ValueType: &pb.Value_IntegerValue{IntegerValue: limit}}
+			case int:
+				optionsPb[k] = &pb.Value{ValueType: &pb.Value_IntegerValue{IntegerValue: int64(limit)}}
+			default:
+				return nil, fmt.Errorf("firestore: invalid type for Search limit: %T", v)
+			}
+
+		case "offset":
+			switch offset := v.(type) {
+			case int64:
+				optionsPb[k] = &pb.Value{ValueType: &pb.Value_IntegerValue{IntegerValue: offset}}
+			case int:
+				optionsPb[k] = &pb.Value{ValueType: &pb.Value_IntegerValue{IntegerValue: int64(offset)}}
+			default:
+				return nil, fmt.Errorf("firestore: invalid type for Search offset: %T", v)
+			}
+
+		case "language_code":
+			s, ok := v.(string)
+			if !ok {
+				return nil, fmt.Errorf("firestore: invalid type for Search language_code: %T", v)
+			}
+			optionsPb[k] = &pb.Value{ValueType: &pb.Value_StringValue{StringValue: s}}
+
 		default:
 			valPb, _, err := toProtoValue(reflect.ValueOf(v))
 			if err != nil {

--- a/firestore/pipeline_test.go
+++ b/firestore/pipeline_test.go
@@ -84,6 +84,9 @@ func TestPipeline_Search(t *testing.T) {
 		WithSearchQuery("waffles"),
 		WithSearchSort(Descending(Score())),
 		WithSearchRetrievalDepth(10),
+		WithSearchLimit(5),
+		WithSearchOffset(2),
+		WithSearchLanguageCode("en"),
 	)
 
 	proto, err := p.toProto()
@@ -121,6 +124,9 @@ func TestPipeline_Search(t *testing.T) {
 		Options: map[string]*pb.Value{
 			"query":           queryExpr,
 			"retrieval_depth": {ValueType: &pb.Value_IntegerValue{IntegerValue: 10}},
+			"limit":           {ValueType: &pb.Value_IntegerValue{IntegerValue: 5}},
+			"offset":          {ValueType: &pb.Value_IntegerValue{IntegerValue: 2}},
+			"language_code":   {ValueType: &pb.Value_StringValue{StringValue: "en"}},
 			"sort": {
 				ValueType: &pb.Value_ArrayValue{
 					ArrayValue: &pb.ArrayValue{


### PR DESCRIPTION
This change introduces new SearchOption helpers in the Firestore package to support setting limit, offset, and languageCode directly on the Search stage of pipeline queries.

Specifically, it adds:
- WithSearchLimit: specifies the maximum number of documents to return from the search stage.
- WithSearchOffset: specifies the number of documents to skip from the beginning of the search result set.
- WithSearchLanguageCode: specifies the BCP-47 language code of text in the search query.

The serialization logic in newSearchStage has been updated to explicitly handle these options, ensuring they are correctly converted to their proto representations.

Unit tests in TestPipeline_Search and integration tests in TestIntegration_PipelineSearch have been expanded to verify the correctness of these options under both default and enterprise database configurations.

This brings the Go SDK to full parity with the reference Java src https://github.com/googleapis/google-cloud-java/blob/825f7dde23ac3d4c8509269e8cd9e8747d8828aa/java-firestore/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/stages/Search.java#L151-L177

