### PR TITLE
revert: feat(o11y): add experimental trace fields and construction API (#19968)

### DIFF
--- a/longrunning/longrunning.go
+++ b/longrunning/longrunning.go
@@ -31,7 +31,6 @@ import (
 	pb "cloud.google.com/go/longrunning/autogen/longrunningpb"
 	gax "github.com/googleapis/gax-go/v2"
 	"github.com/googleapis/gax-go/v2/apierror"
-	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/protoadapt"
@@ -43,10 +42,8 @@ var ErrNoMetadata = errors.New("operation contains no metadata")
 
 // Operation represents the result of an API call that may not be ready yet.
 type Operation struct {
-	c               operationsClient
-	proto           *pb.Operation
-	opName          string
-	initSpanContext trace.SpanContext
+	c     operationsClient
+	proto *pb.Operation
 }
 
 type operationsClient interface {
@@ -55,33 +52,15 @@ type operationsClient interface {
 	DeleteOperation(context.Context, *pb.DeleteOperationRequest, ...gax.CallOption) error
 }
 
-// InternalNewOperation is for use by the Google Cloud Libraries only.
+// InternalNewOperation is for use by the google Cloud Libraries only.
 //
 // InternalNewOperation returns an long-running operation, abstracting the raw pb.Operation.
+// The conn parameter refers to a server that proto was received from.
 func InternalNewOperation(inner *autogen.OperationsClient, proto *pb.Operation) *Operation {
-	return InternalNewOperationWithMetadata(inner, proto, "")
-}
-
-// InternalNewOperationWithMetadata is for use by the Google Cloud Libraries only.
-//
-// InternalNewOperationWithMetadata returns a long-running operation, abstracting the raw pb.Operation,
-// and storing the service-specific operation metadata/type name for tracing.
-//
-// InternalNewOperationWithMetadata is an EXPERIMENTAL API and may be changed or removed in the future.
-func InternalNewOperationWithMetadata(inner *autogen.OperationsClient, proto *pb.Operation, opName string) *Operation {
 	return &Operation{
-		c:      inner,
-		proto:  proto,
-		opName: opName,
+		c:     inner,
+		proto: proto,
 	}
-}
-
-// SetParentSpanContext sets the parent/initiating span context for the operation,
-// which is used to create a Span Link from the LRO Wait span.
-//
-// SetParentSpanContext is an EXPERIMENTAL API and may be changed or removed in the future.
-func (op *Operation) SetParentSpanContext(sc trace.SpanContext) {
-	op.initSpanContext = sc
 }
 
 // Name returns the name of the long-running operation.

--- a/longrunning/longrunning_test.go
+++ b/longrunning/longrunning_test.go
@@ -26,7 +26,6 @@ import (
 	pb "cloud.google.com/go/longrunning/autogen/longrunningpb"
 	gax "github.com/googleapis/gax-go/v2"
 	"github.com/googleapis/gax-go/v2/apierror"
-	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	rpcstatus "google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/grpc"
@@ -224,19 +223,5 @@ func TestDeleteReturnsError(t *testing.T) {
 	}
 	if got, want := op.Delete(context.Background()), s.errDelete; got != want {
 		t.Errorf("cancel, got error %s, want %s", got, want)
-	}
-}
-
-func TestInternalNewOperationWithMetadata(t *testing.T) {
-	opName := "test-operation"
-	op := InternalNewOperationWithMetadata(nil, &pb.Operation{Name: "foo"}, opName)
-	if op.opName != opName {
-		t.Errorf("expected opName to be %q, got %q", opName, op.opName)
-	}
-
-	sc := trace.SpanContext{}
-	op.SetParentSpanContext(sc)
-	if !op.initSpanContext.Equal(sc) {
-		t.Error("expected initSpanContext to match the set SpanContext")
 	}
 }


### PR DESCRIPTION
revert: feat(o11y): add experimental trace fields and construction API (#19968)

Revert commit c71dd55685bf2437011b580973a7c28d7ade93b0 because the librarian generate diff check failed on the main branch.

For #20049