### PR TITLE
feat(o11y): instrument LRO loop with poll attempt and sleep child spans

### DIFF
--- a/longrunning/longrunning.go
+++ b/longrunning/longrunning.go
@@ -191,7 +191,9 @@ func (op *Operation) waitWithInterval(ctx context.Context, resp protoadapt.Messa
 	tracer := otel.GetTracerProvider().Tracer("cloud.google.com/go")
 	ctx, span := tracer.Start(ctx, spanName, startOpts...)
 	defer span.End()
-	span.SetAttributes(attribute.String("gcp.resource.destination.id", op.Name()))
+	span.SetAttributes(
+		attribute.String("gcp.resource.destination.id", op.Name()),
+	)
 
 	err := op.waitTraced(ctx, resp, &bo, sl, opts...)
 	if err != nil {
@@ -261,7 +263,9 @@ func (op *Operation) waitTraced(ctx context.Context, resp protoadapt.MessageV1, 
 		}
 
 		_, sleepSpan := tracer.Start(ctx, "LRO Sleep")
-		sleepSpan.SetAttributes(attribute.String("gcp.resource.destination.id", op.Name()))
+		sleepSpan.SetAttributes(
+			attribute.String("gcp.resource.destination.id", op.Name()),
+		)
 		sleepErr := sl(ctx, bo.Pause())
 		if sleepErr != nil {
 			sleepSpan.SetStatus(codes.Error, sleepErr.Error())

--- a/longrunning/longrunning.go
+++ b/longrunning/longrunning.go
@@ -263,11 +263,13 @@ func (op *Operation) waitTraced(ctx context.Context, resp protoadapt.MessageV1, 
 		_, sleepSpan := tracer.Start(ctx, "LRO Sleep")
 		sleepSpan.SetAttributes(attribute.String("gcp.resource.destination.id", op.Name()))
 		sleepErr := sl(ctx, bo.Pause())
-		sleepSpan.End()
-
 		if sleepErr != nil {
+			sleepSpan.SetStatus(codes.Error, sleepErr.Error())
+			sleepSpan.RecordError(sleepErr)
+			sleepSpan.End()
 			return sleepErr
 		}
+		sleepSpan.End()
 	}
 }
 

--- a/longrunning/longrunning.go
+++ b/longrunning/longrunning.go
@@ -263,9 +263,6 @@ func (op *Operation) waitTraced(ctx context.Context, resp protoadapt.MessageV1, 
 		}
 
 		_, sleepSpan := tracer.Start(ctx, "LRO Sleep")
-		sleepSpan.SetAttributes(
-			attribute.String("gcp.resource.destination.id", op.Name()),
-		)
 		sleepErr := sl(ctx, bo.Pause())
 		if sleepErr != nil {
 			sleepSpan.SetStatus(codes.Error, sleepErr.Error())

--- a/longrunning/longrunning.go
+++ b/longrunning/longrunning.go
@@ -35,6 +35,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
+	grpccodes "google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/protoadapt"
@@ -192,7 +193,7 @@ func (op *Operation) waitWithInterval(ctx context.Context, resp protoadapt.Messa
 	defer span.End()
 	span.SetAttributes(attribute.String("gcp.resource.destination.id", op.Name()))
 
-	err := op.wait(ctx, resp, &bo, sl, opts...)
+	err := op.waitTraced(ctx, resp, &bo, sl, opts...)
 	if err != nil {
 		span.SetStatus(codes.Error, err.Error())
 		span.RecordError(err)
@@ -213,6 +214,59 @@ func (op *Operation) wait(ctx context.Context, resp protoadapt.MessageV1, bo *ga
 		}
 		if err := sl(ctx, bo.Pause()); err != nil {
 			return err
+		}
+	}
+}
+
+func (op *Operation) waitTraced(ctx context.Context, resp protoadapt.MessageV1, bo *gax.Backoff, sl sleeper, opts ...gax.CallOption) error {
+	tracer := otel.GetTracerProvider().Tracer("cloud.google.com/go")
+	pollAttempt := 0
+
+	for {
+		pollAttempt++
+		pollSpanName := "*longrunning.OperationsClient.GetOperation"
+
+		pollCtx, pollSpan := tracer.Start(ctx, pollSpanName)
+		pollSpan.SetAttributes(
+			attribute.String("gcp.resource.destination.id", op.Name()),
+			attribute.Int("gcp.longrunning.poll_attempt_count", pollAttempt),
+		)
+
+		err := op.Poll(pollCtx, resp, opts...)
+
+		pollSpan.SetAttributes(attribute.Bool("gcp.longrunning.done", op.Done()))
+		if op.Done() {
+			var statusCode int
+			if err != nil {
+				if s, ok := status.FromError(err); ok {
+					statusCode = int(s.Code())
+				} else {
+					statusCode = int(grpccodes.Unknown)
+				}
+			}
+			pollSpan.SetAttributes(attribute.Int("gcp.longrunning.status_code", statusCode))
+		}
+
+		if err != nil {
+			pollSpan.SetStatus(codes.Error, err.Error())
+			pollSpan.RecordError(err)
+			pollSpan.End()
+			return err
+		}
+
+		pollSpan.End()
+
+		if op.Done() {
+			return nil
+		}
+
+		_, sleepSpan := tracer.Start(ctx, "LRO Sleep")
+		sleepSpan.SetAttributes(attribute.String("gcp.resource.destination.id", op.Name()))
+		sleepErr := sl(ctx, bo.Pause())
+		sleepSpan.End()
+
+		if sleepErr != nil {
+			return sleepErr
 		}
 	}
 }

--- a/longrunning/longrunning.go
+++ b/longrunning/longrunning.go
@@ -240,8 +240,8 @@ func (op *Operation) waitTraced(ctx context.Context, resp protoadapt.MessageV1, 
 		if op.Done() {
 			var statusCode int
 			if err != nil {
-				if s, ok := status.FromError(err); ok {
-					statusCode = int(s.Code())
+				if apiErr, ok := apierror.FromError(err); ok {
+					statusCode = int(apiErr.GRPCStatus().Code())
 				} else {
 					statusCode = int(grpccodes.Unknown)
 				}

--- a/longrunning/longrunning_test.go
+++ b/longrunning/longrunning_test.go
@@ -339,41 +339,45 @@ func TestWaitTraced(t *testing.T) {
 		t.Fatalf("expected 3 poll spans, got %d", len(pollSpans))
 	}
 
+	verifyPollAndSleepSpans(t, pollSpans, sleepSpans, "foo")
+}
+
+func verifyPollAndSleepSpans(t *testing.T, pollSpans, sleepSpans []sdktrace.ReadOnlySpan, expectedResID string) {
+	t.Helper()
 	for i, pollSpan := range pollSpans {
 		attrs := pollSpan.Attributes()
 		var resID string
+		var hasCount bool
 		var count int
 		var done bool
-		var hasDone, hasCount bool
-
 		for _, attr := range attrs {
-			switch attr.Key {
-			case "gcp.resource.destination.id":
+			if attr.Key == "gcp.resource.destination.id" {
 				resID = attr.Value.AsString()
-			case "gcp.longrunning.poll_attempt_count":
-				count = int(attr.Value.AsInt64())
+			}
+			if attr.Key == "gcp.longrunning.poll_attempt_count" {
 				hasCount = true
-			case "gcp.longrunning.done":
+				count = int(attr.Value.AsInt64())
+			}
+			if attr.Key == "gcp.longrunning.done" {
 				done = attr.Value.AsBool()
-				hasDone = true
 			}
 		}
 
-		if resID != "foo" {
-			t.Errorf("poll span %d expected gcp.resource.destination.id to be 'foo', got '%s'", i, resID)
+		if resID != expectedResID {
+			t.Errorf("poll span %d expected gcp.resource.destination.id to be '%s', got '%s'", i, expectedResID, resID)
 		}
 		if !hasCount || count != i+1 {
 			t.Errorf("poll span %d expected count to be %d, got %d", i, i+1, count)
 		}
-		if !hasDone {
+
+		if i != len(pollSpans)-1 && done {
 			t.Errorf("poll span %d expected gcp.longrunning.done to be set", i)
 		}
 
-		if i == 2 {
+		if i == len(pollSpans)-1 {
 			if !done {
 				t.Error("expected done to be true on terminal poll span")
 			}
-			// check status code is present and 0 (OK)
 			hasStatus := false
 			var statusCode int
 			for _, attr := range attrs {
@@ -385,28 +389,13 @@ func TestWaitTraced(t *testing.T) {
 			if !hasStatus || statusCode != 0 {
 				t.Errorf("expected status code 0 on terminal poll, got %d (hasStatus: %t)", statusCode, hasStatus)
 			}
-		} else {
-			if done {
-				t.Errorf("expected done to be false on non-terminal poll span %d", i)
-			}
 		}
 	}
 
 	// Verify T5 Sleep Spans
-	if len(sleepSpans) != 2 {
-		t.Errorf("expected 2 sleep spans, got %d", len(sleepSpans))
-	}
-	for i, sleepSpan := range sleepSpans {
-		attrs := sleepSpan.Attributes()
-		var resID string
-		for _, attr := range attrs {
-			if attr.Key == "gcp.resource.destination.id" {
-				resID = attr.Value.AsString()
-			}
-		}
-		if resID != "foo" {
-			t.Errorf("sleep span %d expected gcp.resource.destination.id to be 'foo', got '%s'", i, resID)
-		}
+	expectedSleeps := len(pollSpans) - 1
+	if len(sleepSpans) != expectedSleeps {
+		t.Errorf("expected %d sleep spans, got %d", expectedSleeps, len(sleepSpans))
 	}
 }
 
@@ -462,6 +451,7 @@ func TestWaitTracedResumed(t *testing.T) {
 	spans := sr.Ended()
 	var waitSpan sdktrace.ReadOnlySpan
 	var pollSpans []sdktrace.ReadOnlySpan
+	var sleepSpans []sdktrace.ReadOnlySpan
 
 	for _, span := range spans {
 		switch span.Name() {
@@ -469,6 +459,8 @@ func TestWaitTracedResumed(t *testing.T) {
 			waitSpan = span
 		case "*longrunning.OperationsClient.GetOperation":
 			pollSpans = append(pollSpans, span)
+		case "LRO Sleep":
+			sleepSpans = append(sleepSpans, span)
 		}
 	}
 
@@ -484,6 +476,8 @@ func TestWaitTracedResumed(t *testing.T) {
 	if len(pollSpans) != 2 {
 		t.Fatalf("expected 2 poll spans, got %d", len(pollSpans))
 	}
+
+	verifyPollAndSleepSpans(t, pollSpans, sleepSpans, "foo")
 }
 
 func TestWaitTracedFallback(t *testing.T) {
@@ -537,6 +531,7 @@ func TestWaitTracedFallback(t *testing.T) {
 	spans := sr.Ended()
 	var waitSpan sdktrace.ReadOnlySpan
 	var pollSpans []sdktrace.ReadOnlySpan
+	var sleepSpans []sdktrace.ReadOnlySpan
 
 	for _, span := range spans {
 		switch span.Name() {
@@ -544,6 +539,8 @@ func TestWaitTracedFallback(t *testing.T) {
 			waitSpan = span
 		case "*longrunning.OperationsClient.GetOperation":
 			pollSpans = append(pollSpans, span)
+		case "LRO Sleep":
+			sleepSpans = append(sleepSpans, span)
 		}
 	}
 
@@ -559,4 +556,6 @@ func TestWaitTracedFallback(t *testing.T) {
 	if len(pollSpans) != 2 {
 		t.Fatalf("expected 2 poll spans, got %d", len(pollSpans))
 	}
+
+	verifyPollAndSleepSpans(t, pollSpans, sleepSpans, "foo")
 }

--- a/longrunning/longrunning_test.go
+++ b/longrunning/longrunning_test.go
@@ -244,7 +244,7 @@ func TestInternalNewOperationWithMetadata(t *testing.T) {
 	}
 }
 
-func TestWaitTracedWaitSpanOnly(t *testing.T) {
+func TestWaitTraced(t *testing.T) {
 	t.Setenv("GOOGLE_SDK_GO_EXPERIMENTAL_TRACING", "true")
 	if !gax.IsFeatureEnabled("TRACING") {
 		t.Skip("TRACING feature flag is not enabled")
@@ -264,6 +264,7 @@ func TestWaitTracedWaitSpanOnly(t *testing.T) {
 
 	s := &getterService{
 		results: []*pb.Operation{
+			{Name: "foo"},
 			{Name: "foo"},
 			{
 				Name: "foo",
@@ -296,9 +297,17 @@ func TestWaitTracedWaitSpanOnly(t *testing.T) {
 
 	spans := sr.Ended()
 	var waitSpan sdktrace.ReadOnlySpan
+	var pollSpans []sdktrace.ReadOnlySpan
+	var sleepSpans []sdktrace.ReadOnlySpan
+
 	for _, span := range spans {
-		if span.Name() == "*speech.Client.BatchRecognizeOperation.Wait" {
+		switch span.Name() {
+		case "*speech.Client.BatchRecognizeOperation.Wait":
 			waitSpan = span
+		case "*longrunning.OperationsClient.GetOperation":
+			pollSpans = append(pollSpans, span)
+		case "LRO Sleep":
+			sleepSpans = append(sleepSpans, span)
 		}
 	}
 
@@ -324,9 +333,84 @@ func TestWaitTracedWaitSpanOnly(t *testing.T) {
 	if !hasResID {
 		t.Error("expected wait span to have gcp.resource.destination.id attribute set to 'foo'")
 	}
+
+	// Verify T3 Poll Spans
+	if len(pollSpans) != 3 {
+		t.Fatalf("expected 3 poll spans, got %d", len(pollSpans))
+	}
+
+	for i, pollSpan := range pollSpans {
+		attrs := pollSpan.Attributes()
+		var resID string
+		var count int
+		var done bool
+		var hasDone, hasCount bool
+
+		for _, attr := range attrs {
+			switch attr.Key {
+			case "gcp.resource.destination.id":
+				resID = attr.Value.AsString()
+			case "gcp.longrunning.poll_attempt_count":
+				count = int(attr.Value.AsInt64())
+				hasCount = true
+			case "gcp.longrunning.done":
+				done = attr.Value.AsBool()
+				hasDone = true
+			}
+		}
+
+		if resID != "foo" {
+			t.Errorf("poll span %d expected gcp.resource.destination.id to be 'foo', got '%s'", i, resID)
+		}
+		if !hasCount || count != i+1 {
+			t.Errorf("poll span %d expected count to be %d, got %d", i, i+1, count)
+		}
+		if !hasDone {
+			t.Errorf("poll span %d expected gcp.longrunning.done to be set", i)
+		}
+
+		if i == 2 {
+			if !done {
+				t.Error("expected done to be true on terminal poll span")
+			}
+			// check status code is present and 0 (OK)
+			hasStatus := false
+			var statusCode int
+			for _, attr := range attrs {
+				if attr.Key == "gcp.longrunning.status_code" {
+					statusCode = int(attr.Value.AsInt64())
+					hasStatus = true
+				}
+			}
+			if !hasStatus || statusCode != 0 {
+				t.Errorf("expected status code 0 on terminal poll, got %d (hasStatus: %t)", statusCode, hasStatus)
+			}
+		} else {
+			if done {
+				t.Errorf("expected done to be false on non-terminal poll span %d", i)
+			}
+		}
+	}
+
+	// Verify T5 Sleep Spans
+	if len(sleepSpans) != 2 {
+		t.Errorf("expected 2 sleep spans, got %d", len(sleepSpans))
+	}
+	for i, sleepSpan := range sleepSpans {
+		attrs := sleepSpan.Attributes()
+		var resID string
+		for _, attr := range attrs {
+			if attr.Key == "gcp.resource.destination.id" {
+				resID = attr.Value.AsString()
+			}
+		}
+		if resID != "foo" {
+			t.Errorf("sleep span %d expected gcp.resource.destination.id to be 'foo', got '%s'", i, resID)
+		}
+	}
 }
 
-func TestWaitTracedResumedWaitSpanOnly(t *testing.T) {
+func TestWaitTracedResumed(t *testing.T) {
 	t.Setenv("GOOGLE_SDK_GO_EXPERIMENTAL_TRACING", "true")
 	if !gax.IsFeatureEnabled("TRACING") {
 		t.Skip("TRACING feature flag is not enabled")
@@ -377,9 +461,14 @@ func TestWaitTracedResumedWaitSpanOnly(t *testing.T) {
 
 	spans := sr.Ended()
 	var waitSpan sdktrace.ReadOnlySpan
+	var pollSpans []sdktrace.ReadOnlySpan
+
 	for _, span := range spans {
-		if span.Name() == "*speech.BatchRecognizeOperation.Wait" {
+		switch span.Name() {
+		case "*speech.BatchRecognizeOperation.Wait":
 			waitSpan = span
+		case "*longrunning.OperationsClient.GetOperation":
+			pollSpans = append(pollSpans, span)
 		}
 	}
 
@@ -391,9 +480,13 @@ func TestWaitTracedResumedWaitSpanOnly(t *testing.T) {
 	if len(links) != 0 {
 		t.Fatalf("expected 0 span links for resumed LRO tracing, got %d", len(links))
 	}
+
+	if len(pollSpans) != 2 {
+		t.Fatalf("expected 2 poll spans, got %d", len(pollSpans))
+	}
 }
 
-func TestWaitTracedFallbackWaitSpanOnly(t *testing.T) {
+func TestWaitTracedFallback(t *testing.T) {
 	t.Setenv("GOOGLE_SDK_GO_EXPERIMENTAL_TRACING", "true")
 	if !gax.IsFeatureEnabled("TRACING") {
 		t.Skip("TRACING feature flag is not enabled")
@@ -443,9 +536,14 @@ func TestWaitTracedFallbackWaitSpanOnly(t *testing.T) {
 
 	spans := sr.Ended()
 	var waitSpan sdktrace.ReadOnlySpan
+	var pollSpans []sdktrace.ReadOnlySpan
+
 	for _, span := range spans {
-		if span.Name() == "*longrunning.Operation.Wait" {
+		switch span.Name() {
+		case "*longrunning.Operation.Wait":
 			waitSpan = span
+		case "*longrunning.OperationsClient.GetOperation":
+			pollSpans = append(pollSpans, span)
 		}
 	}
 
@@ -456,5 +554,9 @@ func TestWaitTracedFallbackWaitSpanOnly(t *testing.T) {
 	links := waitSpan.Links()
 	if len(links) != 0 {
 		t.Fatalf("expected 0 span links for fallback LRO tracing, got %d", len(links))
+	}
+
+	if len(pollSpans) != 2 {
+		t.Fatalf("expected 2 poll spans, got %d", len(pollSpans))
 	}
 }


### PR DESCRIPTION
Complete the tracing instrumentation of the LRO polling loop.
It adds two new trace spans to the inner polling cycle:
- T3 Poll Span: tracks individual `GetOperation` poll attempts and records the gRPC status code, poll attempt count, and whether the LRO is done.
- T5 Sleep Span: captures the exponential backoff between poll attempts (`LRO Sleep`), ensuring wait times are visualized in the trace.

Additionally, it marks the parent `Wait` span and the active poll span with an `ERROR` status if the LRO returns a logical error. 