### PR TITLE
fix(firestore): retry transient connection errors during document reads

### DIFF
--- a/firestore/client.go
+++ b/firestore/client.go
@@ -20,9 +20,11 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"net"
 	"net/url"
 	"os"
 	"strings"
+	"syscall"
 	"time"
 
 	vkit "cloud.google.com/go/firestore/apiv1"
@@ -324,80 +326,159 @@ func (c *Client) getAll(ctx context.Context, docRefs []*DocumentRef, tid []byte,
 	ctx = trace.StartSpan(ctx, "cloud.google.com/go/firestore.Client.BatchGetDocuments")
 	defer func() { trace.EndSpan(ctx, err) }()
 
-	var docNames []string
 	docIndices := map[string][]int{} // doc name to positions in docRefs
 	for i, dr := range docRefs {
 		if err := dr.isValid(); err != nil {
 			return nil, err
 		}
-		docNames = append(docNames, dr.Path)
 		docIndices[dr.Path] = append(docIndices[dr.Path], i)
 	}
-	req := &pb.BatchGetDocumentsRequest{
-		Database:  c.path(),
-		Documents: docNames,
+
+	// Track outstanding documents.
+	outstanding := make(map[string]bool)
+	for _, dr := range docRefs {
+		outstanding[dr.Path] = true
 	}
 
-	// Note that transaction ID and other consistency selectors are mutually exclusive.
-	// We respect the transaction first, any read options passed by the caller second,
-	// and any read options stored in the client third.
-	if rt, hasOpts := parseReadTime(c, rs); hasOpts {
-		req.ConsistencySelector = &pb.BatchGetDocumentsRequest_ReadTime{ReadTime: rt}
+	docs := make([]*DocumentSnapshot, len(docRefs))
+
+	maxAttempts := 5
+	backoff := gax.Backoff{
+		Initial:    100 * time.Millisecond,
+		Max:        5 * time.Second,
+		Multiplier: 2.0,
 	}
 
-	if tid != nil {
-		req.ConsistencySelector = &pb.BatchGetDocumentsRequest_Transaction{Transaction: tid}
-	}
-
-	batchGetDocsCtx := withResourceHeader(ctx, req.Database)
-	batchGetDocsCtx = withRequestParamsHeader(batchGetDocsCtx, reqParamsHeaderVal(c.path()))
-	streamClient, err := c.c.BatchGetDocuments(batchGetDocsCtx, req)
-	if err != nil {
-		return nil, err
-	}
-
-	// Read and remember all results from the stream.
-	var resps []*pb.BatchGetDocumentsResponse
-	for {
-		resp, err := streamClient.Recv()
-		if err == io.EOF {
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		if len(outstanding) == 0 {
 			break
 		}
+
+		var activeDocNames []string
+		for _, dr := range docRefs {
+			if outstanding[dr.Path] {
+				activeDocNames = append(activeDocNames, dr.Path)
+			}
+		}
+
+		req := &pb.BatchGetDocumentsRequest{
+			Database:  c.path(),
+			Documents: activeDocNames,
+		}
+
+		if rt, hasOpts := parseReadTime(c, rs); hasOpts {
+			req.ConsistencySelector = &pb.BatchGetDocumentsRequest_ReadTime{ReadTime: rt}
+		}
+		if tid != nil {
+			req.ConsistencySelector = &pb.BatchGetDocumentsRequest_Transaction{Transaction: tid}
+		}
+
+		batchGetDocsCtx := withResourceHeader(ctx, req.Database)
+		batchGetDocsCtx = withRequestParamsHeader(batchGetDocsCtx, reqParamsHeaderVal(c.path()))
+		streamClient, err := c.c.BatchGetDocuments(batchGetDocsCtx, req)
 		if err != nil {
+			if tid == nil && isRetryableStreamError(err) && attempt < maxAttempts-1 {
+				dur := backoff.Pause()
+				select {
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				case <-time.After(dur):
+				}
+				continue
+			}
 			return nil, err
 		}
-		resps = append(resps, resp)
+
+		var streamErr error
+		for {
+			resp, recvErr := streamClient.Recv()
+			if recvErr == io.EOF {
+				break
+			}
+			if recvErr != nil {
+				streamErr = recvErr
+				break
+			}
+
+			var (
+				indices []int
+				doc     *pb.Document
+			)
+			switch r := resp.Result.(type) {
+			case *pb.BatchGetDocumentsResponse_Found:
+				indices = docIndices[r.Found.Name]
+				doc = r.Found
+				delete(outstanding, r.Found.Name)
+			case *pb.BatchGetDocumentsResponse_Missing:
+				indices = docIndices[r.Missing]
+				doc = nil
+				delete(outstanding, r.Missing)
+			default:
+				return nil, errors.New("firestore: unknown BatchGetDocumentsResponse result type")
+			}
+			for _, index := range indices {
+				if docs[index] != nil {
+					return nil, fmt.Errorf("firestore: %q seen twice", docRefs[index].Path)
+				}
+				docs[index], err = newDocumentSnapshot(docRefs[index], doc, c, resp.ReadTime)
+				if err != nil {
+					return nil, err
+				}
+			}
+		}
+
+		if streamErr == nil {
+			if len(outstanding) > 0 {
+				return nil, fmt.Errorf("firestore: stream completed but some documents were not received: %v", outstanding)
+			}
+			break
+		}
+
+		if tid != nil {
+			return nil, streamErr
+		}
+
+		if !isRetryableStreamError(streamErr) {
+			return nil, streamErr
+		}
+
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, streamErr
+		}
+
+		if attempt == maxAttempts-1 {
+			return nil, streamErr
+		}
+
+		dur := backoff.Pause()
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(dur):
+		}
 	}
 
-	// Results may arrive out of order. Put each at the right indices.
-	docs := make([]*DocumentSnapshot, len(docNames))
-	for _, resp := range resps {
-		var (
-			indices []int
-			doc     *pb.Document
-			err     error
-		)
-		switch r := resp.Result.(type) {
-		case *pb.BatchGetDocumentsResponse_Found:
-			indices = docIndices[r.Found.Name]
-			doc = r.Found
-		case *pb.BatchGetDocumentsResponse_Missing:
-			indices = docIndices[r.Missing]
-			doc = nil
-		default:
-			return nil, errors.New("firestore: unknown BatchGetDocumentsResponse result type")
-		}
-		for _, index := range indices {
-			if docs[index] != nil {
-				return nil, fmt.Errorf("firestore: %q seen twice", docRefs[index].Path)
-			}
-			docs[index], err = newDocumentSnapshot(docRefs[index], doc, c, resp.ReadTime)
-			if err != nil {
-				return nil, err
-			}
+	return docs, nil
+}
+
+func isRetryableStreamError(err error) bool {
+	if err == nil {
+		return false
+	}
+	s, ok := status.FromError(err)
+	if ok {
+		switch s.Code() {
+		case codes.Unavailable, codes.Internal, codes.DeadlineExceeded:
+			return true
 		}
 	}
-	return docs, nil
+	if errors.Is(err, syscall.ECONNRESET) ||
+		errors.Is(err, syscall.ECONNREFUSED) ||
+		errors.Is(err, net.ErrClosed) ||
+		errors.Is(err, io.ErrUnexpectedEOF) {
+		return true
+	}
+	return false
 }
 
 // Collections returns an iterator over the top-level collections.

--- a/firestore/client.go
+++ b/firestore/client.go
@@ -391,6 +391,9 @@ func (c *Client) getAll(ctx context.Context, docRefs []*DocumentRef, tid []byte,
 			}
 			return nil, err
 		}
+		if streamClient == nil {
+			return nil, errors.New("firestore: received nil stream client")
+		}
 
 		var streamErr error
 		for {
@@ -400,6 +403,10 @@ func (c *Client) getAll(ctx context.Context, docRefs []*DocumentRef, tid []byte,
 			}
 			if recvErr != nil {
 				streamErr = recvErr
+				break
+			}
+			if resp == nil {
+				streamErr = errors.New("firestore: received nil response from stream")
 				break
 			}
 

--- a/firestore/client.go
+++ b/firestore/client.go
@@ -366,6 +366,9 @@ func (c *Client) getAll(ctx context.Context, docRefs []*DocumentRef, tid []byte,
 			Documents: activeDocNames,
 		}
 
+		// Note that transaction ID and other consistency selectors are mutually exclusive.
+		// We respect the transaction first, any read options passed by the caller second,
+		// and any read options stored in the client third.
 		if rt, hasOpts := parseReadTime(c, rs); hasOpts {
 			req.ConsistencySelector = &pb.BatchGetDocumentsRequest_ReadTime{ReadTime: rt}
 		}
@@ -406,6 +409,9 @@ func (c *Client) getAll(ctx context.Context, docRefs []*DocumentRef, tid []byte,
 			)
 			switch r := resp.Result.(type) {
 			case *pb.BatchGetDocumentsResponse_Found:
+				if r.Found == nil {
+					return nil, errors.New("firestore: received nil Document in BatchGetDocumentsResponse_Found")
+				}
 				indices = docIndices[r.Found.Name]
 				doc = r.Found
 				delete(outstanding, r.Found.Name)
@@ -416,6 +422,7 @@ func (c *Client) getAll(ctx context.Context, docRefs []*DocumentRef, tid []byte,
 			default:
 				return nil, errors.New("firestore: unknown BatchGetDocumentsResponse result type")
 			}
+			// Results may arrive out of order. Put each at the right indices.
 			for _, index := range indices {
 				if docs[index] != nil {
 					return nil, fmt.Errorf("firestore: %q seen twice", docRefs[index].Path)
@@ -434,6 +441,8 @@ func (c *Client) getAll(ctx context.Context, docRefs []*DocumentRef, tid []byte,
 			break
 		}
 
+		// If we are in a transaction, do not retry here. Transaction retries
+		// are handled by the transaction runner (outer loop).
 		if tid != nil {
 			return nil, streamErr
 		}
@@ -443,7 +452,7 @@ func (c *Client) getAll(ctx context.Context, docRefs []*DocumentRef, tid []byte,
 		}
 
 		if ctxErr := ctx.Err(); ctxErr != nil {
-			return nil, streamErr
+			return nil, ctxErr
 		}
 
 		if attempt == maxAttempts-1 {

--- a/firestore/client_test.go
+++ b/firestore/client_test.go
@@ -731,4 +731,3 @@ func TestIsRetryableStreamError(t *testing.T) {
 		}
 	}
 }
-

--- a/firestore/client_test.go
+++ b/firestore/client_test.go
@@ -16,7 +16,11 @@ package firestore
 
 import (
 	"context"
+	"fmt"
+	"io"
+	"net"
 	"os"
+	"syscall"
 	"testing"
 	"time"
 
@@ -696,6 +700,35 @@ func TestGetAllRetry(t *testing.T) {
 	}
 	if diff := testDiff(docs[2], wantSnapC); diff != "" {
 		t.Errorf("docC diff:\n%s", diff)
+	}
+}
+
+func TestIsRetryableStreamError(t *testing.T) {
+	tests := []struct {
+		err  error
+		want bool
+	}{
+		{nil, false},
+		{status.Errorf(codes.Unavailable, "unavailable"), true},
+		{status.Errorf(codes.Internal, "internal"), true},
+		{status.Errorf(codes.DeadlineExceeded, "deadline exceeded"), true},
+		{status.Errorf(codes.InvalidArgument, "invalid argument"), false},
+		{status.Errorf(codes.ResourceExhausted, "resource exhausted"), false},
+		{syscall.ECONNRESET, true},
+		{syscall.ECONNREFUSED, true},
+		{net.ErrClosed, true},
+		{io.ErrUnexpectedEOF, true},
+		{io.EOF, false},
+		{fmt.Errorf("wrapped: %w", syscall.ECONNRESET), true},
+		{fmt.Errorf("wrapped: %w", status.Errorf(codes.Unavailable, "unavailable")), true},
+		{fmt.Errorf("generic error"), false},
+	}
+
+	for _, tc := range tests {
+		got := isRetryableStreamError(tc.err)
+		if got != tc.want {
+			t.Errorf("isRetryableStreamError(%v) = %t; want %t", tc.err, got, tc.want)
+		}
 	}
 }
 

--- a/firestore/client_test.go
+++ b/firestore/client_test.go
@@ -489,13 +489,15 @@ func TestGetAllErrors(t *testing.T) {
 	}
 
 	// Internal server error.
-	srv.addRPC(
-		&pb.BatchGetDocumentsRequest{
-			Database:  dbPath,
-			Documents: []string{docPath},
-		},
-		[]interface{}{status.Errorf(codes.Internal, "")},
-	)
+	for i := 0; i < 5; i++ {
+		srv.addRPC(
+			&pb.BatchGetDocumentsRequest{
+				Database:  dbPath,
+				Documents: []string{docPath},
+			},
+			[]interface{}{status.Errorf(codes.Internal, "")},
+		)
+	}
 	_, err := c.GetAll(ctx, []*DocumentRef{c.Doc("C/a")})
 	codeEq(t, "GetAll #1", codes.Internal, err)
 
@@ -555,7 +557,11 @@ func TestClient_WithReadOptions(t *testing.T) {
 		&pb.BatchGetDocumentsResponse{
 			ReadTime: &tspb.Timestamp{Seconds: tm.Unix()},
 			Result: &pb.BatchGetDocumentsResponse_Found{
-				Found: &pb.Document{},
+				Found: &pb.Document{
+					Name:       docPath,
+					CreateTime: aTimestamp,
+					UpdateTime: aTimestamp,
+				},
 			},
 		},
 	})
@@ -605,3 +611,91 @@ func TestNormalizeEmulatorAddress(t *testing.T) {
 		}
 	}
 }
+
+func TestGetAllRetry(t *testing.T) {
+	c, srv, cleanup := newMock(t)
+	defer cleanup()
+
+	const dbPath = "projects/projectID/databases/(default)"
+
+	coll := c.Collection("C")
+	drA := coll.Doc("a")
+	drB := coll.Doc("b")
+	drC := coll.Doc("c")
+	drs := []*DocumentRef{drA, drB, drC}
+
+	pbDocA := &pb.Document{
+		Name:       dbPath + "/documents/C/a",
+		CreateTime: aTimestamp,
+		UpdateTime: aTimestamp,
+		Fields:     map[string]*pb.Value{"f": intval(1)},
+	}
+	pbDocB := &pb.Document{
+		Name:       dbPath + "/documents/C/b",
+		CreateTime: aTimestamp,
+		UpdateTime: aTimestamp,
+		Fields:     map[string]*pb.Value{"f": intval(2)},
+	}
+	pbDocC := &pb.Document{
+		Name:       dbPath + "/documents/C/c",
+		CreateTime: aTimestamp,
+		UpdateTime: aTimestamp,
+		Fields:     map[string]*pb.Value{"f": intval(3)},
+	}
+
+	// First request: all docs
+	req1 := &pb.BatchGetDocumentsRequest{
+		Database:  dbPath,
+		Documents: []string{drA.Path, drB.Path, drC.Path},
+	}
+	// First response: returns docA, then fails with UNAVAILABLE
+	srv.addRPC(req1, []interface{}{
+		&pb.BatchGetDocumentsResponse{
+			Result:   &pb.BatchGetDocumentsResponse_Found{Found: pbDocA},
+			ReadTime: aTimestamp,
+		},
+		status.Errorf(codes.Unavailable, "connection closed"),
+	})
+
+	// Second request (retry): only outstanding docs (B and C)
+	req2 := &pb.BatchGetDocumentsRequest{
+		Database:  dbPath,
+		Documents: []string{drB.Path, drC.Path},
+	}
+	// Second response: returns docB and docC
+	srv.addRPC(req2, []interface{}{
+		&pb.BatchGetDocumentsResponse{
+			Result:   &pb.BatchGetDocumentsResponse_Found{Found: pbDocB},
+			ReadTime: aTimestamp,
+		},
+		&pb.BatchGetDocumentsResponse{
+			Result:   &pb.BatchGetDocumentsResponse_Found{Found: pbDocC},
+			ReadTime: aTimestamp,
+		},
+	})
+
+	docs, err := c.GetAll(context.Background(), drs)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got, want := len(docs), 3; got != want {
+		t.Fatalf("got %d docs, want %d", got, want)
+	}
+
+	// Verify snapshots
+	wantSnapA, _ := newDocumentSnapshot(drA, pbDocA, c, aTimestamp)
+	wantSnapB, _ := newDocumentSnapshot(drB, pbDocB, c, aTimestamp)
+	wantSnapC, _ := newDocumentSnapshot(drC, pbDocC, c, aTimestamp)
+
+	if diff := testDiff(docs[0], wantSnapA); diff != "" {
+		t.Errorf("docA diff:\n%s", diff)
+	}
+	if diff := testDiff(docs[1], wantSnapB); diff != "" {
+		t.Errorf("docB diff:\n%s", diff)
+	}
+	if diff := testDiff(docs[2], wantSnapC); diff != "" {
+		t.Errorf("docC diff:\n%s", diff)
+	}
+}
+


### PR DESCRIPTION
The Firestore client now retries transient connection errors during document reads (GetAll).

Previously, if the BatchGetDocuments stream failed mid-stream due to a transient network issue (such as ECONNRESET, ECONNREFUSED, or unexpected EOF), the error was immediately returned to the user.

Now, the client tracks outstanding documents and resumes the stream by requesting only the remaining documents. It will attempt to retry up to 5 times, applying backoff between attempts, and respecting the context deadline. This resumption strategy aligns with the behavior of the Java and Node.js Firestore SDKs.

Transactional reads are not retried at this level to avoid interfering with transaction retry logic.

Queries (`RunQuery`) are excluded from this retry mechanism. Mid-stream query resumption is significantly more complex (requiring tracking cursors, limits, and ordering) and is out of scope for the reported issue which specifically affects document gets (`GetAll`).

Fixes #10350
