### PR TITLE
feat: enrich retry operations with bucket and object metadata for missed codepaths.

### DIFF
--- a/storage/grpc_client.go
+++ b/storage/grpc_client.go
@@ -614,17 +614,13 @@ func (c *grpcStorageClient) ListObjects(ctx context.Context, bucket string, q *Q
 		// Add trace span around List API call within the fetch.
 		ctx, _ = startSpan(ctx, "grpcStorageClient.ObjectsListCall")
 		defer func() { endSpan(ctx, err) }()
-		objName := it.query.Prefix
-		if objName == "" {
-			objName = "/"
-		}
 		var objects []*storagepb.Object
 		var gitr *gapic.ObjectIterator
 		err = run(it.ctx, func(ctx context.Context) error {
 			gitr = c.raw.ListObjects(ctx, req, s.gax...)
 			objects, token, err = gitr.InternalFetch(pageSize, pageToken)
 			return err
-		}, s.retry, s.idempotent, withOperation("ListObjects"), withBucket(bucket), withObject(objName))
+		}, s.retry, s.idempotent, withOperation("ListObjects"), withBucket(bucket), withObject(it.query.Prefix))
 		if err != nil {
 			return "", formatBucketError(err)
 		}

--- a/storage/grpc_client.go
+++ b/storage/grpc_client.go
@@ -614,13 +614,17 @@ func (c *grpcStorageClient) ListObjects(ctx context.Context, bucket string, q *Q
 		// Add trace span around List API call within the fetch.
 		ctx, _ = startSpan(ctx, "grpcStorageClient.ObjectsListCall")
 		defer func() { endSpan(ctx, err) }()
+		objName := it.query.Prefix
+		if objName == "" {
+			objName = "/"
+		}
 		var objects []*storagepb.Object
 		var gitr *gapic.ObjectIterator
 		err = run(it.ctx, func(ctx context.Context) error {
 			gitr = c.raw.ListObjects(ctx, req, s.gax...)
 			objects, token, err = gitr.InternalFetch(pageSize, pageToken)
 			return err
-		}, s.retry, s.idempotent)
+		}, s.retry, s.idempotent, withOperation("ListObjects"), withBucket(bucket), withObject(objName))
 		if err != nil {
 			return "", formatBucketError(err)
 		}
@@ -1369,7 +1373,7 @@ func (c *grpcStorageClient) NewRangeReader(ctx context.Context, params *newRange
 			}
 			err = decoder.readFullObjectResponse()
 			return err
-		}, s.retry, s.idempotent)
+		}, s.retry, s.idempotent, withOperation("ReadObject"), withBucket(params.bucket), withObject(params.object))
 		if err != nil {
 			// Close the stream context we just created to ensure we don't leak
 			// resources.

--- a/storage/grpc_reader_multi_range.go
+++ b/storage/grpc_reader_multi_range.go
@@ -775,7 +775,7 @@ func (m *multiRangeDownloaderManager) createNewSession(id int, readSpec *storage
 		newSession = session
 		firstResult = result
 		return nil
-	}, retry, true, withOperation("ReadObject"), withBucket(readSpec.GetBucket()), withObject(readSpec.GetObject()))
+	}, retry, true, withOperation("ReadObject"), withBucket(m.params.bucket), withObject(m.params.object))
 
 	if err != nil {
 		return nil, nil, err

--- a/storage/grpc_reader_multi_range.go
+++ b/storage/grpc_reader_multi_range.go
@@ -775,7 +775,7 @@ func (m *multiRangeDownloaderManager) createNewSession(id int, readSpec *storage
 		newSession = session
 		firstResult = result
 		return nil
-	}, retry, true)
+	}, retry, true, withOperation("ReadObject"), withBucket(readSpec.GetBucket()), withObject(readSpec.GetObject()))
 
 	if err != nil {
 		return nil, nil, err

--- a/storage/http_client.go
+++ b/storage/http_client.go
@@ -1625,7 +1625,7 @@ func readerReopen(ctx context.Context, header http.Header, params *newRangeReade
 				params.gen = gen64
 			}
 			return nil
-		}, s.retry, s.idempotent)
+		}, s.retry, s.idempotent, withOperation("ReadObject"), withBucket(params.bucket), withObject(params.object))
 		if err != nil {
 			return nil, err
 		}

--- a/storage/retry_context_test.go
+++ b/storage/retry_context_test.go
@@ -15,8 +15,16 @@
 package storage
 
 import (
+	"context"
 	"errors"
+	"net/http"
+	"reflect"
 	"testing"
+
+	"cloud.google.com/go/storage/experimental"
+	"google.golang.org/api/option"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 func TestRetryContextSignatures(t *testing.T) {
@@ -114,5 +122,212 @@ func TestLegacySignatureStillWorks(t *testing.T) {
 
 	if !called {
 		t.Error("Legacy error function was not called")
+	}
+}
+
+// TestHTTPRetryContextMetadataReaderReopen verifies that the RetryContext is correctly
+// populated for HTTP range reader reopen retry logic.
+func TestHTTPRetryContextMetadataReaderReopen(t *testing.T) {
+	t.Parallel()
+
+	transport := &mockTransport{}
+	// First request returns 503 Service Unavailable (retriable)
+	transport.addResult(&http.Response{
+		StatusCode: http.StatusServiceUnavailable,
+		Body:       bodyReader("Service Unavailable"),
+	}, nil)
+	// Second request also returns 503 Service Unavailable
+	transport.addResult(&http.Response{
+		StatusCode: http.StatusServiceUnavailable,
+		Body:       bodyReader("Service Unavailable"),
+	}, nil)
+	client := mockClient(t, transport)
+	defer client.Close()
+
+	var capturedCtx *RetryContext
+	var attempts []int
+	reader, err := client.Bucket("test-bucket").Object("test-object").Retryer(
+		WithErrorFuncWithContext(func(err error, ctx *RetryContext) bool {
+			capturedCtx = ctx
+			attempts = append(attempts, ctx.Attempt)
+			return ctx.Attempt < 2 // Retry once
+		}),
+	).NewReader(context.Background())
+
+	// We expect NewReader to fail because of the mocked 503s and our policy stopping retries.
+	if err == nil {
+		if reader != nil {
+			reader.Close()
+		}
+		t.Fatalf("expected NewReader to fail, but got success")
+	}
+	if capturedCtx == nil {
+		t.Fatal("expected RetryContext to be captured in shouldRetry, but it was nil")
+	}
+	if capturedCtx.Operation != "ReadObject" {
+		t.Errorf("Operation: got %q, want %q", capturedCtx.Operation, "ReadObject")
+	}
+	if capturedCtx.Bucket != "test-bucket" {
+		t.Errorf("Bucket: got %q, want %q", capturedCtx.Bucket, "test-bucket")
+	}
+	if capturedCtx.Object != "test-object" {
+		t.Errorf("Object: got %q, want %q", capturedCtx.Object, "test-object")
+	}
+	wantAttempts := []int{1, 2}
+	if !reflect.DeepEqual(attempts, wantAttempts) {
+		t.Errorf("Attempt sequence: got %v, want %v", attempts, wantAttempts)
+	}
+}
+
+// TestGRPCRetryContextMetadataListObjects verifies that the RetryContext is correctly
+// populated with metadata for gRPC ListObjects operation retries.
+func TestGRPCRetryContextMetadataListObjects(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	// Points to an invalid address to trigger connection failure (Unavailable error)
+	client, err := NewGRPCClient(ctx,
+		option.WithEndpoint("localhost:1"),
+		option.WithoutAuthentication(),
+		option.WithGRPCDialOption(grpc.WithTransportCredentials(insecure.NewCredentials())),
+	)
+	if err != nil {
+		t.Fatalf("NewGRPCClient: %v", err)
+	}
+	defer client.Close()
+	var capturedCtx *RetryContext
+	var attempts []int
+	it := client.Bucket("test-bucket").Retryer(
+		WithErrorFuncWithContext(func(err error, ctx *RetryContext) bool {
+			capturedCtx = ctx
+			attempts = append(attempts, ctx.Attempt)
+			return ctx.Attempt < 3 // Retry up to 3 attempts
+		}),
+	).Objects(ctx, &Query{Prefix: "test-prefix"})
+
+	// it.Next() triggers the fetch, which triggers ListObjects call
+	_, err = it.Next()
+
+
+	if err == nil {
+		t.Fatalf("expected call to fail due to invalid address, but got success")
+	}
+	if capturedCtx == nil {
+		t.Fatal("expected RetryContext to be captured, but got nil")
+	}
+	if capturedCtx.Operation != "ListObjects" {
+		t.Errorf("Operation: got %q, want %q", capturedCtx.Operation, "ListObjects")
+	}
+	if capturedCtx.Bucket != "test-bucket" {
+		t.Errorf("Bucket: got %q, want %q", capturedCtx.Bucket, "test-bucket")
+	}
+	if capturedCtx.Object != "test-prefix" {
+		t.Errorf("Object: got %q, want %q", capturedCtx.Object, "test-prefix")
+	}
+	wantAttempts := []int{1, 2, 3}
+	if !reflect.DeepEqual(attempts, wantAttempts) {
+		t.Errorf("Attempt sequence: got %v, want %v", attempts, wantAttempts)
+	}
+}
+
+// TestGRPCRetryContextMetadataNewReader verifies that the RetryContext is correctly
+// populated with metadata for gRPC NewRangeReader operation retries.
+func TestGRPCRetryContextMetadataNewReader(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	client, err := NewGRPCClient(ctx,
+		option.WithEndpoint("localhost:1"),
+		option.WithoutAuthentication(),
+		option.WithGRPCDialOption(grpc.WithTransportCredentials(insecure.NewCredentials())),
+	)
+	if err != nil {
+		t.Fatalf("NewGRPCClient: %v", err)
+	}
+	defer client.Close()
+
+	var capturedCtx *RetryContext
+	var attempts []int
+	reader, err := client.Bucket("test-bucket").Object("test-object").Retryer(
+		WithErrorFuncWithContext(func(err error, ctx *RetryContext) bool {
+			capturedCtx = ctx
+			attempts = append(attempts, ctx.Attempt)
+			return ctx.Attempt < 3
+		}),
+	).NewReader(ctx)
+
+	if err == nil {
+		if reader != nil {
+			reader.Close()
+		}
+		t.Fatalf("expected NewReader to fail due to connection error, but got success")
+	}
+	if capturedCtx == nil {
+		t.Fatal("expected RetryContext to be captured, but got nil")
+	}
+	if capturedCtx.Operation != "ReadObject" {
+		t.Errorf("Operation: got %q, want %q", capturedCtx.Operation, "ReadObject")
+	}
+	if capturedCtx.Bucket != "test-bucket" {
+		t.Errorf("Bucket: got %q, want %q", capturedCtx.Bucket, "test-bucket")
+	}
+	if capturedCtx.Object != "test-object" {
+		t.Errorf("Object: got %q, want %q", capturedCtx.Object, "test-object")
+	}
+	wantAttempts := []int{1, 2, 3}
+	if !reflect.DeepEqual(attempts, wantAttempts) {
+		t.Errorf("Attempt sequence: got %v, want %v", attempts, wantAttempts)
+	}
+}
+
+// TestGRPCRetryContextMetadataMultiRangeDownloader verifies that the RetryContext is
+// correctly populated for gRPC MultiRangeDownloader session establishment retries.
+func TestGRPCRetryContextMetadataMultiRangeDownloader(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	client, err := NewGRPCClient(ctx,
+		option.WithEndpoint("localhost:1"),
+		option.WithoutAuthentication(),
+		option.WithGRPCDialOption(grpc.WithTransportCredentials(insecure.NewCredentials())),
+		experimental.WithGRPCBidiReads(),
+	)
+	if err != nil {
+		t.Fatalf("NewGRPCClient: %v", err)
+	}
+	defer client.Close()
+
+	var capturedCtx *RetryContext
+	var attempts []int
+	mrd, err := client.Bucket("test-bucket").Object("test-object").Retryer(
+		WithErrorFuncWithContext(func(err error, ctx *RetryContext) bool {
+			capturedCtx = ctx
+			attempts = append(attempts, ctx.Attempt)
+			return ctx.Attempt < 3
+		}),
+	).NewMultiRangeDownloader(ctx)
+
+
+	if err == nil {
+		if mrd != nil {
+			mrd.Close()
+		}
+		t.Fatalf("expected NewMultiRangeDownloader to fail, but got success")
+	}
+	if capturedCtx == nil {
+		t.Fatal("expected RetryContext to be captured, but got nil")
+	}
+	if capturedCtx.Operation != "ReadObject" {
+		t.Errorf("Operation: got %q, want %q", capturedCtx.Operation, "ReadObject")
+	}
+	if capturedCtx.Bucket != "test-bucket" {
+		t.Errorf("Bucket: got %q, want %q", capturedCtx.Bucket, "test-bucket")
+	}
+	if capturedCtx.Object != "test-object" {
+		t.Errorf("Object: got %q, want %q", capturedCtx.Object, "test-object")
+	}
+	wantAttempts := []int{1, 2, 3}
+	if !reflect.DeepEqual(attempts, wantAttempts) {
+		t.Errorf("Attempt sequence: got %v, want %v", attempts, wantAttempts)
 	}
 }

--- a/storage/retry_context_test.go
+++ b/storage/retry_context_test.go
@@ -208,7 +208,6 @@ func TestGRPCRetryContextMetadataListObjects(t *testing.T) {
 	// it.Next() triggers the fetch, which triggers ListObjects call
 	_, err = it.Next()
 
-
 	if err == nil {
 		t.Fatalf("expected call to fail due to invalid address, but got success")
 	}
@@ -306,7 +305,6 @@ func TestGRPCRetryContextMetadataMultiRangeDownloader(t *testing.T) {
 			return ctx.Attempt < 3
 		}),
 	).NewMultiRangeDownloader(ctx)
-
 
 	if err == nil {
 		if mrd != nil {


### PR DESCRIPTION
## Summary
Enriches internal SDK retry execution wrappers (`run`, `runWithRetry`) with missing `withOperation`, `withBucket`, and `withObject` options across gRPC and HTTP streaming read and object listing code paths.
## Motivation & Background
When applications (such as GCSFuse) consume the Go Storage SDK and register retry callbacks via `storage.ShouldRetryWithRetryContext`, certain transient error retries (e.g., streaming read reconnects or directory listings) passed incomplete `storage.RetryContext` objects containing empty strings (`""`) for `Operation`, `Bucket`, or `Object`. 
This change ensures that retry callbacks receive fully populated metadata during retries across both HTTP (JSON/REST) and gRPC streaming implementations.
## Detailed Changes
### 1. **gRPC Client (`storage/grpc_client.go`)**
* **`ListObjects`**: Passed `withOperation("ListObjects")`, `withBucket(bucket)`, and `withObject(it.query.Prefix)` into the `run` call. `it.query.Prefix` is passed directly without modification so that an empty prefix (`""`) accurately represents listing at the bucket root (or root directory in HNS buckets), matching standard GCS object listing semantics and keeping parity with the HTTP client implementation.
* **`NewRangeReader`**: Instrumented the streaming read retry execution loop with `withOperation("ReadObject")`, `withBucket(params.bucket)`, and `withObject(params.object)`.
### 2. **gRPC Multi-Range Reader (`storage/grpc_reader_multi_range.go`)**
* **`createNewSession`**: Added `withOperation("ReadObject")`, `withBucket(readSpec.GetBucket())`, and `withObject(readSpec.GetObject())` during multi-range parallel download session initialization retries.
### 3. **HTTP Client (`storage/http_client.go`)**
* **`readerReopen`**: Instrumented the HTTP range reader re-connect retry loop with `withOperation("ReadObject")`, `withBucket(params.bucket)`, and `withObject(params.object)`.
