### PR TITLE
chore: add protoc tool

### DIFF
--- a/.github/workflows/generation_check.yaml
+++ b/.github/workflows/generation_check.yaml
@@ -32,11 +32,11 @@ jobs:
           protoc-checksum: '8c0a8577311720cc83488f813aeb5046d69cb9824cbf39cb7447e0c5132d677952d5bb7c1130d9df381835eee7352828878d409873ebb407d7a4649ea2a4aee5'
       - name: Install tools
         if: steps.changes.outputs.librarian == 'true' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
-        run: librarian install
+        run: librarian install -v
       - name: Regenerate
         if: steps.changes.outputs.librarian == 'true' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
         run: |
-          librarian generate --all
+          librarian generate --all -v
           if [ -n "$(git status --porcelain)" ]; then
             git status
             echo "==================== GIT DIFF ===================="

--- a/.github/workflows/generation_check.yaml
+++ b/.github/workflows/generation_check.yaml
@@ -32,11 +32,11 @@ jobs:
           protoc-checksum: '8c0a8577311720cc83488f813aeb5046d69cb9824cbf39cb7447e0c5132d677952d5bb7c1130d9df381835eee7352828878d409873ebb407d7a4649ea2a4aee5'
       - name: Install tools
         if: steps.changes.outputs.librarian == 'true' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
-        run: librarian install -v
+        run: librarian install
       - name: Regenerate
         if: steps.changes.outputs.librarian == 'true' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
         run: |
-          librarian generate --all -v
+          librarian generate --all
           if [ -n "$(git status --porcelain)" ]; then
             git status
             echo "==================== GIT DIFF ===================="

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -31,6 +31,9 @@ tools:
       version: v1.3.0
     - name: google.golang.org/protobuf/cmd/protoc-gen-go
       version: v1.36.11
+  protoc:
+    version: "33.2"
+    sha256: b24b53f87c151bfd48b112fe4c3a6e6574e5198874f38036aff41df3456b8caf
 default:
   tag_format: '{name}/v{version}'
   go:


### PR DESCRIPTION
Add `protoc` to librarian.yaml.

`librarian generate` will use protoc version defined in librarian.yaml.

The log shows the protoc path from bin directory managed by librarian:
```
/home/runner/.cache/librarian/bin/protoc/v33.2/bin/protoc --experimental_allow_proto3_optional --go_out=/home/runner/work/google-cloud-go/google-cloud-go/bigtable/librarian-gen-2273262982 -I=/home/runner/.cache/librarian/github.com/googleapis/googleapis@f63acc613f0b6f27b85c98d71cd67c764d48e908 --go-grpc_out=/home/runner/work/google-cloud-go/google-cloud-go/bigtable/librarian-gen-2273262982 --go-grpc_opt=require_unimplemented_servers=false /home/runner/.cache/librarian/github.com/googleapis/googleapis@f63acc613f0b6f27b85c98d71cd67c764d48e908/google/bigtable/v2/bigtable.proto /home/runner/.cache/librarian/github.com/googleapis/googleapis@f63acc613f0b6f27b85c98d71cd67c764d48e908/google/bigtable/v2/data.proto /home/runner/.cache/librarian/github.com/googleapis/googleapis@f63acc613f0b6f27b85c98d71cd67c764d48e908/google/bigtable/v2/feature_flags.proto /home/runner/.cache/librarian/github.com/googleapis/googleapis@f63acc613f0b6f27b85c98d71cd67c764d48e908/google/bigtable/v2/peer_info.proto /home/runner/.cache/librarian/github.com/googleapis/googleapis@f63acc613f0b6f27b85c98d71cd67c764d48e908/google/bigtable/v2/request_stats.proto /home/runner/.cache/librarian/github.com/googleapis/googleapis@f63acc613f0b6f27b85c98d71cd67c764d48e908/google/bigtable/v2/response_params.proto /home/runner/.cache/librarian/github.com/googleapis/googleapis@f63acc613f0b6f27b85c98d71cd67c764d48e908/google/bigtable/v2/session.proto /home/runner/.cache/librarian/github.com/googleapis/googleapis@f63acc613f0b6f27b85c98d71cd67c764d48e908/google/bigtable/v2/types.proto
```

Fixes https://github.com/googleapis/librarian/issues/6770