### PR TITLE
fix(datastore): save PropertyLoadSaver field output as nested entity

### DIFF
--- a/datastore/save.go
+++ b/datastore/save.go
@@ -164,11 +164,19 @@ func reflectFieldSave(props *[]Property, p Property, name string, opts saveOpts,
 	if v.CanAddr() {
 		vi := v.Addr().Interface()
 		if pSaver, ok := vi.(PropertyLoadSaver); ok {
-			val, err := pSaver.Save()
+			subProps, err := pSaver.Save()
 			if err != nil {
 				return fmt.Errorf("field save error: %w", err)
 			}
-			p.Value = val
+			if opts.flatten {
+				for _, subp := range subProps {
+					subp.Name = name + "." + subp.Name
+					*props = append(*props, subp)
+				}
+				return nil
+			}
+			// []Property is not a valid Property value; save it as a nested entity.
+			p.Value = &Entity{Properties: subProps}
 		}
 	}
 

--- a/datastore/save_test.go
+++ b/datastore/save_test.go
@@ -15,6 +15,8 @@
 package datastore
 
 import (
+	"encoding/json"
+	"errors"
 	"fmt"
 	"reflect"
 	"strings"
@@ -460,7 +462,14 @@ func TestSaveFieldsWithInterface(t *testing.T) {
 			name: "Nil map",
 			in:   &Struct{},
 			want: []Property{
-				{Name: "Map", Value: []Property{}},
+				{Name: "Map", Value: &Entity{Properties: []Property{}}},
+			},
+		},
+		{
+			name: "Non-nil map",
+			in:   &Struct{Map: Map{1: 2}},
+			want: []Property{
+				{Name: "Map", Value: &Entity{Properties: []Property{}}},
 			},
 		},
 		{
@@ -559,6 +568,184 @@ func TestSaveFieldsWithInterface(t *testing.T) {
 				t.Fatalf("got - want +\n%s", diff)
 			}
 		})
+	}
+}
+
+// plsMap is used by TestSaveMapPropertyLoadSaver to test saving of custom
+// map types that implement PropertyLoadSaver.
+type plsMap map[string]string
+
+func (m *plsMap) Load(props []Property) error {
+	for _, p := range props {
+		if p.Name == "JSON" {
+			return json.Unmarshal(p.Value.([]byte), m)
+		}
+	}
+	return nil
+}
+
+func (m *plsMap) Save() ([]Property, error) {
+	b, err := json.Marshal(m)
+	if err != nil {
+		return nil, err
+	}
+	return []Property{{Name: "JSON", Value: b, NoIndex: true}}, nil
+}
+
+// plsMapErr is used by TestSaveMapPropertyLoadSaver to test Save errors.
+type plsMapErr map[string]string
+
+func (m *plsMapErr) Load(_ []Property) error {
+	return nil
+}
+
+func (m *plsMapErr) Save() ([]Property, error) {
+	return nil, errors.New("save failed")
+}
+
+func TestSaveMapPropertyLoadSaver(t *testing.T) {
+	type mapEnt struct {
+		A string `datastore:"a"`
+		M plsMap `datastore:"m"`
+	}
+	type mapEntFlatten struct {
+		A string `datastore:"a"`
+		M plsMap `datastore:"m,flatten"`
+	}
+	type mapEntOmit struct {
+		A string `datastore:"a"`
+		M plsMap `datastore:"m,omitempty"`
+	}
+	type mapEntSlice struct {
+		Ms []plsMap `datastore:"ms"`
+	}
+	type mapEntErr struct {
+		M plsMapErr `datastore:"m"`
+	}
+
+	entity := func(json string) *Entity {
+		return &Entity{Properties: []Property{{Name: "JSON", Value: []byte(json), NoIndex: true}}}
+	}
+
+	cases := []struct {
+		name    string
+		in      interface{}
+		want    []Property
+		wantErr string
+	}{
+		{
+			name: "nil map",
+			in:   &mapEnt{A: "a"},
+			want: []Property{
+				{Name: "a", Value: "a"},
+				{Name: "m", Value: entity("null")},
+			},
+		},
+		{
+			name: "non-nil map",
+			in:   &mapEnt{A: "a", M: plsMap{"k": "v"}},
+			want: []Property{
+				{Name: "a", Value: "a"},
+				{Name: "m", Value: entity(`{"k":"v"}`)},
+			},
+		},
+		{
+			name: "empty map",
+			in:   &mapEnt{A: "a", M: plsMap{}},
+			want: []Property{
+				{Name: "a", Value: "a"},
+				{Name: "m", Value: entity("{}")},
+			},
+		},
+		{
+			name: "nil map with flatten",
+			in:   &mapEntFlatten{A: "a"},
+			want: []Property{
+				{Name: "a", Value: "a"},
+				{Name: "m.JSON", Value: []byte("null"), NoIndex: true},
+			},
+		},
+		{
+			name: "non-nil map with flatten",
+			in:   &mapEntFlatten{A: "a", M: plsMap{"k": "v"}},
+			want: []Property{
+				{Name: "a", Value: "a"},
+				{Name: "m.JSON", Value: []byte(`{"k":"v"}`), NoIndex: true},
+			},
+		},
+		{
+			name: "nil map with omitempty",
+			in:   &mapEntOmit{A: "a"},
+			want: []Property{{Name: "a", Value: "a"}},
+		},
+		{
+			name: "empty map with omitempty",
+			in:   &mapEntOmit{A: "a", M: plsMap{}},
+			want: []Property{{Name: "a", Value: "a"}},
+		},
+		{
+			name: "slice of maps with nil element",
+			in:   &mapEntSlice{Ms: []plsMap{{"k": "v"}, nil}},
+			want: []Property{
+				{Name: "ms", Value: []interface{}{entity(`{"k":"v"}`), entity("null")}},
+			},
+		},
+		{
+			name:    "save error on nil map",
+			in:      &mapEntErr{},
+			wantErr: "field save error: save failed",
+		},
+		{
+			name:    "save error on non-nil map",
+			in:      &mapEntErr{M: plsMapErr{"k": "v"}},
+			wantErr: "save failed",
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := SaveStruct(tt.in)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("got error %v, want error containing %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := testutil.Diff(got, tt.want); diff != "" {
+				t.Fatalf("got - want +\n%s", diff)
+			}
+			// The saved properties must be usable by the Put path.
+			if _, err := propertiesToProto(testKey0, got, false); err != nil {
+				t.Fatalf("propertiesToProto: %v", err)
+			}
+		})
+	}
+}
+
+func TestSaveLoadMapPropertyLoadSaver(t *testing.T) {
+	type mapEnt struct {
+		A string `datastore:"a"`
+		M plsMap `datastore:"m"`
+	}
+
+	for _, in := range []*mapEnt{
+		{A: "a", M: plsMap{"k": "v"}},
+		{A: "a"},
+	} {
+		props, err := SaveStruct(in)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var out mapEnt
+		if err := LoadStruct(&out, props); err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(&out, in) {
+			t.Errorf("round trip mismatch: got %+v, want %+v", &out, in)
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #20176
Updates #2611

## Problem

`Put` fails with `datastore: invalid Value type []datastore.Property for a Property with Name "..."` when a struct field of a nil-able kind (in practice, a custom map type) implements `PropertyLoadSaver` and holds its zero (nil) value.

Non-nil PLS fields are handled by `plsFieldSave`, which wraps the `Save()` output in `&Entity{Properties: subProps}`. Nil fields are intentionally skipped by `plsForSave` and fall through to the fallback PLS block in `reflectFieldSave` (added in #2794 to fix #2611), which assigned the raw `[]Property` to `p.Value`. `[]Property` is not a valid `Property.Value` type, so `interfaceToProto` rejects it and every `Put`/`Mutate` through this path has failed since v1.3.0. The block also ignored the `flatten` option.

## Fix

Match `plsFieldSave` in the fallback block: wrap the `Save()` output in `&Entity{Properties: subProps}`, and prefix + append sub-properties directly when `flatten` is set. Nil and non-nil PLS fields now produce identical output shapes.

No previously-succeeding save is affected: the modified block is only reachable for nil map/chan/func fields whose pointer type implements `PropertyLoadSaver`, and every write through it previously failed client-side, so no stored data can be contradicted by the new output. Verified against the Datastore emulator: with this change, `Put` and `Get` round-trip both nil and populated custom map fields.

An alternative considered was exempting `reflect.Map` from the `IsNil` guard in `plsForSave` and deleting the fallback block, letting nil maps flow through `plsFieldSave` naturally. This PR keeps the narrower change at the defect site; happy to switch approaches if maintainers prefer.

## Tests

- `TestSaveMapPropertyLoadSaver` (new): nil / non-nil / empty PLS map fields, `flatten` with nil and non-nil, `omitempty` with nil and empty, a slice of PLS maps with a nil element, and `Save()` error propagation on both paths. Each passing case is additionally run through `propertiesToProto`, the conversion that used to reject the value.
- `TestSaveLoadMapPropertyLoadSaver` (new): save/load round-trip for nil and populated maps.
- `TestSaveFieldsWithInterface`: the "Nil map" expectation previously asserted the invalid `[]Property{}` value; it now asserts the `*Entity` wrapping, and a "Non-nil map" case is added to pin both code paths to identical output.