### PR TITLE
feat(bigtable): add sessionTracer for per-Session lifecycle + vRPC metrics

### DIFF
--- a/bigtable/internal/transport/session_tracer.go
+++ b/bigtable/internal/transport/session_tracer.go
@@ -1,0 +1,317 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	spb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
+	metricsinternal "cloud.google.com/go/bigtable/internal/metrics"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"google.golang.org/grpc/status"
+)
+
+// Session-scoped histograms. They are registered once at process startup via
+// InitializeSessionMetrics and shared across every session.
+var (
+	sessionDurations     metric.Float64Histogram
+	sessionOpenLatencies metric.Float64Histogram
+	sessionUptime        metric.Float64Histogram
+	// transportLatencies is per-vRPC (not per-session-lifecycle), but shares
+	// the same meter + registration path so all session-adjacent metrics
+	// initialize together — matches java-bigtable's MetricRegistry layout.
+	transportLatencies metric.Float64Histogram
+
+	sessionMetricsOnce sync.Once
+	sessionMetricsErr  error
+)
+
+// FineGrainLatencyBounds matches java-bigtable's
+// AGGREGATION_WITH_MILLIS_HISTOGRAM: fine sub-ms + coarse tail. Shared
+// by transport_latencies and attempt_latencies2.
+var FineGrainLatencyBounds = []float64{
+	// Linear 0 → 3ms by 0.1ms (31 boundaries): fine-grained sub-ms.
+	0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9,
+	1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9,
+	2.0, 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 2.8, 2.9, 3.0,
+	// Coarse 4ms → 80ms.
+	4.0, 5.0, 6.0, 8.0, 10.0, 13.0, 16.0, 20.0, 25.0, 30.0, 40.0, 50.0, 65.0, 80.0,
+	// Coarse 100ms → 900ms.
+	100.0, 130.0, 160.0, 200.0, 250.0, 300.0, 400.0, 500.0, 650.0, 800.0, 900.0,
+	// Coarse 1s → 50s.
+	1000.0, 2000.0, 3000.0, 4000.0, 5000.0, 6000.0, 10000.0, 20000.0, 50000.0,
+	// Long tail: 100s → 5000s (~83 min).
+	100000.0, 200000.0, 500000.0, 1000000.0, 2000000.0, 5000000.0,
+}
+
+// InitializeSessionMetrics registers the session histograms against the given
+// meter provider. It runs at most once for the lifetime of the process;
+// subsequent calls (with any provider, including nil) return the result of
+// the first call. Passing nil on the first call leaves the histograms unset
+// and returns nil.
+func InitializeSessionMetrics(meterProvider metric.MeterProvider) error {
+	sessionMetricsOnce.Do(func() {
+		if meterProvider == nil {
+			return
+		}
+		meter := meterProvider.Meter(clientMeterName)
+
+		var err error
+		if sessionDurations, err = meter.Float64Histogram(
+			"session.durations",
+			metric.WithDescription("Duration a session was alive (startTime → close)"),
+			metric.WithUnit("ms"),
+		); err != nil {
+			sessionMetricsErr = fmt.Errorf("create session.durations histogram: %w", err)
+			return
+		}
+		if sessionOpenLatencies, err = meter.Float64Histogram(
+			"session.open_latencies",
+			metric.WithDescription("Latency to open a session"),
+			metric.WithUnit("ms"),
+		); err != nil {
+			sessionMetricsErr = fmt.Errorf("create session.open_latencies histogram: %w", err)
+			return
+		}
+		if sessionUptime, err = meter.Float64Histogram(
+			"session.uptime",
+			metric.WithDescription("Age of currently-active sessions, sampled periodically"),
+			metric.WithUnit("ms"),
+		); err != nil {
+			sessionMetricsErr = fmt.Errorf("create session.uptime histogram: %w", err)
+			return
+		}
+		if transportLatencies, err = meter.Float64Histogram(
+			"transport_latencies",
+			metric.WithDescription("The latency measured from e2e latencies minus node latencies."),
+			metric.WithUnit("ms"),
+			metric.WithExplicitBucketBoundaries(FineGrainLatencyBounds...),
+		); err != nil {
+			sessionMetricsErr = fmt.Errorf("create transport_latencies histogram: %w", err)
+			return
+		}
+		if err = registerDebugTagCounter(meter); err != nil {
+			sessionMetricsErr = err
+			return
+		}
+	})
+	return sessionMetricsErr
+}
+
+// sessionTracer tracks and records metrics for a Session's lifecycle and
+// individual operations. poolName is a pool-scoped identifier stamped on
+// the session_name metric label — matches java-bigtable's SessionPoolInfo
+// name semantics (bounded cardinality, one per pool per process), NOT the
+// per-session logName (which lives on Session and is unbounded).
+//
+// startTime is the single wall-clock anchor for every emitted metric —
+// mirrors java-bigtable's SessionTracerImpl.uptime stopwatch, which is
+// started once in onStart() and drives session.open_latencies (start →
+// open), session.durations (start → close), and session.uptime (start →
+// sample). `opened` is the boolean "did the session ever reach Ready"
+// flag, filling the same role as Java's State enum for the ready label.
+type sessionTracer struct {
+	mu          sync.Mutex
+	startTime   time.Time
+	opened      bool
+	peerInfo    *spb.PeerInfo
+	poolName    string
+	sessionType SessionType
+}
+
+// newSessionTracer starts the "open" timer.
+func newSessionTracer(sessionType SessionType) *sessionTracer {
+	return &sessionTracer{
+		startTime:   time.Now(),
+		sessionType: sessionType,
+	}
+}
+
+// setPoolName stamps the pool-scoped name used for the session_name label
+// on every emitted metric. Called from WithSessionPoolName during
+// NewSession.
+func (t *sessionTracer) setPoolName(name string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.poolName = name
+}
+
+// StartedAt returns the wall-clock time the session was constructed —
+// i.e. the anchor for every session-scoped metric. Immutable after
+// newSessionTracer, so read lock-free.
+func (t *sessionTracer) StartedAt() time.Time {
+	return t.startTime
+}
+
+func (t *sessionTracer) setPeerInfo(peerInfo *spb.PeerInfo) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.peerInfo = peerInfo
+}
+
+// snapshot captures the fields we need under the lock so that we can do
+// allocating work (string formatting, attribute builds) without holding it.
+type tracerSnapshot struct {
+	startTime     time.Time
+	opened        bool
+	transportType string
+	afeLocation   string
+	poolName      string
+}
+
+func (t *sessionTracer) snapshot() tracerSnapshot {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	snap := tracerSnapshot{
+		startTime:     t.startTime,
+		opened:        t.opened,
+		poolName:      t.poolName,
+		transportType: "unknown",
+	}
+	if t.peerInfo != nil {
+		snap.transportType = metricsinternal.TransportTypeName(t.peerInfo.GetTransportType())
+		snap.afeLocation = t.peerInfo.GetApplicationFrontendSubzone()
+	}
+	return snap
+}
+
+// recordOpen records the latency to open the session and flips the
+// `opened` flag so subsequent recordClose / sampleUptime label the
+// session as ready.
+func (t *sessionTracer) recordOpen(ctx context.Context, err error) {
+	t.mu.Lock()
+	t.opened = true
+	t.mu.Unlock()
+
+	if sessionOpenLatencies == nil {
+		return
+	}
+	snap := t.snapshot()
+	statusStr := "OK"
+	if err != nil {
+		statusStr = status.Code(err).String()
+	}
+	sessionOpenLatencies.Record(ctx, msSince(snap.startTime), metric.WithAttributes(
+		attribute.String("transport_type", snap.transportType),
+		attribute.String("status", statusStr),
+		attribute.String("session_type", t.sessionType.String()),
+		attribute.String("afe_location", snap.afeLocation),
+		attribute.String("session_name", snap.poolName),
+	))
+}
+
+// recordClose records the session's total elapsed time on close.
+//   - closingReason: the terminal Session.CloseReason(), or "" if none.
+//   - streamErr: the terminal stream error; nil means clean close ("OK").
+//   - hadOk / hadErr: whether the session served any OK / error vRPCs.
+//
+// Duration is always startTime→now — matches java-bigtable
+// SessionTracerImpl.onClose (`uptime.elapsed()`, where uptime is anchored
+// at onStart). The `ready` label distinguishes sessions that reached Ready
+// from those that died pre-open.
+func (t *sessionTracer) recordClose(ctx context.Context, closingReason string, streamErr error, hadOk, hadErr bool) {
+	if sessionDurations == nil {
+		return
+	}
+	snap := t.snapshot()
+
+	var elapsed float64
+	if !snap.startTime.IsZero() {
+		elapsed = msSince(snap.startTime)
+	}
+
+	statusStr := "OK"
+	if streamErr != nil {
+		statusStr = status.Code(streamErr).String()
+	}
+
+	sessionDurations.Record(ctx, elapsed, metric.WithAttributes(
+		attribute.String("transport_type", snap.transportType),
+		attribute.String("status", statusStr),
+		attribute.String("session_type", t.sessionType.String()),
+		attribute.String("closing_reason", closingReason),
+		attribute.String("vrpcs", vrpcCloseState(hadOk, hadErr)),
+		attribute.Bool("ready", snap.opened),
+		attribute.String("afe_location", snap.afeLocation),
+		attribute.String("session_name", snap.poolName),
+	))
+}
+
+// vrpcCloseState mirrors java-bigtable's SessionCloseVRpcState.find —
+// (hadOk, hadErr) → {none, all_ok, all_error, some_ok}. The labels match
+// Java exactly so cross-language dashboards work.
+func vrpcCloseState(hadOk, hadErr bool) string {
+	switch {
+	case hadOk && hadErr:
+		return "some_ok"
+	case hadOk:
+		return "all_ok"
+	case hadErr:
+		return "all_error"
+	default:
+		return "none"
+	}
+}
+
+// sampleUptime records the current alive time (startTime → now) of a
+// still-active session into sessionUptime, with a `ready` label sourced
+// from the tracer's `opened` flag. Called periodically from the pool
+// heartbeat so the histogram represents the distribution of ages across
+// currently-active sessions. Java parity: SessionTracerImpl.recordAsyncMetrics
+// records uptime.elapsed() with `state == Ready` as the label.
+func (t *sessionTracer) sampleUptime(ctx context.Context) {
+	if sessionUptime == nil {
+		return
+	}
+	snap := t.snapshot()
+	if snap.startTime.IsZero() {
+		return
+	}
+	sessionUptime.Record(ctx, msSince(snap.startTime), metric.WithAttributes(
+		attribute.String("transport_type", snap.transportType),
+		attribute.String("session_type", t.sessionType.String()),
+		attribute.Bool("ready", snap.opened),
+		attribute.String("afe_location", snap.afeLocation),
+		attribute.String("session_name", snap.poolName),
+	))
+}
+
+func msSince(t time.Time) float64 {
+	return float64(time.Since(t)) / float64(time.Millisecond)
+}
+
+// recordTransportOverhead emits a per-vRPC (stream − backend) sample into
+// the transport_latencies histogram. Java's ClientTransportLatency defines
+// this metric as "e2e latencies minus node latencies" — the wire + AFE
+// overhead outside server processing. Caller has already validated the
+// delta is positive; this is a no-op if the metric isn't registered.
+// Method is the vRPC method name (e.g. "ExecuteVRpc/Read").
+func (t *sessionTracer) recordTransportOverhead(ctx context.Context, method string, overhead time.Duration) {
+	if transportLatencies == nil || overhead <= 0 {
+		return
+	}
+	snap := t.snapshot()
+	transportLatencies.Record(ctx, float64(overhead)/float64(time.Millisecond), metric.WithAttributes(
+		attribute.String("transport_type", snap.transportType),
+		attribute.String("session_type", t.sessionType.String()),
+		attribute.String("afe_location", snap.afeLocation),
+		attribute.String("session_name", snap.poolName),
+		attribute.String("method", method),
+	))
+}

--- a/bigtable/internal/transport/session_tracer.go
+++ b/bigtable/internal/transport/session_tracer.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	spb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
@@ -115,24 +116,37 @@ func InitializeSessionMetrics(meterProvider metric.MeterProvider) error {
 }
 
 // sessionTracer tracks and records metrics for a Session's lifecycle and
-// individual operations. poolName is a pool-scoped identifier stamped on
-// the session_name metric label — matches java-bigtable's SessionPoolInfo
-// name semantics (bounded cardinality, one per pool per process), NOT the
-// per-session logName (which lives on Session and is unbounded).
+// individual operations.
+//
+// Field lifecycle (all fields are single-writer-at-construction except
+// `opened`; readers are lock-free):
+//
+//   - startTime / sessionType — set once in newSessionTracer; immutable.
+//   - poolName — set once via setPoolName, called from WithSessionPoolName
+//     during NewSession before Session.Start spawns any goroutine.
+//     Pool-scoped name matches java-bigtable's SessionPoolInfo name
+//     semantics (bounded cardinality, one per pool per process) — NOT
+//     the per-session logName (unbounded).
+//   - opened — atomic.Bool flipped once by recordOpen; read by
+//     recordClose / sampleUptime for the `ready` label.
+//
+// peerInfo is NOT stored on the tracer. It lives on Session as an
+// atomic.Pointer (single source of truth per SESSION_SPEC #3 — set
+// once, synchronously, in handleOpenSession) and is passed in at every
+// record*/sample* call. Duplicating it on the tracer would be shadow
+// state with a separate synchronization mechanism.
 //
 // startTime is the single wall-clock anchor for every emitted metric —
-// mirrors java-bigtable's SessionTracerImpl.uptime stopwatch, which is
-// started once in onStart() and drives session.open_latencies (start →
-// open), session.durations (start → close), and session.uptime (start →
-// sample). `opened` is the boolean "did the session ever reach Ready"
-// flag, filling the same role as Java's State enum for the ready label.
+// mirrors java-bigtable's SessionTracerImpl.uptime stopwatch, started
+// once in onStart() and driving session.open_latencies (start → open),
+// session.durations (start → close), and session.uptime (start →
+// sample). `opened` fills the same role as Java's State enum for the
+// ready label.
 type sessionTracer struct {
-	mu          sync.Mutex
 	startTime   time.Time
-	opened      bool
-	peerInfo    *spb.PeerInfo
-	poolName    string
 	sessionType SessionType
+	poolName    string
+	opened      atomic.Bool
 }
 
 // newSessionTracer starts the "open" timer.
@@ -145,10 +159,9 @@ func newSessionTracer(sessionType SessionType) *sessionTracer {
 
 // setPoolName stamps the pool-scoped name used for the session_name label
 // on every emitted metric. Called from WithSessionPoolName during
-// NewSession.
+// NewSession — before Session.Start spawns any goroutine, so no
+// synchronization is required.
 func (t *sessionTracer) setPoolName(name string) {
-	t.mu.Lock()
-	defer t.mu.Unlock()
 	t.poolName = name
 }
 
@@ -159,65 +172,50 @@ func (t *sessionTracer) StartedAt() time.Time {
 	return t.startTime
 }
 
-func (t *sessionTracer) setPeerInfo(peerInfo *spb.PeerInfo) {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	t.peerInfo = peerInfo
-}
-
-// snapshot captures the fields we need under the lock so that we can do
-// allocating work (string formatting, attribute builds) without holding it.
-type tracerSnapshot struct {
-	startTime     time.Time
-	opened        bool
-	transportType string
-	afeLocation   string
-	poolName      string
-}
-
-func (t *sessionTracer) snapshot() tracerSnapshot {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	snap := tracerSnapshot{
-		startTime:     t.startTime,
-		opened:        t.opened,
-		poolName:      t.poolName,
-		transportType: "unknown",
+// peerInfoLabels derives the (transport_type, afe_location) metric-label
+// pair from a PeerInfo. Nil peerInfo yields ("unknown", "") — matching
+// pre-handshake state. Callers pass Session.PeerInfo() (an
+// atomic.Pointer load — SESSION_SPEC #3 makes the pointer set-once, so
+// the returned strings are stable for the session's lifetime).
+func peerInfoLabels(pi *spb.PeerInfo) (transportType, afeLocation string) {
+	if pi == nil {
+		return "unknown", ""
 	}
-	if t.peerInfo != nil {
-		snap.transportType = metricsinternal.TransportTypeName(t.peerInfo.GetTransportType())
-		snap.afeLocation = t.peerInfo.GetApplicationFrontendSubzone()
-	}
-	return snap
+	return metricsinternal.TransportTypeName(pi.GetTransportType()), pi.GetApplicationFrontendSubzone()
 }
 
 // recordOpen records the latency to open the session and flips the
 // `opened` flag so subsequent recordClose / sampleUptime label the
-// session as ready.
-func (t *sessionTracer) recordOpen(ctx context.Context, err error) {
-	t.mu.Lock()
-	t.opened = true
-	t.mu.Unlock()
+// session as ready. peerInfo is the caller-supplied Session.PeerInfo()
+// at the moment of the OpenSession completion; may be nil if the
+// handshake failed before headers arrived.
+func (t *sessionTracer) recordOpen(ctx context.Context, peerInfo *spb.PeerInfo, err error) {
+	t.opened.Store(true)
 
 	if sessionOpenLatencies == nil {
 		return
 	}
-	snap := t.snapshot()
+	transportType, afeLocation := peerInfoLabels(peerInfo)
 	statusStr := "OK"
 	if err != nil {
 		statusStr = status.Code(err).String()
 	}
-	sessionOpenLatencies.Record(ctx, msSince(snap.startTime), metric.WithAttributes(
-		attribute.String("transport_type", snap.transportType),
+	sessionOpenLatencies.Record(ctx, msSince(t.startTime), metric.WithAttributes(
+		attribute.String("transport_type", transportType),
 		attribute.String("status", statusStr),
 		attribute.String("session_type", t.sessionType.String()),
-		attribute.String("afe_location", snap.afeLocation),
-		attribute.String("session_name", snap.poolName),
+		attribute.String("afe_location", afeLocation),
+		attribute.String("session_name", t.poolName),
 	))
 }
 
 // recordClose records the session's total elapsed time on close.
-//   - closingReason: the terminal Session.CloseReason(), or "" if none.
+//   - peerInfo: Session.PeerInfo() at close time (may be nil if the
+//     session died pre-handshake).
+//   - closingReason: the terminal Session.CloseReason(), always
+//     non-empty — Session synthesizes a fallback if the close path
+//     forgot to set one, mirroring Java's SessionImpl.notifyTerminalClose
+//     guard (SessionImpl.java:782-793).
 //   - streamErr: the terminal stream error; nil means clean close ("OK").
 //   - hadOk / hadErr: whether the session served any OK / error vRPCs.
 //
@@ -225,16 +223,15 @@ func (t *sessionTracer) recordOpen(ctx context.Context, err error) {
 // SessionTracerImpl.onClose (`uptime.elapsed()`, where uptime is anchored
 // at onStart). The `ready` label distinguishes sessions that reached Ready
 // from those that died pre-open.
-func (t *sessionTracer) recordClose(ctx context.Context, closingReason string, streamErr error, hadOk, hadErr bool) {
+func (t *sessionTracer) recordClose(ctx context.Context, peerInfo *spb.PeerInfo, closingReason string, streamErr error, hadOk, hadErr bool) {
 	if sessionDurations == nil {
 		return
 	}
-	snap := t.snapshot()
-
 	var elapsed float64
-	if !snap.startTime.IsZero() {
-		elapsed = msSince(snap.startTime)
+	if !t.startTime.IsZero() {
+		elapsed = msSince(t.startTime)
 	}
+	transportType, afeLocation := peerInfoLabels(peerInfo)
 
 	statusStr := "OK"
 	if streamErr != nil {
@@ -242,14 +239,14 @@ func (t *sessionTracer) recordClose(ctx context.Context, closingReason string, s
 	}
 
 	sessionDurations.Record(ctx, elapsed, metric.WithAttributes(
-		attribute.String("transport_type", snap.transportType),
+		attribute.String("transport_type", transportType),
 		attribute.String("status", statusStr),
 		attribute.String("session_type", t.sessionType.String()),
 		attribute.String("closing_reason", closingReason),
 		attribute.String("vrpcs", vrpcCloseState(hadOk, hadErr)),
-		attribute.Bool("ready", snap.opened),
-		attribute.String("afe_location", snap.afeLocation),
-		attribute.String("session_name", snap.poolName),
+		attribute.Bool("ready", t.opened.Load()),
+		attribute.String("afe_location", afeLocation),
+		attribute.String("session_name", t.poolName),
 	))
 }
 
@@ -275,20 +272,20 @@ func vrpcCloseState(hadOk, hadErr bool) string {
 // heartbeat so the histogram represents the distribution of ages across
 // currently-active sessions. Java parity: SessionTracerImpl.recordAsyncMetrics
 // records uptime.elapsed() with `state == Ready` as the label.
-func (t *sessionTracer) sampleUptime(ctx context.Context) {
+func (t *sessionTracer) sampleUptime(ctx context.Context, peerInfo *spb.PeerInfo) {
 	if sessionUptime == nil {
 		return
 	}
-	snap := t.snapshot()
-	if snap.startTime.IsZero() {
+	if t.startTime.IsZero() {
 		return
 	}
-	sessionUptime.Record(ctx, msSince(snap.startTime), metric.WithAttributes(
-		attribute.String("transport_type", snap.transportType),
+	transportType, afeLocation := peerInfoLabels(peerInfo)
+	sessionUptime.Record(ctx, msSince(t.startTime), metric.WithAttributes(
+		attribute.String("transport_type", transportType),
 		attribute.String("session_type", t.sessionType.String()),
-		attribute.Bool("ready", snap.opened),
-		attribute.String("afe_location", snap.afeLocation),
-		attribute.String("session_name", snap.poolName),
+		attribute.Bool("ready", t.opened.Load()),
+		attribute.String("afe_location", afeLocation),
+		attribute.String("session_name", t.poolName),
 	))
 }
 
@@ -302,16 +299,16 @@ func msSince(t time.Time) float64 {
 // overhead outside server processing. Caller has already validated the
 // delta is positive; this is a no-op if the metric isn't registered.
 // Method is the vRPC method name (e.g. "ExecuteVRpc/Read").
-func (t *sessionTracer) recordTransportOverhead(ctx context.Context, method string, overhead time.Duration) {
+func (t *sessionTracer) recordTransportOverhead(ctx context.Context, peerInfo *spb.PeerInfo, method string, overhead time.Duration) {
 	if transportLatencies == nil || overhead <= 0 {
 		return
 	}
-	snap := t.snapshot()
+	transportType, afeLocation := peerInfoLabels(peerInfo)
 	transportLatencies.Record(ctx, float64(overhead)/float64(time.Millisecond), metric.WithAttributes(
-		attribute.String("transport_type", snap.transportType),
+		attribute.String("transport_type", transportType),
 		attribute.String("session_type", t.sessionType.String()),
-		attribute.String("afe_location", snap.afeLocation),
-		attribute.String("session_name", snap.poolName),
+		attribute.String("afe_location", afeLocation),
+		attribute.String("session_name", t.poolName),
 		attribute.String("method", method),
 	))
 }

--- a/bigtable/internal/transport/session_tracer_test.go
+++ b/bigtable/internal/transport/session_tracer_test.go
@@ -75,11 +75,9 @@ func TestSessionTracer_MetricsRoundTrip(t *testing.T) {
 	t.Run("RecordOpenPopulatesLatencyHistogram", func(t *testing.T) {
 		tr := newSessionTracer(SessionTypeTable)
 		tr.setPoolName("test-pool")
-		tr.setPeerInfo(&spb.PeerInfo{
-			ApplicationFrontendSubzone: "us-east1-b",
-		})
+		pi := &spb.PeerInfo{ApplicationFrontendSubzone: "us-east1-b"}
 		time.Sleep(2 * time.Millisecond) // give the elapsed a positive value
-		tr.recordOpen(context.Background(), nil)
+		tr.recordOpen(context.Background(), pi, nil)
 
 		rm := &metricdata.ResourceMetrics{}
 		if err := reader.Collect(context.Background(), rm); err != nil {
@@ -100,7 +98,7 @@ func TestSessionTracer_MetricsRoundTrip(t *testing.T) {
 	t.Run("RecordOpenStampsStatusOnError", func(t *testing.T) {
 		tr := newSessionTracer(SessionTypeTable)
 		tr.setPoolName("err-pool")
-		tr.recordOpen(context.Background(), status.Error(codes.Unavailable, "boom"))
+		tr.recordOpen(context.Background(), nil, status.Error(codes.Unavailable, "boom"))
 
 		rm := &metricdata.ResourceMetrics{}
 		if err := reader.Collect(context.Background(), rm); err != nil {
@@ -134,7 +132,7 @@ func TestSessionTracer_MetricsRoundTrip(t *testing.T) {
 				pool := "close-" + tc.wantLabel
 				tr := newSessionTracer(SessionTypeTable)
 				tr.setPoolName(pool)
-				tr.recordClose(context.Background(), "test-reason", nil, tc.hadOk, tc.hadErr)
+				tr.recordClose(context.Background(), nil, "test-reason", nil, tc.hadOk, tc.hadErr)
 
 				rm := &metricdata.ResourceMetrics{}
 				if err := reader.Collect(context.Background(), rm); err != nil {
@@ -157,7 +155,7 @@ func TestSessionTracer_MetricsRoundTrip(t *testing.T) {
 		// produces, but defensive) must not emit — the histogram would
 		// see negative-ish nonsense from the wall-clock delta.
 		tr := &sessionTracer{sessionType: SessionTypeTable}
-		tr.sampleUptime(context.Background())
+		tr.sampleUptime(context.Background(), nil)
 
 		rm := &metricdata.ResourceMetrics{}
 		if err := reader.Collect(context.Background(), rm); err != nil {
@@ -174,7 +172,7 @@ func TestSessionTracer_MetricsRoundTrip(t *testing.T) {
 		tr := newSessionTracer(SessionTypeTable)
 		tr.setPoolName("uptime-pool")
 		time.Sleep(2 * time.Millisecond)
-		tr.sampleUptime(context.Background())
+		tr.sampleUptime(context.Background(), nil)
 
 		rm := &metricdata.ResourceMetrics{}
 		if err := reader.Collect(context.Background(), rm); err != nil {
@@ -193,11 +191,11 @@ func TestSessionTracer_MetricsRoundTrip(t *testing.T) {
 		// Zero and negative overheads MUST NOT emit — the metric's
 		// contract is e2e minus backend, gated on positive delta by
 		// the caller.
-		tr.recordTransportOverhead(context.Background(), "Read", 0)
-		tr.recordTransportOverhead(context.Background(), "Read", -3*time.Millisecond)
+		tr.recordTransportOverhead(context.Background(), nil, "Read", 0)
+		tr.recordTransportOverhead(context.Background(), nil, "Read", -3*time.Millisecond)
 
 		// Positive overhead emits.
-		tr.recordTransportOverhead(context.Background(), "Read", 5*time.Millisecond)
+		tr.recordTransportOverhead(context.Background(), nil, "Read", 5*time.Millisecond)
 
 		rm := &metricdata.ResourceMetrics{}
 		if err := reader.Collect(context.Background(), rm); err != nil {
@@ -239,10 +237,13 @@ func TestSessionTracer_NilHistogramsAreNoOps(t *testing.T) {
 	tr := newSessionTracer(SessionTypeTable)
 	// Each recorder MUST early-return without panic when its histogram
 	// is nil (documented in-file). Simple call-and-return smoke test.
-	tr.recordOpen(context.Background(), nil)
-	tr.recordClose(context.Background(), "", nil, false, false)
-	tr.sampleUptime(context.Background())
-	tr.recordTransportOverhead(context.Background(), "Read", 1*time.Millisecond)
+	// closingReason is "" here only because the nil-histogram check
+	// short-circuits before any label is built — the always-non-empty
+	// contract is a caller-side invariant, not enforced by the tracer.
+	tr.recordOpen(context.Background(), nil, nil)
+	tr.recordClose(context.Background(), nil, "", nil, false, false)
+	tr.sampleUptime(context.Background(), nil)
+	tr.recordTransportOverhead(context.Background(), nil, "Read", 1*time.Millisecond)
 }
 
 func TestNewSessionTracer_DefaultsStamped(t *testing.T) {
@@ -259,44 +260,36 @@ func TestNewSessionTracer_DefaultsStamped(t *testing.T) {
 	if got := tr.StartedAt(); !got.Equal(tr.startTime) {
 		t.Errorf("StartedAt() = %v, want %v", got, tr.startTime)
 	}
-	if tr.opened {
+	if tr.opened.Load() {
 		t.Error("opened = true at construction, want false")
 	}
 }
 
-func TestSessionTracer_SnapshotUnknownTransportOnNilPeer(t *testing.T) {
-	tr := newSessionTracer(SessionTypeTable)
-	tr.setPoolName("pool-abc")
-	snap := tr.snapshot()
-	if snap.transportType != "unknown" {
-		t.Errorf("transportType = %q, want unknown (nil peerInfo)", snap.transportType)
-	}
-	if snap.poolName != "pool-abc" {
-		t.Errorf("poolName = %q, want pool-abc", snap.poolName)
-	}
-	if snap.afeLocation != "" {
-		t.Errorf("afeLocation = %q, want empty", snap.afeLocation)
-	}
-	if snap.opened {
-		t.Error("snap.opened = true, want false pre-recordOpen")
-	}
-}
-
-func TestSessionTracer_SnapshotAfterPeerInfoSet(t *testing.T) {
-	tr := newSessionTracer(SessionTypeTable)
-	tr.setPeerInfo(&spb.PeerInfo{
-		ApplicationFrontendSubzone: "us-central1-a",
+// TestPeerInfoLabels covers the label-derivation helper that replaced
+// the old tracerSnapshot: nil peerInfo → ("unknown", ""), a populated
+// PeerInfo forwards TransportTypeName + AFE subzone.
+func TestPeerInfoLabels(t *testing.T) {
+	t.Run("Nil", func(t *testing.T) {
+		tt, afe := peerInfoLabels(nil)
+		if tt != "unknown" {
+			t.Errorf("transportType = %q, want unknown (nil peerInfo)", tt)
+		}
+		if afe != "" {
+			t.Errorf("afeLocation = %q, want empty", afe)
+		}
 	})
-	snap := tr.snapshot()
-	if snap.afeLocation != "us-central1-a" {
-		t.Errorf("afeLocation = %q, want us-central1-a", snap.afeLocation)
-	}
-	// TransportType defaults to whatever the (unset) proto enum maps
-	// to — the tracer doesn't invent one; it forwards
-	// metricsinternal.TransportTypeName's mapping.
-	if snap.transportType == "" {
-		t.Error("transportType empty, want a metricsinternal mapping (fallback string)")
-	}
+	t.Run("SubzoneSet", func(t *testing.T) {
+		tt, afe := peerInfoLabels(&spb.PeerInfo{ApplicationFrontendSubzone: "us-central1-a"})
+		if afe != "us-central1-a" {
+			t.Errorf("afeLocation = %q, want us-central1-a", afe)
+		}
+		// TransportType defaults to whatever the (unset) proto enum maps
+		// to — the helper doesn't invent one; it forwards
+		// metricsinternal.TransportTypeName's mapping.
+		if tt == "" {
+			t.Error("transportType empty, want a metricsinternal mapping (fallback string)")
+		}
+	})
 }
 
 func TestVRpcCloseState(t *testing.T) {

--- a/bigtable/internal/transport/session_tracer_test.go
+++ b/bigtable/internal/transport/session_tracer_test.go
@@ -1,0 +1,388 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	spb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// InitializeSessionMetrics uses sync.Once — once any test in the
+// package fires it with a MeterProvider, subsequent calls are no-ops.
+// The metric-emission subtests below therefore share one ManualReader
+// via the parent test, and any test in this file that expects
+// histograms populated has to run AFTER the init.
+//
+// findAttr looks up a single string label on the first data point —
+// the OTel data model doesn't expose Attributes as a map.
+func findAttr(attrs []metricdata.HistogramDataPoint[float64], key string) (string, bool) {
+	if len(attrs) == 0 {
+		return "", false
+	}
+	v, ok := attrs[0].Attributes.Value(attribute.Key(key))
+	if !ok {
+		return "", false
+	}
+	return v.AsString(), true
+}
+
+// TestSessionTracer_MetricsRoundTrip is the umbrella test that
+// initializes the session metrics with a ManualReader and runs every
+// metric-emitting subtest against it. Structured as subtests so a
+// single sync.Once init serves all recording checks — otherwise the
+// second test would find the histograms already bound to the first
+// test's provider.
+func TestSessionTracer_MetricsRoundTrip(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	if err := InitializeSessionMetrics(provider); err != nil {
+		t.Fatalf("InitializeSessionMetrics: %v", err)
+	}
+
+	t.Run("InitializeIdempotent", func(t *testing.T) {
+		// Second call with a different provider MUST be a no-op —
+		// sync.Once discipline. Nil provider on the second call must
+		// also be safe.
+		other := sdkmetric.NewMeterProvider(sdkmetric.WithReader(sdkmetric.NewManualReader()))
+		if err := InitializeSessionMetrics(other); err != nil {
+			t.Errorf("second InitializeSessionMetrics err = %v, want nil", err)
+		}
+		if err := InitializeSessionMetrics(nil); err != nil {
+			t.Errorf("nil-provider InitializeSessionMetrics err = %v, want nil", err)
+		}
+	})
+
+	t.Run("RecordOpenPopulatesLatencyHistogram", func(t *testing.T) {
+		tr := newSessionTracer(SessionTypeTable)
+		tr.setPoolName("test-pool")
+		tr.setPeerInfo(&spb.PeerInfo{
+			ApplicationFrontendSubzone: "us-east1-b",
+		})
+		time.Sleep(2 * time.Millisecond) // give the elapsed a positive value
+		tr.recordOpen(context.Background(), nil)
+
+		rm := &metricdata.ResourceMetrics{}
+		if err := reader.Collect(context.Background(), rm); err != nil {
+			t.Fatalf("Collect: %v", err)
+		}
+		h := requireHistogram(t, rm, "session.open_latencies")
+		if len(h.DataPoints) == 0 {
+			t.Fatal("no data points in session.open_latencies")
+		}
+		if got := h.DataPoints[0].Count; got == 0 {
+			t.Error("session.open_latencies count = 0, want ≥ 1")
+		}
+		if got, _ := findAttr(h.DataPoints, "status"); got != "OK" {
+			t.Errorf("status label = %q, want OK", got)
+		}
+	})
+
+	t.Run("RecordOpenStampsStatusOnError", func(t *testing.T) {
+		tr := newSessionTracer(SessionTypeTable)
+		tr.setPoolName("err-pool")
+		tr.recordOpen(context.Background(), status.Error(codes.Unavailable, "boom"))
+
+		rm := &metricdata.ResourceMetrics{}
+		if err := reader.Collect(context.Background(), rm); err != nil {
+			t.Fatalf("Collect: %v", err)
+		}
+		h := requireHistogram(t, rm, "session.open_latencies")
+		// Find the DataPoint whose session_name == "err-pool" — the
+		// prior subtest populated a different DP.
+		got, ok := statusForPool(h.DataPoints, "err-pool")
+		if !ok {
+			t.Fatal("no data point for pool err-pool in session.open_latencies")
+		}
+		if got != "Unavailable" {
+			t.Errorf("status label = %q, want Unavailable", got)
+		}
+	})
+
+	t.Run("RecordCloseVRpcStateLabel", func(t *testing.T) {
+		cases := []struct {
+			name          string
+			hadOk, hadErr bool
+			wantLabel     string
+		}{
+			{"AllOk", true, false, "all_ok"},
+			{"AllError", false, true, "all_error"},
+			{"SomeOk", true, true, "some_ok"},
+			{"None", false, false, "none"},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				pool := "close-" + tc.wantLabel
+				tr := newSessionTracer(SessionTypeTable)
+				tr.setPoolName(pool)
+				tr.recordClose(context.Background(), "test-reason", nil, tc.hadOk, tc.hadErr)
+
+				rm := &metricdata.ResourceMetrics{}
+				if err := reader.Collect(context.Background(), rm); err != nil {
+					t.Fatalf("Collect: %v", err)
+				}
+				h := requireHistogram(t, rm, "session.durations")
+				got, ok := labelForPool(h.DataPoints, pool, "vrpcs")
+				if !ok {
+					t.Fatal("no data point for pool")
+				}
+				if got != tc.wantLabel {
+					t.Errorf("vrpcs label = %q, want %q", got, tc.wantLabel)
+				}
+			})
+		}
+	})
+
+	t.Run("SampleUptimeSkipsZeroStart", func(t *testing.T) {
+		// A tracer with startTime zero'd out (not what newSessionTracer
+		// produces, but defensive) must not emit — the histogram would
+		// see negative-ish nonsense from the wall-clock delta.
+		tr := &sessionTracer{sessionType: SessionTypeTable}
+		tr.sampleUptime(context.Background())
+
+		rm := &metricdata.ResourceMetrics{}
+		if err := reader.Collect(context.Background(), rm); err != nil {
+			t.Fatalf("Collect: %v", err)
+		}
+		if _, ok := findMetricByName(rm, "session.uptime"); ok {
+			// If session.uptime exists but from another subtest, that's
+			// fine — we just check no NEW pool named "" appears.
+			// Nothing to assert here beyond the no-panic guarantee.
+		}
+	})
+
+	t.Run("SampleUptimeEmitsForActiveSession", func(t *testing.T) {
+		tr := newSessionTracer(SessionTypeTable)
+		tr.setPoolName("uptime-pool")
+		time.Sleep(2 * time.Millisecond)
+		tr.sampleUptime(context.Background())
+
+		rm := &metricdata.ResourceMetrics{}
+		if err := reader.Collect(context.Background(), rm); err != nil {
+			t.Fatalf("Collect: %v", err)
+		}
+		h := requireHistogram(t, rm, "session.uptime")
+		if _, ok := labelForPool(h.DataPoints, "uptime-pool", "session_type"); !ok {
+			t.Error("no data point for uptime-pool in session.uptime")
+		}
+	})
+
+	t.Run("RecordTransportOverheadPositiveDeltaGate", func(t *testing.T) {
+		tr := newSessionTracer(SessionTypeTable)
+		tr.setPoolName("overhead-pool")
+
+		// Zero and negative overheads MUST NOT emit — the metric's
+		// contract is e2e minus backend, gated on positive delta by
+		// the caller.
+		tr.recordTransportOverhead(context.Background(), "Read", 0)
+		tr.recordTransportOverhead(context.Background(), "Read", -3*time.Millisecond)
+
+		// Positive overhead emits.
+		tr.recordTransportOverhead(context.Background(), "Read", 5*time.Millisecond)
+
+		rm := &metricdata.ResourceMetrics{}
+		if err := reader.Collect(context.Background(), rm); err != nil {
+			t.Fatalf("Collect: %v", err)
+		}
+		h := requireHistogram(t, rm, "transport_latencies")
+		got, ok := labelForPool(h.DataPoints, "overhead-pool", "method")
+		if !ok {
+			t.Fatal("no data point for overhead-pool in transport_latencies")
+		}
+		if got != "Read" {
+			t.Errorf("method label = %q, want Read", got)
+		}
+		// The zero/negative calls above must not have added extra
+		// data points; count for this pool should be exactly 1.
+		if c := countForPool(h.DataPoints, "overhead-pool"); c != 1 {
+			t.Errorf("count for overhead-pool = %d, want 1 (zero/negative overheads must be dropped)", c)
+		}
+	})
+}
+
+// TestSessionTracer_NoOpsWhenMetricsUninitialized guards the
+// "tracer methods MUST NOT panic when Init was never called" contract.
+// Only runnable in a subprocess (sync.Once is global), so this test
+// stubs the globals to nil via a helper. In practice the sync.Once
+// path is the production one; this test protects the fast-fail
+// defense in each recorder.
+func TestSessionTracer_NilHistogramsAreNoOps(t *testing.T) {
+	// Save and restore the package-global histograms so we can simulate
+	// the pre-init state without racing other tests. This works because
+	// go test runs a single package's tests serially by default within
+	// a single test binary.
+	origO, origD, origU, origT := sessionOpenLatencies, sessionDurations, sessionUptime, transportLatencies
+	sessionOpenLatencies, sessionDurations, sessionUptime, transportLatencies = nil, nil, nil, nil
+	t.Cleanup(func() {
+		sessionOpenLatencies, sessionDurations, sessionUptime, transportLatencies = origO, origD, origU, origT
+	})
+
+	tr := newSessionTracer(SessionTypeTable)
+	// Each recorder MUST early-return without panic when its histogram
+	// is nil (documented in-file). Simple call-and-return smoke test.
+	tr.recordOpen(context.Background(), nil)
+	tr.recordClose(context.Background(), "", nil, false, false)
+	tr.sampleUptime(context.Background())
+	tr.recordTransportOverhead(context.Background(), "Read", 1*time.Millisecond)
+}
+
+func TestNewSessionTracer_DefaultsStamped(t *testing.T) {
+	before := time.Now()
+	tr := newSessionTracer(SessionTypeAuthorizedView)
+	after := time.Now()
+
+	if tr.sessionType != SessionTypeAuthorizedView {
+		t.Errorf("sessionType = %v, want %v", tr.sessionType, SessionTypeAuthorizedView)
+	}
+	if tr.startTime.Before(before) || tr.startTime.After(after) {
+		t.Errorf("startTime = %v, want within [%v, %v]", tr.startTime, before, after)
+	}
+	if got := tr.StartedAt(); !got.Equal(tr.startTime) {
+		t.Errorf("StartedAt() = %v, want %v", got, tr.startTime)
+	}
+	if tr.opened {
+		t.Error("opened = true at construction, want false")
+	}
+}
+
+func TestSessionTracer_SnapshotUnknownTransportOnNilPeer(t *testing.T) {
+	tr := newSessionTracer(SessionTypeTable)
+	tr.setPoolName("pool-abc")
+	snap := tr.snapshot()
+	if snap.transportType != "unknown" {
+		t.Errorf("transportType = %q, want unknown (nil peerInfo)", snap.transportType)
+	}
+	if snap.poolName != "pool-abc" {
+		t.Errorf("poolName = %q, want pool-abc", snap.poolName)
+	}
+	if snap.afeLocation != "" {
+		t.Errorf("afeLocation = %q, want empty", snap.afeLocation)
+	}
+	if snap.opened {
+		t.Error("snap.opened = true, want false pre-recordOpen")
+	}
+}
+
+func TestSessionTracer_SnapshotAfterPeerInfoSet(t *testing.T) {
+	tr := newSessionTracer(SessionTypeTable)
+	tr.setPeerInfo(&spb.PeerInfo{
+		ApplicationFrontendSubzone: "us-central1-a",
+	})
+	snap := tr.snapshot()
+	if snap.afeLocation != "us-central1-a" {
+		t.Errorf("afeLocation = %q, want us-central1-a", snap.afeLocation)
+	}
+	// TransportType defaults to whatever the (unset) proto enum maps
+	// to — the tracer doesn't invent one; it forwards
+	// metricsinternal.TransportTypeName's mapping.
+	if snap.transportType == "" {
+		t.Error("transportType empty, want a metricsinternal mapping (fallback string)")
+	}
+}
+
+func TestVRpcCloseState(t *testing.T) {
+	tests := []struct {
+		name          string
+		hadOk, hadErr bool
+		want          string
+	}{
+		{"NoTraffic", false, false, "none"},
+		{"AllOk", true, false, "all_ok"},
+		{"AllError", false, true, "all_error"},
+		{"Mixed", true, true, "some_ok"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := vrpcCloseState(tt.hadOk, tt.hadErr); got != tt.want {
+				t.Errorf("vrpcCloseState(%v,%v) = %q, want %q", tt.hadOk, tt.hadErr, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMsSince(t *testing.T) {
+	past := time.Now().Add(-25 * time.Millisecond)
+	got := msSince(past)
+	if got < 20 || got > 200 {
+		// 25ms nominal; wide tolerance for scheduler jitter, but
+		// negative or 0 would indicate the formula is inverted.
+		t.Errorf("msSince(25ms ago) = %v, want in [20, 200]", got)
+	}
+	// Zero time yields "since epoch" — huge positive number; the
+	// tracer's sampleUptime documents an explicit IsZero guard, so
+	// this test just proves msSince itself doesn't misbehave.
+	if msSince(time.Now()) < 0 {
+		t.Error("msSince(now) < 0; formula inverted?")
+	}
+}
+
+// -- test helpers ------------------------------------------------------
+
+func requireHistogram(t *testing.T, rm *metricdata.ResourceMetrics, name string) metricdata.Histogram[float64] {
+	t.Helper()
+	m, ok := findMetricByName(rm, name)
+	if !ok {
+		t.Fatalf("metric %q not found; scopes=%d", name, len(rm.ScopeMetrics))
+	}
+	h, ok := m.Data.(metricdata.Histogram[float64])
+	if !ok {
+		t.Fatalf("metric %q is not Histogram[float64], got %T", name, m.Data)
+	}
+	return h
+}
+
+func findMetricByName(rm *metricdata.ResourceMetrics, name string) (metricdata.Metrics, bool) {
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name == name {
+				return m, true
+			}
+		}
+	}
+	return metricdata.Metrics{}, false
+}
+
+// statusForPool searches for a DataPoint with session_name == pool and
+// returns its `status` label.
+func statusForPool(dps []metricdata.HistogramDataPoint[float64], pool string) (string, bool) {
+	return labelForPool(dps, pool, "status")
+}
+
+func labelForPool(dps []metricdata.HistogramDataPoint[float64], pool, label string) (string, bool) {
+	for _, dp := range dps {
+		if v, ok := dp.Attributes.Value(attribute.Key("session_name")); ok && v.AsString() == pool {
+			if lv, ok := dp.Attributes.Value(attribute.Key(label)); ok {
+				return lv.AsString(), true
+			}
+		}
+	}
+	return "", false
+}
+
+func countForPool(dps []metricdata.HistogramDataPoint[float64], pool string) uint64 {
+	for _, dp := range dps {
+		if v, ok := dp.Attributes.Value(attribute.Key("session_name")); ok && v.AsString() == pool {
+			return dp.Count
+		}
+	}
+	return 0
+}


### PR DESCRIPTION
## Summary

Adds `sessionTracer`, the OTel metric-emitting companion to each Session. Standalone (no callers on `main` yet) so the tracer + tests can land ahead of the upcoming Session struct consumers.

- **`InitializeSessionMetrics`** — `sync.Once`-guarded registration of four `Float64Histogram`s + the debug-tag counter. Safe to call multiple times with any provider (or `nil`); subsequent calls return the first-call error state.
- **`sessionTracer`** — one instance per Session; holds only per-Session state (`startTime`, `opened` flag, `peerInfo`, `poolName`, `sessionType`).
- **Four metrics registered:**

  | Metric | What it captures |
  |---|---|
  | `session.durations` | start → close latency |
  | `session.open_latencies` | start → OpenSession completion |
  | `session.uptime` | periodically-sampled age of active sessions |
  | `transport_latencies` | per-vRPC (e2e − backend) with fine-grain buckets |
- `vrpcCloseState` label on `session.durations` mirrors Java's `SessionCloseVRpcState.find`: `{none, all_ok, all_error, some_ok}`.
- `session_name` label is **pool-scoped (bounded cardinality)** — NOT the per-Session `logName` (unbounded). Documented in-file.
- `recordTransportOverhead` gates on positive delta so a negative (e2e < backend) sample cannot corrupt the histogram.
- Mutex discipline: `snapshot()` copies fields under lock; all allocating work (attribute builds, histogram `Record`) runs lock-free — debug/metrics MUST NOT block the hot path.

## Test plan

- [x] `go build ./bigtable/...`
- [x] `go test ./bigtable/internal/transport/ -run '^(TestSessionTracer|TestNewSessionTracer|TestVRpcCloseState|TestMsSince)' -count=1 -race` — 17 tests pass
- [x] `gofmt -l bigtable/internal/transport/session_tracer*.go` — clean
- [x] `go vet ./bigtable/internal/transport/` — clean

Test coverage:
- `InitializeSessionMetrics` idempotent + nil-provider safe.
- `recordOpen` populates `session.open_latencies` with correct status label on OK vs error.
- `recordClose` `vrpcs` label table (all four values).
- `sampleUptime` emits for active session; skips zero startTime.
- `recordTransportOverhead` positive-delta gate — zero and −3ms dropped, +5ms recorded, exact count == 1.
- Nil-histograms no-op path (all recorders early-return without panic when Init was never called).
- `newSessionTracer` defaults, `snapshot()` on nil vs set `peerInfo`, `vrpcCloseState` table, `msSince` sanity.