### PR TITLE
chore: update CODEOWNERS management of unowned files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -30,5 +30,5 @@
 # a single owner.  This allows multiple teams to interact with librarian operations that cause
 # changes to librarian state.
 /.librarian/state.yaml
-# We mark the release please individual manifest unowned as well to allow teams to release the individal modules without secondary approvals.
+# We mark the release please individual manifest unowned as well to allow teams to release the individual modules without secondary approvals.
 /.release-please-individual-manifest.json

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -30,8 +30,5 @@
 # a single owner.  This allows multiple teams to interact with librarian operations that cause
 # changes to librarian state.
 /.librarian/state.yaml
-# Similarly, we mark the internal/generated/snippets directory unowned to avoid
-# tracking granular ownership in the snippets directories, and to avoid chasing
-# code owners approvals for things like snippet metadata versioning bumps which
-# happen naturally as part of release activities.
-/internal/generated/snippets/
+# We mark the release please individual manifest unowned as well to allow teams to release the individal modules without secondary approvals.
+/..release-please-individual-manifest.json

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -26,9 +26,5 @@
 /internal/protoveneer/  @googleapis/cloud-sdk-go-team @googleapis/cloud-sdk-librarian-team
 
 
-# We mark the librarian state file as unowned to avoid gatekeeping librarian operations on 
-# a single owner.  This allows multiple teams to interact with librarian operations that cause
-# changes to librarian state.
-/.librarian/state.yaml
 # We mark the release please individual manifest unowned as well to allow teams to release the individual modules without secondary approvals.
 /.release-please-individual-manifest.json

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -31,4 +31,4 @@
 # changes to librarian state.
 /.librarian/state.yaml
 # We mark the release please individual manifest unowned as well to allow teams to release the individal modules without secondary approvals.
-/..release-please-individual-manifest.json
+/.release-please-individual-manifest.json


### PR DESCRIPTION
This PR adds the release please manifest to unowned files to allow partners to release without needing central approval.

It also removes the carveout for the old location of generated snippets, which was removed in PR 19917.