### PR TITLE
fix(spanner): update dynamic channel pool default configuration

### DIFF
--- a/spanner/dynamic_channel_pool.go
+++ b/spanner/dynamic_channel_pool.go
@@ -85,11 +85,11 @@ type DynamicChannelPoolConfig struct {
 func DefaultDynamicChannelPoolConfig() DynamicChannelPoolConfig {
 	return DynamicChannelPoolConfig{
 		DCPInitialChannels:                   4,
-		DCPMinChannels:                       4,
-		DCPMaxChannels:                       256,
-		DCPMaxRPCPerChannel:                  50,
-		DCPMinRPCPerChannel:                  5,
-		DCPScaleDownCheckInterval:            30 * time.Second,
+		DCPMinChannels:                       2,
+		DCPMaxChannels:                       10,
+		DCPMaxRPCPerChannel:                  25,
+		DCPMinRPCPerChannel:                  15,
+		DCPScaleDownCheckInterval:            3 * time.Minute,
 		DCPScaleUpCooldown:                   10 * time.Second,
 		DCPDownscaleConsecutiveLowLoadChecks: 3,
 		DCPMaxScaleUpPercent:                 30,

--- a/spanner/dynamic_channel_pool_test.go
+++ b/spanner/dynamic_channel_pool_test.go
@@ -974,6 +974,32 @@ func TestDynamicChannelPoolScaleUpDialFailureDoesNotPublishEntry(t *testing.T) {
 	}
 }
 
+func TestDefaultDynamicChannelPoolConfigValues(t *testing.T) {
+	// Pins the documented DCP default values via a full-struct comparison, so any
+	// default change (or a new knob added without a pinned default) is a deliberate,
+	// test-visible decision rather than a silently green diff.
+	got := DefaultDynamicChannelPoolConfig()
+	want := DynamicChannelPoolConfig{
+		DCPInitialChannels:                   4,
+		DCPMinChannels:                       2,
+		DCPMaxChannels:                       10,
+		DCPMaxRPCPerChannel:                  25,
+		DCPMinRPCPerChannel:                  15,
+		DCPScaleDownCheckInterval:            3 * time.Minute,
+		DCPScaleUpCooldown:                   10 * time.Second,
+		DCPDownscaleConsecutiveLowLoadChecks: 3,
+		DCPMaxScaleUpPercent:                 30,
+		DCPMaxRemoveChannels:                 2,
+		DCPDrainIdleGrace:                    time.Minute,
+		DCPPrimeTimeout:                      10 * time.Second,
+		DCPPrimeMaxAttempts:                  3,
+		DCPSelectionStrategy:                 DCPPowerOfTwoLeastBusy,
+	}
+	if got != want {
+		t.Fatalf("DefaultDynamicChannelPoolConfig() = %+v, want %+v", got, want)
+	}
+}
+
 func TestDynamicChannelPoolConfigDefaultsInitialChannelsToMinWhenInitialUnset(t *testing.T) {
 	cfg, err := normalizeDCPConfig(DynamicChannelPoolConfig{DCPEnabled: true, DCPMinChannels: 8, DCPMaxChannels: 10})
 	if err != nil {


### PR DESCRIPTION
Set DCP defaults to DCPMaxRPCPerChannel=25, DCPMinRPCPerChannel=15, DCPScaleDownCheckInterval=3m, DCPInitialChannels=4, DCPMaxChannels=10, DCPMinChannels=2.

Internal Ref: go/dynamic-channel-pooling-non-sab