### PR TITLE
feat: add a basic go module validator tool

### DIFF
--- a/internal/actions/cmd/modvalidator/README.md
+++ b/internal/actions/cmd/modvalidator/README.md
@@ -1,0 +1,7 @@
+# modvalidator
+
+
+modvalidator is a tool that helps ensure we correctly preserve the correct minimum version of the go language as expressed
+through go.mod files.
+
+

--- a/internal/actions/cmd/modvalidator/main.go
+++ b/internal/actions/cmd/modvalidator/main.go
@@ -26,7 +26,7 @@ import (
 )
 
 var (
-	dir      = flag.String("dir", "", "the root directory to evaluate")
+	dir      = flag.String("dir", ".", "the root directory to evaluate")
 	enforced = flag.String("enforced_version", "", "go version string to be enforced")
 )
 

--- a/internal/actions/cmd/modvalidator/main.go
+++ b/internal/actions/cmd/modvalidator/main.go
@@ -1,0 +1,90 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io/fs"
+	"log"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/mod/modfile"
+)
+
+var (
+	dir      = flag.String("dir", "", "the root directory to evaluate")
+	enforced = flag.String("enforced_version", "", "go version string to be enforced")
+)
+
+func main() {
+	flag.Parse()
+	if *enforced == "" {
+		log.Fatalf("invalid -enforced_version specified.  failing.")
+	}
+	paths, err := collectModFiles(*dir)
+	if err != nil {
+		log.Fatalf("collectModFiles: %v", err)
+	}
+
+	var failCount, successCount int
+	for _, p := range paths {
+		if err := validateModFile(p, *enforced); err != nil {
+			log.Printf("validation failed for %q: %v", p, err)
+			failCount = failCount + 1
+		} else {
+			successCount = successCount + 1
+		}
+	}
+	log.Printf("%d mod files failed, %d succeeded validation", failCount, successCount)
+	if failCount > 0 {
+		os.Exit(1)
+	}
+}
+
+func validateModFile(path string, enforcedVersion string) error {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	mf, err := modfile.Parse(path, b, nil)
+	if err != nil {
+		return err
+	}
+	if mf.Go == nil {
+		return fmt.Errorf("modfile missing Go version")
+	}
+	if mf.Go.Version != enforcedVersion {
+		return fmt.Errorf("version mismatch, modfile set to %q", mf.Go.Version)
+	}
+	return nil
+}
+
+// traverse a directory and its subdirectories to collect the paths to all go.mod files.
+func collectModFiles(rootDir string) ([]string, error) {
+	var paths []string
+
+	err := filepath.WalkDir(rootDir, func(path string, d fs.DirEntry, err error) error {
+		if !d.IsDir() && filepath.Base(path) == "go.mod" {
+			paths = append(paths, path)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return paths, nil
+}

--- a/internal/actions/cmd/modvalidator/main.go
+++ b/internal/actions/cmd/modvalidator/main.go
@@ -78,6 +78,9 @@ func collectModFiles(rootDir string) ([]string, error) {
 	var paths []string
 
 	err := filepath.WalkDir(rootDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
 		if !d.IsDir() && filepath.Base(path) == "go.mod" {
 			paths = append(paths, path)
 		}

--- a/internal/actions/cmd/modvalidator/main_test.go
+++ b/internal/actions/cmd/modvalidator/main_test.go
@@ -1,0 +1,86 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestValidateModFile(t *testing.T) {
+	for _, tc := range []struct {
+		desc         string
+		fileContents []byte
+		probeVersion string
+		wantErr      bool
+	}{
+		{
+			desc:    "empty",
+			wantErr: true,
+		},
+		{
+			desc: "invalid",
+			fileContents: []byte(
+				`
+				random gobbledegook
+
+				`),
+			wantErr: true,
+		},
+		{
+			desc: "valid but mismatch",
+			fileContents: []byte(
+				`
+				module foo
+
+				go 1.23.4
+				`),
+			probeVersion: "1.25",
+			wantErr:      true,
+		},
+		{
+			desc: "validated",
+			fileContents: []byte(
+				`module foobarbaz
+
+				go 1.23.4
+				`),
+			probeVersion: "1.23.4",
+			wantErr:      false,
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			modPath := filepath.Join(tmpDir, "go.mod")
+			err := os.WriteFile(modPath, tc.fileContents, 0644)
+			if err != nil {
+				t.Fatalf("failed to write test data (%q): %v", modPath, err)
+			}
+			err = validateModFile(modPath, tc.probeVersion)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("wanted error, got success")
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("wanted success, got err: %v", err)
+				}
+			}
+		})
+
+	}
+
+}


### PR DESCRIPTION
This PR creates a very simple go module validation tool to help us maintain the property of all packages should support some minimum go version.

There's a couple of followup items of work here:
* wiring this up into a github action so we can see when the invariant is violated
* defining an exception mechanism if/when we decide one is warranted

I'm deferring these items while I clean up the rest of the violations.