### PR TITLE
feat(bigtable): add PoolSizer for server-driven session pool capacity

### DIFF
--- a/bigtable/internal/transport/pool_sizer.go
+++ b/bigtable/internal/transport/pool_sizer.go
@@ -1,0 +1,232 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"math"
+	"sync"
+
+	spb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
+)
+
+// PoolStats is a snapshot of a session pool's current state, sufficient
+// to drive one PoolSizer decision. Values are integers taken at a single
+// instant — no windowing, no averaging.
+type PoolStats struct {
+	ReadyCount    int // sessions handshake-complete and available for checkout
+	StartingCount int // sessions mid-open (OpenSession in flight)
+	InUseCount    int // sessions with an active vRPC
+	PendingCount  int // callers parked at the pool boundary waiting for a session
+}
+
+// StatsFetcher returns the current PoolStats. Returning nil signals
+// "pool not started yet" and PoolSizer.Decide short-circuits to the
+// no-stats branch (no decision made).
+type StatsFetcher func() *PoolStats
+
+// PoolSizer calculates the optimal session pool size from a snapshot
+// of workload metrics. Decisions are stateless — no windowed peak
+// tracking, no scale-down cooldown, no historical state.
+//
+// The client only ever GROWS the pool proactively: growth fires when
+// CheckoutSession misses. Shrinkage is passive — sessions die when the
+// server closes them (GoAway, maxAge, error) and the pool's OnClose
+// decides whether to replace based on the sizer's current delta. When
+// the pool is overprovisioned the sizer returns delta < 0, OnClose
+// declines the replacement, and the pool shrinks by exactly one.
+// Convergence rate is bounded by server-driven session churn.
+//
+// This design cannot oscillate: the client never proactively kills a
+// healthy session, so a burst-then-lull traffic wave whose trough sits
+// outside any peak-window cannot trigger a mass prune followed by a
+// cold-start scale-up on the next crest.
+type PoolSizer struct {
+	mu              sync.Mutex
+	fetcher         StatsFetcher
+	minSessions     int
+	maxSessions     int
+	headroomPct     float64 // Idle headroom as a fraction of sessions in use (e.g., 0.10 = 10%)
+	newSessionQLen  int     // server-driven per-session pending queue length; divides PendingCount
+	minIdleSessions int     // floor on the idle cushion so headroom never collapses to 0
+}
+
+const (
+	defaultNewSessionQueueLength = 10
+	defaultMinIdleSessions       = 1
+)
+
+// NewPoolSizer creates a new PoolSizer. headroomPct <= 0 defaults to
+// 0.10 (10%). NewSessionQueueLength and MinIdleSessions get built-in
+// defaults; UpdateConfig can override the queue length from server
+// config.
+func NewPoolSizer(fetcher StatsFetcher, minSessions, maxSessions int, headroomPct float64) *PoolSizer {
+	if headroomPct <= 0 {
+		headroomPct = 0.10
+	}
+	return &PoolSizer{
+		fetcher:         fetcher,
+		minSessions:     minSessions,
+		maxSessions:     maxSessions,
+		headroomPct:     headroomPct,
+		newSessionQLen:  defaultNewSessionQueueLength,
+		minIdleSessions: defaultMinIdleSessions,
+	}
+}
+
+// UpdateConfig dynamically adjusts the sizer's capacity bounds,
+// headroom cushion, and per-session queue length at runtime. Called
+// from the server-config listener path; safe against concurrent
+// Decide calls via the sizer's own mutex.
+func (s *PoolSizer) UpdateConfig(config *spb.SessionClientConfiguration_SessionPoolConfiguration) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.minSessions = int(config.MinSessionCount)
+	s.maxSessions = int(config.MaxSessionCount)
+	// Mirror the constructor guard: a zero or negative headroom from
+	// the server would render as HeadroomPct=0 on the loadz trace and
+	// collapse IdleHeadroom to the MinIdleSessions floor — the pool
+	// still works but operators would see a confusing decision trace.
+	// Fall back to the same default the constructor uses.
+	if hp := float64(config.Headroom); hp > 0 {
+		s.headroomPct = hp
+	} else {
+		s.headroomPct = 0.10
+	}
+	if nsql := int(config.GetNewSessionQueueLength()); nsql > 0 {
+		s.newSessionQLen = nsql
+	}
+}
+
+// ScaleDecision is the full trace from one Decide() evaluation. Every
+// input, every intermediate, plus the final delta and the branch it
+// landed in — surfaced in ScalingEvent so operators can answer "WHY
+// did the sizer choose this?" without re-running the math by hand.
+type ScaleDecision struct {
+	// Inputs (copy of PoolStats at the moment of decision)
+	ReadyCount    int
+	StartingCount int
+	InUseCount    int
+	PendingCount  int // pool-boundary waiters
+
+	// Sizer config snapshot
+	MinSessions     int
+	MaxSessions     int
+	HeadroomPct     float64
+	NewSessionQLen  int
+	MinIdleSessions int
+
+	// Intermediates
+	EffectivePending  int // ceil(PendingCount / NewSessionQLen)
+	SessionsInUse     int // InUseCount + EffectivePending
+	IdleHeadroom      int // max(MinIdleSessions, ceil(SessionsInUse * HeadroomPct))
+	DesiredRaw        int // SessionsInUse + IdleHeadroom (pre-clamp)
+	DesiredCapacity   int // clamped to [MinSessions, MaxSessions]
+	ImmediateCapacity int // ReadyCount
+	EventualCapacity  int // ReadyCount + StartingCount
+
+	// Final decision
+	Delta  int    // desired − eventual (scale-up) or desired − immediate (scale-down); 0 otherwise
+	Branch string // "scale-up" | "scale-down" | "dead-band" | "no-stats"
+}
+
+// GetScaleDelta is a thin wrapper around Decide() that returns only
+// the final delta — for callers that don't need the trace.
+func (s *PoolSizer) GetScaleDelta() int {
+	return s.Decide().Delta
+}
+
+// Decide computes a full ScaleDecision from the current snapshot.
+//
+// Branch semantics:
+//   - scale-up   (Delta > 0): desired capacity exceeds what will be
+//     available once starting sessions finish. Caller SHOULD create
+//     Delta new sessions.
+//   - scale-down (Delta < 0): desired capacity is below what's already
+//     ready. Caller MUST NOT proactively kill sessions to close the
+//     gap — that's the whole point of the passive-shrink design. This
+//     branch is advisory: OnClose reads the delta and lets the pool
+//     shrink by one (per closed session) when the sign is negative.
+//   - dead-band  (Delta == 0): desired sits between immediate and
+//     eventual capacity — do nothing; in-flight starts will absorb any
+//     pending demand.
+//   - no-stats:  the StatsFetcher returned nil (pool not started yet).
+func (s *PoolSizer) Decide() ScaleDecision {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	d := ScaleDecision{
+		MinSessions:     s.minSessions,
+		MaxSessions:     s.maxSessions,
+		HeadroomPct:     s.headroomPct,
+		NewSessionQLen:  s.newSessionQLen,
+		MinIdleSessions: s.minIdleSessions,
+	}
+
+	stats := s.fetcher()
+	if stats == nil {
+		d.Branch = "no-stats"
+		return d
+	}
+	d.ReadyCount = stats.ReadyCount
+	d.StartingCount = stats.StartingCount
+	d.InUseCount = stats.InUseCount
+	d.PendingCount = stats.PendingCount
+
+	// effectivePending = ceil(PendingCount / NewSessionQueueLength)
+	// Waiters at the pool boundary become the number of *sessions* we'd
+	// need to open to drain them (each new session can absorb up to
+	// NewSessionQLen concurrent vRPCs).
+	divisor := s.newSessionQLen
+	if divisor <= 0 {
+		divisor = defaultNewSessionQueueLength
+	}
+	d.EffectivePending = int(math.Ceil(float64(stats.PendingCount) / float64(divisor)))
+	d.SessionsInUse = stats.InUseCount + d.EffectivePending
+
+	// Idle headroom as a fraction of in-use, floored so a brief in-use
+	// dip can't collapse the cushion to zero.
+	d.IdleHeadroom = int(math.Ceil(float64(d.SessionsInUse) * s.headroomPct))
+	if d.IdleHeadroom < s.minIdleSessions {
+		d.IdleHeadroom = s.minIdleSessions
+	}
+	d.DesiredRaw = d.SessionsInUse + d.IdleHeadroom
+	d.DesiredCapacity = clamp(d.DesiredRaw, s.minSessions, s.maxSessions)
+
+	d.ImmediateCapacity = stats.ReadyCount
+	d.EventualCapacity = stats.ReadyCount + stats.StartingCount
+
+	switch {
+	case d.DesiredCapacity > d.EventualCapacity:
+		d.Delta = d.DesiredCapacity - d.EventualCapacity
+		d.Branch = "scale-up"
+	case d.DesiredCapacity < d.ImmediateCapacity:
+		d.Delta = d.DesiredCapacity - d.ImmediateCapacity // negative; ADVISORY
+		d.Branch = "scale-down"
+	default:
+		d.Branch = "dead-band"
+	}
+	return d
+}
+
+func clamp(v, lo, hi int) int {
+	if v < lo {
+		return lo
+	}
+	if v > hi {
+		return hi
+	}
+	return v
+}

--- a/bigtable/internal/transport/pool_sizer.go
+++ b/bigtable/internal/transport/pool_sizer.go
@@ -88,8 +88,13 @@ func NewPoolSizer(fetcher StatsFetcher, minSessions, maxSessions int, headroomPc
 // UpdateConfig dynamically adjusts the sizer's capacity bounds,
 // headroom cushion, and per-session queue length at runtime. Called
 // from the server-config listener path; safe against concurrent
-// Decide calls via the sizer's own mutex.
+// Decide calls via the sizer's own mutex. A nil config is a no-op —
+// the listener path is defensive about intermediate zero-valued
+// updates during startup.
 func (s *PoolSizer) UpdateConfig(config *spb.SessionClientConfiguration_SessionPoolConfiguration) {
+	if config == nil {
+		return
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -164,6 +169,17 @@ func (s *PoolSizer) GetScaleDelta() int {
 //     pending demand.
 //   - no-stats:  the StatsFetcher returned nil (pool not started yet).
 func (s *PoolSizer) Decide() ScaleDecision {
+	// Call the fetcher BEFORE acquiring s.mu — the fetcher runs
+	// pool-owned code that may take the pool's own mutex, and holding
+	// two mutexes across a callback is a lock-inversion trap. Fetcher
+	// is read-only after construction so this races nothing. A nil
+	// fetcher short-circuits to no-stats (defensive; production
+	// always passes one).
+	var stats *PoolStats
+	if s.fetcher != nil {
+		stats = s.fetcher()
+	}
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -175,7 +191,6 @@ func (s *PoolSizer) Decide() ScaleDecision {
 		MinIdleSessions: s.minIdleSessions,
 	}
 
-	stats := s.fetcher()
 	if stats == nil {
 		d.Branch = "no-stats"
 		return d
@@ -185,19 +200,22 @@ func (s *PoolSizer) Decide() ScaleDecision {
 	d.InUseCount = stats.InUseCount
 	d.PendingCount = stats.PendingCount
 
-	// effectivePending = ceil(PendingCount / NewSessionQueueLength)
-	// Waiters at the pool boundary become the number of *sessions* we'd
-	// need to open to drain them (each new session can absorb up to
+	// effectivePending = ceil(PendingCount / NewSessionQueueLength) via
+	// integer arithmetic: (a + b - 1) / b for non-negative a. Waiters
+	// at the pool boundary become the number of *sessions* we'd need
+	// to open to drain them (each new session can absorb up to
 	// NewSessionQLen concurrent vRPCs).
 	divisor := s.newSessionQLen
 	if divisor <= 0 {
 		divisor = defaultNewSessionQueueLength
 	}
-	d.EffectivePending = int(math.Ceil(float64(stats.PendingCount) / float64(divisor)))
+	d.EffectivePending = (stats.PendingCount + divisor - 1) / divisor
 	d.SessionsInUse = stats.InUseCount + d.EffectivePending
 
 	// Idle headroom as a fraction of in-use, floored so a brief in-use
-	// dip can't collapse the cushion to zero.
+	// dip can't collapse the cushion to zero. Kept as math.Ceil on a
+	// float multiply — HeadroomPct is a fraction (e.g. 0.10), not a
+	// discrete count, so the integer-ceil trick doesn't apply cleanly.
 	d.IdleHeadroom = int(math.Ceil(float64(d.SessionsInUse) * s.headroomPct))
 	if d.IdleHeadroom < s.minIdleSessions {
 		d.IdleHeadroom = s.minIdleSessions

--- a/bigtable/internal/transport/pool_sizer.go
+++ b/bigtable/internal/transport/pool_sizer.go
@@ -62,25 +62,37 @@ type PoolSizer struct {
 	minIdleSessions int     // floor on the idle cushion so headroom never collapses to 0
 }
 
-const (
-	defaultNewSessionQueueLength = 10
-	defaultMinIdleSessions       = 1
-)
+// defaultMinIdleSessions is the only knob without a matching field on
+// the SessionPoolConfiguration proto — a purely client-side cushion
+// floor that prevents ceil(0 * HeadroomPct)==0 from starving the
+// warmup path. All other fallbacks read from defaultClientConfig so
+// there's one place to update when a proto default moves.
+const defaultMinIdleSessions = 1
 
-// NewPoolSizer creates a new PoolSizer. headroomPct <= 0 defaults to
-// 0.10 (10%). NewSessionQueueLength and MinIdleSessions get built-in
-// defaults; UpdateConfig can override the queue length from server
-// config.
+// defaultPoolConfig returns the server-shipped pool configuration
+// defaults (headroom, min/max session count, per-session queue length,
+// etc.) from defaultClientConfig. Kept as a helper so both NewPoolSizer
+// and UpdateConfig read the same table when the server hasn't yet
+// supplied a value.
+func defaultPoolConfig() *spb.SessionClientConfiguration_SessionPoolConfiguration {
+	return defaultClientConfig.GetSessionConfiguration().GetSessionPoolConfiguration()
+}
+
+// NewPoolSizer creates a new PoolSizer. headroomPct <= 0 falls back to
+// the server-shipped default carried in defaultClientConfig. The
+// per-session queue length and MinIdleSessions use the same source /
+// built-in floor; UpdateConfig can override any of these once the
+// server config lands.
 func NewPoolSizer(fetcher StatsFetcher, minSessions, maxSessions int, headroomPct float64) *PoolSizer {
 	if headroomPct <= 0 {
-		headroomPct = 0.10
+		headroomPct = float64(defaultPoolConfig().GetHeadroom())
 	}
 	return &PoolSizer{
 		fetcher:         fetcher,
 		minSessions:     minSessions,
 		maxSessions:     maxSessions,
 		headroomPct:     headroomPct,
-		newSessionQLen:  defaultNewSessionQueueLength,
+		newSessionQLen:  int(defaultPoolConfig().GetNewSessionQueueLength()),
 		minIdleSessions: defaultMinIdleSessions,
 	}
 }
@@ -108,7 +120,7 @@ func (s *PoolSizer) UpdateConfig(config *spb.SessionClientConfiguration_SessionP
 	if hp := float64(config.Headroom); hp > 0 {
 		s.headroomPct = hp
 	} else {
-		s.headroomPct = 0.10
+		s.headroomPct = float64(defaultPoolConfig().GetHeadroom())
 	}
 	if nsql := int(config.GetNewSessionQueueLength()); nsql > 0 {
 		s.newSessionQLen = nsql
@@ -207,7 +219,7 @@ func (s *PoolSizer) Decide() ScaleDecision {
 	// NewSessionQLen concurrent vRPCs).
 	divisor := s.newSessionQLen
 	if divisor <= 0 {
-		divisor = defaultNewSessionQueueLength
+		divisor = int(defaultPoolConfig().GetNewSessionQueueLength())
 	}
 	d.EffectivePending = (stats.PendingCount + divisor - 1) / divisor
 	d.SessionsInUse = stats.InUseCount + d.EffectivePending

--- a/bigtable/internal/transport/pool_sizer_test.go
+++ b/bigtable/internal/transport/pool_sizer_test.go
@@ -15,9 +15,11 @@
 package internal
 
 import (
+	"math"
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	spb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
 )
@@ -233,6 +235,96 @@ func TestPoolSizer_UpdateConfigTakesEffect(t *testing.T) {
 	if after.MinSessions != 2 || after.MaxSessions != 50 ||
 		after.HeadroomPct != 0.25 || after.NewSessionQLen != 20 {
 		t.Errorf("post-update snapshot mismatch: %+v", after)
+	}
+}
+
+// TestPoolSizer_UpdateConfigNilNoOp pins the nil-guard on UpdateConfig:
+// a nil config from the listener path (defensive against startup
+// intermediates) must be a no-op rather than a nil-pointer panic.
+func TestPoolSizer_UpdateConfigNilNoOp(t *testing.T) {
+	s := NewPoolSizer(fixedFetcher(&PoolStats{}), 3, 30, 0.20)
+	before := s.Decide()
+
+	s.UpdateConfig(nil) // must not panic
+
+	after := s.Decide()
+	if before.MinSessions != after.MinSessions ||
+		before.MaxSessions != after.MaxSessions ||
+		before.HeadroomPct != after.HeadroomPct ||
+		before.NewSessionQLen != after.NewSessionQLen {
+		t.Errorf("UpdateConfig(nil) mutated sizer: before=%+v after=%+v", before, after)
+	}
+}
+
+// TestPoolSizer_DecideNilFetcher pins the fetcher-nil guard: a sizer
+// constructed with a nil fetcher (defensive; not expected in
+// production) must return the no-stats branch rather than panic.
+func TestPoolSizer_DecideNilFetcher(t *testing.T) {
+	s := NewPoolSizer(nil, 1, 10, 0.10)
+	d := s.Decide()
+	if d.Branch != "no-stats" {
+		t.Errorf("Branch = %q, want no-stats (nil fetcher)", d.Branch)
+	}
+	if d.Delta != 0 {
+		t.Errorf("Delta = %d, want 0", d.Delta)
+	}
+}
+
+// TestPoolSizer_DecideFetcherOutsideLock pins the lock-ordering fix:
+// Decide must call the fetcher BEFORE acquiring s.mu, so a fetcher
+// implementation that reaches back into the sizer (or acquires
+// another mutex the sizer's caller already holds) cannot deadlock.
+// Uses a fetcher that calls Decide() re-entrantly on a second sizer
+// which shares no lock with the first — the assertion is simply that
+// the outer Decide returns without hanging.
+func TestPoolSizer_DecideFetcherOutsideLock(t *testing.T) {
+	inner := NewPoolSizer(fixedFetcher(&PoolStats{}), 1, 10, 0.10)
+	outerCalled := false
+	outer := NewPoolSizer(func() *PoolStats {
+		// Access the SAME sizer's config via a locked read (Decide);
+		// if Decide held s.mu across the fetcher call, this would
+		// deadlock on re-entry via a different Decide caller. Here we
+		// use `inner` (a distinct sizer) to make the intent
+		// transparent — the point is that the fetcher can safely call
+		// into lock-taking code.
+		_ = inner.Decide()
+		outerCalled = true
+		return &PoolStats{InUseCount: 2}
+	}, 1, 10, 0.10)
+
+	done := make(chan struct{})
+	go func() {
+		_ = outer.Decide()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Decide hung — fetcher likely called while holding s.mu")
+	}
+	if !outerCalled {
+		t.Error("fetcher was not invoked")
+	}
+}
+
+// TestPoolSizer_EffectivePendingIntegerArithmeticExhaustive pins the
+// integer-ceiling formula against math.Ceil across a wide input
+// grid. Guards against a boundary bug in the (a+b-1)/b idiom (e.g.
+// negative inputs would give the wrong sign, but PendingCount is
+// non-negative by contract).
+func TestPoolSizer_EffectivePendingIntegerArithmeticExhaustive(t *testing.T) {
+	for pending := 0; pending <= 100; pending++ {
+		for qlen := 1; qlen <= 20; qlen++ {
+			s := NewPoolSizer(fixedFetcher(&PoolStats{PendingCount: pending}), 1, 1000, 0.10)
+			s.newSessionQLen = qlen
+			got := s.Decide().EffectivePending
+			// Reference: math.Ceil-based formula.
+			want := int(math.Ceil(float64(pending) / float64(qlen)))
+			if got != want {
+				t.Errorf("EffectivePending(pending=%d, qlen=%d) = %d, want %d",
+					pending, qlen, got, want)
+			}
+		}
 	}
 }
 

--- a/bigtable/internal/transport/pool_sizer_test.go
+++ b/bigtable/internal/transport/pool_sizer_test.go
@@ -1,0 +1,381 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	spb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
+)
+
+// fixedFetcher returns the same *PoolStats on every call. Pass nil to
+// simulate a pool that hasn't started yet (no-stats branch).
+func fixedFetcher(s *PoolStats) StatsFetcher {
+	return func() *PoolStats { return s }
+}
+
+func TestPoolSizer_NoStatsBranch(t *testing.T) {
+	s := NewPoolSizer(fixedFetcher(nil), 1, 10, 0.10)
+	d := s.Decide()
+	if d.Branch != "no-stats" {
+		t.Errorf("Branch = %q, want no-stats", d.Branch)
+	}
+	if d.Delta != 0 {
+		t.Errorf("Delta = %d, want 0 (no-stats must not scale)", d.Delta)
+	}
+	// Inputs must be zero — the fetcher returned nil, so nothing to
+	// copy in.
+	if d.ReadyCount != 0 || d.InUseCount != 0 || d.PendingCount != 0 {
+		t.Errorf("input fields non-zero on no-stats: %+v", d)
+	}
+	// Config snapshot MUST still be filled — operators read it to
+	// diagnose "why did the sizer choose nothing" without a stats
+	// snapshot.
+	if d.MinSessions != 1 || d.MaxSessions != 10 || d.HeadroomPct != 0.10 {
+		t.Errorf("config snapshot not populated on no-stats: %+v", d)
+	}
+}
+
+// TestPoolSizer_ScaleUpFromZero pins the cold-start path: an empty
+// pool with pending demand must scale up to at least MinSessions.
+func TestPoolSizer_ScaleUpFromZero(t *testing.T) {
+	// 5 waiters, qlen=10 → EffectivePending=1; in-use=0; SessionsInUse=1;
+	// headroom=max(1, ceil(1*0.10))=1; DesiredRaw=2; clamp[3,10]=3;
+	// ready=0, starting=0, eventual=0; delta = 3 − 0 = 3.
+	s := NewPoolSizer(fixedFetcher(&PoolStats{PendingCount: 5}), 3, 10, 0.10)
+	d := s.Decide()
+	if d.Branch != "scale-up" {
+		t.Errorf("Branch = %q, want scale-up", d.Branch)
+	}
+	if d.Delta != 3 {
+		t.Errorf("Delta = %d, want 3 (clamp to MinSessions)", d.Delta)
+	}
+	if d.DesiredCapacity != 3 {
+		t.Errorf("DesiredCapacity = %d, want 3 (min-clamp fired)", d.DesiredCapacity)
+	}
+	if d.EffectivePending != 1 {
+		t.Errorf("EffectivePending = %d, want 1 (ceil(5/10))", d.EffectivePending)
+	}
+}
+
+// TestPoolSizer_ScaleUpAbsorbedByStarting pins the dead-band case
+// where starting sessions already cover the new demand.
+func TestPoolSizer_ScaleUpAbsorbedByStarting(t *testing.T) {
+	// InUse=4, Pending=0 → SessionsInUse=4; headroom=ceil(4*0.10)=1;
+	// DesiredRaw=5; clamp[1,20]=5. Ready=3, Starting=2, Eventual=5.
+	// Desired (5) == Eventual (5) → dead-band.
+	s := NewPoolSizer(fixedFetcher(&PoolStats{
+		ReadyCount:    3,
+		StartingCount: 2,
+		InUseCount:    4,
+	}), 1, 20, 0.10)
+	d := s.Decide()
+	if d.Branch != "dead-band" {
+		t.Errorf("Branch = %q, want dead-band (Desired=Eventual)", d.Branch)
+	}
+	if d.Delta != 0 {
+		t.Errorf("Delta = %d, want 0", d.Delta)
+	}
+}
+
+// TestPoolSizer_ScaleDownAdvisoryOnly pins the passive-shrink
+// contract: delta is negative when the pool is overprovisioned, but
+// the sizer NEVER instructs the caller to kill sessions — it's
+// advisory for OnClose replacement decisions.
+func TestPoolSizer_ScaleDownAdvisoryOnly(t *testing.T) {
+	// Ready=10, Starting=0, InUse=1, Pending=0. SessionsInUse=1;
+	// headroom=max(1, ceil(1*0.10))=1; DesiredRaw=2; clamp[1,20]=2.
+	// Immediate=10, Eventual=10. Desired (2) < Immediate (10) → scale-down.
+	// Delta = 2 − 10 = −8.
+	s := NewPoolSizer(fixedFetcher(&PoolStats{
+		ReadyCount: 10,
+		InUseCount: 1,
+	}), 1, 20, 0.10)
+	d := s.Decide()
+	if d.Branch != "scale-down" {
+		t.Errorf("Branch = %q, want scale-down", d.Branch)
+	}
+	if d.Delta != -8 {
+		t.Errorf("Delta = %d, want -8 (advisory shrink hint)", d.Delta)
+	}
+}
+
+// TestPoolSizer_MaxSessionsClamp pins the top-end clamp: even under
+// extreme demand, DesiredCapacity cannot exceed MaxSessions.
+func TestPoolSizer_MaxSessionsClamp(t *testing.T) {
+	// 500 waiters, qlen=10 → EffectivePending=50; InUse=200;
+	// SessionsInUse=250; headroom=ceil(250*0.10)=25; DesiredRaw=275;
+	// clamp[1,100]=100. Ready=0, Starting=0, Eventual=0; delta=100.
+	s := NewPoolSizer(fixedFetcher(&PoolStats{
+		InUseCount:   200,
+		PendingCount: 500,
+	}), 1, 100, 0.10)
+	d := s.Decide()
+	if d.DesiredCapacity != 100 {
+		t.Errorf("DesiredCapacity = %d, want 100 (max-clamped)", d.DesiredCapacity)
+	}
+	if d.DesiredRaw != 275 {
+		t.Errorf("DesiredRaw = %d, want 275 (pre-clamp)", d.DesiredRaw)
+	}
+	if d.Delta != 100 {
+		t.Errorf("Delta = %d, want 100", d.Delta)
+	}
+}
+
+// TestPoolSizer_HeadroomFloorPreventsCushionCollapse pins the
+// MinIdleSessions floor: a pool with tiny in-use count must still
+// carry at least 1 idle slot so cold-start doesn't stall the next
+// checkout.
+func TestPoolSizer_HeadroomFloorPreventsCushionCollapse(t *testing.T) {
+	// InUse=1, Pending=0. SessionsInUse=1; ceil(1*0.10) = 1 (already
+	// above floor). Now try InUse=0 with a huge headroom multiplier
+	// that would still round down to 0 without the floor.
+	//
+	// InUse=0, Pending=0 → SessionsInUse=0; ceil(0*anything)=0.
+	// Floor kicks in: IdleHeadroom = MinIdleSessions = 1.
+	// DesiredRaw = 0 + 1 = 1; clamp[1,10]=1.
+	s := NewPoolSizer(fixedFetcher(&PoolStats{}), 1, 10, 0.10)
+	d := s.Decide()
+	if d.IdleHeadroom != 1 {
+		t.Errorf("IdleHeadroom = %d, want 1 (MinIdleSessions floor)", d.IdleHeadroom)
+	}
+	if d.DesiredCapacity != 1 {
+		t.Errorf("DesiredCapacity = %d, want 1 (floor + min-clamp)", d.DesiredCapacity)
+	}
+	if d.Branch != "scale-up" {
+		t.Errorf("Branch = %q, want scale-up (need to reach floor)", d.Branch)
+	}
+	if d.Delta != 1 {
+		t.Errorf("Delta = %d, want 1", d.Delta)
+	}
+}
+
+// TestPoolSizer_EffectivePendingCeil pins the ceil() semantics on
+// pending-to-sessions conversion: any leftover waiter (even 1 out of
+// qlen) requires a full extra session, never a fractional one.
+func TestPoolSizer_EffectivePendingCeil(t *testing.T) {
+	tests := []struct {
+		name    string
+		pending int
+		qlen    int
+		want    int
+	}{
+		{"exact-multiple", 20, 10, 2},
+		{"one-over", 21, 10, 3},
+		{"single-waiter", 1, 10, 1},
+		{"zero", 0, 10, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := NewPoolSizer(fixedFetcher(&PoolStats{PendingCount: tt.pending}), 1, 100, 0.10)
+			if tt.qlen != defaultNewSessionQueueLength {
+				s.newSessionQLen = tt.qlen
+			}
+			d := s.Decide()
+			if d.EffectivePending != tt.want {
+				t.Errorf("EffectivePending(pending=%d, qlen=%d) = %d, want %d",
+					tt.pending, tt.qlen, d.EffectivePending, tt.want)
+			}
+		})
+	}
+}
+
+// TestPoolSizer_HeadroomDefaultOnNonPositive pins the constructor
+// guard: headroomPct <= 0 falls back to 0.10 so a mis-configured
+// callsite doesn't shrink the pool to the exact in-use count and
+// starve the next checkout.
+func TestPoolSizer_HeadroomDefaultOnNonPositive(t *testing.T) {
+	for _, hp := range []float64{0, -1, -0.5} {
+		t.Run("", func(t *testing.T) {
+			s := NewPoolSizer(fixedFetcher(&PoolStats{}), 1, 10, hp)
+			if got := s.Decide().HeadroomPct; got != 0.10 {
+				t.Errorf("headroomPct=%v → decision.HeadroomPct=%v, want default 0.10",
+					hp, got)
+			}
+		})
+	}
+}
+
+// TestPoolSizer_UpdateConfigTakesEffect pins the runtime-swap
+// contract: UpdateConfig mutates the sizer atomically w.r.t. Decide,
+// and the next Decide reflects the new values.
+func TestPoolSizer_UpdateConfigTakesEffect(t *testing.T) {
+	s := NewPoolSizer(fixedFetcher(&PoolStats{InUseCount: 5}), 1, 10, 0.10)
+
+	// Before: max=10, headroom=0.10.
+	before := s.Decide()
+	if before.MaxSessions != 10 {
+		t.Fatalf("pre-update MaxSessions = %d, want 10", before.MaxSessions)
+	}
+
+	s.UpdateConfig(&spb.SessionClientConfiguration_SessionPoolConfiguration{
+		MinSessionCount:       2,
+		MaxSessionCount:       50,
+		Headroom:              0.25,
+		NewSessionQueueLength: 20,
+	})
+
+	after := s.Decide()
+	if after.MinSessions != 2 || after.MaxSessions != 50 ||
+		after.HeadroomPct != 0.25 || after.NewSessionQLen != 20 {
+		t.Errorf("post-update snapshot mismatch: %+v", after)
+	}
+}
+
+// TestPoolSizer_UpdateConfigNormalizesNonPositiveHeadroom pins the
+// contract that UpdateConfig mirrors the constructor's headroom guard:
+// a zero or negative Headroom from the server falls back to 0.10
+// instead of being written through as-is. Without this, HeadroomPct
+// on the ScaleDecision trace would render as 0 on loadz/sessionz and
+// mislead operators — the pool would still work (MinIdleSessions
+// floor prevents cushion-collapse), but the diagnostic trace would
+// lie.
+func TestPoolSizer_UpdateConfigNormalizesNonPositiveHeadroom(t *testing.T) {
+	for _, hp := range []float32{0, -1, -0.5} {
+		t.Run("", func(t *testing.T) {
+			s := NewPoolSizer(fixedFetcher(&PoolStats{}), 1, 10, 0.25)
+			s.UpdateConfig(&spb.SessionClientConfiguration_SessionPoolConfiguration{
+				MinSessionCount:       1,
+				MaxSessionCount:       10,
+				Headroom:              hp,
+				NewSessionQueueLength: 10,
+			})
+			if got := s.Decide().HeadroomPct; got != 0.10 {
+				t.Errorf("UpdateConfig headroom=%v → HeadroomPct=%v, want default 0.10", hp, got)
+			}
+		})
+	}
+}
+
+// TestPoolSizer_UpdateConfigIgnoresZeroQueueLength pins the guard on
+// NewSessionQueueLength: a zero from the server would divide-by-zero
+// the pending calculation, so the sizer keeps its prior (or default)
+// value instead of overwriting.
+func TestPoolSizer_UpdateConfigIgnoresZeroQueueLength(t *testing.T) {
+	s := NewPoolSizer(fixedFetcher(&PoolStats{}), 1, 10, 0.10)
+	s.newSessionQLen = 7 // simulate a prior non-default value
+
+	s.UpdateConfig(&spb.SessionClientConfiguration_SessionPoolConfiguration{
+		MinSessionCount:       1,
+		MaxSessionCount:       10,
+		Headroom:              0.10,
+		NewSessionQueueLength: 0, // must be ignored
+	})
+
+	if got := s.Decide().NewSessionQLen; got != 7 {
+		t.Errorf("NewSessionQLen after zero-update = %d, want prior 7", got)
+	}
+}
+
+// TestPoolSizer_DecideTraceFieldsPopulated pins the ScaleDecision
+// contract that ops read: every intermediate MUST be filled from the
+// same evaluation so operators can trace the arithmetic without
+// re-running.
+func TestPoolSizer_DecideTraceFieldsPopulated(t *testing.T) {
+	stats := &PoolStats{
+		ReadyCount:    2,
+		StartingCount: 1,
+		InUseCount:    3,
+		PendingCount:  15,
+	}
+	s := NewPoolSizer(fixedFetcher(stats), 1, 100, 0.20)
+	d := s.Decide()
+
+	if d.ReadyCount != 2 || d.StartingCount != 1 || d.InUseCount != 3 || d.PendingCount != 15 {
+		t.Errorf("input fields not copied through: %+v", d)
+	}
+	// EffectivePending = ceil(15 / 10) = 2.
+	if d.EffectivePending != 2 {
+		t.Errorf("EffectivePending = %d, want 2", d.EffectivePending)
+	}
+	// SessionsInUse = 3 + 2 = 5.
+	if d.SessionsInUse != 5 {
+		t.Errorf("SessionsInUse = %d, want 5", d.SessionsInUse)
+	}
+	// IdleHeadroom = max(1, ceil(5 * 0.20)) = 1.
+	if d.IdleHeadroom != 1 {
+		t.Errorf("IdleHeadroom = %d, want 1", d.IdleHeadroom)
+	}
+	// DesiredRaw = 5 + 1 = 6.
+	if d.DesiredRaw != 6 {
+		t.Errorf("DesiredRaw = %d, want 6", d.DesiredRaw)
+	}
+	// ImmediateCapacity = ReadyCount = 2.
+	if d.ImmediateCapacity != 2 {
+		t.Errorf("ImmediateCapacity = %d, want 2", d.ImmediateCapacity)
+	}
+	// EventualCapacity = 2 + 1 = 3.
+	if d.EventualCapacity != 3 {
+		t.Errorf("EventualCapacity = %d, want 3", d.EventualCapacity)
+	}
+}
+
+// TestPoolSizer_GetScaleDeltaMatchesDecide pins that the convenience
+// wrapper returns the same delta the trace-carrying Decide() returns.
+func TestPoolSizer_GetScaleDeltaMatchesDecide(t *testing.T) {
+	s := NewPoolSizer(fixedFetcher(&PoolStats{
+		InUseCount:   4,
+		PendingCount: 12,
+	}), 1, 20, 0.10)
+	want := s.Decide().Delta
+	if got := s.GetScaleDelta(); got != want {
+		t.Errorf("GetScaleDelta() = %d, want %d (Decide().Delta)", got, want)
+	}
+}
+
+// TestPoolSizer_ConcurrentDecideAndUpdateConfig stresses the sizer's
+// mutex under concurrent UpdateConfig + Decide calls. Meaningful
+// under -race — the Decide return type is a value copy, so no shared
+// state escapes.
+func TestPoolSizer_ConcurrentDecideAndUpdateConfig(t *testing.T) {
+	var callCount atomic.Int64
+	fetcher := func() *PoolStats {
+		callCount.Add(1)
+		return &PoolStats{InUseCount: 5, PendingCount: 3}
+	}
+	s := NewPoolSizer(fetcher, 1, 50, 0.10)
+
+	var wg sync.WaitGroup
+	const workers = 8
+	const iters = 500
+
+	wg.Add(workers * 2)
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iters; j++ {
+				_ = s.Decide()
+			}
+		}()
+		go func(seed int) {
+			defer wg.Done()
+			for j := 0; j < iters; j++ {
+				s.UpdateConfig(&spb.SessionClientConfiguration_SessionPoolConfiguration{
+					MinSessionCount:       int32(1 + seed%3),
+					MaxSessionCount:       int32(50 + seed%10),
+					Headroom:              0.10,
+					NewSessionQueueLength: int32(10 + seed%5),
+				})
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	if callCount.Load() == 0 {
+		t.Error("fetcher never called; Decide loop may have short-circuited")
+	}
+}

--- a/bigtable/internal/transport/pool_sizer_test.go
+++ b/bigtable/internal/transport/pool_sizer_test.go
@@ -184,9 +184,7 @@ func TestPoolSizer_EffectivePendingCeil(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := NewPoolSizer(fixedFetcher(&PoolStats{PendingCount: tt.pending}), 1, 100, 0.10)
-			if tt.qlen != defaultNewSessionQueueLength {
-				s.newSessionQLen = tt.qlen
-			}
+			s.newSessionQLen = tt.qlen
 			d := s.Decide()
 			if d.EffectivePending != tt.want {
 				t.Errorf("EffectivePending(pending=%d, qlen=%d) = %d, want %d",
@@ -197,16 +195,18 @@ func TestPoolSizer_EffectivePendingCeil(t *testing.T) {
 }
 
 // TestPoolSizer_HeadroomDefaultOnNonPositive pins the constructor
-// guard: headroomPct <= 0 falls back to 0.10 so a mis-configured
-// callsite doesn't shrink the pool to the exact in-use count and
-// starve the next checkout.
+// guard: headroomPct <= 0 falls back to the server-shipped default
+// carried in defaultClientConfig so a mis-configured callsite doesn't
+// shrink the pool to the exact in-use count and starve the next
+// checkout.
 func TestPoolSizer_HeadroomDefaultOnNonPositive(t *testing.T) {
+	want := float64(defaultPoolConfig().GetHeadroom())
 	for _, hp := range []float64{0, -1, -0.5} {
 		t.Run("", func(t *testing.T) {
 			s := NewPoolSizer(fixedFetcher(&PoolStats{}), 1, 10, hp)
-			if got := s.Decide().HeadroomPct; got != 0.10 {
-				t.Errorf("headroomPct=%v → decision.HeadroomPct=%v, want default 0.10",
-					hp, got)
+			if got := s.Decide().HeadroomPct; got != want {
+				t.Errorf("headroomPct=%v → decision.HeadroomPct=%v, want default %v",
+					hp, got, want)
 			}
 		})
 	}
@@ -330,13 +330,14 @@ func TestPoolSizer_EffectivePendingIntegerArithmeticExhaustive(t *testing.T) {
 
 // TestPoolSizer_UpdateConfigNormalizesNonPositiveHeadroom pins the
 // contract that UpdateConfig mirrors the constructor's headroom guard:
-// a zero or negative Headroom from the server falls back to 0.10
-// instead of being written through as-is. Without this, HeadroomPct
-// on the ScaleDecision trace would render as 0 on loadz/sessionz and
-// mislead operators — the pool would still work (MinIdleSessions
-// floor prevents cushion-collapse), but the diagnostic trace would
-// lie.
+// a zero or negative Headroom from the server falls back to the
+// defaultClientConfig value instead of being written through as-is.
+// Without this, HeadroomPct on the ScaleDecision trace would render
+// as 0 on loadz/sessionz and mislead operators — the pool would still
+// work (MinIdleSessions floor prevents cushion-collapse), but the
+// diagnostic trace would lie.
 func TestPoolSizer_UpdateConfigNormalizesNonPositiveHeadroom(t *testing.T) {
+	want := float64(defaultPoolConfig().GetHeadroom())
 	for _, hp := range []float32{0, -1, -0.5} {
 		t.Run("", func(t *testing.T) {
 			s := NewPoolSizer(fixedFetcher(&PoolStats{}), 1, 10, 0.25)
@@ -346,8 +347,8 @@ func TestPoolSizer_UpdateConfigNormalizesNonPositiveHeadroom(t *testing.T) {
 				Headroom:              hp,
 				NewSessionQueueLength: 10,
 			})
-			if got := s.Decide().HeadroomPct; got != 0.10 {
-				t.Errorf("UpdateConfig headroom=%v → HeadroomPct=%v, want default 0.10", hp, got)
+			if got := s.Decide().HeadroomPct; got != want {
+				t.Errorf("UpdateConfig headroom=%v → HeadroomPct=%v, want default %v", hp, got, want)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Adds `PoolSizer`, a stateless snapshot-driven calculator that produces scale-up / scale-down / dead-band / no-stats decisions from current pool metrics + server config. Standalone (no callers on main yet) so the type + tests can land ahead of the upcoming `SessionPoolImpl` consumers.

- **`PoolStats`** — snapshot of ready / starting / in-use / pending counts at a single instant.
- **`StatsFetcher`** — closure indirection so the sizer never reaches into pool internals; the pool passes a getter, the sizer calls it once per `Decide`.
- **`PoolSizer.Decide`** — returns a full `ScaleDecision` trace: every input, every intermediate (`EffectivePending`, `SessionsInUse`, `IdleHeadroom`, `DesiredRaw`, `DesiredCapacity`, `ImmediateCapacity`, `EventualCapacity`), and the final `Delta` + `Branch`. Operators consume the trace on debug pages to answer "why did the sizer choose this" without re-running the arithmetic.
- **`PoolSizer.UpdateConfig`** — driven by the server-config listener. Guards the same way the constructor does: non-positive `Headroom` falls back to `0.10`; zero `NewSessionQueueLength` is ignored (would divide-by-zero the pending calculation).
- **Passive-shrink contract**: scale-down `Delta` is **advisory only**. The client never proactively kills sessions; the pool's `OnClose` reads the delta and lets the pool shrink by one per naturally-closed session. This design cannot oscillate.
- **`MinIdleSessions` floor** (default 1) prevents cushion-collapse — an idle pool with `InUseCount==0` would otherwise want zero sessions and starve cold-start.
- **Fail-safe `no-stats` branch** when the fetcher returns nil (pool not started yet).

## Test plan

- [x] `go build ./bigtable/...`
- [x] `go test ./bigtable/internal/transport/ -run '^TestPoolSizer' -count=1 -race` — 13 tests pass (1.0s)
- [x] `gofmt -l bigtable/internal/transport/pool_sizer*.go` — clean
- [x] `go vet ./bigtable/internal/transport/` — clean

Test coverage:
- `no-stats` branch on nil fetcher
- Cold-start scale-up (clamp to `MinSessions`)
- Dead-band absorbed by starting sessions
- Scale-down advisory-only (negative delta, never zero-cross)
- `MaxSessions` clamp under extreme demand
- `MinIdleSessions` floor prevents cushion-collapse
- `EffectivePending = ceil(PendingCount / NewSessionQueueLength)` (table-driven)
- Constructor + `UpdateConfig` both normalize non-positive `HeadroomPct` to `0.10`
- `UpdateConfig` live-swap takes effect
- Zero `NewSessionQueueLength` from server ignored (divide-by-zero guard)
- Every `ScaleDecision` intermediate populated from one evaluation
- `GetScaleDelta` matches `Decide().Delta`
- Concurrent `Decide` + `UpdateConfig` under `-race` (single mutex)