### PR TITLE
feat(storage): implement high-precision microsecond telemetry for Bidi reads

### DIFF
--- a/storage/experimental_metrics.go
+++ b/storage/experimental_metrics.go
@@ -255,6 +255,8 @@ func initMetrics(ctx context.Context, projectID string, config *storageConfig) (
 				sdkmetric.NewView(
 					sdkmetric.Instrument{Name: "gcp.storage.client.auth.credential_refresh.duration", Kind: sdkmetric.InstrumentKindHistogram},
 					sdkmetric.Stream{Aggregation: sdkmetric.AggregationExplicitBucketHistogram{Boundaries: latencyHistogramBoundaries()}},
+				),
+				sdkmetric.NewView(
 					sdkmetric.Instrument{Name: "gcp.storage.client.bidi.stream_open_latency_us", Kind: sdkmetric.InstrumentKindHistogram},
 					sdkmetric.Stream{Aggregation: sdkmetric.AggregationExplicitBucketHistogram{Boundaries: latencyMicrosecondsHistogramBoundaries()}},
 				),
@@ -523,12 +525,6 @@ func initMetrics(ctx context.Context, projectID string, config *storageConfig) (
 		networkBytesSent:          networkBytesSent,
 		networkBytesReceived:      networkBytesReceived,
 		stallDuration:             stallDuration,
-		duration:                        duration,
-		operations:                      operations,
-		attempts:                        attempts,
-		requestBodySize:                 requestBodySize,
-		responseBodySize:                responseBodySize,
-		errors:                          errors,
 		bidiStreamOpenLatency:           bidiStreamOpenLatency,
 		bidiNetworkHandshakeLatency:     bidiNetworkHandshakeLatency,
 		bidiServerMetadataLatency:       bidiServerMetadataLatency,

--- a/storage/experimental_metrics.go
+++ b/storage/experimental_metrics.go
@@ -505,26 +505,26 @@ func initMetrics(ctx context.Context, projectID string, config *storageConfig) (
 	}
 
 	cm := &clientMetrics{
-		provider:                  provider,
-		rpcClientCallDuration:     rpcDuration,
-		httpClientRequestDuration: httpDuration,
-		duration:                  duration,
-		operations:                operations,
-		attempts:                  attempts,
-		requestBodySize:           requestBodySize,
-		responseBodySize:          responseBodySize,
-		ttfb:                      ttfb,
-		errors:                    errors,
-		activeRequests:            activeRequests,
-		gfeHeaderMissing:          gfeHeaderMissing,
-		dnsLookupDuration:         dnsLookupDuration,
-		tcpConnectDuration:        tcpConnectDuration,
-		tlsHandshakeDuration:      tlsHandshakeDuration,
-		gfeDuration:               gfeDuration,
-		credentialRefreshDuration: credentialRefreshDuration,
-		networkBytesSent:          networkBytesSent,
-		networkBytesReceived:      networkBytesReceived,
-		stallDuration:             stallDuration,
+		provider:                        provider,
+		rpcClientCallDuration:           rpcDuration,
+		httpClientRequestDuration:       httpDuration,
+		duration:                        duration,
+		operations:                      operations,
+		attempts:                        attempts,
+		requestBodySize:                 requestBodySize,
+		responseBodySize:                responseBodySize,
+		ttfb:                            ttfb,
+		errors:                          errors,
+		activeRequests:                  activeRequests,
+		gfeHeaderMissing:                gfeHeaderMissing,
+		dnsLookupDuration:               dnsLookupDuration,
+		tcpConnectDuration:              tcpConnectDuration,
+		tlsHandshakeDuration:            tlsHandshakeDuration,
+		gfeDuration:                     gfeDuration,
+		credentialRefreshDuration:       credentialRefreshDuration,
+		networkBytesSent:                networkBytesSent,
+		networkBytesReceived:            networkBytesReceived,
+		stallDuration:                   stallDuration,
 		bidiStreamOpenLatency:           bidiStreamOpenLatency,
 		bidiNetworkHandshakeLatency:     bidiNetworkHandshakeLatency,
 		bidiServerMetadataLatency:       bidiServerMetadataLatency,
@@ -1789,4 +1789,8 @@ func (cm *clientMetrics) recordStallDuration(ctx context.Context, duration time.
 		attribute.String("server.address", target),
 	}
 	cm.stallDuration.Record(ctx, duration.Seconds(), metric.WithAttributes(attrs...))
+}
+
+func durationMicros(d time.Duration) float64 {
+	return float64(d) / float64(time.Microsecond)
 }

--- a/storage/grpc_metrics.go
+++ b/storage/grpc_metrics.go
@@ -256,6 +256,15 @@ func latencyHistogramBoundaries() []float64 {
 	return boundaries
 }
 
+func latencyMicrosecondsHistogramBoundaries() []float64 {
+	sBoundaries := latencyHistogramBoundaries()
+	usBoundaries := make([]float64, len(sBoundaries))
+	for i, b := range sBoundaries {
+		usBoundaries[i] = b * 1000000.0
+	}
+	return usBoundaries
+}
+
 func sizeHistogramBoundaries() []float64 {
 	kb := 1024.0
 	mb := 1024.0 * kb

--- a/storage/grpc_reader_multi_range.go
+++ b/storage/grpc_reader_multi_range.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"log"
 	"sync"
+	"time"
 
 	"cloud.google.com/go/storage/internal/apiv2/storagepb"
 	"google.golang.org/grpc"
@@ -350,6 +351,8 @@ type mrdSessionResult struct {
 	err      error
 	session  *bidiReadStreamSession
 	redirect *storagepb.BidiReadObjectRedirectedError
+	t5       time.Time
+	t6       time.Time
 }
 
 var (
@@ -404,6 +407,7 @@ type rangeRequest struct {
 	readID       int64
 	bytesWritten int64
 	completed    bool
+	t4           time.Time
 }
 
 // Methods implementing internalMultiRangeDownloader
@@ -1063,9 +1067,27 @@ func (m *multiRangeDownloaderManager) processDataRanges(result mrdSessionResult,
 			continue
 		}
 
+		if result.session != nil {
+			if t, ok := result.session.t4Map.LoadAndDelete(readID); ok {
+				req.t4 = t.(time.Time)
+			}
+		}
+
 		written, _, err := result.decoder.writeToAndUpdateCRC(req.output, readID, nil)
 		req.bytesWritten += written
 		mrdStream.updateCapacity(m, 0, -written)
+
+		t7 := time.Now()
+		if m.client != nil && m.client.metrics != nil {
+			ctx := context.WithoutCancel(m.spanCtx)
+			if !req.t4.IsZero() {
+				m.client.metrics.bidiEndToEndRangeReadLatency.Record(ctx, float64(t7.Sub(req.t4))/float64(time.Microsecond))
+				m.client.metrics.bidiServerNetworkTransitLatency.Record(ctx, float64(result.t5.Sub(req.t4))/float64(time.Microsecond))
+			}
+			m.client.metrics.bidiSDKProcessingOverhead.Record(ctx, float64(result.t6.Sub(result.t5))/float64(time.Microsecond))
+			m.client.metrics.bidiClientHandoffDelay.Record(ctx, float64(t7.Sub(result.t6))/float64(time.Microsecond))
+		}
+
 		if err != nil {
 			m.failRange(mrdStream, req, err)
 			continue
@@ -1239,6 +1261,12 @@ type bidiReadStreamSession struct {
 	errOnce        sync.Once
 	streamErr      error
 	manualShutdown bool
+
+	t0        time.Time
+	t1        time.Time
+	t2        time.Time
+	t4Map     sync.Map
+	firstResp bool
 }
 
 func newBidiReadStreamSession(ctx context.Context, id int, respC chan<- mrdSessionResult, client *grpcStorageClient, settings *settings, params *newMultiRangeDownloaderParams, readSpec *storagepb.BidiReadObjectSpec) (*bidiReadStreamSession, error) {
@@ -1263,7 +1291,9 @@ func newBidiReadStreamSession(ctx context.Context, id int, respC chan<- mrdSessi
 	reqCtx := gax.InsertMetadataIntoOutgoingContext(s.ctx, contextMetadataFromBidiReadObject(initialReq)...)
 
 	var err error
+	t0 := time.Now()
 	s.stream, err = client.raw.BidiReadObject(reqCtx, s.settings.gax...)
+	t1 := time.Now()
 	if err != nil {
 		cancel()
 		return nil, err
@@ -1274,6 +1304,11 @@ func newBidiReadStreamSession(ctx context.Context, id int, respC chan<- mrdSessi
 		cancel()
 		return nil, err
 	}
+	t2 := time.Now()
+	s.t0 = t0
+	s.t1 = t1
+	s.t2 = t2
+	s.firstResp = true
 
 	s.wg.Add(2)
 	go s.sendLoop()
@@ -1318,6 +1353,7 @@ func (s *bidiReadStreamSession) sendLoop() {
 	defer s.stream.CloseSend()
 	for {
 		select {
+
 		case req, ok := <-s.reqC:
 			if !ok {
 				return
@@ -1329,6 +1365,11 @@ func (s *bidiReadStreamSession) sendLoop() {
 				}
 				return
 			}
+			t4 := time.Now()
+			for _, rr := range req.ReadRanges {
+				s.t4Map.Store(rr.ReadId, t4)
+			}
+
 		case <-s.ctx.Done():
 			return
 		}
@@ -1341,6 +1382,7 @@ func (s *bidiReadStreamSession) receiveLoop() {
 		// Receive message without a copy.
 		databufs := mem.BufferSlice{}
 		err := s.stream.RecvMsg(&databufs)
+		t5 := time.Now()
 		var decoder *readResponseDecoder
 		if err == nil {
 			// Use the custom decoder to parse the raw buffer without copying object data.
@@ -1352,6 +1394,7 @@ func (s *bidiReadStreamSession) receiveLoop() {
 				decoder.verifyChecksums()
 			}
 		}
+		t6 := time.Now()
 
 		if err != nil {
 			databufs.Free()
@@ -1392,7 +1435,20 @@ func (s *bidiReadStreamSession) receiveLoop() {
 			decoder: decoder,
 			id:      s.id,
 			session: s,
+			t5:      t5,
+			t6:      t6,
 		}:
+			if s.client != nil && s.client.metrics != nil {
+				m := s.client.metrics
+				ctx := context.WithoutCancel(s.managerCtx)
+				if s.firstResp {
+					s.firstResp = false
+					t3 := t5
+					m.bidiStreamOpenLatency.Record(ctx, float64(t3.Sub(s.t0))/float64(time.Microsecond))
+					m.bidiNetworkHandshakeLatency.Record(ctx, float64(s.t1.Sub(s.t0))/float64(time.Microsecond))
+					m.bidiServerMetadataLatency.Record(ctx, float64(t3.Sub(s.t2))/float64(time.Microsecond))
+				}
+			}
 
 		case <-s.ctx.Done():
 			s.mu.RLock()

--- a/storage/grpc_reader_multi_range.go
+++ b/storage/grpc_reader_multi_range.go
@@ -1101,8 +1101,8 @@ func (m *multiRangeDownloaderManager) processDataRanges(result mrdSessionResult,
 		}
 		if m.client != nil && m.client.metrics != nil {
 			ctx := context.WithoutCancel(m.spanCtx)
-			m.client.metrics.bidiClientHandoffDelay.Record(ctx, durationMicros(t7.Sub(result.t6)))
 			if !t4.IsZero() {
+				m.client.metrics.bidiClientHandoffDelay.Record(ctx, durationMicros(t7.Sub(result.t6)))
 				m.client.metrics.bidiEndToEndRangeReadLatency.Record(ctx, durationMicros(t7.Sub(t4)))
 				m.client.metrics.bidiServerNetworkTransitLatency.Record(ctx, durationMicros(result.t5.Sub(t4)))
 			}

--- a/storage/grpc_reader_multi_range.go
+++ b/storage/grpc_reader_multi_range.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"log"
 	"sync"
+	"time"
 
 	"cloud.google.com/go/storage/internal/apiv2/storagepb"
 	"google.golang.org/grpc"
@@ -350,6 +351,8 @@ type mrdSessionResult struct {
 	err      error
 	session  *bidiReadStreamSession
 	redirect *storagepb.BidiReadObjectRedirectedError
+	t5       time.Time
+	t6       time.Time
 }
 
 var (
@@ -404,6 +407,7 @@ type rangeRequest struct {
 	readID       int64
 	bytesWritten int64
 	completed    bool
+	t4           time.Time
 }
 
 // Methods implementing internalMultiRangeDownloader
@@ -1066,9 +1070,27 @@ func (m *multiRangeDownloaderManager) processDataRanges(result mrdSessionResult,
 			continue
 		}
 
+		if result.session != nil {
+			if t, ok := result.session.t4Map.LoadAndDelete(readID); ok {
+				req.t4 = t.(time.Time)
+			}
+		}
+
 		written, _, err := result.decoder.writeToAndUpdateCRC(req.output, readID, nil)
 		req.bytesWritten += written
 		mrdStream.updateCapacity(m, 0, -written)
+
+		t7 := time.Now()
+		if m.client != nil && m.client.metrics != nil {
+			ctx := context.WithoutCancel(m.spanCtx)
+			if !req.t4.IsZero() {
+				m.client.metrics.bidiEndToEndRangeReadLatency.Record(ctx, float64(t7.Sub(req.t4))/float64(time.Microsecond))
+				m.client.metrics.bidiServerNetworkTransitLatency.Record(ctx, float64(result.t5.Sub(req.t4))/float64(time.Microsecond))
+			}
+			m.client.metrics.bidiSDKProcessingOverhead.Record(ctx, float64(result.t6.Sub(result.t5))/float64(time.Microsecond))
+			m.client.metrics.bidiClientHandoffDelay.Record(ctx, float64(t7.Sub(result.t6))/float64(time.Microsecond))
+		}
+
 		if err != nil {
 			m.failRange(mrdStream, req, err)
 			continue
@@ -1242,6 +1264,12 @@ type bidiReadStreamSession struct {
 	errOnce        sync.Once
 	streamErr      error
 	manualShutdown bool
+
+	t0        time.Time
+	t1        time.Time
+	t2        time.Time
+	t4Map     sync.Map
+	firstResp bool
 }
 
 func newBidiReadStreamSession(ctx context.Context, id int, respC chan<- mrdSessionResult, client *grpcStorageClient, settings *settings, params *newMultiRangeDownloaderParams, readSpec *storagepb.BidiReadObjectSpec) (*bidiReadStreamSession, error) {
@@ -1266,7 +1294,9 @@ func newBidiReadStreamSession(ctx context.Context, id int, respC chan<- mrdSessi
 	reqCtx := gax.InsertMetadataIntoOutgoingContext(s.ctx, contextMetadataFromBidiReadObject(initialReq)...)
 
 	var err error
+	t0 := time.Now()
 	s.stream, err = client.raw.BidiReadObject(reqCtx, s.settings.gax...)
+	t1 := time.Now()
 	if err != nil {
 		cancel()
 		return nil, err
@@ -1277,6 +1307,11 @@ func newBidiReadStreamSession(ctx context.Context, id int, respC chan<- mrdSessi
 		cancel()
 		return nil, err
 	}
+	t2 := time.Now()
+	s.t0 = t0
+	s.t1 = t1
+	s.t2 = t2
+	s.firstResp = true
 
 	s.wg.Add(2)
 	go s.sendLoop()
@@ -1321,6 +1356,7 @@ func (s *bidiReadStreamSession) sendLoop() {
 	defer s.stream.CloseSend()
 	for {
 		select {
+
 		case req, ok := <-s.reqC:
 			if !ok {
 				return
@@ -1332,6 +1368,11 @@ func (s *bidiReadStreamSession) sendLoop() {
 				}
 				return
 			}
+			t4 := time.Now()
+			for _, rr := range req.ReadRanges {
+				s.t4Map.Store(rr.ReadId, t4)
+			}
+
 		case <-s.ctx.Done():
 			return
 		}
@@ -1344,6 +1385,7 @@ func (s *bidiReadStreamSession) receiveLoop() {
 		// Receive message without a copy.
 		databufs := mem.BufferSlice{}
 		err := s.stream.RecvMsg(&databufs)
+		t5 := time.Now()
 		var decoder *readResponseDecoder
 		if err == nil {
 			// Use the custom decoder to parse the raw buffer without copying object data.
@@ -1355,6 +1397,7 @@ func (s *bidiReadStreamSession) receiveLoop() {
 				decoder.verifyChecksums()
 			}
 		}
+		t6 := time.Now()
 
 		if err != nil {
 			databufs.Free()
@@ -1395,7 +1438,20 @@ func (s *bidiReadStreamSession) receiveLoop() {
 			decoder: decoder,
 			id:      s.id,
 			session: s,
+			t5:      t5,
+			t6:      t6,
 		}:
+			if s.client != nil && s.client.metrics != nil {
+				m := s.client.metrics
+				ctx := context.WithoutCancel(s.managerCtx)
+				if s.firstResp {
+					s.firstResp = false
+					t3 := t5
+					m.bidiStreamOpenLatency.Record(ctx, float64(t3.Sub(s.t0))/float64(time.Microsecond))
+					m.bidiNetworkHandshakeLatency.Record(ctx, float64(s.t1.Sub(s.t0))/float64(time.Microsecond))
+					m.bidiServerMetadataLatency.Record(ctx, float64(t3.Sub(s.t2))/float64(time.Microsecond))
+				}
+			}
 
 		case <-s.ctx.Done():
 			s.mu.RLock()

--- a/storage/grpc_reader_multi_range.go
+++ b/storage/grpc_reader_multi_range.go
@@ -1066,11 +1066,9 @@ func (m *multiRangeDownloaderManager) processSessionResult(result mrdSessionResu
 }
 
 func (m *multiRangeDownloaderManager) processDataRanges(result mrdSessionResult, mrdStream *mrdStream, resp *storagepb.BidiReadObjectResponse) {
-	handoffTime := time.Now()
 	if m.client != nil && m.client.metrics != nil {
 		ctx := context.WithoutCancel(m.spanCtx)
 		m.client.metrics.bidiSDKProcessingOverhead.Record(ctx, durationMicros(result.t6.Sub(result.t5)))
-		m.client.metrics.bidiClientHandoffDelay.Record(ctx, durationMicros(handoffTime.Sub(result.t6)))
 	}
 
 	for _, dataRange := range resp.GetObjectDataRanges() {
@@ -1097,12 +1095,13 @@ func (m *multiRangeDownloaderManager) processDataRanges(result mrdSessionResult,
 			span.AddEvent("gcp.storage.client.bidi.read_range", trace.WithAttributes(
 				attribute.Float64("gcp.storage.client.bidi.latency.network_transit_us", durationMicros(result.t5.Sub(t4))),
 				attribute.Float64("gcp.storage.client.bidi.latency.sdk_processing_overhead_us", durationMicros(result.t6.Sub(result.t5))),
-				attribute.Float64("gcp.storage.client.bidi.latency.client_handoff_delay_us", durationMicros(handoffTime.Sub(result.t6))),
+				attribute.Float64("gcp.storage.client.bidi.latency.client_handoff_delay_us", durationMicros(t7.Sub(result.t6))),
 				attribute.Float64("gcp.storage.client.bidi.latency.end_to_end_us", durationMicros(t7.Sub(t4))),
 			))
 		}
 		if m.client != nil && m.client.metrics != nil {
 			ctx := context.WithoutCancel(m.spanCtx)
+			m.client.metrics.bidiClientHandoffDelay.Record(ctx, durationMicros(t7.Sub(result.t6)))
 			if !t4.IsZero() {
 				m.client.metrics.bidiEndToEndRangeReadLatency.Record(ctx, durationMicros(t7.Sub(t4)))
 				m.client.metrics.bidiServerNetworkTransitLatency.Record(ctx, durationMicros(result.t5.Sub(t4)))

--- a/storage/grpc_reader_multi_range.go
+++ b/storage/grpc_reader_multi_range.go
@@ -410,7 +410,6 @@ type rangeRequest struct {
 	readID       int64
 	bytesWritten int64
 	completed    bool
-	t4           time.Time
 }
 
 // Methods implementing internalMultiRangeDownloader
@@ -1066,6 +1065,13 @@ func (m *multiRangeDownloaderManager) processSessionResult(result mrdSessionResu
 }
 
 func (m *multiRangeDownloaderManager) processDataRanges(result mrdSessionResult, mrdStream *mrdStream, resp *storagepb.BidiReadObjectResponse) {
+	if m.client != nil && m.client.metrics != nil {
+		ctx := context.WithoutCancel(m.spanCtx)
+		handoffTime := time.Now()
+		m.client.metrics.bidiSDKProcessingOverhead.Record(ctx, durationMicros(result.t6.Sub(result.t5)))
+		m.client.metrics.bidiClientHandoffDelay.Record(ctx, durationMicros(handoffTime.Sub(result.t6)))
+	}
+
 	for _, dataRange := range resp.GetObjectDataRanges() {
 		readID := dataRange.GetReadRange().GetReadId()
 		req, exists := mrdStream.pendingRanges[readID]
@@ -1073,9 +1079,10 @@ func (m *multiRangeDownloaderManager) processDataRanges(result mrdSessionResult,
 			continue
 		}
 
+		var t4 time.Time
 		if result.session != nil {
 			if t, ok := result.session.t4Map.LoadAndDelete(readID); ok {
-				req.t4 = t.(time.Time)
+				t4 = t.(time.Time)
 			}
 		}
 
@@ -1084,23 +1091,21 @@ func (m *multiRangeDownloaderManager) processDataRanges(result mrdSessionResult,
 		mrdStream.updateCapacity(m, 0, -written)
 
 		t7 := time.Now()
-		if !req.t4.IsZero() {
+		if !t4.IsZero() {
 			span := trace.SpanFromContext(m.spanCtx)
 			span.AddEvent("gcp.storage.client.bidi.read_range", trace.WithAttributes(
-				attribute.Float64("gcp.storage.client.bidi.latency.network_transit_us", float64(result.t5.Sub(req.t4))/float64(time.Microsecond)),
-				attribute.Float64("gcp.storage.client.bidi.latency.sdk_processing_overhead_us", float64(result.t6.Sub(result.t5))/float64(time.Microsecond)),
-				attribute.Float64("gcp.storage.client.bidi.latency.client_handoff_delay_us", float64(t7.Sub(result.t6))/float64(time.Microsecond)),
-				attribute.Float64("gcp.storage.client.bidi.latency.end_to_end_us", float64(t7.Sub(req.t4))/float64(time.Microsecond)),
+				attribute.Float64("gcp.storage.client.bidi.latency.network_transit_us", durationMicros(result.t5.Sub(t4))),
+				attribute.Float64("gcp.storage.client.bidi.latency.sdk_processing_overhead_us", durationMicros(result.t6.Sub(result.t5))),
+				attribute.Float64("gcp.storage.client.bidi.latency.client_handoff_delay_us", durationMicros(t7.Sub(result.t6))),
+				attribute.Float64("gcp.storage.client.bidi.latency.end_to_end_us", durationMicros(t7.Sub(t4))),
 			))
 		}
 		if m.client != nil && m.client.metrics != nil {
 			ctx := context.WithoutCancel(m.spanCtx)
-			if !req.t4.IsZero() {
-				m.client.metrics.bidiEndToEndRangeReadLatency.Record(ctx, float64(t7.Sub(req.t4))/float64(time.Microsecond))
-				m.client.metrics.bidiServerNetworkTransitLatency.Record(ctx, float64(result.t5.Sub(req.t4))/float64(time.Microsecond))
+			if !t4.IsZero() {
+				m.client.metrics.bidiEndToEndRangeReadLatency.Record(ctx, durationMicros(t7.Sub(t4)))
+				m.client.metrics.bidiServerNetworkTransitLatency.Record(ctx, durationMicros(result.t5.Sub(t4)))
 			}
-			m.client.metrics.bidiSDKProcessingOverhead.Record(ctx, float64(result.t6.Sub(result.t5))/float64(time.Microsecond))
-			m.client.metrics.bidiClientHandoffDelay.Record(ctx, float64(t7.Sub(result.t6))/float64(time.Microsecond))
 		}
 
 		if err != nil {
@@ -1458,16 +1463,16 @@ func (s *bidiReadStreamSession) receiveLoop() {
 				t3 := t5
 				span := trace.SpanFromContext(s.managerCtx)
 				span.AddEvent("gcp.storage.client.bidi.stream_open", trace.WithAttributes(
-					attribute.Float64("gcp.storage.client.bidi.latency.network_handshake_us", float64(s.t1.Sub(s.t0))/float64(time.Microsecond)),
-					attribute.Float64("gcp.storage.client.bidi.latency.server_metadata_us", float64(t3.Sub(s.t2))/float64(time.Microsecond)),
-					attribute.Float64("gcp.storage.client.bidi.latency.stream_open_us", float64(t3.Sub(s.t0))/float64(time.Microsecond)),
+					attribute.Float64("gcp.storage.client.bidi.latency.network_handshake_us", durationMicros(s.t1.Sub(s.t0))),
+					attribute.Float64("gcp.storage.client.bidi.latency.server_metadata_us", durationMicros(t3.Sub(s.t2))),
+					attribute.Float64("gcp.storage.client.bidi.latency.stream_open_us", durationMicros(t3.Sub(s.t0))),
 				))
 				if s.client != nil && s.client.metrics != nil {
 					m := s.client.metrics
 					ctx := context.WithoutCancel(s.managerCtx)
-					m.bidiStreamOpenLatency.Record(ctx, float64(t3.Sub(s.t0))/float64(time.Microsecond))
-					m.bidiNetworkHandshakeLatency.Record(ctx, float64(s.t1.Sub(s.t0))/float64(time.Microsecond))
-					m.bidiServerMetadataLatency.Record(ctx, float64(t3.Sub(s.t2))/float64(time.Microsecond))
+					m.bidiStreamOpenLatency.Record(ctx, durationMicros(t3.Sub(s.t0)))
+					m.bidiNetworkHandshakeLatency.Record(ctx, durationMicros(s.t1.Sub(s.t0)))
+					m.bidiServerMetadataLatency.Record(ctx, durationMicros(t3.Sub(s.t2)))
 				}
 			}
 

--- a/storage/grpc_reader_multi_range.go
+++ b/storage/grpc_reader_multi_range.go
@@ -20,12 +20,13 @@ import (
 
 	"errors"
 	"fmt"
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/trace"
 	"io"
 	"log"
 	"sync"
 	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 
 	"cloud.google.com/go/storage/internal/apiv2/storagepb"
 	"google.golang.org/grpc"
@@ -1065,9 +1066,9 @@ func (m *multiRangeDownloaderManager) processSessionResult(result mrdSessionResu
 }
 
 func (m *multiRangeDownloaderManager) processDataRanges(result mrdSessionResult, mrdStream *mrdStream, resp *storagepb.BidiReadObjectResponse) {
+	handoffTime := time.Now()
 	if m.client != nil && m.client.metrics != nil {
 		ctx := context.WithoutCancel(m.spanCtx)
-		handoffTime := time.Now()
 		m.client.metrics.bidiSDKProcessingOverhead.Record(ctx, durationMicros(result.t6.Sub(result.t5)))
 		m.client.metrics.bidiClientHandoffDelay.Record(ctx, durationMicros(handoffTime.Sub(result.t6)))
 	}
@@ -1096,7 +1097,7 @@ func (m *multiRangeDownloaderManager) processDataRanges(result mrdSessionResult,
 			span.AddEvent("gcp.storage.client.bidi.read_range", trace.WithAttributes(
 				attribute.Float64("gcp.storage.client.bidi.latency.network_transit_us", durationMicros(result.t5.Sub(t4))),
 				attribute.Float64("gcp.storage.client.bidi.latency.sdk_processing_overhead_us", durationMicros(result.t6.Sub(result.t5))),
-				attribute.Float64("gcp.storage.client.bidi.latency.client_handoff_delay_us", durationMicros(t7.Sub(result.t6))),
+				attribute.Float64("gcp.storage.client.bidi.latency.client_handoff_delay_us", durationMicros(handoffTime.Sub(result.t6))),
 				attribute.Float64("gcp.storage.client.bidi.latency.end_to_end_us", durationMicros(t7.Sub(t4))),
 			))
 		}

--- a/storage/grpc_reader_multi_range.go
+++ b/storage/grpc_reader_multi_range.go
@@ -17,8 +17,11 @@ package storage
 import (
 	"container/list"
 	"context"
+
 	"errors"
 	"fmt"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 	"io"
 	"log"
 	"sync"
@@ -1081,6 +1084,15 @@ func (m *multiRangeDownloaderManager) processDataRanges(result mrdSessionResult,
 		mrdStream.updateCapacity(m, 0, -written)
 
 		t7 := time.Now()
+		if !req.t4.IsZero() {
+			span := trace.SpanFromContext(m.spanCtx)
+			span.AddEvent("gcp.storage.client.bidi.read_range", trace.WithAttributes(
+				attribute.Float64("gcp.storage.client.bidi.latency.network_transit_us", float64(result.t5.Sub(req.t4))/float64(time.Microsecond)),
+				attribute.Float64("gcp.storage.client.bidi.latency.sdk_processing_overhead_us", float64(result.t6.Sub(result.t5))/float64(time.Microsecond)),
+				attribute.Float64("gcp.storage.client.bidi.latency.client_handoff_delay_us", float64(t7.Sub(result.t6))/float64(time.Microsecond)),
+				attribute.Float64("gcp.storage.client.bidi.latency.end_to_end_us", float64(t7.Sub(req.t4))/float64(time.Microsecond)),
+			))
+		}
 		if m.client != nil && m.client.metrics != nil {
 			ctx := context.WithoutCancel(m.spanCtx)
 			if !req.t4.IsZero() {
@@ -1441,12 +1453,18 @@ func (s *bidiReadStreamSession) receiveLoop() {
 			t5:      t5,
 			t6:      t6,
 		}:
-			if s.client != nil && s.client.metrics != nil {
-				m := s.client.metrics
-				ctx := context.WithoutCancel(s.managerCtx)
-				if s.firstResp {
-					s.firstResp = false
-					t3 := t5
+			if s.firstResp {
+				s.firstResp = false
+				t3 := t5
+				span := trace.SpanFromContext(s.managerCtx)
+				span.AddEvent("gcp.storage.client.bidi.stream_open", trace.WithAttributes(
+					attribute.Float64("gcp.storage.client.bidi.latency.network_handshake_us", float64(s.t1.Sub(s.t0))/float64(time.Microsecond)),
+					attribute.Float64("gcp.storage.client.bidi.latency.server_metadata_us", float64(t3.Sub(s.t2))/float64(time.Microsecond)),
+					attribute.Float64("gcp.storage.client.bidi.latency.stream_open_us", float64(t3.Sub(s.t0))/float64(time.Microsecond)),
+				))
+				if s.client != nil && s.client.metrics != nil {
+					m := s.client.metrics
+					ctx := context.WithoutCancel(s.managerCtx)
 					m.bidiStreamOpenLatency.Record(ctx, float64(t3.Sub(s.t0))/float64(time.Microsecond))
 					m.bidiNetworkHandshakeLatency.Record(ctx, float64(s.t1.Sub(s.t0))/float64(time.Microsecond))
 					m.bidiServerMetadataLatency.Record(ctx, float64(t3.Sub(s.t2))/float64(time.Microsecond))

--- a/storage/grpc_reader_multi_range_test.go
+++ b/storage/grpc_reader_multi_range_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//      http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/storage/grpc_reader_multi_range_test.go
+++ b/storage/grpc_reader_multi_range_test.go
@@ -41,7 +41,7 @@ func TestBidiTracing_receiveLoop(t *testing.T) {
 	ch := make(chan mrdSessionResult, 10)
 
 	s := &bidiReadStreamSession{
-		managerCtx: ctx, // Context used for Span extraction
+		managerCtx: ctx,
 		ctx:        ctx,
 		client:     &grpcStorageClient{},
 		firstResp:  true,
@@ -99,21 +99,23 @@ func TestBidiTracing_processDataRanges(t *testing.T) {
 	ctx, span := tracer.Start(context.Background(), "test_read_range")
 
 	m := &multiRangeDownloaderManager{
-		spanCtx: ctx, // Context used for Span extraction
+		spanCtx: ctx,
 		client:  &grpcStorageClient{},
 	}
 
-	req := &rangeRequest{
-		t4: time.Now().Add(-10 * time.Millisecond),
-	}
+	req := &rangeRequest{}
 	mrdStream := &mrdStream{
 		pendingRanges: map[int64]*rangeRequest{
 			1: req,
 		},
 	}
 
+	session := &bidiReadStreamSession{}
+	session.t4Map.Store(int64(1), time.Now().Add(-10*time.Millisecond))
+
 	result := mrdSessionResult{
 		decoder: &readResponseDecoder{},
+		session: session,
 		t5:      time.Now().Add(-5 * time.Millisecond),
 		t6:      time.Now().Add(-2 * time.Millisecond),
 	}

--- a/storage/grpc_reader_multi_range_test.go
+++ b/storage/grpc_reader_multi_range_test.go
@@ -1,3 +1,16 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package storage
 
 import (

--- a/storage/grpc_reader_multi_range_test.go
+++ b/storage/grpc_reader_multi_range_test.go
@@ -1,0 +1,162 @@
+package storage
+
+import (
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"cloud.google.com/go/storage/internal/apiv2/storagepb"
+)
+
+type mockBidiStream struct {
+	storagepb.Storage_BidiReadObjectClient
+	resps []*storagepb.BidiReadObjectResponse
+	err   error
+	i     int
+}
+
+func (m *mockBidiStream) Recv() (*storagepb.BidiReadObjectResponse, error) {
+	if m.i < len(m.resps) {
+		r := m.resps[m.i]
+		m.i++
+		return r, nil
+	}
+	if m.err != nil {
+		return nil, m.err
+	}
+	return nil, io.EOF
+}
+
+func TestBidiTracing_receiveLoop(t *testing.T) {
+	sr := tracetest.NewSpanRecorder()
+	tp := trace.NewTracerProvider(trace.WithSpanProcessor(sr))
+	tracer := tp.Tracer("test")
+
+	ctx, span := tracer.Start(context.Background(), "test_stream_open")
+
+	ch := make(chan mrdSessionResult, 10)
+
+	s := &bidiReadStreamSession{
+		managerCtx: ctx, // Context used for Span extraction
+		ctx:        ctx,
+		client:     &grpcStorageClient{},
+		firstResp:  true,
+		t0:         time.Now().Add(-10 * time.Millisecond),
+		t1:         time.Now().Add(-8 * time.Millisecond),
+		t2:         time.Now().Add(-5 * time.Millisecond),
+		respC:      ch,
+		stream: &mockBidiStream{
+			resps: []*storagepb.BidiReadObjectResponse{
+				{ObjectDataRanges: []*storagepb.ObjectRangeData{}},
+			},
+			err: io.EOF,
+		},
+	}
+
+	s.receiveLoop()
+	span.End()
+
+	spans := sr.Ended()
+	if len(spans) != 1 {
+		t.Fatalf("expected 1 span, got %d", len(spans))
+	}
+	gotSpan := spans[0]
+
+	found := false
+	for _, ev := range gotSpan.Events() {
+		if ev.Name == "gcp.storage.client.bidi.stream_open" {
+			found = true
+			if len(ev.Attributes) != 3 {
+				t.Errorf("expected 3 attributes, got %d", len(ev.Attributes))
+			}
+			var numFound int
+			for _, attr := range ev.Attributes {
+				if attr.Key == "gcp.storage.client.bidi.latency.network_handshake_us" ||
+					attr.Key == "gcp.storage.client.bidi.latency.server_metadata_us" ||
+					attr.Key == "gcp.storage.client.bidi.latency.stream_open_us" {
+					numFound++
+				}
+			}
+			if numFound != 3 {
+				t.Errorf("expected the 3 specific attributes, only found %d", numFound)
+			}
+		}
+	}
+	if !found {
+		t.Error("expected event gcp.storage.client.bidi.stream_open not found in span")
+	}
+}
+
+func TestBidiTracing_processDataRanges(t *testing.T) {
+	sr := tracetest.NewSpanRecorder()
+	tp := trace.NewTracerProvider(trace.WithSpanProcessor(sr))
+	tracer := tp.Tracer("test")
+
+	ctx, span := tracer.Start(context.Background(), "test_read_range")
+
+	m := &multiRangeDownloaderManager{
+		spanCtx: ctx, // Context used for Span extraction
+		client:  &grpcStorageClient{},
+	}
+
+	req := &rangeRequest{
+		t4: time.Now().Add(-10 * time.Millisecond),
+	}
+	mrdStream := &mrdStream{
+		pendingRanges: map[int64]*rangeRequest{
+			1: req,
+		},
+	}
+
+	result := mrdSessionResult{
+		decoder: &readResponseDecoder{},
+		t5:      time.Now().Add(-5 * time.Millisecond),
+		t6:      time.Now().Add(-2 * time.Millisecond),
+	}
+	resp := &storagepb.BidiReadObjectResponse{
+		ObjectDataRanges: []*storagepb.ObjectRangeData{
+			{
+				ReadRange: &storagepb.ReadRange{ReadId: 1},
+			},
+		},
+	}
+
+	m.processDataRanges(result, mrdStream, resp)
+
+	span.End()
+
+	spans := sr.Ended()
+	if len(spans) != 1 {
+		t.Fatalf("expected 1 span, got %d", len(spans))
+	}
+	gotSpan := spans[0]
+
+	found := false
+	for _, ev := range gotSpan.Events() {
+		if ev.Name == "gcp.storage.client.bidi.read_range" {
+			found = true
+			if len(ev.Attributes) != 4 {
+				t.Errorf("expected 4 attributes, got %d", len(ev.Attributes))
+			}
+			var numFound int
+			for _, attr := range ev.Attributes {
+				if attr.Key == "gcp.storage.client.bidi.latency.network_transit_us" ||
+					attr.Key == "gcp.storage.client.bidi.latency.sdk_processing_overhead_us" ||
+					attr.Key == "gcp.storage.client.bidi.latency.client_handoff_delay_us" ||
+					attr.Key == "gcp.storage.client.bidi.latency.end_to_end_us" {
+					numFound++
+				}
+			}
+			if numFound != 4 {
+				t.Errorf("expected 4 specific attributes, got %d", numFound)
+			}
+		}
+	}
+	if !found {
+		t.Error("expected event gcp.storage.client.bidi.read_range not found in span")
+	}
+}

--- a/storage/metrics.go
+++ b/storage/metrics.go
@@ -59,6 +59,14 @@ type clientMetrics struct {
 	responseBodySize          metric.Int64Histogram
 	ttfb                      metric.Float64Histogram
 	errors                    metric.Int64Counter
+
+	bidiStreamOpenLatency           metric.Float64Histogram
+	bidiNetworkHandshakeLatency     metric.Float64Histogram
+	bidiServerMetadataLatency       metric.Float64Histogram
+	bidiEndToEndRangeReadLatency    metric.Float64Histogram
+	bidiServerNetworkTransitLatency metric.Float64Histogram
+	bidiSDKProcessingOverhead       metric.Float64Histogram
+	bidiClientHandoffDelay          metric.Float64Histogram
 }
 
 func formatMetricWithPrefix(m metricdata.Metrics, prefix string) string {
@@ -162,6 +170,34 @@ func initMetrics(ctx context.Context, projectID string, config *storageConfig) (
 					sdkmetric.Instrument{Name: "gcp.storage.client.response.body.size", Kind: sdkmetric.InstrumentKindHistogram},
 					sdkmetric.Stream{Aggregation: sdkmetric.AggregationExplicitBucketHistogram{Boundaries: sizeHistogramBoundaries()}},
 				),
+				sdkmetric.NewView(
+					sdkmetric.Instrument{Name: "gcp.storage.client.bidi.stream_open_latency_us", Kind: sdkmetric.InstrumentKindHistogram},
+					sdkmetric.Stream{Aggregation: sdkmetric.AggregationExplicitBucketHistogram{Boundaries: latencyMicrosecondsHistogramBoundaries()}},
+				),
+				sdkmetric.NewView(
+					sdkmetric.Instrument{Name: "gcp.storage.client.bidi.network_handshake_latency_us", Kind: sdkmetric.InstrumentKindHistogram},
+					sdkmetric.Stream{Aggregation: sdkmetric.AggregationExplicitBucketHistogram{Boundaries: latencyMicrosecondsHistogramBoundaries()}},
+				),
+				sdkmetric.NewView(
+					sdkmetric.Instrument{Name: "gcp.storage.client.bidi.server_metadata_latency_us", Kind: sdkmetric.InstrumentKindHistogram},
+					sdkmetric.Stream{Aggregation: sdkmetric.AggregationExplicitBucketHistogram{Boundaries: latencyMicrosecondsHistogramBoundaries()}},
+				),
+				sdkmetric.NewView(
+					sdkmetric.Instrument{Name: "gcp.storage.client.bidi.end_to_end_range_read_latency_us", Kind: sdkmetric.InstrumentKindHistogram},
+					sdkmetric.Stream{Aggregation: sdkmetric.AggregationExplicitBucketHistogram{Boundaries: latencyMicrosecondsHistogramBoundaries()}},
+				),
+				sdkmetric.NewView(
+					sdkmetric.Instrument{Name: "gcp.storage.client.bidi.server_network_transit_latency_us", Kind: sdkmetric.InstrumentKindHistogram},
+					sdkmetric.Stream{Aggregation: sdkmetric.AggregationExplicitBucketHistogram{Boundaries: latencyMicrosecondsHistogramBoundaries()}},
+				),
+				sdkmetric.NewView(
+					sdkmetric.Instrument{Name: "gcp.storage.client.bidi.sdk_processing_overhead_us", Kind: sdkmetric.InstrumentKindHistogram},
+					sdkmetric.Stream{Aggregation: sdkmetric.AggregationExplicitBucketHistogram{Boundaries: latencyMicrosecondsHistogramBoundaries()}},
+				),
+				sdkmetric.NewView(
+					sdkmetric.Instrument{Name: "gcp.storage.client.bidi.client_handoff_delay_us", Kind: sdkmetric.InstrumentKindHistogram},
+					sdkmetric.Stream{Aggregation: sdkmetric.AggregationExplicitBucketHistogram{Boundaries: latencyMicrosecondsHistogramBoundaries()}},
+				),
 			),
 		)
 		ownProvider = true
@@ -241,6 +277,35 @@ func initMetrics(ctx context.Context, projectID string, config *storageConfig) (
 		return nil, nil, err
 	}
 
+	bidiStreamOpenLatency, err := meter.Float64Histogram("gcp.storage.client.bidi.stream_open_latency_us", metric.WithDescription("Total perceived time for connection, handshake, and metadata"), metric.WithUnit("us"))
+	if err != nil {
+		return nil, nil, err
+	}
+	bidiNetworkHandshakeLatency, err := meter.Float64Histogram("gcp.storage.client.bidi.network_handshake_latency_us", metric.WithDescription("Perceived time to establish the connection"), metric.WithUnit("us"))
+	if err != nil {
+		return nil, nil, err
+	}
+	bidiServerMetadataLatency, err := meter.Float64Histogram("gcp.storage.client.bidi.server_metadata_latency_us", metric.WithDescription("Time Fastpusher takes to process initial spec and look up metadata"), metric.WithUnit("us"))
+	if err != nil {
+		return nil, nil, err
+	}
+	bidiEndToEndRangeReadLatency, err := meter.Float64Histogram("gcp.storage.client.bidi.end_to_end_range_read_latency_us", metric.WithDescription("Total perceived latency from request to application readiness"), metric.WithUnit("us"))
+	if err != nil {
+		return nil, nil, err
+	}
+	bidiServerNetworkTransitLatency, err := meter.Float64Histogram("gcp.storage.client.bidi.server_network_transit_latency_us", metric.WithDescription("Time from range registration to data arrival at the VM"), metric.WithUnit("us"))
+	if err != nil {
+		return nil, nil, err
+	}
+	bidiSDKProcessingOverhead, err := meter.Float64Histogram("gcp.storage.client.bidi.sdk_processing_overhead_us", metric.WithDescription("Time spent in proto parsing and CRC32C verification"), metric.WithUnit("us"))
+	if err != nil {
+		return nil, nil, err
+	}
+	bidiClientHandoffDelay, err := meter.Float64Histogram("gcp.storage.client.bidi.client_handoff_delay_us", metric.WithDescription("Delay between SDK completion and user application receiving the data callback"), metric.WithUnit("us"))
+	if err != nil {
+		return nil, nil, err
+	}
+
 	errors, err := meter.Int64Counter(
 		"gcp.storage.client.errors",
 		metric.WithDescription("Number of GCS client errors"),
@@ -251,16 +316,23 @@ func initMetrics(ctx context.Context, projectID string, config *storageConfig) (
 	}
 
 	cm := &clientMetrics{
-		provider:                  provider,
-		rpcClientCallDuration:     rpcDuration,
-		httpClientRequestDuration: httpDuration,
-		duration:                  duration,
-		operations:                operations,
-		attempts:                  attempts,
-		requestBodySize:           requestBodySize,
-		responseBodySize:          responseBodySize,
-		ttfb:                      ttfb,
-		errors:                    errors,
+		provider:                        provider,
+		rpcClientCallDuration:           rpcDuration,
+		httpClientRequestDuration:       httpDuration,
+		duration:                        duration,
+		operations:                      operations,
+		attempts:                        attempts,
+		requestBodySize:                 requestBodySize,
+		responseBodySize:                responseBodySize,
+		ttfb:                            ttfb,
+		errors:                          errors,
+		bidiStreamOpenLatency:           bidiStreamOpenLatency,
+		bidiNetworkHandshakeLatency:     bidiNetworkHandshakeLatency,
+		bidiServerMetadataLatency:       bidiServerMetadataLatency,
+		bidiEndToEndRangeReadLatency:    bidiEndToEndRangeReadLatency,
+		bidiServerNetworkTransitLatency: bidiServerNetworkTransitLatency,
+		bidiSDKProcessingOverhead:       bidiSDKProcessingOverhead,
+		bidiClientHandoffDelay:          bidiClientHandoffDelay,
 	}
 
 	var cleanup func()

--- a/storage/metrics.go
+++ b/storage/metrics.go
@@ -77,6 +77,14 @@ type clientMetrics struct {
 	networkBytesSent          metric.Int64Counter
 	networkBytesReceived      metric.Int64Counter
 	stallDuration             metric.Float64Histogram
+
+	bidiStreamOpenLatency           metric.Float64Histogram
+	bidiNetworkHandshakeLatency     metric.Float64Histogram
+	bidiServerMetadataLatency       metric.Float64Histogram
+	bidiEndToEndRangeReadLatency    metric.Float64Histogram
+	bidiServerNetworkTransitLatency metric.Float64Histogram
+	bidiSDKProcessingOverhead       metric.Float64Histogram
+	bidiClientHandoffDelay          metric.Float64Histogram
 }
 
 func formatMetricWithPrefix(m metricdata.Metrics, prefix string) string {
@@ -247,6 +255,32 @@ func initMetrics(ctx context.Context, projectID string, config *storageConfig) (
 				sdkmetric.NewView(
 					sdkmetric.Instrument{Name: "gcp.storage.client.auth.credential_refresh.duration", Kind: sdkmetric.InstrumentKindHistogram},
 					sdkmetric.Stream{Aggregation: sdkmetric.AggregationExplicitBucketHistogram{Boundaries: latencyHistogramBoundaries()}},
+					sdkmetric.Instrument{Name: "gcp.storage.client.bidi.stream_open_latency_us", Kind: sdkmetric.InstrumentKindHistogram},
+					sdkmetric.Stream{Aggregation: sdkmetric.AggregationExplicitBucketHistogram{Boundaries: latencyMicrosecondsHistogramBoundaries()}},
+				),
+				sdkmetric.NewView(
+					sdkmetric.Instrument{Name: "gcp.storage.client.bidi.network_handshake_latency_us", Kind: sdkmetric.InstrumentKindHistogram},
+					sdkmetric.Stream{Aggregation: sdkmetric.AggregationExplicitBucketHistogram{Boundaries: latencyMicrosecondsHistogramBoundaries()}},
+				),
+				sdkmetric.NewView(
+					sdkmetric.Instrument{Name: "gcp.storage.client.bidi.server_metadata_latency_us", Kind: sdkmetric.InstrumentKindHistogram},
+					sdkmetric.Stream{Aggregation: sdkmetric.AggregationExplicitBucketHistogram{Boundaries: latencyMicrosecondsHistogramBoundaries()}},
+				),
+				sdkmetric.NewView(
+					sdkmetric.Instrument{Name: "gcp.storage.client.bidi.end_to_end_range_read_latency_us", Kind: sdkmetric.InstrumentKindHistogram},
+					sdkmetric.Stream{Aggregation: sdkmetric.AggregationExplicitBucketHistogram{Boundaries: latencyMicrosecondsHistogramBoundaries()}},
+				),
+				sdkmetric.NewView(
+					sdkmetric.Instrument{Name: "gcp.storage.client.bidi.server_network_transit_latency_us", Kind: sdkmetric.InstrumentKindHistogram},
+					sdkmetric.Stream{Aggregation: sdkmetric.AggregationExplicitBucketHistogram{Boundaries: latencyMicrosecondsHistogramBoundaries()}},
+				),
+				sdkmetric.NewView(
+					sdkmetric.Instrument{Name: "gcp.storage.client.bidi.sdk_processing_overhead_us", Kind: sdkmetric.InstrumentKindHistogram},
+					sdkmetric.Stream{Aggregation: sdkmetric.AggregationExplicitBucketHistogram{Boundaries: latencyMicrosecondsHistogramBoundaries()}},
+				),
+				sdkmetric.NewView(
+					sdkmetric.Instrument{Name: "gcp.storage.client.bidi.client_handoff_delay_us", Kind: sdkmetric.InstrumentKindHistogram},
+					sdkmetric.Stream{Aggregation: sdkmetric.AggregationExplicitBucketHistogram{Boundaries: latencyMicrosecondsHistogramBoundaries()}},
 				),
 			),
 		)
@@ -323,6 +357,35 @@ func initMetrics(ctx context.Context, projectID string, config *storageConfig) (
 		metric.WithDescription("Time to first byte of GCS client operations"),
 		metric.WithUnit("s"),
 	)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	bidiStreamOpenLatency, err := meter.Float64Histogram("gcp.storage.client.bidi.stream_open_latency_us", metric.WithDescription("Total perceived time for connection, handshake, and metadata"), metric.WithUnit("us"))
+	if err != nil {
+		return nil, nil, err
+	}
+	bidiNetworkHandshakeLatency, err := meter.Float64Histogram("gcp.storage.client.bidi.network_handshake_latency_us", metric.WithDescription("Perceived time to establish the connection"), metric.WithUnit("us"))
+	if err != nil {
+		return nil, nil, err
+	}
+	bidiServerMetadataLatency, err := meter.Float64Histogram("gcp.storage.client.bidi.server_metadata_latency_us", metric.WithDescription("Time Fastpusher takes to process initial spec and look up metadata"), metric.WithUnit("us"))
+	if err != nil {
+		return nil, nil, err
+	}
+	bidiEndToEndRangeReadLatency, err := meter.Float64Histogram("gcp.storage.client.bidi.end_to_end_range_read_latency_us", metric.WithDescription("Total perceived latency from request to application readiness"), metric.WithUnit("us"))
+	if err != nil {
+		return nil, nil, err
+	}
+	bidiServerNetworkTransitLatency, err := meter.Float64Histogram("gcp.storage.client.bidi.server_network_transit_latency_us", metric.WithDescription("Time from range registration to data arrival at the VM"), metric.WithUnit("us"))
+	if err != nil {
+		return nil, nil, err
+	}
+	bidiSDKProcessingOverhead, err := meter.Float64Histogram("gcp.storage.client.bidi.sdk_processing_overhead_us", metric.WithDescription("Time spent in proto parsing and CRC32C verification"), metric.WithUnit("us"))
+	if err != nil {
+		return nil, nil, err
+	}
+	bidiClientHandoffDelay, err := meter.Float64Histogram("gcp.storage.client.bidi.client_handoff_delay_us", metric.WithDescription("Delay between SDK completion and user application receiving the data callback"), metric.WithUnit("us"))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -460,6 +523,19 @@ func initMetrics(ctx context.Context, projectID string, config *storageConfig) (
 		networkBytesSent:          networkBytesSent,
 		networkBytesReceived:      networkBytesReceived,
 		stallDuration:             stallDuration,
+		duration:                        duration,
+		operations:                      operations,
+		attempts:                        attempts,
+		requestBodySize:                 requestBodySize,
+		responseBodySize:                responseBodySize,
+		errors:                          errors,
+		bidiStreamOpenLatency:           bidiStreamOpenLatency,
+		bidiNetworkHandshakeLatency:     bidiNetworkHandshakeLatency,
+		bidiServerMetadataLatency:       bidiServerMetadataLatency,
+		bidiEndToEndRangeReadLatency:    bidiEndToEndRangeReadLatency,
+		bidiServerNetworkTransitLatency: bidiServerNetworkTransitLatency,
+		bidiSDKProcessingOverhead:       bidiSDKProcessingOverhead,
+		bidiClientHandoffDelay:          bidiClientHandoffDelay,
 	}
 
 	var cleanup func()


### PR DESCRIPTION
This PR introduces 7 new high-precision microsecond-level latency metrics for Bi-directional (Bidi) Read operations in the GCS Go SDK. This allows developers to monitor and pinpoint bottlenecks in download performance with microsecond granularity, distinguishing between SDK overhead, network transit, and server processing.

Key Metrics Added:
gcp.storage.client.bidi.stream_open_latency_us
gcp.storage.client.bidi.network_handshake_latency_us
gcp.storage.client.bidi.server_metadata_latency_us
gcp.storage.client.bidi.end_to_end_range_read_latency_us
gcp.storage.client.bidi.server_network_transit_latency_us
gcp.storage.client.bidi.sdk_processing_overhead_us
gcp.storage.client.bidi.client_handoff_delay_us