### PR TITLE
feat(bigtable): add Session primitives (AttemptOutcome, vRPC ctx, msgtype)

### DIFF
--- a/bigtable/internal/metrics/tracer.go
+++ b/bigtable/internal/metrics/tracer.go
@@ -575,7 +575,7 @@ func (mt *Tracer) RecordAttemptCompletion(attemptHeaderMD, attempTrailerMD metad
 	// on). Feeds the attempt_latencies2 metric only; other metrics stay on
 	// the classic label set. No-op when the header is absent.
 	if peerInfo, _ := extractPeerInfo(attemptHeaderMD, attempTrailerMD); peerInfo != nil {
-		mt.currOp.currAttempt.transportType = transportTypeName(peerInfo.GetTransportType())
+		mt.currOp.currAttempt.transportType = TransportTypeName(peerInfo.GetTransportType())
 		mt.currOp.currAttempt.transportRegion = peerInfo.GetApplicationFrontendRegion()
 		mt.currOp.currAttempt.transportZone = peerInfo.GetApplicationFrontendZone()
 		mt.currOp.currAttempt.transportSubZone = peerInfo.GetApplicationFrontendSubzone()

--- a/bigtable/internal/metrics/util.go
+++ b/bigtable/internal/metrics/util.go
@@ -208,11 +208,13 @@ func extractPeerInfo(headerMD metadata.MD, trailerMD metadata.MD) (*btpb.PeerInf
 	return &peerInfo, nil
 }
 
-// transportTypeName maps the PeerInfo transport type enum to the short
+// TransportTypeName maps the PeerInfo transport type enum to the short
 // label used in metric attributes and debug UIs (e.g. "cloudpath",
 // "session_directpath"). Prefer this over .String(), which yields the
-// verbose "TRANSPORT_TYPE_…" proto enum names.
-func transportTypeName(tt btpb.PeerInfo_TransportType) string {
+// verbose "TRANSPORT_TYPE_…" proto enum names. Exported so the transport
+// package's session tracer + debug surfaces share the same mapping
+// without duplicating the switch.
+func TransportTypeName(tt btpb.PeerInfo_TransportType) string {
 	switch tt {
 	case btpb.PeerInfo_TRANSPORT_TYPE_EXTERNAL:
 		return "external"

--- a/bigtable/internal/transport/attempt_outcome.go
+++ b/bigtable/internal/transport/attempt_outcome.go
@@ -1,0 +1,113 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import "errors"
+
+// AttemptState classifies how far a single vRPC attempt progressed before
+// terminating. RetryingVRpc consumes this instead of raw gRPC codes so
+// retry decisions match Java's VRpc.VRpcResult.State semantics:
+//
+//   - Uncommitted: safe to retry unconditionally (server saw nothing).
+//   - TransportFailure: safe only for idempotent ops (server may have applied).
+//   - ServerResult: retry only if the server explicitly permits it via
+//     RetryInfo, or the code is in the narrowed always-retryable set.
+type AttemptState int
+
+const (
+	// StateServerResult is the zero value: any bare error from a code
+	// path that hasn't yet adopted tagErr (or an error introduced by a
+	// non-vRPC layer) classifies here. Under the strict Java-parity
+	// default (see shouldRetryDefault in retrying.go) StateServerResult
+	// does NOT retry unless the server explicitly attached RetryInfo or
+	// the caller set RetryingOptions.ShouldRetry to override the whole
+	// classifier. Callers that need a permissive fallback must opt in.
+	StateServerResult AttemptState = iota
+	// StateUncommitted means the attempt never reached the wire — encode
+	// failed, session was Closing, etc. Retry is safe regardless of
+	// idempotency.
+	StateUncommitted
+	// StateTransportFailure means the frame was handed to the transport but
+	// we never observed a server response — the server may or may not have
+	// processed it. Retry only for idempotent ops.
+	StateTransportFailure
+)
+
+func (s AttemptState) String() string {
+	switch s {
+	case StateUncommitted:
+		return "Uncommitted"
+	case StateTransportFailure:
+		return "TransportFailure"
+	case StateServerResult:
+		return "ServerResult"
+	}
+	return "Unknown"
+}
+
+// AttemptOutcome pairs the classification with the underlying error so
+// callers can inspect both. Err is always non-nil for a failed attempt.
+type AttemptOutcome struct {
+	State AttemptState
+	Err   error
+}
+
+// vrpcErr wraps a raw error with its outcome so RetryingVRpc can classify
+// by state. Unwrap() exposes the underlying err so status.FromError(err) and
+// errors.Is(err, ...) continue to work for callers that don't know about
+// the wrapper.
+type vrpcErr struct {
+	outcome AttemptOutcome
+}
+
+func (e *vrpcErr) Error() string { return e.outcome.Err.Error() }
+func (e *vrpcErr) Unwrap() error { return e.outcome.Err }
+
+// tagErr wraps err with the given AttemptState. Returns nil for nil err so
+// call sites can compose without extra guards.
+func tagErr(state AttemptState, err error) error {
+	if err == nil {
+		return nil
+	}
+	return &vrpcErr{outcome: AttemptOutcome{State: state, Err: err}}
+}
+
+// TagErr wraps err with the given AttemptState so callers outside this
+// package can produce errors that carry the same classifier hint the
+// real transport attaches. Intended for test doubles / fakes that stand
+// in for a Session or a SessionPool: production errors from Session.Invoke
+// are always tagged (see session_vrpc.go, session_pool.go), so a test's
+// fake Invoker must tag its errors the same way for the RetryingVRpc
+// interceptor's default classification to see them.
+//
+// Returns nil for nil err. Wraps unwrap()-transparently — errors.Is and
+// status.FromError continue to see the underlying err.
+func TagErr(state AttemptState, err error) error { return tagErr(state, err) }
+
+// ClassifyErr returns the outcome for any error. Untagged errors fall
+// through as StateServerResult — which, under the current default, is
+// NOT retryable without server-attached RetryInfo. Callers that produce
+// errors on paths where retry is expected must tag with the appropriate
+// state via tagErr (see session_vrpc.go for the reference call sites).
+func ClassifyErr(err error) AttemptOutcome {
+	if err == nil {
+		return AttemptOutcome{}
+	}
+	var v *vrpcErr
+	if errors.As(err, &v) {
+		return v.outcome
+	}
+	return AttemptOutcome{State: StateServerResult, Err: err}
+}

--- a/bigtable/internal/transport/attempt_outcome_test.go
+++ b/bigtable/internal/transport/attempt_outcome_test.go
@@ -1,0 +1,106 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestAttemptState_String(t *testing.T) {
+	tests := []struct {
+		s    AttemptState
+		want string
+	}{
+		{StateServerResult, "ServerResult"},
+		{StateUncommitted, "Uncommitted"},
+		{StateTransportFailure, "TransportFailure"},
+		{AttemptState(99), "Unknown"},
+	}
+	for _, tt := range tests {
+		if got := tt.s.String(); got != tt.want {
+			t.Errorf("AttemptState(%d).String() = %q, want %q", int(tt.s), got, tt.want)
+		}
+	}
+}
+
+// TestTagErr_NilPassesThrough guarantees callers can compose without extra
+// guards: tagErr(state, nil) must return nil regardless of state.
+func TestTagErr_NilPassesThrough(t *testing.T) {
+	if got := tagErr(StateUncommitted, nil); got != nil {
+		t.Errorf("tagErr(StateUncommitted, nil) = %v, want nil", got)
+	}
+	if got := TagErr(StateTransportFailure, nil); got != nil {
+		t.Errorf("TagErr(StateTransportFailure, nil) = %v, want nil", got)
+	}
+}
+
+// TestTagErr_WrapsAndUnwraps verifies the wrapper is transparent to
+// errors.Is and errors.Unwrap so upstream callers that don't know about
+// the AttemptOutcome tagging still see the original sentinel.
+func TestTagErr_WrapsAndUnwraps(t *testing.T) {
+	sentinel := errors.New("sentinel")
+	wrapped := tagErr(StateUncommitted, fmt.Errorf("wrap: %w", sentinel))
+
+	if !errors.Is(wrapped, sentinel) {
+		t.Error("errors.Is should see the underlying sentinel through the tagErr wrapper")
+	}
+	if wrapped.Error() == "" {
+		t.Error("wrapped error should have non-empty message")
+	}
+}
+
+// TestClassifyErr_Cases covers the three branches: nil, tagged, and
+// untagged. Untagged errors default to StateServerResult (retry only with
+// server-attached RetryInfo — Java-parity behavior).
+func TestClassifyErr_Cases(t *testing.T) {
+	// Nil error → zero outcome.
+	if got := ClassifyErr(nil); got.State != StateServerResult || got.Err != nil {
+		t.Errorf("ClassifyErr(nil) = %+v, want zero-value outcome", got)
+	}
+
+	// Tagged error → preserves state and err.
+	inner := errors.New("boom")
+	tagged := tagErr(StateTransportFailure, inner)
+	out := ClassifyErr(tagged)
+	if out.State != StateTransportFailure {
+		t.Errorf("ClassifyErr(tagged).State = %v, want StateTransportFailure", out.State)
+	}
+	if !errors.Is(out.Err, inner) {
+		t.Errorf("ClassifyErr(tagged).Err should preserve inner, got %v", out.Err)
+	}
+
+	// Untagged error → StateServerResult fallback with err preserved.
+	untagged := errors.New("plain")
+	out = ClassifyErr(untagged)
+	if out.State != StateServerResult {
+		t.Errorf("ClassifyErr(untagged).State = %v, want StateServerResult", out.State)
+	}
+	if out.Err != untagged {
+		t.Errorf("ClassifyErr(untagged).Err = %v, want %v", out.Err, untagged)
+	}
+}
+
+// TestClassifyErr_FindsThroughWrapper ensures errors.As-style traversal
+// works even when the tagErr wrapper is buried behind another fmt.Errorf.
+func TestClassifyErr_FindsThroughWrapper(t *testing.T) {
+	tagged := tagErr(StateUncommitted, errors.New("x"))
+	outer := fmt.Errorf("outer: %w", tagged)
+	out := ClassifyErr(outer)
+	if out.State != StateUncommitted {
+		t.Errorf("ClassifyErr(outer-wrapped).State = %v, want StateUncommitted", out.State)
+	}
+}

--- a/bigtable/internal/transport/session_msgtype.go
+++ b/bigtable/internal/transport/session_msgtype.go
@@ -28,7 +28,7 @@ type reqMsgType int
 
 const (
 	reqMsgOpenSession reqMsgType = iota
-	reqMsgVirtualRpc
+	reqMsgVirtualRPC
 	reqMsgCloseSession
 	reqMsgOther
 	numReqMsgTypes
@@ -37,8 +37,8 @@ const (
 func (t reqMsgType) String() string {
 	switch t {
 	case reqMsgOpenSession:
-		return "OpenSession"
-	case reqMsgVirtualRpc:
+		return "OpenSessionRequest"
+	case reqMsgVirtualRPC:
 		return "VirtualRpc"
 	case reqMsgCloseSession:
 		return "CloseSession"
@@ -55,7 +55,7 @@ func classifyReq(req *spb.SessionRequest) reqMsgType {
 	case *spb.SessionRequest_OpenSession:
 		return reqMsgOpenSession
 	case *spb.SessionRequest_VirtualRpc:
-		return reqMsgVirtualRpc
+		return reqMsgVirtualRPC
 	case *spb.SessionRequest_CloseSession:
 		return reqMsgCloseSession
 	default:
@@ -67,7 +67,7 @@ type respMsgType int
 
 const (
 	respMsgOpenSession respMsgType = iota
-	respMsgVirtualRpc
+	respMsgVirtualRPC
 	respMsgError
 	respMsgSessionParameters
 	respMsgHeartbeat
@@ -80,8 +80,8 @@ const (
 func (t respMsgType) String() string {
 	switch t {
 	case respMsgOpenSession:
-		return "OpenSession"
-	case respMsgVirtualRpc:
+		return "OpenSessionResponse"
+	case respMsgVirtualRPC:
 		return "VirtualRpc"
 	case respMsgError:
 		return "Error"
@@ -106,7 +106,7 @@ func classifyResp(resp *spb.SessionResponse) respMsgType {
 	case *spb.SessionResponse_OpenSession:
 		return respMsgOpenSession
 	case *spb.SessionResponse_VirtualRpc:
-		return respMsgVirtualRpc
+		return respMsgVirtualRPC
 	case *spb.SessionResponse_Error:
 		return respMsgError
 	case *spb.SessionResponse_SessionParameters:

--- a/bigtable/internal/transport/session_msgtype.go
+++ b/bigtable/internal/transport/session_msgtype.go
@@ -1,0 +1,123 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import spb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
+
+// reqMsgType / respMsgType label the oneof payload variants of
+// SessionRequest / SessionResponse. They're used as indices into the fixed
+// per-session atomic-counter arrays so the breakdown stays lock-free.
+//
+// The "other" bucket catches frames whose oneof is unset or carries a
+// payload type we haven't enumerated here (forward-compat with new server
+// frames). Add new values BEFORE numReq/Resp so the totals stay aligned
+// with the array size.
+type reqMsgType int
+
+const (
+	reqMsgOpenSession reqMsgType = iota
+	reqMsgVirtualRpc
+	reqMsgCloseSession
+	reqMsgOther
+	numReqMsgTypes
+)
+
+func (t reqMsgType) String() string {
+	switch t {
+	case reqMsgOpenSession:
+		return "OpenSession"
+	case reqMsgVirtualRpc:
+		return "VirtualRpc"
+	case reqMsgCloseSession:
+		return "CloseSession"
+	default:
+		return "other"
+	}
+}
+
+func classifyReq(req *spb.SessionRequest) reqMsgType {
+	if req == nil {
+		return reqMsgOther
+	}
+	switch req.GetPayload().(type) {
+	case *spb.SessionRequest_OpenSession:
+		return reqMsgOpenSession
+	case *spb.SessionRequest_VirtualRpc:
+		return reqMsgVirtualRpc
+	case *spb.SessionRequest_CloseSession:
+		return reqMsgCloseSession
+	default:
+		return reqMsgOther
+	}
+}
+
+type respMsgType int
+
+const (
+	respMsgOpenSession respMsgType = iota
+	respMsgVirtualRpc
+	respMsgError
+	respMsgSessionParameters
+	respMsgHeartbeat
+	respMsgGoAway
+	respMsgSessionRefreshConfig
+	respMsgOther
+	numRespMsgTypes
+)
+
+func (t respMsgType) String() string {
+	switch t {
+	case respMsgOpenSession:
+		return "OpenSession"
+	case respMsgVirtualRpc:
+		return "VirtualRpc"
+	case respMsgError:
+		return "Error"
+	case respMsgSessionParameters:
+		return "SessionParameters"
+	case respMsgHeartbeat:
+		return "Heartbeat"
+	case respMsgGoAway:
+		return "GoAway"
+	case respMsgSessionRefreshConfig:
+		return "SessionRefreshConfig"
+	default:
+		return "other"
+	}
+}
+
+func classifyResp(resp *spb.SessionResponse) respMsgType {
+	if resp == nil {
+		return respMsgOther
+	}
+	switch resp.GetPayload().(type) {
+	case *spb.SessionResponse_OpenSession:
+		return respMsgOpenSession
+	case *spb.SessionResponse_VirtualRpc:
+		return respMsgVirtualRpc
+	case *spb.SessionResponse_Error:
+		return respMsgError
+	case *spb.SessionResponse_SessionParameters:
+		return respMsgSessionParameters
+	case *spb.SessionResponse_Heartbeat:
+		return respMsgHeartbeat
+	case *spb.SessionResponse_GoAway:
+		return respMsgGoAway
+	case *spb.SessionResponse_SessionRefreshConfig:
+		return respMsgSessionRefreshConfig
+	default:
+		return respMsgOther
+	}
+}

--- a/bigtable/internal/transport/vrpc.go
+++ b/bigtable/internal/transport/vrpc.go
@@ -1,0 +1,101 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"context"
+)
+
+type contextKey struct{}
+
+type vrpcMetadata struct {
+	method  string
+	attempt int
+}
+
+// WithVRpcMetadata returns a new context with virtual RPC metadata set.
+func WithVRpcMetadata(ctx context.Context, method string, attempt int) context.Context {
+	return context.WithValue(ctx, contextKey{}, &vrpcMetadata{
+		method:  method,
+		attempt: attempt,
+	})
+}
+
+// WithAttempt returns a new context with the virtual RPC attempt updated.
+func WithAttempt(ctx context.Context, attempt int) context.Context {
+	if md, ok := ctx.Value(contextKey{}).(*vrpcMetadata); ok {
+		return context.WithValue(ctx, contextKey{}, &vrpcMetadata{
+			method:  md.method,
+			attempt: attempt,
+		})
+	}
+	return ctx
+}
+
+// VRpcMethod extracts the virtual RPC method name from the context.
+func VRpcMethod(ctx context.Context) string {
+	if md, ok := ctx.Value(contextKey{}).(*vrpcMetadata); ok {
+		return md.method
+	}
+	return ""
+}
+
+// VRpcAttempt extracts the virtual RPC attempt number (1-indexed) from the context.
+func VRpcAttempt(ctx context.Context) int {
+	if md, ok := ctx.Value(contextKey{}).(*vrpcMetadata); ok {
+		return md.attempt
+	}
+	return 0
+}
+
+// prevAttemptErrKey carries the previous attempt's error across retry
+// boundaries inside RetryingVRpc. Lets the downstream Session.Invoke
+// observe what caused the retry so sessionz can record a "retry"
+// SessionEvent with the original gRPC code + message.
+type prevAttemptErrKey struct{}
+
+// WithPrevAttemptErr returns a derived context tagged with the prior
+// attempt's error. Set by RetryingVRpc immediately before invoking the
+// next attempt. A nil err clears the value.
+func WithPrevAttemptErr(ctx context.Context, err error) context.Context {
+	return context.WithValue(ctx, prevAttemptErrKey{}, err)
+}
+
+// PrevAttemptErr returns the previous attempt's error stashed by
+// WithPrevAttemptErr, or nil if this is the first attempt or the context
+// wasn't tagged.
+func PrevAttemptErr(ctx context.Context) error {
+	if err, ok := ctx.Value(prevAttemptErrKey{}).(error); ok {
+		return err
+	}
+	return nil
+}
+
+// Handler represents the core execution function of a virtual RPC downstream invocation.
+type Handler func(ctx context.Context, req interface{}) (interface{}, error)
+
+// Interceptor represents a decorator middleware that intercepts a virtual RPC downstream invocation.
+type Interceptor func(ctx context.Context, req interface{}, handler Handler) (interface{}, error)
+
+// VRpcTracer receives per-attempt lifecycle notifications from
+// RetryingVRpc. Matches Java's VRpcTracer role and the tracing/OTel
+// vocabulary — this is a passive observer, not an event subscription
+// (nothing is buffered or delivered asynchronously).
+type VRpcTracer interface {
+	// OnAttemptStart is called before a new attempt is executed.
+	OnAttemptStart(ctx context.Context)
+	// OnAttemptComplete is called after an attempt completes (with success or error).
+	OnAttemptComplete(ctx context.Context, err error)
+}

--- a/bigtable/internal/transport/vrpc_test.go
+++ b/bigtable/internal/transport/vrpc_test.go
@@ -1,0 +1,48 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"context"
+	"testing"
+)
+
+// TestVRpc_ContextMetadataRetention verifies that WithVRpcMetadata attaches
+// (method, attempt) to a ctx such that VRpcMethod / VRpcAttempt can recover
+// them, and that further wrapping with context.WithValue does not lose the
+// vRPC metadata. Guards against a regression where a custom context-key
+// scheme would only survive a single Get.
+func TestVRpc_ContextMetadataRetention(t *testing.T) {
+	ctx := WithVRpcMetadata(context.Background(), "QueryMethod", 42)
+
+	if got := VRpcMethod(ctx); got != "QueryMethod" {
+		t.Errorf("VRpcMethod = %q, want %q", got, "QueryMethod")
+	}
+	if got := VRpcAttempt(ctx); got != 42 {
+		t.Errorf("VRpcAttempt = %d, want %d", got, 42)
+	}
+
+	// Wrapping with context.WithValue (e.g. a standard tracing span setter)
+	// must not clobber the vRPC metadata.
+	type extraKey struct{}
+	wrapped := context.WithValue(ctx, extraKey{}, "extraValue")
+
+	if got := VRpcMethod(wrapped); got != "QueryMethod" {
+		t.Errorf("VRpcMethod (wrapped) = %q, want preserved %q", got, "QueryMethod")
+	}
+	if got := VRpcAttempt(wrapped); got != 42 {
+		t.Errorf("VRpcAttempt (wrapped) = %d, want preserved %d", got, 42)
+	}
+}


### PR DESCRIPTION
## Summary

Adds the standalone types that the Session struct and its lifecycle / vRPC / debug halves all depend on. Each file is self-contained (no cross-references) so this PR compiles and passes tests on its own.

- **`attempt_outcome.go`** — `AttemptState` (`StateUncommitted` / `StateTransportFailure` / `StateServerResult`), `tagErr`, `TagErr`, `ClassifyErr`. Models Java's `VRpc.VRpcResult.State` so the `RetryingVRpc` interceptor (later PR) can classify errors the same way as java-bigtable.
- **`vrpc.go`** — ctx-metadata helpers (`WithVRpcMetadata`, `WithAttempt`, `VRpcAttempt`, `VRpcMethod`, `WithPrevAttemptErr`, `PrevAttemptErr`). `Session.Invoke` reads these from its ctx.
- **`session_msgtype.go`** — `reqMsgType` / `respMsgType` enums + `classifyReq` / `classifyResp` helpers. Used by the debug surface + tracer to bucket Session request/response types.

**Part 3a of 3 in the Session core sub-split** (a follow-up to the original Session core PR #20112, which is being reshaped into three thinner PRs). Stacks on #20115 (`metrics.TransportTypeName` export) and #20114 (debug tag counter); each of those can merge in any order. Sub-split order:

1. **3a — this PR:** Session primitives (~337 LOC).
2. **3b — TBD:** Session struct + tracer + debug surface + picker (~1.1k LOC).
3. **3c — reshaped #20112:** Session lifecycle + vRPC + tests (~2k LOC).

## Test plan

- [x] `go build ./bigtable/...`
- [x] `go test ./bigtable/internal/transport/ -count=1 -short` — passes (4.0s)
- [x] `gofmt -l bigtable/internal/transport/` — clean
- [ ] CI: presubmit
