### PR TITLE
feat(bigtable): add session package with SessionClient + SessionTableAPI interfaces

### DIFF
--- a/bigtable/internal/session/api.go
+++ b/bigtable/internal/session/api.go
@@ -75,7 +75,12 @@ type SessionClient interface {
 	// Returns an unregister thunk.
 	AddSessionLoadListener(func(load float64)) func()
 
-	// Close closes the underlying channel pool. SessionTableAPI
-	// instances previously vended become unusable.
+	// Close closes the underlying channel pool.
+	//
+	// Callers should close every vended SessionTableAPI first — this
+	// tears down the shared channel pool, and vended tables can no
+	// longer issue cleanup RPCs (e.g., session deletion) once the pool
+	// is gone. Any SessionTableAPI still open at the time of this call
+	// becomes unusable.
 	Close() error
 }

--- a/bigtable/internal/session/api.go
+++ b/bigtable/internal/session/api.go
@@ -1,0 +1,81 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package session hosts the vRPC-over-session data-plane API surface
+// for the bigtable Go client. The interfaces defined here describe a
+// proto-native alternative to the classic gRPC TableAPI: methods take
+// and return *SessionReadRow{Request,Response} /
+// *SessionMutateRow{Request,Response} instead of bigtable.Row.
+//
+// This file establishes the shape only; implementations land in
+// follow-up changes. Nothing in this package imports the top-level
+// bigtable package.
+package session
+
+import (
+	"context"
+
+	btpb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
+	"go.opentelemetry.io/otel/metric"
+)
+
+// SessionTableAPI is the per-resource, proto-native data-plane API.
+// Implementations route ReadRow over a read session pool and MutateRow
+// over a separate write session pool; callers do not see the
+// distinction. Pools open lazily on first call, so a resource that
+// only ever reads never pays for a write pool.
+type SessionTableAPI interface {
+	ReadRow(ctx context.Context, req *btpb.SessionReadRowRequest) (*btpb.SessionReadRowResponse, error)
+	MutateRow(ctx context.Context, req *btpb.SessionMutateRowRequest) (*btpb.SessionMutateRowResponse, error)
+
+	// Close releases this resource's underlying read + write session
+	// pools. Independent from SessionClient.Close — closing a single
+	// resource does not close the shared channel pool.
+	Close() error
+}
+
+// SessionClient owns the underlying gRPC channel pool + stub and vends
+// per-resource SessionTableAPI instances. Does NOT cache — callers are
+// responsible for caching per-resource entries so repeat Opens reuse
+// the same underlying pools.
+type SessionClient interface {
+	// OpenSessionTable returns a SessionTableAPI for a standard table,
+	// identified by the leaf table name (e.g. "my-table"). Full
+	// resource composition happens inside the implementation.
+	OpenSessionTable(tableName string) SessionTableAPI
+
+	// OpenAuthorizedView returns a SessionTableAPI for a specific
+	// authorized view under table.
+	OpenAuthorizedView(table, view string) SessionTableAPI
+
+	// OpenMaterializedView returns a read-only SessionTableAPI for a
+	// materialized view. MutateRow on the returned handle errors.
+	OpenMaterializedView(view string) SessionTableAPI
+
+	// MeterProvider exposes the OpenTelemetry meter provider the
+	// SessionClient was constructed with — same instance the bigtable
+	// client uses for its own metrics, so callers can register
+	// additional instruments against the same provider.
+	MeterProvider() metric.MeterProvider
+
+	// AddSessionLoadListener registers a listener invoked every time
+	// the server-driven client configuration reports a new
+	// session-load ratio (0.0 = classic-only, 1.0 = session-only).
+	// Returns an unregister thunk.
+	AddSessionLoadListener(func(load float64)) func()
+
+	// Close closes the underlying channel pool. SessionTableAPI
+	// instances previously vended become unusable.
+	Close() error
+}

--- a/bigtable/internal/session/api.go
+++ b/bigtable/internal/session/api.go
@@ -30,41 +30,41 @@ import (
 	"go.opentelemetry.io/otel/metric"
 )
 
-// SessionTableAPI is the per-resource, proto-native data-plane API.
+// TableAPI is the per-resource, proto-native data-plane API.
 // Implementations route ReadRow over a read session pool and MutateRow
 // over a separate write session pool; callers do not see the
 // distinction. Pools open lazily on first call, so a resource that
 // only ever reads never pays for a write pool.
-type SessionTableAPI interface {
+type TableAPI interface {
 	ReadRow(ctx context.Context, req *btpb.SessionReadRowRequest) (*btpb.SessionReadRowResponse, error)
 	MutateRow(ctx context.Context, req *btpb.SessionMutateRowRequest) (*btpb.SessionMutateRowResponse, error)
 
 	// Close releases this resource's underlying read + write session
-	// pools. Independent from SessionClient.Close — closing a single
+	// pools. Independent from Client.Close — closing a single
 	// resource does not close the shared channel pool.
 	Close() error
 }
 
-// SessionClient owns the underlying gRPC channel pool + stub and vends
-// per-resource SessionTableAPI instances. Does NOT cache — callers are
+// Client owns the underlying gRPC channel pool + stub and vends
+// per-resource TableAPI instances. Does NOT cache — callers are
 // responsible for caching per-resource entries so repeat Opens reuse
 // the same underlying pools.
-type SessionClient interface {
-	// OpenSessionTable returns a SessionTableAPI for a standard table,
+type Client interface {
+	// OpenSessionTable returns a TableAPI for a standard table,
 	// identified by the leaf table name (e.g. "my-table"). Full
 	// resource composition happens inside the implementation.
-	OpenSessionTable(tableName string) SessionTableAPI
+	OpenSessionTable(tableName string) TableAPI
 
-	// OpenAuthorizedView returns a SessionTableAPI for a specific
+	// OpenAuthorizedView returns a TableAPI for a specific
 	// authorized view under table.
-	OpenAuthorizedView(table, view string) SessionTableAPI
+	OpenAuthorizedView(table, view string) TableAPI
 
-	// OpenMaterializedView returns a read-only SessionTableAPI for a
+	// OpenMaterializedView returns a read-only TableAPI for a
 	// materialized view. MutateRow on the returned handle errors.
-	OpenMaterializedView(view string) SessionTableAPI
+	OpenMaterializedView(view string) TableAPI
 
 	// MeterProvider exposes the OpenTelemetry meter provider the
-	// SessionClient was constructed with — same instance the bigtable
+	// Client was constructed with — same instance the bigtable
 	// client uses for its own metrics, so callers can register
 	// additional instruments against the same provider.
 	MeterProvider() metric.MeterProvider
@@ -77,10 +77,10 @@ type SessionClient interface {
 
 	// Close closes the underlying channel pool.
 	//
-	// Callers should close every vended SessionTableAPI first — this
+	// Callers should close every vended TableAPI first — this
 	// tears down the shared channel pool, and vended tables can no
 	// longer issue cleanup RPCs (e.g., session deletion) once the pool
-	// is gone. Any SessionTableAPI still open at the time of this call
+	// is gone. Any TableAPI still open at the time of this call
 	// becomes unusable.
 	Close() error
 }


### PR DESCRIPTION
## Summary

Introduces `bigtable/internal/session`, an internal package that establishes the vRPC-over-session data-plane API surface for the Bigtable Go client. **This PR ships interfaces only** — the implementation (lazy per-resource read/write pools, the `SessionClient` that owns the channel pool, and the per-resource `sessionTable`) lands in subsequent, individually reviewable PRs.

Two interfaces:

- **`SessionTableAPI`** — per-resource, proto-native data-plane surface. `ReadRow` / `MutateRow` take and return `*SessionReadRow{Request,Response}` and `*SessionMutateRow{Request,Response}` (from `bigtable/apiv2/bigtablepb`) instead of `bigtable.Row`. `Close` releases the resource's read + write pools without touching the shared channel pool.
- **`SessionClient`** — owns the underlying gRPC channel pool + stub and vends per-resource `SessionTableAPI` instances for standard tables, authorized views, and materialized views (read-only). Exposes the OTel `MeterProvider` used for metrics and an `AddSessionLoadListener` hook that mixed-mode callers can wire to the server-driven session-load ratio (0.0 = classic-only, 1.0 = session-only).

## Why split it out first

The follow-up PRs (lazy-pool + `sessionTable`, `sessionClient` construction, per-resource pool wiring) each depend on this shape. Landing the API first keeps each subsequent PR small enough to review against a stable target and lets consumers (the top-level `bigtable` package's TableShim + Diverter, or standalone `SessionClient` users) type-check against a single import path.

Everything in this file is internal (`bigtable/internal/session/...`) — nothing is exposed on the public `bigtable` package API.

## Test plan

- [x] `go build ./bigtable/internal/session/`
- [x] `go vet ./bigtable/internal/session/`
- [ ] End-to-end tests land alongside the implementation PRs.