### PR TITLE
ci: librarian to use Go 1.25.8 toolchain

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -37,7 +37,7 @@ tools:
 default:
   tag_format: '{name}/v{version}'
   go:
-    toolchain: go1.25.0
+    toolchain: go1.25.8
     default_enabled_generator_features:
       - F_open_telemetry_attributes
 libraries:


### PR DESCRIPTION
This will fix `librarian generate` Go toolchain mismatch:

```
go: toolchain upgrade needed to resolve google.golang.org/genproto/googleapis/type/interval
go: google.golang.org/genproto@v0.0.0-20260720211330-0afa2a65878a requires go >= 1.25.8 (running go 1.25.0; GOTOOLCHAIN=go1.25.0)
: exit status 1
```

Fixes https://github.com/googleapis/google-cloud-go/issues/20198
