### PR TITLE
chore(actions): address zizmor findings

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,7 +3,6 @@
         "config:best-practices",
         "schedule:weekly",
         ":disableDependencyDashboard",
-        "helpers:pinGitHubActionDigests",
         "docker:disable"
     ],
     "semanticCommits": false,

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,6 @@
 {
     "extends": [
-        "config:base",
+        "config:best-practices",
         "schedule:weekly",
         ":disableDependencyDashboard",
         "helpers:pinGitHubActionDigests",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,6 +3,7 @@
         "config:base",
         "schedule:weekly",
         ":disableDependencyDashboard",
+        "helpers:pinGitHubActionDigests",
         "docker:disable"
     ],
     "semanticCommits": false,

--- a/.github/workflows/action_syntax.yml
+++ b/.github/workflows/action_syntax.yml
@@ -14,5 +14,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/checkout@v6
-      - uses: reviewdog/action-actionlint@v1
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+      - uses: reviewdog/action-actionlint@6fb7acc99f4a1008869fa8a0f09cfca740837d9d # v1

--- a/.github/workflows/apidiff.yml
+++ b/.github/workflows/apidiff.yml
@@ -13,14 +13,17 @@ jobs:
   scan_changes:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       with:
         ref: main
+        persist-credentials: false
     - name: Get main commit
       id: main
       run: echo "hash=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-    - uses: actions/checkout@v6
-    - uses: actions/setup-go@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      with:
+        persist-credentials: false
+    - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
       with:
         go-version: '1.26.x'
     - name: Get changed directories
@@ -52,14 +55,15 @@ jobs:
     strategy:
       matrix: ${{ fromJson(needs.scan_changes.outputs.changed_dirs) }}
     steps:
-    - uses: actions/setup-go@v6
+    - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
       with:
         go-version: '1.26.x'
     - name: Install latest apidiff
       run: go install golang.org/x/exp/cmd/apidiff@latest
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       with:
         ref: main
+        persist-credentials: false
     - name: Create baseline
       id: baseline
       run: |
@@ -73,14 +77,16 @@ jobs:
         MATRIX_CHANGED: ${{ matrix.changed }}
         STEPS_BASELINE_OUTPUTS_PKG: ${{ steps.baseline.outputs.pkg }}
     - name: Upload baseline package data
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: ${{ steps.baseline.outputs.pkg }}
         path: ${{ matrix.changed }}/${{ steps.baseline.outputs.pkg }}
         retention-days: 1
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      with:
+        persist-credentials: false
     - name: Download baseline package data
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         name: ${{ steps.baseline.outputs.pkg }}
         path: ${{ matrix.changed }}
@@ -134,7 +140,7 @@ jobs:
     # review, even if they don't block the PR.
     - name: Add breaking change label
       if: ${{ steps.detect.outputs.breaking_change_found == 'true' && !github.event.pull_request.head.repo.fork }}
-      uses: actions/github-script@v9
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
       with:
         script: |
           github.rest.issues.addLabels({
@@ -150,7 +156,7 @@ jobs:
     # the failed presubmit check is the primary signal.
     - name: Post breaking change details as a comment
       if: ${{ steps.ga_check.outcome == 'success' && !github.event.pull_request.head.repo.fork }}
-      uses: actions/github-script@v9
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
       with:
         script: |
           const fs = require('fs');

--- a/.github/workflows/apidiff.yml
+++ b/.github/workflows/apidiff.yml
@@ -157,11 +157,13 @@ jobs:
     - name: Post breaking change details as a comment
       if: ${{ steps.ga_check.outcome == 'success' && !github.event.pull_request.head.repo.fork }}
       uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+      env:
+        CHANGED_MODULE: ${{ matrix.changed }}
       with:
         script: |
           const fs = require('fs');
-          const diff = fs.readFileSync('${{ matrix.changed }}/diff.txt', 'utf8');
-          const moduleName = '${{ matrix.changed }}';
+          const diff = fs.readFileSync(`${process.env.CHANGED_MODULE}/diff.txt`, 'utf8');
+          const moduleName = process.env.CHANGED_MODULE;
           const commentHeader = `### ⚠️ Breaking change detected in pre-GA module: \`${moduleName}\``;
           const body = `${commentHeader}\n\nThe apidiff check has detected one or more breaking changes in this module for pre-GA APIs.\n\nPre-GA breaking changes do not block the pull request, but are flagged here for review.\n\nFor any pre-GA breaking change that needs investigation, open a new issue containing a link to this comment, then you may proceed with reviewing and merging this PR.\n\n\`\`\`\n${diff}\n\`\`\``;
           const { data: comments } = await github.rest.issues.listComments({

--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -39,15 +39,17 @@ jobs:
         go: [ '1.25', '1.26']
         folders: ['bigtable']
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       with:
         path: google-cloud-go
-    - uses: actions/checkout@v6
+        persist-credentials: false
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       with:
         repository: googleapis/cloud-bigtable-clients-test
         ref: v0.0.3
         path: cloud-bigtable-clients-test
-    - uses: actions/setup-go@v6
+        persist-credentials: false
+    - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
       with:
           go-version: ${{ matrix.go }}
     - run: go version

--- a/.github/workflows/generation_check.yaml
+++ b/.github/workflows/generation_check.yaml
@@ -25,7 +25,7 @@ jobs:
               - 'librarian.yaml'
       # Version of librarian is pulled from librarian.yaml,
       # main corresponds to the action's source definition.
-      - uses: googleapis/librarian@main
+      - uses: googleapis/librarian@main # zizmor: ignore[unpinned-uses]
         if: steps.changes.outputs.librarian == 'true' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
         with:
           protoc-version: '33.2'
@@ -47,7 +47,7 @@ jobs:
           fi
       - name: Create issue if previous step fails
         if: ${{ failure() && github.ref == 'refs/heads/main' }}
-        uses: googleapis/librarian/.github/actions/create-issue-on-failure@main
+        uses: googleapis/librarian/.github/actions/create-issue-on-failure@main # zizmor: ignore[unpinned-uses]
         with:
           title: "Librarian generate diff check failed on main branch"
           body: |

--- a/.github/workflows/generation_check.yaml
+++ b/.github/workflows/generation_check.yaml
@@ -14,8 +14,10 @@ jobs:
   regeneration:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
         id: changes
         with:
           filters: |

--- a/.github/workflows/librarian_tidy.yml
+++ b/.github/workflows/librarian_tidy.yml
@@ -11,8 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
         id: changes
         with:
           filters: |

--- a/.github/workflows/librarian_tidy.yml
+++ b/.github/workflows/librarian_tidy.yml
@@ -22,7 +22,7 @@ jobs:
               - 'librarian.yaml'
       # Version of librarian is pulled from librarian.yaml,
       # main corresponds to the action's source definition.
-      - uses: googleapis/librarian@main
+      - uses: googleapis/librarian@main # zizmor: ignore[unpinned-uses]
 
       - name: Run librarian tidy
         if: steps.changes.outputs.librarian == 'true'

--- a/.github/workflows/third_party_check.yml
+++ b/.github/workflows/third_party_check.yml
@@ -15,10 +15,11 @@ jobs:
   changed_gomods:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       with:
         fetch-depth: 2
-    - uses: actions/setup-go@v6
+        persist-credentials: false
+    - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
       with:
         go-version: 1.26.x
     - name: Find modified go.mod files
@@ -45,7 +46,9 @@ jobs:
     strategy:
       matrix: ${{ fromJson(needs.changed_gomods.outputs.mods) }}
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      with:
+        persist-credentials: false
     - run: |
         cd internal/actions
         go run ./internal/actions/cmd/thirdpartycheck -q --dir=${{ github.workspace }} -mod ${MATRIX_MODS}/go.mod

--- a/.github/workflows/vet.yml
+++ b/.github/workflows/vet.yml
@@ -16,8 +16,10 @@ jobs:
   vet:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
-    - uses: actions/setup-go@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      with:
+        persist-credentials: false
+    - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
       with:
         go-version: '1.26.x'
     - name: Install tools


### PR DESCRIPTION
This PR is an auto-generated attempt to address zizmor findings. It may not catch everything, and should be reviewed by repository owners.

These changes were generated by running `zizmor --fix=all --gh-token=$(gh auth token) ./.github/workflows`, and then applying some fixes for any remaining issues reported by zizmor. See go/github-zizmor-help for instructions to install and run. 

Additionally, it updates renovate configuration (if present) to extend [best-practices](https://docs.renovatebot.com/presets-config/#configbest-practices), which includes pinning action digests and image digests, among other things.

If this PR is unhelpful, feel free to close the PR and address separately. If it is helpful, feel free to approve and merge, or edit/modify as needed to get it to the right state. Repository owners must ultimately ensure compliance by 2026-07-13. The purpose of this PR is to provide some assistance with achieving that as a first pass. This will become a blocking check for new changes to github workflows on 2026-07-13 within the `googleapis` org.

There may be some ignored findings (with the comment `# zizmor: ignore[...]`), which you may fix if feasible.
