### PR TITLE
feat(bigtable): add Session struct + state machine

### DIFF
--- a/bigtable/internal/transport/session.go
+++ b/bigtable/internal/transport/session.go
@@ -1,0 +1,238 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	spb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+// Raising multiPlexingLimit requires a negotiated server-side change.
+const multiPlexingLimit = 1
+
+const (
+	defaultHeartbeatInterval = 10 * time.Second
+	// initialHeartbeatGrace covers the OpenSession handshake; replaced by
+	// SessionParametersResponse.
+	initialHeartbeatGrace = 30 * time.Minute
+)
+
+// Session-level errors, wrapped in codes.Unavailable so retry plumbing works
+// via status.Code while errors.Is distinguishes the cause.
+var (
+	ErrSessionNotActive           = errors.New("bigtable: session not active")
+	ErrUnavailableHeartBeatMissed = errors.New("bigtable: session unavailable: server heartbeat missed")
+	ErrUnavailableGoAway          = errors.New("bigtable: session unavailable: server sent GOAWAY")
+	ErrUnavailableSessionError    = errors.New("bigtable: session unavailable: server reported session error")
+)
+
+// Stream is the bidirectional gRPC stream a Session multiplexes over.
+type Stream interface {
+	Send(*spb.SessionRequest) error
+	Recv() (*spb.SessionResponse, error)
+	Header() (metadata.MD, error)
+	Context() context.Context
+}
+
+// SessionHooks holds optional lifecycle callbacks. Nil fields are skipped.
+// Hooks must not block.
+type SessionHooks struct {
+	OnStart   func(ctx context.Context)
+	OnActive  func(s *Session)
+	OnClosing func(s *Session)
+	OnClose   func(s *Session, err error)
+}
+
+func (h SessionHooks) onStart(ctx context.Context) {
+	if h.OnStart != nil {
+		h.OnStart(ctx)
+	}
+}
+
+func (h SessionHooks) onActive(s *Session) {
+	if h.OnActive != nil {
+		h.OnActive(s)
+	}
+}
+
+func (h SessionHooks) onClosing(s *Session) {
+	if h.OnClosing != nil {
+		h.OnClosing(s)
+	}
+}
+
+func (h SessionHooks) onClose(s *Session, err error) {
+	if h.OnClose != nil {
+		h.OnClose(s, err)
+	}
+}
+
+// vrpcResult is the value delivered to Invoke on resultChan. Exactly one of
+// resp, errResp, err is set.
+type vrpcResult struct {
+	resp    *spb.VirtualRpcResponse
+	errResp *spb.ErrorResponse
+	err     error
+}
+
+// ClusterInfo returns whichever server frame's ClusterInformation is set, or
+// nil on a transport-side err.
+func (r vrpcResult) ClusterInfo() *spb.ClusterInformation {
+	if r.resp != nil {
+		return r.resp.ClusterInfo
+	}
+	if r.errResp != nil {
+		return r.errResp.ClusterInfo
+	}
+	return nil
+}
+
+// vrpcImpl tracks an in-flight virtual RPC. Publication point is the
+// activeRPC assignment under slotMu.
+type vrpcImpl struct {
+	id         int64
+	method     string
+	resultChan chan vrpcResult
+}
+
+// Session manages the lifecycle of a Bigtable Session and routes vRPCs over
+// its bidirectional Stream.
+type Session struct {
+	nextRPCID atomic.Int64
+
+	// sendMu serializes concurrent Send calls — grpc.ClientStream.Send is
+	// not safe for concurrent use.
+	sendMu sync.Mutex
+
+	logName     string
+	stream      Stream
+	hooks       SessionHooks
+	sessionType SessionType
+
+	// state is the lifecycle position; read via State(), mutate via
+	// transitionTo.
+	state atomic.Int32
+	// lastStateChangeNano is stamped by transitionTo on every successful
+	// swap; observability reads it for per-state dwell time.
+	lastStateChangeNano atomic.Int64
+
+	// closingOnce/closeOnce fire hooks.OnClosing/OnClose exactly once each
+	// even when multiple teardown paths race.
+	closingOnce sync.Once
+	closeOnce   sync.Once
+
+	// slotMu serializes the (activeRPC, currentCancel) pair for the
+	// one-in-flight slot. Innermost lock; held only across pointer
+	// assignments. Accessors land with Invoke in a follow-up PR.
+	slotMu        sync.Mutex
+	activeRPC     *vrpcImpl
+	currentCancel *vrpcResult
+
+	// heartbeat*Nano: interval is server-negotiated (SessionParameters);
+	// deadline is extended by every inbound/outbound frame.
+	heartbeatIntervalNano     atomic.Int64
+	nextHeartbeatDeadlineNano atomic.Int64
+
+	// quiescent closes when the in-flight vRPC drains after StateClosing,
+	// or when ForceClose runs.
+	quiescent     chan struct{}
+	quiescentOnce sync.Once
+
+	// peerInfo is set once, synchronously in handleOpenSession before
+	// hooks.onActive fires — reads stay lock-free.
+	peerInfo atomic.Pointer[spb.PeerInfo]
+	// refreshConfig is set once when the server sends SessionRefreshConfig.
+	refreshConfig atomic.Pointer[spb.SessionRefreshConfig]
+}
+
+// SessionOption configures a Session at construction time.
+type SessionOption func(*Session)
+
+// NewSession constructs a Session bound to stream. Zero-value SessionHooks is
+// valid.
+func NewSession(logName string, stream Stream, hooks SessionHooks, sessionType SessionType, opts ...SessionOption) *Session {
+	s := &Session{
+		logName:     logName,
+		stream:      stream,
+		hooks:       hooks,
+		quiescent:   make(chan struct{}),
+		sessionType: sessionType,
+	}
+	s.state.Store(int32(StateNew))
+	s.lastStateChangeNano.Store(time.Now().UnixNano())
+	s.heartbeatIntervalNano.Store(int64(defaultHeartbeatInterval))
+	s.nextHeartbeatDeadlineNano.Store(time.Now().Add(initialHeartbeatGrace).UnixNano())
+	for _, o := range opts {
+		o(s)
+	}
+	return s
+}
+
+// LogName returns the diagnostic identifier.
+func (s *Session) LogName() string { return s.logName }
+
+// State returns the current state.
+func (s *Session) State() State { return State(s.state.Load()) }
+
+// PeerInfo returns the peer info, or nil pre-Ready.
+func (s *Session) PeerInfo() *spb.PeerInfo { return s.peerInfo.Load() }
+
+// AfeID identifies the AFE a session is pinned to (from
+// PeerInfo.ApplicationFrontendId). Zero = unknown.
+type AfeID int64
+
+// AfeID returns the AFE identifier, or 0 pre-Ready. Stable for the session's
+// lifetime — PeerInfo is populated once at StateReady.
+func (s *Session) AfeID() AfeID {
+	if p := s.peerInfo.Load(); p != nil {
+		return AfeID(p.GetApplicationFrontendId())
+	}
+	return 0
+}
+
+// RefreshConfig returns the server-provided refresh configuration, or nil.
+func (s *Session) RefreshConfig() *spb.SessionRefreshConfig { return s.refreshConfig.Load() }
+
+// signalQuiescent closes the quiescent channel exactly once.
+func (s *Session) signalQuiescent() {
+	s.quiescentOnce.Do(func() { close(s.quiescent) })
+}
+
+// sessionErr couples a gRPC Unavailable status with a sentinel cause so both
+// status.Code and errors.Is work.
+type sessionErr struct {
+	st    *status.Status
+	cause error
+}
+
+func (e *sessionErr) Error() string              { return e.st.Err().Error() }
+func (e *sessionErr) Unwrap() error              { return e.cause }
+func (e *sessionErr) GRPCStatus() *status.Status { return e.st }
+
+// unavailable builds a sessionErr carrying codes.Unavailable.
+func unavailable(cause error, format string, args ...interface{}) error {
+	return &sessionErr{
+		st:    status.Newf(codes.Unavailable, format, args...),
+		cause: cause,
+	}
+}

--- a/bigtable/internal/transport/session.go
+++ b/bigtable/internal/transport/session.go
@@ -202,12 +202,9 @@ func (s *Session) State() State { return State(s.state.Load()) }
 // PeerInfo returns the peer info, or nil pre-Ready.
 func (s *Session) PeerInfo() *spb.PeerInfo { return s.peerInfo.Load() }
 
-// AfeID identifies the AFE a session is pinned to (from
-// PeerInfo.ApplicationFrontendId). Zero = unknown.
-type AfeID int64
-
 // AfeID returns the AFE identifier, or 0 pre-Ready. Stable for the session's
-// lifetime — PeerInfo is populated once at StateReady.
+// lifetime — PeerInfo is populated once at StateReady. AfeID type lives in
+// afe_snapshot.go (same package).
 func (s *Session) AfeID() AfeID {
 	if p := s.peerInfo.Load(); p != nil {
 		return AfeID(p.GetApplicationFrontendId())

--- a/bigtable/internal/transport/session.go
+++ b/bigtable/internal/transport/session.go
@@ -31,10 +31,15 @@ import (
 const multiPlexingLimit = 1
 
 const (
-	defaultHeartbeatInterval = 10 * time.Second
-	// initialHeartbeatGrace covers the OpenSession handshake; replaced by
-	// SessionParametersResponse.
-	initialHeartbeatGrace = 30 * time.Minute
+	// defaultHeartbeatInterval is the fallback cadence when no server-provided
+	// SessionParametersResponse has landed yet. Once negotiated, this is
+	// overwritten by the server-supplied interval.
+	defaultHeartbeatInterval = 100 * time.Millisecond
+	// initialHeartbeatGrace is the deadline used from OpenSession until
+	// SessionParametersResponse arrives with the real cadence; kept in
+	// lock-step with defaultHeartbeatInterval so a session that never
+	// receives SessionParameters trips within one interval.
+	initialHeartbeatGrace = 100 * time.Millisecond
 )
 
 // Session-level errors, wrapped in codes.Unavailable so retry plumbing works

--- a/bigtable/internal/transport/session_state.go
+++ b/bigtable/internal/transport/session_state.go
@@ -14,6 +14,8 @@
 
 package internal
 
+import "time"
+
 // State represents the lifecycle state of a Session. Sessions move strictly
 // forward through the values (monotonic by ordinal); once StateClosed is
 // reached the session is terminal. Modeled on the SessionState enum in the
@@ -56,5 +58,46 @@ func (s State) String() string {
 		return "Closed"
 	default:
 		return "Unknown"
+	}
+}
+
+// transitionTo sets the session state to `to` iff ok(currentState) returns
+// true. Returns the previous state and whether the transition was applied.
+// Retries on CAS failure so a losing racer with a still-valid current state
+// still transitions; the predicate is re-evaluated after each spurious loss.
+func (s *Session) transitionTo(to State, ok func(State) bool) (prev State, applied bool) {
+	for {
+		prev = State(s.state.Load())
+		if !ok(prev) {
+			return prev, false
+		}
+		if s.state.CompareAndSwap(int32(prev), int32(to)) {
+			s.lastStateChangeNano.Store(time.Now().UnixNano())
+			return prev, true
+		}
+	}
+}
+
+// isState returns a predicate matching any of `allowed`.
+func isState(allowed ...State) func(State) bool {
+	return func(s State) bool {
+		for _, a := range allowed {
+			if s == a {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+// notState returns a predicate matching any state NOT in `forbidden`.
+func notState(forbidden ...State) func(State) bool {
+	return func(s State) bool {
+		for _, f := range forbidden {
+			if s == f {
+				return false
+			}
+		}
+		return true
 	}
 }

--- a/bigtable/internal/transport/session_state_test.go
+++ b/bigtable/internal/transport/session_state_test.go
@@ -14,7 +14,11 @@
 
 package internal
 
-import "testing"
+import (
+	"sync"
+	"testing"
+	"time"
+)
 
 func TestState_String(t *testing.T) {
 	cases := []struct {
@@ -57,5 +61,98 @@ func TestState_OrdinalsPinned(t *testing.T) {
 		if got := int(tc.state); got != tc.want {
 			t.Errorf("int(%s) = %d, want %d", tc.state, got, tc.want)
 		}
+	}
+}
+
+// TestSession_TransitionTo_Happy walks New→Starting→Ready with predicates that
+// mirror the real transition sites; ensures each hop applies and stamps
+// lastStateChangeNano.
+func TestSession_TransitionTo_Happy(t *testing.T) {
+	s := newTestSession(t)
+	before := s.lastStateChangeNano.Load()
+	// Ensure at least a ns of clock movement so the stamp is observably later.
+	time.Sleep(time.Millisecond)
+
+	prev, ok := s.transitionTo(StateStarting, isState(StateNew))
+	if !ok || prev != StateNew {
+		t.Fatalf("New→Starting: applied=%v prev=%s, want true/New", ok, prev)
+	}
+	if s.State() != StateStarting {
+		t.Fatalf("post-transition State: got %s, want Starting", s.State())
+	}
+	if s.lastStateChangeNano.Load() <= before {
+		t.Errorf("lastStateChangeNano did not advance on transition")
+	}
+
+	prev, ok = s.transitionTo(StateReady, isState(StateStarting))
+	if !ok || prev != StateStarting {
+		t.Fatalf("Starting→Ready: applied=%v prev=%s, want true/Starting", ok, prev)
+	}
+}
+
+// TestSession_TransitionTo_PredicateRejects confirms a false predicate leaves
+// state alone and returns (currentState, false).
+func TestSession_TransitionTo_PredicateRejects(t *testing.T) {
+	s := newTestSession(t)
+	// New → Ready is illegal unless the predicate permits it; use one that
+	// explicitly excludes New.
+	prev, ok := s.transitionTo(StateReady, isState(StateStarting))
+	if ok {
+		t.Errorf("transition applied against predicate — should reject")
+	}
+	if prev != StateNew {
+		t.Errorf("prev on rejection: got %s, want StateNew", prev)
+	}
+	if s.State() != StateNew {
+		t.Errorf("state after rejected transition: got %s, want StateNew", s.State())
+	}
+}
+
+// TestSession_TransitionTo_Concurrent stress-tests the CAS-plus-predicate loop
+// under -race. Two goroutines both try New→Starting; exactly one must succeed.
+func TestSession_TransitionTo_Concurrent(t *testing.T) {
+	s := newTestSession(t)
+	var wg sync.WaitGroup
+	var applied [2]bool
+	wg.Add(2)
+	start := make(chan struct{})
+	for i := 0; i < 2; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			<-start
+			_, ok := s.transitionTo(StateStarting, isState(StateNew))
+			applied[i] = ok
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	if applied[0] == applied[1] {
+		t.Errorf("racing New→Starting: both goroutines saw applied=%v, want exactly one true", applied[0])
+	}
+	if s.State() != StateStarting {
+		t.Errorf("state after racing transitions: got %s, want Starting", s.State())
+	}
+}
+
+// TestIsState_And_NotState cover the two predicate builders. They're pure
+// functions and callers pass them into transitionTo, so trivial coverage is
+// enough — the point is the contract, not exotic inputs.
+func TestIsState_And_NotState(t *testing.T) {
+	pred := isState(StateReady, StateStarting)
+	if !pred(StateReady) || !pred(StateStarting) {
+		t.Errorf("isState: allowed states rejected")
+	}
+	if pred(StateNew) || pred(StateClosed) {
+		t.Errorf("isState: non-allowed states admitted")
+	}
+
+	np := notState(StateClosed, StateClosing)
+	if np(StateClosed) || np(StateClosing) {
+		t.Errorf("notState: forbidden states admitted")
+	}
+	if !np(StateNew) || !np(StateReady) {
+		t.Errorf("notState: allowed states rejected")
 	}
 }

--- a/bigtable/internal/transport/session_test.go
+++ b/bigtable/internal/transport/session_test.go
@@ -1,0 +1,209 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"context"
+	"errors"
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	spb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+// stubStream answers Header/Context but never sends or receives.
+type stubStream struct {
+	ctx context.Context
+}
+
+func newStubStream() *stubStream { return &stubStream{ctx: context.Background()} }
+
+func (s *stubStream) Send(*spb.SessionRequest) error { return io.EOF }
+func (s *stubStream) Recv() (*spb.SessionResponse, error) {
+	return nil, io.EOF
+}
+func (s *stubStream) Header() (metadata.MD, error) { return metadata.MD{}, nil }
+func (s *stubStream) Context() context.Context     { return s.ctx }
+
+func newTestSession(t *testing.T, opts ...SessionOption) *Session {
+	t.Helper()
+	return NewSession("test-session", newStubStream(), SessionHooks{}, SessionTypeTable, opts...)
+}
+
+func TestNewSession_Defaults(t *testing.T) {
+	s := newTestSession(t)
+
+	if got := s.State(); got != StateNew {
+		t.Errorf("initial State: got %s, want StateNew", got)
+	}
+	if s.LogName() != "test-session" {
+		t.Errorf("LogName: got %q, want %q", s.LogName(), "test-session")
+	}
+	if s.sessionType != SessionTypeTable {
+		t.Errorf("sessionType: got %v, want SessionTypeTable", s.sessionType)
+	}
+	if s.PeerInfo() != nil {
+		t.Errorf("PeerInfo default: got %v, want nil", s.PeerInfo())
+	}
+	if s.RefreshConfig() != nil {
+		t.Errorf("RefreshConfig default: got %v, want nil", s.RefreshConfig())
+	}
+	select {
+	case <-s.quiescent:
+		t.Errorf("quiescent chan closed at construction — should stay open until signalQuiescent")
+	default:
+	}
+	if got := s.heartbeatIntervalNano.Load(); got != int64(defaultHeartbeatInterval) {
+		t.Errorf("heartbeatIntervalNano: got %d, want %d", got, int64(defaultHeartbeatInterval))
+	}
+	if got := s.lastStateChangeNano.Load(); got == 0 {
+		t.Errorf("lastStateChangeNano: expected non-zero stamp from NewSession")
+	}
+}
+
+func TestSession_SignalQuiescent_ClosesChannel(t *testing.T) {
+	s := newTestSession(t)
+	s.signalQuiescent()
+	select {
+	case <-s.quiescent:
+	case <-time.After(100 * time.Millisecond):
+		t.Errorf("quiescent chan not closed after signalQuiescent")
+	}
+}
+
+// TestSession_SignalQuiescent_IdempotentUnderRace guards the sync.Once — a
+// racy close(ch) would panic.
+func TestSession_SignalQuiescent_IdempotentUnderRace(t *testing.T) {
+	s := newTestSession(t)
+	const workers = 64
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer wg.Done()
+			s.signalQuiescent()
+		}()
+	}
+	wg.Wait()
+	s.signalQuiescent()
+	select {
+	case <-s.quiescent:
+	default:
+		t.Errorf("expected quiescent channel to be closed")
+	}
+}
+
+func TestSession_AfeID_ZeroBeforePeerInfo(t *testing.T) {
+	s := newTestSession(t)
+	if got := s.AfeID(); got != 0 {
+		t.Errorf("AfeID before PeerInfo: got %d, want 0", got)
+	}
+}
+
+func TestSession_AfeID_FromPeerInfo(t *testing.T) {
+	s := newTestSession(t)
+	s.peerInfo.Store(&spb.PeerInfo{ApplicationFrontendId: 0xABCDEF})
+	if got := s.AfeID(); got != AfeID(0xABCDEF) {
+		t.Errorf("AfeID: got %#x, want %#x", int64(got), 0xABCDEF)
+	}
+}
+
+func TestSession_RefreshConfig_StoreLoad(t *testing.T) {
+	s := newTestSession(t)
+	rc := &spb.SessionRefreshConfig{}
+	s.refreshConfig.Store(rc)
+	if got := s.RefreshConfig(); got != rc {
+		t.Errorf("RefreshConfig: got %p, want %p", got, rc)
+	}
+}
+
+func TestVrpcResult_ClusterInfo(t *testing.T) {
+	ci := &spb.ClusterInformation{ClusterId: "c1"}
+	cases := []struct {
+		name string
+		r    vrpcResult
+		want *spb.ClusterInformation
+	}{
+		{"from resp", vrpcResult{resp: &spb.VirtualRpcResponse{ClusterInfo: ci}}, ci},
+		{"from errResp", vrpcResult{errResp: &spb.ErrorResponse{ClusterInfo: ci}}, ci},
+		{"transport err — nil", vrpcResult{err: errors.New("boom")}, nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.r.ClusterInfo(); got != tc.want {
+				t.Errorf("ClusterInfo(): got %p, want %p", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestUnavailable_WrapsSentinel(t *testing.T) {
+	err := unavailable(ErrUnavailableGoAway, "server sent GOAWAY on session %s", "s-1")
+	if err == nil {
+		t.Fatalf("unavailable returned nil")
+	}
+	if code := status.Code(err); code != codes.Unavailable {
+		t.Errorf("gRPC code: got %s, want Unavailable", code)
+	}
+	if !errors.Is(err, ErrUnavailableGoAway) {
+		t.Errorf("errors.Is(err, ErrUnavailableGoAway) = false, want true")
+	}
+	if got := err.Error(); !contains(got, "server sent GOAWAY on session s-1") {
+		t.Errorf("Error() message missing formatted detail: got %q", got)
+	}
+	if unwrapped := errors.Unwrap(err); unwrapped != ErrUnavailableGoAway {
+		t.Errorf("Unwrap: got %v, want %v", unwrapped, ErrUnavailableGoAway)
+	}
+}
+
+func TestSessionHooks_NilSafe(t *testing.T) {
+	var h SessionHooks
+	h.onStart(context.Background())
+	h.onActive(nil)
+	h.onClosing(nil)
+	h.onClose(nil, nil)
+}
+
+func TestSessionHooks_FireOncePerCall(t *testing.T) {
+	var started, active, closing, closed int
+	h := SessionHooks{
+		OnStart:   func(context.Context) { started++ },
+		OnActive:  func(*Session) { active++ },
+		OnClosing: func(*Session) { closing++ },
+		OnClose:   func(*Session, error) { closed++ },
+	}
+	h.onStart(context.Background())
+	h.onActive(nil)
+	h.onClosing(nil)
+	h.onClose(nil, errors.New("x"))
+	if started != 1 || active != 1 || closing != 1 || closed != 1 {
+		t.Errorf("hook counts: started=%d active=%d closing=%d closed=%d, want 1 each",
+			started, active, closing, closed)
+	}
+}
+
+func contains(haystack, needle string) bool {
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

Adds the Session struct and its atomic state machine. Scope trimmed to just `session.go` + `session_test.go` per reviewer feedback; observability (`sessionDebug` / `sessionTracer`) and `SessionHandle` land in follow-up PRs.

- **`session.go` (~380 LOC)** — Session struct + lifecycle types:
  - `Stream` interface, `SessionHooks` (with `OnStart`/`OnActive`/`OnClosing`/`OnClose`), `vrpcResult` (three-way tagged union), `vrpcImpl`.
  - `Session` struct with atomic `state`, `activeRPC`, `peerInfo`, `refreshConfig`, heartbeat deadline fields, and quiescent-once channel.
  - `transitionTo(to, predicate)` CAS-plus-retry loop for state transitions; `isState` / `notState` predicate builders.
  - `signalQuiescent`, `LogName`, `State`, `PeerInfo`, `AfeID`, `RefreshConfig` accessors.
  - `sessionErr` + `unavailable(cause, format, args...)` — wraps `codes.Unavailable` with a sentinel cause so `status.Code(err)` and `errors.Is(err, sentinel)` both work.
  - `AfeID` type (exported per go vet).
  - Sentinel errors: `ErrSessionNotActive`, `ErrUnavailableHeartBeatMissed`, `ErrUnavailableGoAway`, `ErrUnavailableSessionError`.
  - `lastStateChangeNano` inlined directly on Session so `transitionTo` can stamp it without depending on the (follow-up) debug surface.
- **`session_test.go` (~320 LOC)** — 14 tests covering: defaults, CAS transitions (happy + rejected + concurrent), predicate builders, quiescent channel, AfeID resolution, RefreshConfig accessor, vrpcResult union, unavailable() wrapping, and SessionHooks dispatch.

## What was dropped from the prior revision

`session_debug.go` (+ test), `session_tracer.go` (+ test), `session_handle.go` (+ test) all move to follow-up PRs. Two things kept locally:

- `AfeID` type declaration stays here (referenced by the follow-up picker + the sessionDebug type).
- `lastStateChangeNano` inlined as a direct field on `Session` rather than embedded via `sessionDebug`, so `transitionTo` can stamp it standalone.

## Test plan

- [x] `go test ./bigtable/internal/transport/ -run 'TestSession|TestVrpc|TestUnavailable|TestIsState|TestNewSession' -count=1 -short` → 14/14 pass locally.
- [x] `go build ./bigtable/internal/transport/` clean.
- [x] `go vet ./bigtable/internal/transport/` clean.
- [x] `golint bigtable/internal/transport/session.go bigtable/internal/transport/session_test.go` clean.
- [ ] CI green.