### PR TITLE
fix(pubsub/v2): release flow control credit on scheduler.Add error

### DIFF
--- a/pubsub/topic.go
+++ b/pubsub/topic.go
@@ -1266,6 +1266,7 @@ func (t *Topic) Publish(ctx context.Context, msg *Message) *PublishResult {
 	}
 
 	if err := t.scheduler.Add(msg.OrderingKey, bmsg, msgSize); err != nil {
+		t.flowController.release(ctx, msgSize)
 		t.scheduler.Pause(msg.OrderingKey)
 		ipubsub.SetPublishResult(r, "", err)
 		spanRecordError(createSpan, err)

--- a/pubsub/topic_test.go
+++ b/pubsub/topic_test.go
@@ -953,3 +953,47 @@ func TestPublishCompression(t *testing.T) {
 		t.Errorf("publish result got err: %v", err)
 	}
 }
+
+func TestPublishFlowControl_OversizedLeak(t *testing.T) {
+	ctx := context.Background()
+	c, srv := newFake(t)
+	defer c.Close()
+	defer srv.Close()
+
+	topic, err := c.CreateTopic(ctx, "test-topic")
+	if err != nil {
+		t.Fatal(err)
+	}
+	topic.PublishSettings.FlowControlSettings = FlowControlSettings{
+		MaxOutstandingMessages: 1,
+		LimitExceededBehavior:  FlowControlBlock,
+	}
+	// Flush immediately
+	topic.PublishSettings.CountThreshold = 1
+	topic.PublishSettings.DelayThreshold = time.Millisecond
+
+	// Oversized message should fail.
+	// MaxPublishRequestBytes is 1e7 (10MB).
+	big := &Message{Data: make([]byte, 11*1024*1024)}
+	res := topic.Publish(ctx, big)
+	if _, err := res.Get(ctx); !errors.Is(err, ErrOversizedMessage) {
+		t.Fatalf("got %v, want ErrOversizedMessage", err)
+	}
+
+	// Subsequent publish should not block.
+	done := make(chan struct{})
+	go func() {
+		res2 := publishSingleMessage(ctx, topic, "small")
+		// We need to set a response in fake server for this to complete.
+		addSingleResponse(srv, "1")
+		_, _ = res2.Get(ctx)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// OK
+	case <-time.After(3 * time.Second):
+		t.Fatal("BUG: publish blocked, credit leaked by oversized message")
+	}
+}

--- a/pubsub/v2/publisher.go
+++ b/pubsub/v2/publisher.go
@@ -273,6 +273,7 @@ func (t *Publisher) Publish(ctx context.Context, msg *Message) *PublishResult {
 	}
 
 	if err := t.scheduler.Add(msg.OrderingKey, bmsg, msgSize); err != nil {
+		t.flowController.release(ctx, msgSize)
 		t.scheduler.Pause(msg.OrderingKey)
 		ipubsub.SetPublishResult(r, "", err)
 		spanRecordError(createSpan, err)

--- a/pubsub/v2/publisher_test.go
+++ b/pubsub/v2/publisher_test.go
@@ -415,3 +415,47 @@ func TestPublishCompression(t *testing.T) {
 		t.Errorf("publish result got err: %v", err)
 	}
 }
+
+func TestPublishFlowControl_OversizedLeak(t *testing.T) {
+	ctx := context.Background()
+	c, srv := newFake(t)
+	defer c.Close()
+	defer srv.Close()
+
+	topic := fmt.Sprintf("projects/%s/topics/test-topic", testutil.ProjID())
+	publisher := mustCreateTopic(t, c, topic)
+	defer publisher.Stop()
+
+	publisher.PublishSettings.FlowControlSettings = FlowControlSettings{
+		MaxOutstandingMessages: 1,
+		LimitExceededBehavior:  FlowControlBlock,
+	}
+	// Flush immediately
+	publisher.PublishSettings.CountThreshold = 1
+	publisher.PublishSettings.DelayThreshold = time.Millisecond
+
+	// Oversized message should fail.
+	// MaxPublishRequestBytes is 1e7 (10MB).
+	big := &Message{Data: make([]byte, 11*1024*1024)}
+	res := publisher.Publish(ctx, big)
+	if _, err := res.Get(ctx); !errors.Is(err, ErrOversizedMessage) {
+		t.Fatalf("got %v, want ErrOversizedMessage", err)
+	}
+
+	// Subsequent publish should not block.
+	done := make(chan struct{})
+	go func() {
+		res2 := publishSingleMessage(ctx, publisher, "small")
+		// We need to set a response in fake server for this to complete.
+		addSingleResponse(srv, "1")
+		_, _ = res2.Get(ctx)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// OK
+	case <-time.After(3 * time.Second):
+		t.Fatal("BUG: publish blocked, credit leaked by oversized message")
+	}
+}


### PR DESCRIPTION
When publishing a message, flow control credits are acquired before
adding the message to the scheduler. If scheduler.Add fails (e.g. due to
oversized message), the value was never released.

Also added regression tests in v1 and v2.

Fixes #20078 