### PR TITLE
chore(librarian): align Go toolchain to 1.25.0

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -34,7 +34,7 @@ tools:
 default:
   tag_format: '{name}/v{version}'
   go:
-    toolchain: go1.25.8
+    toolchain: go1.25.0
     default_enabled_generator_features:
       - F_open_telemetry_attributes
 libraries:


### PR DESCRIPTION
Ensure `go.toolchain` used by `librarian` is using the target version of the client libraries.

`generate --all` produced no diffs.