### PR TITLE
fix(firestore): more precision fixes

### DIFF
--- a/firestore/client.go
+++ b/firestore/client.go
@@ -554,12 +554,14 @@ type readSettings struct {
 }
 
 // parseReadTime ensures that fallback order of read options is respected.
+// As firestore only accepts usec precision, more precise (e.g. nano) values
+// are clamped accordingly.
 func parseReadTime(c *Client, rs *readSettings) (*timestamppb.Timestamp, bool) {
 	if rs != nil && !rs.readTime.IsZero() {
-		return timestamppb.New(rs.readTime), true
+		return timestamppb.New(rs.readTime.Truncate(time.Microsecond)), true
 	}
 	if c.readSettings != nil && !c.readSettings.readTime.IsZero() {
-		return timestamppb.New(c.readSettings.readTime), true
+		return timestamppb.New(c.readSettings.readTime.Truncate(time.Microsecond)), true
 	}
 	return nil, false
 }

--- a/firestore/util_test.go
+++ b/firestore/util_test.go
@@ -31,9 +31,9 @@ import (
 )
 
 var (
-	aTime       = time.Date(2017, 1, 26, 1, 2, 3, 0, time.UTC)
-	aTime2      = time.Date(2017, 2, 5, 2, 3, 4, 0, time.UTC)
-	aTime3      = time.Date(2017, 3, 20, 5, 4, 3, 0, time.UTC)
+	aTime       = time.Date(2017, 1, 26, 1, 2, 3, 4000, time.UTC)
+	aTime2      = time.Date(2017, 2, 5, 2, 3, 4, 5000, time.UTC)
+	aTime3      = time.Date(2017, 3, 20, 5, 4, 3, 2000, time.UTC)
 	aTimestamp  = mustTimestampProto(aTime)
 	aTimestamp2 = mustTimestampProto(aTime2)
 	aTimestamp3 = mustTimestampProto(aTime3)

--- a/firestore/util_test.go
+++ b/firestore/util_test.go
@@ -31,9 +31,9 @@ import (
 )
 
 var (
-	aTime       = time.Date(2017, 1, 26, 1, 2, 3, 4, time.UTC)
-	aTime2      = time.Date(2017, 2, 5, 2, 3, 4, 5, time.UTC)
-	aTime3      = time.Date(2017, 3, 20, 5, 4, 3, 2, time.UTC)
+	aTime       = time.Date(2017, 1, 26, 1, 2, 3, 0, time.UTC)
+	aTime2      = time.Date(2017, 2, 5, 2, 3, 4, 0, time.UTC)
+	aTime3      = time.Date(2017, 3, 20, 5, 4, 3, 0, time.UTC)
 	aTimestamp  = mustTimestampProto(aTime)
 	aTimestamp2 = mustTimestampProto(aTime2)
 	aTimestamp3 = mustTimestampProto(aTime3)


### PR DESCRIPTION
Turns out precision for read snapshots is clamped to usec precision, so this updates the parse code to truncate precision accordingly.