### PR TITLE
chore(spanner): keep handwritten omni_client files in librarian.yaml

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -1299,6 +1299,8 @@ libraries:
           no_snippets: true
     keep:
       - README.md
+      - admin/database/apiv1/omni_client.go
+      - admin/database/apiv1/omni_client_test.go
     skip_release: true
   - name: speech
     version: 1.35.0


### PR DESCRIPTION
Fixes: https://github.com/googleapis/google-cloud-go/issues/20030