### PR TITLE
fix(bigquery): improve random ID generation in bigquery

### DIFF
--- a/bigquery/integration_test.go
+++ b/bigquery/integration_test.go
@@ -250,7 +250,6 @@ func initTestState(client *Client, t time.Time) func() {
 	routineIDs = uid.NewSpace("routine", opts)
 	testTableExpiration = t.Add(2 * time.Hour).Round(time.Second)
 	// For replayability, seed the random source with t.
-	Seed(t.UnixNano())
 
 	prefixes := []string{
 		"dataset_",                    // bigquery package tests

--- a/bigquery/integration_test.go
+++ b/bigquery/integration_test.go
@@ -249,7 +249,6 @@ func initTestState(client *Client, t time.Time) func() {
 	modelIDs = uid.NewSpace("model", opts)
 	routineIDs = uid.NewSpace("routine", opts)
 	testTableExpiration = t.Add(2 * time.Hour).Round(time.Second)
-	// For replayability, seed the random source with t.
 
 	prefixes := []string{
 		"dataset_",                    // bigquery package tests

--- a/bigquery/random.go
+++ b/bigquery/random.go
@@ -31,3 +31,8 @@ func randomID() string {
 	}
 	return hex.EncodeToString(b[:]) // 32 alphanumeric hex characters (e.g. "4a7f9c2d1e8b3a0f...")
 }
+
+// Seed is a no-op.
+//
+// Deprecated: Seed is no longer supported as random IDs are now cryptographically secure.
+func Seed(s int64) {}

--- a/bigquery/random_test.go
+++ b/bigquery/random_test.go
@@ -14,20 +14,19 @@
 
 package bigquery
 
-import (
-	"crypto/rand"
-	"encoding/hex"
-)
+import "testing"
 
-// Support for random values (typically job IDs and insert IDs).
-
-// For testing.
-var randomIDFn = randomID
-
-func randomID() string {
-	var b [16]byte
-	if _, err := rand.Read(b[:]); err != nil {
-		panic("bigquery: failed to generate random ID: " + err.Error())
+func TestRandomID(t *testing.T) {
+	// A very simplistic collision test.
+	colMap := make(map[string]struct{})
+	for i := 0; i < 50000; i++ {
+		id := randomID()
+		if len(id) != 32 {
+			t.Fatalf("anomalous ID len (%d): %q", len(id), id)
+		}
+		if _, ok := colMap[id]; ok {
+			t.Fatalf("collision on id: %q", id)
+		}
+		colMap[id] = struct{}{}
 	}
-	return hex.EncodeToString(b[:]) // 32 alphanumeric hex characters (e.g. "4a7f9c2d1e8b3a0f...")
 }

--- a/bigquery/random_test.go
+++ b/bigquery/random_test.go
@@ -18,8 +18,9 @@ import "testing"
 
 func TestRandomID(t *testing.T) {
 	// A very simplistic collision test.
-	colMap := make(map[string]struct{})
-	for i := 0; i < 50000; i++ {
+	testSize := 50000
+	colMap := make(map[string]struct{}, testSize)
+	for i := 0; i < testSize; i++ {
 		id := randomID()
 		if len(id) != 32 {
 			t.Fatalf("anomalous ID len (%d): %q", len(id), id)

--- a/bigquery/random_test.go
+++ b/bigquery/random_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
This moves from math/rand to crypto/rand for the random value producer. It also removes some cruft.  Hat tip to jba@ for forwarding this one on.

Related: internal b/532634700