### PR TITLE
fix(auth): fix OpenTelemetry test flake in grpctransport

### DIFF
--- a/auth/grpctransport/grpctransport_otel_test.go
+++ b/auth/grpctransport/grpctransport_otel_test.go
@@ -69,14 +69,6 @@ func TestDial_OpenTelemetry_Enabled(t *testing.T) {
 	// Ensure any lingering HTTP/2 connections are closed to avoid goroutine leaks.
 	defer http.DefaultTransport.(*http.Transport).CloseIdleConnections()
 
-	exporter := tracetest.NewInMemoryExporter()
-	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
-	defer tp.Shutdown(context.Background())
-
-	// Restore the global tracer provider after the test to avoid side effects.
-	defer func(prev oteltrace.TracerProvider) { otel.SetTracerProvider(prev) }(otel.GetTracerProvider())
-	otel.SetTracerProvider(tp)
-
 	successfulEchoer := &fakeEchoService{
 		Fn: func(ctx context.Context, req *echo.EchoRequest) (*echo.EchoReply, error) {
 			return &echo.EchoReply{Message: req.Message}, nil
@@ -257,7 +249,13 @@ func TestDial_OpenTelemetry_Enabled(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			exporter.Reset()
+			exporter := tracetest.NewInMemoryExporter()
+			tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+			defer tp.Shutdown(context.Background())
+
+			// Restore the global tracer provider after the test to avoid side effects.
+			defer func(prev oteltrace.TracerProvider) { otel.SetTracerProvider(prev) }(otel.GetTracerProvider())
+			otel.SetTracerProvider(tp)
 
 			l, err := net.Listen("tcp", "127.0.0.1:0")
 			if err != nil {
@@ -348,14 +346,6 @@ func TestDial_OpenTelemetry_Disabled(t *testing.T) {
 
 	// Ensure any lingering HTTP/2 connections are closed to avoid goroutine leaks.
 	defer http.DefaultTransport.(*http.Transport).CloseIdleConnections()
-
-	exporter := tracetest.NewInMemoryExporter()
-	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
-	defer tp.Shutdown(context.Background())
-
-	// Restore the global tracer provider after the test to avoid side effects.
-	defer func(prev oteltrace.TracerProvider) { otel.SetTracerProvider(prev) }(otel.GetTracerProvider())
-	otel.SetTracerProvider(tp)
 
 	successfulEchoer := &fakeEchoService{
 		Fn: func(ctx context.Context, req *echo.EchoRequest) (*echo.EchoReply, error) {
@@ -523,7 +513,13 @@ func TestDial_OpenTelemetry_Disabled(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			exporter.Reset()
+			exporter := tracetest.NewInMemoryExporter()
+			tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+			defer tp.Shutdown(context.Background())
+
+			// Restore the global tracer provider after the test to avoid side effects.
+			defer func(prev oteltrace.TracerProvider) { otel.SetTracerProvider(prev) }(otel.GetTracerProvider())
+			otel.SetTracerProvider(tp)
 
 			l, err := net.Listen("tcp", "127.0.0.1:0")
 			if err != nil {
@@ -835,14 +831,6 @@ func TestDial_Telemetry_Combinations(t *testing.T) {
 	// Ensure any lingering HTTP/2 connections are closed to avoid goroutine leaks.
 	defer http.DefaultTransport.(*http.Transport).CloseIdleConnections()
 
-	exporter := tracetest.NewInMemoryExporter()
-	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
-	defer tp.Shutdown(context.Background())
-
-	// Restore the global tracer provider after the test to avoid side effects.
-	defer func(prev oteltrace.TracerProvider) { otel.SetTracerProvider(prev) }(otel.GetTracerProvider())
-	otel.SetTracerProvider(tp)
-
 	errorEchoer := &fakeEchoService{
 		Fn: func(ctx context.Context, req *echo.EchoRequest) (*echo.EchoReply, error) {
 			return nil, status.Error(grpccodes.Internal, "test error")
@@ -934,7 +922,14 @@ func TestDial_Telemetry_Combinations(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			exporter.Reset()
+			exporter := tracetest.NewInMemoryExporter()
+			tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+			defer tp.Shutdown(context.Background())
+
+			// Restore the global tracer provider after the test to avoid side effects.
+			defer func(prev oteltrace.TracerProvider) { otel.SetTracerProvider(prev) }(otel.GetTracerProvider())
+			otel.SetTracerProvider(tp)
+
 			gax.TestOnlyResetIsFeatureEnabled()
 			defer gax.TestOnlyResetIsFeatureEnabled()
 


### PR DESCRIPTION
### Description                                                            
                                                                             
  Fixes a subtle race condition in grpctransport_otel_test.go that caused    
  flaky failures in TestDial_OpenTelemetry_Disabled and other OpenTelemetry  
  tests (e.g. Issue #20175).                                                 
                                                                             
  ### Root Cause                                                             
                                                                             
  The flake was caused by cross-test leakage of OpenTelemetry spans. Tests   
  looped over several sub-test conditions (t.Run), but the test set up the   
  tracetest.NewInMemoryExporter() and the global TracerProvider only once    
  outside of this loop, attempting to clear out previous test data by calling
  exporter.Reset() at the start of each iteration.                           
                                                                             
  However, the OpenTelemetry gRPC stats handler runs asynchronously. For the 
  test cases simulating an error (e.g., client timeout or client cancelled), 
  the client.Echo method returned immediately, but the background goroutine  
  tearing down the gRPC stream hadn't generated its stats.End event yet. If  
  these delayed spans were flushed after the next test case ("telemetry      
  disabled") called exporter.Reset(), they were written to the shared        
  exporter. The "telemetry disabled" test case would then assert that        
  len(spans) == 0 but would instead find 1 from the previous test causing the
  flake.                                                                     
                                                                             
  ### The Fix                                                                
                                                                             
  Scope the OpenTelemetry exporter and TracerProvider initialization strictly
  inside the t.Run block so a completely fresh exporter instance is created  
  per sub-test. This ensures delayed background spans end up in the old      
  provider's memory where they are harmlessly discarded.                     
                                                                             
  ### Evidence of Fix                                                        
                                                                             
  Ran the transport tests with -race and a high -count locally to ensure the 
  race condition is resolved and no cross-test pollution occurs.             
                                                                             
    $ cd auth/grpctransport && go test -v -race -count 20 .                  
    === RUN   TestDial_OpenTelemetry_Disabled                                
    === RUN   TestDial_OpenTelemetry_Disabled/telemetry_disabled             
    === RUN                                                                  
  TestDial_OpenTelemetry_Disabled/telemetry_disabled_client_timeout          
    === RUN                                                                  
  TestDial_OpenTelemetry_Disabled/telemetry_disabled_client_cancelled        
    === RUN   TestDial_OpenTelemetry_Disabled/telemetry_disabled_client_error
    --- PASS: TestDial_OpenTelemetry_Disabled (0.01s)                        
        --- PASS: TestDial_OpenTelemetry_Disabled/telemetry_disabled (0.00s) 
        --- PASS:                                                            
  TestDial_OpenTelemetry_Disabled/telemetry_disabled_client_timeout (0.00s)  
        --- PASS:                                                            
  TestDial_OpenTelemetry_Disabled/telemetry_disabled_client_cancelled (0.00s)
        --- PASS:                                                            
  TestDial_OpenTelemetry_Disabled/telemetry_disabled_client_error (0.00s)    
                                                                             
    # ... (repeated across other tests for 20 iterations without failure)    
                                                                             
    PASS                                                                     
    ok      cloud.google.com/go/auth/grpctransport    5.689s                        
    ```***    