### PR TITLE
feat(o11y): wrap wait loop in T2 LRO Wait span with feature gating

### DIFF
--- a/longrunning/go.mod
+++ b/longrunning/go.mod
@@ -5,6 +5,8 @@ go 1.25.8
 require (
 	cloud.google.com/go v0.123.0
 	github.com/googleapis/gax-go/v2 v2.22.0
+	go.opentelemetry.io/otel v1.43.0
+	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
 	google.golang.org/api v0.285.0
 	google.golang.org/genproto v0.0.0-20260319201613-d00831a3d3e7
@@ -23,11 +25,11 @@ require (
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.16 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.67.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.67.0 // indirect
-	go.opentelemetry.io/otel v1.43.0 // indirect
 	go.opentelemetry.io/otel/metric v1.43.0 // indirect
 	golang.org/x/crypto v0.53.0 // indirect
 	golang.org/x/net v0.56.0 // indirect

--- a/longrunning/go.sum
+++ b/longrunning/go.sum
@@ -58,6 +58,8 @@ go.opentelemetry.io/otel/sdk/metric v1.43.0 h1:S88dyqXjJkuBNLeMcVPRFXpRw2fuwdvfC
 go.opentelemetry.io/otel/sdk/metric v1.43.0/go.mod h1:C/RJtwSEJ5hzTiUz5pXF1kILHStzb9zFlIEe85bhj6A=
 go.opentelemetry.io/otel/trace v1.43.0 h1:BkNrHpup+4k4w+ZZ86CZoHHEkohws8AY+WTX09nk+3A=
 go.opentelemetry.io/otel/trace v1.43.0/go.mod h1:/QJhyVBUUswCphDVxq+8mld+AvhXZLhe+8WVFxiFff0=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 golang.org/x/crypto v0.53.0 h1:QZ4Muo8THX6CizN2vPPd5fBGHyogrdK9fG4wLPFUsto=
 golang.org/x/crypto v0.53.0/go.mod h1:DNLU434OwVakk9PzuwV8w62mAJpRJL3vsgcfp4Qnsio=
 golang.org/x/net v0.56.0 h1:Rw8j/hFzGvJUZwNBXnAtf5sVDVt+65SK2C7IxCxZt5o=

--- a/longrunning/longrunning.go
+++ b/longrunning/longrunning.go
@@ -163,14 +163,15 @@ func (op *Operation) WaitWithInterval(ctx context.Context, resp protoadapt.Messa
 }
 
 func (op *Operation) waitWithInterval(ctx context.Context, resp protoadapt.MessageV1, interval time.Duration, sl sleeper, opts ...gax.CallOption) error {
+	bo := gax.Backoff{
+		Initial: 1 * time.Second,
+		Max:     interval,
+	}
+	if bo.Max < bo.Initial {
+		bo.Max = bo.Initial
+	}
+
 	if !gax.IsFeatureEnabled("TRACING") {
-		bo := gax.Backoff{
-			Initial: 1 * time.Second,
-			Max:     interval,
-		}
-		if bo.Max < bo.Initial {
-			bo.Max = bo.Initial
-		}
 		return op.wait(ctx, resp, &bo, sl, opts...)
 	}
 
@@ -188,22 +189,14 @@ func (op *Operation) waitWithInterval(ctx context.Context, resp protoadapt.Messa
 
 	tracer := otel.GetTracerProvider().Tracer("cloud.google.com/go")
 	ctx, span := tracer.Start(ctx, spanName, startOpts...)
+	defer span.End()
 	span.SetAttributes(attribute.String("gcp.resource.destination.id", op.Name()))
-
-	bo := gax.Backoff{
-		Initial: 1 * time.Second,
-		Max:     interval,
-	}
-	if bo.Max < bo.Initial {
-		bo.Max = bo.Initial
-	}
 
 	err := op.wait(ctx, resp, &bo, sl, opts...)
 	if err != nil {
 		span.SetStatus(codes.Error, err.Error())
 		span.RecordError(err)
 	}
-	span.End()
 	return err
 }
 

--- a/longrunning/longrunning.go
+++ b/longrunning/longrunning.go
@@ -31,6 +31,9 @@ import (
 	pb "cloud.google.com/go/longrunning/autogen/longrunningpb"
 	gax "github.com/googleapis/gax-go/v2"
 	"github.com/googleapis/gax-go/v2/apierror"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
@@ -156,6 +159,37 @@ func (op *Operation) Wait(ctx context.Context, resp protoadapt.MessageV1, opts .
 //
 // See documentation of Poll for error-handling information.
 func (op *Operation) WaitWithInterval(ctx context.Context, resp protoadapt.MessageV1, interval time.Duration, opts ...gax.CallOption) error {
+	return op.waitWithInterval(ctx, resp, interval, gax.Sleep, opts...)
+}
+
+func (op *Operation) waitWithInterval(ctx context.Context, resp protoadapt.MessageV1, interval time.Duration, sl sleeper, opts ...gax.CallOption) error {
+	if !gax.IsFeatureEnabled("TRACING") {
+		bo := gax.Backoff{
+			Initial: 1 * time.Second,
+			Max:     interval,
+		}
+		if bo.Max < bo.Initial {
+			bo.Max = bo.Initial
+		}
+		return op.wait(ctx, resp, &bo, sl, opts...)
+	}
+
+	spanName := op.opName
+	if spanName == "" {
+		spanName = "*longrunning.Operation.Wait"
+	} else {
+		spanName = spanName + ".Wait"
+	}
+
+	var startOpts []trace.SpanStartOption
+	if op.initSpanContext.IsValid() {
+		startOpts = append(startOpts, trace.WithLinks(trace.Link{SpanContext: op.initSpanContext}))
+	}
+
+	tracer := otel.GetTracerProvider().Tracer("cloud.google.com/go")
+	ctx, span := tracer.Start(ctx, spanName, startOpts...)
+	span.SetAttributes(attribute.String("gcp.resource.destination.id", op.Name()))
+
 	bo := gax.Backoff{
 		Initial: 1 * time.Second,
 		Max:     interval,
@@ -163,7 +197,14 @@ func (op *Operation) WaitWithInterval(ctx context.Context, resp protoadapt.Messa
 	if bo.Max < bo.Initial {
 		bo.Max = bo.Initial
 	}
-	return op.wait(ctx, resp, &bo, gax.Sleep, opts...)
+
+	err := op.wait(ctx, resp, &bo, sl, opts...)
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		span.RecordError(err)
+	}
+	span.End()
+	return err
 }
 
 type sleeper func(context.Context, time.Duration) error

--- a/longrunning/longrunning_test.go
+++ b/longrunning/longrunning_test.go
@@ -26,6 +26,9 @@ import (
 	pb "cloud.google.com/go/longrunning/autogen/longrunningpb"
 	gax "github.com/googleapis/gax-go/v2"
 	"github.com/googleapis/gax-go/v2/apierror"
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	rpcstatus "google.golang.org/genproto/googleapis/rpc/status"
@@ -238,5 +241,214 @@ func TestInternalNewOperationWithMetadata(t *testing.T) {
 	op.SetParentSpanContext(sc)
 	if !op.initSpanContext.Equal(sc) {
 		t.Error("expected initSpanContext to match the set SpanContext")
+	}
+}
+
+func TestWaitTracedWaitSpanOnly(t *testing.T) {
+	t.Setenv("GOOGLE_SDK_GO_EXPERIMENTAL_TRACING", "true")
+	if !gax.IsFeatureEnabled("TRACING") {
+		t.Skip("TRACING feature flag is not enabled")
+	}
+
+	sr := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
+	otel.SetTracerProvider(tp)
+
+	responseDur := durationpb.New(42 * time.Second)
+	responseAny, err := anypb.New(responseDur)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s := &getterService{
+		results: []*pb.Operation{
+			{Name: "foo"},
+			{
+				Name: "foo",
+				Done: true,
+				Result: &pb.Operation_Response{
+					Response: responseAny,
+				},
+			},
+		},
+	}
+
+	op := &Operation{
+		c:      s,
+		proto:  &pb.Operation{Name: "foo"},
+		opName: "*speech.Client.BatchRecognizeOperation",
+	}
+
+	ctx := context.Background()
+	tracer := otel.GetTracerProvider().Tracer("test-tracer")
+	parentCtx, parentSpan := tracer.Start(ctx, "creation-span")
+	op.SetParentSpanContext(parentSpan.SpanContext())
+
+	var resp durationpb.Duration
+	err = op.waitWithInterval(parentCtx, &resp, 3*time.Millisecond, s.sleeper())
+	parentSpan.End()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	spans := sr.Ended()
+	var waitSpan sdktrace.ReadOnlySpan
+	for _, span := range spans {
+		if span.Name() == "*speech.Client.BatchRecognizeOperation.Wait" {
+			waitSpan = span
+		}
+	}
+
+	if waitSpan == nil {
+		t.Fatal("expected a T2 LRO Wait span, got nil")
+	}
+
+	links := waitSpan.Links()
+	if len(links) != 1 {
+		t.Fatalf("expected 1 span link, got %d", len(links))
+	}
+	if links[0].SpanContext.SpanID() != parentSpan.SpanContext().SpanID() {
+		t.Errorf("expected span link pointing to parent span, got different span ID")
+	}
+
+	waitAttrs := waitSpan.Attributes()
+	hasResID := false
+	for _, attr := range waitAttrs {
+		if attr.Key == "gcp.resource.destination.id" && attr.Value.AsString() == "foo" {
+			hasResID = true
+		}
+	}
+	if !hasResID {
+		t.Error("expected wait span to have gcp.resource.destination.id attribute set to 'foo'")
+	}
+}
+
+func TestWaitTracedResumedWaitSpanOnly(t *testing.T) {
+	t.Setenv("GOOGLE_SDK_GO_EXPERIMENTAL_TRACING", "true")
+	if !gax.IsFeatureEnabled("TRACING") {
+		t.Skip("TRACING feature flag is not enabled")
+	}
+
+	sr := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
+	otel.SetTracerProvider(tp)
+
+	responseDur := durationpb.New(42 * time.Second)
+	responseAny, err := anypb.New(responseDur)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s := &getterService{
+		results: []*pb.Operation{
+			{Name: "foo"},
+			{
+				Name: "foo",
+				Done: true,
+				Result: &pb.Operation_Response{
+					Response: responseAny,
+				},
+			},
+		},
+	}
+
+	op := &Operation{
+		c:      s,
+		proto:  &pb.Operation{Name: "foo"},
+		opName: "*speech.BatchRecognizeOperation",
+	}
+
+	ctx := context.Background()
+	tracer := otel.GetTracerProvider().Tracer("test-tracer")
+	parentCtx, parentSpan := tracer.Start(ctx, "resumed-polling")
+
+	var resp durationpb.Duration
+	err = op.waitWithInterval(parentCtx, &resp, 3*time.Millisecond, s.sleeper())
+	parentSpan.End()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	spans := sr.Ended()
+	var waitSpan sdktrace.ReadOnlySpan
+	for _, span := range spans {
+		if span.Name() == "*speech.BatchRecognizeOperation.Wait" {
+			waitSpan = span
+		}
+	}
+
+	if waitSpan == nil {
+		t.Fatal("expected a T2 LRO Wait span, got nil")
+	}
+
+	links := waitSpan.Links()
+	if len(links) != 0 {
+		t.Fatalf("expected 0 span links for resumed LRO tracing, got %d", len(links))
+	}
+}
+
+func TestWaitTracedFallbackWaitSpanOnly(t *testing.T) {
+	t.Setenv("GOOGLE_SDK_GO_EXPERIMENTAL_TRACING", "true")
+	if !gax.IsFeatureEnabled("TRACING") {
+		t.Skip("TRACING feature flag is not enabled")
+	}
+
+	sr := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
+	otel.SetTracerProvider(tp)
+
+	responseDur := durationpb.New(42 * time.Second)
+	responseAny, err := anypb.New(responseDur)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s := &getterService{
+		results: []*pb.Operation{
+			{Name: "foo"},
+			{
+				Name: "foo",
+				Done: true,
+				Result: &pb.Operation_Response{
+					Response: responseAny,
+				},
+			},
+		},
+	}
+
+	op := &Operation{
+		c:     s,
+		proto: &pb.Operation{Name: "foo"},
+	}
+
+	ctx := context.Background()
+	tracer := otel.GetTracerProvider().Tracer("test-tracer")
+	parentCtx, parentSpan := tracer.Start(ctx, "fallback-polling")
+
+	var resp durationpb.Duration
+	err = op.waitWithInterval(parentCtx, &resp, 3*time.Millisecond, s.sleeper())
+	parentSpan.End()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	spans := sr.Ended()
+	var waitSpan sdktrace.ReadOnlySpan
+	for _, span := range spans {
+		if span.Name() == "*longrunning.Operation.Wait" {
+			waitSpan = span
+		}
+	}
+
+	if waitSpan == nil {
+		t.Fatal("expected a T2 LRO Wait span, got nil")
+	}
+
+	links := waitSpan.Links()
+	if len(links) != 0 {
+		t.Fatalf("expected 0 span links for fallback LRO tracing, got %d", len(links))
 	}
 }

--- a/longrunning/longrunning_test.go
+++ b/longrunning/longrunning_test.go
@@ -252,6 +252,8 @@ func TestWaitTracedWaitSpanOnly(t *testing.T) {
 
 	sr := tracetest.NewSpanRecorder()
 	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
+	oldTP := otel.GetTracerProvider()
+	defer otel.SetTracerProvider(oldTP)
 	otel.SetTracerProvider(tp)
 
 	responseDur := durationpb.New(42 * time.Second)
@@ -332,6 +334,8 @@ func TestWaitTracedResumedWaitSpanOnly(t *testing.T) {
 
 	sr := tracetest.NewSpanRecorder()
 	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
+	oldTP := otel.GetTracerProvider()
+	defer otel.SetTracerProvider(oldTP)
 	otel.SetTracerProvider(tp)
 
 	responseDur := durationpb.New(42 * time.Second)
@@ -397,6 +401,8 @@ func TestWaitTracedFallbackWaitSpanOnly(t *testing.T) {
 
 	sr := tracetest.NewSpanRecorder()
 	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
+	oldTP := otel.GetTracerProvider()
+	defer otel.SetTracerProvider(oldTP)
 	otel.SetTracerProvider(tp)
 
 	responseDur := durationpb.New(42 * time.Second)


### PR DESCRIPTION
Implement the outer LRO Wait span (T2) inside the `WaitWithInterval` method. This span acts as the parent context for all subsequent poll attempts and links the polling lifecycle back to the client span that initiated the operation.