### PR TITLE
chore: use strict constraints filtering for renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -19,6 +19,11 @@
         "**/snippets/**"
     ],
     "packageRules": [
+    	{
+   	    "description": "prevent go version upgrades",
+      	    "matchManagers": ["gomod"],
+            "constraintsFiltering": "strict"
+    	},
         {
             "matchPackagePatterns": [
                 "^github.com/google/go-github/v",
@@ -43,7 +48,6 @@
             "go": "1.25"
         }
     },
-    "constraintsFiltering": "strict", 
     "baseBranchPatterns": [
         "main",
         "preview"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -43,6 +43,7 @@
             "go": "1.25"
         }
     },
+    "constraintsFiltering": "strict", 
     "baseBranchPatterns": [
         "main",
         "preview"


### PR DESCRIPTION
This should prevent renovate attempting to modify the go version.

https://docs.renovatebot.com/modules/manager/gomod/#only-suggesting-updates-that-match-your-go-directive