### PR TITLE
feat(bigtable): add ChainInterceptors and RetryingVRpc for vRPC pipeline

### DIFF
--- a/bigtable/internal/transport/attempt_outcome.go
+++ b/bigtable/internal/transport/attempt_outcome.go
@@ -31,9 +31,7 @@ const (
 	// path that hasn't yet adopted tagErr (or an error introduced by a
 	// non-vRPC layer) classifies here. Under the strict Java-parity
 	// default (see shouldRetryDefault in retrying.go) StateServerResult
-	// does NOT retry unless the server explicitly attached RetryInfo or
-	// the caller set RetryingOptions.ShouldRetry to override the whole
-	// classifier. Callers that need a permissive fallback must opt in.
+	// does NOT retry unless the server explicitly attached RetryInfo.
 	StateServerResult AttemptState = iota
 	// StateUncommitted means the attempt never reached the wire — encode
 	// failed, session was Closing, etc. Retry is safe regardless of

--- a/bigtable/internal/transport/chain.go
+++ b/bigtable/internal/transport/chain.go
@@ -21,9 +21,9 @@ import (
 // ChainInterceptors chains multiple interceptors into a single virtual RPC execution Handler.
 // The first interceptor in the list is executed first, wrapping the subsequent ones.
 //
-// Fast paths for the degenerate cases (0 or 1 interceptors) match
-// gRPC's own ChainUnaryInterceptor convention — no nested closure or
-// per-call allocation when there is nothing to chain.
+// Fast paths for 0 or 1 interceptors match gRPC's own
+// ChainUnaryInterceptor convention — no nested closure or per-call
+// allocation when there is nothing to chain.
 func ChainInterceptors(interceptors ...Interceptor) Interceptor {
 	if len(interceptors) == 0 {
 		return func(ctx context.Context, req interface{}, invoker Handler) (interface{}, error) {

--- a/bigtable/internal/transport/chain.go
+++ b/bigtable/internal/transport/chain.go
@@ -20,7 +20,19 @@ import (
 
 // ChainInterceptors chains multiple interceptors into a single virtual RPC execution Handler.
 // The first interceptor in the list is executed first, wrapping the subsequent ones.
+//
+// Fast paths for the degenerate cases (0 or 1 interceptors) match
+// gRPC's own ChainUnaryInterceptor convention — no nested closure or
+// per-call allocation when there is nothing to chain.
 func ChainInterceptors(interceptors ...Interceptor) Interceptor {
+	if len(interceptors) == 0 {
+		return func(ctx context.Context, req interface{}, invoker Handler) (interface{}, error) {
+			return invoker(ctx, req)
+		}
+	}
+	if len(interceptors) == 1 {
+		return interceptors[0]
+	}
 	return func(ctx context.Context, req interface{}, invoker Handler) (interface{}, error) {
 		chain := invoker
 		for i := len(interceptors) - 1; i >= 0; i-- {

--- a/bigtable/internal/transport/chain.go
+++ b/bigtable/internal/transport/chain.go
@@ -1,0 +1,35 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"context"
+)
+
+// ChainInterceptors chains multiple interceptors into a single virtual RPC execution Handler.
+// The first interceptor in the list is executed first, wrapping the subsequent ones.
+func ChainInterceptors(interceptors ...Interceptor) Interceptor {
+	return func(ctx context.Context, req interface{}, invoker Handler) (interface{}, error) {
+		chain := invoker
+		for i := len(interceptors) - 1; i >= 0; i-- {
+			currentIdx := i
+			nextHandler := chain
+			chain = func(c context.Context, r interface{}) (interface{}, error) {
+				return interceptors[currentIdx](c, r, nextHandler)
+			}
+		}
+		return chain(ctx, req)
+	}
+}

--- a/bigtable/internal/transport/chain_test.go
+++ b/bigtable/internal/transport/chain_test.go
@@ -1,0 +1,65 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"context"
+	"testing"
+)
+
+func TestChainedInterceptors_Success(t *testing.T) {
+	var order []string
+
+	int1 := func(ctx context.Context, req interface{}, next Handler) (interface{}, error) {
+		order = append(order, "int1_start")
+		res, err := next(ctx, req)
+		order = append(order, "int1_end")
+		return res, err
+	}
+
+	int2 := func(ctx context.Context, req interface{}, next Handler) (interface{}, error) {
+		order = append(order, "int2_start")
+		res, err := next(ctx, req)
+		order = append(order, "int2_end")
+		return res, err
+	}
+
+	baseHandler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		order = append(order, "base")
+		return "response", nil
+	}
+
+	chained := ChainInterceptors(int1, int2)
+	ctx := WithVRpcMetadata(context.Background(), "TestMethod", 1)
+
+	resp, err := chained(ctx, "request", baseHandler)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	if resp.(string) != "response" {
+		t.Errorf("Expected response to be 'response', got %v", resp)
+	}
+
+	expectedOrder := []string{"int1_start", "int2_start", "base", "int2_end", "int1_end"}
+	if len(order) != len(expectedOrder) {
+		t.Fatalf("Expected order length %d, got %d", len(expectedOrder), len(order))
+	}
+	for i, v := range expectedOrder {
+		if order[i] != v {
+			t.Errorf("At index %d: expected %q, got %q", i, v, order[i])
+		}
+	}
+}

--- a/bigtable/internal/transport/retrying.go
+++ b/bigtable/internal/transport/retrying.go
@@ -24,66 +24,39 @@ import (
 
 // RetryingOptions configures the retry behavior of RetryingVRpc.
 type RetryingOptions struct {
-	// MaxAttempts caps the total number of tries per Invoke (initial +
-	// retries). Defaults to 3 for Java parity — RetryingVRpc.java
-	// hardcodes a 3-attempt cap. Read once at RetryingVRpc construction
-	// and captured in the closure; the server-driven client config has
-	// no channel to swap this today (no matching proto field), so
-	// mutating it after RetryingVRpc(...) returns has no effect on
-	// in-flight loops.
-	MaxAttempts       int32
-	InitialBackoff    time.Duration
-	MaxBackoff        time.Duration
-	BackoffMultiplier float64
-	Tracer            VRpcTracer
+	// MaxAttempts caps the number of tries per Invoke — but ONLY for
+	// non-server-directed retries (Uncommitted or TransportFailure with
+	// no server RetryInfo). Attempts driven by server-attached
+	// RetryInfo are uncapped, so a server that keeps sending
+	// RetryDelay-carrying errors keeps getting retried until the
+	// caller's ctx deadline runs out. Defaults to 3.
+	MaxAttempts int32
+	Tracer      VRpcTracer
 	// Idempotent tells the interceptor whether TransportFailure attempts
-	// (frame handed to the wire, no server response observed) are safe to
-	// retry. Reads set this true; non-idempotent Apply sets it false.
+	// (frame handed to the wire, no server response observed) are safe
+	// to retry. Reads set this true; non-idempotent Apply sets it false.
 	// Uncommitted attempts (never left the client) retry regardless.
-	// Ignored if ShouldRetry is non-nil.
 	Idempotent bool
-	// ShouldRetry, if non-nil, overrides the default state-based check.
-	// Callers with unusual retry policies use it; the default (nil)
-	// applies Java-parity classification via AttemptState + Idempotent.
-	//
-	// Server-attached RetryInfo is checked BEFORE ShouldRetry and always
-	// wins — a server-directed retry is honored even if ShouldRetry
-	// would otherwise return false (SESSION_SPEC #9 "server-only
-	// inputs"). ShouldRetry sees only errors the server did not
-	// explicitly grant retry for.
-	ShouldRetry func(error) bool
 }
 
-// RetryingVRpc returns an Interceptor that retries failed virtual RPCs with
-// exponential delay backoffs and optional custom server RetryInfo parsing.
+// RetryingVRpc returns an Interceptor that retries failed virtual RPCs
+// per the AttemptState oracle (Uncommitted always, TransportFailure if
+// idempotent) and honors server-attached RetryInfo. Backoff is
+// server-driven: RetryInfo.retryDelay if the server sent one, otherwise
+// immediate retry. There is no client-side exponential backoff.
 func RetryingVRpc(opts RetryingOptions) Interceptor {
 	if opts.MaxAttempts <= 0 {
 		opts.MaxAttempts = 3
 	}
-	if opts.InitialBackoff <= 0 {
-		opts.InitialBackoff = 20 * time.Millisecond
-	}
-	if opts.MaxBackoff <= 0 {
-		opts.MaxBackoff = 32 * time.Second
-	}
-	if opts.BackoffMultiplier <= 0 {
-		opts.BackoffMultiplier = 1.3
-	}
-
 	maxAttempts := opts.MaxAttempts
 
 	return func(ctx context.Context, req interface{}, next Handler) (interface{}, error) {
 		var attempt int32
-		backoff := opts.InitialBackoff
 		tracer := opts.Tracer // may be nil
-
 		var lastErr error
 
 		for {
 			attempt++
-			if attempt > maxAttempts {
-				break
-			}
 
 			attemptCtx := WithAttempt(ctx, int(attempt))
 			// Tag the next attempt's context with the prior attempt's
@@ -110,109 +83,84 @@ func RetryingVRpc(opts RetryingOptions) Interceptor {
 
 			lastErr = err
 
-			// SESSION_SPEC #9 "last-observed err preserved": Java's
-			// RetryingVRpc returns the last attempt's typed error, not
-			// raw context.Canceled/DeadlineExceeded. lastErr carries the
+			// Return the last attempt's typed error, not raw
+			// context.Canceled/DeadlineExceeded. lastErr carries the
 			// gRPC code + AttemptState tag callers need.
 			if ctx.Err() != nil {
 				return nil, lastErr
 			}
 
+			// Server RetryInfo is server-only authority. Only a
+			// well-formed RetryDelay counts as the server saying
+			// "retry"; an empty or malformed RetryInfo detail is not
+			// enough to bypass the state-based default gate.
 			var delay time.Duration
-			hasServerDelay := false
-
-			s, hasStatus := status.FromError(err)
-			// Server RetryInfo is checked first so a server-directed delay
-			// permits retry even for otherwise-non-retryable outcomes
-			// (e.g. server DEADLINE_EXCEEDED that the server explicitly
-			// says is safe to retry).
 			serverPermitsRetry := false
-			if hasStatus {
+			if s, ok := status.FromError(err); ok {
 				for _, detail := range s.Details() {
 					if retryInfo, ok := detail.(*errdetails.RetryInfo); ok {
 						if retryInfo.GetRetryDelay().IsValid() {
 							delay = retryInfo.GetRetryDelay().AsDuration()
-							hasServerDelay = true
 							serverPermitsRetry = true
-							break
 						}
+						break
 					}
 				}
 			}
 
-			// Server RetryInfo is server-only authority (SESSION_SPEC #9
-			// "server-only inputs"): if the server explicitly grants
-			// retry, honor it regardless of any caller-supplied
-			// ShouldRetry policy or state-based default. Falling into
-			// either gate would let a client-side rule veto the server.
-			if !serverPermitsRetry {
-				if opts.ShouldRetry != nil {
-					if !opts.ShouldRetry(err) {
-						return nil, err
-					}
-				} else if !shouldRetryDefault(err, opts.Idempotent) {
+			if serverPermitsRetry {
+				// Server-directed retries are uncapped by MaxAttempts —
+				// the server is telling us this specific request is
+				// safe to retry, so we honor it until the caller's
+				// ctx deadline runs out.
+			} else {
+				if !shouldRetryDefault(err, opts.Idempotent) {
 					return nil, err
 				}
-			}
-
-			if !hasServerDelay {
-				delay = backoff
-				nextBackoff := float64(backoff) * opts.BackoffMultiplier
-				if nextBackoff > float64(opts.MaxBackoff) {
-					backoff = opts.MaxBackoff
-				} else {
-					backoff = time.Duration(nextBackoff)
+				// The 3-attempt cap applies only to non-server-directed
+				// retries. Once we've done maxAttempts and would need
+				// to retry again for a non-server reason, stop.
+				if attempt >= maxAttempts {
+					return nil, lastErr
 				}
 			}
 
-			// SESSION_SPEC #9 "deadline-fit check": if the delay would
+			// If a delay is scheduled (server RetryInfo) and it would
 			// exhaust the caller's remaining deadline, skip the retry
-			// entirely and surface lastErr — Java parity
-			// (RetryingVRpc.java:290-298). Waiting past the deadline
-			// only to have the next attempt immediately fail with
-			// DeadlineExceeded loses the typed error and burns budget.
-			// Applied to any delay (server RetryInfo or client
-			// backoff) — the rationale is the same in either case.
-			if dl, ok := ctx.Deadline(); ok && time.Until(dl) < delay {
-				return nil, lastErr
+			// entirely and surface lastErr. Waiting past the deadline
+			// only to have the next attempt fail with DeadlineExceeded
+			// loses the typed error and burns budget.
+			if delay > 0 {
+				if dl, ok := ctx.Deadline(); ok && time.Until(dl) < delay {
+					return nil, lastErr
+				}
+				// time.NewTimer + Stop() (rather than time.After) so a
+				// ctx-cancel exit path releases the timer immediately
+				// instead of leaking it until delay elapses.
+				timer := time.NewTimer(delay)
+				select {
+				case <-ctx.Done():
+					timer.Stop()
+					return nil, lastErr
+				case <-timer.C:
+				}
 			}
-
-			// time.NewTimer + Stop() (rather than time.After) so a
-			// ctx-cancel exit path releases the timer immediately
-			// instead of leaking it until `delay` elapses.
-			timer := time.NewTimer(delay)
-			select {
-			case <-ctx.Done():
-				timer.Stop()
-				// Preserve lastErr on the backoff-window cancel, same
-				// rationale as the post-attempt ctx.Err() branch above.
-				return nil, lastErr
-			case <-timer.C:
-			}
+			// If delay == 0 (no server RetryInfo, or a non-server-
+			// directed retry) we loop immediately — no client backoff.
 		}
-
-		return nil, lastErr
 	}
 }
 
-// shouldRetryDefault applies strict Java-parity retry classification for
-// the default retry path (no caller-supplied ShouldRetry, no server
-// RetryInfo). Server RetryInfo is handled by the caller before this fn
-// is consulted — its short-circuit lives at the interceptor level so the
-// custom-ShouldRetry path honors it uniformly (SESSION_SPEC #9).
+// shouldRetryDefault applies strict retry classification for the
+// default retry path (no server RetryInfo). Server RetryInfo is handled
+// by the caller before this fn is consulted.
 //
 // Retry rules (see AttemptState doc for state semantics):
 //   - Uncommitted → always retry (server saw nothing).
 //   - TransportFailure → retry only if idempotent (server may have applied).
 //   - ServerResult → NEVER retry from this path. A bare server-explicit
-//     error — even Unavailable / Aborted / DeadlineExceeded — is NOT
-//     retried without an explicit server go-ahead (RetryInfo handled
-//     upstream). This matches Java's RetryingVRpc: the server said
-//     something specific; the client doesn't second-guess it.
-//
-// Callers that need the pre-parity permissive behavior (retry on
-// {Aborted, Internal, ResourceExhausted, Unavailable} without RetryInfo)
-// set RetryingOptions.ShouldRetry.
+//     error is NOT retried without an explicit server go-ahead
+//     (RetryInfo handled upstream).
 func shouldRetryDefault(err error, idempotent bool) bool {
 	outcome := ClassifyErr(err)
 	switch outcome.State {

--- a/bigtable/internal/transport/retrying.go
+++ b/bigtable/internal/transport/retrying.go
@@ -67,12 +67,16 @@ func RetryingVRpc(opts RetryingOptions) Interceptor {
 		var lastErr error
 
 		for {
-			currentAttempt := atomic.AddInt32(&attempt, 1)
-			if currentAttempt > atomic.LoadInt32(&opts.MaxAttempts) {
+			attempt++
+			// opts.MaxAttempts stays behind atomic.Load — outside code
+			// (config-manager UpdateConfig fan-out) may swap it while
+			// the loop is running. The local attempt counter is
+			// goroutine-local and needs no synchronization.
+			if attempt > atomic.LoadInt32(&opts.MaxAttempts) {
 				break
 			}
 
-			attemptCtx := WithAttempt(ctx, int(currentAttempt))
+			attemptCtx := WithAttempt(ctx, int(attempt))
 			// Tag the next attempt's context with the prior attempt's
 			// error so the downstream Session.Invoke can record a
 			// "retry" SessionEvent carrying the original gRPC code +
@@ -141,10 +145,15 @@ func RetryingVRpc(opts RetryingOptions) Interceptor {
 				}
 			}
 
+			// time.NewTimer + Stop() (rather than time.After) so a
+			// ctx-cancel exit path releases the timer immediately
+			// instead of leaking it until `delay` elapses.
+			timer := time.NewTimer(delay)
 			select {
 			case <-ctx.Done():
+				timer.Stop()
 				return nil, ctx.Err()
-			case <-time.After(delay):
+			case <-timer.C:
 			}
 		}
 

--- a/bigtable/internal/transport/retrying.go
+++ b/bigtable/internal/transport/retrying.go
@@ -16,7 +16,6 @@ package internal
 
 import (
 	"context"
-	"sync/atomic"
 	"time"
 
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
@@ -25,7 +24,14 @@ import (
 
 // RetryingOptions configures the retry behavior of RetryingVRpc.
 type RetryingOptions struct {
-	MaxAttempts       int32 // Atomic race cap for max attempts.
+	// MaxAttempts caps the total number of tries per Invoke (initial +
+	// retries). Defaults to 3 for Java parity — RetryingVRpc.java
+	// hardcodes a 3-attempt cap. Read once at RetryingVRpc construction
+	// and captured in the closure; the server-driven client config has
+	// no channel to swap this today (no matching proto field), so
+	// mutating it after RetryingVRpc(...) returns has no effect on
+	// in-flight loops.
+	MaxAttempts       int32
 	InitialBackoff    time.Duration
 	MaxBackoff        time.Duration
 	BackoffMultiplier float64
@@ -36,10 +42,15 @@ type RetryingOptions struct {
 	// Uncommitted attempts (never left the client) retry regardless.
 	// Ignored if ShouldRetry is non-nil.
 	Idempotent bool
-	// ShouldRetry, if non-nil, overrides the default state-based check
-	// entirely. Callers with unusual retry policies use it; the default
-	// (nil) applies Java-parity classification via AttemptState +
-	// Idempotent + server-provided RetryInfo.
+	// ShouldRetry, if non-nil, overrides the default state-based check.
+	// Callers with unusual retry policies use it; the default (nil)
+	// applies Java-parity classification via AttemptState + Idempotent.
+	//
+	// Server-attached RetryInfo is checked BEFORE ShouldRetry and always
+	// wins — a server-directed retry is honored even if ShouldRetry
+	// would otherwise return false (SESSION_SPEC #9 "server-only
+	// inputs"). ShouldRetry sees only errors the server did not
+	// explicitly grant retry for.
 	ShouldRetry func(error) bool
 }
 
@@ -59,6 +70,8 @@ func RetryingVRpc(opts RetryingOptions) Interceptor {
 		opts.BackoffMultiplier = 1.3
 	}
 
+	maxAttempts := opts.MaxAttempts
+
 	return func(ctx context.Context, req interface{}, next Handler) (interface{}, error) {
 		var attempt int32
 		backoff := opts.InitialBackoff
@@ -68,11 +81,7 @@ func RetryingVRpc(opts RetryingOptions) Interceptor {
 
 		for {
 			attempt++
-			// opts.MaxAttempts stays behind atomic.Load — outside code
-			// (config-manager UpdateConfig fan-out) may swap it while
-			// the loop is running. The local attempt counter is
-			// goroutine-local and needs no synchronization.
-			if attempt > atomic.LoadInt32(&opts.MaxAttempts) {
+			if attempt > maxAttempts {
 				break
 			}
 
@@ -101,8 +110,12 @@ func RetryingVRpc(opts RetryingOptions) Interceptor {
 
 			lastErr = err
 
+			// SESSION_SPEC #9 "last-observed err preserved": Java's
+			// RetryingVRpc returns the last attempt's typed error, not
+			// raw context.Canceled/DeadlineExceeded. lastErr carries the
+			// gRPC code + AttemptState tag callers need.
 			if ctx.Err() != nil {
-				return nil, ctx.Err()
+				return nil, lastErr
 			}
 
 			var delay time.Duration
@@ -127,12 +140,19 @@ func RetryingVRpc(opts RetryingOptions) Interceptor {
 				}
 			}
 
-			if opts.ShouldRetry != nil {
-				if !opts.ShouldRetry(err) {
+			// Server RetryInfo is server-only authority (SESSION_SPEC #9
+			// "server-only inputs"): if the server explicitly grants
+			// retry, honor it regardless of any caller-supplied
+			// ShouldRetry policy or state-based default. Falling into
+			// either gate would let a client-side rule veto the server.
+			if !serverPermitsRetry {
+				if opts.ShouldRetry != nil {
+					if !opts.ShouldRetry(err) {
+						return nil, err
+					}
+				} else if !shouldRetryDefault(err, opts.Idempotent) {
 					return nil, err
 				}
-			} else if !shouldRetryDefault(err, opts.Idempotent, serverPermitsRetry) {
-				return nil, err
 			}
 
 			if !hasServerDelay {
@@ -145,6 +165,18 @@ func RetryingVRpc(opts RetryingOptions) Interceptor {
 				}
 			}
 
+			// SESSION_SPEC #9 "deadline-fit check": if the delay would
+			// exhaust the caller's remaining deadline, skip the retry
+			// entirely and surface lastErr — Java parity
+			// (RetryingVRpc.java:290-298). Waiting past the deadline
+			// only to have the next attempt immediately fail with
+			// DeadlineExceeded loses the typed error and burns budget.
+			// Applied to any delay (server RetryInfo or client
+			// backoff) — the rationale is the same in either case.
+			if dl, ok := ctx.Deadline(); ok && time.Until(dl) < delay {
+				return nil, lastErr
+			}
+
 			// time.NewTimer + Stop() (rather than time.After) so a
 			// ctx-cancel exit path releases the timer immediately
 			// instead of leaking it until `delay` elapses.
@@ -152,7 +184,9 @@ func RetryingVRpc(opts RetryingOptions) Interceptor {
 			select {
 			case <-ctx.Done():
 				timer.Stop()
-				return nil, ctx.Err()
+				// Preserve lastErr on the backoff-window cancel, same
+				// rationale as the post-attempt ctx.Err() branch above.
+				return nil, lastErr
 			case <-timer.C:
 			}
 		}
@@ -161,27 +195,25 @@ func RetryingVRpc(opts RetryingOptions) Interceptor {
 	}
 }
 
-// shouldRetryDefault applies strict Java-parity retry classification.
-// Callers with a bespoke policy set RetryingOptions.ShouldRetry to bypass
-// this entirely.
+// shouldRetryDefault applies strict Java-parity retry classification for
+// the default retry path (no caller-supplied ShouldRetry, no server
+// RetryInfo). Server RetryInfo is handled by the caller before this fn
+// is consulted — its short-circuit lives at the interceptor level so the
+// custom-ShouldRetry path honors it uniformly (SESSION_SPEC #9).
 //
 // Retry rules (see AttemptState doc for state semantics):
 //   - Uncommitted → always retry (server saw nothing).
 //   - TransportFailure → retry only if idempotent (server may have applied).
-//   - ServerResult → retry ONLY if the server attached RetryInfo (checked
-//     by the caller and passed in as serverPermitsRetry). A bare
-//     server-explicit error — even Unavailable / Aborted / DeadlineExceeded —
-//     is NOT retried without an explicit server go-ahead. This matches
-//     Java's RetryingVRpc: the server said something specific; the client
-//     doesn't second-guess it.
+//   - ServerResult → NEVER retry from this path. A bare server-explicit
+//     error — even Unavailable / Aborted / DeadlineExceeded — is NOT
+//     retried without an explicit server go-ahead (RetryInfo handled
+//     upstream). This matches Java's RetryingVRpc: the server said
+//     something specific; the client doesn't second-guess it.
 //
 // Callers that need the pre-parity permissive behavior (retry on
 // {Aborted, Internal, ResourceExhausted, Unavailable} without RetryInfo)
 // set RetryingOptions.ShouldRetry.
-func shouldRetryDefault(err error, idempotent, serverPermitsRetry bool) bool {
-	if serverPermitsRetry {
-		return true
-	}
+func shouldRetryDefault(err error, idempotent bool) bool {
 	outcome := ClassifyErr(err)
 	switch outcome.State {
 	case StateUncommitted:

--- a/bigtable/internal/transport/retrying.go
+++ b/bigtable/internal/transport/retrying.go
@@ -1,0 +1,186 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"context"
+	"sync/atomic"
+	"time"
+
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	"google.golang.org/grpc/status"
+)
+
+// RetryingOptions configures the retry behavior of RetryingVRpc.
+type RetryingOptions struct {
+	MaxAttempts       int32 // Atomic race cap for max attempts.
+	InitialBackoff    time.Duration
+	MaxBackoff        time.Duration
+	BackoffMultiplier float64
+	Tracer            VRpcTracer
+	// Idempotent tells the interceptor whether TransportFailure attempts
+	// (frame handed to the wire, no server response observed) are safe to
+	// retry. Reads set this true; non-idempotent Apply sets it false.
+	// Uncommitted attempts (never left the client) retry regardless.
+	// Ignored if ShouldRetry is non-nil.
+	Idempotent bool
+	// ShouldRetry, if non-nil, overrides the default state-based check
+	// entirely. Callers with unusual retry policies use it; the default
+	// (nil) applies Java-parity classification via AttemptState +
+	// Idempotent + server-provided RetryInfo.
+	ShouldRetry func(error) bool
+}
+
+// RetryingVRpc returns an Interceptor that retries failed virtual RPCs with
+// exponential delay backoffs and optional custom server RetryInfo parsing.
+func RetryingVRpc(opts RetryingOptions) Interceptor {
+	if opts.MaxAttempts <= 0 {
+		opts.MaxAttempts = 3
+	}
+	if opts.InitialBackoff <= 0 {
+		opts.InitialBackoff = 20 * time.Millisecond
+	}
+	if opts.MaxBackoff <= 0 {
+		opts.MaxBackoff = 32 * time.Second
+	}
+	if opts.BackoffMultiplier <= 0 {
+		opts.BackoffMultiplier = 1.3
+	}
+
+	return func(ctx context.Context, req interface{}, next Handler) (interface{}, error) {
+		var attempt int32
+		backoff := opts.InitialBackoff
+		tracer := opts.Tracer // may be nil
+
+		var lastErr error
+
+		for {
+			currentAttempt := atomic.AddInt32(&attempt, 1)
+			if currentAttempt > atomic.LoadInt32(&opts.MaxAttempts) {
+				break
+			}
+
+			attemptCtx := WithAttempt(ctx, int(currentAttempt))
+			// Tag the next attempt's context with the prior attempt's
+			// error so the downstream Session.Invoke can record a
+			// "retry" SessionEvent carrying the original gRPC code +
+			// message. lastErr is nil on the very first attempt.
+			if lastErr != nil {
+				attemptCtx = WithPrevAttemptErr(attemptCtx, lastErr)
+			}
+
+			if tracer != nil {
+				tracer.OnAttemptStart(attemptCtx)
+			}
+
+			res, err := next(attemptCtx, req)
+
+			if tracer != nil {
+				tracer.OnAttemptComplete(attemptCtx, err)
+			}
+
+			if err == nil {
+				return res, nil
+			}
+
+			lastErr = err
+
+			if ctx.Err() != nil {
+				return nil, ctx.Err()
+			}
+
+			var delay time.Duration
+			hasServerDelay := false
+
+			s, hasStatus := status.FromError(err)
+			// Server RetryInfo is checked first so a server-directed delay
+			// permits retry even for otherwise-non-retryable outcomes
+			// (e.g. server DEADLINE_EXCEEDED that the server explicitly
+			// says is safe to retry).
+			serverPermitsRetry := false
+			if hasStatus {
+				for _, detail := range s.Details() {
+					if retryInfo, ok := detail.(*errdetails.RetryInfo); ok {
+						if retryInfo.GetRetryDelay().IsValid() {
+							delay = retryInfo.GetRetryDelay().AsDuration()
+							hasServerDelay = true
+							serverPermitsRetry = true
+							break
+						}
+					}
+				}
+			}
+
+			if opts.ShouldRetry != nil {
+				if !opts.ShouldRetry(err) {
+					return nil, err
+				}
+			} else if !shouldRetryDefault(err, opts.Idempotent, serverPermitsRetry) {
+				return nil, err
+			}
+
+			if !hasServerDelay {
+				delay = backoff
+				nextBackoff := float64(backoff) * opts.BackoffMultiplier
+				if nextBackoff > float64(opts.MaxBackoff) {
+					backoff = opts.MaxBackoff
+				} else {
+					backoff = time.Duration(nextBackoff)
+				}
+			}
+
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(delay):
+			}
+		}
+
+		return nil, lastErr
+	}
+}
+
+// shouldRetryDefault applies strict Java-parity retry classification.
+// Callers with a bespoke policy set RetryingOptions.ShouldRetry to bypass
+// this entirely.
+//
+// Retry rules (see AttemptState doc for state semantics):
+//   - Uncommitted → always retry (server saw nothing).
+//   - TransportFailure → retry only if idempotent (server may have applied).
+//   - ServerResult → retry ONLY if the server attached RetryInfo (checked
+//     by the caller and passed in as serverPermitsRetry). A bare
+//     server-explicit error — even Unavailable / Aborted / DeadlineExceeded —
+//     is NOT retried without an explicit server go-ahead. This matches
+//     Java's RetryingVRpc: the server said something specific; the client
+//     doesn't second-guess it.
+//
+// Callers that need the pre-parity permissive behavior (retry on
+// {Aborted, Internal, ResourceExhausted, Unavailable} without RetryInfo)
+// set RetryingOptions.ShouldRetry.
+func shouldRetryDefault(err error, idempotent, serverPermitsRetry bool) bool {
+	if serverPermitsRetry {
+		return true
+	}
+	outcome := ClassifyErr(err)
+	switch outcome.State {
+	case StateUncommitted:
+		return true
+	case StateTransportFailure:
+		return idempotent
+	case StateServerResult:
+		return false
+	}
+	return false
+}

--- a/bigtable/internal/transport/retrying_test.go
+++ b/bigtable/internal/transport/retrying_test.go
@@ -68,10 +68,9 @@ func TestRetryingVRpc_SuccessOnRetry(t *testing.T) {
 
 	tracer := &mockTracer{}
 	retryInterceptor := RetryingVRpc(RetryingOptions{
-		MaxAttempts:    5,
-		InitialBackoff: 1 * time.Millisecond,
-		Tracer:         tracer,
-		Idempotent:     true,
+		MaxAttempts: 5,
+		Tracer:      tracer,
+		Idempotent:  true,
 	})
 
 	ctx := WithVRpcMetadata(context.Background(), "TestMethod", 1)
@@ -115,8 +114,7 @@ func TestRetryingVRpc_NonRetryableError(t *testing.T) {
 	}
 
 	retryInterceptor := RetryingVRpc(RetryingOptions{
-		MaxAttempts:    5,
-		InitialBackoff: 1 * time.Millisecond,
+		MaxAttempts: 5,
 	})
 
 	ctx := WithVRpcMetadata(context.Background(), "TestMethod", 1)
@@ -141,7 +139,7 @@ func TestRetryingVRpc_HonorServerRetryDelay(t *testing.T) {
 		attempts++
 		if attempts == 1 {
 			// Server-returned error carrying RetryInfo — permits retry
-			// regardless of state (Java parity: server explicitly said
+			// regardless of state (Server explicitly said
 			// "try again in Nms"). Tag as ServerResult to match the real
 			// production path (handleVRPCErrorResponse).
 			st := status.New(codes.Unavailable, "overloaded")
@@ -157,8 +155,7 @@ func TestRetryingVRpc_HonorServerRetryDelay(t *testing.T) {
 	}
 
 	retryInterceptor := RetryingVRpc(RetryingOptions{
-		MaxAttempts:    3,
-		InitialBackoff: 200 * time.Millisecond, // Default initial backoff is large, but server details should override it
+		MaxAttempts: 3,
 	})
 
 	startTime := time.Now()
@@ -187,9 +184,8 @@ func TestRetryingVRpc_MaxAttemptsExceeded(t *testing.T) {
 	}
 
 	retryInterceptor := RetryingVRpc(RetryingOptions{
-		MaxAttempts:    3,
-		InitialBackoff: 1 * time.Millisecond,
-		Idempotent:     true,
+		MaxAttempts: 3,
+		Idempotent:  true,
 	})
 
 	ctx := WithVRpcMetadata(context.Background(), "TestMethod", 1)
@@ -211,8 +207,7 @@ func TestRetryingVRpc_NonGrpcError(t *testing.T) {
 	}
 
 	retryInterceptor := RetryingVRpc(RetryingOptions{
-		MaxAttempts:    3,
-		InitialBackoff: 1 * time.Millisecond,
+		MaxAttempts: 3,
 	})
 
 	ctx := WithVRpcMetadata(context.Background(), "TestMethod", 1)
@@ -240,9 +235,8 @@ func TestRetryingVRpc_UncommittedAlwaysRetries(t *testing.T) {
 	}
 
 	retryInterceptor := RetryingVRpc(RetryingOptions{
-		MaxAttempts:    5,
-		InitialBackoff: 1 * time.Millisecond,
-		Idempotent:     false, // non-idempotent: uncommitted still retries
+		MaxAttempts: 5,
+		Idempotent:  false, // non-idempotent: uncommitted still retries
 	})
 
 	ctx := WithVRpcMetadata(context.Background(), "TestMethod", 1)
@@ -271,9 +265,8 @@ func TestRetryingVRpc_TransportFailureIdempotent(t *testing.T) {
 	}
 
 	retryInterceptor := RetryingVRpc(RetryingOptions{
-		MaxAttempts:    5,
-		InitialBackoff: 1 * time.Millisecond,
-		Idempotent:     true,
+		MaxAttempts: 5,
+		Idempotent:  true,
 	})
 
 	ctx := WithVRpcMetadata(context.Background(), "TestMethod", 1)
@@ -298,9 +291,8 @@ func TestRetryingVRpc_TransportFailureNonIdempotentNoRetry(t *testing.T) {
 	}
 
 	retryInterceptor := RetryingVRpc(RetryingOptions{
-		MaxAttempts:    5,
-		InitialBackoff: 1 * time.Millisecond,
-		Idempotent:     false,
+		MaxAttempts: 5,
+		Idempotent:  false,
 	})
 
 	ctx := WithVRpcMetadata(context.Background(), "TestMethod", 1)
@@ -314,11 +306,11 @@ func TestRetryingVRpc_TransportFailureNonIdempotentNoRetry(t *testing.T) {
 }
 
 // TestRetryingVRpc_ServerResultNotRetriedByDefault verifies strict
-// Java parity for the ServerResult path: a server-explicit error is NOT
+// Strict oracle for the ServerResult path: a server-explicit error is NOT
 // retried without server-attached RetryInfo, regardless of gRPC code.
 // The permissive pre-parity behavior (retry on Unavailable / Aborted /
-// Internal / ResourceExhausted / DeadlineExceeded) is gone; callers who
-// need it must set RetryingOptions.ShouldRetry.
+// Internal / ResourceExhausted / DeadlineExceeded) is gone; the server
+// must attach RetryInfo to opt in.
 func TestRetryingVRpc_ServerResultNotRetriedByDefault(t *testing.T) {
 	cases := []struct {
 		name string
@@ -338,9 +330,8 @@ func TestRetryingVRpc_ServerResultNotRetriedByDefault(t *testing.T) {
 				return nil, tagErr(StateServerResult, status.Error(tc.code, "server said no"))
 			}
 			retryInterceptor := RetryingVRpc(RetryingOptions{
-				MaxAttempts:    5,
-				InitialBackoff: 1 * time.Millisecond,
-				Idempotent:     true, // even idempotent: ServerResult without RetryInfo never retries
+				MaxAttempts: 5,
+				Idempotent:  true, // even idempotent: ServerResult without RetryInfo never retries
 			})
 			ctx := WithVRpcMetadata(context.Background(), "TestMethod", 1)
 			_, err := retryInterceptor(ctx, "req", baseHandler)
@@ -355,7 +346,7 @@ func TestRetryingVRpc_ServerResultNotRetriedByDefault(t *testing.T) {
 	}
 }
 
-// TestRetryingVRpc_ServerDeadlineExceededNoRetryByDefault verifies Java
+// TestRetryingVRpc_ServerDeadlineExceededNoRetryByDefault verifies
 // parity: a server-returned DEADLINE_EXCEEDED is NOT retried by default.
 // The server said "I gave up"; blindly retrying burns budget on ops the
 // server already discarded.
@@ -367,9 +358,8 @@ func TestRetryingVRpc_ServerDeadlineExceededNoRetryByDefault(t *testing.T) {
 	}
 
 	retryInterceptor := RetryingVRpc(RetryingOptions{
-		MaxAttempts:    5,
-		InitialBackoff: 1 * time.Millisecond,
-		Idempotent:     true, // even idempotent: server DEADLINE_EXCEEDED still no retry
+		MaxAttempts: 5,
+		Idempotent:  true, // even idempotent: server DEADLINE_EXCEEDED still no retry
 	})
 
 	ctx := WithVRpcMetadata(context.Background(), "TestMethod", 1)
@@ -404,9 +394,8 @@ func TestRetryingVRpc_ServerDeadlineExceededRetriesWithRetryInfo(t *testing.T) {
 	}
 
 	retryInterceptor := RetryingVRpc(RetryingOptions{
-		MaxAttempts:    3,
-		InitialBackoff: 1 * time.Millisecond,
-		Idempotent:     true,
+		MaxAttempts: 3,
+		Idempotent:  true,
 	})
 
 	ctx := WithVRpcMetadata(context.Background(), "TestMethod", 1)
@@ -419,6 +408,75 @@ func TestRetryingVRpc_ServerDeadlineExceededRetriesWithRetryInfo(t *testing.T) {
 	}
 	if attempts != 2 {
 		t.Errorf("expected 2 attempts, got %d", attempts)
+	}
+}
+
+// TestRetryingVRpc_ServerRetryInfoUncapsMaxAttempts pins the contract
+// that MaxAttempts applies only to non-server-directed retries
+// (Uncommitted or TransportFailure without RetryInfo). When the server
+// keeps returning RetryInfo, we honor it beyond MaxAttempts —
+// bounded only by the caller's ctx deadline.
+func TestRetryingVRpc_ServerRetryInfoUncapsMaxAttempts(t *testing.T) {
+	attempts := 0
+	baseHandler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		attempts++
+		if attempts < 6 {
+			return nil, tagErr(StateServerResult, mustStatusWithRetryInfo(t,
+				codes.Unavailable, "still overloaded", 1*time.Millisecond))
+		}
+		return "ok", nil
+	}
+
+	// MaxAttempts=3 would cap a non-server-directed retry after the
+	// third attempt. Server RetryInfo must bypass that cap; we expect
+	// to reach attempt 6.
+	retryInterceptor := RetryingVRpc(RetryingOptions{MaxAttempts: 3})
+
+	ctx := WithVRpcMetadata(context.Background(), "TestMethod", 1)
+	resp, err := retryInterceptor(ctx, "req", baseHandler)
+	if err != nil {
+		t.Fatalf("expected success (server-directed retries uncap MaxAttempts), got %v", err)
+	}
+	if resp.(string) != "ok" {
+		t.Errorf("expected 'ok', got %v", resp)
+	}
+	if attempts != 6 {
+		t.Errorf("expected 6 attempts (server RetryInfo bypasses MaxAttempts=3), got %d", attempts)
+	}
+}
+
+// TestRetryingVRpc_NoClientBackoffOnNonServerRetry pins that a
+// non-server-directed retry (e.g. TransportFailure) fires with zero
+// delay — no client-side exponential backoff. The
+// onStateChange(new Idle()) branch when RetryInfo is absent triggers
+// the next attempt immediately.
+func TestRetryingVRpc_NoClientBackoffOnNonServerRetry(t *testing.T) {
+	attempts := 0
+	baseHandler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		attempts++
+		if attempts < 3 {
+			return nil, tagErr(StateTransportFailure, status.Error(codes.Unavailable, "wire error"))
+		}
+		return "ok", nil
+	}
+
+	retryInterceptor := RetryingVRpc(RetryingOptions{
+		MaxAttempts: 5,
+		Idempotent:  true,
+	})
+
+	start := time.Now()
+	ctx := WithVRpcMetadata(context.Background(), "TestMethod", 1)
+	_, err := retryInterceptor(ctx, "req", baseHandler)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+	// 3 back-to-back attempts with no client sleep should complete
+	// within a couple of ms on any machine. Generous cap for CI jitter.
+	if elapsed > 50*time.Millisecond {
+		t.Errorf("elapsed = %v, want < 50ms (no client-side backoff between attempts)", elapsed)
 	}
 }
 
@@ -436,9 +494,8 @@ func TestRetryingVRpc_CtxCancelPreservesLastErr(t *testing.T) {
 	ctx, cancel := context.WithCancel(WithVRpcMetadata(context.Background(), "TestMethod", 1))
 
 	retryInterceptor := RetryingVRpc(RetryingOptions{
-		MaxAttempts:    5,
-		InitialBackoff: 50 * time.Millisecond,
-		Idempotent:     true,
+		MaxAttempts: 5,
+		Idempotent:  true,
 	})
 
 	// Cancel after the first attempt lands but before the backoff timer fires.
@@ -474,9 +531,8 @@ func TestRetryingVRpc_DeadlineFitSkipsRetry(t *testing.T) {
 	defer cancel()
 
 	retryInterceptor := RetryingVRpc(RetryingOptions{
-		MaxAttempts:    5,
-		InitialBackoff: 1 * time.Millisecond,
-		Idempotent:     true,
+		MaxAttempts: 5,
+		Idempotent:  true,
 	})
 
 	start := time.Now()
@@ -491,42 +547,6 @@ func TestRetryingVRpc_DeadlineFitSkipsRetry(t *testing.T) {
 	}
 	if elapsed > 100*time.Millisecond {
 		t.Errorf("expected fast return (no 5s sleep), took %v", elapsed)
-	}
-}
-
-// TestRetryingVRpc_ServerRetryInfoOverridesShouldRetry pins SESSION_SPEC
-// #9's "server-only inputs" contract: server RetryInfo is server-only
-// authority and MUST override any caller-supplied ShouldRetry callback.
-// Without this, a strict client policy could veto a server-directed
-// retry — losing the whole point of the RetryInfo detail.
-func TestRetryingVRpc_ServerRetryInfoOverridesShouldRetry(t *testing.T) {
-	attempts := 0
-	baseHandler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		attempts++
-		if attempts == 1 {
-			return nil, tagErr(StateServerResult, mustStatusWithRetryInfo(t,
-				codes.DeadlineExceeded, "overloaded, retry", 1*time.Millisecond))
-		}
-		return "ok", nil
-	}
-
-	// ShouldRetry says "never retry"; the server's RetryInfo must win.
-	retryInterceptor := RetryingVRpc(RetryingOptions{
-		MaxAttempts:    5,
-		InitialBackoff: 1 * time.Millisecond,
-		ShouldRetry:    func(error) bool { return false },
-	})
-
-	ctx := WithVRpcMetadata(context.Background(), "TestMethod", 1)
-	resp, err := retryInterceptor(ctx, "req", baseHandler)
-	if err != nil {
-		t.Fatalf("expected success (server RetryInfo overrides ShouldRetry), got %v", err)
-	}
-	if resp.(string) != "ok" {
-		t.Errorf("expected 'ok', got %v", resp)
-	}
-	if attempts != 2 {
-		t.Errorf("expected 2 attempts, got %d", attempts)
 	}
 }
 

--- a/bigtable/internal/transport/retrying_test.go
+++ b/bigtable/internal/transport/retrying_test.go
@@ -421,3 +421,122 @@ func TestRetryingVRpc_ServerDeadlineExceededRetriesWithRetryInfo(t *testing.T) {
 		t.Errorf("expected 2 attempts, got %d", attempts)
 	}
 }
+
+// TestRetryingVRpc_CtxCancelPreservesLastErr pins SESSION_SPEC #9's
+// "last-observed err preserved" rule: when the caller ctx cancels
+// between attempts (after a real RPC failure), the returned error MUST
+// be the typed lastErr (carrying the gRPC code + AttemptState tag), not
+// raw context.Canceled. Regression would strip the retry oracle's view
+// of what actually failed.
+func TestRetryingVRpc_CtxCancelPreservesLastErr(t *testing.T) {
+	sentinel := tagErr(StateTransportFailure, status.Error(codes.Unavailable, "wire error"))
+	baseHandler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return nil, sentinel
+	}
+	ctx, cancel := context.WithCancel(WithVRpcMetadata(context.Background(), "TestMethod", 1))
+
+	retryInterceptor := RetryingVRpc(RetryingOptions{
+		MaxAttempts:    5,
+		InitialBackoff: 50 * time.Millisecond,
+		Idempotent:     true,
+	})
+
+	// Cancel after the first attempt lands but before the backoff timer fires.
+	go func() {
+		time.Sleep(5 * time.Millisecond)
+		cancel()
+	}()
+
+	_, err := retryInterceptor(ctx, "req", baseHandler)
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("expected lastErr sentinel, got %v", err)
+	}
+	if errors.Is(err, context.Canceled) {
+		t.Errorf("expected typed lastErr, not raw context.Canceled: %v", err)
+	}
+}
+
+// TestRetryingVRpc_DeadlineFitSkipsRetry pins SESSION_SPEC #9's
+// "deadline-fit check": when the next delay would exhaust the caller's
+// remaining deadline, skip the retry and surface lastErr. Sleeping past
+// the deadline only to have the retry immediately fail with
+// DeadlineExceeded burns budget and loses the typed error.
+func TestRetryingVRpc_DeadlineFitSkipsRetry(t *testing.T) {
+	sentinel := tagErr(StateServerResult, mustStatusWithRetryInfo(t, codes.Unavailable, "overloaded", 5*time.Second))
+	attempts := 0
+	baseHandler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		attempts++
+		return nil, sentinel
+	}
+
+	// 20ms remaining, server asks for a 5s delay — skip.
+	ctx, cancel := context.WithTimeout(WithVRpcMetadata(context.Background(), "TestMethod", 1), 20*time.Millisecond)
+	defer cancel()
+
+	retryInterceptor := RetryingVRpc(RetryingOptions{
+		MaxAttempts:    5,
+		InitialBackoff: 1 * time.Millisecond,
+		Idempotent:     true,
+	})
+
+	start := time.Now()
+	_, err := retryInterceptor(ctx, "req", baseHandler)
+	elapsed := time.Since(start)
+
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("expected lastErr sentinel, got %v", err)
+	}
+	if attempts != 1 {
+		t.Errorf("expected 1 attempt (deadline-fit skip), got %d", attempts)
+	}
+	if elapsed > 100*time.Millisecond {
+		t.Errorf("expected fast return (no 5s sleep), took %v", elapsed)
+	}
+}
+
+// TestRetryingVRpc_ServerRetryInfoOverridesShouldRetry pins SESSION_SPEC
+// #9's "server-only inputs" contract: server RetryInfo is server-only
+// authority and MUST override any caller-supplied ShouldRetry callback.
+// Without this, a strict client policy could veto a server-directed
+// retry — losing the whole point of the RetryInfo detail.
+func TestRetryingVRpc_ServerRetryInfoOverridesShouldRetry(t *testing.T) {
+	attempts := 0
+	baseHandler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		attempts++
+		if attempts == 1 {
+			return nil, tagErr(StateServerResult, mustStatusWithRetryInfo(t,
+				codes.DeadlineExceeded, "overloaded, retry", 1*time.Millisecond))
+		}
+		return "ok", nil
+	}
+
+	// ShouldRetry says "never retry"; the server's RetryInfo must win.
+	retryInterceptor := RetryingVRpc(RetryingOptions{
+		MaxAttempts:    5,
+		InitialBackoff: 1 * time.Millisecond,
+		ShouldRetry:    func(error) bool { return false },
+	})
+
+	ctx := WithVRpcMetadata(context.Background(), "TestMethod", 1)
+	resp, err := retryInterceptor(ctx, "req", baseHandler)
+	if err != nil {
+		t.Fatalf("expected success (server RetryInfo overrides ShouldRetry), got %v", err)
+	}
+	if resp.(string) != "ok" {
+		t.Errorf("expected 'ok', got %v", resp)
+	}
+	if attempts != 2 {
+		t.Errorf("expected 2 attempts, got %d", attempts)
+	}
+}
+
+func mustStatusWithRetryInfo(t *testing.T, code codes.Code, msg string, delay time.Duration) error {
+	t.Helper()
+	st, err := status.New(code, msg).WithDetails(&errdetails.RetryInfo{
+		RetryDelay: durationpb.New(delay),
+	})
+	if err != nil {
+		t.Fatalf("WithDetails: %v", err)
+	}
+	return st.Err()
+}

--- a/bigtable/internal/transport/retrying_test.go
+++ b/bigtable/internal/transport/retrying_test.go
@@ -1,0 +1,423 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/durationpb"
+)
+
+// mockTracer captures per-attempt tracer callbacks for assertions.
+type mockTracer struct {
+	mu             sync.Mutex
+	starts         []int
+	completes      []int
+	completeErrors []error
+}
+
+func (m *mockTracer) OnAttemptStart(ctx context.Context) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.starts = append(m.starts, VRpcAttempt(ctx))
+}
+
+func (m *mockTracer) OnAttemptComplete(ctx context.Context, err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.completes = append(m.completes, VRpcAttempt(ctx))
+	m.completeErrors = append(m.completeErrors, err)
+}
+
+func TestRetryingVRpc_SuccessOnRetry(t *testing.T) {
+	var attempts int
+	baseHandler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		attempts++
+		attemptInCtx := VRpcAttempt(ctx)
+		if attemptInCtx != attempts {
+			t.Errorf("Expected attempt %d in context, got %d", attempts, attemptInCtx)
+		}
+
+		if attempts < 3 {
+			// TransportFailure matches what session_vrpc.go produces for a
+			// mid-stream Unavailable (session-side cancellation, GoAway,
+			// heartbeat miss). Idempotent=true gates the retry.
+			return nil, tagErr(StateTransportFailure, status.Error(codes.Unavailable, "service temporarily unavailable"))
+		}
+		return "success_resp", nil
+	}
+
+	tracer := &mockTracer{}
+	retryInterceptor := RetryingVRpc(RetryingOptions{
+		MaxAttempts:    5,
+		InitialBackoff: 1 * time.Millisecond,
+		Tracer:         tracer,
+		Idempotent:     true,
+	})
+
+	ctx := WithVRpcMetadata(context.Background(), "TestMethod", 1)
+	resp, err := retryInterceptor(ctx, "request", baseHandler)
+	if err != nil {
+		t.Fatalf("Expected success, got error: %v", err)
+	}
+
+	if resp.(string) != "success_resp" {
+		t.Errorf("Expected response 'success_resp', got %q", resp)
+	}
+
+	if attempts != 3 {
+		t.Errorf("Expected 3 attempts, got %d", attempts)
+	}
+
+	tracer.mu.Lock()
+	defer tracer.mu.Unlock()
+
+	expectedStarts := []int{1, 2, 3}
+	if len(tracer.starts) != len(expectedStarts) {
+		t.Errorf("Expected %d starts, got %d", len(expectedStarts), len(tracer.starts))
+	}
+	for i, v := range expectedStarts {
+		if tracer.starts[i] != v {
+			t.Errorf("Expected start attempt at index %d to be %d, got %d", i, v, tracer.starts[i])
+		}
+	}
+
+	expectedCompletes := []int{1, 2, 3}
+	if len(tracer.completes) != len(expectedCompletes) {
+		t.Errorf("Expected %d completes, got %d", len(expectedCompletes), len(tracer.completes))
+	}
+}
+
+func TestRetryingVRpc_NonRetryableError(t *testing.T) {
+	var attempts int
+	baseHandler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		attempts++
+		return nil, status.Error(codes.InvalidArgument, "invalid parameter value")
+	}
+
+	retryInterceptor := RetryingVRpc(RetryingOptions{
+		MaxAttempts:    5,
+		InitialBackoff: 1 * time.Millisecond,
+	})
+
+	ctx := WithVRpcMetadata(context.Background(), "TestMethod", 1)
+	_, err := retryInterceptor(ctx, "request", baseHandler)
+	if err == nil {
+		t.Fatal("Expected error, got nil")
+	}
+
+	st, ok := status.FromError(err)
+	if !ok || st.Code() != codes.InvalidArgument {
+		t.Errorf("Expected InvalidArgument status error, got %v", err)
+	}
+
+	if attempts != 1 {
+		t.Errorf("Expected non-retryable error to abort immediately (1 attempt), got %d attempts", attempts)
+	}
+}
+
+func TestRetryingVRpc_HonorServerRetryDelay(t *testing.T) {
+	var attempts int
+	baseHandler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		attempts++
+		if attempts == 1 {
+			// Server-returned error carrying RetryInfo — permits retry
+			// regardless of state (Java parity: server explicitly said
+			// "try again in Nms"). Tag as ServerResult to match the real
+			// production path (handleVRPCErrorResponse).
+			st := status.New(codes.Unavailable, "overloaded")
+			stWithDetails, err := st.WithDetails(&errdetails.RetryInfo{
+				RetryDelay: durationpb.New(10 * time.Millisecond),
+			})
+			if err != nil {
+				return nil, err
+			}
+			return nil, tagErr(StateServerResult, stWithDetails.Err())
+		}
+		return "ok", nil
+	}
+
+	retryInterceptor := RetryingVRpc(RetryingOptions{
+		MaxAttempts:    3,
+		InitialBackoff: 200 * time.Millisecond, // Default initial backoff is large, but server details should override it
+	})
+
+	startTime := time.Now()
+	ctx := WithVRpcMetadata(context.Background(), "TestMethod", 1)
+	resp, err := retryInterceptor(ctx, "request", baseHandler)
+	duration := time.Since(startTime)
+
+	if err != nil {
+		t.Fatalf("Expected successful response, got %v", err)
+	}
+
+	if resp.(string) != "ok" {
+		t.Errorf("Expected response 'ok', got %v", resp)
+	}
+
+	if duration >= 100*time.Millisecond {
+		t.Errorf("Expected retry delay to be small (10ms) honoring server RetryInfo, but took %v (might have used 200ms client backoff)", duration)
+	}
+}
+
+func TestRetryingVRpc_MaxAttemptsExceeded(t *testing.T) {
+	var attempts int
+	baseHandler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		attempts++
+		return nil, tagErr(StateTransportFailure, status.Error(codes.Unavailable, "temporary failure"))
+	}
+
+	retryInterceptor := RetryingVRpc(RetryingOptions{
+		MaxAttempts:    3,
+		InitialBackoff: 1 * time.Millisecond,
+		Idempotent:     true,
+	})
+
+	ctx := WithVRpcMetadata(context.Background(), "TestMethod", 1)
+	_, err := retryInterceptor(ctx, "request", baseHandler)
+	if err == nil {
+		t.Fatal("Expected failure after maximum attempts, got success")
+	}
+
+	if attempts != 3 {
+		t.Errorf("Expected exactly 3 attempts before giving up, got %d", attempts)
+	}
+}
+
+func TestRetryingVRpc_NonGrpcError(t *testing.T) {
+	var attempts int
+	baseHandler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		attempts++
+		return nil, errors.New("some custom raw go error")
+	}
+
+	retryInterceptor := RetryingVRpc(RetryingOptions{
+		MaxAttempts:    3,
+		InitialBackoff: 1 * time.Millisecond,
+	})
+
+	ctx := WithVRpcMetadata(context.Background(), "TestMethod", 1)
+	_, err := retryInterceptor(ctx, "request", baseHandler)
+	if err == nil {
+		t.Fatal("Expected error, got nil")
+	}
+
+	if attempts != 1 {
+		t.Errorf("Expected non-gRPC raw errors to be treated as non-retryable and fail immediately (1 attempt), got %d attempts", attempts)
+	}
+}
+
+// TestRetryingVRpc_UncommittedAlwaysRetries verifies that an attempt tagged
+// as StateUncommitted retries even when Idempotent is false. Uncommitted
+// means the request never reached the wire; a retry cannot double-apply.
+func TestRetryingVRpc_UncommittedAlwaysRetries(t *testing.T) {
+	var attempts int
+	baseHandler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		attempts++
+		if attempts < 3 {
+			return nil, tagErr(StateUncommitted, status.Error(codes.Unavailable, "session closing before Send"))
+		}
+		return "ok", nil
+	}
+
+	retryInterceptor := RetryingVRpc(RetryingOptions{
+		MaxAttempts:    5,
+		InitialBackoff: 1 * time.Millisecond,
+		Idempotent:     false, // non-idempotent: uncommitted still retries
+	})
+
+	ctx := WithVRpcMetadata(context.Background(), "TestMethod", 1)
+	resp, err := retryInterceptor(ctx, "req", baseHandler)
+	if err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+	if resp.(string) != "ok" {
+		t.Errorf("expected 'ok', got %v", resp)
+	}
+	if attempts != 3 {
+		t.Errorf("expected 3 attempts, got %d", attempts)
+	}
+}
+
+// TestRetryingVRpc_TransportFailureIdempotent verifies that TransportFailure
+// retries for an idempotent op (reads).
+func TestRetryingVRpc_TransportFailureIdempotent(t *testing.T) {
+	var attempts int
+	baseHandler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		attempts++
+		if attempts < 3 {
+			return nil, tagErr(StateTransportFailure, status.Error(codes.Unavailable, "send failed"))
+		}
+		return "ok", nil
+	}
+
+	retryInterceptor := RetryingVRpc(RetryingOptions{
+		MaxAttempts:    5,
+		InitialBackoff: 1 * time.Millisecond,
+		Idempotent:     true,
+	})
+
+	ctx := WithVRpcMetadata(context.Background(), "TestMethod", 1)
+	_, err := retryInterceptor(ctx, "req", baseHandler)
+	if err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+	if attempts != 3 {
+		t.Errorf("expected 3 attempts, got %d", attempts)
+	}
+}
+
+// TestRetryingVRpc_TransportFailureNonIdempotentNoRetry verifies that a
+// TransportFailure on a non-idempotent op (Apply of a ServerTime mutation)
+// does NOT retry — the server may have already applied the mutation, and
+// a retry would create a duplicate cell.
+func TestRetryingVRpc_TransportFailureNonIdempotentNoRetry(t *testing.T) {
+	var attempts int
+	baseHandler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		attempts++
+		return nil, tagErr(StateTransportFailure, status.Error(codes.Unavailable, "wire error"))
+	}
+
+	retryInterceptor := RetryingVRpc(RetryingOptions{
+		MaxAttempts:    5,
+		InitialBackoff: 1 * time.Millisecond,
+		Idempotent:     false,
+	})
+
+	ctx := WithVRpcMetadata(context.Background(), "TestMethod", 1)
+	_, err := retryInterceptor(ctx, "req", baseHandler)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if attempts != 1 {
+		t.Errorf("expected exactly 1 attempt (no retry for non-idempotent TransportFailure), got %d", attempts)
+	}
+}
+
+// TestRetryingVRpc_ServerResultNotRetriedByDefault verifies strict
+// Java parity for the ServerResult path: a server-explicit error is NOT
+// retried without server-attached RetryInfo, regardless of gRPC code.
+// The permissive pre-parity behavior (retry on Unavailable / Aborted /
+// Internal / ResourceExhausted / DeadlineExceeded) is gone; callers who
+// need it must set RetryingOptions.ShouldRetry.
+func TestRetryingVRpc_ServerResultNotRetriedByDefault(t *testing.T) {
+	cases := []struct {
+		name string
+		code codes.Code
+	}{
+		{"Unavailable", codes.Unavailable},
+		{"Aborted", codes.Aborted},
+		{"Internal", codes.Internal},
+		{"ResourceExhausted", codes.ResourceExhausted},
+		{"DeadlineExceeded", codes.DeadlineExceeded},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var attempts int
+			baseHandler := func(ctx context.Context, req interface{}) (interface{}, error) {
+				attempts++
+				return nil, tagErr(StateServerResult, status.Error(tc.code, "server said no"))
+			}
+			retryInterceptor := RetryingVRpc(RetryingOptions{
+				MaxAttempts:    5,
+				InitialBackoff: 1 * time.Millisecond,
+				Idempotent:     true, // even idempotent: ServerResult without RetryInfo never retries
+			})
+			ctx := WithVRpcMetadata(context.Background(), "TestMethod", 1)
+			_, err := retryInterceptor(ctx, "req", baseHandler)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if attempts != 1 {
+				t.Errorf("expected 1 attempt (bare ServerResult %s must not retry), got %d",
+					tc.name, attempts)
+			}
+		})
+	}
+}
+
+// TestRetryingVRpc_ServerDeadlineExceededNoRetryByDefault verifies Java
+// parity: a server-returned DEADLINE_EXCEEDED is NOT retried by default.
+// The server said "I gave up"; blindly retrying burns budget on ops the
+// server already discarded.
+func TestRetryingVRpc_ServerDeadlineExceededNoRetryByDefault(t *testing.T) {
+	var attempts int
+	baseHandler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		attempts++
+		return nil, tagErr(StateServerResult, status.Error(codes.DeadlineExceeded, "server timed out"))
+	}
+
+	retryInterceptor := RetryingVRpc(RetryingOptions{
+		MaxAttempts:    5,
+		InitialBackoff: 1 * time.Millisecond,
+		Idempotent:     true, // even idempotent: server DEADLINE_EXCEEDED still no retry
+	})
+
+	ctx := WithVRpcMetadata(context.Background(), "TestMethod", 1)
+	_, err := retryInterceptor(ctx, "req", baseHandler)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if attempts != 1 {
+		t.Errorf("expected 1 attempt (server DEADLINE_EXCEEDED not retried), got %d", attempts)
+	}
+}
+
+// TestRetryingVRpc_ServerDeadlineExceededRetriesWithRetryInfo verifies the
+// escape hatch: if the server explicitly attaches RetryInfo, the client
+// honors it — even for DEADLINE_EXCEEDED — because the server has stated
+// the retry is safe and given a specific backoff.
+func TestRetryingVRpc_ServerDeadlineExceededRetriesWithRetryInfo(t *testing.T) {
+	var attempts int
+	baseHandler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		attempts++
+		if attempts == 1 {
+			st := status.New(codes.DeadlineExceeded, "overloaded, retry later")
+			stWithDetails, derr := st.WithDetails(&errdetails.RetryInfo{
+				RetryDelay: durationpb.New(1 * time.Millisecond),
+			})
+			if derr != nil {
+				return nil, derr
+			}
+			return nil, tagErr(StateServerResult, stWithDetails.Err())
+		}
+		return "ok", nil
+	}
+
+	retryInterceptor := RetryingVRpc(RetryingOptions{
+		MaxAttempts:    3,
+		InitialBackoff: 1 * time.Millisecond,
+		Idempotent:     true,
+	})
+
+	ctx := WithVRpcMetadata(context.Background(), "TestMethod", 1)
+	resp, err := retryInterceptor(ctx, "req", baseHandler)
+	if err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+	if resp.(string) != "ok" {
+		t.Errorf("expected 'ok', got %v", resp)
+	}
+	if attempts != 2 {
+		t.Errorf("expected 2 attempts, got %d", attempts)
+	}
+}


### PR DESCRIPTION
## Summary

Builds on the vRPC primitives merged in #20116 by adding the two building blocks that consumers need to actually run interceptor pipelines with retries:

- **`ChainInterceptors`** (`internal/transport/chain.go`) — composes multiple `Interceptor`s around a base `Handler`. First interceptor in the list is outermost, so it sees setup before and teardown after the rest.
- **`RetryingVRpc`** (`internal/transport/retrying.go`) — an `Interceptor` that retries failed virtual RPCs with exponential backoff. Default classification is Java-parity:
  - `StateUncommitted` → always retry (server never saw the frame).
  - `StateTransportFailure` → retry only when `Idempotent` is true (server may have applied).
  - `StateServerResult` → retry only if the server attached `errdetails.RetryInfo`; a bare server-explicit error (even `Unavailable` / `Aborted` / `DeadlineExceeded`) does NOT retry without explicit server go-ahead.
  - Callers with bespoke policies can set `ShouldRetry` to override the default entirely.

Per-attempt tracing goes through `VRpcTracer`; the previous attempt's error is tagged onto the next attempt's context via `WithPrevAttemptErr` for downstream metrics/logging.

## Test plan

- [x] `go build ./internal/transport/...`
- [x] `go vet ./internal/transport/...`
- [x] `go test ./internal/transport/... -run 'Retrying|Chained|Interceptor' -count=1 -race -timeout=90s` — 12 new tests pass:
  - `TestChainedInterceptors_Success` — interceptor call ordering (outer→inner→base→inner→outer)
  - `TestRetryingVRpc_SuccessOnRetry` — recovers on attempt 3, tracer sees all 3 starts/completes
  - `TestRetryingVRpc_NonRetryableError` — `InvalidArgument` aborts after 1 attempt
  - `TestRetryingVRpc_HonorServerRetryDelay` — server `RetryInfo` overrides client backoff
  - `TestRetryingVRpc_MaxAttemptsExceeded` — stops at `MaxAttempts`
  - `TestRetryingVRpc_NonGrpcError` — raw Go errors are non-retryable
  - `TestRetryingVRpc_UncommittedAlwaysRetries` — `StateUncommitted` retries even when `Idempotent=false`
  - `TestRetryingVRpc_TransportFailureIdempotent` — `StateTransportFailure` retries with `Idempotent=true`
  - `TestRetryingVRpc_TransportFailureNonIdempotentNoRetry` — no retry when `Idempotent=false`
  - `TestRetryingVRpc_ServerResultNotRetriedByDefault` — bare `ServerResult` never retries (5 codes)
  - `TestRetryingVRpc_ServerDeadlineExceededNoRetryByDefault` — server `DEADLINE_EXCEEDED` alone is not retried
  - `TestRetryingVRpc_ServerDeadlineExceededRetriesWithRetryInfo` — `DEADLINE_EXCEEDED` + `RetryInfo` is retried
- [x] `goimports -d` clean
- [x] `golint` clean