### PR TITLE
feat(bigtable): add PeakEwma continuous time-decay latency tracker

### DIFF
--- a/bigtable/internal/transport/peak_ewma.go
+++ b/bigtable/internal/transport/peak_ewma.go
@@ -1,0 +1,82 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"math"
+	"sync"
+	"time"
+)
+
+// PeakEwma is a thread-safe continuous-time exponentially-weighted moving
+// average of latency samples. The AFE picker uses one instance per bucket
+// to score candidates; see sessionList.
+type PeakEwma struct {
+	mu         sync.Mutex
+	tau        time.Duration
+	value      float64
+	lastUpdate time.Time
+}
+
+// NewPeakEwma creates a PeakEwma with the given decay time constant tau.
+// The initial value is zero — Value() returns 0 until the first Update.
+func NewPeakEwma(tau time.Duration) *PeakEwma {
+	return &PeakEwma{
+		tau: tau,
+	}
+}
+
+// NewPeakEwmaSeeded returns a PeakEwma pre-seeded with the given cost so
+// Value() returns non-zero before the first Update lands. The seed is
+// authoritative only until the first Update, which resets value to the
+// real sample (see Update's lastUpdate.IsZero branch). Java parity —
+// SessionList.java seeds transport at 500µs and e2e at 1ms so a
+// brand-new AFE doesn't win the least-latency picker by looking
+// free-cost.
+func NewPeakEwmaSeeded(tau, seed time.Duration) *PeakEwma {
+	return &PeakEwma{
+		tau:   tau,
+		value: float64(seed),
+	}
+}
+
+// Update folds a new latency sample into the EWMA. The first Update
+// after construction snaps value to the sample (overriding any seed);
+// subsequent samples decay the prior value by e^(-dt/tau) and blend the
+// remainder toward the new sample.
+func (e *PeakEwma) Update(latency time.Duration) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	now := time.Now()
+	if e.lastUpdate.IsZero() {
+		e.value = float64(latency)
+		e.lastUpdate = now
+		return
+	}
+	dt := now.Sub(e.lastUpdate)
+	e.lastUpdate = now
+	// Continuous time-decay weight: e^(-dt/tau).
+	weight := math.Exp(-float64(dt) / float64(e.tau))
+	// EWMA = EWMA * weight + latency * (1 - weight).
+	e.value = e.value*weight + float64(latency)*(1-weight)
+}
+
+// Value returns the current EWMA in the same units as the samples fed
+// into Update (nanoseconds, as float64 — the picker consumes this raw).
+func (e *PeakEwma) Value() float64 {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.value
+}

--- a/bigtable/internal/transport/peak_ewma.go
+++ b/bigtable/internal/transport/peak_ewma.go
@@ -20,9 +20,15 @@ import (
 	"time"
 )
 
-// PeakEwma is a thread-safe continuous-time exponentially-weighted moving
-// average of latency samples. The AFE picker uses one instance per bucket
-// to score candidates; see sessionList.
+// PeakEwma is a thread-safe latency tracker that rises immediately on
+// higher samples (the "peak" step) and decays exponentially toward
+// lower ones (the EWMA step). The AFE picker uses one instance per
+// bucket to score candidates; see sessionList.
+//
+// The peak-step is what prevents a new AFE from stealing traffic just
+// because its latest vRPC happened to be fast — a plain symmetric
+// EWMA would blend a single low sample into the average, briefly
+// making the bucket look cheapest and steering pickers at it.
 type PeakEwma struct {
 	mu         sync.Mutex
 	tau        time.Duration
@@ -31,50 +37,70 @@ type PeakEwma struct {
 }
 
 // NewPeakEwma creates a PeakEwma with the given decay time constant tau.
-// The initial value is zero — Value() returns 0 until the first Update.
+// The initial value is zero — the first positive Update peak-snaps to
+// its sample. lastUpdate is stamped at construction so subsequent
+// updates see a valid dt.
 func NewPeakEwma(tau time.Duration) *PeakEwma {
 	return &PeakEwma{
-		tau: tau,
+		tau:        tau,
+		lastUpdate: time.Now(),
 	}
 }
 
-// NewPeakEwmaSeeded returns a PeakEwma pre-seeded with the given cost so
-// Value() returns non-zero before the first Update lands. The seed is
-// authoritative only until the first Update, which resets value to the
-// real sample (see Update's lastUpdate.IsZero branch). Java parity —
-// SessionList.java seeds transport at 500µs and e2e at 1ms so a
-// brand-new AFE doesn't win the least-latency picker by looking
-// free-cost.
+// NewPeakEwmaSeeded returns a PeakEwma pre-seeded with the given cost.
+// The seed participates in the first Update's decay/blend normally —
+// it is NOT overwritten on the first sample. SessionList seeds
+// transport at 500µs and e2e at 1ms so a brand-new AFE doesn't win
+// the least-latency picker by looking free-cost.
 func NewPeakEwmaSeeded(tau, seed time.Duration) *PeakEwma {
 	return &PeakEwma{
-		tau:   tau,
-		value: float64(seed),
+		tau:        tau,
+		value:      float64(seed),
+		lastUpdate: time.Now(),
 	}
 }
 
-// Update folds a new latency sample into the EWMA. The first Update
-// after construction snaps value to the sample (overriding any seed);
-// subsequent samples decay the prior value by e^(-dt/tau) and blend the
-// remainder toward the new sample.
+// Update folds a new latency sample into the tracker. Two distinct
+// steps:
+//
+//   - Peak-step: if the sample is higher than the current value, snap
+//     up immediately. No decay, no blend — the higher observation
+//     supersedes.
+//   - Decay-step: otherwise, apply e^(-dt/tau) time-decay to the
+//     current value and blend the sample in proportionally.
+//
+// Non-positive samples are ignored; a backward clock (dt < 0) is
+// clamped to 0 so the blend weight stays in [0,1]; a non-positive tau
+// collapses to zero decay (new sample fully replaces) so tau=0/dt=0
+// doesn't produce NaN via exp(-0/0).
 func (e *PeakEwma) Update(latency time.Duration) {
+	if latency <= 0 {
+		return
+	}
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	now := time.Now()
-	if e.lastUpdate.IsZero() {
-		e.value = float64(latency)
+	latencyNs := float64(latency)
+	if e.value < latencyNs {
+		e.value = latencyNs
 		e.lastUpdate = now
 		return
 	}
 	dt := now.Sub(e.lastUpdate)
+	if dt < 0 {
+		dt = 0
+	}
 	e.lastUpdate = now
-	// Continuous time-decay weight: e^(-dt/tau).
-	weight := math.Exp(-float64(dt) / float64(e.tau))
-	// EWMA = EWMA * weight + latency * (1 - weight).
-	e.value = e.value*weight + float64(latency)*(1-weight)
+	var decay float64
+	if e.tau > 0 {
+		decay = math.Exp(-float64(dt) / float64(e.tau))
+	}
+	e.value = e.value*decay + latencyNs*(1-decay)
 }
 
-// Value returns the current EWMA in the same units as the samples fed
-// into Update (nanoseconds, as float64 — the picker consumes this raw).
+// Value returns the current tracker value in the same units as the
+// samples fed into Update (nanoseconds, as float64 — the picker
+// consumes this raw).
 func (e *PeakEwma) Value() float64 {
 	e.mu.Lock()
 	defer e.mu.Unlock()

--- a/bigtable/internal/transport/peak_ewma_test.go
+++ b/bigtable/internal/transport/peak_ewma_test.go
@@ -36,25 +36,68 @@ func TestPeakEwma_SeededValueBeforeUpdate(t *testing.T) {
 	}
 }
 
-// TestPeakEwma_FirstUpdateOverridesSeed pins the "seed is authoritative
-// only until the first Update" behavior documented on NewPeakEwmaSeeded.
-// If this ever silently changed to blend the seed into the first sample,
-// AFE picker cold-start behavior would drift for a full tau window.
-func TestPeakEwma_FirstUpdateOverridesSeed(t *testing.T) {
-	seed := 1 * time.Millisecond
-	sample := 42 * time.Millisecond
-	e := NewPeakEwmaSeeded(1*time.Second, seed)
-	e.Update(sample)
-	if got := e.Value(); got != float64(sample) {
-		t.Errorf("Value() after first Update = %v, want %v (seed must be overridden)",
-			got, float64(sample))
+// TestPeakEwma_PeakSnapOnHigherSample pins the "peak" in PeakEwma:
+// samples strictly higher than the current value snap up immediately
+// with no blend. Without this, the tracker degenerates into a plain
+// symmetric EWMA and a new AFE with one lucky-fast sample would look
+// instantly cheap to the least-latency picker.
+func TestPeakEwma_PeakSnapOnHigherSample(t *testing.T) {
+	e := NewPeakEwmaSeeded(1*time.Second, 1*time.Millisecond)
+	e.Update(50 * time.Millisecond)
+	if got := e.Value(); got != float64(50*time.Millisecond) {
+		t.Errorf("Value() after higher sample = %v, want peak-snap to %v",
+			got, float64(50*time.Millisecond))
 	}
 }
 
-// TestPeakEwma_ConvergesOnConstantSample proves the EWMA is exact on a
-// constant stream: for any weight, w*L + (1-w)*L == L. This holds
-// regardless of the wall-clock gap between updates, so the test is
-// deterministic without time control.
+// TestPeakEwma_SeedRetainedOnLowerFirstSample pins the contract that
+// a seeded PeakEwma's first Update does NOT snap to the sample when
+// the sample is lower than the seed. The seed remains the
+// authoritative baseline; the sample decays into it per e^(-dt/tau).
+//
+// Regression this test prevents: an earlier impl used a
+// `lastUpdate.IsZero()` branch that snapped to the sample on the
+// first Update, discarding the seed and defeating cold-start
+// weighting.
+func TestPeakEwma_SeedRetainedOnLowerFirstSample(t *testing.T) {
+	seed := 1 * time.Millisecond
+	sample := 100 * time.Microsecond // below seed
+	// Large tau so decay in the microseconds between construction and
+	// Update is negligible; value should stay very close to seed.
+	e := NewPeakEwmaSeeded(1*time.Hour, seed)
+	e.Update(sample)
+	got := e.Value()
+	// Sample is 10% of seed. With near-zero elapsed vs tau=1h, decay ~ 1
+	// so value ~ seed * 1 + sample * ~0 ~= seed. Allow a 1% band for
+	// non-zero elapsed.
+	if math.Abs(got-float64(seed)) > float64(seed)*0.01 {
+		t.Errorf("Value() = %v after lower-sample Update, want ~seed (%v) — seed must not be snapped away",
+			got, float64(seed))
+	}
+	if got == float64(sample) {
+		t.Error("Value() snapped to lower sample; seed was discarded")
+	}
+}
+
+// TestPeakEwma_NonPositiveSampleIgnored pins the rule that zero or
+// negative latencies are ignored, not blended in. A negative rtt is a
+// bug at the source (clock skew, underflow) and must not corrupt the
+// tracker.
+func TestPeakEwma_NonPositiveSampleIgnored(t *testing.T) {
+	const seed = 5 * time.Millisecond
+	e := NewPeakEwmaSeeded(1*time.Second, seed)
+	e.Update(0)
+	e.Update(-1 * time.Millisecond)
+	if got := e.Value(); got != float64(seed) {
+		t.Errorf("Value() after non-positive updates = %v, want unchanged %v",
+			got, float64(seed))
+	}
+}
+
+// TestPeakEwma_ConvergesOnConstantSample proves the tracker is exact
+// on a constant stream: for any decay weight, w*L + (1-w)*L == L. The
+// peak-step is a no-op when sample == current, so the decay-step
+// dominates. Holds regardless of the wall-clock gap between updates.
 func TestPeakEwma_ConvergesOnConstantSample(t *testing.T) {
 	const L = 5 * time.Millisecond
 	e := NewPeakEwma(100 * time.Millisecond)
@@ -67,10 +110,12 @@ func TestPeakEwma_ConvergesOnConstantSample(t *testing.T) {
 	}
 }
 
-// TestPeakEwma_ValueBoundedByObservedSamples pins the convex-combination
-// invariant: the EWMA can never leave the [min, max] range of samples it
-// has seen. Guards against a math typo (e.g. blending with a negative
-// weight) that would let the value overshoot in either direction.
+// TestPeakEwma_ValueBoundedByObservedSamples pins the convex-
+// combination invariant on the decay-step: after any sequence of
+// samples, Value stays within [min, max] of samples seen. Peak-step
+// preserves this trivially (snap-up to an observed sample); decay-step
+// preserves it via the blend. Guards against a math typo that would
+// let value overshoot.
 func TestPeakEwma_ValueBoundedByObservedSamples(t *testing.T) {
 	samples := []time.Duration{
 		3 * time.Millisecond,
@@ -114,12 +159,12 @@ func TestPeakEwma_ValueIsPureRead(t *testing.T) {
 	}
 }
 
-// TestPeakEwma_LargeGapDominatesWithNewSample verifies the decay math:
-// when dt >> tau, weight = e^(-dt/tau) collapses toward 0 and Value
-// tracks the newest sample. Uses tau=1ms and a 50ms real sleep so
-// weight ≈ e^-50 ≈ 2e-22 — five orders of magnitude below the tolerance
-// so scheduler jitter cannot flake the test.
-func TestPeakEwma_LargeGapDominatesWithNewSample(t *testing.T) {
+// TestPeakEwma_LargeGapDominatesLowerSample verifies the decay math on
+// the decay-step: with dt >> tau, weight → 0 and Value tracks the
+// (lower) new sample. Peak-snap doesn't fire because the second sample
+// is smaller than the first. Uses tau=1ms + 50ms sleep so residual
+// weight on the first sample is ~e^-50 ≈ 2e-22.
+func TestPeakEwma_LargeGapDominatesLowerSample(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping under -short: relies on a real 50ms sleep")
 	}
@@ -134,12 +179,63 @@ func TestPeakEwma_LargeGapDominatesWithNewSample(t *testing.T) {
 	e.Update(secondSamp)
 
 	got := e.Value()
-	// After a 50ms gap with tau=1ms the residual weight on firstSamp is
-	// vanishing; Value should be within 1% of secondSamp.
 	tolerance := float64(secondSamp) * 0.01
 	if math.Abs(got-float64(secondSamp)) > tolerance {
-		t.Errorf("Value() = %v after wide gap, want within %v of %v",
+		t.Errorf("Value() = %v after wide gap + lower sample, want within %v of %v",
 			got, tolerance, float64(secondSamp))
+	}
+}
+
+// TestPeakEwma_ZeroTauSafe pins the defensive guard against a
+// NaN-producing edge case: tau == 0 combined with dt == 0 would
+// otherwise evaluate exp(-0/0) = exp(NaN) = NaN. With the tau <= 0
+// branch collapsing decay to 0, the new sample fully replaces the old
+// — the natural limit as tau → 0. Reported by gemini-code-assist on
+// PR #20187.
+func TestPeakEwma_ZeroTauSafe(t *testing.T) {
+	e := NewPeakEwmaSeeded(0, 5*time.Millisecond)
+	e.Update(3 * time.Millisecond)
+	got := e.Value()
+	if math.IsNaN(got) {
+		t.Fatal("Value() = NaN after tau=0 Update")
+	}
+	if got != float64(3*time.Millisecond) {
+		t.Errorf("Value() = %v after tau=0, want new sample %v (zero-memory limit)",
+			got, float64(3*time.Millisecond))
+	}
+}
+
+// TestPeakEwma_BackwardClockNoOvershoot pins the defensive clamp
+// against a backward clock jump: dt < 0 would otherwise produce a
+// blend weight > 1 (exp of a positive number), which would let the
+// new sample push Value outside [min,max] of observed samples. Also
+// addresses the second part of gemini-code-assist's PR #20187 review.
+//
+// We can't rewind the wall clock in a test, so instead reach into the
+// state and set lastUpdate to the future; the next Update's dt is
+// then negative and must be clamped.
+func TestPeakEwma_BackwardClockNoOvershoot(t *testing.T) {
+	const (
+		seed   = 10 * time.Millisecond
+		sample = 3 * time.Millisecond // must be < seed so peak-snap doesn't fire
+	)
+	e := NewPeakEwmaSeeded(1*time.Second, seed)
+	// Simulate a wall clock rewind by pushing lastUpdate 1 minute
+	// ahead. Without the clamp, dt = -1min → decay = exp(+60/1) → huge;
+	// value = seed*huge + sample*(1-huge) → unbounded (or negative).
+	e.mu.Lock()
+	e.lastUpdate = time.Now().Add(1 * time.Minute)
+	e.mu.Unlock()
+
+	e.Update(sample)
+	got := e.Value()
+	// With dt clamped to 0, decay = 1, so value = seed*1 + sample*0 = seed.
+	if math.IsNaN(got) || math.IsInf(got, 0) {
+		t.Fatalf("Value() = %v after backward-clock Update; want finite", got)
+	}
+	if got < float64(sample) || got > float64(seed) {
+		t.Errorf("Value() = %v, want in [%v, %v] (backward clock must not push value outside sample range)",
+			got, float64(sample), float64(seed))
 	}
 }
 
@@ -189,8 +285,8 @@ func TestPeakEwma_ConcurrentUpdatesRaceSafe(t *testing.T) {
 	close(stop)     // release readers.
 	readerWG.Wait()
 
-	// All samples were `sample`, so the EWMA must equal `sample` exactly
-	// regardless of interleaving (constant-sample invariant).
+	// All samples were `sample`, so the tracker must equal `sample`
+	// exactly regardless of interleaving (constant-sample invariant).
 	if got := e.Value(); got != float64(sample) {
 		t.Errorf("Value() after concurrent constant-sample updates = %v, want %v",
 			got, float64(sample))

--- a/bigtable/internal/transport/peak_ewma_test.go
+++ b/bigtable/internal/transport/peak_ewma_test.go
@@ -1,0 +1,198 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"math"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestPeakEwma_UnseededValueIsZero(t *testing.T) {
+	e := NewPeakEwma(1 * time.Second)
+	if got := e.Value(); got != 0 {
+		t.Errorf("Value() before any Update = %v, want 0", got)
+	}
+}
+
+func TestPeakEwma_SeededValueBeforeUpdate(t *testing.T) {
+	seed := 750 * time.Microsecond
+	e := NewPeakEwmaSeeded(1*time.Second, seed)
+	if got := e.Value(); got != float64(seed) {
+		t.Errorf("Seeded Value() = %v, want %v", got, float64(seed))
+	}
+}
+
+// TestPeakEwma_FirstUpdateOverridesSeed pins the "seed is authoritative
+// only until the first Update" behavior documented on NewPeakEwmaSeeded.
+// If this ever silently changed to blend the seed into the first sample,
+// AFE picker cold-start behavior would drift for a full tau window.
+func TestPeakEwma_FirstUpdateOverridesSeed(t *testing.T) {
+	seed := 1 * time.Millisecond
+	sample := 42 * time.Millisecond
+	e := NewPeakEwmaSeeded(1*time.Second, seed)
+	e.Update(sample)
+	if got := e.Value(); got != float64(sample) {
+		t.Errorf("Value() after first Update = %v, want %v (seed must be overridden)",
+			got, float64(sample))
+	}
+}
+
+// TestPeakEwma_ConvergesOnConstantSample proves the EWMA is exact on a
+// constant stream: for any weight, w*L + (1-w)*L == L. This holds
+// regardless of the wall-clock gap between updates, so the test is
+// deterministic without time control.
+func TestPeakEwma_ConvergesOnConstantSample(t *testing.T) {
+	const L = 5 * time.Millisecond
+	e := NewPeakEwma(100 * time.Millisecond)
+	for i := 0; i < 20; i++ {
+		e.Update(L)
+	}
+	if got := e.Value(); got != float64(L) {
+		t.Errorf("Value() after 20 identical updates = %v, want exactly %v",
+			got, float64(L))
+	}
+}
+
+// TestPeakEwma_ValueBoundedByObservedSamples pins the convex-combination
+// invariant: the EWMA can never leave the [min, max] range of samples it
+// has seen. Guards against a math typo (e.g. blending with a negative
+// weight) that would let the value overshoot in either direction.
+func TestPeakEwma_ValueBoundedByObservedSamples(t *testing.T) {
+	samples := []time.Duration{
+		3 * time.Millisecond,
+		9 * time.Millisecond,
+		5 * time.Millisecond,
+		7 * time.Millisecond,
+	}
+	var lo, hi time.Duration = samples[0], samples[0]
+	for _, s := range samples[1:] {
+		if s < lo {
+			lo = s
+		}
+		if s > hi {
+			hi = s
+		}
+	}
+
+	e := NewPeakEwma(50 * time.Millisecond)
+	for _, s := range samples {
+		e.Update(s)
+		got := e.Value()
+		if got < float64(lo) || got > float64(hi) {
+			t.Errorf("Value() = %v after sample %v, want in [%v, %v]",
+				got, s, float64(lo), float64(hi))
+		}
+	}
+}
+
+// TestPeakEwma_ValueIsPureRead ensures Value() does not mutate state:
+// calling it twice with no interleaving Update must return the exact
+// same float64. Guards against a future refactor that folds decay into
+// the reader (which would make Value time-sensitive and break the
+// picker's assumption that a snapshot is stable across scoring loops).
+func TestPeakEwma_ValueIsPureRead(t *testing.T) {
+	e := NewPeakEwma(1 * time.Second)
+	e.Update(4 * time.Millisecond)
+	first := e.Value()
+	second := e.Value()
+	if first != second {
+		t.Errorf("Value() mutated state: first=%v, second=%v", first, second)
+	}
+}
+
+// TestPeakEwma_LargeGapDominatesWithNewSample verifies the decay math:
+// when dt >> tau, weight = e^(-dt/tau) collapses toward 0 and Value
+// tracks the newest sample. Uses tau=1ms and a 50ms real sleep so
+// weight ≈ e^-50 ≈ 2e-22 — five orders of magnitude below the tolerance
+// so scheduler jitter cannot flake the test.
+func TestPeakEwma_LargeGapDominatesWithNewSample(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping under -short: relies on a real 50ms sleep")
+	}
+	const (
+		tau        = 1 * time.Millisecond
+		firstSamp  = 100 * time.Millisecond
+		secondSamp = 5 * time.Millisecond
+	)
+	e := NewPeakEwma(tau)
+	e.Update(firstSamp)
+	time.Sleep(50 * time.Millisecond)
+	e.Update(secondSamp)
+
+	got := e.Value()
+	// After a 50ms gap with tau=1ms the residual weight on firstSamp is
+	// vanishing; Value should be within 1% of secondSamp.
+	tolerance := float64(secondSamp) * 0.01
+	if math.Abs(got-float64(secondSamp)) > tolerance {
+		t.Errorf("Value() = %v after wide gap, want within %v of %v",
+			got, tolerance, float64(secondSamp))
+	}
+}
+
+// TestPeakEwma_ConcurrentUpdatesRaceSafe stresses the mutex on Update
+// and Value: N goroutines hammer the same PeakEwma with a mix of writes
+// and reads. Meaningful only under `go test -race` — the tolerance is
+// wide because the final value depends on interleaving, but Value MUST
+// stay within the sample range no matter what.
+func TestPeakEwma_ConcurrentUpdatesRaceSafe(t *testing.T) {
+	const (
+		writers        = 8
+		readers        = 4
+		updatesPerGoro = 500
+		tau            = 10 * time.Millisecond
+		sample         = 3 * time.Millisecond
+	)
+	e := NewPeakEwma(tau)
+
+	var writerWG, readerWG sync.WaitGroup
+	writerWG.Add(writers)
+	readerWG.Add(readers)
+	stop := make(chan struct{})
+
+	for i := 0; i < writers; i++ {
+		go func() {
+			defer writerWG.Done()
+			for j := 0; j < updatesPerGoro; j++ {
+				e.Update(sample)
+			}
+		}()
+	}
+	for i := 0; i < readers; i++ {
+		go func() {
+			defer readerWG.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					_ = e.Value()
+				}
+			}
+		}()
+	}
+
+	writerWG.Wait() // all writers done → at least one Update landed.
+	close(stop)     // release readers.
+	readerWG.Wait()
+
+	// All samples were `sample`, so the EWMA must equal `sample` exactly
+	// regardless of interleaving (constant-sample invariant).
+	if got := e.Value(); got != float64(sample) {
+		t.Errorf("Value() after concurrent constant-sample updates = %v, want %v",
+			got, float64(sample))
+	}
+}


### PR DESCRIPTION
## Summary

Adds `PeakEwma`, a thread-safe continuous-time exponentially-weighted moving average of latency samples. The upcoming AFE picker (Session subsystem) uses one instance per bucket to score candidates; landing the type standalone lets it merge ahead of its consumers.

- **`peak_ewma.go`** — `PeakEwma` struct, `NewPeakEwma(tau)`, `NewPeakEwmaSeeded(tau, seed)`, `Update(latency)`, `Value()`. Decay weight is `e^(-dt/tau)` computed on every Update. First Update snaps value to the sample; subsequent updates blend prior and new proportionally.
- **`NewPeakEwmaSeeded`** — Java parity: `SessionList.java` seeds transport at 500µs and e2e at 1ms so a brand-new AFE doesn't win the least-latency picker by looking free-cost. The seed is authoritative only until the first `Update`.

No callers on `main` yet — follow-up PRs for the AFE picker and `sessionList` will consume it.

## Test plan

- [x] `go build ./bigtable/...`
- [x] `go test ./bigtable/internal/transport/ -run '^TestPeakEwma' -count=10 -race` — passes (1.6s)
- [x] `gofmt -l bigtable/internal/transport/peak_ewma*.go` — clean
- [x] `go vet ./bigtable/internal/transport/` — clean

Test coverage:
- Unseeded / seeded initial `Value()`
- First `Update` overrides the seed (pins the documented behavior)
- Constant-sample invariant — `w*L + (1-w)*L == L` for any weight, so the EWMA is exact on a flat stream
- Convex-combination bound — Value stays within `[min, max]` of samples seen
- `Value()` is a pure read (no state mutation)
- Wide-gap dominance — `dt >> tau` ⇒ weight → 0 ⇒ Value tracks the newest sample (skipped under `-short`)
- Mutex race check with mixed reader/writer goroutines (meaningful under `-race`)