### PR TITLE
[5/5] feat(bigtable): add Session lifecycle, vRPC, and tests

### DIFF
--- a/bigtable/internal/metrics/tracer.go
+++ b/bigtable/internal/metrics/tracer.go
@@ -575,7 +575,7 @@ func (mt *Tracer) RecordAttemptCompletion(attemptHeaderMD, attempTrailerMD metad
 	// on). Feeds the attempt_latencies2 metric only; other metrics stay on
 	// the classic label set. No-op when the header is absent.
 	if peerInfo, _ := extractPeerInfo(attemptHeaderMD, attempTrailerMD); peerInfo != nil {
-		mt.currOp.currAttempt.transportType = transportTypeName(peerInfo.GetTransportType())
+		mt.currOp.currAttempt.transportType = TransportTypeName(peerInfo.GetTransportType())
 		mt.currOp.currAttempt.transportRegion = peerInfo.GetApplicationFrontendRegion()
 		mt.currOp.currAttempt.transportZone = peerInfo.GetApplicationFrontendZone()
 		mt.currOp.currAttempt.transportSubZone = peerInfo.GetApplicationFrontendSubzone()

--- a/bigtable/internal/metrics/util.go
+++ b/bigtable/internal/metrics/util.go
@@ -208,11 +208,13 @@ func extractPeerInfo(headerMD metadata.MD, trailerMD metadata.MD) (*btpb.PeerInf
 	return &peerInfo, nil
 }
 
-// transportTypeName maps the PeerInfo transport type enum to the short
+// TransportTypeName maps the PeerInfo transport type enum to the short
 // label used in metric attributes and debug UIs (e.g. "cloudpath",
 // "session_directpath"). Prefer this over .String(), which yields the
-// verbose "TRANSPORT_TYPE_…" proto enum names.
-func transportTypeName(tt btpb.PeerInfo_TransportType) string {
+// verbose "TRANSPORT_TYPE_…" proto enum names. Exported so the transport
+// package's session tracer + debug surfaces share the same mapping
+// without duplicating the switch.
+func TransportTypeName(tt btpb.PeerInfo_TransportType) string {
 	switch tt {
 	case btpb.PeerInfo_TRANSPORT_TYPE_EXTERNAL:
 		return "external"

--- a/bigtable/internal/transport/attempt_outcome.go
+++ b/bigtable/internal/transport/attempt_outcome.go
@@ -1,0 +1,113 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import "errors"
+
+// AttemptState classifies how far a single vRPC attempt progressed before
+// terminating. RetryingVRpc consumes this instead of raw gRPC codes so
+// retry decisions match Java's VRpc.VRpcResult.State semantics:
+//
+//   - Uncommitted: safe to retry unconditionally (server saw nothing).
+//   - TransportFailure: safe only for idempotent ops (server may have applied).
+//   - ServerResult: retry only if the server explicitly permits it via
+//     RetryInfo, or the code is in the narrowed always-retryable set.
+type AttemptState int
+
+const (
+	// StateServerResult is the zero value: any bare error from a code
+	// path that hasn't yet adopted tagErr (or an error introduced by a
+	// non-vRPC layer) classifies here. Under the strict Java-parity
+	// default (see shouldRetryDefault in retrying.go) StateServerResult
+	// does NOT retry unless the server explicitly attached RetryInfo or
+	// the caller set RetryingOptions.ShouldRetry to override the whole
+	// classifier. Callers that need a permissive fallback must opt in.
+	StateServerResult AttemptState = iota
+	// StateUncommitted means the attempt never reached the wire — encode
+	// failed, session was Closing, etc. Retry is safe regardless of
+	// idempotency.
+	StateUncommitted
+	// StateTransportFailure means the frame was handed to the transport but
+	// we never observed a server response — the server may or may not have
+	// processed it. Retry only for idempotent ops.
+	StateTransportFailure
+)
+
+func (s AttemptState) String() string {
+	switch s {
+	case StateUncommitted:
+		return "Uncommitted"
+	case StateTransportFailure:
+		return "TransportFailure"
+	case StateServerResult:
+		return "ServerResult"
+	}
+	return "Unknown"
+}
+
+// AttemptOutcome pairs the classification with the underlying error so
+// callers can inspect both. Err is always non-nil for a failed attempt.
+type AttemptOutcome struct {
+	State AttemptState
+	Err   error
+}
+
+// vrpcErr wraps a raw error with its outcome so RetryingVRpc can classify
+// by state. Unwrap() exposes the underlying err so status.FromError(err) and
+// errors.Is(err, ...) continue to work for callers that don't know about
+// the wrapper.
+type vrpcErr struct {
+	outcome AttemptOutcome
+}
+
+func (e *vrpcErr) Error() string { return e.outcome.Err.Error() }
+func (e *vrpcErr) Unwrap() error { return e.outcome.Err }
+
+// tagErr wraps err with the given AttemptState. Returns nil for nil err so
+// call sites can compose without extra guards.
+func tagErr(state AttemptState, err error) error {
+	if err == nil {
+		return nil
+	}
+	return &vrpcErr{outcome: AttemptOutcome{State: state, Err: err}}
+}
+
+// TagErr wraps err with the given AttemptState so callers outside this
+// package can produce errors that carry the same classifier hint the
+// real transport attaches. Intended for test doubles / fakes that stand
+// in for a Session or a SessionPool: production errors from Session.Invoke
+// are always tagged (see session_vrpc.go, session_pool.go), so a test's
+// fake Invoker must tag its errors the same way for the RetryingVRpc
+// interceptor's default classification to see them.
+//
+// Returns nil for nil err. Wraps unwrap()-transparently — errors.Is and
+// status.FromError continue to see the underlying err.
+func TagErr(state AttemptState, err error) error { return tagErr(state, err) }
+
+// ClassifyErr returns the outcome for any error. Untagged errors fall
+// through as StateServerResult — which, under the current default, is
+// NOT retryable without server-attached RetryInfo. Callers that produce
+// errors on paths where retry is expected must tag with the appropriate
+// state via tagErr (see session_vrpc.go for the reference call sites).
+func ClassifyErr(err error) AttemptOutcome {
+	if err == nil {
+		return AttemptOutcome{}
+	}
+	var v *vrpcErr
+	if errors.As(err, &v) {
+		return v.outcome
+	}
+	return AttemptOutcome{State: StateServerResult, Err: err}
+}

--- a/bigtable/internal/transport/attempt_outcome_test.go
+++ b/bigtable/internal/transport/attempt_outcome_test.go
@@ -1,0 +1,106 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestAttemptState_String(t *testing.T) {
+	tests := []struct {
+		s    AttemptState
+		want string
+	}{
+		{StateServerResult, "ServerResult"},
+		{StateUncommitted, "Uncommitted"},
+		{StateTransportFailure, "TransportFailure"},
+		{AttemptState(99), "Unknown"},
+	}
+	for _, tt := range tests {
+		if got := tt.s.String(); got != tt.want {
+			t.Errorf("AttemptState(%d).String() = %q, want %q", int(tt.s), got, tt.want)
+		}
+	}
+}
+
+// TestTagErr_NilPassesThrough guarantees callers can compose without extra
+// guards: tagErr(state, nil) must return nil regardless of state.
+func TestTagErr_NilPassesThrough(t *testing.T) {
+	if got := tagErr(StateUncommitted, nil); got != nil {
+		t.Errorf("tagErr(StateUncommitted, nil) = %v, want nil", got)
+	}
+	if got := TagErr(StateTransportFailure, nil); got != nil {
+		t.Errorf("TagErr(StateTransportFailure, nil) = %v, want nil", got)
+	}
+}
+
+// TestTagErr_WrapsAndUnwraps verifies the wrapper is transparent to
+// errors.Is and errors.Unwrap so upstream callers that don't know about
+// the AttemptOutcome tagging still see the original sentinel.
+func TestTagErr_WrapsAndUnwraps(t *testing.T) {
+	sentinel := errors.New("sentinel")
+	wrapped := tagErr(StateUncommitted, fmt.Errorf("wrap: %w", sentinel))
+
+	if !errors.Is(wrapped, sentinel) {
+		t.Error("errors.Is should see the underlying sentinel through the tagErr wrapper")
+	}
+	if wrapped.Error() == "" {
+		t.Error("wrapped error should have non-empty message")
+	}
+}
+
+// TestClassifyErr_Cases covers the three branches: nil, tagged, and
+// untagged. Untagged errors default to StateServerResult (retry only with
+// server-attached RetryInfo — Java-parity behavior).
+func TestClassifyErr_Cases(t *testing.T) {
+	// Nil error → zero outcome.
+	if got := ClassifyErr(nil); got.State != StateServerResult || got.Err != nil {
+		t.Errorf("ClassifyErr(nil) = %+v, want zero-value outcome", got)
+	}
+
+	// Tagged error → preserves state and err.
+	inner := errors.New("boom")
+	tagged := tagErr(StateTransportFailure, inner)
+	out := ClassifyErr(tagged)
+	if out.State != StateTransportFailure {
+		t.Errorf("ClassifyErr(tagged).State = %v, want StateTransportFailure", out.State)
+	}
+	if !errors.Is(out.Err, inner) {
+		t.Errorf("ClassifyErr(tagged).Err should preserve inner, got %v", out.Err)
+	}
+
+	// Untagged error → StateServerResult fallback with err preserved.
+	untagged := errors.New("plain")
+	out = ClassifyErr(untagged)
+	if out.State != StateServerResult {
+		t.Errorf("ClassifyErr(untagged).State = %v, want StateServerResult", out.State)
+	}
+	if out.Err != untagged {
+		t.Errorf("ClassifyErr(untagged).Err = %v, want %v", out.Err, untagged)
+	}
+}
+
+// TestClassifyErr_FindsThroughWrapper ensures errors.As-style traversal
+// works even when the tagErr wrapper is buried behind another fmt.Errorf.
+func TestClassifyErr_FindsThroughWrapper(t *testing.T) {
+	tagged := tagErr(StateUncommitted, errors.New("x"))
+	outer := fmt.Errorf("outer: %w", tagged)
+	out := ClassifyErr(outer)
+	if out.State != StateUncommitted {
+		t.Errorf("ClassifyErr(outer-wrapped).State = %v, want StateUncommitted", out.State)
+	}
+}

--- a/bigtable/internal/transport/picker.go
+++ b/bigtable/internal/transport/picker.go
@@ -1,0 +1,81 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"sync/atomic"
+	"time"
+)
+
+// SessionHandle wraps a Session with the counters the pool needs to
+// account for it. Picking has moved to the two-tier AFE-aware flow (see
+// afe_picker.go + session_list.go); this type no longer tracks
+// per-session PeakEwma or a pool wake-up signal — the pool drives the
+// wake-up centrally from Invoke's defer.
+type SessionHandle struct {
+	session      *Session
+	outstanding  int64
+	lastActivity int64 // UnixNano timestamp of the last completed call
+	picks        int64 // Number of times the picker has picked this handle.
+	// createdAt is the wall-clock time this handle joined the pool
+	// (from OnActive). Read by recordLifetime and Pool.Close to bucket
+	// per-session lifetimes into the ring buffer. Zero for
+	// test-constructed handles that never went through OnActive — code
+	// paths that consume this must handle the zero-time case.
+	createdAt time.Time
+	// inExpectedCount tracks whether this handle currently counts toward
+	// sessionList.readyCount (the scale-up budget). Set true in
+	// sl.OnSessionStarted, cleared by whichever of sl.OnSessionClosing /
+	// sl.OnSessionClosed fires first. Guarded by owning sessionList.mu;
+	// do not touch outside sl methods. Java-parity: SessionList.java's
+	// inExpectedCount field.
+	inExpectedCount bool
+}
+
+// Picks returns the number of times this handle has been picked by the pool's
+// picker. Bumped exactly once per successful CheckoutSession.
+func (h *SessionHandle) Picks() int64 {
+	return atomic.LoadInt64(&h.picks)
+}
+
+// NewSessionHandle creates a new SessionHandle wrapping a Session. The
+// createdAt stamp is used by the pool's lifetime histogram; pass
+// time.Now() from OnActive, or the zero time from tests that don't
+// care about lifetime accounting.
+func NewSessionHandle(session *Session, createdAt time.Time) *SessionHandle {
+	return &SessionHandle{session: session, createdAt: createdAt}
+}
+
+// IncOutstanding increments outstanding calls.
+func (h *SessionHandle) IncOutstanding() {
+	atomic.AddInt64(&h.outstanding, 1)
+}
+
+// DecOutstanding decrements outstanding calls and stamps lastActivity.
+// The pool wakes waiters and returns the session to its AFE queue from
+// Invoke's defer, so this method no longer signals directly.
+func (h *SessionHandle) DecOutstanding() {
+	atomic.AddInt64(&h.outstanding, -1)
+	atomic.StoreInt64(&h.lastActivity, time.Now().UnixNano())
+}
+
+// GetLastActivity returns the time of the last activity.
+func (h *SessionHandle) GetLastActivity() time.Time {
+	nano := atomic.LoadInt64(&h.lastActivity)
+	if nano == 0 {
+		return time.Time{}
+	}
+	return time.Unix(0, nano)
+}

--- a/bigtable/internal/transport/session.go
+++ b/bigtable/internal/transport/session.go
@@ -1,0 +1,375 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	spb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+// multiPlexingLimit caps the number of vRPCs in flight on a single session
+// stream. The current protocol does not support multiplexing, so the value
+// must stay at 1; raising it requires a negotiated server-side change.
+const multiPlexingLimit = 1
+
+// Default heartbeat tunables. The interval is replaced once the server sends a
+// SessionParametersResponse; the initial deadline is generous enough to span
+// the first handshake.
+const (
+	defaultHeartbeatInterval = 10 * time.Second
+	initialHeartbeatGrace    = 30 * time.Minute
+)
+
+// Sentinel session-level error codes. They are wrapped in a gRPC Unavailable
+// status (so existing retry plumbing sees codes.Unavailable) while errors.Is
+// lets callers distinguish the underlying cause.
+var (
+	// ErrSessionNotActive is returned by Invoke pre-Send when the session
+	// is not yet active or has begun shutting down. Errors carrying this
+	// cause are delivered tagged StateUncommitted (never left the client)
+	// so RetryingVRpc retries them regardless of Idempotent.
+	ErrSessionNotActive = errors.New("bigtable: session not active")
+	// ErrUnavailableHeartBeatMissed indicates the session was torn down because
+	// the server stopped sending heartbeats within the negotiated window.
+	// Delivered via cancelActiveRPCs and tagged StateTransportFailure.
+	ErrUnavailableHeartBeatMissed = errors.New("bigtable: session unavailable: server heartbeat missed")
+	// ErrUnavailableGoAway indicates the server sent GOAWAY. The session
+	// transitions to Closing (pool stops handing it out) but any in-flight
+	// vRPC keeps running — if the server sends the response before dropping
+	// the stream, the RPC completes cleanly (Java parity). Only if the
+	// stream actually terminates without a response does the RPC get failed
+	// via handleClose → cancelActiveRPCs (tagged StateTransportFailure).
+	ErrUnavailableGoAway = errors.New("bigtable: session unavailable: server sent GOAWAY")
+	// ErrUnavailableSessionError indicates the server reported a fatal
+	// session-level error (an ErrorResponse with rpc_id == 0). Delivered
+	// via cancelActiveRPCs and tagged StateTransportFailure.
+	ErrUnavailableSessionError = errors.New("bigtable: session unavailable: server reported session error")
+)
+
+// Stream is the bidirectional gRPC stream a Session multiplexes over.
+type Stream interface {
+	Send(*spb.SessionRequest) error
+	Recv() (*spb.SessionResponse, error)
+	Header() (metadata.MD, error)
+	// Context is the stream's context. After Header() returns, peer info
+	// (remote TCP addr) is available via peer.FromContext — sessionz uses
+	// it to link a slow vRPC row to the specific conn in tcpz.
+	Context() context.Context
+}
+
+// SessionHooks contains optional callbacks invoked at points in a session's
+// lifecycle. Any field may be nil; the session calls only the non-nil hooks.
+// Hooks must not block; dispatch long work to a goroutine. This follows the
+// net/http/httptrace.ClientTrace pattern.
+//
+// Lifecycle ordering guarantees:
+//
+//	OnStart   → fires once when Session.Start is invoked.
+//	OnActive  → fires once at Starting → Ready transition (after PeerInfo
+//	             is populated).
+//	OnClosing → fires once when the session is FIRST known to be dying —
+//	             on the first successful transition out of Ready (any
+//	             non-Ready terminal-bound state). Java parity:
+//	             SessionImpl.onSessionClosing. Consumers use it to
+//	             remove the session from pool routing structures BEFORE
+//	             the actual close (potentially up to
+//	             waitServerCloseGrace seconds) completes.
+//	OnClose   → fires once at the end of teardown, after the stream has
+//	             actually closed. Always fires AFTER OnClosing (the
+//	             session guarantees the ordering via closingOnce +
+//	             closeOnce).
+type SessionHooks struct {
+	OnStart   func(ctx context.Context)
+	OnActive  func(s *Session)
+	OnClosing func(s *Session)
+	OnClose   func(s *Session, err error)
+}
+
+func (h SessionHooks) onStart(ctx context.Context) {
+	if h.OnStart != nil {
+		h.OnStart(ctx)
+	}
+}
+
+func (h SessionHooks) onActive(s *Session) {
+	if h.OnActive != nil {
+		h.OnActive(s)
+	}
+}
+
+func (h SessionHooks) onClosing(s *Session) {
+	if h.OnClosing != nil {
+		h.OnClosing(s)
+	}
+}
+
+func (h SessionHooks) onClose(s *Session, err error) {
+	if h.OnClose != nil {
+		h.OnClose(s, err)
+	}
+}
+
+// vrpcResult is the single value delivered to Invoke through resultChan.
+// Exactly one of resp, errResp, err is set:
+//
+//	resp    — server success frame; ClusterInfo lives on it.
+//	errResp — server error frame; ClusterInfo lives on it, Status carries
+//	          the gRPC code and any RetryInfo.
+//	err     — transport-side failure (cancel, close, heartbeat miss);
+//	          already tagged StateTransportFailure at the source. No server
+//	          frame arrived, so no ClusterInfo.
+type vrpcResult struct {
+	resp    *spb.VirtualRpcResponse
+	errResp *spb.ErrorResponse
+	err     error
+}
+
+// ClusterInfo returns whichever server frame's ClusterInformation is set,
+// or nil if the result carries a transport-side error.
+func (r vrpcResult) ClusterInfo() *spb.ClusterInformation {
+	if r.resp != nil {
+		return r.resp.ClusterInfo
+	}
+	if r.errResp != nil {
+		return r.errResp.ClusterInfo
+	}
+	return nil
+}
+
+// vrpcImpl tracks the state of an in-flight virtual RPC. Populated once
+// by Session.Invoke at construction, never mutated after — activeRPC.CAS
+// is the publication point.
+type vrpcImpl struct {
+	id         int64
+	method     string
+	resultChan chan vrpcResult
+}
+
+// Session manages the lifecycle of a Bigtable Session and routes vRPCs
+// over its bidirectional Stream.
+//
+// All fields formerly guarded by an internal mu are now atomics — the hot
+// path (Invoke, State(), the picker) no longer takes a per-session mutex,
+// removing four lock/unlock pairs and the cross-goroutine cache-line
+// ping-pong the picker used to trigger by calling State() per session
+// under lock. sendMu still guards concurrent Send() writers since
+// grpc.ClientStream.Send is not safe for concurrent use.
+//
+// Observability state (counters, event ring, latency histogram, tracer,
+// logger, metric-attribution plumbing) lives in the embedded sessionDebug
+// — see session_debug.go. Embedded so bare field access (s.okRpcs,
+// s.recordEvent, s.tracer, …) still resolves.
+type Session struct {
+	// nextRPCID is mutated exclusively via atomic ops.
+	nextRPCID atomic.Int64
+
+	sendMu sync.Mutex
+
+	logName     string
+	stream      Stream
+	hooks       SessionHooks
+	sessionType SessionType
+
+	// state is the session's lifecycle position (State constants). Read
+	// with State(); mutate through transitionTo.
+	state atomic.Int32
+
+	// closingOnce serializes hooks.OnClosing so it fires exactly once
+	// across the four transition sites that can drive a session out of
+	// Ready (Close, ForceClose, handleGoAway, handleClose). Java parity
+	// with onSessionClosing.
+	closingOnce sync.Once
+	// closeOnce serializes hooks.OnClose and tracer.recordClose so they
+	// fire exactly once even if multiple paths race to close the session.
+	closeOnce sync.Once
+
+	// activeRPC holds the single in-flight vRPC (multiPlexingLimit=1).
+	// Invoke sets it via CompareAndSwap(nil, rpc) — the CAS is the
+	// pool-serialization invariant made explicit: if it fails, someone
+	// bypassed the pool's per-session checkout gate.
+	activeRPC atomic.Pointer[vrpcImpl]
+
+	// poolHandle is the back-ref to this session's SessionHandle, stored
+	// once by SessionPoolImpl.OnActive right after the handle is minted.
+	// OnClose reads it to hand the handle to sl.OnSessionClosed without a
+	// per-pool bookkeeping map. Nil for sessions never promoted from
+	// starting → active or for tests that bypass the pool.
+	poolHandle atomic.Pointer[SessionHandle]
+
+	// heartbeatIntervalNano is the server-negotiated keep-alive interval
+	// (ns). handleSessionParameters mutates it from readLoop while the
+	// hot path reads it via resetHeartbeatDeadline.
+	heartbeatIntervalNano atomic.Int64
+	// nextHeartbeatDeadlineNano is the wall-clock deadline (UnixNano)
+	// the heartbeat watchdog compares against. Every outbound frame + every
+	// inbound frame extends it via resetHeartbeatDeadline.
+	nextHeartbeatDeadlineNano atomic.Int64
+
+	// quiescent is closed when the in-flight vRPC (if any) has drained
+	// after the session entered StateClosing, or when ForceClose runs.
+	quiescent     chan struct{}
+	quiescentOnce sync.Once
+
+	// peerInfo is populated by peerInfoExtracter from the stream header,
+	// synchronously in handleOpenSession before hooks.onActive fires.
+	// atomic.Pointer so the picker / AfeID / snapshot can read it lock-free.
+	peerInfo atomic.Pointer[spb.PeerInfo]
+
+	// refreshConfig is stored once when the server sends
+	// SessionRefreshConfig. atomic.Pointer keeps the getter allocation-
+	// and lock-free.
+	refreshConfig atomic.Pointer[spb.SessionRefreshConfig]
+
+	// sessionDebug carries the observability state. See session_debug.go.
+	sessionDebug
+}
+
+// SessionOption configures a Session at construction time.
+type SessionOption func(*Session)
+
+// NewSession constructs a Session bound to the given stream. Pass a zero-value
+// SessionHooks if you don't need lifecycle callbacks.
+func NewSession(logName string, stream Stream, hooks SessionHooks, sessionType SessionType, opts ...SessionOption) *Session {
+	s := &Session{
+		logName:     logName,
+		stream:      stream,
+		hooks:       hooks,
+		quiescent:   make(chan struct{}),
+		sessionType: sessionType,
+	}
+	s.sessionDebug.init(sessionType)
+	s.state.Store(int32(StateNew))
+	s.heartbeatIntervalNano.Store(int64(defaultHeartbeatInterval))
+	s.nextHeartbeatDeadlineNano.Store(time.Now().Add(initialHeartbeatGrace).UnixNano())
+	for _, o := range opts {
+		o(s)
+	}
+	return s
+}
+
+// LogName returns the session's diagnostic identifier. Set once at
+// construction; safe to read lock-free.
+func (s *Session) LogName() string {
+	return s.logName
+}
+
+// State returns the current state.
+func (s *Session) State() State {
+	return State(s.state.Load())
+}
+
+// PeerInfo returns the peer info, or nil if it has not been parsed yet.
+func (s *Session) PeerInfo() *spb.PeerInfo {
+	return s.peerInfo.Load()
+}
+
+// afeID identifies the AFE (Application Front End) a session is pinned to,
+// derived from PeerInfo.ApplicationFrontendId. The zero value is the
+// sentinel for "unknown" — used before PeerInfo is populated or when the
+// server did not send the bigtable-peer-info header. Java-parity: mirrors
+// the AutoValue AfeId in SessionList.java, which wraps the same signed
+// 64-bit long.
+type afeID int64
+
+// AfeID returns the AFE identifier for this session, or 0 if PeerInfo is
+// nil (header absent or session pre-Active). Stable for the session's
+// lifetime — PeerInfo is populated once, synchronously with the transition
+// to StateReady (see handleOpenSession).
+func (s *Session) AfeID() afeID {
+	if p := s.peerInfo.Load(); p != nil {
+		return afeID(p.GetApplicationFrontendId())
+	}
+	return 0
+}
+
+// RefreshConfig returns the server-provided refresh configuration, or nil
+// if the server has not sent one.
+func (s *Session) RefreshConfig() *spb.SessionRefreshConfig {
+	return s.refreshConfig.Load()
+}
+
+// transitionTo sets the session state to `to` iff ok(currentState) returns
+// true. Returns the previous state and whether the transition was applied.
+// Retries on CAS failure so a losing racer with a still-valid current state
+// still transitions; the predicate is re-evaluated after each spurious loss.
+func (s *Session) transitionTo(to State, ok func(State) bool) (prev State, applied bool) {
+	for {
+		prev = State(s.state.Load())
+		if !ok(prev) {
+			return prev, false
+		}
+		if s.state.CompareAndSwap(int32(prev), int32(to)) {
+			s.lastStateChangeNano.Store(time.Now().UnixNano())
+			return prev, true
+		}
+	}
+}
+
+// isState returns a predicate matching any of `allowed`.
+func isState(allowed ...State) func(State) bool {
+	return func(s State) bool {
+		for _, a := range allowed {
+			if s == a {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+// notState returns a predicate matching any state NOT in `forbidden`.
+func notState(forbidden ...State) func(State) bool {
+	return func(s State) bool {
+		for _, f := range forbidden {
+			if s == f {
+				return false
+			}
+		}
+		return true
+	}
+}
+
+// signalQuiescent closes the quiescent channel exactly once.
+func (s *Session) signalQuiescent() {
+	s.quiescentOnce.Do(func() { close(s.quiescent) })
+}
+
+// sessionErr couples a gRPC Unavailable status with a sentinel cause so that
+// both status.Code(err) and errors.Is(err, sentinel) work.
+type sessionErr struct {
+	st    *status.Status
+	cause error
+}
+
+func (e *sessionErr) Error() string              { return e.st.Err().Error() }
+func (e *sessionErr) Unwrap() error              { return e.cause }
+func (e *sessionErr) GRPCStatus() *status.Status { return e.st }
+
+// unavailable builds a sessionErr from a sentinel cause and human-readable
+// detail. The returned error carries codes.Unavailable.
+func unavailable(cause error, format string, args ...interface{}) error {
+	return &sessionErr{
+		st:    status.Newf(codes.Unavailable, format, args...),
+		cause: cause,
+	}
+}

--- a/bigtable/internal/transport/session_debug.go
+++ b/bigtable/internal/transport/session_debug.go
@@ -1,0 +1,360 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	metrics "cloud.google.com/go/bigtable/internal/metrics"
+	btopt "cloud.google.com/go/bigtable/internal/option"
+)
+
+// sessionDebug groups the Session's observability state — counters,
+// per-session event ring, latency histogram, tracer/logger handles, and
+// the metric-attribution plumbing (close reason, pool-close gate,
+// channel index). Embedded into Session so existing call sites keep
+// using bare field access (s.okRpcs, s.recordEvent, s.tracer, ...).
+// The split exists so session.go stays focused on the protocol state
+// machine and vRPC dispatch; new observability hooks land here.
+type sessionDebug struct {
+	logger *log.Logger
+	tracer *sessionTracer
+
+	// lastStateChangeNano stamps each successful transitionTo with
+	// time.Now().UnixNano(). Approximate ordering across transitions is
+	// enough for the debug UI.
+	lastStateChangeNano atomic.Int64
+
+	// remoteAddr is the TCP remote (AFE) socket address in "ip:port" form,
+	// captured from grpc peer.FromContext once the stream Header returns.
+	// atomic.Pointer so the vRPC hot path can read it lock-free to stamp
+	// slow-vRPC rows for the sessionz→tcpz cross-link.
+	remoteAddr atomic.Pointer[string]
+
+	// okRpcs / errorRpcs are bumped lock-free from the vRPC dispatch paths
+	// so the debug UI can read a numeric total without locking.
+	okRpcs    atomic.Int64
+	errorRpcs atomic.Int64
+
+	// msgsSent / msgsRecv count every Send / Recv frame on the bidi stream
+	// — every session-level frame type (OpenSession, vRPC, CloseSession,
+	// Heartbeat), not just successful vRPCs.
+	msgsSent atomic.Int64
+	msgsRecv atomic.Int64
+
+	// Per-frame-type breakdown of msgsSent / msgsRecv. Indexed by
+	// reqMsgType / respMsgType (see session_msgtype.go).
+	msgsSentByType [numReqMsgTypes]atomic.Int64
+	msgsRecvByType [numRespMsgTypes]atomic.Int64
+
+	// retries counts vRPCs that arrived with VRpcAttempt>1 — i.e. the
+	// retry interceptor re-issued them on this session.
+	retries atomic.Int64
+
+	// closeReason is set exactly once via setCloseReason() at session
+	// teardown so SessionPoolImpl.OnClose can attribute the close to a
+	// category (Heartbeat / GoAway / Error / User).
+	closeReason atomic.Pointer[string]
+
+	// poolCloseRecorded is the once-flag SessionPoolImpl consults so its
+	// sessionsClosed / CloseReasons counters bump exactly once per session
+	// regardless of which removal path arrives first (proactive prune,
+	// CheckoutSession dead-detect, or hooks.OnClose).
+	poolCloseRecorded atomic.Bool
+
+	// latencyMu guards latencySamples — a tiny ring buffer of the last
+	// latencyWindow server-reported BackendLatency values, used to compute
+	// p50/p95/p99 in the debug UI.
+	latencyMu      sync.Mutex
+	latencySamples []time.Duration
+	latencyNext    int
+
+	// clusterCounts tallies per-ClusterInformation.ClusterId responses.
+	// Values are *atomic.Int64.
+	clusterCounts sync.Map
+
+	// channelIndex is set once at construction to the BigtableChannelPool
+	// connEntry index the session's bidi stream was placed on. -1 when
+	// the underlying pool isn't a BigtableChannelPool (e.g. test setups
+	// using option.WithGRPCConn) or when the pick wasn't observed.
+	channelIndex atomic.Int32
+
+	// eventsMu guards the per-session debug-event ring surfaced in
+	// sessionz. maxSessionEvents caps the size.
+	eventsMu sync.Mutex
+	events   []SessionEvent
+}
+
+// init sets the non-zero defaults for a freshly-embedded sessionDebug.
+// Called once from NewSession.
+func (d *sessionDebug) init(sessionType SessionType) {
+	d.tracer = newSessionTracer(sessionType)
+	d.lastStateChangeNano.Store(time.Now().UnixNano())
+	d.channelIndex.Store(-1)
+}
+
+// SessionEvent is one entry in a session's per-session debug ring buffer.
+// Surfaced through SessionSnapshot.RecentEvents and merged across all
+// sessions into PoolSnapshot.RecentEvents for the sessionz UI.
+//
+// Kinds in use:
+//
+//	"close"     — stream tear-down handled by handleClose; Message carries
+//	              reason, age, in-flight count, last rpc id, raw err.
+//	"hb-missed" — heartbeat watchdog fired ForceClose; Message carries
+//	              in-flight count and last-frame age.
+//	"hb-alive"  — heartbeat tick observed in-flight RPC(s) while a recent
+//	              frame had already pushed the deadline; useful for spotting
+//	              "server kept stream alive but lost specific vRPC response"
+//	              stalls. Suppressed (not recorded) unless lastFrameAge is
+//	              at least one heartbeat interval to avoid log noise.
+//	"ctx-done"  — Session.Invoke's per-attempt wait was killed by the
+//	              caller's context (deadline or cancel); Message carries
+//	              method, rpc id, time waited, ctx err, session state.
+//	"dup-deliver" — deliver's default branch fired: something tried to
+//	              publish a second value on rpc.resultChan while it
+//	              was still full. Either a server double-frame
+//	              (protocol violation — also tagged
+//	              tagSessionVRPCDuplicateResult from the receive-loop
+//	              caller) or a cancel racing a completion (benign;
+//	              cancel-side loser). Message carries rpc id and method.
+type SessionEvent struct {
+	At      time.Time
+	Kind    string
+	Message string
+}
+
+const maxSessionEvents = 64
+
+// recordEvent appends a SessionEvent to the per-session ring buffer.
+// Safe to call from any goroutine (readLoop, heartBeatLoop, etc.).
+func (s *Session) recordEvent(kind, format string, args ...interface{}) {
+	ev := SessionEvent{
+		At:      time.Now(),
+		Kind:    kind,
+		Message: fmt.Sprintf(format, args...),
+	}
+	s.eventsMu.Lock()
+	if len(s.events) >= maxSessionEvents {
+		copy(s.events, s.events[1:])
+		s.events = s.events[:len(s.events)-1]
+	}
+	s.events = append(s.events, ev)
+	s.eventsMu.Unlock()
+}
+
+// snapshotEvents returns a copy of the session's debug-event ring buffer
+// (oldest first).
+func (s *Session) snapshotEvents() []SessionEvent {
+	s.eventsMu.Lock()
+	out := make([]SessionEvent, len(s.events))
+	copy(out, s.events)
+	s.eventsMu.Unlock()
+	return out
+}
+
+// peerInfoSummary renders the session's PeerInfo as a compact single line
+// suitable for inclusion in log messages and debug events. Returns
+// "peer=unknown" when the bidi stream header hasn't been parsed yet.
+func (s *Session) peerInfoSummary() string {
+	p := s.peerInfo.Load()
+	if p == nil {
+		return "peer=unknown"
+	}
+	return fmt.Sprintf("peer={afe=%x/%s/%s gfe=%x transport=%s}",
+		p.GetApplicationFrontendId(),
+		p.GetApplicationFrontendRegion(),
+		p.GetApplicationFrontendSubzone(),
+		p.GetGoogleFrontendId(),
+		metrics.TransportTypeName(p.GetTransportType()))
+}
+
+const latencyWindow = 256
+
+// recordLatency appends a server-reported BackendLatency sample to the
+// ring buffer. Called from Invoke whenever the response includes Stats.
+func (s *Session) recordLatency(d time.Duration) {
+	if d <= 0 {
+		return
+	}
+	s.latencyMu.Lock()
+	if len(s.latencySamples) < latencyWindow {
+		s.latencySamples = append(s.latencySamples, d)
+	} else {
+		s.latencySamples[s.latencyNext] = d
+		s.latencyNext = (s.latencyNext + 1) % latencyWindow
+	}
+	s.latencyMu.Unlock()
+}
+
+// snapshotLatencies returns a sorted copy of the current samples so
+// callers can compute percentiles without holding the lock.
+func (s *Session) snapshotLatencies() []time.Duration {
+	s.latencyMu.Lock()
+	out := make([]time.Duration, len(s.latencySamples))
+	copy(out, s.latencySamples)
+	s.latencyMu.Unlock()
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out
+}
+
+// percentile returns the p-th percentile (0-100) of the sorted slice.
+// Uses nearest-rank — small N, linear interpolation isn't worth the
+// complexity.
+func percentile(sorted []time.Duration, p float64) time.Duration {
+	if len(sorted) == 0 {
+		return 0
+	}
+	if p <= 0 {
+		return sorted[0]
+	}
+	if p >= 100 {
+		return sorted[len(sorted)-1]
+	}
+	idx := int(float64(len(sorted)-1) * p / 100)
+	return sorted[idx]
+}
+
+// recordCluster increments the per-cluster response counter.
+func (s *Session) recordCluster(id string) {
+	if id == "" {
+		return
+	}
+	c, _ := s.clusterCounts.LoadOrStore(id, new(atomic.Int64))
+	c.(*atomic.Int64).Add(1)
+}
+
+// snapshotClusters returns the per-cluster response counts as a flat map.
+func (s *Session) snapshotClusters() map[string]int64 {
+	out := map[string]int64{}
+	s.clusterCounts.Range(func(k, v interface{}) bool {
+		out[k.(string)] = v.(*atomic.Int64).Load()
+		return true
+	})
+	return out
+}
+
+// SetChannelIndex records the BigtableChannelPool connEntry index the
+// session's stream landed on. Called once at session construction.
+func (s *Session) SetChannelIndex(idx int) {
+	s.channelIndex.Store(int32(idx))
+}
+
+// ChannelIndex returns the per-pool channel index, or -1 if unset.
+func (s *Session) ChannelIndex() int {
+	return int(s.channelIndex.Load())
+}
+
+// setCloseReason records the reason for the session's terminal close.
+// Only the first call sticks; subsequent calls (racing teardown paths)
+// are ignored so the OnClose callback sees a stable value.
+func (s *Session) setCloseReason(reason string) {
+	if reason == "" {
+		// Every teardown path is supposed to name a reason so the
+		// close-reasons dashboard bucket makes sense; an empty call
+		// means someone forgot to plumb a label.
+		recordDebugTag(tagSessionCloseNoReason)
+		return
+	}
+	s.closeReason.CompareAndSwap(nil, &reason)
+}
+
+// CloseReason returns the recorded close reason, or "" if none was set.
+func (s *Session) CloseReason() string {
+	if p := s.closeReason.Load(); p != nil {
+		return *p
+	}
+	return ""
+}
+
+// SampleUptime records the session's current alive time into the
+// session.uptime histogram. No-op if the session hasn't finished opening.
+func (s *Session) SampleUptime(ctx context.Context) {
+	s.tracer.sampleUptime(ctx)
+}
+
+// RecordTransportOverhead emits a per-vRPC transport-overhead sample —
+// (stream − backend) — to the transport_latencies histogram.
+func (s *Session) RecordTransportOverhead(ctx context.Context, method string, overhead time.Duration) {
+	s.tracer.recordTransportOverhead(ctx, method, overhead)
+}
+
+// Retries returns the number of vRPCs Invoke processed with AttemptNumber > 1.
+func (s *Session) Retries() int64 { return s.retries.Load() }
+
+// OpenedAt returns when the session reached StateReady (zero until then).
+func (s *Session) OpenedAt() time.Time {
+	return s.tracer.openedAtSnapshot()
+}
+
+// HasOkRpcs reports whether the session served at least one successful vRPC.
+func (s *Session) HasOkRpcs() bool { return s.okRpcs.Load() > 0 }
+
+// HasErrorRpcs reports whether the session served at least one failed vRPC.
+func (s *Session) HasErrorRpcs() bool { return s.errorRpcs.Load() > 0 }
+
+// OkRpcs returns the total number of successful vRPC responses delivered
+// on this session.
+func (s *Session) OkRpcs() int64 { return s.okRpcs.Load() }
+
+// ErrorRpcs returns the total number of failed vRPC responses delivered
+// on this session.
+func (s *Session) ErrorRpcs() int64 { return s.errorRpcs.Load() }
+
+// MsgsSent returns the total number of frames sent on this session's
+// bidi stream (every Send, regardless of payload type).
+func (s *Session) MsgsSent() int64 { return s.msgsSent.Load() }
+
+// MsgsRecv returns the total number of frames received on this session's
+// bidi stream (every successful Recv).
+func (s *Session) MsgsRecv() int64 { return s.msgsRecv.Load() }
+
+// RemoteAddr returns the TCP remote (AFE) socket address in "ip:port" form,
+// or "" if the stream Header hasn't been observed yet or gRPC didn't
+// populate peer info.
+func (s *Session) RemoteAddr() string {
+	if p := s.remoteAddr.Load(); p != nil {
+		return *p
+	}
+	return ""
+}
+
+// debugf logs at debug level if a logger has been attached.
+func (s *Session) debugf(format string, args ...interface{}) {
+	if s.logger == nil {
+		return
+	}
+	btopt.Debugf(s.logger, "bigtable_session %s: "+format, append([]interface{}{s.logName}, args...)...)
+}
+
+// WithSessionLogger attaches a logger for diagnostic output. Without it,
+// the session's debugf calls no-op.
+func WithSessionLogger(logger *log.Logger) SessionOption {
+	return func(s *Session) { s.logger = logger }
+}
+
+// WithSessionPoolName stamps the pool-scoped name used for the
+// session_name label on session lifecycle metrics. Matches java-bigtable's
+// per-pool SessionPoolInfo name — cardinality stays bounded by the number
+// of pools per process, not per session.
+func WithSessionPoolName(name string) SessionOption {
+	return func(s *Session) { s.tracer.setPoolName(name) }
+}

--- a/bigtable/internal/transport/session_lifecycle.go
+++ b/bigtable/internal/transport/session_lifecycle.go
@@ -1,0 +1,641 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	spb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
+	metrics "cloud.google.com/go/bigtable/internal/metrics"
+	"google.golang.org/grpc/peer"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+)
+
+const peerInfoHeaderKey = "bigtable-peer-info"
+
+// Start opens the session by sending OpenSessionRequest, then launches the
+// read and heartbeat loops. ctx governs the loops; cancelling it forces the
+// session closed. Unblocking the underlying Recv requires the caller to also
+// cancel the stream's context.
+func (s *Session) Start(ctx context.Context, req *spb.OpenSessionRequest) error {
+	if prev, ok := s.transitionTo(StateStarting, isState(StateNew)); !ok {
+		return fmt.Errorf("session already started or closed (state: %v)", prev)
+	}
+
+	// Fire onStart immediately after entering StateStarting so the
+	// lifecycle invariant "onStart precedes onClose" holds even when
+	// the initial Send fails and we ForceClose (which fires onClose)
+	// before the readLoop / heartBeatLoop are spawned.
+	s.hooks.onStart(ctx)
+
+	openReq := &spb.SessionRequest{
+		Payload: &spb.SessionRequest_OpenSession{OpenSession: req},
+	}
+	if err := s.Send(openReq); err != nil {
+		s.ForceClose(&spb.CloseSessionRequest{
+			Reason:      spb.CloseSessionRequest_CLOSE_SESSION_REASON_ERROR,
+			Description: "failed to send open session request",
+		})
+		return fmt.Errorf("send open session request: %w", err)
+	}
+
+	go s.readLoop(ctx)
+	go s.heartBeatLoop(ctx)
+	return nil
+}
+
+// ForceClose immediately transitions the session to StateClosed and cancels
+// every in-flight RPC. It is safe to call multiple times; only the first call
+// fires the tracer.recordClose and hooks.onClose callbacks.
+func (s *Session) ForceClose(req *spb.CloseSessionRequest) {
+	prev, ok := s.transitionTo(StateClosed, notState(StateClosed))
+	if !ok {
+		return
+	}
+	if prev == StateNew {
+		// Force-closing a NEW session means the pool decided to tear us
+		// down before Start ran — a bookkeeping oddity worth flagging.
+		recordDebugTag(tagSessionForceCloseNeverStarted)
+	}
+
+	// ForceClose skips the Ready → Closing transition (goes straight to
+	// Closed), so this is our one chance to fire onClosing before onClose.
+	s.notifyClosing()
+
+	s.setCloseReason(closeReasonLabel(req))
+	desc := "session force closed"
+	if req != nil && req.Description != "" {
+		desc = "session force closed: " + req.Description
+	}
+	s.cancelActiveRPCs(unavailable(closeReasonToCause(req), "%s", desc))
+	s.signalQuiescent()
+	s.notifyClosed(nil)
+}
+
+// notifyClosing fires hooks.onClosing exactly once over the lifetime of a
+// Session. Called from every path that first transitions the session out of
+// Ready — handleGoAway, Close, ForceClose, handleClose. notifyClosed also
+// invokes it as a safety net so onClosing is guaranteed to precede
+// onClose even if some future path forgets to call it explicitly.
+func (s *Session) notifyClosing() {
+	s.closingOnce.Do(func() {
+		s.hooks.onClosing(s)
+	})
+}
+
+// notifyClosed fires tracer.recordClose and hooks.onClose exactly once over
+// the lifetime of a Session. Ensures hooks.onClosing fires first (via the
+// closingOnce safety net) so the ordering contract onClosing → onClose
+// always holds.
+func (s *Session) notifyClosed(streamErr error) {
+	s.closeOnce.Do(func() {
+		s.notifyClosing()
+		s.tracer.recordClose(
+			context.Background(),
+			s.CloseReason(),
+			streamErr,
+			s.HasOkRpcs(),
+			s.HasErrorRpcs(),
+		)
+		s.hooks.onClose(s, streamErr)
+	})
+}
+
+// Close requests a graceful shutdown:
+//  1. Transitions to StateClosing (no-op if already Closing — callers like
+//     handleGoAway invoke this after the state was advanced upstream).
+//  2. Waits for in-flight RPCs to drain (or for ctx to fire).
+//  3. Sends CloseSessionRequest to the server.
+//  4. Transitions to StateWaitServerClose.
+//  5. The server's EOF eventually drives handleClose → StateClosed.
+//
+// A pool-side monitor (see SessionPoolImpl.startStuckSessionMonitor)
+// force-closes sessions stuck in StateWaitServerClose past a grace period
+// so an unresponsive server can't leak Closing sessions indefinitely.
+func (s *Session) Close(ctx context.Context, req *spb.CloseSessionRequest) error {
+	// Allow being called from Closing too — handleGoAway already
+	// transitioned and now wants the drain + send + WaitServerClose dance.
+	if _, ok := s.transitionTo(StateClosing, isState(StateNew, StateStarting, StateReady)); ok {
+		// We drove the state change; fire onClosing on our goroutine.
+		// If handleGoAway got here first, it already fired — closingOnce
+		// makes this a no-op.
+		s.notifyClosing()
+	}
+	st := s.State()
+	if st != StateClosing {
+		// Already past Closing (WaitServerClose / Closed); nothing to do.
+		return nil
+	}
+	// Record the intended reason now — the eventual handleClose (driven by
+	// the server's EOF) would otherwise stamp "StreamEnd" over it and the
+	// downstream OnClose hook would see the wrong label. setCloseReason is
+	// CompareAndSwap-once so callers like handleGoAway that stamped earlier
+	// win over this one.
+	s.setCloseReason(closeReasonLabel(req))
+
+	// Wait for the in-flight RPC (if any) to drain. The quiescent channel
+	// is closed by the RPC's cleanup defer when it sees state==Closing on
+	// its way out, or by ForceClose if it races us. Order matters: we
+	// transitioned to Closing above BEFORE observing activeRPC — so the
+	// defer's "check state after clearing" side always signals if we miss
+	// the empty snapshot here.
+	empty := s.activeRPC.Load() == nil
+	if empty {
+		s.signalQuiescent()
+	} else {
+		select {
+		case <-s.quiescent:
+		case <-ctx.Done():
+			s.ForceClose(nil)
+			return ctx.Err()
+		}
+	}
+
+	// If ForceClose raced us during the drain, our work is done.
+	if s.State() == StateClosed {
+		return nil
+	}
+
+	closeReq := &spb.SessionRequest{
+		Payload: &spb.SessionRequest_CloseSession{CloseSession: req},
+	}
+	if err := s.Send(closeReq); err != nil {
+		s.ForceClose(nil)
+		return fmt.Errorf("send close session request: %w", err)
+	}
+	// Advance to WaitServerClose so the pool monitor can see we're waiting
+	// on the server. handleClose accepts StateWaitServerClose → Closed.
+	s.transitionTo(StateWaitServerClose, isState(StateClosing))
+	return nil
+}
+
+// Send writes a SessionRequest under sendMu so concurrent producers don't
+// corrupt the underlying stream.
+func (s *Session) Send(req *spb.SessionRequest) error {
+	s.sendMu.Lock()
+	err := s.stream.Send(req)
+	s.sendMu.Unlock()
+	if err == nil {
+		s.msgsSent.Add(1)
+		s.msgsSentByType[classifyReq(req)].Add(1)
+	}
+	return err
+}
+
+// readLoop drives the inbound side of the stream until Recv returns an error.
+func (s *Session) readLoop(ctx context.Context) {
+	// Supervisor: if ctx is cancelled, mark the session closed so callers
+	// observe state immediately. Unblocking Recv() requires the underlying
+	// stream's context to be cancelled by the caller.
+	readLoopDone := make(chan struct{})
+	go func() {
+		select {
+		case <-ctx.Done():
+			s.ForceClose(&spb.CloseSessionRequest{
+				Reason:      spb.CloseSessionRequest_CLOSE_SESSION_REASON_USER,
+				Description: "client context cancelled",
+			})
+		case <-readLoopDone:
+		}
+	}()
+	defer close(readLoopDone)
+
+	for {
+		resp, err := s.stream.Recv()
+		if err != nil {
+			s.handleClose(err)
+			return
+		}
+		s.msgsRecv.Add(1)
+		s.msgsRecvByType[classifyResp(resp)].Add(1)
+		s.handleSessionResponse(resp)
+	}
+}
+
+// handleSessionResponse dispatches every SessionResponse oneof variant.
+// Receiving any recognized frame resets the heartbeat watchdog; unknown
+// frames do NOT, so a misbehaving server cannot keep the watchdog satisfied
+// with junk payloads.
+func (s *Session) handleSessionResponse(resp *spb.SessionResponse) {
+	switch p := resp.GetPayload().(type) {
+	case *spb.SessionResponse_OpenSession:
+		s.handleOpenSession(p.OpenSession)
+	case *spb.SessionResponse_VirtualRpc:
+		s.handleVRPCResponse(p.VirtualRpc)
+	case *spb.SessionResponse_Error:
+		s.handleErrorResponse(p.Error)
+	case *spb.SessionResponse_SessionParameters:
+		s.handleSessionParameters(p.SessionParameters)
+	case *spb.SessionResponse_Heartbeat:
+		// Server emits Heartbeats during long-running VRPCs; the deadline
+		// reset below is what keeps the watchdog from firing on them.
+	case *spb.SessionResponse_GoAway:
+		s.handleGoAway(p.GoAway)
+	case *spb.SessionResponse_SessionRefreshConfig:
+		s.handleSessionRefreshConfig(p.SessionRefreshConfig)
+	default:
+		recordDebugTag(tagSessionUnknownResponse)
+		s.debugf("received SessionResponse with unknown payload type %T", p)
+		return
+	}
+	s.resetHeartbeatDeadline()
+}
+
+// handleOpenSession transitions Starting -> Ready and fires hooks.onActive.
+// Peer info (from the bigtable-peer-info header) and the TCP remote addr are
+// captured synchronously here — gRPC guarantees the header frame precedes
+// any bidi message, so by the time we've received the OpenSession response
+// the header is already buffered and stream.Header() returns without
+// blocking. Ordering: extract first, then fire onActive, so every observer
+// sees a session whose PeerInfo (and therefore AfeID) is populated. This
+// matches Java's onHeaders synchrony.
+func (s *Session) handleOpenSession(_ *spb.OpenSessionResponse) {
+	if prev, ok := s.transitionTo(StateReady, isState(StateStarting)); !ok {
+		// Server confirmed OpenSession while we were in a state that
+		// couldn't accept it (already Ready, Closing, or Closed).
+		// Either the server sent a duplicate confirmation or we raced
+		// with a local teardown — both are bookkeeping oddities.
+		recordDebugTag(tagSessionOpenWrongState)
+		s.debugf("handleOpenSession in wrong state %s (want Starting)", prev)
+		return
+	}
+	if md, err := s.stream.Header(); err == nil {
+		s.peerInfoExtracter(md.Get(peerInfoHeaderKey))
+	} else {
+		s.debugf("stream Header() failed: %v", err)
+	}
+	if p, ok := peer.FromContext(s.stream.Context()); ok && p.Addr != nil {
+		addr := p.Addr.String()
+		s.remoteAddr.Store(&addr)
+	}
+	s.tracer.recordOpen(context.Background(), nil)
+	s.hooks.onActive(s)
+}
+
+// handleErrorResponse splits per-RPC errors (rpc_id != 0) from session-level
+// errors (rpc_id == 0). Session-level errors force-close the session;
+// ForceClose then cancels all in-flight RPCs with ErrUnavailableSessionError.
+func (s *Session) handleErrorResponse(errResp *spb.ErrorResponse) {
+	if errResp == nil {
+		return
+	}
+	if errResp.GetRpcId() != 0 {
+		s.handleVRPCErrorResponse(errResp)
+		return
+	}
+	desc := "server reported session-level error"
+	if errResp.Status != nil && errResp.Status.Message != "" {
+		desc = fmt.Sprintf("server session error: %s", errResp.Status.Message)
+	}
+	s.debugf("%s", desc)
+	s.ForceClose(&spb.CloseSessionRequest{
+		Reason:      spb.CloseSessionRequest_CLOSE_SESSION_REASON_ERROR,
+		Description: desc,
+	})
+}
+
+// handleSessionParameters updates the heartbeat interval negotiated by the
+// server and immediately recomputes the watchdog deadline against the new
+// interval.
+func (s *Session) handleSessionParameters(params *spb.SessionParametersResponse) {
+	if params == nil || params.KeepAlive == nil {
+		return
+	}
+	interval := params.KeepAlive.AsDuration()
+	if interval <= 0 {
+		return
+	}
+	s.heartbeatIntervalNano.Store(int64(interval))
+	s.nextHeartbeatDeadlineNano.Store(time.Now().Add(3 * interval).UnixNano())
+}
+
+// handleSessionRefreshConfig stores the server-provided refresh configuration
+// for later use by reconnection logic.
+func (s *Session) handleSessionRefreshConfig(cfg *spb.SessionRefreshConfig) {
+	s.refreshConfig.Store(cfg)
+	s.debugf("stored SessionRefreshConfig (optimized_open=%t, metadata_entries=%d)",
+		cfg.GetOptimizedOpenRequest() != nil, len(cfg.GetMetadata()))
+}
+
+// handleGoAway processes a server-initiated GoAway:
+//  1. Transitions to StateClosing so pool.CheckoutSession stops handing
+//     this session out for new work (matches Java's onSessionGoAway
+//     which marks the session as no longer eligible for new picks).
+//  2. Stamps "GoAway" as the close reason so it survives the eventual
+//     handleClose stamp.
+//  3. Does NOT cancel the in-flight RPC. Java parity: SessionImpl's
+//     handleGoAwayResponse just transitions state and leaves currentRpc
+//     alone — if the server sends the response before dropping the
+//     stream, the RPC completes successfully. Only when the stream
+//     actually terminates does the RPC get failed with TRANSPORT_FAILURE
+//     (via handleClose → cancelActiveRPCs). This grace period matters
+//     most for non-idempotent Apply on server graceful drains: previously
+//     GoAway made the client fail-fast even when the server was about to
+//     send success.
+//  4. Spawns a goroutine that drives the session through Closing →
+//     WaitServerClose → Closed via s.Close. s.Close already drains the
+//     in-flight RPC (waits on s.quiescent, or ForceCloses after its 30s
+//     ctx) before sending CloseSession, so the RPC gets its chance
+//     without needing extra scheduling here.
+//
+// A late-arriving GOAWAY from an already terminal session is ignored.
+func (s *Session) handleGoAway(goAway *spb.GoAwayResponse) {
+	// Sanity-check state BEFORE attempting the transition: GOAWAY landing
+	// on a NEW session is a protocol oddity (server shouldn't send GOAWAY
+	// before the session is Started). The current predicate below would
+	// silently accept it; the assert makes it observable.
+	preState := s.State()
+	if !assertDebugTagf(preState >= StateStarting, tagSessionGoawayBeforeStart,
+		"GOAWAY arrived while session was in %s (want >= Starting)", preState) {
+		return
+	}
+	if _, ok := s.transitionTo(StateClosing, notState(StateClosing, StateWaitServerClose, StateClosed)); !ok {
+		// Session is already terminal (Closing, WaitServerClose, or
+		// Closed). A late GOAWAY here just races our local teardown —
+		// observable but harmless.
+		recordDebugTag(tagSessionGoawayAfterClose)
+		return
+	}
+	// Fire onClosing immediately so the pool can pull this session out of
+	// routing structures. Firing here (not just from Close's transitionTo
+	// below) matters because handleGoAway is the earliest point we know
+	// the session is dying — up to waitServerCloseGrace seconds before
+	// the actual stream close.
+	s.notifyClosing()
+	s.setCloseReason("GoAway")
+
+	s.debugf("received GOAWAY reason=%q description=%q",
+		goAway.GetReason(), goAway.GetDescription())
+
+	// Drive the lifecycle to completion off the readLoop. s.Close
+	// sends CloseSession, transitions to WaitServerClose, and then the
+	// pool's stuck-session monitor or the server's EOF moves us to Closed.
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		_ = s.Close(ctx, &spb.CloseSessionRequest{
+			Reason:      spb.CloseSessionRequest_CLOSE_SESSION_REASON_GOAWAY,
+			Description: "client teardown after server GOAWAY",
+		})
+	}()
+}
+
+// handleClose is invoked when Recv returns an error. It transitions to
+// StateClosed (from any non-terminal state — including WaitServerClose
+// when the server's EOF arrives after a CloseSession we sent) and cancels
+// every remaining in-flight RPC.
+//
+// The close reason is derived from the Recv error if no more-specific
+// reason was recorded earlier — see streamEndReason. setCloseReason is
+// CompareAndSwap-once, so a GoAway / MissedHeartbeat / Error stamp from
+// upstream always wins; the categorized StreamEnd label only sticks when
+// the stream ended without any other path classifying it first.
+func (s *Session) handleClose(err error) {
+	if _, ok := s.transitionTo(StateClosed, notState(StateClosed)); !ok {
+		return
+	}
+	// Ready → Closed can happen directly here (server EOFed without a
+	// prior GoAway or CloseSession). Guarantee onClosing fires before the
+	// notifyClosed below drives onClose. closingOnce makes this a no-op
+	// when handleGoAway or Close already fired earlier.
+	s.notifyClosing()
+	reason := streamEndReason(err)
+	s.setCloseReason(reason)
+	// After setCloseReason (CompareAndSwap-once), the *final* reason may
+	// be an earlier stamp (GoAway / MissedHeartbeat / Error) or the
+	// streamEndReason we just computed. Only flag as abnormal when the
+	// final reason is a StreamEnd category that isn't a clean shutdown.
+	if isAbnormalCloseReason(s.CloseReason()) {
+		recordDebugTag(tagSessionAbnormalClose)
+	}
+	inFlight := 0
+	if s.activeRPC.Load() != nil {
+		inFlight = 1
+	}
+	age := time.Duration(0)
+	if openedAt := s.OpenedAt(); !openedAt.IsZero() {
+		age = time.Since(openedAt)
+	}
+	lastRPC := s.nextRPCID.Load()
+	peer := s.peerInfoSummary()
+	s.recordEvent("close", "reason=%s age=%v in_flight=%d last_rpc_id=%d %s raw_err=%v",
+		reason, age, inFlight, lastRPC, peer, err)
+	s.cancelActiveRPCs(unavailable(err, "session closed: %v", err))
+	s.signalQuiescent()
+	s.notifyClosed(err)
+}
+
+// streamEndReason classifies the Recv error that ended the stream. The
+// returned label is what shows up in sessionz's Close-reasons breakdown
+// when no upstream path stamped a more specific reason (GoAway,
+// MissedHeartbeat, Error, etc.).
+//
+// Categories the operator typically cares about:
+//
+//	StreamEnd:EOF              — server closed the stream cleanly with
+//	                              io.EOF (graceful shutdown from server's
+//	                              side that didn't go through GoAway)
+//	StreamEnd:Canceled         — local ctx cancel (pool teardown,
+//	                              client app exit) or grpc CANCELED
+//	StreamEnd:DeadlineExceeded — ctx deadline or grpc DEADLINE_EXCEEDED
+//	StreamEnd:Unavailable      — transport-level break (TCP drop,
+//	                              connection recycler killed the channel,
+//	                              load balancer evicted the backend)
+//	StreamEnd:Internal         — server INTERNAL error
+//	StreamEnd:{Code}           — any other gRPC status code (verbatim)
+//	StreamEnd:Other            — no recognizable category (extremely rare)
+//	StreamEnd                  — err was nil (shouldn't happen since Recv
+//	                              only returns on error)
+func streamEndReason(err error) string {
+	if err == nil {
+		return "StreamEnd"
+	}
+	if errors.Is(err, io.EOF) {
+		return "StreamEnd:EOF"
+	}
+	if errors.Is(err, context.Canceled) {
+		return "StreamEnd:Canceled"
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return "StreamEnd:DeadlineExceeded"
+	}
+	if st, ok := status.FromError(err); ok {
+		return "StreamEnd:" + st.Code().String()
+	}
+	return "StreamEnd:Other"
+}
+
+// isAbnormalCloseReason returns true when the recorded close reason
+// looks like something we did NOT initiate cleanly. Clean paths:
+// EOF (server graceful), Canceled (client teardown / ctx cancel), and
+// the explicit client-initiated reasons stamped by handleGoAway /
+// heartBeatLoop / handleErrorResponse. Anything else — a StreamEnd
+// tagged with a transport-failure code, or the bare "StreamEnd" that
+// indicates Recv returned nil (which shouldn't happen) — is abnormal
+// and worth flagging.
+func isAbnormalCloseReason(reason string) bool {
+	switch reason {
+	case "StreamEnd:EOF", "StreamEnd:Canceled",
+		"GoAway", "MissedHeartbeat", "Error", "":
+		return false
+	}
+	return strings.HasPrefix(reason, "StreamEnd")
+}
+
+// resetHeartbeatDeadline pushes out the watchdog to (3 * heartbeatInterval)
+// from now. The 3x multiplier follows the protocol guidance of tolerating two
+// missed heartbeats. Two atomic loads + one atomic store on the hot path.
+func (s *Session) resetHeartbeatDeadline() {
+	s.nextHeartbeatDeadlineNano.Store(time.Now().Add(3 * time.Duration(s.heartbeatIntervalNano.Load())).UnixNano())
+}
+
+// heartBeatLoop watches the session's heartbeat deadline using a single Timer
+// that re-arms itself when a frame extends the deadline. The watchdog is
+// only enforced while at least one VRPC is in flight: the server emits
+// Heartbeats during long-running VRPCs, so an idle session legitimately
+// receives no heartbeats and must not be torn down.
+func (s *Session) heartBeatLoop(ctx context.Context) {
+	deadline := time.Unix(0, s.nextHeartbeatDeadlineNano.Load())
+
+	timer := time.NewTimer(time.Until(deadline))
+	defer timer.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-timer.C:
+			if State(s.state.Load()) == StateClosed {
+				return
+			}
+			active := 0
+			if s.activeRPC.Load() != nil {
+				active = 1
+			}
+			remaining := time.Until(time.Unix(0, s.nextHeartbeatDeadlineNano.Load()))
+			interval := time.Duration(s.heartbeatIntervalNano.Load())
+			// last-frame age = (deadline - now) inverted into "how long
+			// since the last frame extended us" = 3*interval - remaining.
+			lastFrameAge := 3*interval - remaining
+
+			if active == 0 {
+				// Idle session: no heartbeats are expected. Re-check after
+				// one interval so a freshly-started VRPC is picked up.
+				timer.Reset(interval)
+				continue
+			}
+			if remaining > 0 {
+				// Deadline was pushed out while we were sleeping; re-arm.
+				// Only record when last_frame_age has crossed one interval —
+				// otherwise every healthy session would spam the UI ring
+				// buffer ~3x/second and drown out close/missed events.
+				if lastFrameAge >= interval {
+					s.recordEvent("hb-alive", "in_flight=%d last_frame_age=%v remaining=%v interval=%v",
+						active, lastFrameAge, remaining, interval)
+				}
+				timer.Reset(remaining)
+				continue
+			}
+			// active > 0 and deadline elapsed — half-dead stream (no frames
+			// arriving while we have in-flight work). Log before ForceClose
+			// so we have a definitive marker even if downstream cancel races.
+			recordDebugTag(tagSessionHeartbeatMissed)
+			s.debugf("heartbeat MISSED — forcing close in_flight=%d last_frame_age=%v interval=%v",
+				active, lastFrameAge, interval)
+			s.recordEvent("hb-missed", "in_flight=%d last_frame_age=%v interval=%v",
+				active, lastFrameAge, interval)
+			s.ForceClose(&spb.CloseSessionRequest{
+				Reason:      spb.CloseSessionRequest_CLOSE_SESSION_REASON_MISSED_HEARTBEAT,
+				Description: "client terminated session due to missed server heartbeats",
+			})
+			return
+		}
+	}
+}
+
+// peerInfoExtracter parses the base64-encoded peer info header and caches
+// the decoded PeerInfo on the session. Server emits URL-safe base64
+// (matches java-bigtable's Base64.getUrlDecoder()); trailing '=' padding
+// is stripped so a single RawURLEncoding decoder handles both shapes.
+func (s *Session) peerInfoExtracter(peerInfoData []string) {
+	if len(peerInfoData) == 0 {
+		return
+	}
+	decoded, err := base64.RawURLEncoding.DecodeString(strings.TrimRight(peerInfoData[0], "="))
+	if err != nil {
+		s.debugf("decode base64 PeerInfo failed: %v", err)
+		return
+	}
+	var peerInfo spb.PeerInfo
+	if err := proto.Unmarshal(decoded, &peerInfo); err != nil {
+		s.debugf("unmarshal PeerInfo proto failed: %v", err)
+		return
+	}
+	s.peerInfo.Store(&peerInfo)
+	s.tracer.setPeerInfo(&peerInfo)
+	s.debugf("parsed PeerInfo: transport_type=%s afe=%s",
+		metrics.TransportTypeName(peerInfo.GetTransportType()), peerInfo.GetApplicationFrontendSubzone())
+}
+
+// closeReasonLabel maps a CloseSessionRequest reason to a short human-
+// readable category string for the debug UI. Empty when req is nil.
+func closeReasonLabel(req *spb.CloseSessionRequest) string {
+	if req == nil {
+		return ""
+	}
+	switch req.Reason {
+	case spb.CloseSessionRequest_CLOSE_SESSION_REASON_MISSED_HEARTBEAT:
+		return "MissedHeartbeat"
+	case spb.CloseSessionRequest_CLOSE_SESSION_REASON_GOAWAY:
+		return "GoAway"
+	case spb.CloseSessionRequest_CLOSE_SESSION_REASON_ERROR:
+		return "Error"
+	case spb.CloseSessionRequest_CLOSE_SESSION_REASON_USER:
+		return "User"
+	default:
+		// CLOSE_SESSION_REASON_DOWNSIZE folds here — no client code path
+		// produces it anymore after passive-scaling migration (replace-
+		// on-close replaced the periodic pruneSessions).
+		return "Other"
+	}
+}
+
+// closeReasonToCause maps a CloseSessionRequest reason to a sentinel error,
+// or nil when the close is benign (user-initiated, downsize, unset). Callers
+// of unavailable(nil, …) get a codes.Unavailable error without a wrapped
+// sentinel, so errors.Is against the session sentinels returns false — which
+// is the correct signal for "this was an expected shutdown."
+func closeReasonToCause(req *spb.CloseSessionRequest) error {
+	if req == nil {
+		return nil
+	}
+	switch req.Reason {
+	case spb.CloseSessionRequest_CLOSE_SESSION_REASON_MISSED_HEARTBEAT:
+		return ErrUnavailableHeartBeatMissed
+	case spb.CloseSessionRequest_CLOSE_SESSION_REASON_GOAWAY:
+		return ErrUnavailableGoAway
+	case spb.CloseSessionRequest_CLOSE_SESSION_REASON_ERROR:
+		return ErrUnavailableSessionError
+	default:
+		return nil
+	}
+}

--- a/bigtable/internal/transport/session_msgtype.go
+++ b/bigtable/internal/transport/session_msgtype.go
@@ -1,0 +1,123 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import spb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
+
+// reqMsgType / respMsgType label the oneof payload variants of
+// SessionRequest / SessionResponse. They're used as indices into the fixed
+// per-session atomic-counter arrays so the breakdown stays lock-free.
+//
+// The "other" bucket catches frames whose oneof is unset or carries a
+// payload type we haven't enumerated here (forward-compat with new server
+// frames). Add new values BEFORE numReq/Resp so the totals stay aligned
+// with the array size.
+type reqMsgType int
+
+const (
+	reqMsgOpenSession reqMsgType = iota
+	reqMsgVirtualRpc
+	reqMsgCloseSession
+	reqMsgOther
+	numReqMsgTypes
+)
+
+func (t reqMsgType) String() string {
+	switch t {
+	case reqMsgOpenSession:
+		return "OpenSession"
+	case reqMsgVirtualRpc:
+		return "VirtualRpc"
+	case reqMsgCloseSession:
+		return "CloseSession"
+	default:
+		return "other"
+	}
+}
+
+func classifyReq(req *spb.SessionRequest) reqMsgType {
+	if req == nil {
+		return reqMsgOther
+	}
+	switch req.GetPayload().(type) {
+	case *spb.SessionRequest_OpenSession:
+		return reqMsgOpenSession
+	case *spb.SessionRequest_VirtualRpc:
+		return reqMsgVirtualRpc
+	case *spb.SessionRequest_CloseSession:
+		return reqMsgCloseSession
+	default:
+		return reqMsgOther
+	}
+}
+
+type respMsgType int
+
+const (
+	respMsgOpenSession respMsgType = iota
+	respMsgVirtualRpc
+	respMsgError
+	respMsgSessionParameters
+	respMsgHeartbeat
+	respMsgGoAway
+	respMsgSessionRefreshConfig
+	respMsgOther
+	numRespMsgTypes
+)
+
+func (t respMsgType) String() string {
+	switch t {
+	case respMsgOpenSession:
+		return "OpenSession"
+	case respMsgVirtualRpc:
+		return "VirtualRpc"
+	case respMsgError:
+		return "Error"
+	case respMsgSessionParameters:
+		return "SessionParameters"
+	case respMsgHeartbeat:
+		return "Heartbeat"
+	case respMsgGoAway:
+		return "GoAway"
+	case respMsgSessionRefreshConfig:
+		return "SessionRefreshConfig"
+	default:
+		return "other"
+	}
+}
+
+func classifyResp(resp *spb.SessionResponse) respMsgType {
+	if resp == nil {
+		return respMsgOther
+	}
+	switch resp.GetPayload().(type) {
+	case *spb.SessionResponse_OpenSession:
+		return respMsgOpenSession
+	case *spb.SessionResponse_VirtualRpc:
+		return respMsgVirtualRpc
+	case *spb.SessionResponse_Error:
+		return respMsgError
+	case *spb.SessionResponse_SessionParameters:
+		return respMsgSessionParameters
+	case *spb.SessionResponse_Heartbeat:
+		return respMsgHeartbeat
+	case *spb.SessionResponse_GoAway:
+		return respMsgGoAway
+	case *spb.SessionResponse_SessionRefreshConfig:
+		return respMsgSessionRefreshConfig
+	default:
+		return respMsgOther
+	}
+}

--- a/bigtable/internal/transport/session_test.go
+++ b/bigtable/internal/transport/session_test.go
@@ -1,0 +1,977 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	spb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
+	rpcstatus "google.golang.org/genproto/googleapis/rpc/status"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/durationpb"
+)
+
+// fakeStream implements Stream and exposes channels so tests can drive both
+// sides of the conversation.
+type fakeStream struct {
+	sentMu    sync.Mutex
+	sent      []*spb.SessionRequest
+	recv      chan recvOp
+	hdr       metadata.MD
+	hdrErr    error
+	sendFn    func(*spb.SessionRequest) error
+	closeOnce sync.Once
+}
+
+type recvOp struct {
+	resp *spb.SessionResponse
+	err  error
+}
+
+func newFakeStream() *fakeStream {
+	return &fakeStream{
+		recv: make(chan recvOp, 32),
+		hdr:  metadata.MD{},
+	}
+}
+
+// Close unblocks Recv() by closing the recv channel. Production streams
+// exit Recv when the underlying gRPC context cancels; fakeStream models
+// that by closing the channel exactly once. Idempotent so cleanup and
+// explicit test teardown don't collide.
+func (f *fakeStream) Close() {
+	f.closeOnce.Do(func() { close(f.recv) })
+}
+
+func (f *fakeStream) Send(req *spb.SessionRequest) error {
+	if f.sendFn != nil {
+		if err := f.sendFn(req); err != nil {
+			return err
+		}
+	}
+	f.sentMu.Lock()
+	f.sent = append(f.sent, req)
+	f.sentMu.Unlock()
+	return nil
+}
+
+func (f *fakeStream) Recv() (*spb.SessionResponse, error) {
+	op, ok := <-f.recv
+	if !ok {
+		return nil, fmt.Errorf("stream closed")
+	}
+	return op.resp, op.err
+}
+
+func (f *fakeStream) Header() (metadata.MD, error) {
+	return f.hdr, f.hdrErr
+}
+
+func (f *fakeStream) Context() context.Context {
+	return context.Background()
+}
+
+func (f *fakeStream) snapshotSent() []*spb.SessionRequest {
+	f.sentMu.Lock()
+	defer f.sentMu.Unlock()
+	out := make([]*spb.SessionRequest, len(f.sent))
+	copy(out, f.sent)
+	return out
+}
+
+// hookCounts captures lifecycle callbacks via a SessionHooks value.
+type hookCounts struct {
+	mu          sync.Mutex
+	startCount  int
+	activeCount int
+	closeCount  int
+	closeErr    error
+}
+
+func (c *hookCounts) hooks() SessionHooks {
+	return SessionHooks{
+		OnStart: func(context.Context) {
+			c.mu.Lock()
+			defer c.mu.Unlock()
+			c.startCount++
+		},
+		OnActive: func(*Session) {
+			c.mu.Lock()
+			defer c.mu.Unlock()
+			c.activeCount++
+		},
+		OnClose: func(_ *Session, err error) {
+			c.mu.Lock()
+			defer c.mu.Unlock()
+			c.closeCount++
+			c.closeErr = err
+		},
+	}
+}
+
+func (c *hookCounts) counts() (start, active, closed int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.startCount, c.activeCount, c.closeCount
+}
+
+// fakeDesc is a minimal VRpcDescriptor for Invoke tests.
+type fakeDesc struct {
+	method string
+	enc    func(req interface{}) ([]byte, error)
+	dec    func(buf []byte) (interface{}, error)
+}
+
+func (f *fakeDesc) Method() string                         { return f.method }
+func (f *fakeDesc) Encode(req interface{}) ([]byte, error) { return f.enc(req) }
+func (f *fakeDesc) Decode(buf []byte) (interface{}, error) { return f.dec(buf) }
+
+func newTestSession(t *testing.T, stream Stream, hooks SessionHooks) *Session {
+	t.Helper()
+	return NewSession("test-session", stream, hooks, SessionTypeTable)
+}
+
+// waitFor polls cond every 5ms up to timeout, failing the test if cond never
+// becomes true.
+func waitFor(t *testing.T, timeout time.Duration, cond func() bool, msg string) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("timed out after %v waiting for: %s", timeout, msg)
+}
+
+// --- pure value tests --------------------------------------------------------
+
+func TestMultiPlexingLimit(t *testing.T) {
+	if multiPlexingLimit != 1 {
+		t.Errorf("multiPlexingLimit = %d, want 1 (multiplexing unsupported)", multiPlexingLimit)
+	}
+}
+
+func TestNewSession_Defaults(t *testing.T) {
+	stream := newFakeStream()
+	s := NewSession("log", stream, SessionHooks{}, SessionTypeAuthorizedView)
+
+	if got := s.State(); got != StateNew {
+		t.Errorf("initial state = %v, want StateNew", got)
+	}
+	if got := s.LogName(); got != "log" {
+		t.Errorf("LogName = %q, want %q", got, "log")
+	}
+	if got := s.sessionType; got != SessionTypeAuthorizedView {
+		t.Errorf("sessionType = %v, want SessionTypeAuthorizedView", got)
+	}
+	if s.activeRPC.Load() != nil {
+		t.Error("activeRPC slot should start nil")
+	}
+	if s.quiescent == nil {
+		t.Error("quiescent channel not initialized")
+	}
+	if got := time.Duration(s.heartbeatIntervalNano.Load()); got != defaultHeartbeatInterval {
+		t.Errorf("heartbeatInterval = %v, want %v", got, defaultHeartbeatInterval)
+	}
+	if s.PeerInfo() != nil {
+		t.Error("PeerInfo should start nil")
+	}
+	if s.RefreshConfig() != nil {
+		t.Error("RefreshConfig should start nil")
+	}
+	if s.HasOkRpcs() || s.HasErrorRpcs() {
+		t.Error("HasOkRpcs/HasErrorRpcs should start false")
+	}
+}
+
+func TestCloseReasonToCause(t *testing.T) {
+	tests := []struct {
+		name string
+		req  *spb.CloseSessionRequest
+		want error
+	}{
+		{"nil request maps to nil", nil, nil},
+		{"unset reason → nil", &spb.CloseSessionRequest{Reason: spb.CloseSessionRequest_CLOSE_SESSION_REASON_UNSET}, nil},
+		{"user-initiated → nil", &spb.CloseSessionRequest{Reason: spb.CloseSessionRequest_CLOSE_SESSION_REASON_USER}, nil},
+		{"missed heartbeat", &spb.CloseSessionRequest{Reason: spb.CloseSessionRequest_CLOSE_SESSION_REASON_MISSED_HEARTBEAT}, ErrUnavailableHeartBeatMissed},
+		{"goaway", &spb.CloseSessionRequest{Reason: spb.CloseSessionRequest_CLOSE_SESSION_REASON_GOAWAY}, ErrUnavailableGoAway},
+		{"error", &spb.CloseSessionRequest{Reason: spb.CloseSessionRequest_CLOSE_SESSION_REASON_ERROR}, ErrUnavailableSessionError},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := closeReasonToCause(tt.req); !errors.Is(got, tt.want) && got != tt.want {
+				t.Errorf("closeReasonToCause(%v) = %v, want %v", tt.req, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUnavailable_WrapsCauseAndStatus(t *testing.T) {
+	err := unavailable(ErrUnavailableHeartBeatMissed, "heartbeat dead for %s", "test")
+
+	if !errors.Is(err, ErrUnavailableHeartBeatMissed) {
+		t.Error("errors.Is should match ErrUnavailableHeartBeatMissed")
+	}
+	if errors.Is(err, ErrUnavailableGoAway) {
+		t.Error("errors.Is should not match unrelated sentinel")
+	}
+	if code := status.Code(err); code != codes.Unavailable {
+		t.Errorf("status.Code = %v, want Unavailable", code)
+	}
+	if msg := err.Error(); msg == "" {
+		t.Error("error string should be non-empty")
+	}
+
+	// nil cause should not crash and should still be Unavailable.
+	err = unavailable(nil, "no cause")
+	if code := status.Code(err); code != codes.Unavailable {
+		t.Errorf("nil-cause: status.Code = %v, want Unavailable", code)
+	}
+	if errors.Is(err, ErrUnavailableHeartBeatMissed) {
+		t.Error("nil-cause: errors.Is should not match any sentinel")
+	}
+}
+
+// --- handler-level tests (no Start/readLoop) ---------------------------------
+
+// makeActive constructs a session and forces it into StateReady without going
+// through the handshake.
+func makeActive(t *testing.T, hooks SessionHooks) (*Session, *fakeStream) {
+	t.Helper()
+	stream := newFakeStream()
+	s := newTestSession(t, stream, hooks)
+	s.state.Store(int32(StateReady))
+	return s, stream
+}
+
+func TestHandleOpenSession_TransitionsToActive(t *testing.T) {
+	stream := newFakeStream()
+	listener := &hookCounts{}
+	s := newTestSession(t, stream, listener.hooks())
+	s.state.Store(int32(StateStarting))
+
+	s.handleOpenSession(&spb.OpenSessionResponse{})
+
+	if got := s.State(); got != StateReady {
+		t.Errorf("state = %v, want StateReady", got)
+	}
+	if _, active, _ := listener.counts(); active != 1 {
+		t.Errorf("OnActive called %d times, want 1", active)
+	}
+
+	// Re-delivery (idempotent): no extra listener firings.
+	s.handleOpenSession(&spb.OpenSessionResponse{})
+	if _, active, _ := listener.counts(); active != 1 {
+		t.Errorf("OnActive called %d times after re-delivery, want 1", active)
+	}
+}
+
+// TestHandleOpenSession_PeerInfoBeforeOnActive verifies the invariant that
+// PeerInfo is populated *before* the onActive hook fires. The AFE-grouping
+// picker relies on this: it reads s.AfeID() (which reads PeerInfo) inside
+// its OnActive path, so a nil PeerInfo would silently bucket the session
+// under AfeID=0.
+func TestHandleOpenSession_PeerInfoBeforeOnActive(t *testing.T) {
+	pi := &spb.PeerInfo{
+		ApplicationFrontendSubzone: "us-central1-a",
+		TransportType:              spb.PeerInfo_TRANSPORT_TYPE_DIRECT_ACCESS,
+	}
+	raw, err := proto.Marshal(pi)
+	if err != nil {
+		t.Fatalf("proto.Marshal: %v", err)
+	}
+	encoded := base64.RawURLEncoding.EncodeToString(raw)
+
+	stream := newFakeStream()
+	stream.hdr = metadata.MD{peerInfoHeaderKey: []string{encoded}}
+
+	var peerInfoAtActive *spb.PeerInfo
+	hooks := SessionHooks{
+		OnActive: func(s *Session) {
+			peerInfoAtActive = s.PeerInfo()
+		},
+	}
+	s := newTestSession(t, stream, hooks)
+	s.state.Store(int32(StateStarting))
+
+	s.handleOpenSession(&spb.OpenSessionResponse{})
+
+	if peerInfoAtActive == nil {
+		t.Fatal("PeerInfo was nil when onActive fired; expected populated")
+	}
+	if got := peerInfoAtActive.GetApplicationFrontendSubzone(); got != "us-central1-a" {
+		t.Errorf("PeerInfo.ApplicationFrontendSubzone = %q, want us-central1-a", got)
+	}
+}
+
+// TestHandleOpenSession_MissingHeaderStillFiresOnActive covers the case where
+// the server did not send the bigtable-peer-info header (older backends /
+// tests). onActive must still fire; PeerInfo simply remains nil.
+func TestHandleOpenSession_MissingHeaderStillFiresOnActive(t *testing.T) {
+	stream := newFakeStream()
+	// stream.hdr is an empty MD by default; no peer-info header.
+
+	listener := &hookCounts{}
+	s := newTestSession(t, stream, listener.hooks())
+	s.state.Store(int32(StateStarting))
+
+	s.handleOpenSession(&spb.OpenSessionResponse{})
+
+	if _, active, _ := listener.counts(); active != 1 {
+		t.Errorf("OnActive called %d times, want 1", active)
+	}
+	if s.PeerInfo() != nil {
+		t.Error("PeerInfo should be nil when header absent")
+	}
+}
+
+func TestHandleVRPCResponse_RoutesByRpcID(t *testing.T) {
+	s, _ := makeActive(t, SessionHooks{})
+
+	rpc := &vrpcImpl{id: 7, method: "ReadRow", resultChan: make(chan vrpcResult, 1)}
+	s.activeRPC.Store(rpc)
+
+	resp := &spb.VirtualRpcResponse{RpcId: 7, Payload: []byte("p")}
+	s.handleVRPCResponse(resp)
+
+	select {
+	case res := <-rpc.resultChan:
+		if res.resp != resp {
+			t.Errorf("got resp %p, want %p", res.resp, resp)
+		}
+	default:
+		t.Fatal("no result delivered")
+	}
+	if !s.HasOkRpcs() {
+		t.Error("HasOkRpcs should be true after successful response")
+	}
+	// Unknown rpc_id is dropped silently.
+	s.handleVRPCResponse(&spb.VirtualRpcResponse{RpcId: 999})
+}
+
+func TestHandleVRPCErrorResponse_RoutesByRpcID(t *testing.T) {
+	s, _ := makeActive(t, SessionHooks{})
+
+	rpc := &vrpcImpl{id: 3, method: "ReadRow", resultChan: make(chan vrpcResult, 1)}
+	s.activeRPC.Store(rpc)
+
+	errResp := &spb.ErrorResponse{
+		RpcId:  3,
+		Status: &rpcstatus.Status{Code: int32(codes.FailedPrecondition), Message: "boom"},
+	}
+	s.handleVRPCErrorResponse(errResp)
+
+	select {
+	case res := <-rpc.resultChan:
+		if res.errResp == nil {
+			t.Fatal("expected errResp result")
+		}
+		if got := codes.Code(res.errResp.Status.GetCode()); got != codes.FailedPrecondition {
+			t.Errorf("status code = %v, want FailedPrecondition", got)
+		}
+	default:
+		t.Fatal("no result delivered")
+	}
+	if !s.HasErrorRpcs() {
+		t.Error("HasErrorRpcs should be true after error response")
+	}
+}
+
+func TestHandleErrorResponse_SessionFatalForcesClose(t *testing.T) {
+	listener := &hookCounts{}
+	s, _ := makeActive(t, listener.hooks())
+
+	// Pre-existing in-flight RPC; should be cancelled by ForceClose.
+	rpc := &vrpcImpl{id: 11, method: "ReadRow", resultChan: make(chan vrpcResult, 1)}
+	s.activeRPC.Store(rpc)
+
+	s.handleErrorResponse(&spb.ErrorResponse{
+		RpcId:  0,
+		Status: &rpcstatus.Status{Code: int32(codes.Internal), Message: "fatal"},
+	})
+
+	if got := s.State(); got != StateClosed {
+		t.Errorf("state = %v, want StateClosed", got)
+	}
+	select {
+	case res := <-rpc.resultChan:
+		if !errors.Is(res.err, ErrUnavailableSessionError) {
+			t.Errorf("cancelled cause = %v, want ErrUnavailableSessionError", res.err)
+		}
+	default:
+		t.Fatal("in-flight RPC not cancelled by session-fatal error")
+	}
+	if _, _, closed := listener.counts(); closed != 1 {
+		t.Errorf("OnClose called %d times, want 1", closed)
+	}
+}
+
+// TestHandleGoAway_PreservesInFlightRPC verifies Java-parity behavior:
+// GOAWAY transitions the session to Closing (so the pool stops handing
+// this session out for new work) but does NOT cancel the in-flight RPC.
+// If the server sends its response before dropping the stream, the RPC
+// still completes cleanly — critical for non-idempotent Apply on server
+// graceful drains, which previously fail-fasted with Unavailable even
+// when the server was about to return success.
+func TestHandleGoAway_PreservesInFlightRPC(t *testing.T) {
+	s, _ := makeActive(t, SessionHooks{})
+
+	rpc := &vrpcImpl{id: 1, method: "ReadRow", resultChan: make(chan vrpcResult, 1)}
+	s.activeRPC.Store(rpc)
+	s.handleGoAway(&spb.GoAwayResponse{Reason: "test"})
+	if got := s.State(); got != StateClosing {
+		t.Errorf("state = %v, want StateClosing", got)
+	}
+	if s.activeRPC.Load() != rpc {
+		t.Error("in-flight RPC should remain in slot; GOAWAY must not cancel it")
+	}
+	select {
+	case res := <-rpc.resultChan:
+		t.Errorf("in-flight RPC was cancelled (err=%v) but GOAWAY should let it complete", res.err)
+	default:
+		// expected: no cancellation delivered
+	}
+
+	// Now verify the whole point of the grace period: a response arriving
+	// AFTER the GOAWAY still completes the RPC successfully. This is the
+	// scenario the Java-parity change was made for — server sends the
+	// reply, then drops the stream. Client must not fail-fast.
+	s.handleVRPCResponse(&spb.VirtualRpcResponse{RpcId: 1, Payload: []byte("late-but-real")})
+	select {
+	case res := <-rpc.resultChan:
+		if res.err != nil {
+			t.Errorf("post-GOAWAY response delivered with err=%v; want success", res.err)
+		}
+		if got := string(res.resp.Payload); got != "late-but-real" {
+			t.Errorf("post-GOAWAY response payload = %q, want %q", got, "late-but-real")
+		}
+	default:
+		t.Error("post-GOAWAY response was not delivered — RPC would hang")
+	}
+	// activeRPC is cleared by Invoke's defer in the real path, not by
+	// handleVRPCResponse — so this test doesn't assert on that side.
+}
+
+func TestHandleSessionParameters_UpdatesIntervalAndDeadline(t *testing.T) {
+	s, _ := makeActive(t, SessionHooks{})
+	before := time.Now()
+
+	s.handleSessionParameters(&spb.SessionParametersResponse{
+		KeepAlive: durationpb.New(2 * time.Second),
+	})
+
+	gotInterval := time.Duration(s.heartbeatIntervalNano.Load())
+	gotDeadline := time.Unix(0, s.nextHeartbeatDeadlineNano.Load())
+
+	if gotInterval != 2*time.Second {
+		t.Errorf("heartbeatInterval = %v, want 2s", gotInterval)
+	}
+	// Expect deadline ≈ now + 6s (3 * 2s).
+	wantMin := before.Add(5 * time.Second)
+	if gotDeadline.Before(wantMin) {
+		t.Errorf("nextHeartbeatDeadline = %v, want >= %v", gotDeadline, wantMin)
+	}
+
+	// Zero / nil keepalive should be ignored.
+	s.handleSessionParameters(&spb.SessionParametersResponse{})
+	s.handleSessionParameters(&spb.SessionParametersResponse{KeepAlive: durationpb.New(0)})
+
+	if got := time.Duration(s.heartbeatIntervalNano.Load()); got != 2*time.Second {
+		t.Errorf("heartbeatInterval changed after no-op updates: %v", got)
+	}
+}
+
+func TestHandleSessionRefreshConfig_Stored(t *testing.T) {
+	s, _ := makeActive(t, SessionHooks{})
+
+	cfg := &spb.SessionRefreshConfig{
+		OptimizedOpenRequest: &spb.OpenSessionRequest{ProtocolVersion: 7},
+	}
+	s.handleSessionRefreshConfig(cfg)
+
+	got := s.RefreshConfig()
+	if got != cfg {
+		t.Errorf("RefreshConfig = %v, want %v", got, cfg)
+	}
+}
+
+func TestHandleSessionResponse_UnknownDoesNotResetDeadline(t *testing.T) {
+	s, _ := makeActive(t, SessionHooks{})
+	s.nextHeartbeatDeadlineNano.Store(0) // way in the past
+
+	// SessionResponse with no oneof set → unknown payload path.
+	s.handleSessionResponse(&spb.SessionResponse{})
+
+	got := time.Unix(0, s.nextHeartbeatDeadlineNano.Load())
+	if !got.Equal(time.Unix(0, 0)) {
+		t.Errorf("unknown payload reset deadline to %v; expected unchanged", got)
+	}
+
+	// A recognized variant must reset.
+	s.handleSessionResponse(&spb.SessionResponse{
+		Payload: &spb.SessionResponse_Heartbeat{Heartbeat: &spb.HeartbeatResponse{}},
+	})
+	got = time.Unix(0, s.nextHeartbeatDeadlineNano.Load())
+	if got.Equal(time.Unix(0, 0)) {
+		t.Error("recognized heartbeat did not reset deadline")
+	}
+}
+
+// --- Invoke tests -------------------------------------------------------
+
+func newRoundTripDesc() *fakeDesc {
+	return &fakeDesc{
+		method: "RoundTrip",
+		enc: func(req interface{}) ([]byte, error) {
+			return []byte(fmt.Sprintf("req:%v", req)), nil
+		},
+		dec: func(buf []byte) (interface{}, error) {
+			return string(buf), nil
+		},
+	}
+}
+
+func TestInvoke_RejectsWhenNotActive(t *testing.T) {
+	stream := newFakeStream()
+	s := newTestSession(t, stream, SessionHooks{}) // state = New
+	_, err := s.Invoke(context.Background(), newRoundTripDesc(), "hello")
+	if !errors.Is(err, ErrSessionNotActive) {
+		t.Errorf("err = %v, want ErrSessionNotActive in chain", err)
+	}
+	if code := status.Code(err); code != codes.Unavailable {
+		t.Errorf("status.Code = %v, want Unavailable", code)
+	}
+}
+
+func TestInvoke_HappyPath(t *testing.T) {
+	s, stream := makeActive(t, SessionHooks{})
+	desc := newRoundTripDesc()
+
+	done := make(chan struct{})
+	var res InvokeResult
+	var execErr error
+	go func() {
+		defer close(done)
+		res, execErr = s.Invoke(context.Background(), desc, "hello")
+	}()
+
+	// Wait for the request to be sent.
+	waitFor(t, time.Second, func() bool { return len(stream.snapshotSent()) > 0 }, "Send called")
+
+	sent := stream.snapshotSent()[0].GetVirtualRpc()
+	if sent == nil {
+		t.Fatal("sent frame is not a VirtualRpcRequest")
+	}
+	if string(sent.Payload) != "req:hello" {
+		t.Errorf("encoded payload = %q, want %q", sent.Payload, "req:hello")
+	}
+
+	// Deliver response.
+	s.handleVRPCResponse(&spb.VirtualRpcResponse{
+		RpcId:       sent.RpcId,
+		Payload:     []byte("world"),
+		ClusterInfo: &spb.ClusterInformation{ClusterId: "c1"},
+	})
+
+	<-done
+	if execErr != nil {
+		t.Fatalf("Invoke error: %v", execErr)
+	}
+	if got := res.Response.(string); got != "world" {
+		t.Errorf("resp = %q, want %q", got, "world")
+	}
+	if res.ClusterInfo == nil || res.ClusterInfo.ClusterId != "c1" {
+		t.Errorf("clusterInfo = %v, want ClusterId=c1", res.ClusterInfo)
+	}
+}
+
+func TestInvoke_ContextCancel(t *testing.T) {
+	s, _ := makeActive(t, SessionHooks{})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := s.Invoke(ctx, newRoundTripDesc(), "hello")
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("err = %v, want context.Canceled", err)
+	}
+}
+
+func TestInvoke_SendFailureCleansUpMap(t *testing.T) {
+	stream := newFakeStream()
+	stream.sendFn = func(req *spb.SessionRequest) error {
+		return fmt.Errorf("network down")
+	}
+	s := newTestSession(t, stream, SessionHooks{})
+	s.state.Store(int32(StateReady))
+
+	_, err := s.Invoke(context.Background(), newRoundTripDesc(), "hello")
+	if err == nil {
+		t.Fatal("expected error from failed Send")
+	}
+	if s.activeRPC.Load() != nil {
+		t.Error("activeRPC slot should be cleared by defer on Send failure")
+	}
+}
+
+// --- Close / ForceClose ------------------------------------------------------
+
+func TestForceClose_Idempotent(t *testing.T) {
+	listener := &hookCounts{}
+	s, _ := makeActive(t, listener.hooks())
+
+	s.ForceClose(nil)
+	s.ForceClose(nil)
+	s.ForceClose(&spb.CloseSessionRequest{Reason: spb.CloseSessionRequest_CLOSE_SESSION_REASON_ERROR})
+
+	if got := s.State(); got != StateClosed {
+		t.Errorf("state = %v, want StateClosed", got)
+	}
+	if _, _, closed := listener.counts(); closed != 1 {
+		t.Errorf("OnClose fired %d times, want 1", closed)
+	}
+}
+
+func TestForceClose_CancelsInflightWithReason(t *testing.T) {
+	s, _ := makeActive(t, SessionHooks{})
+	rpc := &vrpcImpl{id: 1, resultChan: make(chan vrpcResult, 1)}
+	s.activeRPC.Store(rpc)
+
+	s.ForceClose(&spb.CloseSessionRequest{
+		Reason:      spb.CloseSessionRequest_CLOSE_SESSION_REASON_MISSED_HEARTBEAT,
+		Description: "no heartbeat",
+	})
+
+	select {
+	case res := <-rpc.resultChan:
+		if !errors.Is(res.err, ErrUnavailableHeartBeatMissed) {
+			t.Errorf("cancelled cause = %v, want ErrUnavailableHeartBeatMissed", res.err)
+		}
+	default:
+		t.Fatal("in-flight RPC not notified")
+	}
+}
+
+func TestClose_Graceful_NoInflightSendsCloseRequest(t *testing.T) {
+	stream := newFakeStream()
+	s := newTestSession(t, stream, SessionHooks{})
+	s.state.Store(int32(StateReady))
+
+	if err := s.Close(context.Background(), &spb.CloseSessionRequest{
+		Reason: spb.CloseSessionRequest_CLOSE_SESSION_REASON_USER,
+	}); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+	// After draining (no in-flight RPCs) and sending CloseSession, the
+	// session advances to WaitServerClose. handleClose (server EOF) would
+	// then move it to Closed; the pool's stuck-session monitor force-closes
+	// it otherwise.
+	if got := s.State(); got != StateWaitServerClose {
+		t.Errorf("state = %v, want StateWaitServerClose", got)
+	}
+	sent := stream.snapshotSent()
+	if len(sent) != 1 || sent[0].GetCloseSession() == nil {
+		t.Errorf("expected one CloseSession frame, got %d sent frames", len(sent))
+	}
+}
+
+func TestClose_AlreadyClosingIsNoop(t *testing.T) {
+	stream := newFakeStream()
+	s := newTestSession(t, stream, SessionHooks{})
+	s.state.Store(int32(StateClosed))
+
+	if err := s.Close(context.Background(), nil); err != nil {
+		t.Errorf("Close on closed session = %v, want nil", err)
+	}
+	if got := s.State(); got != StateClosed {
+		t.Errorf("state changed to %v", got)
+	}
+	if len(stream.snapshotSent()) != 0 {
+		t.Error("Close on closed session should not send")
+	}
+}
+
+func TestClose_CtxCancelDuringDrainForceCloses(t *testing.T) {
+	s, _ := makeActive(t, SessionHooks{})
+	// Pin an in-flight RPC so the drain loop is forced to wait.
+	rpc := &vrpcImpl{id: 1, resultChan: make(chan vrpcResult, 1)}
+	s.activeRPC.Store(rpc)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancelDone := make(chan struct{})
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+		close(cancelDone)
+	}()
+
+	err := s.Close(ctx, &spb.CloseSessionRequest{
+		Reason: spb.CloseSessionRequest_CLOSE_SESSION_REASON_USER,
+	})
+	<-cancelDone
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("Close err = %v, want context.Canceled", err)
+	}
+	if got := s.State(); got != StateClosed {
+		t.Errorf("state = %v, want StateClosed after ctx-cancel ForceClose", got)
+	}
+	// In-flight RPC should have been cancelled by ForceClose.
+	select {
+	case res := <-rpc.resultChan:
+		if res.err == nil {
+			t.Error("expected cancellation error on in-flight RPC")
+		}
+	default:
+		t.Error("in-flight RPC not cancelled")
+	}
+}
+
+// --- heartbeat ---------------------------------------------------------------
+
+func TestHeartBeatLoop_ForceClosesOnMissedHeartbeat(t *testing.T) {
+	s, _ := makeActive(t, SessionHooks{})
+	rpc := &vrpcImpl{id: 1, resultChan: make(chan vrpcResult, 1)}
+	s.activeRPC.Store(rpc)
+	s.nextHeartbeatDeadlineNano.Store(time.Now().Add(-time.Second).UnixNano()) // already missed
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go s.heartBeatLoop(ctx)
+
+	waitFor(t, time.Second, func() bool { return s.State() == StateClosed }, "ForceClose from missed heartbeat")
+
+	select {
+	case res := <-rpc.resultChan:
+		if !errors.Is(res.err, ErrUnavailableHeartBeatMissed) {
+			t.Errorf("cancelled cause = %v, want ErrUnavailableHeartBeatMissed", res.err)
+		}
+		if code := status.Code(res.err); code != codes.Unavailable {
+			t.Errorf("status.Code = %v, want Unavailable (so existing retry plumbing applies)", code)
+		}
+	default:
+		t.Error("in-flight RPC not cancelled on heartbeat miss")
+	}
+}
+
+func TestHeartBeatLoop_HeartbeatsKeepInflightVRPCAlive(t *testing.T) {
+	// Positive case: while a VRPC is in flight and the server is sending
+	// Heartbeats, the watchdog must NOT fire. This proves the dispatch in
+	// handleSessionResponse correctly resets the deadline on every
+	// recognized frame.
+	s, _ := makeActive(t, SessionHooks{})
+	s.heartbeatIntervalNano.Store(int64(30 * time.Millisecond))
+	s.nextHeartbeatDeadlineNano.Store(time.Now().Add(90 * time.Millisecond).UnixNano()) // 3 * interval
+	s.activeRPC.Store(&vrpcImpl{id: 1, resultChan: make(chan vrpcResult, 1)})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go s.heartBeatLoop(ctx)
+
+	// Pump heartbeats for longer than 3*interval; without the deadline
+	// reset on each frame, the watchdog would have fired by now.
+	for i := 0; i < 8; i++ {
+		time.Sleep(25 * time.Millisecond)
+		s.handleSessionResponse(&spb.SessionResponse{
+			Payload: &spb.SessionResponse_Heartbeat{Heartbeat: &spb.HeartbeatResponse{}},
+		})
+	}
+
+	if got := s.State(); got != StateReady {
+		t.Errorf("session torn down despite arriving heartbeats; state = %v", got)
+	}
+}
+
+func TestHeartBeatLoop_IdleSessionIsNotTornDown(t *testing.T) {
+	// Server sends Heartbeats only during in-flight VRPCs. An idle session
+	// with an elapsed deadline must NOT be force-closed; the loop should
+	// keep checking until activity returns.
+	s, _ := makeActive(t, SessionHooks{})
+	s.heartbeatIntervalNano.Store(int64(20 * time.Millisecond)) // make idle re-check fast
+	s.nextHeartbeatDeadlineNano.Store(time.Now().Add(-time.Hour).UnixNano())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go func() {
+		s.heartBeatLoop(ctx)
+		close(done)
+	}()
+
+	// Give the loop time to wake up several times on the idle interval.
+	time.Sleep(150 * time.Millisecond)
+	if s.State() == StateClosed {
+		t.Fatal("idle session was force-closed despite having no in-flight VRPCs")
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("heartBeatLoop did not exit on ctx cancel")
+	}
+}
+
+func TestHeartBeatLoop_ExitsOnCtxCancel(t *testing.T) {
+	s, _ := makeActive(t, SessionHooks{})
+	s.nextHeartbeatDeadlineNano.Store(time.Now().Add(time.Hour).UnixNano()) // never expires
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		s.heartBeatLoop(ctx)
+		close(done)
+	}()
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("heartBeatLoop did not exit on ctx cancel")
+	}
+	if s.State() != StateReady {
+		t.Errorf("state = %v, want StateReady (no force-close on ctx exit)", s.State())
+	}
+}
+
+// --- AfeID -------------------------------------------------------------------
+
+func TestSessionAfeID(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		peerInfo *spb.PeerInfo
+		want     afeID
+	}{
+		{"nil-peer-info", nil, 0},
+		{"empty-afe-id", &spb.PeerInfo{}, 0},
+		{"set-afe-id", &spb.PeerInfo{ApplicationFrontendId: 4242}, 4242},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newTestSession(t, newFakeStream(), SessionHooks{})
+			if tc.peerInfo != nil {
+				s.peerInfo.Store(tc.peerInfo)
+			}
+			if got := s.AfeID(); got != tc.want {
+				t.Errorf("AfeID() = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+// --- peerInfoExtracter -------------------------------------------------------
+
+func TestPeerInfoExtracter_ParsesValidHeader(t *testing.T) {
+	pi := &spb.PeerInfo{
+		ApplicationFrontendSubzone: "us-central1-a",
+		TransportType:              spb.PeerInfo_TRANSPORT_TYPE_DIRECT_ACCESS,
+	}
+	raw, err := proto.Marshal(pi)
+	if err != nil {
+		t.Fatalf("proto.Marshal: %v", err)
+	}
+	// Server uses URL-safe base64. Java's Base64.getUrlEncoder() emits
+	// padded output; RawURLEncoding emits unpadded. Extracter must
+	// accept both — the padded case is what live traffic sends.
+	cases := []struct {
+		name    string
+		encoded string
+	}{
+		{"raw_url_unpadded", base64.RawURLEncoding.EncodeToString(raw)},
+		{"url_padded", base64.URLEncoding.EncodeToString(raw)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newTestSession(t, newFakeStream(), SessionHooks{})
+			s.peerInfoExtracter([]string{tc.encoded})
+			got := s.PeerInfo()
+			if got == nil {
+				t.Fatal("PeerInfo nil after extraction")
+			}
+			if got.GetApplicationFrontendSubzone() != "us-central1-a" {
+				t.Errorf("AFE = %q, want us-central1-a", got.GetApplicationFrontendSubzone())
+			}
+			if got.GetTransportType() != spb.PeerInfo_TRANSPORT_TYPE_DIRECT_ACCESS {
+				t.Errorf("TransportType = %v, want DIRECT_ACCESS", got.GetTransportType())
+			}
+		})
+	}
+}
+
+func TestPeerInfoExtracter_EmptyAndBadInputs(t *testing.T) {
+	s := newTestSession(t, newFakeStream(), SessionHooks{})
+
+	s.peerInfoExtracter(nil)
+	s.peerInfoExtracter([]string{})
+	if s.PeerInfo() != nil {
+		t.Error("PeerInfo should remain nil for empty input")
+	}
+
+	s.peerInfoExtracter([]string{"!!!not-base64!!!"})
+	if s.PeerInfo() != nil {
+		t.Error("PeerInfo should remain nil for undecodable input")
+	}
+}
+
+// --- Start integration -------------------------------------------------------
+
+func TestStart_HandshakeAndClose(t *testing.T) {
+	stream := newFakeStream()
+	listener := &hookCounts{}
+	s := newTestSession(t, stream, listener.hooks())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := s.Start(ctx, &spb.OpenSessionRequest{ProtocolVersion: 1}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	waitFor(t, time.Second, func() bool { _, _, _ = listener.counts(); start, _, _ := listener.counts(); return start == 1 }, "OnStart")
+
+	// Initial Open frame sent.
+	if sent := stream.snapshotSent(); len(sent) != 1 || sent[0].GetOpenSession() == nil {
+		t.Fatalf("expected OpenSession frame as first send, got %d frames", len(sent))
+	}
+
+	// Deliver the OpenSession response, then EOF.
+	stream.recv <- recvOp{resp: &spb.SessionResponse{
+		Payload: &spb.SessionResponse_OpenSession{OpenSession: &spb.OpenSessionResponse{}},
+	}}
+	waitFor(t, time.Second, func() bool { return s.State() == StateReady }, "StateReady")
+	if _, active, _ := listener.counts(); active != 1 {
+		t.Errorf("OnActive fired %d times, want 1", active)
+	}
+
+	stream.recv <- recvOp{err: fmt.Errorf("server EOF")}
+	// Wait for BOTH the state transition and the OnClose hook — they're
+	// sequenced inside handleClose but not atomic, so a check on state
+	// alone races the hook fire.
+	waitFor(t, time.Second, func() bool {
+		_, _, closed := listener.counts()
+		return s.State() == StateClosed && closed == 1
+	}, "StateClosed + OnClose after EOF")
+}
+
+func TestStart_RejectsIfNotNew(t *testing.T) {
+	s, _ := makeActive(t, SessionHooks{})
+	if err := s.Start(context.Background(), &spb.OpenSessionRequest{}); err == nil {
+		t.Error("Start on active session should return error")
+	}
+}

--- a/bigtable/internal/transport/session_tracer.go
+++ b/bigtable/internal/transport/session_tracer.go
@@ -1,0 +1,312 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	spb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
+	metrics "cloud.google.com/go/bigtable/internal/metrics"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"google.golang.org/grpc/status"
+)
+
+// Session-scoped histograms. They are registered once at process startup via
+// InitializeSessionMetrics and shared across every session.
+var (
+	sessionDurations     metric.Float64Histogram
+	sessionOpenLatencies metric.Float64Histogram
+	sessionUptime        metric.Float64Histogram
+	// transportLatencies is per-vRPC (not per-session-lifecycle), but shares
+	// the same meter + registration path so all session-adjacent metrics
+	// initialize together — matches java-bigtable's MetricRegistry layout.
+	transportLatencies metric.Float64Histogram
+
+	sessionMetricsOnce sync.Once
+	sessionMetricsErr  error
+)
+
+// FineGrainLatencyBounds matches java-bigtable's
+// AGGREGATION_WITH_MILLIS_HISTOGRAM: fine sub-ms + coarse tail. Shared
+// by transport_latencies and attempt_latencies2.
+var FineGrainLatencyBounds = []float64{
+	// Linear 0 → 3ms by 0.1ms (31 boundaries): fine-grained sub-ms.
+	0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9,
+	1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9,
+	2.0, 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 2.8, 2.9, 3.0,
+	// Coarse 4ms → 80ms.
+	4.0, 5.0, 6.0, 8.0, 10.0, 13.0, 16.0, 20.0, 25.0, 30.0, 40.0, 50.0, 65.0, 80.0,
+	// Coarse 100ms → 900ms.
+	100.0, 130.0, 160.0, 200.0, 250.0, 300.0, 400.0, 500.0, 650.0, 800.0, 900.0,
+	// Coarse 1s → 50s.
+	1000.0, 2000.0, 3000.0, 4000.0, 5000.0, 6000.0, 10000.0, 20000.0, 50000.0,
+	// Long tail: 100s → 5000s (~83 min).
+	100000.0, 200000.0, 500000.0, 1000000.0, 2000000.0, 5000000.0,
+}
+
+// InitializeSessionMetrics registers the session histograms against the given
+// meter provider. It runs at most once for the lifetime of the process;
+// subsequent calls (with any provider, including nil) return the result of
+// the first call. Passing nil on the first call leaves the histograms unset
+// and returns nil.
+func InitializeSessionMetrics(meterProvider metric.MeterProvider) error {
+	sessionMetricsOnce.Do(func() {
+		if meterProvider == nil {
+			return
+		}
+		meter := meterProvider.Meter(clientMeterName)
+
+		var err error
+		if sessionDurations, err = meter.Float64Histogram(
+			"session.durations",
+			metric.WithDescription("Duration a session was alive (openedAt → close)"),
+			metric.WithUnit("ms"),
+		); err != nil {
+			sessionMetricsErr = fmt.Errorf("create session.durations histogram: %w", err)
+			return
+		}
+		if sessionOpenLatencies, err = meter.Float64Histogram(
+			"session.open_latencies",
+			metric.WithDescription("Latency to open a session"),
+			metric.WithUnit("ms"),
+		); err != nil {
+			sessionMetricsErr = fmt.Errorf("create session.open_latencies histogram: %w", err)
+			return
+		}
+		if sessionUptime, err = meter.Float64Histogram(
+			"session.uptime",
+			metric.WithDescription("Age of currently-active sessions, sampled periodically"),
+			metric.WithUnit("ms"),
+		); err != nil {
+			sessionMetricsErr = fmt.Errorf("create session.uptime histogram: %w", err)
+			return
+		}
+		if transportLatencies, err = meter.Float64Histogram(
+			"transport_latencies",
+			metric.WithDescription("The latency measured from e2e latencies minus node latencies."),
+			metric.WithUnit("ms"),
+			metric.WithExplicitBucketBoundaries(FineGrainLatencyBounds...),
+		); err != nil {
+			sessionMetricsErr = fmt.Errorf("create transport_latencies histogram: %w", err)
+			return
+		}
+		if err = registerDebugTagCounter(meter); err != nil {
+			sessionMetricsErr = err
+			return
+		}
+	})
+	return sessionMetricsErr
+}
+
+// sessionTracer tracks and records metrics for a Session's lifecycle and
+// individual operations. poolName is a pool-scoped identifier stamped on
+// the session_name metric label — matches java-bigtable's SessionPoolInfo
+// name semantics (bounded cardinality, one per pool per process), NOT the
+// per-session logName (which lives on Session and is unbounded).
+type sessionTracer struct {
+	mu          sync.Mutex
+	startTime   time.Time
+	openedAt    time.Time
+	peerInfo    *spb.PeerInfo
+	poolName    string
+	sessionType SessionType
+}
+
+// newSessionTracer starts the "open" timer.
+func newSessionTracer(sessionType SessionType) *sessionTracer {
+	return &sessionTracer{
+		startTime:   time.Now(),
+		sessionType: sessionType,
+	}
+}
+
+// setPoolName stamps the pool-scoped name used for the session_name label
+// on every emitted metric. Called from WithSessionPoolName during
+// NewSession.
+func (t *sessionTracer) setPoolName(name string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.poolName = name
+}
+
+// openedAtSnapshot returns the cached open timestamp under the lock so
+// callers don't read a torn value.
+func (t *sessionTracer) openedAtSnapshot() time.Time {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.openedAt
+}
+
+func (t *sessionTracer) setPeerInfo(peerInfo *spb.PeerInfo) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.peerInfo = peerInfo
+}
+
+// snapshot captures the fields we need under the lock so that we can do
+// allocating work (string formatting, attribute builds) without holding it.
+type tracerSnapshot struct {
+	startTime     time.Time
+	openedAt      time.Time
+	transportType string
+	afeLocation   string
+	poolName      string
+}
+
+func (t *sessionTracer) snapshot() tracerSnapshot {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	snap := tracerSnapshot{
+		startTime:     t.startTime,
+		openedAt:      t.openedAt,
+		poolName:      t.poolName,
+		transportType: "unknown",
+	}
+	if t.peerInfo != nil {
+		snap.transportType = metrics.TransportTypeName(t.peerInfo.GetTransportType())
+		snap.afeLocation = t.peerInfo.GetApplicationFrontendSubzone()
+	}
+	return snap
+}
+
+// recordOpen records the latency to open the session and stamps openedAt for
+// uptime accounting.
+func (t *sessionTracer) recordOpen(ctx context.Context, err error) {
+	t.mu.Lock()
+	t.openedAt = time.Now()
+	startedAt := t.startTime
+	t.mu.Unlock()
+
+	if sessionOpenLatencies == nil {
+		return
+	}
+	snap := t.snapshot()
+	statusStr := "OK"
+	if err != nil {
+		statusStr = status.Code(err).String()
+	}
+	sessionOpenLatencies.Record(ctx, msSince(startedAt), metric.WithAttributes(
+		attribute.String("transport_type", snap.transportType),
+		attribute.String("status", statusStr),
+		attribute.String("session_type", t.sessionType.String()),
+		attribute.String("afe_location", snap.afeLocation),
+		attribute.String("session_name", snap.poolName),
+	))
+}
+
+// recordClose records the session's total elapsed time on close.
+//   - closingReason: the terminal Session.CloseReason(), or "" if none.
+//   - streamErr: the terminal stream error; nil means clean close ("OK").
+//   - hadOk / hadErr: whether the session served any OK / error vRPCs.
+//
+// For sessions that reached Active (openedAt set), duration is openedAt→now
+// and ready=true. For sessions that never opened, duration is startTime→now
+// and ready=false — matches java-bigtable SessionTracerImpl.onClose, which
+// records the metric for pre-open sessions too.
+func (t *sessionTracer) recordClose(ctx context.Context, closingReason string, streamErr error, hadOk, hadErr bool) {
+	if sessionDurations == nil {
+		return
+	}
+	snap := t.snapshot()
+
+	ready := !snap.openedAt.IsZero()
+	var elapsed float64
+	if ready {
+		elapsed = msSince(snap.openedAt)
+	} else if !snap.startTime.IsZero() {
+		elapsed = msSince(snap.startTime)
+	}
+
+	statusStr := "OK"
+	if streamErr != nil {
+		statusStr = status.Code(streamErr).String()
+	}
+
+	sessionDurations.Record(ctx, elapsed, metric.WithAttributes(
+		attribute.String("transport_type", snap.transportType),
+		attribute.String("status", statusStr),
+		attribute.String("session_type", t.sessionType.String()),
+		attribute.String("closing_reason", closingReason),
+		attribute.String("vrpcs", vrpcCloseState(hadOk, hadErr)),
+		attribute.Bool("ready", ready),
+		attribute.String("afe_location", snap.afeLocation),
+		attribute.String("session_name", snap.poolName),
+	))
+}
+
+// vrpcCloseState mirrors java-bigtable's SessionCloseVRpcState.find —
+// (hadOk, hadErr) → {none, all_ok, all_error, some_ok}. The labels match
+// Java exactly so cross-language dashboards work.
+func vrpcCloseState(hadOk, hadErr bool) string {
+	switch {
+	case hadOk && hadErr:
+		return "some_ok"
+	case hadOk:
+		return "all_ok"
+	case hadErr:
+		return "all_error"
+	default:
+		return "none"
+	}
+}
+
+// sampleUptime records the current alive time (openedAt → now) of a
+// still-active session into sessionUptime. Called periodically from the
+// pool heartbeat so the histogram represents the distribution of ages
+// across currently-active sessions.
+func (t *sessionTracer) sampleUptime(ctx context.Context) {
+	if sessionUptime == nil {
+		return
+	}
+	snap := t.snapshot()
+	if snap.openedAt.IsZero() {
+		return
+	}
+	sessionUptime.Record(ctx, msSince(snap.openedAt), metric.WithAttributes(
+		attribute.String("transport_type", snap.transportType),
+		attribute.String("session_type", t.sessionType.String()),
+		attribute.Bool("ready", true),
+		attribute.String("afe_location", snap.afeLocation),
+		attribute.String("session_name", snap.poolName),
+	))
+}
+
+func msSince(t time.Time) float64 {
+	return float64(time.Since(t)) / float64(time.Millisecond)
+}
+
+// recordTransportOverhead emits a per-vRPC (stream − backend) sample into
+// the transport_latencies histogram. Java's ClientTransportLatency defines
+// this metric as "e2e latencies minus node latencies" — the wire + AFE
+// overhead outside server processing. Caller has already validated the
+// delta is positive; this is a no-op if the metric isn't registered.
+// Method is the vRPC method name (e.g. "ExecuteVRpc/Read").
+func (t *sessionTracer) recordTransportOverhead(ctx context.Context, method string, overhead time.Duration) {
+	if transportLatencies == nil || overhead <= 0 {
+		return
+	}
+	snap := t.snapshot()
+	transportLatencies.Record(ctx, float64(overhead)/float64(time.Millisecond), metric.WithAttributes(
+		attribute.String("transport_type", snap.transportType),
+		attribute.String("session_type", t.sessionType.String()),
+		attribute.String("afe_location", snap.afeLocation),
+		attribute.String("session_name", snap.poolName),
+		attribute.String("method", method),
+	))
+}

--- a/bigtable/internal/transport/session_vrpc.go
+++ b/bigtable/internal/transport/session_vrpc.go
@@ -1,0 +1,395 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	spb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// InvokeResult carries the full set of outputs from a single Invoke call.
+//
+// Fields:
+//   - Response: decoded vRPC payload (typed per VRpcDescriptor.Decode); nil on error.
+//   - ClusterInfo: server-reported routing/cluster identity; may be set on
+//     both success and error paths if the server included it.
+//   - Stats: server-reported per-request statistics (notably BackendLatency);
+//     nil if the server did not populate Stats on the success frame.
+//   - SentAt: local monotonic timestamp captured immediately before the vRPC
+//     frame was handed to the bidi Send. Used downstream to derive
+//     client-side blocking latency (sentAt - attemptStart).
+//
+// ErrorResponse.RetryInfo from the server is plumbed via the returned error
+// using gRPC status details — callers can extract it with
+// status.FromError(err).Details() and type-asserting to *errdetails.RetryInfo
+// (this is exactly how RetryingVRpc already consumes it).
+type InvokeResult struct {
+	Response    interface{}
+	ClusterInfo *spb.ClusterInformation
+	Stats       *spb.SessionRequestStats
+	SentAt      time.Time
+	// PeerInfo is the serving session's parsed peer info (from the
+	// bigtable-peer-info header the server sent on session open). Bound to
+	// the session, not this specific vRPC — every InvokeResult on the same
+	// session carries the same pointer. Populated by SessionPoolImpl.Invoke;
+	// nil when the pool bypassed a session (checkout failure). Feeds the
+	// outer metrics tracer's transport_type / transport_region /
+	// transport_zone / transport_subzone attributes on attempt_latencies2.
+	PeerInfo *spb.PeerInfo
+	// RpcIDOnSession is the per-session monotonic id of this call
+	// (1, 2, 3, …). Distinguishes warm-up vRPCs (small id) from
+	// established-session vRPCs.
+	RpcIDOnSession int64
+	// TransportLatency is the time between the vRPC frame being handed
+	// to the bidi Send and the response (or server-side error) arriving
+	// on the stream. Approximates network RTT + server queue + Backend;
+	// (TransportLatency - BackendLatency) surfaces "everything except
+	// server processing". Zero when Invoke returned before a Recv event
+	// (context cancellation or pre-Send failure).
+	TransportLatency time.Duration
+}
+
+// Invoke executes a single virtual RPC on this session and returns every
+// observable output of the roundtrip — decoded response, cluster info,
+// server-reported Stats, and the local SentAt timestamp — so callers can
+// populate metrics (client_blocking_latency, server_backend_latency) and
+// respect server-supplied retry hints without losing data on the way out of
+// the transport.
+//
+// The caller MUST have exclusive access to this Session for the duration
+// of the call — the pool guarantees this via CheckoutSession's per-session
+// idle-slot gate. The single-in-flight invariant is enforced with a
+// CompareAndSwap on activeRPC; a failing CAS means the caller bypassed
+// the pool gate and is a programming error, not a runtime condition. This
+// replaces a golang.org/x/sync/semaphore that added two channel ops per
+// call on the hot path.
+func (s *Session) Invoke(ctx context.Context, desc VRpcDescriptor, req interface{}) (result InvokeResult, err error) {
+	startTime := time.Now()
+
+	if st := State(s.state.Load()); st != StateReady {
+		return result, tagErr(StateUncommitted,
+			unavailable(ErrSessionNotActive, "session is not active (state: %v)", st))
+	}
+
+	reqBytes, err := desc.Encode(req)
+	if err != nil {
+		return result, tagErr(StateUncommitted, fmt.Errorf("encode vRPC request: %w", err))
+	}
+
+	rpcID := s.nextRPCID.Add(1)
+	result.RpcIDOnSession = rpcID
+	rpc := &vrpcImpl{
+		id:         rpcID,
+		method:     desc.Method(),
+		resultChan: make(chan vrpcResult, 1),
+	}
+
+	// Claim the single in-flight slot. See method doc — a losing CAS is
+	// a caller-side serialization bug, not a runtime backoff condition.
+	if !s.activeRPC.CompareAndSwap(nil, rpc) {
+		return result, tagErr(StateUncommitted,
+			unavailable(ErrSessionNotActive,
+				"concurrent Invoke on session %q: multiPlexingLimit=1 violated", s.logName))
+	}
+	defer s.releaseSlot(rpc)
+
+	// Reset the heartbeat deadline whenever we send an outbound frame: the
+	// server's keepalive clock is implicitly reset by our activity.
+	s.resetHeartbeatDeadline()
+
+	attempt := currentAttempt(ctx)
+	if attempt > 1 {
+		s.noteRetryAttempt(ctx, desc.Method(), attempt)
+	}
+	sessionReq := buildInvokeRequest(rpcID, reqBytes, attempt, startTime, ctx)
+
+	// Capture SentAt immediately before the frame is handed to Send so
+	// downstream metrics can compute client-side blocking latency as
+	// (SentAt - attemptStart) without double-counting encode/setup overhead.
+	result.SentAt = time.Now()
+	if err := s.Send(sessionReq); err != nil {
+		// Send returning error means the frame did not reach the wire,
+		// so the server saw nothing. StateUncommitted lets the retry
+		// interceptor retry even non-idempotent ops (Java parity —
+		// java-bigtable classifies pre-wire Send errors as Uncommitted).
+		return result, tagErr(StateUncommitted, fmt.Errorf("send vRPC request: %w", err))
+	}
+
+	err = s.awaitInvokeResult(ctx, rpc, desc, &result)
+	return result, err
+}
+
+// releaseSlot clears the active-RPC slot and signals quiescence when the
+// session is closing. Runs from Invoke's defer; safe to call after any
+// completion path (success, error, cancel, panic).
+//
+// Order matters: clear the slot first, THEN check state. Close()
+// transitions to StateClosing first and only then observes activeRPC —
+// so at least one side signals. signalQuiescent is once-guarded, so a
+// double-signal is harmless.
+func (s *Session) releaseSlot(rpc *vrpcImpl) {
+	s.activeRPC.CompareAndSwap(rpc, nil)
+	if State(s.state.Load()) == StateClosing {
+		s.signalQuiescent()
+	}
+}
+
+// currentAttempt reads the retry-interceptor's attempt tag from ctx. Calls
+// that bypass RetryingVRpc have no tag; treat them as attempt 1.
+func currentAttempt(ctx context.Context) int64 {
+	if a := int64(VRpcAttempt(ctx)); a > 0 {
+		return a
+	}
+	return 1
+}
+
+// noteRetryAttempt bumps the per-session retries counter and — if the
+// retry interceptor stashed the prior attempt's error on ctx — emits a
+// debug + sessionz event tagged with the prior gRPC code so operators
+// can trace WHY the retry fired without cross-referencing logs.
+func (s *Session) noteRetryAttempt(ctx context.Context, method string, attempt int64) {
+	s.retries.Add(1)
+	prev := PrevAttemptErr(ctx)
+	if prev == nil {
+		return
+	}
+	prevCode := status.Code(prev).String()
+	s.debugf("retry attempt=%d method=%s prev_code=%s prev_err=%v",
+		attempt, method, prevCode, prev)
+	s.recordEvent("retry", "attempt=%d method=%s prev_code=%s prev_err=%v",
+		attempt, method, prevCode, prev)
+}
+
+// buildInvokeRequest constructs the wire-level SessionRequest envelope
+// for a single vRPC attempt. Pure — no I/O, no side effects. The
+// VirtualRpc.Deadline field carries the remaining budget as a duration
+// so the server measures from receive time rather than an absolute wall
+// clock. Omitted when ctx has no deadline or the budget is already
+// non-positive (the client-side ctx.Done branch will fire immediately).
+func buildInvokeRequest(rpcID int64, reqBytes []byte, attempt int64, startTime time.Time, ctx context.Context) *spb.SessionRequest {
+	virtRpc := &spb.VirtualRpcRequest{
+		RpcId:   rpcID,
+		Payload: reqBytes,
+		Metadata: &spb.VirtualRpcRequest_Metadata{
+			AttemptNumber: attempt,
+			AttemptStart:  timestamppb.New(startTime),
+		},
+	}
+	if deadline, ok := ctx.Deadline(); ok {
+		if remaining := time.Until(deadline); remaining > 0 {
+			virtRpc.Deadline = durationpb.New(remaining)
+		}
+	}
+	return &spb.SessionRequest{
+		Payload: &spb.SessionRequest_VirtualRpc{VirtualRpc: virtRpc},
+	}
+}
+
+// awaitInvokeResult blocks until either ctx cancels or the server
+// delivers a result on rpc.resultChan. Populates the tail of result
+// (TransportLatency, ClusterInfo, Stats, Response) and returns a
+// fully-tagged error on failure. res.err from resultChan is already
+// tagged StateTransportFailure at the source (cancelActiveRPCs); server
+// error frames arrive as res.errResp and are unpacked here into a
+// StateServerResult-tagged error.
+func (s *Session) awaitInvokeResult(ctx context.Context, rpc *vrpcImpl, desc VRpcDescriptor, result *InvokeResult) error {
+	select {
+	case <-ctx.Done():
+		s.recordCtxDone(ctx, rpc, desc.Method(), result.SentAt)
+		return tagErr(StateTransportFailure, ctx.Err())
+	case res := <-rpc.resultChan:
+		result.TransportLatency = time.Since(result.SentAt)
+		ci := res.ClusterInfo()
+		result.ClusterInfo = ci
+		if ci != nil {
+			s.recordCluster(ci.GetClusterId())
+		}
+		if res.err != nil {
+			return res.err
+		}
+		if res.errResp != nil {
+			return tagErr(StateServerResult, errorResponseToErr(res.errResp))
+		}
+		if res.resp == nil {
+			// deliver() only publishes a vrpcResult when at least one of
+			// {resp, errResp, err} is set; a zero-value slip through here
+			// is a bookkeeping bug rather than a server-side event.
+			return tagErr(StateServerResult, fmt.Errorf("internal: received empty vRPC result"))
+		}
+		if res.resp.RpcId != rpc.id {
+			// This is a bookkeeping bug: deliver() only publishes into
+			// resultChan for the matching activeRPC, so a mismatch here
+			// means state got out from under us. Counter separate from
+			// handleVRPC*'s id-mismatch tag so we can distinguish "wrong
+			// response reached deliver" from "wrong response dropped
+			// earlier."
+			recordDebugTagAt(lvl.Error, tagSessionVRPCIDMismatch)
+			return tagErr(StateServerResult,
+				fmt.Errorf("internal: response RpcId %d does not match request RpcId %d", res.resp.RpcId, rpc.id))
+		}
+		respMsg, decodeErr := desc.Decode(res.resp.Payload)
+		if decodeErr != nil {
+			return tagErr(StateServerResult, fmt.Errorf("decode vRPC response: %w", decodeErr))
+		}
+		result.Response = respMsg
+		result.Stats = res.resp.Stats
+		if res.resp.Stats != nil && res.resp.Stats.BackendLatency != nil {
+			s.recordLatency(res.resp.Stats.BackendLatency.AsDuration())
+		}
+		return nil
+	}
+}
+
+// recordCtxDone emits the debug + sessionz event for a ctx cancellation
+// or deadline fire while a vRPC was in flight. Captures whether the RPC
+// was still holding the slot at cancel time — useful for spotting races
+// between our cancel and a late server response.
+func (s *Session) recordCtxDone(ctx context.Context, rpc *vrpcImpl, method string, sentAt time.Time) {
+	stillActive := s.activeRPC.Load() == rpc
+	sessState := State(s.state.Load())
+	waited := time.Since(sentAt)
+	peer := s.peerInfoSummary()
+	s.debugf("vRPC %s rpc_id=%d ctx.Done waited=%v err=%v session_state=%v still_in_flight=%v %s",
+		method, rpc.id, waited, ctx.Err(), sessState, stillActive, peer)
+	s.recordEvent("ctx-done", "method=%s rpc_id=%d waited=%v err=%v session_state=%v still_in_flight=%v %s",
+		method, rpc.id, waited, ctx.Err(), sessState, stillActive, peer)
+}
+
+// handleVRPCResponse delivers a server VirtualRpcResponse to the waiting
+// Invoke caller, if any.
+func (s *Session) handleVRPCResponse(resp *spb.VirtualRpcResponse) {
+	if resp == nil {
+		return
+	}
+	// A vRPC response is only expected while the session is Ready or
+	// Closing (drain window). Any other state means either a bug in
+	// state tracking or a server retransmit after teardown — drop.
+	st := s.State()
+	if !assertDebugTagf(st == StateReady || st == StateClosing, tagSessionVRPCResponseWrongState,
+		"vRPC response for rpc_id=%d arrived in state %s", resp.RpcId, st) {
+		return
+	}
+	rpc := s.activeRPC.Load()
+	if rpc == nil {
+		recordDebugTag(tagSessionVRPCNil)
+		s.debugf("dropping VirtualRpcResponse for rpc_id=%d — no in-flight RPC tracked", resp.RpcId)
+		return
+	}
+	if rpc.id != resp.RpcId {
+		recordDebugTag(tagSessionVRPCIDMismatch)
+		s.debugf("dropping VirtualRpcResponse rpc_id=%d != in-flight rpc_id=%d", resp.RpcId, rpc.id)
+		return
+	}
+	s.okRpcs.Add(1)
+	if !s.deliver(rpc, vrpcResult{resp: resp}) {
+		recordDebugTag(tagSessionVRPCDuplicateResult)
+	}
+}
+
+// handleVRPCErrorResponse routes per-vRPC errors to the waiting caller.
+// Session-level errors (rpc_id == 0) are handled in handleSessionResponse.
+func (s *Session) handleVRPCErrorResponse(errResp *spb.ErrorResponse) {
+	if errResp == nil {
+		return
+	}
+	st := s.State()
+	if !assertDebugTagf(st == StateReady || st == StateClosing, tagSessionVRPCResponseWrongState,
+		"vRPC error for rpc_id=%d arrived in state %s", errResp.RpcId, st) {
+		return
+	}
+	rpc := s.activeRPC.Load()
+	if rpc == nil {
+		recordDebugTag(tagSessionVRPCErrorNil)
+		s.debugf("dropping ErrorResponse for rpc_id=%d — no in-flight RPC tracked", errResp.RpcId)
+		return
+	}
+	if rpc.id != errResp.RpcId {
+		recordDebugTag(tagSessionVRPCIDMismatch)
+		s.debugf("dropping ErrorResponse rpc_id=%d != in-flight rpc_id=%d", errResp.RpcId, rpc.id)
+		return
+	}
+	s.errorRpcs.Add(1)
+	if !s.deliver(rpc, vrpcResult{errResp: errResp}) {
+		recordDebugTag(tagSessionVRPCDuplicateResult)
+	}
+}
+
+// errorResponseToErr converts a server ErrorResponse frame into a Go
+// error carrying the gRPC status code and any RetryInfo the server
+// attached. RetryInfo is packed into the status details so downstream
+// consumers (notably RetryingVRpc) can recover it via status.FromError.
+// WithDetails returns a fresh *Status on success; on the rare failure
+// (e.g. anypb marshal) we fall back to the bare status so the error path
+// still propagates the server's code.
+func errorResponseToErr(errResp *spb.ErrorResponse) error {
+	if errResp.Status == nil {
+		return fmt.Errorf("unknown vRPC error (rpc_id=%d)", errResp.RpcId)
+	}
+	st := status.FromProto(errResp.Status)
+	if errResp.RetryInfo != nil {
+		if withDetails, derr := st.WithDetails(errResp.RetryInfo); derr == nil {
+			st = withDetails
+		}
+	}
+	return st.Err()
+}
+
+// deliver writes a result onto the RPC's buffered (cap 1) channel and
+// returns true. Returns false if the slot is already full (a duplicate
+// frame or a cancel racing a completion) — the first wins, subsequent
+// ones are dropped. Every default-branch drop is stamped into the
+// per-session event ring ("dup-deliver") so operators can see the race
+// in sessionz regardless of which caller lost. Callers on the
+// server-frame path additionally tag it as a metric
+// (tagSessionVRPCDuplicateResult); cancelActiveRPCs ignores false
+// because a filled slot means the completion already landed and no
+// metric warning is warranted.
+func (s *Session) deliver(rpc *vrpcImpl, res vrpcResult) bool {
+	select {
+	case rpc.resultChan <- res:
+		return true
+	default:
+		s.debugf("duplicate result for rpc_id=%d (%s) dropped", rpc.id, rpc.method)
+		s.recordEvent("dup-deliver", "rpc_id=%d method=%s dropped (channel full)", rpc.id, rpc.method)
+		return false
+	}
+}
+
+// cancelActiveRPCs cancels the in-flight vRPC (if any) with the given
+// error. With multiPlexingLimit=1 there is at most one such vRPC.
+// Clear-then-deliver so a racing handleVRPCResponse can't double-deliver
+// on the same slot.
+func (s *Session) cancelActiveRPCs(err error) {
+	rpc := s.activeRPC.Load()
+	if rpc == nil {
+		return
+	}
+	if !s.activeRPC.CompareAndSwap(rpc, nil) {
+		// Concurrent completion cleared the slot; the caller already
+		// received a result. Nothing to cancel.
+		return
+	}
+	// Session-side cancellation: session died / GoAway / heartbeat missed
+	// / benign shutdown while an RPC was in-flight. Server may or may not
+	// have processed — TransportFailure classification lets idempotent ops
+	// retry and prevents non-idempotent ones from double-applying.
+	s.deliver(rpc, vrpcResult{err: tagErr(StateTransportFailure, err)})
+}

--- a/bigtable/internal/transport/vrpc.go
+++ b/bigtable/internal/transport/vrpc.go
@@ -1,0 +1,101 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"context"
+)
+
+type contextKey struct{}
+
+type vrpcMetadata struct {
+	method  string
+	attempt int
+}
+
+// WithVRpcMetadata returns a new context with virtual RPC metadata set.
+func WithVRpcMetadata(ctx context.Context, method string, attempt int) context.Context {
+	return context.WithValue(ctx, contextKey{}, &vrpcMetadata{
+		method:  method,
+		attempt: attempt,
+	})
+}
+
+// WithAttempt returns a new context with the virtual RPC attempt updated.
+func WithAttempt(ctx context.Context, attempt int) context.Context {
+	if md, ok := ctx.Value(contextKey{}).(*vrpcMetadata); ok {
+		return context.WithValue(ctx, contextKey{}, &vrpcMetadata{
+			method:  md.method,
+			attempt: attempt,
+		})
+	}
+	return ctx
+}
+
+// VRpcMethod extracts the virtual RPC method name from the context.
+func VRpcMethod(ctx context.Context) string {
+	if md, ok := ctx.Value(contextKey{}).(*vrpcMetadata); ok {
+		return md.method
+	}
+	return ""
+}
+
+// VRpcAttempt extracts the virtual RPC attempt number (1-indexed) from the context.
+func VRpcAttempt(ctx context.Context) int {
+	if md, ok := ctx.Value(contextKey{}).(*vrpcMetadata); ok {
+		return md.attempt
+	}
+	return 0
+}
+
+// prevAttemptErrKey carries the previous attempt's error across retry
+// boundaries inside RetryingVRpc. Lets the downstream Session.Invoke
+// observe what caused the retry so sessionz can record a "retry"
+// SessionEvent with the original gRPC code + message.
+type prevAttemptErrKey struct{}
+
+// WithPrevAttemptErr returns a derived context tagged with the prior
+// attempt's error. Set by RetryingVRpc immediately before invoking the
+// next attempt. A nil err clears the value.
+func WithPrevAttemptErr(ctx context.Context, err error) context.Context {
+	return context.WithValue(ctx, prevAttemptErrKey{}, err)
+}
+
+// PrevAttemptErr returns the previous attempt's error stashed by
+// WithPrevAttemptErr, or nil if this is the first attempt or the context
+// wasn't tagged.
+func PrevAttemptErr(ctx context.Context) error {
+	if err, ok := ctx.Value(prevAttemptErrKey{}).(error); ok {
+		return err
+	}
+	return nil
+}
+
+// Handler represents the core execution function of a virtual RPC downstream invocation.
+type Handler func(ctx context.Context, req interface{}) (interface{}, error)
+
+// Interceptor represents a decorator middleware that intercepts a virtual RPC downstream invocation.
+type Interceptor func(ctx context.Context, req interface{}, handler Handler) (interface{}, error)
+
+// VRpcTracer receives per-attempt lifecycle notifications from
+// RetryingVRpc. Matches Java's VRpcTracer role and the tracing/OTel
+// vocabulary — this is a passive observer, not an event subscription
+// (nothing is buffered or delivered asynchronously).
+type VRpcTracer interface {
+	// OnAttemptStart is called before a new attempt is executed.
+	OnAttemptStart(ctx context.Context)
+	// OnAttemptComplete is called after an attempt completes (with success or error).
+	OnAttemptComplete(ctx context.Context, err error)
+}

--- a/bigtable/internal/transport/vrpc_test.go
+++ b/bigtable/internal/transport/vrpc_test.go
@@ -1,0 +1,48 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"context"
+	"testing"
+)
+
+// TestVRpc_ContextMetadataRetention verifies that WithVRpcMetadata attaches
+// (method, attempt) to a ctx such that VRpcMethod / VRpcAttempt can recover
+// them, and that further wrapping with context.WithValue does not lose the
+// vRPC metadata. Guards against a regression where a custom context-key
+// scheme would only survive a single Get.
+func TestVRpc_ContextMetadataRetention(t *testing.T) {
+	ctx := WithVRpcMetadata(context.Background(), "QueryMethod", 42)
+
+	if got := VRpcMethod(ctx); got != "QueryMethod" {
+		t.Errorf("VRpcMethod = %q, want %q", got, "QueryMethod")
+	}
+	if got := VRpcAttempt(ctx); got != 42 {
+		t.Errorf("VRpcAttempt = %d, want %d", got, 42)
+	}
+
+	// Wrapping with context.WithValue (e.g. a standard tracing span setter)
+	// must not clobber the vRPC metadata.
+	type extraKey struct{}
+	wrapped := context.WithValue(ctx, extraKey{}, "extraValue")
+
+	if got := VRpcMethod(wrapped); got != "QueryMethod" {
+		t.Errorf("VRpcMethod (wrapped) = %q, want preserved %q", got, "QueryMethod")
+	}
+	if got := VRpcAttempt(wrapped); got != 42 {
+		t.Errorf("VRpcAttempt (wrapped) = %d, want preserved %d", got, 42)
+	}
+}


### PR DESCRIPTION
## Summary

Adds the behavior half of the Session — the lifecycle state machine, the vRPC dispatch path, and the fake-driven test suite that exercises both. Together with the struct + surface half (#20117) and the primitives (#20116), this completes the Session core.

- **`session_lifecycle.go`** — `Start`, `ForceClose`, `Close`, `Send`, `readLoop`, `heartBeatLoop`, `handleOpenSession` / `handleErrorResponse` / `handleGoAway` / `handleClose` / `handleSessionParameters`, `peerInfoExtracter`.
- **`session_vrpc.go`** — `Invoke`, `buildInvokeRequest`, `awaitInvokeResult`, `handleVRPCResponse` / `handleVRPCErrorResponse`, `deliver`, `cancelActiveRPCs`, `noteRetryAttempt`, `releaseSlot`.
- **`session_test.go`** — `fakeStream` / `fakeDesc` plus tests for `handleOpenSession`, `handleVRPC*`, `handleGoAway`, `handleErrorResponse`, `Invoke`, `ForceClose`, `Close`, `heartBeatLoop`, PeerInfo extraction, `AfeID`, `Start`.

**Part 3c of 3 in the Session core sub-split.** Stacks on:

1. #20116 — Session primitives (attempt_outcome, vrpc ctx, msgtype).
2. #20117 — Session struct, tracer, debug surface, picker slot.
3. #20115 — `metrics.TransportTypeName` export.
4. #20114 — debug tag counter.

Until those merge, the diff shown here includes their file changes. The "own" scope of this PR is 3 files under `bigtable/internal/transport/`.

## Review feedback folded in

All 8 findings from @gemini-code-assist on the previous revision (SHA `64e5d43c54`) are addressed in this rewrite:

- Fire `onStart` immediately after `transitionTo(StateStarting)` so the "`onStart` precedes `onClose`" invariant holds even when `Send` fails and `ForceClose` fires `onClose`. (findings on `session_lifecycle.go:46`, `session_lifecycle.go:59`)
- Nil-guard `handleErrorResponse`, `handleSessionParameters`, `handleVRPCResponse`, `handleVRPCErrorResponse`, and the `res.resp` branch in `awaitInvokeResult`; drop instead of panicking in the `readLoop` goroutine. (findings on `session_lifecycle.go:294`, `session_lifecycle.go:312`, `session_vrpc.go:227`, `session_vrpc.go:269`, `session_vrpc.go:297`)
- Retag pre-wire `Send` failures in `Invoke` as `StateUncommitted` (was `StateTransportFailure`) so the retry interceptor can retry non-idempotent ops when the frame never reached the server — Java parity with java-bigtable. (finding on `session_vrpc.go:130`)

## Java parity notes

- State enum values match Java (`SessionState`): `New`/`Starting`/`Ready`/`Closing`/`WaitServerClose`/`Closed`.
- Pre-wire `Send` errors classify as `StateUncommitted`, matching java-bigtable.
- `OK`-gated tracker updates for transport EWMA match `SessionList.java:181-187`.

## Follow-ups (in the queued order)

1. `RetryingVRpc` + retryable classifier that consumes `AttemptOutcome`.
2. `session_list.go` + AFE picker (uses `SessionHandle`).
3. Session pool + scaling + `session_snapshot.go`.
4. `ConfigurationManager` (rebase of #19986).
5. `SessionClient` / `SessionTable` factory.
6. `debugview` handler + per-view PRs (sessionz/afez/flightz/loadz/…).

## Test plan

- [x] `go build ./bigtable/...`
- [x] `go test ./bigtable/internal/transport/ -count=1 -short` — passes (4.5s)
- [x] `gofmt -l bigtable/internal/transport/` — clean
- [ ] CI: presubmit / conformance
