### PR TITLE
fix(firestore): use higher precision for read times

### DIFF
--- a/firestore/client.go
+++ b/firestore/client.go
@@ -556,10 +556,10 @@ type readSettings struct {
 // parseReadTime ensures that fallback order of read options is respected.
 func parseReadTime(c *Client, rs *readSettings) (*timestamppb.Timestamp, bool) {
 	if rs != nil && !rs.readTime.IsZero() {
-		return &timestamppb.Timestamp{Seconds: int64(rs.readTime.Unix())}, true
+		return timestamppb.New(rs.readTime), true
 	}
 	if c.readSettings != nil && !c.readSettings.readTime.IsZero() {
-		return &timestamppb.Timestamp{Seconds: int64(c.readSettings.readTime.Unix())}, true
+		return timestamppb.New(c.readSettings.readTime), true
 	}
 	return nil, false
 }

--- a/firestore/util_test.go
+++ b/firestore/util_test.go
@@ -31,9 +31,9 @@ import (
 )
 
 var (
-	aTime       = time.Date(2017, 1, 26, 0, 0, 0, 0, time.UTC)
-	aTime2      = time.Date(2017, 2, 5, 0, 0, 0, 0, time.UTC)
-	aTime3      = time.Date(2017, 3, 20, 0, 0, 0, 0, time.UTC)
+	aTime       = time.Date(2017, 1, 26, 1, 2, 3, 4, time.UTC)
+	aTime2      = time.Date(2017, 2, 5, 2, 3, 4, 5, time.UTC)
+	aTime3      = time.Date(2017, 3, 20, 5, 4, 3, 2, time.UTC)
 	aTimestamp  = mustTimestampProto(aTime)
 	aTimestamp2 = mustTimestampProto(aTime2)
 	aTimestamp3 = mustTimestampProto(aTime3)


### PR DESCRIPTION
The implementation for snapshot reads snapped precision to the nearest second.  This change switches the conversion code so that full precision is maintained.

Related: internal b/528409928