### PR TITLE
fix(bigquery): don't retry jobRateLimitExceeded/internalError while polling query completion [AI]

### DIFF
--- a/bigquery/job.go
+++ b/bigquery/job.go
@@ -369,15 +369,9 @@ func (j *Job) waitForQuery(ctx context.Context, projectID string) (Schema, uint6
 		res, err = call.Do()
 		trace.EndSpan(sCtx, err)
 		if err != nil {
-			// GetQueryResults is a polling call, not a job-enqueuing call
-			// (jobs.insert / jobs.query). As noted where jobRetryReasons is
-			// defined, retrying "jobRateLimitExceeded" / "internalError" while
-			// polling can cause unwanted retries until the context deadline:
-			// once project query quota is saturated, every poll returns
-			// jobRateLimitExceeded and this loop retries indefinitely,
-			// generating a request storm that never makes progress (see
-			// https://github.com/dbt-labs/dbt-core/issues/14632). Use the
-			// polling-appropriate reason set instead.
+			// GetQueryResults is a polling call, not job enqueuing, so use
+			// defaultRetryReasons; jobRetryReasons is enqueue-only (see its
+			// definition in bigquery.go).
 			return !retryableError(err, defaultRetryReasons), err
 		}
 		if !res.JobComplete { // GetQueryResults may return early without error; retry.

--- a/bigquery/job.go
+++ b/bigquery/job.go
@@ -369,7 +369,16 @@ func (j *Job) waitForQuery(ctx context.Context, projectID string) (Schema, uint6
 		res, err = call.Do()
 		trace.EndSpan(sCtx, err)
 		if err != nil {
-			return !retryableError(err, jobRetryReasons), err
+			// GetQueryResults is a polling call, not a job-enqueuing call
+			// (jobs.insert / jobs.query). As noted where jobRetryReasons is
+			// defined, retrying "jobRateLimitExceeded" / "internalError" while
+			// polling can cause unwanted retries until the context deadline:
+			// once project query quota is saturated, every poll returns
+			// jobRateLimitExceeded and this loop retries indefinitely,
+			// generating a request storm that never makes progress (see
+			// https://github.com/dbt-labs/dbt-core/issues/14632). Use the
+			// polling-appropriate reason set instead.
+			return !retryableError(err, defaultRetryReasons), err
 		}
 		if !res.JobComplete { // GetQueryResults may return early without error; retry.
 			return false, nil

--- a/bigquery/job_test.go
+++ b/bigquery/job_test.go
@@ -15,12 +15,19 @@
 package bigquery
 
 import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"reflect"
 	"testing"
 	"time"
 
 	"cloud.google.com/go/internal/testutil"
 	bq "google.golang.org/api/bigquery/v2"
+	"google.golang.org/api/googleapi"
+	"google.golang.org/api/option"
 )
 
 func TestCreateJobRef(t *testing.T) {
@@ -198,5 +205,68 @@ func checkJob(t *testing.T, i int, got, want *bq.Job) {
 	d := testutil.Diff(got, want)
 	if d != "" {
 		t.Errorf("#%d: (got=-, want=+) %s", i, d)
+	}
+}
+
+// waitForQuery polls jobs.getQueryResults, so it must use
+// defaultRetryReasons: transient reasons are retried, while enqueue-only
+// reasons like jobRateLimitExceeded (see jobRetryReasons) must surface
+// immediately instead of retrying until the context deadline.
+func TestWaitForQueryRetryReasons(t *testing.T) {
+	for _, test := range []struct {
+		name         string
+		reason       string
+		wantAttempts int
+		wantErr      bool
+	}{
+		{
+			name:         "jobRateLimitExceeded is not retried",
+			reason:       "jobRateLimitExceeded",
+			wantAttempts: 1,
+			wantErr:      true,
+		},
+		{
+			name:         "rateLimitExceeded is retried",
+			reason:       "rateLimitExceeded",
+			wantAttempts: 2,
+			wantErr:      false,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			attempts := 0
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				attempts++
+				if attempts >= test.wantAttempts && !test.wantErr {
+					w.Write([]byte(`{"jobReference": {"projectId": "p", "jobId": "j"}, "jobComplete": true, "totalRows": "0"}`))
+					return
+				}
+				w.WriteHeader(http.StatusForbidden)
+				fmt.Fprintf(w, `{"error": {"code": 403, "message": "quota exceeded", "errors": [{"reason": %q, "message": "quota exceeded"}]}}`, test.reason)
+			}))
+			defer ts.Close()
+
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			client, err := NewClient(ctx, "p", option.WithEndpoint(ts.URL), option.WithoutAuthentication())
+			if err != nil {
+				t.Fatalf("NewClient: %v", err)
+			}
+			defer client.Close()
+
+			job := &Job{c: client, projectID: "p", jobID: "j"}
+			_, _, err = job.waitForQuery(ctx, "p")
+			if gotErr := err != nil; gotErr != test.wantErr {
+				t.Fatalf("waitForQuery: got error %v, want error: %t", err, test.wantErr)
+			}
+			if test.wantErr {
+				var e *googleapi.Error
+				if !errors.As(err, &e) || e.Code != http.StatusForbidden {
+					t.Errorf("waitForQuery: got %v, want a googleapi.Error with code 403", err)
+				}
+			}
+			if attempts != test.wantAttempts {
+				t.Errorf("waitForQuery: got %d attempts, want %d", attempts, test.wantAttempts)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Resolves: dbt-labs/dbt-core#14632

## Summary

`Job.waitForQuery` polls `jobs.getQueryResults` to wait for query completion, but passes `jobRetryReasons` to the retry predicate:

```go
// bigquery/job.go, waitForQuery
if err != nil {
    return !retryableError(err, jobRetryReasons), err
}
```

`jobRetryReasons` includes `"jobRateLimitExceeded"` and `"internalError"`. The comment on that variable already warns these are for **job-enqueuing** calls only:

```go
// These reasons are used exclusively for enqueuing jobs (jobs.insert and jobs.query).
// Using them for polling may cause unwanted retries until context deadline/cancellation/etc.
jobRetryReasons = []string{"backendError", "rateLimitExceeded", "jobRateLimitExceeded", "internalError"}
```

Using them in the polling loop means that once a project's query quota is saturated, every `getQueryResults` poll returns `jobRateLimitExceeded` and the retry loop spins (backoff capped at 60s) until the context deadline — a request storm that never makes forward progress.

## Fix

Use `defaultRetryReasons` (`"backendError"`, `"rateLimitExceeded"`) for the polling loop, matching the documented intent for non-enqueue calls.

## History

- #5387 introduced the `defaultRetryReasons` / `jobRetryReasons` split and put `jobRetryReasons` on the `waitForQuery` predicate.
- #9726 added `jobRateLimitExceeded` to `jobRetryReasons` (parity with python-bigquery, #3795) — which made the polling loop retry quota errors, the proximate cause of the freeze reported downstream.
- #10006 documented the reason sets as enqueue-only vs polling and added `TestRetryableErrors` coverage for both sets, but left `waitForQuery` on `jobRetryReasons`. This PR aligns the call site with that documentation.
- #6976's description warns about this exact failure mode ("job execution may appear to hang indefinitely or until context cancellation/expiry").

## Impact

Reported downstream in [dbt-labs/dbt-core#14632](https://github.com/dbt-labs/dbt-core/issues/14632): a compile against a project with ~700 sharded schemas froze after ~30s, with 1,323 `jobRateLimitExceeded` errors captured in 2 minutes, all absorbed inside this retry loop.

## Tests

- `TestWaitForQueryRetryReasons` (new, `bigquery/job_test.go`) exercises the `waitForQuery` call site against an `httptest` server: a 403 `jobRateLimitExceeded` must surface after exactly one attempt (fails on the previous code with 16+ attempts until the context deadline), while a 403 `rateLimitExceeded` is still retried and succeeds.
- `TestRetryableErrors` already covers the `retryableError` predicate for both reason sets; `jobRetryReasons` remains in use for job-enqueuing calls.

`go test ./bigquery/ -run 'TestWaitForQueryRetryReasons|TestRetryableErrors'` passes.
