### PR TITLE
chore(.github/workflows): improve librarian generation check reporting and issue creation

### DIFF
--- a/.github/workflows/generation_check.yaml
+++ b/.github/workflows/generation_check.yaml
@@ -37,30 +37,20 @@ jobs:
           librarian generate --all
           if [ -n "$(git status --porcelain)" ]; then
             git status
+            echo "==================== GIT DIFF ===================="
+            git diff
+            echo "=================================================="
             echo "Regeneration failed. Please run 'librarian generate --all' to update the generated files."
             exit 1
           fi
-      - name: Create issue on diff
-        if: failure() && github.event_name == 'push' && github.ref == 'refs/heads/main'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          if [ -n "$(git status --porcelain)" ]; then
-            TITLE="Regeneration check found diff"
-            RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-            DIFF_STAT=$(git status --porcelain)
-            BODY="The post-submit [regeneration check]($RUN_URL) found a diff.
+      - name: Create issue if previous step fails
+        if: ${{ failure() && github.ref == 'refs/heads/main' }}
+        uses: googleapis/librarian/.github/actions/create-issue-on-failure@main
+        with:
+          title: "Librarian generate diff check failed on main branch"
+          body: |
+            The librarian generate diff check failed on main branch.
 
-            Diff summary:
-            \`\`\`
-            $DIFF_STAT
-            \`\`\`"
+            To keep the `main` branch healthy, please consider **reverting the triggering change** first. Once the revert is merged, you can investigate the failure and submit a new PR with the fix.
 
-            EXISTING_ISSUE=$(gh issue list --state open --search "in:title \"$TITLE\"" --json number --jq '.[0].number')
-            if [ -z "$EXISTING_ISSUE" ]; then
-              gh issue create --title "$TITLE" --body "$BODY"
-            else
-              echo "Issue #$EXISTING_ISSUE already exists, adding a comment."
-              gh issue comment "$EXISTING_ISSUE" --body "Another failure with diff occurred: $RUN_URL"
-            fi
-          fi
+            Please check the logs: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}


### PR DESCRIPTION
Improve the generation check by reporting `git diff` output to the logs when regeneration produces code changes, making failures easier to debug. And use `create-issue-on-failure` from librarian to create/update GitHub issues when the check fails on the `main` branch, in addition to current behavior, it assigns issue to last committer and adds a critical label.
Similar steps in use for java: https://github.com/googleapis/google-cloud-java/blob/main/.github/workflows/librarian_generation_check.yaml

Fixes https://github.com/googleapis/librarian/issues/6524