### PR TITLE
feat(auth): populate http.response.status_code in http transport

### DIFF
--- a/auth/httptransport/httptransport_otel_test.go
+++ b/auth/httptransport/httptransport_otel_test.go
@@ -1518,3 +1518,43 @@ func TestTelemetryTransport_ImplicitPort(t *testing.T) {
 		})
 	}
 }
+
+func TestOtelAttributeTransport_Metrics(t *testing.T) {
+	gax.TestOnlyResetIsFeatureEnabled()
+	defer gax.TestOnlyResetIsFeatureEnabled()
+	t.Setenv("GOOGLE_SDK_GO_EXPERIMENTAL_METRICS", "true")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTeapot) // 418
+	}))
+	defer server.Close()
+
+	client, err := NewClient(&Options{
+		DisableAuthentication: true,
+		Endpoint:              server.URL,
+	})
+	if err != nil {
+		t.Fatalf("NewClient() = %v, want nil", err)
+	}
+
+	ctx := context.Background()
+	data := &gax.TransportTelemetryData{}
+	ctx = gax.InjectTransportTelemetry(ctx, data)
+
+	req, err := http.NewRequestWithContext(ctx, "GET", server.URL, nil)
+	if err != nil {
+		t.Fatalf("http.NewRequest() = %v, want nil", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("client.Do() = %v, want nil", err)
+	}
+	if resp != nil && resp.Body != nil {
+		resp.Body.Close()
+	}
+
+	if data.HTTPStatusCode() != http.StatusTeapot {
+		t.Errorf("data.HTTPStatusCode() = %d, want %d", data.HTTPStatusCode(), http.StatusTeapot)
+	}
+}

--- a/auth/httptransport/httptransport_otel_test.go
+++ b/auth/httptransport/httptransport_otel_test.go
@@ -1520,41 +1520,66 @@ func TestTelemetryTransport_ImplicitPort(t *testing.T) {
 }
 
 func TestOtelAttributeTransport_Metrics(t *testing.T) {
-	gax.TestOnlyResetIsFeatureEnabled()
-	defer gax.TestOnlyResetIsFeatureEnabled()
-	t.Setenv("GOOGLE_SDK_GO_EXPERIMENTAL_METRICS", "true")
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusTeapot) // 418
-	}))
-	defer server.Close()
-
-	client, err := NewClient(&Options{
-		DisableAuthentication: true,
-		Endpoint:              server.URL,
-	})
-	if err != nil {
-		t.Fatalf("NewClient() = %v, want nil", err)
+	tests := []struct {
+		name           string
+		metricsEnabled bool
+		wantStatusCode int
+	}{
+		{
+			name:           "metrics enabled",
+			metricsEnabled: true,
+			wantStatusCode: http.StatusTeapot,
+		},
+		{
+			name:           "metrics disabled",
+			metricsEnabled: false,
+			wantStatusCode: 0,
+		},
 	}
 
-	ctx := context.Background()
-	data := &gax.TransportTelemetryData{}
-	ctx = gax.InjectTransportTelemetry(ctx, data)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gax.TestOnlyResetIsFeatureEnabled()
+			defer gax.TestOnlyResetIsFeatureEnabled()
+			if tt.metricsEnabled {
+				t.Setenv("GOOGLE_SDK_GO_EXPERIMENTAL_METRICS", "true")
+			} else {
+				t.Setenv("GOOGLE_SDK_GO_EXPERIMENTAL_METRICS", "false")
+			}
 
-	req, err := http.NewRequestWithContext(ctx, "GET", server.URL, nil)
-	if err != nil {
-		t.Fatalf("http.NewRequest() = %v, want nil", err)
-	}
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusTeapot) // 418
+			}))
+			defer server.Close()
 
-	resp, err := client.Do(req)
-	if err != nil {
-		t.Fatalf("client.Do() = %v, want nil", err)
-	}
-	if resp != nil && resp.Body != nil {
-		resp.Body.Close()
-	}
+			client, err := NewClient(&Options{
+				DisableAuthentication: true,
+				Endpoint:              server.URL,
+			})
+			if err != nil {
+				t.Fatalf("NewClient() = %v, want nil", err)
+			}
 
-	if data.HTTPStatusCode() != http.StatusTeapot {
-		t.Errorf("data.HTTPStatusCode() = %d, want %d", data.HTTPStatusCode(), http.StatusTeapot)
+			ctx := context.Background()
+			data := &gax.TransportTelemetryData{}
+			ctx = gax.InjectTransportTelemetry(ctx, data)
+
+			req, err := http.NewRequestWithContext(ctx, "GET", server.URL, nil)
+			if err != nil {
+				t.Fatalf("http.NewRequest() = %v, want nil", err)
+			}
+
+			resp, err := client.Do(req)
+			if err != nil {
+				t.Fatalf("client.Do() = %v, want nil", err)
+			}
+			if resp != nil && resp.Body != nil {
+				resp.Body.Close()
+			}
+
+			if data.HTTPStatusCode() != tt.wantStatusCode {
+				t.Errorf("data.HTTPStatusCode() = %d, want %d", data.HTTPStatusCode(), tt.wantStatusCode)
+			}
+		})
 	}
 }

--- a/auth/httptransport/transport.go
+++ b/auth/httptransport/transport.go
@@ -284,8 +284,10 @@ func (t *otelAttributeTransport) RoundTrip(req *http.Request) (*http.Response, e
 	}
 
 	resp, err := t.base.RoundTrip(req)
-	if data != nil && resp != nil {
-		data.SetHTTPStatusCode(resp.StatusCode)
+	if gax.IsFeatureEnabled("METRICS") {
+		if data != nil && resp != nil {
+			data.SetHTTPStatusCode(resp.StatusCode)
+		}
 	}
 
 	var logger *slog.Logger

--- a/auth/httptransport/transport.go
+++ b/auth/httptransport/transport.go
@@ -284,6 +284,9 @@ func (t *otelAttributeTransport) RoundTrip(req *http.Request) (*http.Response, e
 	}
 
 	resp, err := t.base.RoundTrip(req)
+	if data != nil && resp != nil {
+		data.SetHTTPStatusCode(resp.StatusCode)
+	}
 
 	var logger *slog.Logger
 	if gax.IsFeatureEnabled("LOGGING") {


### PR DESCRIPTION
The client-side metric gcp.client.request.duration was missing the http.response.status_code attribute when using the REST/HTTP transport.

This change updates the otelAttributeTransport.RoundTrip method in the auth package to extract the HTTP status code from the response and set it on the TransportTelemetryData container in the context. This allows the gax layer to access the status code and record it in the client-side metrics.

This change depends on the corresponding changes https://github.com/googleapis/gax-go/pull/513 in the gax-go package, which adds support for the httpStatusCode field in TransportTelemetryData.



Fixes b/499375444