### PR TITLE
[1/5] refactor(bigtable/internal/metrics): export TransportTypeName

### DIFF
--- a/bigtable/internal/metrics/tracer.go
+++ b/bigtable/internal/metrics/tracer.go
@@ -575,7 +575,7 @@ func (mt *Tracer) RecordAttemptCompletion(attemptHeaderMD, attempTrailerMD metad
 	// on). Feeds the attempt_latencies2 metric only; other metrics stay on
 	// the classic label set. No-op when the header is absent.
 	if peerInfo, _ := extractPeerInfo(attemptHeaderMD, attempTrailerMD); peerInfo != nil {
-		mt.currOp.currAttempt.transportType = transportTypeName(peerInfo.GetTransportType())
+		mt.currOp.currAttempt.transportType = TransportTypeName(peerInfo.GetTransportType())
 		mt.currOp.currAttempt.transportRegion = peerInfo.GetApplicationFrontendRegion()
 		mt.currOp.currAttempt.transportZone = peerInfo.GetApplicationFrontendZone()
 		mt.currOp.currAttempt.transportSubZone = peerInfo.GetApplicationFrontendSubzone()

--- a/bigtable/internal/metrics/util.go
+++ b/bigtable/internal/metrics/util.go
@@ -208,11 +208,13 @@ func extractPeerInfo(headerMD metadata.MD, trailerMD metadata.MD) (*btpb.PeerInf
 	return &peerInfo, nil
 }
 
-// transportTypeName maps the PeerInfo transport type enum to the short
+// TransportTypeName maps the PeerInfo transport type enum to the short
 // label used in metric attributes and debug UIs (e.g. "cloudpath",
 // "session_directpath"). Prefer this over .String(), which yields the
-// verbose "TRANSPORT_TYPE_…" proto enum names.
-func transportTypeName(tt btpb.PeerInfo_TransportType) string {
+// verbose "TRANSPORT_TYPE_…" proto enum names. Exported so the transport
+// package's session tracer + debug surfaces share the same mapping
+// without duplicating the switch.
+func TransportTypeName(tt btpb.PeerInfo_TransportType) string {
 	switch tt {
 	case btpb.PeerInfo_TRANSPORT_TYPE_EXTERNAL:
 		return "external"


### PR DESCRIPTION
## Summary

Renames `transportTypeName` → `TransportTypeName` in `bigtable/internal/metrics/util.go` and updates its one caller in `tracer.go`. Zero behavior change.

**Motivation.** The upcoming Session core PR needs the same `PeerInfo.TransportType` → short-label mapping (`"cloudpath"`, `"session_directpath"`, …) in the transport package's session tracer, `session_debug`, and `session_lifecycle`. Exporting the existing helper is strictly cheaper than duplicating the 15-line switch in a second package.

No import cycle: `metrics` does not import `transport`, and `transport` does not currently import `metrics`.

**Part 1/3 of the Session core PR split.** Replaces the withdrawn #20113 (which duplicated the helper before I realized it already existed).

## Test plan

- [x] `go build ./bigtable/...`
- [x] `go vet ./bigtable/internal/metrics/...`
- [x] `go test ./bigtable/internal/metrics/... -short` — pass (1.0s)
- [ ] CI: presubmit