### PR TITLE
fix(pubsub): fix concurrent map write

### DIFF
--- a/pubsub/trace.go
+++ b/pubsub/trace.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"maps"
 	"sync"
 
 	pb "cloud.google.com/go/pubsub/apiv1/pubsubpb"
@@ -320,9 +321,14 @@ func (c messageCarrier) Keys() []string {
 func injectPropagation(ctx context.Context, msg *Message) {
 	// only inject propagation if a valid span context was detected.
 	if trace.SpanFromContext(ctx).SpanContext().IsValid() {
-		if msg.Attributes == nil {
-			msg.Attributes = make(map[string]string)
+		// Create a defensive copy of the attributes map to prevent concurrent map writes
+		// when multiple goroutines publish messages with shared attributes.
+		// See https://github.com/googleapis/google-cloud-go/issues/11314
+		attrs := maps.Clone(msg.Attributes)
+		if attrs == nil {
+			attrs = make(map[string]string)
 		}
+		msg.Attributes = attrs
 		propagation.TraceContext{}.Inject(ctx, newMessageCarrier(msg))
 	}
 }

--- a/pubsub/trace_test.go
+++ b/pubsub/trace_test.go
@@ -728,3 +728,50 @@ func BenchmarkNoTracingEnabled(b *testing.B) {
 
 	}
 }
+
+// TestPublish_AttributesNotModified tests that publishing a message with tracing enabled
+// does not modify the original attributes map.
+// This is a regression test for issue #11314.
+//
+// The fix creates a defensive copy of the attributes map before injecting trace context,
+// ensuring the original message attributes are not modified.
+func TestPublish_AttributesNotModified(t *testing.T) {
+	ctx := context.Background()
+	tp := sdktrace.NewTracerProvider()
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+	defer tp.Shutdown(ctx)
+	otel.SetTracerProvider(tp)
+
+	client, srv := newFakeWithTracing(t)
+	defer client.Close()
+	defer srv.Close()
+
+	topicID := "attributes-test-topic"
+	topicName := fmt.Sprintf("projects/%s/topics/%s", testutil.ProjID(), topicID)
+	topic := mustCreateTopic(t, client, topicName)
+
+	// Create an attributes map for the message
+	attrs := map[string]string{
+		"key1": "value1",
+		"key2": "value2",
+		"key3": "value3",
+	}
+
+	msg := &Message{
+		Data:       []byte("test-message"),
+		Attributes: attrs,
+	}
+
+	result := topic.Publish(ctx, msg)
+	if _, err := result.Get(ctx); err != nil {
+		t.Fatalf("failed to publish message: %v", err)
+	}
+
+	// Verify that the original attributes map was not modified
+	if len(attrs) != 3 {
+		t.Errorf("attributes map was modified: expected 3 entries, got %d", len(attrs))
+	}
+	if attrs["key1"] != "value1" || attrs["key2"] != "value2" || attrs["key3"] != "value3" {
+		t.Errorf("attributes map values were modified: %v", attrs)
+	}
+}


### PR DESCRIPTION
This was originally fixed in the pubsub/v2 in #13530 but we are back-porting this to the v1

BEGIN_COMMIT_OVERRIDE
fix(pubsub): fix concurrent map write
END_COMMIT_OVERRIDE
