### PR TITLE
chore: remove bq v2 from release-please config

### DIFF
--- a/.release-please-individual-manifest.json
+++ b/.release-please-individual-manifest.json
@@ -3,7 +3,6 @@
   "auth": "0.21.0",
   "auth/oauth2adapt": "0.2.8",
   "bigquery": "1.77.0",
-  "bigquery/v2": "0.0.0",
   "bigtable": "1.50.0",
   "compute/metadata": "0.9.0",
   "datastore": "1.24.0",

--- a/release-please-individual-config.json
+++ b/release-please-individual-config.json
@@ -19,9 +19,6 @@
         "bigquery/v2"
       ]
     },
-    "bigquery/v2": {
-      "component": "bigquery"
-    },
     "bigtable": {
       "component": "bigtable"
     },


### PR DESCRIPTION
There is currently a bug in how releaseplease is updating the bq release. Since we are not currently releasing v2 lets remove the config for now until things stabilize.