### PR TITLE
chore: wire up mod validation action

### DIFF
--- a/.github/workflows/mod_compatibility.yml
+++ b/.github/workflows/mod_compatibility.yml
@@ -1,5 +1,10 @@
 name: validate go modules
-
+# The purpose of this action is to maintain a simple invariant that all the SDKs we release
+# supported versions of go in accordance with our policy:
+# https://docs.cloud.google.com/go/getting-started/supported-go-versions
+#
+# In a nutshell, this action runs on PRs to identify any go module files that declare an atypical
+# Go release version and flag them to the reviewer for scrutiny.
 on:
   pull_request:
     paths:

--- a/.github/workflows/mod_compatibility.yml
+++ b/.github/workflows/mod_compatibility.yml
@@ -25,5 +25,5 @@ jobs:
       id: validate
       run: |
         cd internal/actions
-        go run ./cmd/modvalidate --enforced_version=1.25.0 --dir=${{ github.workspace }}
+        go run ./cmd/modvalidator --enforced_version=1.25.0 --dir=${{ github.workspace }}
         

--- a/.github/workflows/mod_compatibility.yml
+++ b/.github/workflows/mod_compatibility.yml
@@ -1,0 +1,28 @@
+name: validate go modules
+
+on:
+  pull_request:
+    paths:
+      - '**/go.mod'
+
+
+
+env:
+  GOTOOLCHAIN: local
+
+jobs:
+  validate_go_version:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      with:
+        fetch-depth: 2
+        persist-credentials: false
+    - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+      with:
+        go-version: 1.26.x
+    - name: Validate go minimum version
+      id: modfiles
+      run: |
+        go run internal/actions/cmd/modvalidate --enforced_version=1.25.0 --dir=${{ github.workspace }}
+        

--- a/.github/workflows/mod_compatibility.yml
+++ b/.github/workflows/mod_compatibility.yml
@@ -22,7 +22,7 @@ jobs:
       with:
         go-version: 1.26.x
     - name: Validate go minimum version
-      id: modfiles
+      id: validate
       run: |
         go run internal/actions/cmd/modvalidate --enforced_version=1.25.0 --dir=${{ github.workspace }}
         

--- a/.github/workflows/mod_compatibility.yml
+++ b/.github/workflows/mod_compatibility.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       with:
-        fetch-depth: 2
+        fetch-depth: 1
         persist-credentials: false
     - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
       with:
@@ -24,5 +24,6 @@ jobs:
     - name: Validate go minimum version
       id: validate
       run: |
-        go run internal/actions/cmd/modvalidate --enforced_version=1.25.0 --dir=${{ github.workspace }}
+        cd internal/actions
+        go run ./cmd/modvalidate --enforced_version=1.25.0 --dir=${{ github.workspace }}
         

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module cloud.google.com/go
 
-go 1.25.0
+go 1.25.1
 
 require (
 	cloud.google.com/go/storage v1.62.3

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module cloud.google.com/go
 
-go 1.25.1
+go 1.25.0
 
 require (
 	cloud.google.com/go/storage v1.62.3


### PR DESCRIPTION
Following up on PR#20106, this change invokes the new validator that runs on all pull requests that touch go.mod files.