### PR TITLE
feat(bigtable): add NoOpChannelPrimer for session channel pools

### DIFF
--- a/bigtable/internal/transport/channel_primer.go
+++ b/bigtable/internal/transport/channel_primer.go
@@ -33,11 +33,27 @@ import (
 //   - pingAndWarmChannelPrimer issues a PingAndWarm against the configured
 //     instance / app profile with the supplied feature-flag metadata
 //     (today's only behavior, used by the classic channel pool factory).
+//   - NoOpChannelPrimer skips priming entirely. Prefer this over nil at
+//     construction sites where "no priming" is a deliberate architectural
+//     choice (e.g. session channel pools that warm via OpenSession on
+//     each stream) rather than a placeholder waiting for a real primer.
 type ChannelPrimer interface {
 	// Prime warms conn so the next request served by it does not pay the
 	// first-RPC connection-setup cost. The factory wraps Prime in a retry
 	// loop, so transient errors should propagate as-is.
 	Prime(ctx context.Context, conn *BigtableConn) error
+}
+
+// NoOpChannelPrimer explicitly disables per-connection priming. Session
+// channel pools warm their channels via the OpenSession handshake on
+// each newly-opened stream, so a PingAndWarm at dial time is redundant.
+// Passing NoOpChannelPrimer{} makes the "no priming" choice explicit at
+// the construction site instead of relying on nil-as-sentinel.
+type NoOpChannelPrimer struct{}
+
+// Prime is a no-op — the channel is returned unprimed.
+func (NoOpChannelPrimer) Prime(_ context.Context, _ *BigtableConn) error {
+	return nil
 }
 
 // pingAndWarmChannelPrimer primes a channel by issuing a PingAndWarm RPC

--- a/bigtable/internal/transport/channel_primer_test.go
+++ b/bigtable/internal/transport/channel_primer_test.go
@@ -96,48 +96,36 @@ func TestNoOpChannelPrimer_ImplementsChannelPrimer(t *testing.T) {
 	var _ ChannelPrimer = NoOpChannelPrimer{}
 }
 
-// TestConnectionFactory_NoOpPrimerSkipsPriming verifies NoOpChannelPrimer
-// composes into the factory the same way a nil primer does — dial, no
-// PingAndWarm, hand the raw connection back.
-func TestConnectionFactory_NoOpPrimerSkipsPriming(t *testing.T) {
-	fake := &fakeService{}
-	addr := setupTestServer(t, fake)
-
-	factory := &connectionFactory{
-		dial:   func() (*BigtableConn, error) { return dialBigtableserver(addr) },
-		primer: NoOpChannelPrimer{},
+// TestConnectionFactory_NoPrimingVariants verifies both no-prime primer
+// shapes turn PingAndWarm off: an untyped nil primer AND the explicit
+// NoOpChannelPrimer sentinel. newEntry dials the channel and returns
+// it without issuing PingAndWarm in either case.
+func TestConnectionFactory_NoPrimingVariants(t *testing.T) {
+	cases := []struct {
+		name   string
+		primer ChannelPrimer
+	}{
+		{"nil-primer", nil},
+		{"no-op-primer", NoOpChannelPrimer{}},
 	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fake := &fakeService{}
+			addr := setupTestServer(t, fake)
+			factory := &connectionFactory{
+				dial:   func() (*BigtableConn, error) { return dialBigtableserver(addr) },
+				primer: tc.primer,
+			}
 
-	entry, err := factory.newEntry(context.Background())
-	if err != nil {
-		t.Fatalf("newEntry returned error: %v", err)
-	}
-	t.Cleanup(func() { entry.conn.Close() })
+			entry, err := factory.newEntry(context.Background())
+			if err != nil {
+				t.Fatalf("newEntry returned error: %v", err)
+			}
+			t.Cleanup(func() { entry.conn.Close() })
 
-	if got := fake.getPingCount(); got != 0 {
-		t.Errorf("PingAndWarm call count with NoOpChannelPrimer = %d, want 0", got)
-	}
-}
-
-// TestConnectionFactory_NilPrimerSkipsPriming verifies the contract that a
-// nil ChannelPrimer turns priming off: newEntry dials the channel and
-// returns it without issuing PingAndWarm.
-func TestConnectionFactory_NilPrimerSkipsPriming(t *testing.T) {
-	fake := &fakeService{}
-	addr := setupTestServer(t, fake)
-
-	factory := &connectionFactory{
-		dial:   func() (*BigtableConn, error) { return dialBigtableserver(addr) },
-		primer: nil,
-	}
-
-	entry, err := factory.newEntry(context.Background())
-	if err != nil {
-		t.Fatalf("newEntry returned error: %v", err)
-	}
-	t.Cleanup(func() { entry.conn.Close() })
-
-	if got := fake.getPingCount(); got != 0 {
-		t.Errorf("PingAndWarm call count with nil primer = %d, want 0", got)
+			if got := fake.getPingCount(); got != 0 {
+				t.Errorf("PingAndWarm call count = %d, want 0", got)
+			}
+		})
 	}
 }

--- a/bigtable/internal/transport/channel_primer_test.go
+++ b/bigtable/internal/transport/channel_primer_test.go
@@ -79,6 +79,46 @@ func TestPingAndWarmChannelPrimer_Prime_NotFoundIsBenign(t *testing.T) {
 	}
 }
 
+// TestNoOpChannelPrimer_Prime verifies the primer returns nil without
+// dialing or touching the connection — a nil BigtableConn is safe to
+// pass because Prime never dereferences it.
+func TestNoOpChannelPrimer_Prime(t *testing.T) {
+	var p NoOpChannelPrimer
+	if err := p.Prime(context.Background(), nil); err != nil {
+		t.Errorf("Prime returned err = %v, want nil", err)
+	}
+}
+
+// TestNoOpChannelPrimer_ImplementsChannelPrimer is a compile-time guard:
+// NoOpChannelPrimer must satisfy the ChannelPrimer interface so
+// construction sites can pass it wherever a ChannelPrimer is expected.
+func TestNoOpChannelPrimer_ImplementsChannelPrimer(t *testing.T) {
+	var _ ChannelPrimer = NoOpChannelPrimer{}
+}
+
+// TestConnectionFactory_NoOpPrimerSkipsPriming verifies NoOpChannelPrimer
+// composes into the factory the same way a nil primer does — dial, no
+// PingAndWarm, hand the raw connection back.
+func TestConnectionFactory_NoOpPrimerSkipsPriming(t *testing.T) {
+	fake := &fakeService{}
+	addr := setupTestServer(t, fake)
+
+	factory := &connectionFactory{
+		dial:   func() (*BigtableConn, error) { return dialBigtableserver(addr) },
+		primer: NoOpChannelPrimer{},
+	}
+
+	entry, err := factory.newEntry(context.Background())
+	if err != nil {
+		t.Fatalf("newEntry returned error: %v", err)
+	}
+	t.Cleanup(func() { entry.conn.Close() })
+
+	if got := fake.getPingCount(); got != 0 {
+		t.Errorf("PingAndWarm call count with NoOpChannelPrimer = %d, want 0", got)
+	}
+}
+
 // TestConnectionFactory_NilPrimerSkipsPriming verifies the contract that a
 // nil ChannelPrimer turns priming off: newEntry dials the channel and
 // returns it without issuing PingAndWarm.


### PR DESCRIPTION
## Summary

Adds a `NoOpChannelPrimer` implementation of `ChannelPrimer` that explicitly disables per-connection priming. Session channel pools warm their channels via the OpenSession handshake on each newly-opened stream, so a PingAndWarm at dial time is redundant.

The `ChannelPrimer` contract already allows nil-as-\"no priming\" (see the factory's nil-primer branch), but nil is a placeholder-shaped sentinel — easy to misread as \"primer not wired up yet\" rather than a deliberate architectural choice. `NoOpChannelPrimer` makes the intent explicit at the construction site and gives the follow-up SessionClient refactor a named type to plumb.

## Changes

- **`channel_primer.go`** — new `NoOpChannelPrimer struct{}` + `Prime` method returning nil; interface docstring extended to name it alongside `pingAndWarmChannelPrimer`.
- **`channel_primer_test.go`** — three new tests:
  - `TestNoOpChannelPrimer_Prime` — returns nil and doesn't dereference the connection.
  - `TestNoOpChannelPrimer_ImplementsChannelPrimer` — compile-time guard on interface satisfaction.
  - `TestConnectionFactory_NoOpPrimerSkipsPriming` — composes into the existing `connectionFactory` the same way nil does; no PingAndWarm on the wire.

## Test plan

- [x] \`go test ./bigtable/internal/transport/ -run 'ChannelPrimer|Primer|Prime' -count=1 -short\` → 4/4 relevant + PingAndWarm suite all pass locally.
- [x] \`go build ./bigtable/internal/transport/\` clean.
- [x] \`go vet ./bigtable/internal/transport/\` clean.
- [x] \`golint\` clean.
- [x] CI green (post-rebase + consolidation).
