### PR TITLE
ci: revert "ci: librarian to use Go 1.25.8 toolchain"

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -37,7 +37,7 @@ tools:
 default:
   tag_format: '{name}/v{version}'
   go:
-    toolchain: go1.25.8
+    toolchain: go1.25.0
     default_enabled_generator_features:
       - F_open_telemetry_attributes
 libraries:


### PR DESCRIPTION
Reverts googleapis/google-cloud-go#20200.

Requiring the library users to upgrade Go 1.25.8 was wrong. (go/cloud-sdk-go:pomo-version-creep).