### PR TITLE
feat(bigquery): add query polling retry opt-out

### DIFF
--- a/bigquery/job.go
+++ b/bigquery/job.go
@@ -369,6 +369,9 @@ func (j *Job) waitForQuery(ctx context.Context, projectID string) (Schema, uint6
 		res, err = call.Do()
 		trace.EndSpan(sCtx, err)
 		if err != nil {
+			if cfg := j.c.customConfig; cfg != nil && cfg.disableJobPollingRetries {
+				return true, err
+			}
 			return !retryableError(err, jobRetryReasons), err
 		}
 		if !res.JobComplete { // GetQueryResults may return early without error; retry.

--- a/bigquery/job_test.go
+++ b/bigquery/job_test.go
@@ -15,12 +15,16 @@
 package bigquery
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
 	"reflect"
 	"testing"
 	"time"
 
 	"cloud.google.com/go/internal/testutil"
 	bq "google.golang.org/api/bigquery/v2"
+	"google.golang.org/api/option"
 )
 
 func TestCreateJobRef(t *testing.T) {
@@ -175,6 +179,53 @@ func Test_JobPerformanceInsights(t *testing.T) {
 			out := bqToPerformanceInsights(test.in)
 			if !reflect.DeepEqual(test.want, out) {
 				t.Error("out != want")
+			}
+		})
+	}
+}
+
+func TestWaitForQueryPollingRetriesDisabled(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		opts      []option.ClientOption
+		wantCalls int
+		wantErr   bool
+	}{
+		{name: "default retries", wantCalls: 2},
+		{
+			name:      "disabled surfaces error",
+			opts:      []option.ClientOption{WithJobPollingRetriesDisabled()},
+			wantCalls: 1,
+			wantErr:   true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			calls := 0
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				calls++
+				if calls == 1 {
+					w.WriteHeader(http.StatusForbidden)
+					w.Write([]byte(`{"error":{"code":403,"message":"quota","errors":[{"message":"quota","reason":"jobRateLimitExceeded"}]}}`))
+					return
+				}
+				w.Write([]byte(`{"jobComplete":true,"totalRows":"0"}`))
+			}))
+			defer ts.Close()
+
+			opts := append([]option.ClientOption{option.WithEndpoint(ts.URL), option.WithoutAuthentication()}, tc.opts...)
+			client, err := NewClient(context.Background(), "project-id", opts...)
+			if err != nil {
+				t.Fatalf("NewClient: %v", err)
+			}
+			defer client.Close()
+
+			job := &Job{c: client, projectID: "project-id", jobID: "job-id"}
+			_, _, err = job.waitForQuery(context.Background(), "project-id")
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("waitForQuery() error = %v, wantErr %t", err, tc.wantErr)
+			}
+			if calls != tc.wantCalls {
+				t.Fatalf("poll calls = %d, want %d", calls, tc.wantCalls)
 			}
 		})
 	}

--- a/bigquery/options.go
+++ b/bigquery/options.go
@@ -21,7 +21,8 @@ import (
 
 // type for collecting custom ClientOption values.
 type customClientConfig struct {
-	jobCreationMode JobCreationMode
+	jobCreationMode          JobCreationMode
+	disableJobPollingRetries bool
 }
 
 type customClientOption interface {
@@ -70,4 +71,19 @@ type applierJobCreationMode struct {
 
 func (s *applierJobCreationMode) ApplyCustomClientOpt(c *customClientConfig) {
 	c.jobCreationMode = s.mode
+}
+
+// WithJobPollingRetriesDisabled is a ClientOption that surfaces polling errors
+// from jobs.getQueryResults without retrying them. It does not affect job
+// creation retries for jobs.insert or jobs.query.
+func WithJobPollingRetriesDisabled() option.ClientOption {
+	return &applierJobPollingRetriesDisabled{}
+}
+
+type applierJobPollingRetriesDisabled struct {
+	internaloption.EmbeddableAdapter
+}
+
+func (s *applierJobPollingRetriesDisabled) ApplyCustomClientOpt(c *customClientConfig) {
+	c.disableJobPollingRetries = true
 }


### PR DESCRIPTION
For #20121

## Summary

Adds a BigQuery client option to surface errors from query job polling without retrying them internally.

By default, `waitForQuery` keeps the existing behavior and retries polling errors using `jobRetryReasons`. Callers that need to handle BigQuery polling backpressure themselves can opt out with:

```go
bigquery.WithJobPollingRetriesDisabled()
```

This applies only to jobs.getQueryResults polling. It does not change retry behavior for jobs.insert or jobs.query.